### PR TITLE
fix(codegen): link 1-arg setTimeout — unblocks hono/jsx module imports (#1671)

### DIFF
--- a/crates/perry-codegen/src/lower_call/extern_func.rs
+++ b/crates/perry-codegen/src/lower_call/extern_func.rs
@@ -56,6 +56,26 @@ pub fn try_lower_extern_func_call(
         return Ok(None);
     }
     match name.as_str() {
+        // #1671: `setTimeout(fn)` with no explicit delay. Node treats a
+        // missing/undefined delay as 0 (fires on the next timer tick).
+        // Without this arm a 1-arg `setTimeout` falls through to the
+        // catch-all below, which emits a bare LLVM call to `@setTimeout`
+        // and the linker fails with `Undefined symbols: _setTimeout`
+        // (hit by hono/jsx's `hooks/index.js`, which schedules a re-render
+        // via `setTimeout(() => { … })`). Route it to the same runtime
+        // entry as the 2-arg form with a zero delay.
+        "setTimeout" if args.len() == 1 => {
+            let cb_box = lower_expr(ctx, &args[0])?;
+            let blk = ctx.block();
+            let cb_handle = unbox_to_i64(blk, &cb_box);
+            let zero = double_literal(0.0);
+            let id = blk.call(
+                I64,
+                "js_set_timeout_callback",
+                &[(I64, &cb_handle), (DOUBLE, &zero)],
+            );
+            return Ok(Some(nanbox_pointer_inline(blk, &id)));
+        }
         "setTimeout" if args.len() == 2 => {
             let cb_box = lower_expr(ctx, &args[0])?;
             let delay_box = lower_expr(ctx, &args[1])?;

--- a/test-parity/node-suite/timers/timeout/no-delay.ts
+++ b/test-parity/node-suite/timers/timeout/no-delay.ts
@@ -1,0 +1,15 @@
+// #1671: `setTimeout(fn)` called with a single argument and no delay.
+// Node treats the missing delay as 0. Before the fix, the global 1-arg
+// form fell through codegen's extern-func table to a bare `@setTimeout`
+// call and the binary failed to LINK (`Undefined symbols: _setTimeout`) —
+// the exact failure hit by hono/jsx's `hooks/index.js`, which schedules a
+// re-render via `setTimeout(() => { … })`. Uses the bare global (no
+// `node:timers` import) to exercise that path directly.
+const order: string[] = [];
+await new Promise<void>((resolve) => {
+  setTimeout(() => {
+    order.push("no-delay");
+    resolve();
+  });
+});
+console.log("fired:", order.join(","));

--- a/tests/release/packages/hono-jsx-imports/entry.ts
+++ b/tests/release/packages/hono-jsx-imports/entry.ts
@@ -1,0 +1,20 @@
+// Tier-3 fixture (#1671): the `hono/jsx` + `hono/jsx/streaming` module
+// imports must resolve and LINK under Perry-native compile.
+//
+// `renderToReadableStream` lives in hono/jsx/streaming, which transitively
+// imports hono/jsx/dom/render → hono/jsx/hooks. hooks/index.js schedules a
+// re-render via a single-argument `setTimeout(() => { … })`. Before #1671,
+// codegen had no extern-func arm for 1-arg setTimeout, so the call fell
+// through to a bare `@setTimeout` LLVM call and the binary failed to link
+// with `Undefined symbols: _setTimeout`. This fixture pins the link path.
+//
+// Imports only (no JSX syntax) so `node --experimental-strip-types` — which
+// strips types but does NOT transform JSX — can run it to keep expected.txt
+// honest against the pinned hono version.
+import { renderToReadableStream, Suspense } from "hono/jsx/streaming";
+import { jsx, Fragment } from "hono/jsx";
+
+console.log("renderToReadableStream:", typeof renderToReadableStream);
+console.log("Suspense:", typeof Suspense);
+console.log("jsx:", typeof jsx);
+console.log("Fragment:", typeof Fragment);

--- a/tests/release/packages/hono-jsx-imports/expected.txt
+++ b/tests/release/packages/hono-jsx-imports/expected.txt
@@ -1,0 +1,4 @@
+renderToReadableStream: function
+Suspense: function
+jsx: function
+Fragment: function

--- a/tests/release/packages/hono-jsx-imports/fixture.sh
+++ b/tests/release/packages/hono-jsx-imports/fixture.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Tier-3 fixture: hono-jsx-imports (#1671).
+#
+# Verifies that the `hono/jsx` + `hono/jsx/streaming` module imports —
+# compiled natively via `perry.compilePackages` — resolve and LINK.
+# hono/jsx/streaming transitively imports hono/jsx/hooks, whose 1-arg
+# `setTimeout(() => …)` re-render scheduler previously fell through
+# codegen's extern-func table to a bare `@setTimeout` and failed at link
+# with `Undefined symbols: _setTimeout`. The entry imports the runtime
+# helpers and prints their typeof, byte-for-byte matching Node.
+#
+# Acceptance:
+#   - `npm install` resolves hono into ./node_modules
+#   - `perry entry.ts -o ./out` exits 0 (the regression: it failed at LINK)
+#   - `./out` produces stdout matching expected.txt byte-for-byte
+#   - `node --experimental-strip-types entry.ts` ALSO produces that same
+#     output. The entry deliberately uses imports only (no JSX syntax) so
+#     strip-types can run it — node does not transform JSX.
+
+set -uo pipefail
+cd "$(dirname "$0")"
+
+NAME="hono-jsx-imports"
+PERRY_BIN="${PERRY_BIN:-../../../target/release/perry}"
+
+# 1. Resolve dependencies. node_modules is gitignored at the repo level
+# so first run on a fresh checkout pulls hono. Subsequent runs are fast.
+if [[ ! -d node_modules/hono ]]; then
+    echo "  [1/4] npm install hono..."
+    npm install --silent --no-audit --no-fund > install.log 2>&1
+    if [[ ! -d node_modules/hono ]]; then
+        echo "FAIL $NAME — npm install did not produce node_modules/hono"
+        sed 's/^/    /' install.log
+        exit 1
+    fi
+fi
+
+# 2. Compile with Perry. This is where #1671 regressed (link failure).
+echo "  [2/4] perry compile entry.ts..."
+if ! "$PERRY_BIN" entry.ts -o ./out > perry-compile.log 2>&1; then
+    echo "FAIL $NAME — perry compile errored"
+    sed 's/^/    /' perry-compile.log | tail -40
+    exit 1
+fi
+
+# 3. Run the compiled binary and capture stdout.
+echo "  [3/4] ./out..."
+if ! ./out > perry-out.txt 2> perry-run.log; then
+    echo "FAIL $NAME — perry binary exited non-zero"
+    sed 's/^/    /' perry-run.log | tail -40
+    echo "    --- stdout (truncated) ---"
+    sed 's/^/    /' perry-out.txt | tail -20
+    exit 1
+fi
+
+# 4. Diff against expected.txt. Optionally re-run Node to verify
+# expected.txt is still accurate against the pinned hono version.
+echo "  [4/4] diff against expected.txt..."
+if ! diff -u expected.txt perry-out.txt > diff.log; then
+    echo "FAIL $NAME — perry output diverges from expected.txt"
+    sed 's/^/    /' diff.log
+    if command -v node >/dev/null 2>&1; then
+        node --experimental-strip-types entry.ts > node-out.txt 2>/dev/null || true
+        if [[ -s node-out.txt ]] && ! diff -q expected.txt node-out.txt > /dev/null 2>&1; then
+            echo "    NOTE: expected.txt is also out of sync with node — refresh it"
+            diff -u expected.txt node-out.txt | head -20 | sed 's/^/      /'
+        fi
+    fi
+    exit 1
+fi
+
+echo "PASS $NAME"

--- a/tests/release/packages/hono-jsx-imports/package-lock.json
+++ b/tests/release/packages/hono-jsx-imports/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "perry-release-fixture-hono-jsx-imports",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "perry-release-fixture-hono-jsx-imports",
+      "version": "0.0.0",
+      "dependencies": {
+        "hono": "^4.6.0"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.22",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.22.tgz",
+      "integrity": "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    }
+  }
+}

--- a/tests/release/packages/hono-jsx-imports/package.json
+++ b/tests/release/packages/hono-jsx-imports/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "perry-release-fixture-hono-jsx-imports",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Tier-3 fixture (#1671): static imports from hono/jsx and hono/jsx/streaming must compile + link natively. hono/jsx/streaming transitively pulls in hono/jsx/hooks, whose `setTimeout(() => …)` 1-arg call previously fell through codegen's extern-func table to a bare `@setTimeout` and failed to link (`Undefined symbols: _setTimeout`). Imports only (no JSX syntax) so `node --experimental-strip-types` can run it for the expected.txt sanity check.",
+  "dependencies": {
+    "hono": "^4.6.0"
+  },
+  "perry": {
+    "compilePackages": ["hono"],
+    "allow": {
+      "compilePackages": ["hono"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #1671 — the `hono/jsx` / `hono/jsx/streaming` module imports now compile, link, and run under Perry-native compile.

The remaining blocker (per the reopened comment) was a **link failure**, not a resolution failure:

```
Undefined symbols for architecture arm64:
  "_setTimeout", referenced from:
      _perry_closure_node_modules_hono_dist_jsx_hooks_index_js__30 in node_modules_hono_dist_jsx_hooks_index_js.o
```

### Root cause

A `setTimeout(fn)` call with **a single argument** (no delay) had no arm in codegen's extern-func table — only the 2-arg and `>=3`-arg forms existed (`crates/perry-codegen/src/lower_call/extern_func.rs`). The 1-arg call fell through to the generic catch-all, which emits a bare `@setTimeout` LLVM call. Since no runtime symbol is literally named `setTimeout` (it's `js_set_timeout_callback`), the link failed.

`hono/jsx/streaming` transitively imports `hono/jsx/dom/render` → `hono/jsx/hooks`, whose re-render scheduler calls `setTimeout(() => { ... })` with exactly one argument — so the whole `hono/jsx` module-import path failed to link.

### Fix

Route 1-arg `setTimeout` to the same `js_set_timeout_callback` runtime entry as the 2-arg form, with a zero delay (Node treats a missing/undefined delay as 0, firing on the next timer tick).

`requestAnimationFrame`, also referenced in `hooks/index.js`, is *not* a recognized builtin, so it lowers to a no-op global rather than an undefined symbol — `setTimeout` was the only link blocker.

### Note on `hono/jsx/server`

The issue title mentions `hono/jsx/server`, but that subpath is not a real export in current hono (4.12.x) — the canonical server-side JSX entry points are `hono/jsx` (index, which re-exports `jsx`/`jsxs`/`Fragment`/`JSXNode`/`Suspense`) and `hono/jsx/streaming` (`renderToReadableStream`/`Suspense`). Both now link and resolve.

## Verification

Before (baseline): link fails with `Undefined symbols: _setTimeout`.

After:

```
$ ./repro   # import { renderToReadableStream, Suspense } from 'hono/jsx/streaming'
            # import { jsx, Fragment } from 'hono/jsx'
renderToReadableStream: function
Suspense: function
jsx: function
Fragment: function
```

JSX rendering (#1653) is unaffected — `String(<Hello name="Perry"/>)` still produces `<div><h1>hello, Perry</h1></div>`. The bare global 1-arg `setTimeout` fires and matches `node --experimental-strip-types` byte-for-byte. `cargo test -p perry-codegen` passes; `cargo fmt --all -- --check` clean.

## Tests

- `test-parity/node-suite/timers/timeout/no-delay.ts` — behavioral parity case for the bare global 1-arg form.
- `tests/release/packages/hono-jsx-imports/` — tier-3 fixture that `npm install`s real hono and asserts the `hono/jsx` + `hono/jsx/streaming` imports compile, link, and run (imports-only, no JSX syntax, so `node --experimental-strip-types` validates `expected.txt`).

Related: #1655 (Hono-on-Perry tracker), #1653 (closed).
