### PR TITLE
test(parity): stream — batch of 12 tier-11 tests (iter-115..117) (2 free pass, 10 #1531/#1532/#1545/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2641,5 +2641,65 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Readable.from(asyncGen yielding mixed types) — types lost or wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/readable-event-with-objectmode": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: objectMode 'readable' event — read() returns wrong object values. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/emit-with-arg-array": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: emit(event, a, b, c, d) — listeners receive wrong args. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/many-pushes-accumulate": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: many push() — readableLength does not match total bytes. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/drop-zero-yields-all": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: drop(0) — yields wrong items. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/web/from-async-gen-throws-mid": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: RS.from(asyncGen throws mid) — read() does not reject. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/listener-throw-does-not-stop-others": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: listener throw in emit — second listener may or may not fire (Perry differs from Node). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/cancel-during-pull": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: cancel() during pull — read() does not resolve {done:true}. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/iter-with-custom-return": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: for-await break — custom iterator.return() not invoked. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/events/captureRejections-constructor": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable({captureRejections}) — async listener throws not caught as 'error'. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/pipe-error-handler-on-source": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: src.on('error') during pipe — handler receives wrong error / not called. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/captureRejections-constructor.ts
+++ b/test-parity/node-suite/stream/events/captureRejections-constructor.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+// Readable({captureRejections: true}) — listener throws are caught.
+const r = new Readable({ read() {}, captureRejections: true } as any);
+let caughtErr: any = null;
+r.on("error", (e) => (caughtErr = e && (e as Error).message));
+r.on("custom", async () => {
+  throw new Error("listener-fail");
+});
+r.emit("custom");
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("caught:", caughtErr);
+  });
+});

--- a/test-parity/node-suite/stream/events/emit-with-arg-array.ts
+++ b/test-parity/node-suite/stream/events/emit-with-arg-array.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// emit(event, ...args) — multiple args passed to listeners individually.
+const r = new Readable({ read() {} });
+let captured: any = null;
+r.on("multi", (a: any, b: any, c: any, d: any) => {
+  captured = { a, b, c, d };
+});
+r.emit("multi", 1, "two", { three: 3 }, [4, 5]);
+console.log(JSON.stringify(captured));

--- a/test-parity/node-suite/stream/events/listener-throw-does-not-stop-others.ts
+++ b/test-parity/node-suite/stream/events/listener-throw-does-not-stop-others.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// If one listener throws synchronously, OTHER listeners may still fire,
+// but EE actually throws the error. Verify behavior either way.
+const r = new Readable({ read() {} });
+let second = 0;
+r.on("custom", () => { throw new Error("first-fail"); });
+r.on("custom", () => second++);
+let outerErr: string | null = null;
+try {
+  r.emit("custom");
+} catch (e: any) {
+  outerErr = e && e.message;
+}
+console.log("outer caught:", outerErr);
+console.log("second listener fired:", second);

--- a/test-parity/node-suite/stream/iter-helpers/drop-zero-yields-all.ts
+++ b/test-parity/node-suite/stream/iter-helpers/drop-zero-yields-all.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// drop(0) — yields all original items.
+const r = Readable.from([1, 2, 3, 4]);
+const out: number[] = [];
+for await (const v of (r as any).drop(0)) out.push(v as number);
+console.log("out:", out.join(","));

--- a/test-parity/node-suite/stream/iter-helpers/to-array-empty-stream.ts
+++ b/test-parity/node-suite/stream/iter-helpers/to-array-empty-stream.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// toArray() on empty stream — returns empty array.
+const r = Readable.from([]);
+const result = await (r as any).toArray();
+console.log("is array:", Array.isArray(result));
+console.log("length:", result.length);
+console.log("is empty:", result.length === 0);

--- a/test-parity/node-suite/stream/pipe/pipe-error-handler-on-source.ts
+++ b/test-parity/node-suite/stream/pipe/pipe-error-handler-on-source.ts
@@ -1,0 +1,13 @@
+import { Readable, PassThrough } from "node:stream";
+// Error handler on source — when src errors, the handler fires.
+let srcErrMsg: string | null = null;
+const src = new Readable({ read() {} });
+src.on("error", (e) => (srcErrMsg = e && e.message));
+const dst = new PassThrough();
+dst.on("data", () => {});
+dst.on("error", () => {});
+src.pipe(dst);
+src.destroy(new Error("src-error"));
+setImmediate(() => {
+  setImmediate(() => console.log("src err:", srcErrMsg));
+});

--- a/test-parity/node-suite/stream/readable/iter-with-custom-return.ts
+++ b/test-parity/node-suite/stream/readable/iter-with-custom-return.ts
@@ -1,0 +1,25 @@
+import { Readable } from "node:stream";
+// When for-await breaks early, the iterator's return() is invoked.
+let returnCalled = false;
+const customIter = {
+  [Symbol.asyncIterator]() {
+    let i = 0;
+    return {
+      next: async () => ({ value: i++, done: i > 5 }),
+      return: async () => {
+        returnCalled = true;
+        return { value: undefined, done: true };
+      },
+    };
+  },
+};
+const r = Readable.from(customIter as any);
+let count = 0;
+for await (const _v of r) {
+  count++;
+  if (count === 2) break;
+}
+setImmediate(() => {
+  console.log("count:", count);
+  console.log("return called:", returnCalled);
+});

--- a/test-parity/node-suite/stream/readable/many-pushes-accumulate.ts
+++ b/test-parity/node-suite/stream/readable/many-pushes-accumulate.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// Many push() calls accumulate; final readableLength = sum.
+const r = new Readable({ read() {} });
+let totalBytes = 0;
+for (let i = 0; i < 10; i++) {
+  const s = "x".repeat(i + 1);
+  r.push(s);
+  totalBytes += s.length;
+}
+console.log("expected:", totalBytes);
+console.log("readableLength:", r.readableLength);
+console.log("match:", r.readableLength === totalBytes);

--- a/test-parity/node-suite/stream/readable/readable-event-with-objectmode.ts
+++ b/test-parity/node-suite/stream/readable/readable-event-with-objectmode.ts
@@ -1,0 +1,18 @@
+import { Readable } from "node:stream";
+// 'readable' event with objectMode — each read() returns one object.
+const r = new Readable({
+  objectMode: true,
+  read() {
+    this.push({ id: 1 });
+    this.push({ id: 2 });
+    this.push(null);
+  },
+});
+r.on("readable", () => {
+  const a = r.read();
+  const b = r.read();
+  const c = r.read();
+  console.log("a:", a && a.id);
+  console.log("b:", b && b.id);
+  console.log("c:", c);
+});

--- a/test-parity/node-suite/stream/web/cancel-during-pull.ts
+++ b/test-parity/node-suite/stream/web/cancel-during-pull.ts
@@ -1,0 +1,14 @@
+import { ReadableStream } from "node:stream/web";
+// Cancel during an active pull — pull is interrupted; further reads see done.
+const rs = new ReadableStream({
+  async pull(c) {
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    c.enqueue("x");
+  },
+});
+const reader = rs.getReader();
+const readPromise = reader.read();
+// Cancel before pull resolves
+setTimeout(() => reader.cancel("interrupt"), 5);
+const result = await readPromise;
+console.log("done:", result.done);

--- a/test-parity/node-suite/stream/web/from-async-gen-throws-mid.ts
+++ b/test-parity/node-suite/stream/web/from-async-gen-throws-mid.ts
@@ -1,0 +1,17 @@
+import { ReadableStream } from "node:stream/web";
+// RS.from(asyncGen) where gen throws mid-iteration — read() rejects.
+async function* gen() {
+  yield "a";
+  throw new Error("mid-fail");
+}
+const rs = (ReadableStream as any).from(gen());
+const reader = rs.getReader();
+const first = await reader.read();
+let secondErr: string | null = null;
+try {
+  await reader.read();
+} catch (e: any) {
+  secondErr = e && e.message;
+}
+console.log("first value:", first.value);
+console.log("second err:", secondErr);

--- a/test-parity/node-suite/stream/web/transform-stream-identity-roundtrip.ts
+++ b/test-parity/node-suite/stream/web/transform-stream-identity-roundtrip.ts
@@ -1,0 +1,15 @@
+import { TransformStream } from "node:stream/web";
+// Empty TransformStream is identity — written chunks come out unchanged.
+const ts = new TransformStream();
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("hello");
+await writer.write("world");
+await writer.close();
+const out: string[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(String(value));
+}
+console.log("roundtrip:", out.join("|"));


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-115..117)

**2 free passes + 10 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | transform-stream-identity-roundtrip ✅, from-async-gen-throws-mid, cancel-during-pull | #1545 |
| Readable shape | readable-event-with-objectmode, many-pushes-accumulate, iter-with-custom-return | #1531/#1532 |
| Stream events | emit-with-arg-array, listener-throw-does-not-stop-others, captureRejections-constructor | #1532 |
| Pipe | pipe-error-handler-on-source | #1532 |
| Iter helpers | to-array-empty-stream ✅, drop-zero-yields-all | #1558 |

Free passes:
- `web/transform-stream-identity-roundtrip` (TS w/ no transformer is identity)
- `iter-helpers/to-array-empty-stream` (returns empty array)

All 10 failures tracked in `known_failures.json`.
