### PR TITLE
test(parity): stream — batch of 12 tier-11/12 tests (iter-118..120) (2 free pass, 10 #1532/#1545/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3115,5 +3115,65 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/destroy-emits-error-event": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroy(err) — 'error' fires after 'close', or order wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/listener-count-by-symbol-event": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: listenerCount(Symbol) — count wrong for Symbol-keyed listeners. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/some-finds-match": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: some() — does not short-circuit at first match (calls > N). Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/pipeline/async-iter-source": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline(asyncIterable, dst, cb) — async-iterable source not handled. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-empty-string": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from('') — empty-string source iteration count wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/raw-listeners-empty": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: rawListeners(no-event) — should return empty array, doesn't. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/prepend-listener-returns-this": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: prependListener() does not return emitter (chainable). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/tee-mid-consume-throws": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: tee() after getReader+read — should throw TypeError. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/source-immediate-error": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe() src immediate error — error not fired on src listener. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-string-iterates-codepoints": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(string) — chunk count / shape wrong. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/listener-count-by-symbol-event.ts
+++ b/test-parity/node-suite/stream/events/listener-count-by-symbol-event.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+import { errorMonitor } from "node:events";
+// listenerCount with a Symbol event name works.
+const r = new Readable({ read() {} });
+console.log("before:", r.listenerCount(errorMonitor));
+r.on(errorMonitor, () => {});
+r.on(errorMonitor, () => {});
+console.log("after 2:", r.listenerCount(errorMonitor));

--- a/test-parity/node-suite/stream/events/prepend-listener-returns-this.ts
+++ b/test-parity/node-suite/stream/events/prepend-listener-returns-this.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// prependListener returns the emitter (chainable).
+const r = new Readable({ read() {} });
+const returned = r.prependListener("custom", () => {});
+console.log("returns self:", returned === r);

--- a/test-parity/node-suite/stream/events/raw-listeners-empty.ts
+++ b/test-parity/node-suite/stream/events/raw-listeners-empty.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// rawListeners(no-listeners-event) — returns empty array.
+const r = new Readable({ read() {} });
+const arr = r.rawListeners("never");
+console.log("is array:", Array.isArray(arr));
+console.log("length:", arr.length);
+console.log("is empty:", arr.length === 0);

--- a/test-parity/node-suite/stream/iter-helpers/some-finds-match.ts
+++ b/test-parity/node-suite/stream/iter-helpers/some-finds-match.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// some(fn) returns true on first match; stops early.
+let calls = 0;
+const r = Readable.from([1, 2, 3, 4, 5]);
+const result = await (r as any).some((x: number) => {
+  calls++;
+  return x === 3;
+});
+console.log("result:", result);
+console.log("stopped early (calls <= 3):", calls <= 3);

--- a/test-parity/node-suite/stream/pipe/source-immediate-error.ts
+++ b/test-parity/node-suite/stream/pipe/source-immediate-error.ts
@@ -1,0 +1,17 @@
+import { Readable, PassThrough } from "node:stream";
+// Source emits error before any data — pipe handler still fires.
+const src = new Readable({ read() {} });
+const dst = new PassThrough();
+let dstDataCount = 0;
+let srcErrCount = 0;
+dst.on("data", () => dstDataCount++);
+src.on("error", () => srcErrCount++);
+dst.on("error", () => {});
+src.pipe(dst);
+src.destroy(new Error("immediate"));
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("dst data:", dstDataCount);
+    console.log("src error fired:", srcErrCount);
+  });
+});

--- a/test-parity/node-suite/stream/pipeline/async-iter-source.ts
+++ b/test-parity/node-suite/stream/pipeline/async-iter-source.ts
@@ -1,0 +1,13 @@
+import { PassThrough, pipeline } from "node:stream";
+// pipeline(asyncIterable, dst, cb) — async iterable as the source (not a stream).
+async function* gen() {
+  yield "x";
+  yield "y";
+}
+const dst = new PassThrough();
+const out: string[] = [];
+dst.on("data", (c) => out.push(String(c)));
+pipeline(gen(), dst, (err: any) => {
+  console.log("err:", err);
+  console.log("out:", out.join(","));
+});

--- a/test-parity/node-suite/stream/readable/destroy-emits-error-event.ts
+++ b/test-parity/node-suite/stream/readable/destroy-emits-error-event.ts
@@ -1,0 +1,20 @@
+import { Readable } from "node:stream";
+// destroy(err) emits 'error' event with the supplied error before 'close'.
+const r = new Readable({ read() {} });
+let errFired = false;
+let closeFired = false;
+let order = "";
+r.on("error", () => {
+  errFired = true;
+  order += "E";
+});
+r.on("close", () => {
+  closeFired = true;
+  order += "C";
+});
+r.destroy(new Error("boom"));
+setImmediate(() => {
+  console.log("err fired:", errFired);
+  console.log("close fired:", closeFired);
+  console.log("order:", order);
+});

--- a/test-parity/node-suite/stream/readable/from-empty-string.ts
+++ b/test-parity/node-suite/stream/readable/from-empty-string.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Readable.from("") — empty string is iterable but yields nothing.
+const r = Readable.from("");
+const out: string[] = [];
+r.on("data", (c) => out.push(String(c)));
+r.on("end", () => {
+  console.log("count:", out.length);
+  console.log("is empty:", out.length === 0);
+});

--- a/test-parity/node-suite/stream/readable/from-string-iterates-codepoints.ts
+++ b/test-parity/node-suite/stream/readable/from-string-iterates-codepoints.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Documented Node behavior: Readable.from(string) treats the string as a single
+// chunk (string-as-iterable shortcut). Validates whole-chunk emission.
+const r = Readable.from("abc");
+const chunks: string[] = [];
+r.on("data", (c) => chunks.push(String(c)));
+r.on("end", () => {
+  console.log("chunk count:", chunks.length);
+  console.log("first:", chunks[0]);
+});

--- a/test-parity/node-suite/stream/web/readable-no-init-constructor.ts
+++ b/test-parity/node-suite/stream/web/readable-no-init-constructor.ts
@@ -1,0 +1,7 @@
+import { ReadableStream } from "node:stream/web";
+// new ReadableStream() — no args; constructs an empty stream.
+const rs = new ReadableStream();
+console.log("constructed:", rs instanceof ReadableStream);
+console.log("locked:", rs.locked);
+// Cancel to clean up
+await rs.cancel();

--- a/test-parity/node-suite/stream/web/readable-stream-async-iter-flowing.ts
+++ b/test-parity/node-suite/stream/web/readable-stream-async-iter-flowing.ts
@@ -1,0 +1,12 @@
+import { ReadableStream } from "node:stream/web";
+// Web RS supports Symbol.asyncIterator — iteration drains all chunks.
+const rs = new ReadableStream({
+  start(c) {
+    c.enqueue("p");
+    c.enqueue("q");
+    c.close();
+  },
+});
+const out: string[] = [];
+for await (const v of rs as any) out.push(String(v));
+console.log("collected:", out.join(","));

--- a/test-parity/node-suite/stream/web/tee-mid-consume-throws.ts
+++ b/test-parity/node-suite/stream/web/tee-mid-consume-throws.ts
@@ -1,0 +1,15 @@
+import { ReadableStream } from "node:stream/web";
+// Get a reader, read once, then try tee() — should throw (stream locked).
+const rs = new ReadableStream({
+  start(c) { c.enqueue("a"); c.enqueue("b"); c.close(); },
+});
+const reader = rs.getReader();
+await reader.read(); // partial consume
+let caught: string | null = null;
+try {
+  rs.tee();
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-118..120)

**2 free passes + 10 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | readable-stream-async-iter-flowing ✅, readable-no-init-constructor ✅, tee-mid-consume-throws | #1545 |
| Readable shape | destroy-emits-error-event, from-empty-string, from-string-iterates-codepoints | #1532 |
| Stream events | listener-count-by-symbol-event, raw-listeners-empty, prepend-listener-returns-this | #1532 |
| Pipeline / pipe | async-iter-source, source-immediate-error | #1532 |
| Iter helpers | some-finds-match | #1558 |

Free passes:
- `web/readable-stream-async-iter-flowing` (for-await drains Web RS)
- `web/readable-no-init-constructor` (`new ReadableStream()` no args)

All 10 failures tracked in `known_failures.json`.
