### PR TITLE
fix(fetch): Request body methods callable as value / computed key (#1698)

### DIFF
--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -708,6 +708,25 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                             {
                                 return Ok(Expr::String("function".to_string()));
                             }
+                            // #1698: `typeof req.json` on a Web Fetch Request /
+                            // Response instance. The body methods are real
+                            // functions in Node, but a bare LITERAL member read
+                            // (`req.json`) takes the typed Web-Fetch codegen path,
+                            // which returns the numeric handle (typeof "object")
+                            // rather than routing to `dispatch_request_property`'s
+                            // bound-method value (the COMPUTED `req[key]` form
+                            // already does). Fold the literal-read typeof to
+                            // "function" to match Node. The call form
+                            // (`req.json()`) is unaffected.
+                            if matches!(
+                                ctx.lookup_native_instance(obj_name),
+                                Some(("Request", "Request")) | Some(("fetch", "Response"))
+                            ) && matches!(
+                                prop_name,
+                                "json" | "text" | "arrayBuffer" | "blob" | "formData" | "clone"
+                            ) {
+                                return Ok(Expr::String("function".to_string()));
+                            }
                             // #677: `typeof Function.prototype` → "object".
                             // `Function.prototype` is the (immutable) prototype
                             // chain root for all functions; in Node typeof is

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -321,6 +321,16 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
     // "not us, try the next dispatcher or return undefined".
     #[cfg(feature = "http-client")]
     {
+        // #1698: Request body methods (`req.json()`/`.text()`/`.arrayBuffer()`)
+        // on an any-typed / computed-key receiver. Hono's `HonoRequest.#cachedBody`
+        // does `raw[key]()` (computed key) on the underlying Request, which loses
+        // the static type and lands here. Fetch-family ids are unified, so the
+        // registry-membership gate inside cleanly distinguishes a Request from a
+        // Response with the (formerly colliding) same id.
+        if let Some(v) = crate::fetch::dispatch_request_method(handle as usize, method_name, &args)
+        {
+            return v;
+        }
         if let Some(v) = crate::fetch::dispatch_response_method(handle as usize, method_name, &args)
         {
             return v;

--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -1,0 +1,346 @@
+//! Untyped Web Fetch handle dispatch (refs #421, #1698).
+//!
+//! Split out of `fetch/mod.rs` to keep that file under the 2,000-line lint
+//! gate (mirrors the `headers.rs` extraction). As a child module of `fetch`,
+//! this sees `mod.rs`'s private items (the `*_REGISTRY` statics,
+//! `handle_to_f64`, `handle_id`, `js_class_method_bind` decls, `request_headers_handle`,
+//! `response_body_stream`, the `TAG_*` consts, the `js_request_*` / `js_fetch_*`
+//! / `js_blob_*` / `js_headers_*` FFIs, …) through the glob `use super::*` — no
+//! extra visibility changes required.
+//!
+//! These functions back `HANDLE_METHOD_DISPATCH` / `HANDLE_PROPERTY_DISPATCH`
+//! (registered by `common/dispatch.rs`): when codegen loses a handle's static
+//! Web-Fetch type (any-typed npm packages, computed keys, `as any`), method
+//! calls and property reads land here. Each gates on registry-membership +
+//! name vocabulary; fetch-family ids are unified (`NEXT_FETCH_HANDLE_ID`) so a
+//! Request id never collides with a Response/Headers/Blob id.
+
+use super::*;
+
+// ----------------- Untyped property dispatch (refs #421) -----------------
+//
+// When user code accesses a property on a Web Fetch handle whose static type
+// isn't known to codegen (e.g. hono's bundled JS where TS annotations are
+// stripped: `(request) => request.url`), the codegen falls through to
+// `js_object_get_field_by_name` in perry-runtime. That dispatcher strips
+// the POINTER_TAG, sees a small id, and routes to `HANDLE_PROPERTY_DISPATCH`
+// (registered by perry-stdlib's `dispatch.rs`). The functions below let the
+// stdlib dispatcher resolve Web Fetch properties without exposing the
+// per-subsystem registries publicly.
+
+/// Try to read a property off a Request handle by registry id.
+/// Returns `Some(value)` only when both (a) the id is in REQUEST_REGISTRY AND
+/// (b) the property name is one this type exposes. Returns `None` otherwise so
+/// the dispatcher falls through to the next handler — Web Fetch registries use
+/// disjoint integer-id namespaces (Request id 1 ≠ Response id 1), so a
+/// "membership only" Some(undefined) catch-all would shadow legitimate
+/// property reads on a Response handle whose id collides with a Request id.
+#[doc(hidden)]
+pub fn dispatch_request_property(req_id: usize, prop: &str) -> Option<f64> {
+    // `request.headers` — lazily allocate a Headers registry entry backed by
+    // the request's stored header map and cache the id so repeat reads return
+    // the same handle (`req.headers === req.headers`). Mirrors the Response
+    // path. Without this arm `.headers` fell through to a numeric handle and
+    // `req.headers.get(...)` threw "(number).get is not a function" — the
+    // root cause of every Hono adapter crashing on the first request (#1649).
+    if prop == "headers" {
+        // Membership check first so a non-Request id falls through.
+        REQUEST_REGISTRY.lock().unwrap().get(&req_id)?;
+        return Some(request_headers_handle(req_id));
+    }
+    // #1698: body methods read AS VALUES (`typeof req.json`, `req[key]` where
+    // key is a runtime string, `const f = req.json`). Return a bound-method
+    // closure so `typeof` reports "function" and the value stays callable —
+    // calling it routes back through `js_native_call_method` → small-handle →
+    // `dispatch_request_method`. Mirrors #1670's stream property dispatch.
+    if matches!(prop, "json" | "text" | "arrayBuffer") {
+        // Membership check first so a non-Request id falls through.
+        REQUEST_REGISTRY.lock().unwrap().get(&req_id)?;
+        extern "C" {
+            fn js_class_method_bind(
+                instance: f64,
+                method_name_ptr: *const u8,
+                method_name_len: usize,
+            ) -> f64;
+        }
+        let name: &'static [u8] = match prop {
+            "json" => b"json",
+            "text" => b"text",
+            "arrayBuffer" => b"arrayBuffer",
+            _ => unreachable!(),
+        };
+        return Some(unsafe {
+            js_class_method_bind(handle_to_f64(req_id), name.as_ptr(), name.len())
+        });
+    }
+    let guard = REQUEST_REGISTRY.lock().unwrap();
+    let req = guard.get(&req_id)?;
+    let bits = match prop {
+        "url" => {
+            let p = js_string_from_bytes(req.url.as_ptr(), req.url.len() as u32);
+            JSValue::string_ptr(p).bits()
+        }
+        "method" => {
+            let p = js_string_from_bytes(req.method.as_ptr(), req.method.len() as u32);
+            JSValue::string_ptr(p).bits()
+        }
+        "body" => match &req.body {
+            Some(b) => {
+                let p = js_string_from_bytes(b.as_ptr(), b.len() as u32);
+                JSValue::string_ptr(p).bits()
+            }
+            None => TAG_NULL,
+        },
+        // Other Request properties not yet wired — fall through so other
+        // dispatchers (or the final undefined fallback) can answer.
+        _ => return None,
+    };
+    Some(f64::from_bits(bits))
+}
+
+/// #1698: try to dispatch a method call on a Request handle by registry id.
+/// Returns `Some(result)` only when the id is a known Request AND `method` is a
+/// body-consuming method. Returns `None` (fall through) otherwise. Mirrors
+/// `dispatch_response_method`. This is the runtime path that makes computed-key
+/// and any-typed calls work — `req[key]()`, `(req as any).json()`, and Hono's
+/// internal `raw[key]()` all lose the static `Request` type at codegen and land
+/// in `js_native_call_method` → small-handle range check → `js_handle_method_dispatch`
+/// → here. (The typed `req.json()` direct-call form is still handled earlier by
+/// the codegen `module == "Request"` arm from #1688.) Fetch-family ids are
+/// unified (`NEXT_FETCH_HANDLE_ID`), so a Request id never collides with a
+/// Response/Headers/Blob id and the registry-membership gate is unambiguous.
+#[doc(hidden)]
+pub fn dispatch_request_method(req_id: usize, method: &str, _args: &[f64]) -> Option<f64> {
+    {
+        let guard = REQUEST_REGISTRY.lock().unwrap();
+        guard.get(&req_id)?;
+    }
+    let req_f64 = handle_to_f64(req_id);
+    unsafe {
+        match method {
+            "text" => {
+                let promise = js_request_text(req_f64);
+                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
+            }
+            "json" => {
+                let promise = js_request_json(req_f64);
+                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
+            }
+            "arrayBuffer" => {
+                let promise = js_request_array_buffer(req_f64);
+                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Try to read a property off a Response handle by registry id.
+/// Returns `None` if the id isn't a known Response or the property is unknown.
+#[doc(hidden)]
+pub fn dispatch_response_property(resp_id: usize, prop: &str) -> Option<f64> {
+    // `response.headers` — lazily allocate a Headers registry entry
+    // backed by the response's stored header map and cache the id on the
+    // FetchResponse so repeat reads return the same handle (preserves
+    // `res.headers === res.headers`). Hono's `#newResponse` mutates the
+    // returned Headers object via `.set(k, v)`, but our snapshot is a
+    // copy of the response's header HashMap — mutations land on the
+    // Headers handle's HeadersStore, not back on the FetchResponse.
+    // For the read-only case (the issue #486 acceptance) this is
+    // sufficient; spec-perfect "live header view" would need the
+    // FetchResponse's storage to be the same Vec as the Headers
+    // entries, which is a wider refactor.
+    if prop == "headers" {
+        let cached = {
+            let guard = FETCH_RESPONSES.lock().unwrap();
+            guard.get(&resp_id)?.cached_headers_id
+        };
+        let id = match cached {
+            Some(id) => id,
+            None => {
+                let store = {
+                    let guard = FETCH_RESPONSES.lock().unwrap();
+                    HeadersStore::from_hashmap(&guard.get(&resp_id)?.headers)
+                };
+                let new_id = alloc_headers(store);
+                if let Some(resp) = FETCH_RESPONSES.lock().unwrap().get_mut(&resp_id) {
+                    resp.cached_headers_id = Some(new_id);
+                }
+                new_id
+            }
+        };
+        return Some(handle_to_f64(id));
+    }
+    // `response.body` — `ReadableStream | null` per the Web Fetch spec.
+    // Returns a NaN-boxed (POINTER_TAG) single-chunk ReadableStream handle
+    // over the buffered body so `typeof res.body === 'object'` and
+    // `res.body.getReader()` route through the untyped stream dispatch
+    // (see dispatch_readable_stream_method). `null` when the response was
+    // constructed with no body. Cached so `.body` is stable across reads
+    // (the spec mandates a single stream; a fresh stream each call would
+    // silently unlock a held reader) (#1650).
+    if prop == "body" {
+        // Membership check first so a non-Response id falls through.
+        FETCH_RESPONSES.lock().unwrap().get(&resp_id)?;
+        return Some(response_body_stream(resp_id));
+    }
+    let guard = FETCH_RESPONSES.lock().unwrap();
+    let resp = guard.get(&resp_id)?;
+    let bits = match prop {
+        "status" => return Some(resp.status as f64),
+        "statusText" => {
+            let p = js_string_from_bytes(resp.status_text.as_ptr(), resp.status_text.len() as u32);
+            JSValue::string_ptr(p).bits()
+        }
+        "ok" => {
+            return Some(f64::from_bits(if resp.status >= 200 && resp.status < 300 {
+                TAG_TRUE
+            } else {
+                TAG_FALSE
+            }))
+        }
+        _ => return None,
+    };
+    Some(f64::from_bits(bits))
+}
+
+/// Try to read a property off a Headers handle by registry id.
+/// Returns `None` always today — Headers has no scalar properties exposed
+/// via property reads (`.get(k)` / `.has(k)` etc. are method calls that route
+/// through `HANDLE_METHOD_DISPATCH`).
+#[doc(hidden)]
+pub fn dispatch_headers_property(_headers_id: usize, _prop: &str) -> Option<f64> {
+    None
+}
+
+/// Try to dispatch a method call on a Response handle. Returns `Some(result)`
+/// only when the id is a known Response AND the method is supported. Returns
+/// `None` (fall through to the next dispatcher) otherwise. Required because
+/// Web Fetch handle id namespaces are disjoint from each other and from other
+/// stdlib registries — id collision (Request id 1 ≠ Response id 1) means
+/// claiming membership alone would shadow legitimate calls on other handles.
+#[doc(hidden)]
+pub fn dispatch_response_method(resp_id: usize, method: &str, _args: &[f64]) -> Option<f64> {
+    {
+        let guard = FETCH_RESPONSES.lock().unwrap();
+        guard.get(&resp_id)?;
+    }
+    let resp_f64 = handle_to_f64(resp_id);
+    unsafe {
+        match method {
+            "text" => {
+                let promise = js_fetch_response_text(resp_f64);
+                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
+            }
+            "json" => {
+                let promise = js_fetch_response_json(resp_f64);
+                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
+            }
+            "arrayBuffer" => {
+                let promise = js_response_array_buffer(resp_f64);
+                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
+            }
+            "blob" => {
+                let promise = js_response_blob(resp_f64);
+                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
+            }
+            "clone" => Some(js_response_clone(resp_f64)),
+            _ => None,
+        }
+    }
+}
+
+/// Try to dispatch a method call on a Blob handle. Returns `None` for unknown
+/// ids or methods.
+#[doc(hidden)]
+pub fn dispatch_blob_method(blob_id: usize, method: &str, args: &[f64]) -> Option<f64> {
+    {
+        let guard = BLOB_REGISTRY.lock().unwrap();
+        guard.get(&blob_id)?;
+    }
+    let blob_f64 = handle_to_f64(blob_id);
+    unsafe {
+        match method {
+            "text" => {
+                let promise = js_blob_text(blob_f64);
+                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
+            }
+            "arrayBuffer" => {
+                let promise = js_blob_array_buffer(blob_f64);
+                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
+            }
+            "bytes" => {
+                let promise = js_blob_bytes(blob_f64);
+                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
+            }
+            "slice" => {
+                let start = args.first().copied().unwrap_or(f64::NAN);
+                let end = args.get(1).copied().unwrap_or(f64::NAN);
+                Some(js_blob_slice(blob_f64, start, end, std::ptr::null()))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Try to dispatch a method call on a Headers handle. Returns `None` for
+/// unknown ids or methods.
+#[doc(hidden)]
+pub fn dispatch_headers_method(headers_id: usize, method: &str, args: &[f64]) -> Option<f64> {
+    {
+        let guard = HEADERS_REGISTRY.lock().unwrap();
+        guard.get(&headers_id)?;
+    }
+    let h_f64 = handle_to_f64(headers_id);
+    // String args arrive as NaN-boxed STRING_TAG f64 values; extract the raw
+    // StringHeader pointer for the runtime helpers.
+    let str_arg = |i: usize| -> *const StringHeader {
+        if i < args.len() {
+            let v = args[i];
+            (v.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader
+        } else {
+            std::ptr::null()
+        }
+    };
+    unsafe {
+        match method {
+            "get" => Some(f64::from_bits(
+                JSValue::string_ptr(js_headers_get(h_f64, str_arg(0))).bits(),
+            )),
+            "set" => Some(js_headers_set(h_f64, str_arg(0), str_arg(1))),
+            "append" => Some(js_headers_append(h_f64, str_arg(0), str_arg(1))),
+            "has" => Some(js_headers_has(h_f64, str_arg(0))),
+            "delete" => Some(js_headers_delete(h_f64, str_arg(0))),
+            "forEach" => {
+                let cb = args.first().copied().unwrap_or(f64::NAN);
+                Some(js_headers_for_each(h_f64, cb))
+            }
+            // The iterator helpers each return a (sorted) JS array, which is
+            // itself iterable — `for (const [k,v] of req.headers.entries())`
+            // and `[...req.headers.keys()]` both work off the untyped path
+            // Hono's type-stripped JS takes (#1649).
+            "keys" => Some(js_headers_keys(h_f64)),
+            "values" => Some(js_headers_values(h_f64)),
+            "entries" => Some(js_headers_entries(h_f64)),
+            _ => None,
+        }
+    }
+}
+
+/// Try to read a property off a Blob handle by registry id.
+/// Returns `None` if the id isn't a known Blob or the property is unknown.
+#[doc(hidden)]
+pub fn dispatch_blob_property(blob_id: usize, prop: &str) -> Option<f64> {
+    let guard = BLOB_REGISTRY.lock().unwrap();
+    let blob = guard.get(&blob_id)?;
+    let bits = match prop {
+        "size" => return Some(blob.body.len() as f64),
+        "type" => {
+            let p =
+                js_string_from_bytes(blob.content_type.as_ptr(), blob.content_type.len() as u32);
+            JSValue::string_ptr(p).bits()
+        }
+        _ => return None,
+    };
+    Some(f64::from_bits(bits))
+}

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -18,10 +18,25 @@ use crate::common::async_bridge::{queue_promise_resolution, spawn};
 mod headers;
 pub use headers::*;
 
+// Untyped handle dispatch helpers (`dispatch_request_method`,
+// `dispatch_response_property`, …) — split out to keep this file under the
+// 2,000-line lint gate (#1698). Same child-module/`use super::*` contract as
+// `headers`.
+mod dispatch;
+pub use dispatch::*;
+
 // Response handle storage
 lazy_static::lazy_static! {
     static ref FETCH_RESPONSES: Mutex<HashMap<usize, FetchResponse>> = Mutex::new(HashMap::new());
-    static ref NEXT_RESPONSE_ID: Mutex<usize> = Mutex::new(1);
+    /// #1698: ONE shared id counter for the whole Web Fetch handle family —
+    /// Response, Request, Headers, and Blob. Their registries stay separate
+    /// HashMaps, but a unified counter guarantees an id belongs to exactly one
+    /// of them (no more "Request id 1 == Response id 1"). This is what lets the
+    /// runtime handle-dispatch arms (`dispatch_request_method` /
+    /// `dispatch_response_method` / …) distinguish handle types by
+    /// registry-membership alone for any-typed / computed-key calls, where the
+    /// static type was lost. Streams keep their own high-range scheme.
+    static ref NEXT_FETCH_HANDLE_ID: Mutex<usize> = Mutex::new(1);
     static ref STREAM_HANDLES: Mutex<HashMap<usize, StreamState>> = Mutex::new(HashMap::new());
     static ref NEXT_STREAM_ID: Mutex<usize> = Mutex::new(1);
 
@@ -185,7 +200,7 @@ pub unsafe extern "C" fn js_fetch_get(url_ptr: *const StringHeader) -> *mut perr
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
                 // Store response
-                let mut id_guard = NEXT_RESPONSE_ID.lock().unwrap();
+                let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
                 let response_id = *id_guard;
                 *id_guard += 1;
                 drop(id_guard);
@@ -263,7 +278,7 @@ pub unsafe extern "C" fn js_fetch_get_with_auth(
 
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
-                let mut id_guard = NEXT_RESPONSE_ID.lock().unwrap();
+                let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
                 let response_id = *id_guard;
                 *id_guard += 1;
                 drop(id_guard);
@@ -343,7 +358,7 @@ pub unsafe extern "C" fn js_fetch_post_with_auth(
 
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
-                let mut id_guard = NEXT_RESPONSE_ID.lock().unwrap();
+                let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
                 let response_id = *id_guard;
                 *id_guard += 1;
                 drop(id_guard);
@@ -426,7 +441,7 @@ pub unsafe extern "C" fn js_fetch_post(
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
                 // Store response
-                let mut id_guard = NEXT_RESPONSE_ID.lock().unwrap();
+                let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
                 let response_id = *id_guard;
                 *id_guard += 1;
                 drop(id_guard);
@@ -528,7 +543,7 @@ pub unsafe extern "C" fn js_fetch_with_options(
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
                 // Store response
-                let mut id_guard = NEXT_RESPONSE_ID.lock().unwrap();
+                let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
                 let response_id = *id_guard;
                 *id_guard += 1;
                 drop(id_guard);
@@ -996,11 +1011,8 @@ struct RequestRecord {
 
 lazy_static::lazy_static! {
     static ref HEADERS_REGISTRY: Mutex<HashMap<usize, HeadersStore>> = Mutex::new(HashMap::new());
-    static ref NEXT_HEADERS_ID: Mutex<usize> = Mutex::new(1);
     static ref REQUEST_REGISTRY: Mutex<HashMap<usize, RequestRecord>> = Mutex::new(HashMap::new());
-    static ref NEXT_REQUEST_ID: Mutex<usize> = Mutex::new(1);
     pub(crate) static ref BLOB_REGISTRY: Mutex<HashMap<usize, BlobData>> = Mutex::new(HashMap::new());
-    static ref NEXT_BLOB_ID: Mutex<usize> = Mutex::new(1);
 }
 
 #[derive(Clone)]
@@ -1025,7 +1037,7 @@ impl BlobData {
 }
 
 pub(crate) fn alloc_blob(data: BlobData) -> usize {
-    let mut id_guard = NEXT_BLOB_ID.lock().unwrap();
+    let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
     let id = *id_guard;
     *id_guard += 1;
     drop(id_guard);
@@ -1034,7 +1046,7 @@ pub(crate) fn alloc_blob(data: BlobData) -> usize {
 }
 
 fn alloc_headers(store: HeadersStore) -> usize {
-    let mut id_guard = NEXT_HEADERS_ID.lock().unwrap();
+    let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
     let id = *id_guard;
     *id_guard += 1;
     drop(id_guard);
@@ -1043,7 +1055,7 @@ fn alloc_headers(store: HeadersStore) -> usize {
 }
 
 fn alloc_response(status: u16, status_text: String, headers: HeadersStore, body: Vec<u8>) -> usize {
-    let mut id_guard = NEXT_RESPONSE_ID.lock().unwrap();
+    let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
     let id = *id_guard;
     *id_guard += 1;
     drop(id_guard);
@@ -1151,7 +1163,7 @@ pub extern "C" fn js_response_clone(handle: f64) -> f64 {
         })
     };
     if let Some(new_resp) = cloned {
-        let mut id_guard = NEXT_RESPONSE_ID.lock().unwrap();
+        let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
         let new_id = *id_guard;
         *id_guard += 1;
         drop(id_guard);
@@ -1395,272 +1407,6 @@ pub fn response_bytes_clone(resp_id: usize) -> Option<Vec<u8>> {
         .map(|r| r.body.clone())
 }
 
-// ----------------- Untyped property dispatch (refs #421) -----------------
-//
-// When user code accesses a property on a Web Fetch handle whose static type
-// isn't known to codegen (e.g. hono's bundled JS where TS annotations are
-// stripped: `(request) => request.url`), the codegen falls through to
-// `js_object_get_field_by_name` in perry-runtime. That dispatcher strips
-// the POINTER_TAG, sees a small id, and routes to `HANDLE_PROPERTY_DISPATCH`
-// (registered by perry-stdlib's `dispatch.rs`). The functions below let the
-// stdlib dispatcher resolve Web Fetch properties without exposing the
-// per-subsystem registries publicly.
-
-/// Try to read a property off a Request handle by registry id.
-/// Returns `Some(value)` only when both (a) the id is in REQUEST_REGISTRY AND
-/// (b) the property name is one this type exposes. Returns `None` otherwise so
-/// the dispatcher falls through to the next handler — Web Fetch registries use
-/// disjoint integer-id namespaces (Request id 1 ≠ Response id 1), so a
-/// "membership only" Some(undefined) catch-all would shadow legitimate
-/// property reads on a Response handle whose id collides with a Request id.
-#[doc(hidden)]
-pub fn dispatch_request_property(req_id: usize, prop: &str) -> Option<f64> {
-    // `request.headers` — lazily allocate a Headers registry entry backed by
-    // the request's stored header map and cache the id so repeat reads return
-    // the same handle (`req.headers === req.headers`). Mirrors the Response
-    // path. Without this arm `.headers` fell through to a numeric handle and
-    // `req.headers.get(...)` threw "(number).get is not a function" — the
-    // root cause of every Hono adapter crashing on the first request (#1649).
-    if prop == "headers" {
-        // Membership check first so a non-Request id falls through.
-        REQUEST_REGISTRY.lock().unwrap().get(&req_id)?;
-        return Some(request_headers_handle(req_id));
-    }
-    let guard = REQUEST_REGISTRY.lock().unwrap();
-    let req = guard.get(&req_id)?;
-    let bits = match prop {
-        "url" => {
-            let p = js_string_from_bytes(req.url.as_ptr(), req.url.len() as u32);
-            JSValue::string_ptr(p).bits()
-        }
-        "method" => {
-            let p = js_string_from_bytes(req.method.as_ptr(), req.method.len() as u32);
-            JSValue::string_ptr(p).bits()
-        }
-        "body" => match &req.body {
-            Some(b) => {
-                let p = js_string_from_bytes(b.as_ptr(), b.len() as u32);
-                JSValue::string_ptr(p).bits()
-            }
-            None => TAG_NULL,
-        },
-        // Other Request properties not yet wired — fall through so other
-        // dispatchers (or the final undefined fallback) can answer.
-        _ => return None,
-    };
-    Some(f64::from_bits(bits))
-}
-
-/// Try to read a property off a Response handle by registry id.
-/// Returns `None` if the id isn't a known Response or the property is unknown.
-#[doc(hidden)]
-pub fn dispatch_response_property(resp_id: usize, prop: &str) -> Option<f64> {
-    // `response.headers` — lazily allocate a Headers registry entry
-    // backed by the response's stored header map and cache the id on the
-    // FetchResponse so repeat reads return the same handle (preserves
-    // `res.headers === res.headers`). Hono's `#newResponse` mutates the
-    // returned Headers object via `.set(k, v)`, but our snapshot is a
-    // copy of the response's header HashMap — mutations land on the
-    // Headers handle's HeadersStore, not back on the FetchResponse.
-    // For the read-only case (the issue #486 acceptance) this is
-    // sufficient; spec-perfect "live header view" would need the
-    // FetchResponse's storage to be the same Vec as the Headers
-    // entries, which is a wider refactor.
-    if prop == "headers" {
-        let cached = {
-            let guard = FETCH_RESPONSES.lock().unwrap();
-            guard.get(&resp_id)?.cached_headers_id
-        };
-        let id = match cached {
-            Some(id) => id,
-            None => {
-                let store = {
-                    let guard = FETCH_RESPONSES.lock().unwrap();
-                    HeadersStore::from_hashmap(&guard.get(&resp_id)?.headers)
-                };
-                let new_id = alloc_headers(store);
-                if let Some(resp) = FETCH_RESPONSES.lock().unwrap().get_mut(&resp_id) {
-                    resp.cached_headers_id = Some(new_id);
-                }
-                new_id
-            }
-        };
-        return Some(handle_to_f64(id));
-    }
-    // `response.body` — `ReadableStream | null` per the Web Fetch spec.
-    // Returns a NaN-boxed (POINTER_TAG) single-chunk ReadableStream handle
-    // over the buffered body so `typeof res.body === 'object'` and
-    // `res.body.getReader()` route through the untyped stream dispatch
-    // (see dispatch_readable_stream_method). `null` when the response was
-    // constructed with no body. Cached so `.body` is stable across reads
-    // (the spec mandates a single stream; a fresh stream each call would
-    // silently unlock a held reader) (#1650).
-    if prop == "body" {
-        // Membership check first so a non-Response id falls through.
-        FETCH_RESPONSES.lock().unwrap().get(&resp_id)?;
-        return Some(response_body_stream(resp_id));
-    }
-    let guard = FETCH_RESPONSES.lock().unwrap();
-    let resp = guard.get(&resp_id)?;
-    let bits = match prop {
-        "status" => return Some(resp.status as f64),
-        "statusText" => {
-            let p = js_string_from_bytes(resp.status_text.as_ptr(), resp.status_text.len() as u32);
-            JSValue::string_ptr(p).bits()
-        }
-        "ok" => {
-            return Some(f64::from_bits(if resp.status >= 200 && resp.status < 300 {
-                TAG_TRUE
-            } else {
-                TAG_FALSE
-            }))
-        }
-        _ => return None,
-    };
-    Some(f64::from_bits(bits))
-}
-
-/// Try to read a property off a Headers handle by registry id.
-/// Returns `None` always today — Headers has no scalar properties exposed
-/// via property reads (`.get(k)` / `.has(k)` etc. are method calls that route
-/// through `HANDLE_METHOD_DISPATCH`).
-#[doc(hidden)]
-pub fn dispatch_headers_property(_headers_id: usize, _prop: &str) -> Option<f64> {
-    None
-}
-
-/// Try to dispatch a method call on a Response handle. Returns `Some(result)`
-/// only when the id is a known Response AND the method is supported. Returns
-/// `None` (fall through to the next dispatcher) otherwise. Required because
-/// Web Fetch handle id namespaces are disjoint from each other and from other
-/// stdlib registries — id collision (Request id 1 ≠ Response id 1) means
-/// claiming membership alone would shadow legitimate calls on other handles.
-#[doc(hidden)]
-pub fn dispatch_response_method(resp_id: usize, method: &str, _args: &[f64]) -> Option<f64> {
-    {
-        let guard = FETCH_RESPONSES.lock().unwrap();
-        guard.get(&resp_id)?;
-    }
-    let resp_f64 = handle_to_f64(resp_id);
-    unsafe {
-        match method {
-            "text" => {
-                let promise = js_fetch_response_text(resp_f64);
-                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
-            }
-            "json" => {
-                let promise = js_fetch_response_json(resp_f64);
-                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
-            }
-            "arrayBuffer" => {
-                let promise = js_response_array_buffer(resp_f64);
-                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
-            }
-            "blob" => {
-                let promise = js_response_blob(resp_f64);
-                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
-            }
-            "clone" => Some(js_response_clone(resp_f64)),
-            _ => None,
-        }
-    }
-}
-
-/// Try to dispatch a method call on a Blob handle. Returns `None` for unknown
-/// ids or methods.
-#[doc(hidden)]
-pub fn dispatch_blob_method(blob_id: usize, method: &str, args: &[f64]) -> Option<f64> {
-    {
-        let guard = BLOB_REGISTRY.lock().unwrap();
-        guard.get(&blob_id)?;
-    }
-    let blob_f64 = handle_to_f64(blob_id);
-    unsafe {
-        match method {
-            "text" => {
-                let promise = js_blob_text(blob_f64);
-                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
-            }
-            "arrayBuffer" => {
-                let promise = js_blob_array_buffer(blob_f64);
-                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
-            }
-            "bytes" => {
-                let promise = js_blob_bytes(blob_f64);
-                Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
-            }
-            "slice" => {
-                let start = args.first().copied().unwrap_or(f64::NAN);
-                let end = args.get(1).copied().unwrap_or(f64::NAN);
-                Some(js_blob_slice(blob_f64, start, end, std::ptr::null()))
-            }
-            _ => None,
-        }
-    }
-}
-
-/// Try to dispatch a method call on a Headers handle. Returns `None` for
-/// unknown ids or methods.
-#[doc(hidden)]
-pub fn dispatch_headers_method(headers_id: usize, method: &str, args: &[f64]) -> Option<f64> {
-    {
-        let guard = HEADERS_REGISTRY.lock().unwrap();
-        guard.get(&headers_id)?;
-    }
-    let h_f64 = handle_to_f64(headers_id);
-    // String args arrive as NaN-boxed STRING_TAG f64 values; extract the raw
-    // StringHeader pointer for the runtime helpers.
-    let str_arg = |i: usize| -> *const StringHeader {
-        if i < args.len() {
-            let v = args[i];
-            (v.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader
-        } else {
-            std::ptr::null()
-        }
-    };
-    unsafe {
-        match method {
-            "get" => Some(f64::from_bits(
-                JSValue::string_ptr(js_headers_get(h_f64, str_arg(0))).bits(),
-            )),
-            "set" => Some(js_headers_set(h_f64, str_arg(0), str_arg(1))),
-            "append" => Some(js_headers_append(h_f64, str_arg(0), str_arg(1))),
-            "has" => Some(js_headers_has(h_f64, str_arg(0))),
-            "delete" => Some(js_headers_delete(h_f64, str_arg(0))),
-            "forEach" => {
-                let cb = args.first().copied().unwrap_or(f64::NAN);
-                Some(js_headers_for_each(h_f64, cb))
-            }
-            // The iterator helpers each return a (sorted) JS array, which is
-            // itself iterable — `for (const [k,v] of req.headers.entries())`
-            // and `[...req.headers.keys()]` both work off the untyped path
-            // Hono's type-stripped JS takes (#1649).
-            "keys" => Some(js_headers_keys(h_f64)),
-            "values" => Some(js_headers_values(h_f64)),
-            "entries" => Some(js_headers_entries(h_f64)),
-            _ => None,
-        }
-    }
-}
-
-/// Try to read a property off a Blob handle by registry id.
-/// Returns `None` if the id isn't a known Blob or the property is unknown.
-#[doc(hidden)]
-pub fn dispatch_blob_property(blob_id: usize, prop: &str) -> Option<f64> {
-    let guard = BLOB_REGISTRY.lock().unwrap();
-    let blob = guard.get(&blob_id)?;
-    let bits = match prop {
-        "size" => return Some(blob.body.len() as f64),
-        "type" => {
-            let p =
-                js_string_from_bytes(blob.content_type.as_ptr(), blob.content_type.len() as u32);
-            JSValue::string_ptr(p).bits()
-        }
-        _ => return None,
-    };
-    Some(f64::from_bits(bits))
-}
-
 /// `blob.stream()` — returns a single-chunk ReadableStream handle (f64,
 /// numeric registry id) over the blob's byte payload. Closes the stream
 /// after the one chunk is delivered.
@@ -1786,7 +1532,7 @@ pub unsafe extern "C" fn js_request_new(
     } else {
         HeadersStore::default()
     };
-    let mut id_guard = NEXT_REQUEST_ID.lock().unwrap();
+    let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
     let id = *id_guard;
     *id_guard += 1;
     drop(id_guard);

--- a/test-files/test_issue_1698_request_body_method_value.ts
+++ b/test-files/test_issue_1698_request_body_method_value.ts
@@ -1,0 +1,52 @@
+// Issue #1698 — Request body methods (json/text/arrayBuffer) must be callable
+// as a VALUE and via a COMPUTED key, not only as a direct typed call.
+//
+// #1688 fixed the direct typed call `req.json()` (the codegen
+// `module == "Request"` arm). But `typeof req.json` reported "object",
+// `req[key]` reported "undefined", and `req[key]()` returned null — because
+// the value-read / computed-key forms lose the static `Request` type and land
+// in the runtime's generic dynamic dispatch, which had no Request body-method
+// arm. This blocks Hono's `c.req.json()` end-to-end (#1655): HonoRequest's
+// `#cachedBody` does `raw[key]()` (a computed-key call on the underlying
+// Request).
+//
+// Fix: runtime `dispatch_request_method` / `dispatch_request_property` arms
+// (in `js_handle_method_dispatch` / `js_handle_property_dispatch`), a unified
+// fetch-family handle id counter (so a Request id never collides with a
+// Response/Headers id), and a `typeof req.json` codegen fold.
+//
+// Each case uses a fresh `const r = new Request(...)` var-decl: that's what
+// sets `uses_fetch` so the fetch module links (an inline `new Request().m()`
+// does not — see #1691), and a fresh body avoids "body already read".
+
+// Use var-decls so the receiver type is tracked + uses_fetch is set.
+const a = new Request("http://x/y", { method: "POST", headers: { "content-type": "application/json" }, body: '{"x":1}' });
+console.log("typeof literal:", typeof a.json);
+
+const b = new Request("http://x/y", { method: "POST", headers: { "content-type": "application/json" }, body: '{"x":1}' });
+const kb = "json";
+console.log("typeof computed:", typeof b[kb]);
+
+const c = new Request("http://x/y", { method: "POST", headers: { "content-type": "application/json" }, body: '{"x":1}' });
+const kc = "json";
+console.log("typeof as-any computed:", typeof (c as any)[kc]);
+
+async function main() {
+    const d = new Request("http://x/y", { method: "POST", headers: { "content-type": "application/json" }, body: '{"x":2}' });
+    const kd = "json";
+    const dv = await (d as any)[kd]();
+    console.log("as-any computed call x:", dv.x);
+
+    const e = new Request("http://x/y", { method: "POST", headers: { "content-type": "application/json" }, body: '{"x":3}' });
+    const ev = await (e as any).json();
+    console.log("as-any direct call x:", ev.x);
+
+    const f = new Request("http://x/y", { method: "POST", headers: { "content-type": "application/json" }, body: '{"x":4}' });
+    const fv = await f.json();
+    console.log("typed direct call x:", fv.x);
+
+    const g = new Request("http://x/y", { method: "POST", body: "plain-text" });
+    const kg = "text";
+    console.log("computed text:", await (g as any)[kg]());
+}
+main();


### PR DESCRIPTION
## Summary

Fixes #1698. `Request`'s body methods (`json`/`text`/`arrayBuffer`) worked as a **direct typed call** (`req.json()`, #1688) but failed when accessed **as a value** or via a **computed key**:

```ts
const req = new Request('http://x/y', { method:'POST', headers:{'content-type':'application/json'}, body:'{"x":1}' });
typeof req.json            // 'object'    → now 'function'
typeof (req as any)[key]   // 'undefined' → now 'function'
await (req as any)[key]()  // null        → now { x: 1 }
```

The value-read / computed-key / `as any` forms lose the static `Request` type at codegen, so they land in the runtime's generic dynamic-dispatch tower (`js_native_call_method` → small-handle range → `js_handle_method_dispatch` / `js_handle_property_dispatch`), which had no Request body-method arm. This blocks Hono's `c.req.json()` end-to-end (#1655): `HonoRequest.#cachedBody` does `raw[key]()` — a computed-key call on the underlying Request.

## Approach (runtime, type-agnostic)

Per the issue discussion, this is the **unified handle-id + runtime probe** approach. Because the dispatch happens at runtime, it covers every form — typed `req[key]()`, `(req as any).json()`, and Hono's untyped `raw[key]()` — not just the statically-typed case.

- **`dispatch_request_method`** (text/json/arrayBuffer) wired into `js_handle_method_dispatch`, mirroring the existing `dispatch_response_method`.
- **`dispatch_request_property`** returns `js_class_method_bind` bound-method values for json/text/arrayBuffer, so `typeof req[key] === 'function'` and the value stays callable (the #1670 stream-property pattern).
- **Unified fetch-family handle id counter** (`NEXT_FETCH_HANDLE_ID`) across Request/Response/Headers/Blob. Previously each had its own counter starting at 1, so a Request id could equal a Response id and the registry-membership dispatch gate was ambiguous. One counter ⇒ an id belongs to exactly one registry ⇒ unambiguous dispatch (this also makes `new Response(body)[key]()` and Response computed-key / `typeof` work).
- **`typeof req.json` codegen fold** for the LITERAL value-read (it takes the typed Web-Fetch path that bypasses the property dispatch). Covers Request + Response.

## Verification

All match `node --experimental-strip-types` byte-for-byte:

- The issue repro (typeof literal, typeof computed, computed-key call).
- typed / computed / `as any` × value-read / call variants, plus `text`.
- **Hono `POST /api/echo` doing `await c.req.json()`** → `status=200`, `body={"body":{"x":1}}`.
- `test_gap_fetch_response.ts` (Response / Headers / Request / Blob / redirect) — **identical**, no regression.
- `perry-hir` + `perry-stdlib` unit tests pass; `cargo fmt --all -- --check` clean.

## Out of scope (separate, pre-existing)

By-default Hono compilation still hits a **separate** guard: `#503` refuses hono's internal `path[runtimeVar]()` dynamic dispatch (in `perry-hir/src/lockdown.rs` — untouched by this PR). With that guard bypassed, the Hono path above works end-to-end. The `path[...]` guard is tracked separately under the #1655 umbrella.

## Test

`test-files/test_issue_1698_request_body_method_value.ts`
