### PR TITLE
test(parity): stream — batch of 12 tier-12 tests (iter-121..123) (3 free pass, 9 #1532/#1539)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3115,5 +3115,59 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/destroyed-after-finish": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Writable destroyed false after 'finish' (autoDestroy default true). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/multiple-events-event-names": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: eventNames does not include all registered event names. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/end-cb-fires-after-flush": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: end(cb) — cb fires before write callbacks or before finish. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/events/event-names-empty-array": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: fresh stream eventNames not empty array. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/writable-end-on-source-end": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe(dst) — dst not ended after src ends. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/encoding-via-constructor": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: encoding option in ctor — readableEncoding wrong or data not string. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/new-listener-fires-before-add": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'newListener' fires after the listener is added (should be before). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/pipe-to-plain-writable": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe() to plain Writable — collected wrong / empty. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/destroy-without-error": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroy() no arg — destroyed flag wrong or error event fires. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/event-names-empty-array.ts
+++ b/test-parity/node-suite/stream/events/event-names-empty-array.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// Fresh stream — eventNames returns empty array.
+const r = new Readable({ read() {} });
+const names = r.eventNames();
+console.log("is array:", Array.isArray(names));
+console.log("length:", names.length);
+console.log("empty:", names.length === 0);

--- a/test-parity/node-suite/stream/events/multiple-events-event-names.ts
+++ b/test-parity/node-suite/stream/events/multiple-events-event-names.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Multiple events registered — eventNames returns all of them.
+const r = new Readable({ read() {} });
+r.on("data", () => {});
+r.on("end", () => {});
+r.on("error", () => {});
+r.on("close", () => {});
+const names = r.eventNames();
+console.log("count:", names.length);
+console.log("has data:", names.includes("data"));
+console.log("has end:", names.includes("end"));
+console.log("has error:", names.includes("error"));
+console.log("has close:", names.includes("close"));

--- a/test-parity/node-suite/stream/events/new-listener-fires-before-add.ts
+++ b/test-parity/node-suite/stream/events/new-listener-fires-before-add.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// 'newListener' fires BEFORE the listener is added to the list.
+const r = new Readable({ read() {} });
+r.on("newListener", (event) => {
+  if (event === "custom") {
+    console.log("count at newListener:", r.listenerCount("custom"));
+    // Should still be 0 (the listener hasn't been added yet)
+  }
+});
+r.on("custom", () => {});
+console.log("count after add:", r.listenerCount("custom"));

--- a/test-parity/node-suite/stream/pipe/pipe-to-plain-writable.ts
+++ b/test-parity/node-suite/stream/pipe/pipe-to-plain-writable.ts
@@ -1,0 +1,9 @@
+import { Readable, Writable } from "node:stream";
+// pipe to a Writable instance directly.
+const r = Readable.from(["a", "b"]);
+const collected: string[] = [];
+const w = new Writable({
+  write(c, _e, cb) { collected.push(String(c)); cb(); },
+});
+r.pipe(w);
+w.on("finish", () => console.log("collected:", collected.join(",")));

--- a/test-parity/node-suite/stream/pipe/writable-end-on-source-end.ts
+++ b/test-parity/node-suite/stream/pipe/writable-end-on-source-end.ts
@@ -1,0 +1,13 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe() — destination receives end() when source ends (autoEnd default).
+const r = Readable.from(["a"]);
+const dst = new PassThrough();
+let dstEnded = false;
+dst.on("end", () => (dstEnded = true));
+dst.on("data", () => {});
+r.pipe(dst);
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("dst ended on src end:", dstEnded);
+  });
+});

--- a/test-parity/node-suite/stream/readable/destroy-without-error.ts
+++ b/test-parity/node-suite/stream/readable/destroy-without-error.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// destroy() (no arg) — destroyed becomes true; no 'error' fired.
+const r = new Readable({ read() {} });
+let errFired = false;
+let closeFired = false;
+r.on("error", () => (errFired = true));
+r.on("close", () => (closeFired = true));
+r.destroy();
+setImmediate(() => {
+  console.log("destroyed:", r.destroyed);
+  console.log("error fired:", errFired);
+  console.log("close fired:", closeFired);
+});

--- a/test-parity/node-suite/stream/readable/destroyed-after-finish.ts
+++ b/test-parity/node-suite/stream/readable/destroyed-after-finish.ts
@@ -1,0 +1,9 @@
+import { Writable } from "node:stream";
+// After 'finish', destroyed should be true (autoDestroy default).
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+w.on("finish", () => {
+  setImmediate(() => {
+    console.log("destroyed after finish:", w.destroyed);
+  });
+});
+w.end("done");

--- a/test-parity/node-suite/stream/readable/encoding-via-constructor.ts
+++ b/test-parity/node-suite/stream/readable/encoding-via-constructor.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// encoding option in constructor sets readableEncoding.
+const r = new Readable({ encoding: "utf8", read() {} });
+console.log("encoding:", r.readableEncoding);
+r.push(Buffer.from("xyz"));
+r.push(null);
+r.on("data", (c) => {
+  console.log("data is string:", typeof c === "string");
+  console.log("value:", c);
+});

--- a/test-parity/node-suite/stream/web/identity-with-strategies.ts
+++ b/test-parity/node-suite/stream/web/identity-with-strategies.ts
@@ -1,0 +1,11 @@
+import { TransformStream, CountQueuingStrategy } from "node:stream/web";
+// new TransformStream(undefined, ws, rs) — Identity with explicit HWMs.
+const ws = new CountQueuingStrategy({ highWaterMark: 5 });
+const rs = new CountQueuingStrategy({ highWaterMark: 3 });
+const ts = new TransformStream(undefined, ws, rs);
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("x");
+await writer.close();
+const result = await reader.read();
+console.log("value:", result.value);

--- a/test-parity/node-suite/stream/web/pipe-to-failing-sink.ts
+++ b/test-parity/node-suite/stream/web/pipe-to-failing-sink.ts
@@ -1,0 +1,15 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// pipeTo() to a sink whose write() throws — Promise rejects.
+const rs = new ReadableStream({
+  start(c) { c.enqueue("x"); c.close(); },
+});
+const ws = new WritableStream({
+  write() { throw new Error("sink-fail"); },
+});
+let errMsg: string | null = null;
+try {
+  await rs.pipeTo(ws);
+} catch (e: any) {
+  errMsg = e && e.message;
+}
+console.log("rejected with:", errMsg);

--- a/test-parity/node-suite/stream/web/pull-called-per-read.ts
+++ b/test-parity/node-suite/stream/web/pull-called-per-read.ts
@@ -1,0 +1,16 @@
+import { ReadableStream } from "node:stream/web";
+// pull() is called each time the queue is empty + read requested.
+let pullCount = 0;
+const rs = new ReadableStream({
+  pull(c) {
+    pullCount++;
+    if (pullCount <= 3) c.enqueue(pullCount);
+    else c.close();
+  },
+});
+const reader = rs.getReader();
+while (true) {
+  const { done } = await reader.read();
+  if (done) break;
+}
+console.log("pull count:", pullCount);

--- a/test-parity/node-suite/stream/writable/end-cb-fires-after-flush.ts
+++ b/test-parity/node-suite/stream/writable/end-cb-fires-after-flush.ts
@@ -1,0 +1,17 @@
+import { Writable } from "node:stream";
+// end(cb) — cb fires after all pending writes flush + finish event.
+const order: string[] = [];
+const w = new Writable({
+  write(_c, _e, cb) {
+    setImmediate(() => {
+      order.push("write");
+      cb();
+    });
+  },
+});
+w.on("finish", () => order.push("finish"));
+w.write("a");
+w.end(() => {
+  order.push("end-cb");
+  console.log("order:", order.join(","));
+});


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-121..123)

**3 free passes + 9 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | identity-with-strategies ✅, pull-called-per-read ✅, pipe-to-failing-sink ✅ | #1545 |
| Readable shape | destroyed-after-finish, encoding-via-constructor, destroy-without-error | #1532 |
| Stream events | multiple-events-event-names, event-names-empty-array, new-listener-fires-before-add | #1532 |
| Pipe | writable-end-on-source-end, pipe-to-plain-writable | #1532 |
| Writable buffering | end-cb-fires-after-flush | #1539 |

Free passes:
- `web/identity-with-strategies` (3-arg TS ctor)
- `web/pull-called-per-read` (pull invoked per empty queue)
- `web/pipe-to-failing-sink` (sink throw rejects pipeTo)

All 9 failures tracked in `known_failures.json`.
