### PR TITLE
fix(lockdown): #503 guard must not fire on locals shadowing a stdlib namespace name (#1701)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1337,6 +1337,20 @@ pub(super) fn stdlib_namespace_receiver(
     };
     let name = ident.sym.as_ref();
 
+    // #1701: a LOCAL binding (function param / `let` / `const`) that merely
+    // shares a name with a stdlib namespace is NOT the namespace — it shadows
+    // it. hono's trie-router has `path` (a URL-path string param) and does
+    // `path[0] === "/"`; treating that local as the `node:path` namespace
+    // false-fired the #503 refusal and blocked the whole package from
+    // compiling. A real stdlib namespace is never a local: it's the global
+    // (`process`) or an import, which the alias / namespace-import branches
+    // below resolve. So skip the direct name-match when `name` is shadowed by
+    // a local. (If a package shadows `process` with its own local, that local
+    // is genuinely theirs and likewise shouldn't be refused.)
+    if ctx.lookup_local(name).is_some() {
+        return None;
+    }
+
     // Direct global / module specifier match.
     if let Some(canon) = STDLIB_NAMESPACE_NAMES.iter().find(|n| **n == name) {
         return Some(*canon);

--- a/test-files/test_issue_1701_local_shadows_stdlib_namespace.ts
+++ b/test-files/test_issue_1701_local_shadows_stdlib_namespace.ts
@@ -1,0 +1,34 @@
+// Issue #1701 — the #503 dynamic-stdlib-dispatch guard must NOT fire on a
+// LOCAL variable that merely shares a name with a stdlib namespace.
+//
+// hono's trie-router has a `path` parameter (a URL-path string) and does
+// `path[0] === "/"`. The #503 guard (which refuses `node:path`-namespace
+// dynamic dispatch like `path[runtimeVar]()`) matched the local `path` by
+// NAME, without checking it was actually the imported namespace, and refused
+// to compile the whole `hono` package. Fix: a local binding shadowing a
+// namespace name is the user's own variable, never the namespace — skip it.
+//
+// This exercises locals named after several stdlib namespaces, with both
+// computed index reads and a computed method call (the exact shapes the guard
+// targets, but on locals). All must compile and match Node.
+
+function firstSlash(path: string): number {
+    const i = 0;
+    return path[i] === "/" ? 1 : 0;
+}
+
+// Local `fs` shadowing the node:fs namespace name, computed method call.
+function pick(fs: Record<string, () => string>, key: string): string {
+    return fs[key]();
+}
+
+// Locals named `crypto`, `os`, `url` with computed index.
+function joinFirst(crypto: string[], os: number, url: string): string {
+    const k = os;
+    return crypto[k] + ":" + url[0];
+}
+
+console.log("firstSlash /abc:", firstSlash("/abc"));
+console.log("firstSlash abc:", firstSlash("abc"));
+console.log("pick:", pick({ go: () => "went" }, "go"));
+console.log("joinFirst:", joinFirst(["a", "b"], 1, "xyz"));


### PR DESCRIPTION
## Summary

Fixes #1701. The `#503` dynamic-stdlib-dispatch guard refused any computed member access on a bare ident whose **name** equals a stdlib namespace (`path`, `fs`, `crypto`, …) — without checking it was actually the imported namespace rather than a **local variable / parameter** that happens to share the name.

hono's trie-router has a `path` string parameter and does `path[0] === "/"`. The guard treated that local as the `node:path` namespace and refused the index as the `path[runtimeVar]()` obfuscation pattern, blocking the entire `hono` package from compiling:

```
Error: dynamic dispatch on stdlib namespace `path` is refused at compile time (in package `hono`) … (#503)
```

(Surfaced while verifying #1698 / unblocking the #1655 Hono `c.req.json()` path.)

## Fix

In `stdlib_namespace_receiver` (`crates/perry-hir/src/lower/expr_member.rs`), skip the direct name-match when the ident is bound to a local (`ctx.lookup_local(name).is_some()`). A local that shadows a namespace name is the user's own variable, never the namespace — and a *real* stdlib namespace is the global `process` or an import, both of which the alias / namespace-import branches resolve independently. So the refusal path for genuine namespace receivers is unchanged.

## Verification

- **Guard intact (negative):** a real `(fs as any)[k]()` is **still refused** with the #503 error.
- **False positive fixed (positive):** a local `path[i]` / `fs[key]()` / `crypto[k]` compiles and matches `node --experimental-strip-types`.
- **End goal:** with this + #1698, a Hono `POST /api/echo` doing `await c.req.json()` compiles and runs **by default** (no `PERRY_ALLOW_DYNAMIC_STDLIB` bypass) → `status=200`, `body={"body":{"x":1}}`.
- `cargo fmt --all -- --check` clean; `perry-hir` unit tests pass.

## Test

`test-files/test_issue_1701_local_shadows_stdlib_namespace.ts` — locals named after stdlib namespaces (`path`/`fs`/`crypto`/`os`/`url`) with computed index + computed method call, all matching Node.

Related: #1698 (Request body methods), #1655 (Hono tracker), #503 (the guard).
