### PR TITLE
test(parity): stream — batch of 12 tier-12/13 tests (iter-124..126) (3 free pass, 9 #1531/#1532/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3115,5 +3115,59 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/byob-reader-method-shape": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: BYOB reader missing methods (read/releaseLock) or .closed prop. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/instance-method-bind-this": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: detached instance method called without `this` — wrong behavior (Perry should throw). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/dst-write-returns-false-pauses-src": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe() src pause/resume events on backpressure — wrong order/missing. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/remove-listener-after-removal": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'removeListener' meta-event fires before removal (should be after). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/three-stages-order": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose(src,t1,t2) — output transformation order wrong. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/duplex-acts-as-writable": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Duplex write side — received array empty / wrong order. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/remove-non-registered-listener": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: removeListener of non-registered fn — returns wrong value or eventNames non-empty. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipeline/async-source-throws-mid": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline(asyncGen src throws mid, dst, cb) — error not received in cb. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/compose-non-stream-throws": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose(string) — does not throw TypeError. Flips to PASS when #1531 lands."
   }
 }

--- a/test-parity/node-suite/stream/compose/three-stages-order.ts
+++ b/test-parity/node-suite/stream/compose/three-stages-order.ts
@@ -1,0 +1,8 @@
+import { compose, Readable, Transform } from "node:stream";
+// compose(src, t1, t2) — order of transforms preserved.
+const src = Readable.from(["a"]);
+const upper = new Transform({ transform(c, _e, cb) { cb(null, String(c).toUpperCase()); } });
+const wrap = new Transform({ transform(c, _e, cb) { cb(null, "<" + String(c) + ">"); } });
+const composed: any = compose(src, upper, wrap);
+composed.on("data", (c: any) => console.log("got:", String(c)));
+composed.on("end", () => console.log("done"));

--- a/test-parity/node-suite/stream/events/error-with-listener-no-throw.ts
+++ b/test-parity/node-suite/stream/events/error-with-listener-no-throw.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// emit('error', err) with a listener — does NOT throw synchronously.
+const r = new Readable({ read() {} });
+r.on("error", () => {});
+let thrown: any = null;
+try {
+  r.emit("error", new Error("with-listener"));
+} catch (e: any) {
+  thrown = e && e.message;
+}
+console.log("threw:", thrown !== null);

--- a/test-parity/node-suite/stream/events/remove-listener-after-removal.ts
+++ b/test-parity/node-suite/stream/events/remove-listener-after-removal.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// 'removeListener' meta-event fires AFTER the listener is removed.
+const r = new Readable({ read() {} });
+const target = () => {};
+r.on("custom", target);
+let countAtMeta: number = -1;
+r.on("removeListener", (event) => {
+  if (event === "custom") countAtMeta = r.listenerCount("custom");
+});
+r.removeListener("custom", target);
+console.log("count at meta:", countAtMeta);
+console.log("count after:", r.listenerCount("custom"));

--- a/test-parity/node-suite/stream/events/remove-non-registered-listener.ts
+++ b/test-parity/node-suite/stream/events/remove-non-registered-listener.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// removeListener of a function never registered — safely no-op.
+const r = new Readable({ read() {} });
+const fn = () => {};
+const result = r.removeListener("never-registered", fn);
+console.log("returns self:", result === r);
+console.log("eventNames empty:", r.eventNames().length === 0);

--- a/test-parity/node-suite/stream/pipe/dst-write-returns-false-pauses-src.ts
+++ b/test-parity/node-suite/stream/pipe/dst-write-returns-false-pauses-src.ts
@@ -1,0 +1,15 @@
+import { Readable, Writable } from "node:stream";
+// When dst.write() returns false, src auto-pauses; resumes after 'drain'.
+let srcEvents: string[] = [];
+const src = new Readable({ highWaterMark: 1, read() {} });
+src.on("pause", () => srcEvents.push("pause"));
+src.on("resume", () => srcEvents.push("resume"));
+const w = new Writable({
+  highWaterMark: 1,
+  write(_c, _e, cb) { setImmediate(cb); },
+});
+src.pipe(w);
+src.push("aa");
+src.push("bb");
+src.push(null);
+w.on("finish", () => console.log("src events:", srcEvents.join(",")));

--- a/test-parity/node-suite/stream/pipeline/async-source-throws-mid.ts
+++ b/test-parity/node-suite/stream/pipeline/async-source-throws-mid.ts
@@ -1,0 +1,13 @@
+import { PassThrough, pipeline } from "node:stream";
+// pipeline(asyncGenSrc, dst, cb) — asyncGen throws mid → cb receives error.
+async function* gen() {
+  yield "a";
+  throw new Error("src-fail");
+}
+const dst = new PassThrough();
+dst.on("data", () => {});
+let errMsg: string | null = null;
+pipeline(gen(), dst, (err: any) => {
+  errMsg = err && err.message;
+  console.log("err:", errMsg);
+});

--- a/test-parity/node-suite/stream/readable/compose-non-stream-throws.ts
+++ b/test-parity/node-suite/stream/readable/compose-non-stream-throws.ts
@@ -1,0 +1,10 @@
+import { compose } from "node:stream";
+// compose(non-stream) — should throw TypeError.
+let caught: string | null = null;
+try {
+  (compose as any)("just a string");
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/readable/duplex-acts-as-writable.ts
+++ b/test-parity/node-suite/stream/readable/duplex-acts-as-writable.ts
@@ -1,0 +1,11 @@
+import { Duplex } from "node:stream";
+// A Duplex stream has both read and write sides.
+const received: string[] = [];
+const d = new Duplex({
+  read() { this.push(null); }, // empty readable
+  write(c, _e, cb) { received.push(String(c)); cb(); },
+});
+d.on("data", () => {});
+d.write("x");
+d.end("y");
+d.on("finish", () => console.log("received:", received.join(",")));

--- a/test-parity/node-suite/stream/readable/instance-method-bind-this.ts
+++ b/test-parity/node-suite/stream/readable/instance-method-bind-this.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Instance method extracted and called — `this` no longer set; should throw.
+const r = Readable.from(["a"]);
+const detachedPush = r.push;
+let caught: string | null = null;
+try {
+  detachedPush("x");
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("detached push threw:", caught !== null);

--- a/test-parity/node-suite/stream/web/byob-reader-method-shape.ts
+++ b/test-parity/node-suite/stream/web/byob-reader-method-shape.ts
@@ -1,0 +1,7 @@
+import { ReadableStream } from "node:stream/web";
+// BYOB reader should have read(view) and releaseLock methods.
+const rs = new ReadableStream({ type: "bytes" } as any);
+const reader = (rs as any).getReader({ mode: "byob" });
+console.log("has read:", typeof reader.read);
+console.log("has releaseLock:", typeof reader.releaseLock);
+console.log("has closed:", "closed" in reader);

--- a/test-parity/node-suite/stream/web/release-lock-after-close.ts
+++ b/test-parity/node-suite/stream/web/release-lock-after-close.ts
@@ -1,0 +1,8 @@
+import { ReadableStream } from "node:stream/web";
+// releaseLock after the stream closes — should still work.
+const rs = new ReadableStream({ start(c) { c.close(); } });
+const reader = rs.getReader();
+const { done } = await reader.read();
+console.log("done:", done);
+reader.releaseLock();
+console.log("locked after release:", rs.locked);

--- a/test-parity/node-suite/stream/web/transform-backpressure-write-blocks.ts
+++ b/test-parity/node-suite/stream/web/transform-backpressure-write-blocks.ts
@@ -1,0 +1,10 @@
+import { TransformStream } from "node:stream/web";
+// Without reading from the readable, the writable should backpressure.
+const ts = new TransformStream({ transform(c, ctrl) { ctrl.enqueue(c); } });
+const writer = ts.writable.getWriter();
+// Write more than buffer can hold without reading
+await writer.write("a");
+await writer.write("b");
+// desiredSize should be ≤ 0 (backpressured)
+console.log("desiredSize:", writer.desiredSize);
+console.log("backpressure active:", (writer.desiredSize ?? 0) <= 0);


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-124..126)

**3 free passes + 9 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | byob-reader-method-shape, release-lock-after-close ✅, transform-backpressure-write-blocks ✅ | #1545 |
| Readable shape | instance-method-bind-this, duplex-acts-as-writable, compose-non-stream-throws | #1531/#1532 |
| Stream events | error-with-listener-no-throw ✅, remove-listener-after-removal, remove-non-registered-listener | #1532 |
| Pipe / pipeline | dst-write-returns-false-pauses-src, async-source-throws-mid | #1532 |
| Compose | three-stages-order | #1531 |

Free passes:
- `events/error-with-listener-no-throw` (emit('error') w/ listener doesn't throw)
- `web/release-lock-after-close` (releaseLock on closed stream works)
- `web/transform-backpressure-write-blocks` (backpressure desiredSize ≤ 0)

All 9 failures tracked in `known_failures.json`.
