### PR TITLE
test(parity): stream — batch of 12 tier-13 tests (iter-127..129) (5 free pass, 7 #1531/#1532)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3109,5 +3109,47 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/static-from-with-options": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(iter, opts) — objectMode/hwm 2nd-arg not applied. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/multiple-pipes-from-same-source": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe to two dsts — each dst receives wrong chunks. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/two-stage-error-stops": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose 2-stage err — composite 'error' event not fired. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/from-buffer-emits-single": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Buffer) — not single Buffer chunk (iterates byte-by-byte). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/listener-cleanup-after-once-fires": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: once() — rawListeners count after fire not zero. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/push-string-with-encoding-set": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: setEncoding + push(string) — data not delivered as string. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/with-passthrough-mid": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose(src, t1, PassThrough, t2) — chain produces wrong output. Flips to PASS when #1531 lands."
   }
 }

--- a/test-parity/node-suite/stream/compose/two-stage-error-stops.ts
+++ b/test-parity/node-suite/stream/compose/two-stage-error-stops.ts
@@ -1,0 +1,12 @@
+import { compose, Readable, Transform } from "node:stream";
+// compose(src, t1, t2) where t2 errors — composite emits error.
+const src = Readable.from(["a", "b"]);
+const t1 = new Transform({ transform(c, _e, cb) { cb(null, c); } });
+const t2 = new Transform({
+  transform(_c, _e, cb) { cb(new Error("t2-fail")); },
+});
+const composed: any = compose(src, t1, t2);
+let errMsg: string | null = null;
+composed.on("error", (e: any) => (errMsg = e && e.message));
+composed.on("data", () => {});
+composed.on("close", () => console.log("err:", errMsg));

--- a/test-parity/node-suite/stream/compose/with-passthrough-mid.ts
+++ b/test-parity/node-suite/stream/compose/with-passthrough-mid.ts
@@ -1,0 +1,9 @@
+import { compose, Readable, Transform, PassThrough } from "node:stream";
+// compose(src, t1, PassThrough, t2) — PassThrough in the middle.
+const src = Readable.from(["a"]);
+const upper = new Transform({ transform(c, _e, cb) { cb(null, String(c).toUpperCase()); } });
+const pt = new PassThrough();
+const wrap = new Transform({ transform(c, _e, cb) { cb(null, "<" + String(c) + ">"); } });
+const composed: any = compose(src, upper, pt, wrap);
+composed.on("data", (c: any) => console.log("got:", String(c)));
+composed.on("end", () => console.log("done"));

--- a/test-parity/node-suite/stream/events/captureRejection-symbol-fn.ts
+++ b/test-parity/node-suite/stream/events/captureRejection-symbol-fn.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// Stream constructor with captureRejections — async handler errors caught.
+const r = new Readable({ read() {}, captureRejections: true } as any);
+let caught: any = null;
+r.on("error", (e) => (caught = e && (e as Error).message));
+r.on("data", async () => {
+  throw new Error("rejection-in-data");
+});
+r.push("x");
+r.push(null);
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("captured:", caught);
+  });
+});

--- a/test-parity/node-suite/stream/events/listener-cleanup-after-once-fires.ts
+++ b/test-parity/node-suite/stream/events/listener-cleanup-after-once-fires.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// once() — listener removed cleanly; rawListeners is empty after fire.
+const r = new Readable({ read() {} });
+r.once("custom", () => {});
+const beforeFire = r.rawListeners("custom").length;
+r.emit("custom");
+const afterFire = r.rawListeners("custom").length;
+console.log("before:", beforeFire);
+console.log("after:", afterFire);
+console.log("cleaned:", afterFire === 0);

--- a/test-parity/node-suite/stream/events/symbol-for-rejection.ts
+++ b/test-parity/node-suite/stream/events/symbol-for-rejection.ts
@@ -1,0 +1,5 @@
+import { captureRejectionSymbol } from "node:events";
+// Symbol.for("nodejs.rejection") is captureRejectionSymbol.
+const builtIn = Symbol.for("nodejs.rejection");
+console.log("symbol matches:", builtIn === captureRejectionSymbol);
+console.log("is symbol:", typeof captureRejectionSymbol === "symbol");

--- a/test-parity/node-suite/stream/pipe/multiple-pipes-from-same-source.ts
+++ b/test-parity/node-suite/stream/pipe/multiple-pipes-from-same-source.ts
@@ -1,0 +1,20 @@
+import { Readable, PassThrough } from "node:stream";
+// Two pipes from same source — each dst sees all data.
+const r = Readable.from(["x", "y"]);
+const a = new PassThrough();
+const b = new PassThrough();
+let aGot: string[] = [];
+let bGot: string[] = [];
+a.on("data", (c) => aGot.push(String(c)));
+b.on("data", (c) => bGot.push(String(c)));
+r.pipe(a);
+r.pipe(b);
+let endCount = 0;
+const checkDone = () => {
+  if (++endCount === 2) {
+    console.log("a:", aGot.join(","));
+    console.log("b:", bGot.join(","));
+  }
+};
+a.on("end", checkDone);
+b.on("end", checkDone);

--- a/test-parity/node-suite/stream/readable/from-buffer-emits-single.ts
+++ b/test-parity/node-suite/stream/readable/from-buffer-emits-single.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Readable.from(Buffer) — Node short-circuits and emits the whole buffer
+// as a single chunk.
+const r = Readable.from(Buffer.from("abc"));
+const chunks: any[] = [];
+r.on("data", (c) => chunks.push(c));
+r.on("end", () => {
+  console.log("count:", chunks.length);
+  console.log("first is buffer:", Buffer.isBuffer(chunks[0]));
+});

--- a/test-parity/node-suite/stream/readable/push-string-with-encoding-set.ts
+++ b/test-parity/node-suite/stream/readable/push-string-with-encoding-set.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// setEncoding then push(string) — string is delivered as string, not Buffer.
+const r = new Readable({ read() {} });
+r.setEncoding("utf8");
+r.push("hello");
+r.push(null);
+r.on("data", (c) => {
+  console.log("is string:", typeof c === "string");
+  console.log("value:", c);
+});

--- a/test-parity/node-suite/stream/readable/static-from-with-options.ts
+++ b/test-parity/node-suite/stream/readable/static-from-with-options.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Readable.from(iter, {objectMode: true}) — explicit objectMode.
+const r = Readable.from(["a"], { objectMode: true });
+console.log("objectMode:", r.readableObjectMode);
+console.log("hwm:", r.readableHighWaterMark);
+const out: any[] = [];
+r.on("data", (c) => out.push(c));
+r.on("end", () => console.log("count:", out.length));

--- a/test-parity/node-suite/stream/web/pipe-through-then-cancel.ts
+++ b/test-parity/node-suite/stream/web/pipe-through-then-cancel.ts
@@ -1,0 +1,16 @@
+import { ReadableStream, TransformStream } from "node:stream/web";
+// pipeThrough → then cancel the output. Source upstream should be cancelled too.
+const rs = new ReadableStream({
+  pull(c) { setTimeout(() => c.enqueue("x"), 30); },
+});
+const ts = new TransformStream();
+const result = rs.pipeThrough(ts);
+let cancelOk = false;
+try {
+  await result.cancel("downstream");
+  cancelOk = true;
+} catch {
+  cancelOk = false;
+}
+console.log("cancel ok:", cancelOk);
+console.log("result locked:", result.locked);

--- a/test-parity/node-suite/stream/web/readable-cancel-multi.ts
+++ b/test-parity/node-suite/stream/web/readable-cancel-multi.ts
@@ -1,0 +1,7 @@
+import { ReadableStream } from "node:stream/web";
+// Multiple cancel() calls — second is a no-op (resolves).
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); } });
+await rs.cancel("first");
+const second = await rs.cancel("second");
+console.log("second resolved:", second);
+console.log("is undefined:", second === undefined);

--- a/test-parity/node-suite/stream/web/tee-drain-only-one-branch.ts
+++ b/test-parity/node-suite/stream/web/tee-drain-only-one-branch.ts
@@ -1,0 +1,23 @@
+import { ReadableStream } from "node:stream/web";
+// tee() then drain only one branch — the other accumulates in queue (HWM allows).
+const rs = new ReadableStream({
+  start(c) {
+    c.enqueue("a");
+    c.enqueue("b");
+    c.close();
+  },
+});
+const [a, b] = rs.tee();
+// Drain a only
+const reader = a.getReader();
+const out: string[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(String(value));
+}
+console.log("a:", out.join(","));
+// b is still readable
+const bReader = b.getReader();
+const first = await bReader.read();
+console.log("b first:", first.value);


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-127..129)

**5 free passes + 7 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | readable-cancel-multi ✅, pipe-through-then-cancel ✅, tee-drain-only-one-branch ✅ | #1545 |
| Events | captureRejection-symbol-fn ✅, symbol-for-rejection ✅, listener-cleanup-after-once-fires | #1532 |
| Readable shape | static-from-with-options, from-buffer-emits-single, push-string-with-encoding-set | #1532 |
| Pipe | multiple-pipes-from-same-source | #1532 |
| Compose | two-stage-error-stops, with-passthrough-mid | #1531 |

Free passes — Perry already matches Node for 5 behaviors this batch (highest free-pass density yet).

All 7 failures tracked in `known_failures.json`.
