### PR TITLE
Add #1090 exact-head GC evidence packet hardening

### DIFF
--- a/scripts/gc_1090_evidence_packet.sh
+++ b/scripts/gc_1090_evidence_packet.sh
@@ -254,11 +254,12 @@ run_logged() {
 run_for_label() {
   local label="$1"
   local worktree="$2"
+  local perry_bin="$worktree/target/release/perry"
   local label_out="$OUT_ABS/$label"
   mkdir -p "$label_out/logs" "$label_out/benchmarks"
 
   run_logged "$label" "build" "$worktree" "$label_out/logs/build.log" \
-    cargo build --release -p perry
+    env "CARGO_TARGET_DIR=$worktree/target" cargo build --release -p perry
 
   if [[ "$(command_status "$label" build)" == "fail" ]]; then
     record_command "$label" "memory_stability" "skipped" 0 "" "build failed"
@@ -267,12 +268,28 @@ run_for_label() {
   fi
 
   run_logged "$label" "memory_stability" "$worktree" "$label_out/logs/memory-stability.command.log" \
-    env "PERRY_GC_EVIDENCE_DIR=$label_out/memory" scripts/run_memory_stability_tests.sh
+    env "CARGO_TARGET_DIR=$worktree/target" "PERRY_BIN=$perry_bin" "PERRY_GC_EVIDENCE_DIR=$label_out/memory" scripts/run_memory_stability_tests.sh
 
   run_logged "$label" "benchmarks" "$worktree" "$label_out/logs/benchmarks-full-runs${RUNS}.log" \
-    benchmarks/compare.sh --full --runs "$RUNS" --json-out "$label_out/benchmarks/full.json"
+    env "PERRY_BIN=$perry_bin" benchmarks/compare.sh --full --runs "$RUNS" --json-out "$label_out/benchmarks/full.json"
 
   run_perf_comprehensive "$label" "$worktree" "$label_out"
+}
+
+clean_label_target() {
+  local label="$1"
+  local worktree="$2"
+  if [[ "$KEEP_WORKTREES" -ne 0 || ! -d "$worktree/target" ]]; then
+    return
+  fi
+  local log="$OUT_ABS/$label/logs/target-cleanup.log"
+  mkdir -p "$(dirname "$log")"
+  {
+    du -sh "$worktree/target" 2>/dev/null || true
+    rm -rf "$worktree/target"
+  } >"$log" 2>&1 || true
+  echo "=== $label: target_cleanup ==="
+  echo "  pass (log=$log)"
 }
 
 command_status() {
@@ -303,6 +320,7 @@ run_perf_comprehensive() {
   local label="$1"
   local worktree="$2"
   local label_out="$3"
+  local perry_bin="$worktree/target/release/perry"
   local log="$label_out/logs/perf-comprehensive.log"
 
   if [[ "$SKIP_PERF_COMPREHENSIVE" -eq 1 ]]; then
@@ -316,7 +334,8 @@ run_perf_comprehensive() {
     return
   fi
 
-  run_logged "$label" "perf_comprehensive" "$worktree" "$log" "$cmd"
+  run_logged "$label" "perf_comprehensive" "$worktree" "$log" \
+    env "CARGO_TARGET_DIR=$worktree/target" "PERRY_BIN=$perry_bin" "$cmd"
 }
 
 run_perf_frontier() {
@@ -356,8 +375,459 @@ run_perf_frontier() {
   echo "  $status (exit=$code, log=$log)"
 }
 
+write_old_page_policy_workloads() {
+  local out_dir="$1"
+  mkdir -p "$out_dir"
+
+  cat >"$out_dir/bench_json_roundtrip_retained.ts" <<'EOF'
+declare function gc(): void;
+declare const process: any;
+
+function forceGc(): void {
+  gc();
+  gc();
+  gc();
+}
+
+const items: any[] = [];
+for (let i = 0; i < 10000; i++) {
+  items.push({
+    id: i,
+    name: "item_" + i,
+    value: i * 3.14159,
+    tags: ["tag_" + (i % 10), "tag_" + (i % 5)],
+    nested: { x: i, y: i * 2 }
+  });
+}
+const blob = JSON.stringify(items);
+items.length = 0;
+
+for (let i = 0; i < 3; i++) {
+  const parsed = JSON.parse(blob);
+  JSON.stringify(parsed);
+}
+
+const ITERATIONS = 50;
+const start = Date.now();
+let checksum = 0;
+for (let iter = 0; iter < ITERATIONS; iter++) {
+  const parsed = JSON.parse(blob);
+  checksum += parsed.length;
+  const reStringified = JSON.stringify(parsed);
+  checksum += reStringified.length;
+}
+
+forceGc();
+const retainedRss = process.memoryUsage().rss;
+const elapsed = Date.now() - start;
+console.log("json_roundtrip:" + elapsed);
+console.log("checksum:" + checksum);
+console.log("retained_rss_bytes:" + retainedRss);
+EOF
+
+  cat >"$out_dir/old_gen_churn_retained.ts" <<'EOF'
+declare function gc(): void;
+declare const process: any;
+
+function forceGc(): void {
+  gc();
+  gc();
+}
+
+function makeRecord(i: number): { id: number; name: string; tags: string[] } {
+  return {
+    id: i,
+    name: "record_" + i,
+    tags: ["tag_a_" + i, "tag_b_" + i, "tag_c_" + i, "tag_d_" + i],
+  };
+}
+
+const survivors: any[] = [];
+let checksum = 0;
+
+for (let cycle = 0; cycle < 14; cycle++) {
+  for (let i = 0; i < 24000; i++) {
+    const id = cycle * 24000 + i;
+    const record = makeRecord(id);
+    checksum += record.id + record.tags.length + record.name.length;
+    if (i % 3000 === 0) {
+      survivors[(cycle + i / 3000) % 32] = record;
+    }
+  }
+
+  forceGc();
+  checksum += survivors[cycle % 32].id;
+  console.log("rss_sample_bytes:" + process.memoryUsage().rss);
+}
+
+forceGc();
+console.log("old_gen_churn_retained:" + checksum);
+EOF
+}
+
+run_policy_binary() {
+  local stdout="$1"
+  local stderr="$2"
+  local bin="$3"
+  shift 3
+  mkdir -p "$(dirname "$stdout")" "$(dirname "$stderr")"
+  set +e
+  if [[ "$(uname)" == "Darwin" ]]; then
+    env "$@" /usr/bin/time -l "$bin" >"$stdout" 2>"$stderr"
+  else
+    env "$@" /usr/bin/time -v "$bin" >"$stdout" 2>"$stderr"
+  fi
+  local code=$?
+  set -e
+  return "$code"
+}
+
+run_old_page_policy_evidence() {
+  local policy_root="$OUT_ABS/old-page-policy"
+  local workloads_dir="$policy_root/workloads"
+  local log="$OUT_ABS/logs/old-page-policy.log"
+  local json_out="$OUT_ABS/old-page-policy.json"
+  local code=0
+  mkdir -p "$policy_root" "$(dirname "$log")"
+  : >"$log"
+
+  write_old_page_policy_workloads "$workloads_dir"
+
+  local label worktree perry_bin label_out bin compile_log stdout stderr compile_code run_code
+  for label in base head; do
+    if [[ "$label" == "base" ]]; then
+      worktree="$BASE_WT"
+    else
+      worktree="$HEAD_WT"
+    fi
+    perry_bin="$worktree/target/release/perry"
+    label_out="$policy_root/$label/bench_json_roundtrip_retained"
+    bin="$label_out/bench_json_roundtrip_retained"
+    compile_log="$label_out/compile.log"
+    stdout="$label_out/stdout.log"
+    stderr="$label_out/stderr-trace.log"
+    mkdir -p "$label_out"
+
+    echo "=== $label: old-page bench_json_roundtrip_retained compile ===" >>"$log"
+    set +e
+    (
+      cd "$worktree"
+      "$perry_bin" compile --no-cache "$workloads_dir/bench_json_roundtrip_retained.ts" -o "$bin"
+    ) >"$compile_log" 2>&1
+    compile_code=$?
+    set -e
+    echo "$compile_code" >"$label_out/compile.exit"
+    cat "$compile_log" >>"$log" || true
+    if [[ "$compile_code" -ne 0 ]]; then
+      code=1
+      continue
+    fi
+
+    echo "=== $label: old-page bench_json_roundtrip_retained run ===" >>"$log"
+    if run_policy_binary "$stdout" "$stderr" "$bin" PERRY_GC_TRACE=1; then
+      run_code=0
+    else
+      run_code=$?
+      code=1
+    fi
+    echo "$run_code" >"$label_out/run.exit"
+    cat "$stdout" >>"$log" || true
+    cat "$stderr" >>"$log" || true
+  done
+
+  local churn_out="$policy_root/head/old_gen_churn_retained"
+  mkdir -p "$churn_out"
+  set +e
+  (
+    cd "$HEAD_WT"
+    "$HEAD_WT/target/release/perry" compile --no-cache "$workloads_dir/old_gen_churn_retained.ts" -o "$churn_out/old_gen_churn_retained"
+  ) >"$churn_out/compile.log" 2>&1
+  compile_code=$?
+  set -e
+  echo "$compile_code" >"$churn_out/compile.exit"
+  cat "$churn_out/compile.log" >>"$log" || true
+  if [[ "$compile_code" -ne 0 ]]; then
+    code=1
+  else
+    if run_policy_binary \
+      "$churn_out/stdout.log" \
+      "$churn_out/stderr-trace.log" \
+      "$churn_out/old_gen_churn_retained" \
+      PERRY_GC_TRACE=1 PERRY_GEN_GC=1; then
+      run_code=0
+    else
+      run_code=$?
+      code=1
+    fi
+    echo "$run_code" >"$churn_out/run.exit"
+    cat "$churn_out/stdout.log" >>"$log" || true
+    cat "$churn_out/stderr-trace.log" >>"$log" || true
+  fi
+
+  python3 - "$OUT_ABS" "$json_out" <<'PY'
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+root = Path(sys.argv[1])
+out = Path(sys.argv[2])
+policy_root = root / "old-page-policy"
+
+
+def read_json(path, default):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return default
+
+
+def read_exit(path):
+    try:
+        return int(path.read_text(encoding="utf-8").strip())
+    except Exception:
+        return None
+
+
+def parse_stdout(path):
+    result = {
+        "checksum": None,
+        "retained_rss_bytes": None,
+        "retained_rss_kb": None,
+        "samples_rss_kb": [],
+        "stdout_path": str(path),
+    }
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except Exception:
+        return result
+    for line in lines:
+        if line.startswith("checksum:"):
+            try:
+                result["checksum"] = int(line.split(":", 1)[1])
+            except ValueError:
+                pass
+        elif line.startswith("retained_rss_bytes:"):
+            try:
+                value = int(line.split(":", 1)[1])
+            except ValueError:
+                continue
+            result["retained_rss_bytes"] = value
+            result["retained_rss_kb"] = (value + 1023) // 1024
+        elif line.startswith("rss_sample_bytes:"):
+            try:
+                value = int(line.split(":", 1)[1])
+            except ValueError:
+                continue
+            result["samples_rss_kb"].append((value + 1023) // 1024)
+        elif line.startswith("old_gen_churn_retained:"):
+            try:
+                result["checksum"] = int(line.split(":", 1)[1])
+            except ValueError:
+                pass
+    return result
+
+
+def parse_time_bytes_or_kb(value):
+    if value > 10_000_000:
+        return value // 1024
+    return value
+
+
+def parse_peak_rss_kb(path):
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return None
+    match = re.search(r"(\d+)\s+maximum resident set size", text)
+    if match:
+        return parse_time_bytes_or_kb(int(match.group(1)))
+    match = re.search(r"Maximum resident set size \(kbytes\):\s+(\d+)", text)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def parse_peak_footprint_kb(path):
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return None
+    match = re.search(r"(\d+)\s+peak memory footprint", text)
+    if match:
+        return parse_time_bytes_or_kb(int(match.group(1)))
+    return None
+
+
+def trace_totals(path):
+    totals = {
+        "candidate_pages": 0,
+        "selected_pages": 0,
+        "selected_live_bytes": 0,
+        "reclaimable_bytes": 0,
+        "old_page_scanned_objects": 0,
+        "old_page_scanned_bytes": 0,
+        "old_page_moved_objects": 0,
+        "old_page_moved_bytes": 0,
+        "released_original_objects": 0,
+        "released_original_bytes": 0,
+        "released_original_reusable_bytes": 0,
+        "released_original_returned_bytes": 0,
+        "reusable_bytes": 0,
+        "returned_bytes": 0,
+    }
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except Exception:
+        return totals
+    for line in lines:
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict) or event.get("event") != "gc_cycle":
+            continue
+        policy = event.get("evacuation_policy", {})
+        evacuation = event.get("evacuation", {})
+        old_pages = event.get("old_pages", {})
+        sweep = event.get("sweep", {})
+        if isinstance(policy, dict):
+            totals["candidate_pages"] += max(0, int(policy.get("old_page_candidate_pages", 0) or 0))
+            totals["selected_pages"] += max(0, int(policy.get("old_page_selected_pages", 0) or 0))
+            totals["selected_live_bytes"] += max(0, int(policy.get("old_page_selected_live_bytes", 0) or 0))
+            totals["reclaimable_bytes"] += max(0, int(policy.get("old_page_reclaimable_bytes", 0) or 0))
+        if isinstance(evacuation, dict):
+            for key in (
+                "old_page_scanned_objects",
+                "old_page_scanned_bytes",
+                "old_page_moved_objects",
+                "old_page_moved_bytes",
+                "released_original_objects",
+                "released_original_bytes",
+                "released_original_reusable_bytes",
+                "released_original_returned_bytes",
+            ):
+                totals[key] += max(0, int(evacuation.get(key, 0) or 0))
+        if isinstance(old_pages, dict):
+            totals["reusable_bytes"] += max(0, int(old_pages.get("reusable_bytes", 0) or 0))
+            totals["returned_bytes"] += max(0, int(old_pages.get("returned_bytes", 0) or 0))
+        if isinstance(sweep, dict):
+            totals["reusable_bytes"] += max(0, int(sweep.get("reusable_bytes", 0) or 0))
+            totals["returned_bytes"] += max(0, int(sweep.get("returned_bytes", 0) or 0))
+    return totals
+
+
+def benchmark_peak(label):
+    report = read_json(root / label / "benchmarks" / "full.json", {})
+    try:
+        return report["benchmarks"]["bench_json_roundtrip"]["perry_rss_kb"]
+    except Exception:
+        return None
+
+
+def bench_entry(label):
+    run_dir = policy_root / label / "bench_json_roundtrip_retained"
+    stdout = run_dir / "stdout.log"
+    stderr = run_dir / "stderr-trace.log"
+    parsed = parse_stdout(stdout)
+    parsed.update({
+        "compile_exit": read_exit(run_dir / "compile.exit"),
+        "run_exit": read_exit(run_dir / "run.exit"),
+        "compile_log": str(run_dir / "compile.log"),
+        "trace_path": str(stderr),
+        "peak_rss_kb": parse_peak_rss_kb(stderr),
+        "benchmark_peak_reported_kb": benchmark_peak(label),
+        "probe_peak_rss_kb": parse_peak_rss_kb(stderr),
+        "probe_peak_footprint_kb": parse_peak_footprint_kb(stderr),
+        "old_page": trace_totals(stderr),
+    })
+    return parsed
+
+
+def churn_entry():
+    run_dir = policy_root / "head" / "old_gen_churn_retained"
+    stdout = run_dir / "stdout.log"
+    stderr = run_dir / "stderr-trace.log"
+    parsed = parse_stdout(stdout)
+    samples = parsed.get("samples_rss_kb", [])
+    warmup = 8
+    plateau = samples[warmup:]
+    parsed.update({
+        "compile_exit": read_exit(run_dir / "compile.exit"),
+        "run_exit": read_exit(run_dir / "run.exit"),
+        "compile_log": str(run_dir / "compile.log"),
+        "trace_path": str(stderr),
+        "probe_peak_rss_kb": parse_peak_rss_kb(stderr),
+        "probe_peak_footprint_kb": parse_peak_footprint_kb(stderr),
+        "old_page": trace_totals(stderr),
+        "warmup_samples": warmup,
+        "plateau_allowance_kb": 64 * 1024,
+        "plateau_delta_kb": (max(plateau) - min(plateau)) if plateau else None,
+    })
+    return parsed
+
+
+packet = {
+    "schema_version": 1,
+    "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "workloads_dir": str(policy_root / "workloads"),
+    "bench_json_roundtrip_retained": {
+        "base": bench_entry("base"),
+        "head": bench_entry("head"),
+    },
+    "old_gen_churn_retained": churn_entry(),
+}
+
+out.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+  if [[ ! -f "$json_out" ]]; then
+    code=1
+  fi
+
+  local status="pass"
+  if [[ "$code" -ne 0 ]]; then
+    status="fail"
+  fi
+  record_command "packet" "old_page_policy" "$status" "$code" "$log" ""
+  echo "=== packet: old_page_policy ==="
+  echo "  $status (exit=$code, log=$log)"
+}
+
+run_gc_store_inventory() {
+  local log="$OUT_ABS/logs/gc-store-site-inventory.log"
+  local out="$OUT_ABS/gc-store-site-inventory.json"
+  local code=0
+  local args=(--json-out "$out")
+  if [[ "$GATE" -eq 1 ]]; then
+    args+=(--gate)
+  fi
+  mkdir -p "$(dirname "$log")"
+  echo "=== packet: gc_store_inventory ==="
+  set +e
+  (
+    cd "$HEAD_WT"
+    python3 scripts/gc_store_site_inventory.py "${args[@]}"
+  ) >"$log" 2>&1
+  code=$?
+  set -e
+  local status="pass"
+  if [[ "$code" -ne 0 ]]; then
+    status="fail"
+  fi
+  record_command "packet" "gc_store_inventory" "$status" "$code" "$log" ""
+  echo "  $status (exit=$code, log=$log)"
+}
+
 run_for_label "base" "$BASE_WT"
 run_for_label "head" "$HEAD_WT"
+run_old_page_policy_evidence
+clean_label_target "base" "$BASE_WT"
+clean_label_target "head" "$HEAD_WT"
+run_gc_store_inventory
 run_perf_frontier
 
 set +e

--- a/scripts/gc_1090_evidence_packet.sh
+++ b/scripts/gc_1090_evidence_packet.sh
@@ -10,6 +10,8 @@ RUNS=5
 OUT=""
 SKIP_PERF_COMPREHENSIVE=0
 KEEP_WORKTREES=0
+GATE=0
+PERF_MATH_SLICE_ROWS=()
 
 usage() {
   cat <<'EOF'
@@ -20,6 +22,8 @@ Options:
   --head-ref REF                 Head/PR ref (default: HEAD)
   --runs N                       Benchmark samples per benchmark (default: 5)
   --out PATH                     Output root (default: tmp/gc-1090-evidence-<utc>)
+  --gate                         Fail on missing strict evidence
+  --perf-math-slice-row NAME     Limit nested perf-frontier math slices
   --skip-perf-comprehensive      Skip optional perf-comprehensive probe
   --keep-worktrees               Keep detached worktrees after the run
   -h, --help                     Show this help
@@ -32,6 +36,8 @@ while [[ $# -gt 0 ]]; do
     --head-ref) HEAD_REF="$2"; shift 2 ;;
     --runs) RUNS="$2"; shift 2 ;;
     --out) OUT="$2"; shift 2 ;;
+    --gate) GATE=1; shift ;;
+    --perf-math-slice-row) PERF_MATH_SLICE_ROWS+=("$2"); shift 2 ;;
     --skip-perf-comprehensive) SKIP_PERF_COMPREHENSIVE=1; shift ;;
     --keep-worktrees) KEEP_WORKTREES=1; shift ;;
     -h|--help) usage; exit 0 ;;
@@ -52,6 +58,14 @@ cd "$ROOT"
 
 BASE_SHA="$(git rev-parse --verify "$BASE_REF^{commit}")"
 HEAD_SHA="$(git rev-parse --verify "$HEAD_REF^{commit}")"
+if ! [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "base ref did not resolve to an exact 40-char SHA: $BASE_REF -> $BASE_SHA" >&2
+  exit 2
+fi
+if ! [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "head ref did not resolve to an exact 40-char SHA: $HEAD_REF -> $HEAD_SHA" >&2
+  exit 2
+fi
 OUT_ABS="$(python3 - "$ROOT" "$OUT" <<'PY'
 import os
 import sys
@@ -103,7 +117,7 @@ cleanup() {
 trap cleanup EXIT
 
 write_metadata() {
-  python3 - "$METADATA" "$BASE_REF" "$HEAD_REF" "$BASE_SHA" "$HEAD_SHA" "$RUNS" "$SKIP_PERF_COMPREHENSIVE" <<'PY'
+  python3 - "$METADATA" "$BASE_REF" "$HEAD_REF" "$BASE_SHA" "$HEAD_SHA" "$RUNS" "$SKIP_PERF_COMPREHENSIVE" "$GATE" <<'PY'
 import json
 import sys
 from datetime import datetime, timezone
@@ -122,10 +136,50 @@ existing.update({
     "head_sha": sys.argv[5],
     "runs": int(sys.argv[6]),
     "skip_perf_comprehensive": sys.argv[7] == "1",
+    "gate": sys.argv[8] == "1",
     "commands": existing.get("commands", {}),
+    "tool_versions": existing.get("tool_versions", {}),
 })
 path.parent.mkdir(parents=True, exist_ok=True)
 path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+}
+
+capture_tool_versions() {
+  python3 - "$METADATA" "$ROOT" <<'PY'
+import json
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+metadata = Path(sys.argv[1])
+root = Path(sys.argv[2])
+
+def run(cmd):
+    try:
+        completed = subprocess.run(cmd, cwd=root, text=True, capture_output=True, timeout=15)
+    except Exception as exc:
+        return {"available": False, "error": str(exc)}
+    return {
+        "available": completed.returncode == 0,
+        "exit_code": completed.returncode,
+        "stdout": completed.stdout.strip().splitlines()[:3],
+        "stderr": completed.stderr.strip().splitlines()[:3],
+    }
+
+data = json.loads(metadata.read_text(encoding="utf-8"))
+data["tool_versions"] = {
+    "platform": platform.platform(),
+    "python": sys.version.split()[0],
+    "git": run(["git", "--version"]),
+    "cargo": run(["cargo", "--version"]),
+    "rustc": run(["rustc", "--version"]),
+    "node": run(["node", "--version"]),
+    "sample": run(["/usr/bin/sample", "-h"]) if Path("/usr/bin/sample").exists() else {"available": False},
+    "perf": run(["perf", "--version"]),
+}
+metadata.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 PY
 }
 
@@ -162,6 +216,7 @@ PY
 }
 
 write_metadata
+capture_tool_versions
 
 echo "=== #1090 exact-head GC evidence packet ==="
 echo "base: $BASE_REF -> $BASE_SHA"
@@ -264,14 +319,57 @@ run_perf_comprehensive() {
   run_logged "$label" "perf_comprehensive" "$worktree" "$log" "$cmd"
 }
 
+run_perf_frontier() {
+  local perf_out="$OUT_ABS/perf-frontier"
+  local log="$OUT_ABS/logs/perf-frontier.command.log"
+  local baseline="$ROOT/tmp/perf-frontier-baseline.json"
+  local code=0
+  local args=(
+    --base-ref "$BASE_SHA"
+    --head-ref "$HEAD_SHA"
+    --runs "$RUNS"
+    --out "$perf_out"
+  )
+  if [[ -f "$baseline" ]]; then
+    args+=(--baseline-in "$baseline")
+  else
+    args+=(--update-baseline "$baseline")
+  fi
+  if [[ "$GATE" -eq 1 ]]; then
+    args+=(--gate)
+  fi
+  local row
+  for row in "${PERF_MATH_SLICE_ROWS[@]}"; do
+    args+=(--math-slice-row "$row")
+  done
+  mkdir -p "$(dirname "$log")"
+  echo "=== packet: perf_frontier ==="
+  set +e
+  "$ROOT/scripts/perf_frontier_gate.sh" "${args[@]}" >"$log" 2>&1
+  code=$?
+  set -e
+  local status="pass"
+  if [[ "$code" -ne 0 ]]; then
+    status="fail"
+  fi
+  record_command "packet" "perf_frontier" "$status" "$code" "$log" ""
+  echo "  $status (exit=$code, log=$log)"
+}
+
 run_for_label "base" "$BASE_WT"
 run_for_label "head" "$HEAD_WT"
+run_perf_frontier
 
 set +e
-python3 "$ROOT/scripts/gc_1090_evidence_report.py" \
-  --root "$OUT_ABS" \
-  --json-out "$OUT_ABS/gc-1090-packet.json" \
+REPORT_ARGS=(
+  --root "$OUT_ABS"
+  --json-out "$OUT_ABS/gc-1090-packet.json"
   --md-out "$OUT_ABS/gc-1090-packet.md"
+)
+if [[ "$GATE" -eq 1 ]]; then
+  REPORT_ARGS+=(--gate)
+fi
+python3 "$ROOT/scripts/gc_1090_evidence_report.py" "${REPORT_ARGS[@]}"
 REPORT_EXIT=$?
 set -e
 

--- a/scripts/gc_1090_evidence_report.py
+++ b/scripts/gc_1090_evidence_report.py
@@ -20,6 +20,17 @@ REQUIRED_BENCHMARKS = (
     "12_binary_trees",
 )
 
+SCALING_FACTORS = (1, 2, 4, 8)
+YOUNG_ONLY_SCALING_WORKLOADS = tuple(
+    f"young_only_{factor}x" for factor in SCALING_FACTORS
+)
+DEAD_YOUNG_SCALING_WORKLOADS = tuple(
+    f"dead_young_{factor}x" for factor in SCALING_FACTORS
+)
+FIXED_DIRTY_SCALING_WORKLOADS = tuple(
+    f"fixed_dirty_edge_{factor}x" for factor in SCALING_FACTORS
+)
+
 STRICT_COPIED_MINOR_WORKLOADS = (
     "json_roundtrip",
     "string_churn",
@@ -29,11 +40,31 @@ STRICT_COPIED_MINOR_WORKLOADS = (
     "promise_churn",
 )
 
+OPTIONAL_COPIED_MINOR_WORKLOADS = (
+    *YOUNG_ONLY_SCALING_WORKLOADS,
+    *DEAD_YOUNG_SCALING_WORKLOADS,
+    "simple_object_churn",
+    *FIXED_DIRTY_SCALING_WORKLOADS,
+    "map_object_key_identity_after_gc",
+    "buffer_churn",
+    "typed_array_churn",
+    "huge_string_churn",
+    "native_resource_owner_churn",
+    "async_resource_churn",
+    "async_promise_closures",
+    "verify_copied_young",
+    "verify_dirty_old_to_young",
+    "verify_promise_churn",
+)
+
 FALLBACK_REASONS = (
     "none",
     "copy_only_roots",
     "barriers_inactive",
     "conservative_stack",
+    "conservative_stack_truncated",
+    "conservative_stack_unbounded",
+    "unattributed_root_source",
     "malloc_registry_unavailable",
     "pinned_young_root",
     "pinned_young_dirty_slot",
@@ -45,6 +76,10 @@ SPEED_THRESHOLD_PCT = 15.0
 MEMORY_THRESHOLD_PCT = 25.0
 MIN_SPEED_DELTA_MS = 20
 MIN_MEMORY_DELTA_KB = 2048
+OLD_PAGE_RSS_IMPROVEMENT_PCT = 20.0
+OLD_PAGE_RSS_IMPROVEMENT_KB = 10 * 1024
+OLD_PAGE_BASELINE_SMALL_KB = 64 * 1024
+OLD_GEN_CHURN_PLATEAU_ALLOWANCE_KB = 64 * 1024
 
 
 def load_json(path: Path, default: Any = None) -> Any:
@@ -231,6 +266,11 @@ def copied_report_summary(root: Path, label: str) -> dict[str, Any]:
     report = load_json(label_paths(root, label)["copied_minor"], {})
     summary = report.get("summary", {}) if isinstance(report, dict) else {}
     workloads = report.get("workloads", {}) if isinstance(report, dict) else {}
+    legacy_summary = (
+        summary.get("legacy_copy_only_scanner_pinned", {})
+        if isinstance(summary, dict)
+        else {}
+    )
     return {
         "present": bool(report),
         "path": str(label_paths(root, label)["copied_minor"]),
@@ -242,8 +282,44 @@ def copied_report_summary(root: Path, label: str) -> dict[str, Any]:
             "conservative_pinned_bytes": int_value(
                 summary.get("conservative_pinned_bytes") if isinstance(summary, dict) else 0
             ),
+            "compiled_frame_conservative_pinned_bytes": int_value(
+                summary.get("compiled_frame_conservative_pinned_bytes")
+                if isinstance(summary, dict)
+                else 0
+            ),
             "legacy_copy_only_scanner_pinned_bytes": int_value(
                 nested(summary, "legacy_copy_only_scanner_pinned", "bytes", default=0)
+            ),
+            "legacy_copy_only_scanner_emitted_young_roots": int_value(
+                nested(
+                    summary,
+                    "legacy_copy_only_scanner_pinned",
+                    "emitted_young_roots",
+                    default=0,
+                )
+            ),
+            "legacy_copy_only_scanner_emitted_malloc_roots": int_value(
+                nested(
+                    summary,
+                    "legacy_copy_only_scanner_pinned",
+                    "emitted_malloc_roots",
+                    default=0,
+                )
+            ),
+            "legacy_copy_only_scanner_unattributed_roots": int_value(
+                nested(
+                    legacy_summary,
+                    "sources",
+                    "unattributed",
+                    "emitted_roots",
+                    default=0,
+                )
+            ),
+            "conservative_stack_truncated_cycles": int_value(
+                nested(summary, "conservative_stack", "truncated_cycles", default=0)
+            ),
+            "conservative_stack_unbounded_cycles": int_value(
+                nested(summary, "conservative_stack", "unbounded_cycles", default=0)
             ),
             "copied_objects": int_value(nested(summary, "copying_nursery", "copied_objects", default=0)),
             "copied_bytes": int_value(nested(summary, "copying_nursery", "copied_bytes", default=0)),
@@ -252,8 +328,41 @@ def copied_report_summary(root: Path, label: str) -> dict[str, Any]:
             "malloc_registry_rebuilds": int_value(
                 nested(summary, "copying_nursery", "malloc_registry_rebuilds", default=0)
             ),
+            "external_live_bytes_last": int_value(
+                nested(summary, "external_memory", "live_bytes", "last", default=0)
+            ),
+            "external_cache_reserved_bytes_last": int_value(
+                nested(
+                    summary,
+                    "external_memory",
+                    "cache_reserved_bytes",
+                    "last",
+                    default=0,
+                )
+            ),
+            "external_registered_bytes": int_value(
+                nested(summary, "external_memory", "registered_bytes", default=0)
+            ),
+            "external_finalized_bytes": int_value(
+                nested(summary, "external_memory", "finalized_bytes", default=0)
+            ),
+            "external_owner_moves": int_value(
+                nested(summary, "external_memory", "owner_moves", default=0)
+            ),
+            "external_copied_minor_young_owner_checks": int_value(
+                nested(
+                    summary,
+                    "external_memory",
+                    "copied_minor_young_owner_checks",
+                    default=0,
+                )
+            ),
+            "remembered_set_stale_entries": int_value(
+                nested(summary, "remembered_set", "stale_entries", default=0)
+            ),
         },
         "workloads": workloads if isinstance(workloads, dict) else {},
+        "scaling": report.get("scaling", {}) if isinstance(report, dict) else {},
     }
 
 
@@ -274,6 +383,17 @@ def target_collector_summary(root: Path, label: str) -> dict[str, Any]:
         "malloc_registry_rebuilds": int_value(
             nested(summary, "copying_nursery", "malloc_registry_rebuilds", default=0)
         ),
+        "external_live_bytes_last": int_value(
+            nested(summary, "external_memory", "live_bytes", "last", default=0)
+        ),
+        "external_copied_minor_young_owner_checks": int_value(
+            nested(
+                summary,
+                "external_memory",
+                "copied_minor_young_owner_checks",
+                default=0,
+            )
+        ),
         "old_page_accounting": summary.get("old_page_accounting", {})
         if isinstance(summary, dict)
         else {},
@@ -286,11 +406,138 @@ def workload_counts(workload: dict[str, Any]) -> dict[str, Any]:
             workload.get("fallback_reason_counts", {})
         ),
         "conservative_pinned_bytes": int_value(workload.get("conservative_pinned_bytes")),
+        "compiled_frame_conservative_pinned_bytes": int_value(
+            workload.get("compiled_frame_conservative_pinned_bytes")
+        ),
         "legacy_copy_only_scanner_pinned_bytes": int_value(
             nested(workload, "legacy_copy_only_scanner_pinned", "bytes", default=0)
         ),
+        "legacy_copy_only_scanner_emitted_young_roots": int_value(
+            nested(
+                workload,
+                "legacy_copy_only_scanner_pinned",
+                "emitted_young_roots",
+                default=0,
+            )
+        ),
+        "legacy_copy_only_scanner_emitted_malloc_roots": int_value(
+            nested(
+                workload,
+                "legacy_copy_only_scanner_pinned",
+                "emitted_malloc_roots",
+                default=0,
+            )
+        ),
+        "legacy_copy_only_scanner_unattributed_roots": int_value(
+            nested(
+                workload,
+                "legacy_copy_only_scanner_pinned",
+                "sources",
+                "unattributed",
+                "emitted_roots",
+                default=0,
+            )
+        ),
+        "conservative_stack_truncated_cycles": int_value(
+            nested(workload, "conservative_stack", "truncated_cycles", default=0)
+        ),
+        "conservative_stack_unbounded_cycles": int_value(
+            nested(workload, "conservative_stack", "unbounded_cycles", default=0)
+        ),
         "malloc_registry_rebuilds": int_value(
             nested(workload, "copying_nursery", "malloc_registry_rebuilds", default=0)
+        ),
+        "malloc_sweep_due": int_value(
+            nested(workload, "copying_nursery", "malloc_sweep_due", default=0)
+        ),
+        "external_live_bytes_max": int_value(
+            nested(workload, "external_memory", "live_bytes", "max", default=0)
+        ),
+        "external_young_owner_count_max": int_value(
+            nested(workload, "external_memory", "young_owner_count", "max", default=0)
+        ),
+        "external_copied_minor_young_owner_checks": int_value(
+            nested(
+                workload,
+                "external_memory",
+                "copied_minor_young_owner_checks",
+                default=0,
+            )
+        ),
+        "ineligible_cycles": int_value(
+            nested(workload, "copying_nursery", "ineligible_cycles", default=0)
+        ),
+        "non_minor_cycles": int_value(
+            nested(workload, "non_minor_cycles", default=0)
+        ),
+        "phase_sweep_us": int_value(
+            nested(workload, "phase_us", "sweep", default=0)
+        ),
+        "phase_block_persistence_us": int_value(
+            nested(workload, "phase_us", "block_persistence", default=0)
+        ),
+        "phase_root_marking_us": int_value(
+            nested(workload, "phase_us", "root_marking", default=0)
+        ),
+        "phase_trace_worklist_us": int_value(
+            nested(workload, "phase_us", "trace_worklist", default=0)
+        ),
+        "phase_reference_rewrite_us": int_value(
+            nested(workload, "phase_us", "reference_rewrite", default=0)
+        ),
+        "block_persist_iterations": int_value(
+            nested(workload, "block_persist", "iterations", default=0)
+        ),
+        "block_persist_candidate_blocks": int_value(
+            nested(workload, "block_persist", "candidate_blocks", default=0)
+        ),
+        "block_persist_live_blocks": int_value(
+            nested(workload, "block_persist", "live_blocks", default=0)
+        ),
+        "block_persist_marked_objects": int_value(
+            nested(workload, "block_persist", "marked_objects", default=0)
+        ),
+        "mutable_root_slots_first": int_value(
+            nested(workload, "root_growth", "mutable_slots_scanned", "first", default=0)
+        ),
+        "mutable_root_slots_max": int_value(
+            nested(workload, "root_growth", "mutable_slots_scanned", "max", default=0)
+        ),
+        "mutable_registered_slots_first": int_value(
+            nested(
+                workload,
+                "root_growth",
+                "mutable_registered_slots_scanned",
+                "first",
+                default=0,
+            )
+        ),
+        "mutable_registered_slots_max": int_value(
+            nested(
+                workload,
+                "root_growth",
+                "mutable_registered_slots_scanned",
+                "max",
+                default=0,
+            )
+        ),
+        "remembered_set_stale_entries": int_value(
+            nested(workload, "remembered_set", "stale_entries", default=0)
+        ),
+        "dirty_pages_scanned": int_value(
+            nested(workload, "remembered_set", "dirty_pages_scanned", default=0)
+        ),
+        "dirty_slots_scanned": int_value(
+            nested(workload, "remembered_set", "dirty_slots_scanned", default=0)
+        ),
+        "old_objects_considered": int_value(
+            nested(workload, "remembered_set", "old_objects_considered", default=0)
+        ),
+        "mutable_root_slots_scanned": int_value(
+            nested(workload, "mutable_roots", "slots_scanned", default=0)
+        ),
+        "mutable_registered_slots_scanned": int_value(
+            nested(workload, "mutable_roots", "registered_slots_scanned", default=0)
         ),
         "copied_objects": int_value(
             nested(workload, "copying_nursery", "copied_objects", default=0)
@@ -298,6 +545,7 @@ def workload_counts(workload: dict[str, Any]) -> dict[str, Any]:
         "promoted_objects": int_value(
             nested(workload, "copying_nursery", "promoted_objects", default=0)
         ),
+        "pause_us": int_value(workload.get("pause_us")),
     }
 
 
@@ -312,10 +560,11 @@ def gate_copied_minor(
 
     workload_results: dict[str, Any] = {}
     workloads = head_copied["workloads"]
-    for name in STRICT_COPIED_MINOR_WORKLOADS:
+    for name in (*STRICT_COPIED_MINOR_WORKLOADS, *OPTIONAL_COPIED_MINOR_WORKLOADS):
         workload = workloads.get(name)
         if not isinstance(workload, dict):
-            warnings.append(f"head:{name}: strict copied-minor workload missing")
+            if name in STRICT_COPIED_MINOR_WORKLOADS:
+                errors.append(f"head:{name}: strict copied-minor workload missing")
             continue
         counts = workload_counts(workload)
         workload_results[name] = counts
@@ -324,25 +573,180 @@ def gate_copied_minor(
             for reason, count in counts["fallback_reason_counts"].items()
             if reason != "none" and count > 0
         }
-        if name == "json_roundtrip" and non_none:
+        if non_none:
             errors.append(f"head:{name}: fallback reasons other than none: {non_none}")
+        barriers_inactive = counts["fallback_reason_counts"].get("barriers_inactive", 0)
+        if barriers_inactive:
+            errors.append(
+                f"head:{name}: barriers_inactive fallback cycles={barriers_inactive}, want 0"
+            )
+        if counts["ineligible_cycles"] != 0:
+            errors.append(
+                f"head:{name}: copied-minor ineligible cycles="
+                f"{counts['ineligible_cycles']}, want 0"
+            )
+        if counts["remembered_set_stale_entries"] != 0:
+            errors.append(
+                f"head:{name}: remembered_set.stale_entries="
+                f"{counts['remembered_set_stale_entries']}, want 0"
+            )
         if counts["conservative_pinned_bytes"] != 0:
             errors.append(
                 f"head:{name}: conservative_pinned_bytes="
                 f"{counts['conservative_pinned_bytes']}, want 0"
+            )
+        if counts["compiled_frame_conservative_pinned_bytes"] != 0:
+            errors.append(
+                f"head:{name}: compiled_frame_conservative_pinned_bytes="
+                f"{counts['compiled_frame_conservative_pinned_bytes']}, want 0"
+            )
+        if counts["conservative_stack_truncated_cycles"] != 0:
+            errors.append(
+                f"head:{name}: conservative_stack_truncated cycles="
+                f"{counts['conservative_stack_truncated_cycles']}, want 0"
+            )
+        if counts["conservative_stack_unbounded_cycles"] != 0:
+            errors.append(
+                f"head:{name}: conservative_stack_unbounded cycles="
+                f"{counts['conservative_stack_unbounded_cycles']}, want 0"
             )
         if counts["legacy_copy_only_scanner_pinned_bytes"] != 0:
             errors.append(
                 f"head:{name}: legacy_copy_only_scanner_pinned.bytes="
                 f"{counts['legacy_copy_only_scanner_pinned_bytes']}, want 0"
             )
+        if counts["legacy_copy_only_scanner_emitted_young_roots"] != 0:
+            errors.append(
+                f"head:{name}: legacy_copy_only_scanner_pinned.emitted_young_roots="
+                f"{counts['legacy_copy_only_scanner_emitted_young_roots']}, want 0"
+            )
+        if counts["legacy_copy_only_scanner_emitted_malloc_roots"] != 0:
+            errors.append(
+                f"head:{name}: legacy_copy_only_scanner_pinned.emitted_malloc_roots="
+                f"{counts['legacy_copy_only_scanner_emitted_malloc_roots']}, want 0"
+            )
+        if counts["legacy_copy_only_scanner_unattributed_roots"] != 0:
+            errors.append(
+                f"head:{name}: unattributed root scanner emitted roots="
+                f"{counts['legacy_copy_only_scanner_unattributed_roots']}, want 0"
+            )
         if counts["malloc_registry_rebuilds"] != 0:
             errors.append(
                 f"head:{name}: malloc_registry_rebuilds="
                 f"{counts['malloc_registry_rebuilds']}, want 0"
             )
+        if counts["malloc_sweep_due"] != 0:
+            errors.append(
+                f"head:{name}: malloc_sweep_due cycles="
+                f"{counts['malloc_sweep_due']}, want 0"
+            )
+        if (
+            counts["external_young_owner_count_max"] == 0
+            and counts["external_copied_minor_young_owner_checks"] != 0
+        ):
+            errors.append(
+                f"head:{name}: copied-minor external young-owner checks="
+                f"{counts['external_copied_minor_young_owner_checks']} "
+                "with no young external owners"
+            )
+        if counts["non_minor_cycles"] != 0:
+            errors.append(
+                f"head:{name}: non-minor gc cycles="
+                f"{counts['non_minor_cycles']}, want 0"
+            )
+        if counts["phase_sweep_us"] != 0:
+            errors.append(
+                f"head:{name}: phase_us.sweep="
+                f"{counts['phase_sweep_us']}, want 0"
+            )
+        old_walk_us = (
+            counts["phase_root_marking_us"]
+            + counts["phase_trace_worklist_us"]
+            + counts["phase_reference_rewrite_us"]
+        )
+        if old_walk_us != 0:
+            errors.append(
+                f"head:{name}: broad old-gen walk phase_us={old_walk_us}, want 0"
+            )
+        block_persist_work = (
+            counts["phase_block_persistence_us"]
+            + counts["block_persist_iterations"]
+            + counts["block_persist_candidate_blocks"]
+            + counts["block_persist_live_blocks"]
+            + counts["block_persist_marked_objects"]
+        )
+        if block_persist_work != 0:
+            errors.append(
+                f"head:{name}: block_persistence work={block_persist_work}, want 0"
+            )
+        for label, first_key, max_key in (
+            (
+                "mutable_slots_scanned",
+                "mutable_root_slots_first",
+                "mutable_root_slots_max",
+            ),
+            (
+                "mutable_registered_slots_scanned",
+                "mutable_registered_slots_first",
+                "mutable_registered_slots_max",
+            ),
+        ):
+            first = counts[first_key]
+            max_value = counts[max_key]
+            allowance = max(first * 8, first + 2048, 64)
+            if max_value > allowance:
+                errors.append(
+                    f"head:{name}: root_growth.{label}.max={max_value} "
+                    f"exceeds bounded allowance {allowance} from first={first}"
+                )
+        if counts["copied_objects"] + counts["promoted_objects"] == 0:
+            errors.append(f"head:{name}: no copied-minor cycle copied or promoted an object")
+
+    gate_copied_minor_scaling(workload_results, errors)
 
     return workload_results
+
+
+def gate_copied_minor_scaling(
+    workload_results: dict[str, dict[str, Any]],
+    errors: list[str],
+) -> None:
+    if all(name in workload_results for name in DEAD_YOUNG_SCALING_WORKLOADS):
+        pause_1x = workload_results["dead_young_1x"]["pause_us"]
+        pause_8x = workload_results["dead_young_8x"]["pause_us"]
+        if pause_1x <= 0:
+            errors.append("head:dead_young_1x: pause_us must be > 0 for scaling gate")
+        elif pause_8x >= pause_1x * 8:
+            errors.append(
+                "head:dead_young_8x: pause_us="
+                f"{pause_8x} is not sublinear versus dead_young_1x={pause_1x}"
+            )
+
+    bounded_fields = (
+        "dirty_pages_scanned",
+        "dirty_slots_scanned",
+        "old_objects_considered",
+        "mutable_root_slots_scanned",
+        "mutable_registered_slots_scanned",
+    )
+    for group_name, names in (
+        ("young_only", YOUNG_ONLY_SCALING_WORKLOADS),
+        ("dead_young", DEAD_YOUNG_SCALING_WORKLOADS),
+        ("fixed_dirty_edge", FIXED_DIRTY_SCALING_WORKLOADS),
+    ):
+        if not all(name in workload_results for name in names):
+            continue
+        base = workload_results[names[0]]
+        for field in bounded_fields:
+            base_value = int_value(base.get(field))
+            allowance = max(base_value + 8, base_value * 2)
+            for name in names[1:]:
+                value = int_value(workload_results[name].get(field))
+                if value > allowance:
+                    errors.append(
+                        f"head:{name}: {field}={value} exceeds bounded "
+                        f"{group_name} allowance {allowance} from {names[0]}={base_value}"
+                    )
 
 
 def perf_summary(metadata: dict[str, Any], base_label: str, head_label: str) -> dict[str, Any]:
@@ -395,7 +799,11 @@ def perf_frontier_summary(root: Path, metadata: dict[str, Any], errors: list[str
     elif not packet:
         warnings.append("perf frontier packet is missing")
     elif packet.get("status") != "pass":
-        errors.append(f"perf frontier packet status is {packet.get('status')}")
+        message = f"perf frontier packet status is {packet.get('status')}"
+        if gate:
+            errors.append(message)
+        else:
+            warnings.append(message)
     if gate and isinstance(packet, dict):
         profile = packet.get("profile_summary", {})
         if not isinstance(profile, dict) or not profile.get("top_non_gc_costs"):
@@ -405,6 +813,353 @@ def perf_frontier_summary(root: Path, metadata: dict[str, Any], errors: list[str
             if not isinstance(classification, dict) or name not in classification:
                 errors.append(f"perf frontier classification missing for {name}")
     return summary
+
+
+def gc_store_inventory_summary(
+    root: Path,
+    metadata: dict[str, Any],
+    errors: list[str],
+    warnings: list[str],
+    *,
+    gate: bool,
+) -> dict[str, Any]:
+    path = root / "gc-store-site-inventory.json"
+    inventory = load_json(path, {})
+    command = nested(metadata, "commands", "packet", "gc_store_inventory", default={})
+    command_status_value = command.get("status") if isinstance(command, dict) else "missing"
+    summary = inventory.get("summary", {}) if isinstance(inventory, dict) else {}
+    result = {
+        "present": bool(inventory),
+        "path": str(path),
+        "command": command if isinstance(command, dict) else {},
+        "status": inventory.get("status") if isinstance(inventory, dict) else "missing",
+        "summary": summary if isinstance(summary, dict) else {},
+        "errors": inventory.get("errors", []) if isinstance(inventory, dict) else [],
+    }
+
+    if gate and command_status_value != "pass":
+        errors.append(f"packet: gc_store_inventory command status is {command_status_value}")
+    elif command_status_value not in ("pass", "skipped"):
+        warnings.append(f"packet: gc_store_inventory command status is {command_status_value}")
+
+    if gate and not inventory:
+        errors.append("GC store-site inventory is missing")
+        return result
+    if not inventory:
+        warnings.append("GC store-site inventory is missing")
+        return result
+
+    if inventory.get("status") != "pass":
+        errors.append(f"GC store-site inventory status is {inventory.get('status')}")
+
+    for field in (
+        "unaudited_sites",
+        "invalid_annotations",
+        "stale_annotations",
+        "missing_gc_type_metadata",
+        "duplicate_gc_type_metadata",
+    ):
+        count = int_value(summary.get(field)) if isinstance(summary, dict) else 0
+        if count != 0:
+            errors.append(f"GC store-site inventory {field}={count}, want 0")
+
+    return result
+
+
+def old_page_policy_path(root: Path) -> Path:
+    return root / "old-page-policy.json"
+
+
+def material_improvement(delta: dict[str, Any]) -> bool:
+    pct = delta.get("delta_pct")
+    raw = delta.get("delta")
+    return (
+        pct is not None
+        and raw is not None
+        and pct <= -OLD_PAGE_RSS_IMPROVEMENT_PCT
+        and abs(raw) >= OLD_PAGE_RSS_IMPROVEMENT_KB
+    )
+
+
+def material_regression(delta: dict[str, Any]) -> bool:
+    pct = delta.get("delta_pct")
+    raw = delta.get("delta")
+    return (
+        pct is not None
+        and raw is not None
+        and pct > 0
+        and raw >= OLD_PAGE_RSS_IMPROVEMENT_KB
+    )
+
+
+def retained_rss_kb(entry: dict[str, Any]) -> int | None:
+    value = entry.get("retained_rss_kb")
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    value = entry.get("retained_rss_bytes")
+    if isinstance(value, int) and not isinstance(value, bool):
+        return (value + 1023) // 1024
+    return None
+
+
+def old_page_totals_from_policy(policy: dict[str, Any]) -> dict[str, int]:
+    totals = {
+        "candidate_pages": 0,
+        "selected_pages": 0,
+        "selected_live_bytes": 0,
+        "reclaimable_bytes": 0,
+        "old_page_scanned_objects": 0,
+        "old_page_scanned_bytes": 0,
+        "old_page_moved_objects": 0,
+        "old_page_moved_bytes": 0,
+        "released_original_objects": 0,
+        "released_original_bytes": 0,
+        "released_original_reusable_bytes": 0,
+        "released_original_returned_bytes": 0,
+        "reusable_bytes": 0,
+        "returned_bytes": 0,
+    }
+
+    def add(source: Any) -> None:
+        if not isinstance(source, dict):
+            return
+        aliases = {
+            "reclaimable_bytes": ("reclaimable_bytes", "old_page_reclaimable_bytes"),
+            "old_page_moved_bytes": ("old_page_moved_bytes",),
+            "old_page_moved_objects": ("old_page_moved_objects",),
+        }
+        for key in totals:
+            keys = aliases.get(key, (key,))
+            for source_key in keys:
+                value = source.get(source_key)
+                if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                    totals[key] += value
+                    break
+
+    for label in ("head",):
+        entry = nested(policy, "bench_json_roundtrip_retained", label, default={})
+        add(nested(entry, "old_page", default={}))
+        add(nested(entry, "trace_totals", default={}))
+    add(nested(policy, "old_gen_churn_retained", "old_page", default={}))
+    add(nested(policy, "old_gen_churn_retained", "trace_totals", default={}))
+    add(policy.get("head_old_page_accounting", {}))
+    add(policy.get("head_structural_old_page", {}))
+    return totals
+
+
+def merge_old_page_totals(*sources: dict[str, Any]) -> dict[str, int]:
+    totals = old_page_totals_from_policy({})
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        for key in totals:
+            value = source.get(key)
+            if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                totals[key] += value
+    return totals
+
+
+def old_page_structural_proof(
+    policy: dict[str, Any],
+    head_target: dict[str, Any],
+) -> dict[str, Any]:
+    policy_totals = old_page_totals_from_policy(policy)
+    target_totals = (
+        head_target.get("old_page_accounting", {}) if isinstance(head_target, dict) else {}
+    )
+    totals = merge_old_page_totals(policy_totals, target_totals)
+    reusable_or_returned = (
+        totals["released_original_reusable_bytes"]
+        + totals["released_original_returned_bytes"]
+        + totals["reusable_bytes"]
+        + totals["returned_bytes"]
+    )
+    moved_and_released = totals["old_page_moved_bytes"] > 0 and totals["released_original_bytes"] > 0
+    returned_or_reused = reusable_or_returned > 0
+    passed = (
+        totals["selected_pages"] > 0
+        and returned_or_reused
+        and (moved_and_released or totals["reclaimable_bytes"] > 0)
+    )
+    return {
+        "status": "pass" if passed else "fail",
+        "totals": totals,
+        "requirements": {
+            "selected_pages": totals["selected_pages"] > 0,
+            "moved_and_released_bytes": moved_and_released,
+            "reclaimable_bytes": totals["reclaimable_bytes"] > 0,
+            "reusable_or_returned_bytes": returned_or_reused,
+            "moved_or_reclaimable_returned_pages": moved_and_released
+            or (totals["reclaimable_bytes"] > 0 and returned_or_reused),
+        },
+    }
+
+
+def old_gen_churn_summary(policy: dict[str, Any]) -> dict[str, Any]:
+    churn = policy.get("old_gen_churn_retained", {})
+    if not isinstance(churn, dict):
+        churn = {}
+    samples = churn.get("samples_rss_kb")
+    if not isinstance(samples, list):
+        samples = []
+    samples = [
+        value for value in samples
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0
+    ]
+    warmup = churn.get("warmup_samples", 2)
+    if not isinstance(warmup, int) or isinstance(warmup, bool) or warmup < 0:
+        warmup = 2
+    allowance = churn.get("plateau_allowance_kb", OLD_GEN_CHURN_PLATEAU_ALLOWANCE_KB)
+    if not isinstance(allowance, int) or isinstance(allowance, bool) or allowance < 0:
+        allowance = OLD_GEN_CHURN_PLATEAU_ALLOWANCE_KB
+    plateau_samples = samples[warmup:]
+    plateau_delta = None
+    if plateau_samples:
+        plateau_delta = max(plateau_samples) - min(plateau_samples)
+    passed = len(plateau_samples) >= 3 and plateau_delta is not None and plateau_delta <= allowance
+    result = dict(churn)
+    result.update({
+        "samples_rss_kb": samples,
+        "warmup_samples": warmup,
+        "plateau_allowance_kb": allowance,
+        "plateau_delta_kb": plateau_delta,
+        "status": "pass" if passed else "fail",
+    })
+    return result
+
+
+def old_page_policy_summary(
+    root: Path,
+    benchmarks: dict[str, Any],
+    head_target: dict[str, Any],
+    metadata: dict[str, Any],
+    errors: list[str],
+    warnings: list[str],
+    *,
+    gate: bool,
+) -> dict[str, Any]:
+    path = old_page_policy_path(root)
+    policy = load_json(path, {})
+    command = nested(metadata, "commands", "packet", "old_page_policy", default={})
+    command_status_value = command.get("status") if isinstance(command, dict) else "missing"
+    result: dict[str, Any] = {
+        "present": bool(policy),
+        "path": str(path),
+        "command": command if isinstance(command, dict) else {},
+        "status": "missing",
+        "bench_json_roundtrip": {},
+        "structural_old_page": {},
+        "old_gen_churn_retained": {},
+        "raw": policy if isinstance(policy, dict) else {},
+    }
+
+    if gate and command_status_value != "pass":
+        errors.append(f"packet: old_page_policy command status is {command_status_value}")
+    elif command_status_value not in ("pass", "skipped", "missing"):
+        warnings.append(f"packet: old_page_policy command status is {command_status_value}")
+
+    if not isinstance(policy, dict) or not policy:
+        if gate:
+            errors.append("old-page policy evidence is missing")
+        else:
+            warnings.append("old-page policy evidence is missing")
+        return result
+
+    bench = policy.get("bench_json_roundtrip_retained", {})
+    if not isinstance(bench, dict):
+        bench = {}
+    base = bench.get("base", {})
+    head = bench.get("head", {})
+    if not isinstance(base, dict):
+        base = {}
+    if not isinstance(head, dict):
+        head = {}
+
+    matrix_peak = benchmarks.get("bench_json_roundtrip", {}).get("rss_kb", {})
+    base_peak = base.get("peak_rss_kb")
+    head_peak = head.get("peak_rss_kb")
+    if not isinstance(base_peak, int) or isinstance(base_peak, bool):
+        base_peak = matrix_peak.get("base") if isinstance(matrix_peak, dict) else None
+    if not isinstance(head_peak, int) or isinstance(head_peak, bool):
+        head_peak = matrix_peak.get("head") if isinstance(matrix_peak, dict) else None
+    base_retained = retained_rss_kb(base)
+    head_retained = retained_rss_kb(head)
+    peak_delta = ratio_delta(base_peak, head_peak)
+    retained_delta = ratio_delta(base_retained, head_retained)
+
+    structural = old_page_structural_proof(policy, head_target)
+    churn = old_gen_churn_summary(policy)
+    checksum_match = base.get("checksum") is not None and base.get("checksum") == head.get("checksum")
+    peak_pass = material_improvement(peak_delta)
+    retained_pass = material_improvement(retained_delta)
+    small_baseline = isinstance(base_peak, int) and base_peak < OLD_PAGE_BASELINE_SMALL_KB
+    no_material_peak_regression = not material_regression(peak_delta)
+    no_material_retained_regression = not material_regression(retained_delta)
+    same_exact_ref = (
+        metadata.get("base_sha") == metadata.get("head_sha")
+        and exact_sha(metadata.get("base_sha"))
+    )
+
+    if same_exact_ref:
+        rss_gate = no_material_peak_regression and no_material_retained_regression
+        gate_reason = "same_ref_non_regression"
+    elif small_baseline:
+        rss_gate = (
+            no_material_peak_regression
+            and no_material_retained_regression
+            and structural["status"] == "pass"
+        )
+        gate_reason = "small_baseline_non_regression"
+    else:
+        rss_gate = peak_pass or retained_pass
+        gate_reason = "peak_improved" if peak_pass else "retained_improved" if retained_pass else "missing_improvement"
+
+    result.update({
+        "status": "pass" if rss_gate and structural["status"] == "pass" and churn["status"] == "pass" and checksum_match else "fail",
+        "bench_json_roundtrip": {
+            "base_checksum": base.get("checksum"),
+            "head_checksum": head.get("checksum"),
+            "checksum_match": checksum_match,
+            "peak_rss_kb": peak_delta,
+            "retained_rss_kb": retained_delta,
+            "small_baseline": small_baseline,
+            "peak_gate": "pass" if peak_pass else "fail",
+            "retained_gate": "pass" if retained_pass else "fail",
+            "rss_gate": "pass" if rss_gate else "fail",
+            "gate_reason": gate_reason,
+            "base_trace_path": base.get("trace_path"),
+            "head_trace_path": head.get("trace_path"),
+        },
+        "structural_old_page": structural,
+        "old_gen_churn_retained": churn,
+    })
+
+    if gate:
+        if not checksum_match:
+            errors.append("old-page policy bench_json_roundtrip_retained checksum mismatch")
+        if not rss_gate:
+            if small_baseline:
+                errors.append(
+                    "old-page policy RSS gate failed: base peak RSS is below 64MB, "
+                    "but head did not preserve non-regression with structural proof"
+                )
+            else:
+                errors.append(
+                    "old-page policy RSS gate failed: bench_json_roundtrip improved by "
+                    "neither peak RSS nor retained RSS at >=20% and >=10MB"
+                )
+        if structural["status"] != "pass":
+            errors.append(
+                "old-page policy structural proof missing selected moved-or-reclaimable "
+                "and reusable/returned evidence"
+            )
+        if churn["status"] != "pass":
+            errors.append(
+                "old-page policy old_gen_churn_retained RSS did not plateau within "
+                f"{churn.get('plateau_allowance_kb', OLD_GEN_CHURN_PLATEAU_ALLOWANCE_KB)}KB"
+            )
+
+    return result
 
 
 def collect_report(root: Path, base_label: str, head_label: str, *, gate: bool = False) -> dict[str, Any]:
@@ -453,7 +1208,17 @@ def collect_report(root: Path, base_label: str, head_label: str, *, gate: bool =
     strict_workloads = gate_copied_minor(copied_minor[head_label], errors, warnings)
 
     perf = perf_summary(metadata, base_label, head_label)
+    gc_store_inventory = gc_store_inventory_summary(root, metadata, errors, warnings, gate=gate)
     perf_frontier = perf_frontier_summary(root, metadata, errors, warnings, gate=gate)
+    old_page_policy = old_page_policy_summary(
+        root,
+        benchmarks,
+        target_collector[head_label],
+        metadata,
+        errors,
+        warnings,
+        gate=gate,
+    )
 
     packet = {
         "schema_version": 1,
@@ -480,6 +1245,8 @@ def collect_report(root: Path, base_label: str, head_label: str, *, gate: bool =
         "copied_minor": copied_minor,
         "strict_head_workloads": strict_workloads,
         "target_collector": target_collector,
+        "gc_store_inventory": gc_store_inventory,
+        "old_page_policy": old_page_policy,
         "perf_comprehensive": perf,
         "perf_frontier": perf_frontier,
     }
@@ -541,6 +1308,39 @@ def render_markdown(packet: dict[str, Any]) -> str:
             f"| {fmt_delta(entry.get('rss_kb', {}), 'KB')} | {entry.get('gate', 'missing')} |"
         )
 
+    old_page_policy = packet.get("old_page_policy", {})
+    lines.extend(["", "## Old-Page Policy Evidence", ""])
+    if isinstance(old_page_policy, dict):
+        bench = old_page_policy.get("bench_json_roundtrip", {})
+        structural = old_page_policy.get("structural_old_page", {})
+        churn = old_page_policy.get("old_gen_churn_retained", {})
+        lines.append(
+            f"- Status: `{old_page_policy.get('status', 'missing')}` "
+            f"packet: `{old_page_policy.get('path', '')}`"
+        )
+        if isinstance(bench, dict):
+            lines.append(
+                f"- `bench_json_roundtrip`: peak {fmt_delta(bench.get('peak_rss_kb', {}), 'KB')}; "
+                f"retained {fmt_delta(bench.get('retained_rss_kb', {}), 'KB')}; "
+                f"gate `{bench.get('rss_gate', 'missing')}` ({bench.get('gate_reason', 'missing')})"
+            )
+        if isinstance(structural, dict):
+            totals = structural.get("totals", {})
+            if isinstance(totals, dict):
+                lines.append(
+                    f"- Structural old-page proof: `{structural.get('status', 'missing')}` "
+                    f"selected_pages={totals.get('selected_pages', 0)} "
+                    f"moved_bytes={totals.get('old_page_moved_bytes', 0)} "
+                    f"released_bytes={totals.get('released_original_bytes', 0)} "
+                    f"reusable_or_returned={totals.get('released_original_reusable_bytes', 0) + totals.get('released_original_returned_bytes', 0) + totals.get('reusable_bytes', 0) + totals.get('returned_bytes', 0)}"
+                )
+        if isinstance(churn, dict):
+            lines.append(
+                f"- `old_gen_churn_retained`: `{churn.get('status', 'missing')}` "
+                f"plateau_delta_kb={churn.get('plateau_delta_kb')} "
+                f"allowance_kb={churn.get('plateau_allowance_kb', OLD_GEN_CHURN_PLATEAU_ALLOWANCE_KB)}"
+            )
+
     lines.extend(["", "## Memory Stability", "", "| Ref | Passed | Failed | Skipped |"])
     lines.append("|---|---:|---:|---:|")
     for label, summary in packet["memory_stability"].items():
@@ -553,8 +1353,8 @@ def render_markdown(packet: dict[str, Any]) -> str:
             "",
             "## Copied-Minor Evidence",
             "",
-            "| Ref | Fallback Reasons | Conservative Pinned Bytes | Copy-Only Pinned Bytes | Copied/Promoted Objects | Copied/Promoted Bytes | Malloc Registry Rebuilds |",
-            "|---|---|---:|---:|---:|---:|---:|",
+            "| Ref | Fallback Reasons | Conservative Pinned Bytes | Compiled-Frame Pinned Bytes | Copy-Only Pinned Bytes | Copied/Promoted Objects | Copied/Promoted Bytes | Malloc Registry Rebuilds | External Live Bytes | External Young-Owner Checks |",
+            "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|",
         ]
     )
     for label, report in packet["copied_minor"].items():
@@ -564,10 +1364,13 @@ def render_markdown(packet: dict[str, Any]) -> str:
         lines.append(
             f"| `{label}` | {reason_summary(summary['fallback_reason_counts'])} "
             f"| {summary['conservative_pinned_bytes']} "
+            f"| {summary['compiled_frame_conservative_pinned_bytes']} "
             f"| {summary['legacy_copy_only_scanner_pinned_bytes']} "
             f"| {copied_promoted} "
             f"| {copied_promoted_bytes} "
-            f"| {summary['malloc_registry_rebuilds']} |"
+            f"| {summary['malloc_registry_rebuilds']} "
+            f"| {summary['external_live_bytes_last']} "
+            f"| {summary['external_copied_minor_young_owner_checks']} |"
         )
 
     lines.extend(
@@ -575,8 +1378,8 @@ def render_markdown(packet: dict[str, Any]) -> str:
             "",
             "## Target Collector Gates",
             "",
-            "| Ref | Present | Fallback Reasons | Copied Objects | Copied Bytes | Promoted Objects | Promoted Bytes | Malloc Registry Rebuilds |",
-            "|---|---|---|---:|---:|---:|---:|---:|",
+            "| Ref | Present | Fallback Reasons | Copied Objects | Copied Bytes | Promoted Objects | Promoted Bytes | Malloc Registry Rebuilds | External Live Bytes | External Young-Owner Checks |",
+            "|---|---|---|---:|---:|---:|---:|---:|---:|---:|",
         ]
     )
     for label, report in packet["target_collector"].items():
@@ -585,7 +1388,21 @@ def render_markdown(packet: dict[str, Any]) -> str:
             f"| {reason_summary(report['fallback_reason_counts'])} "
             f"| {report['copied_objects']} | {report['copied_bytes']} "
             f"| {report['promoted_objects']} | {report['promoted_bytes']} "
-            f"| {report['malloc_registry_rebuilds']} |"
+            f"| {report['malloc_registry_rebuilds']} "
+            f"| {report['external_live_bytes_last']} "
+            f"| {report['external_copied_minor_young_owner_checks']} |"
+        )
+
+    inventory = packet.get("gc_store_inventory", {})
+    lines.extend(["", "## GC Store-Site Inventory", ""])
+    if isinstance(inventory, dict):
+        summary = inventory.get("summary", {})
+        lines.append(
+            f"- Status: `{inventory.get('status', 'missing')}` "
+            f"audited_sites={summary.get('audited_sites', 0) if isinstance(summary, dict) else 0} "
+            f"unaudited_sites={summary.get('unaudited_sites', 0) if isinstance(summary, dict) else 0} "
+            f"missing_gc_type_metadata={summary.get('missing_gc_type_metadata', 0) if isinstance(summary, dict) else 0} "
+            f"packet: `{inventory.get('path', '')}`"
         )
 
     lines.extend(["", "## Perf-Comprehensive Outlier Check", ""])

--- a/scripts/gc_1090_evidence_report.py
+++ b/scripts/gc_1090_evidence_report.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+
+EXACT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 REQUIRED_BENCHMARKS = (
     "bench_json_roundtrip",
@@ -106,6 +109,10 @@ def command_status(metadata: dict[str, Any], label: str, command: str) -> str:
     return "pass" if exit_code == 0 else "fail"
 
 
+def exact_sha(value: Any) -> bool:
+    return isinstance(value, str) and EXACT_SHA_RE.fullmatch(value) is not None
+
+
 def label_paths(root: Path, label: str) -> dict[str, Path]:
     base = root / label
     return {
@@ -138,6 +145,8 @@ def benchmark_matrix(
     head_label: str,
     errors: list[str],
     warnings: list[str],
+    *,
+    gate: bool = False,
 ) -> dict[str, Any]:
     base = load_json(label_paths(root, base_label)["benchmarks"], {})
     head = load_json(label_paths(root, head_label)["benchmarks"], {})
@@ -150,7 +159,11 @@ def benchmark_matrix(
         for name, entry in nested(report, "benchmarks", default={}).items():
             correctness = entry.get("correctness", {})
             status = correctness.get("status")
-            if status == "fail":
+            if gate and not isinstance(correctness, dict):
+                errors.append(f"{report_label}:{name}: correctness output missing")
+            elif gate and status != "pass":
+                errors.append(f"{report_label}:{name}: correctness status is {status}")
+            elif status == "fail":
                 errors.append(
                     f"{report_label}:{name}: correctness failed: "
                     f"{correctness.get('reason', 'semantic output mismatch')}"
@@ -357,10 +370,53 @@ def perf_summary(metadata: dict[str, Any], base_label: str, head_label: str) -> 
     return result
 
 
-def collect_report(root: Path, base_label: str, head_label: str) -> dict[str, Any]:
+def perf_frontier_summary(root: Path, metadata: dict[str, Any], errors: list[str], warnings: list[str], *, gate: bool) -> dict[str, Any]:
+    path = root / "perf-frontier" / "perf-frontier-packet.json"
+    packet = load_json(path, {})
+    command = nested(metadata, "commands", "packet", "perf_frontier", default={})
+    summary = {
+        "present": bool(packet),
+        "path": str(path),
+        "command": command if isinstance(command, dict) else {},
+        "status": packet.get("status") if isinstance(packet, dict) else "missing",
+        "errors": packet.get("errors", []) if isinstance(packet, dict) else [],
+        "warnings": packet.get("warnings", []) if isinstance(packet, dict) else [],
+        "classification": packet.get("classification", {}) if isinstance(packet, dict) else {},
+        "profile_summary": packet.get("profile_summary", {}) if isinstance(packet, dict) else {},
+        "baseline": packet.get("baseline", {}) if isinstance(packet, dict) else {},
+    }
+    command_status_value = command.get("status") if isinstance(command, dict) else "missing"
+    if gate and command_status_value != "pass":
+        errors.append(f"packet: perf_frontier command status is {command_status_value}")
+    elif command_status_value not in ("pass", "skipped"):
+        warnings.append(f"packet: perf_frontier command status is {command_status_value}")
+    if gate and not packet:
+        errors.append("perf frontier packet is missing")
+    elif not packet:
+        warnings.append("perf frontier packet is missing")
+    elif packet.get("status") != "pass":
+        errors.append(f"perf frontier packet status is {packet.get('status')}")
+    if gate and isinstance(packet, dict):
+        profile = packet.get("profile_summary", {})
+        if not isinstance(profile, dict) or not profile.get("top_non_gc_costs"):
+            errors.append("perf frontier profiler attribution is missing")
+        classification = packet.get("classification", {})
+        for name in REQUIRED_BENCHMARKS:
+            if not isinstance(classification, dict) or name not in classification:
+                errors.append(f"perf frontier classification missing for {name}")
+    return summary
+
+
+def collect_report(root: Path, base_label: str, head_label: str, *, gate: bool = False) -> dict[str, Any]:
     metadata = load_json(root / "metadata.json", {})
     errors: list[str] = []
     warnings: list[str] = []
+
+    for key in ("base_sha", "head_sha"):
+        if not exact_sha(metadata.get(key)):
+            (errors if gate else warnings).append(
+                f"metadata {key} is not an exact 40-char SHA"
+            )
 
     for label in (base_label, head_label):
         if command_exit(metadata, label, "build") not in (0, None):
@@ -385,7 +441,7 @@ def collect_report(root: Path, base_label: str, head_label: str) -> dict[str, An
         if summary["failed"] != 0:
             errors.append(f"{label}: memory stability failed={summary['failed']}")
 
-    benchmarks = benchmark_matrix(root, base_label, head_label, errors, warnings)
+    benchmarks = benchmark_matrix(root, base_label, head_label, errors, warnings, gate=gate)
     copied_minor = {
         base_label: copied_report_summary(root, base_label),
         head_label: copied_report_summary(root, head_label),
@@ -397,6 +453,7 @@ def collect_report(root: Path, base_label: str, head_label: str) -> dict[str, An
     strict_workloads = gate_copied_minor(copied_minor[head_label], errors, warnings)
 
     perf = perf_summary(metadata, base_label, head_label)
+    perf_frontier = perf_frontier_summary(root, metadata, errors, warnings, gate=gate)
 
     packet = {
         "schema_version": 1,
@@ -416,6 +473,7 @@ def collect_report(root: Path, base_label: str, head_label: str) -> dict[str, An
                 "sha": metadata.get("head_sha"),
             },
         },
+        "tool_versions": metadata.get("tool_versions", {}),
         "commands": metadata.get("commands", {}),
         "memory_stability": memory,
         "benchmarks": benchmarks,
@@ -423,6 +481,7 @@ def collect_report(root: Path, base_label: str, head_label: str) -> dict[str, An
         "strict_head_workloads": strict_workloads,
         "target_collector": target_collector,
         "perf_comprehensive": perf,
+        "perf_frontier": perf_frontier,
     }
     return packet
 
@@ -540,6 +599,27 @@ def render_markdown(packet: dict[str, Any]) -> str:
         for outlier in perf.get("outlier_lines", []) if isinstance(perf, dict) else []:
             lines.append(f"  - `{outlier}`")
 
+    frontier = packet.get("perf_frontier", {})
+    lines.extend(["", "## Perf Frontier", ""])
+    if isinstance(frontier, dict):
+        lines.append(
+            f"- Status: `{frontier.get('status', 'missing')}` packet: `{frontier.get('path', '')}`"
+        )
+        baseline = frontier.get("baseline", {})
+        if isinstance(baseline, dict) and baseline:
+            lines.append(
+                f"- Baseline reference: `{baseline.get('input_path')}` "
+                f"sha=`{baseline.get('baseline_sha', 'missing')}`"
+            )
+        profile = frontier.get("profile_summary", {})
+        if isinstance(profile, dict):
+            lines.append(
+                f"- Profiled typed row: `{profile.get('row', 'missing')}`"
+            )
+            for row in profile.get("top_non_gc_costs", [])[:3]:
+                if isinstance(row, dict):
+                    lines.append(f"  - `{row.get('symbol')}` samples={row.get('samples')}")
+
     lines.append("")
     return "\n".join(lines)
 
@@ -551,10 +631,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--head-label", default="head")
     parser.add_argument("--json-out", help="Packet JSON path")
     parser.add_argument("--md-out", help="Packet Markdown path")
+    parser.add_argument("--gate", action="store_true", help="Enable strict evidence gates")
     args = parser.parse_args(argv)
 
     root = Path(args.root)
-    packet = collect_report(root, args.base_label, args.head_label)
+    packet = collect_report(root, args.base_label, args.head_label, gate=args.gate)
 
     json_out = Path(args.json_out) if args.json_out else root / "gc-1090-packet.json"
     md_out = Path(args.md_out) if args.md_out else root / "gc-1090-packet.md"

--- a/scripts/gc_store_site_inventory.py
+++ b/scripts/gc_store_site_inventory.py
@@ -9,6 +9,8 @@ and requires a nearby `GC_STORE_AUDIT(...)` marker with a reason.
 
 from __future__ import annotations
 
+import argparse
+import json
 import re
 import sys
 from dataclasses import dataclass
@@ -511,21 +513,66 @@ def run_self_tests() -> int:
     return 0
 
 
-def main(argv: list[str] | None = None) -> int:
-    argv = sys.argv[1:] if argv is None else argv
-    if argv == ["--self-test"]:
-        return run_self_tests()
-    if argv:
-        print("usage: gc_store_site_inventory.py [--self-test]", file=sys.stderr)
-        return 2
-
+def collect_inventory() -> tuple[list[Finding], int, int]:
     findings: list[Finding] = []
+    marker_count = 0
     seen: set[Path] = set()
     for path in iter_scan_roots():
         if path in seen:
             continue
         seen.add(path)
+        try:
+            marker_count += sum(
+                1
+                for line in path.read_text(encoding="utf-8", errors="replace").splitlines()
+                if MARKER_RE.search(line)
+            )
+        except OSError:
+            pass
         findings.extend(scan_file(path))
+    return findings, len(seen), marker_count
+
+
+def write_inventory_json(path: Path, findings: list[Finding], files_scanned: int, marker_count: int) -> None:
+    packet = {
+        "schema_version": 1,
+        "status": "fail" if findings else "pass",
+        "errors": [finding.render() for finding in findings],
+        "summary": {
+            "files_scanned": files_scanned,
+            "audited_sites": marker_count,
+            "unaudited_sites": len(findings),
+        },
+        "unaudited_sites": [
+            {
+                "path": str(finding.path.relative_to(REPO_ROOT)),
+                "line": finding.line_no,
+                "reason": finding.reason,
+                "text": finding.text.strip(),
+            }
+            for finding in findings
+        ],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if argv == ["--self-test"]:
+        return run_self_tests()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--gate", action="store_true")
+    args = parser.parse_args(argv)
+    if args.self_test:
+        return run_self_tests()
+
+    findings, files_scanned, marker_count = collect_inventory()
+    if args.json_out:
+        write_inventory_json(args.json_out, findings, files_scanned, marker_count)
 
     if findings:
         print("GC store-site inventory failed; add nearby GC_STORE_AUDIT markers:")
@@ -538,7 +585,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    print(f"GC store-site inventory passed ({len(seen)} files scanned).")
+    print(f"GC store-site inventory passed ({files_scanned} files scanned).")
     return 0
 
 

--- a/tests/test_gc_1090_evidence_packet_smoke.sh
+++ b/tests/test_gc_1090_evidence_packet_smoke.sh
@@ -4,25 +4,37 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OUT="${1:-$ROOT/tmp/gc-1090-evidence-smoke-$(date -u +%Y%m%dT%H%M%SZ)}"
 
+set +e
 "$ROOT/scripts/gc_1090_evidence_packet.sh" \
   --base-ref HEAD \
   --head-ref HEAD \
   --runs 1 \
   --out "$OUT" \
+  --gate \
+  --perf-math-slice-row 01_free_function_numeric \
+  --perf-math-slice-row 02_class_method_no_field_access \
   --skip-perf-comprehensive
+STATUS=$?
+set -e
 
-python3 - "$OUT" <<'PY'
+python3 - "$OUT" "$STATUS" <<'PY'
 import json
 import sys
 from pathlib import Path
 
 root = Path(sys.argv[1])
+status = int(sys.argv[2])
 metadata = json.loads((root / "metadata.json").read_text(encoding="utf-8"))
 packet = json.loads((root / "gc-1090-packet.json").read_text(encoding="utf-8"))
 
 assert metadata["base_sha"] == metadata["head_sha"], metadata
 assert (root / "gc-1090-packet.md").exists()
 assert (root / "gc-1090-packet.json").exists()
+assert (root / "perf-frontier" / "perf-frontier-packet.json").exists()
+if status == 0:
+    assert packet["status"] == "pass", packet["errors"]
+else:
+    assert packet["status"] == "fail", packet
 
 for name in ("bench_json_roundtrip", "bench_gc_pressure", "07_object_create", "12_binary_trees"):
     assert name in packet["benchmarks"], packet["benchmarks"].keys()

--- a/tests/test_gc_1090_evidence_packet_smoke.sh
+++ b/tests/test_gc_1090_evidence_packet_smoke.sh
@@ -30,6 +30,7 @@ packet = json.loads((root / "gc-1090-packet.json").read_text(encoding="utf-8"))
 assert metadata["base_sha"] == metadata["head_sha"], metadata
 assert (root / "gc-1090-packet.md").exists()
 assert (root / "gc-1090-packet.json").exists()
+assert (root / "old-page-policy.json").exists()
 assert (root / "perf-frontier" / "perf-frontier-packet.json").exists()
 if status == 0:
     assert packet["status"] == "pass", packet["errors"]
@@ -42,4 +43,8 @@ for name in ("bench_json_roundtrip", "bench_gc_pressure", "07_object_create", "1
 head = packet["copied_minor"]["head"]["summary"]
 assert "fallback_reason_counts" in head
 assert "conservative_pinned_bytes" in head
+assert "compiled_frame_conservative_pinned_bytes" in head
+assert "conservative_stack_truncated_cycles" in head
+assert "old_page_policy" in packet
+assert "bench_json_roundtrip" in packet["old_page_policy"]
 PY

--- a/tests/test_gc_1090_evidence_report.py
+++ b/tests/test_gc_1090_evidence_report.py
@@ -31,22 +31,146 @@ def write_json(path, data):
 def copied_workload(
     *,
     fallback_reason="none",
+    ineligible_cycles=0,
     conservative_pinned_bytes=0,
+    compiled_frame_conservative_pinned_bytes=0,
+    conservative_stack_truncated_cycles=0,
+    conservative_stack_unbounded_cycles=0,
     copy_only_pinned_bytes=0,
+    copy_only_young_roots=0,
+    copy_only_malloc_roots=0,
+    unattributed_roots=0,
     malloc_registry_rebuilds=0,
+    non_minor_cycles=0,
+    phase_sweep_us=0,
+    phase_block_persistence_us=0,
+    phase_root_marking_us=0,
+    phase_trace_worklist_us=0,
+    phase_reference_rewrite_us=0,
+    block_persist_iterations=0,
+    block_persist_candidate_blocks=0,
+    block_persist_live_blocks=0,
+    block_persist_marked_objects=0,
+    root_growth_mutable_first=1,
+    root_growth_mutable_max=1,
+    root_growth_registered_first=0,
+    root_growth_registered_max=0,
+    remembered_set_stale_entries=0,
+    pause_us=10,
+    dirty_pages_scanned=0,
+    dirty_slots_scanned=0,
+    old_objects_considered=0,
+    mutable_root_slots_scanned=1,
+    mutable_registered_slots_scanned=0,
+    external_live_bytes_last=0,
+    external_live_bytes_max=0,
+    external_cache_reserved_bytes_last=0,
+    external_registered_bytes=0,
+    external_finalized_bytes=0,
+    external_owner_moves=0,
+    external_young_owner_count_max=0,
+    external_young_owner_checks=0,
 ):
     counts = {reason: 0 for reason in REPORT.FALLBACK_REASONS}
     counts[fallback_reason] = 1
     return {
         "fallback_reason_counts": counts,
         "conservative_pinned_bytes": conservative_pinned_bytes,
-        "legacy_copy_only_scanner_pinned": {"bytes": copy_only_pinned_bytes},
+        "compiled_frame_conservative_pinned_bytes": (
+            compiled_frame_conservative_pinned_bytes
+        ),
+        "conservative_stack": {
+            "truncated_cycles": conservative_stack_truncated_cycles,
+            "unbounded_cycles": conservative_stack_unbounded_cycles,
+        },
+        "legacy_copy_only_scanner_pinned": {
+            "bytes": copy_only_pinned_bytes,
+            "emitted_young_roots": copy_only_young_roots,
+            "emitted_malloc_roots": copy_only_malloc_roots,
+            "sources": {
+                "unattributed": {"emitted_roots": unattributed_roots}
+            },
+        },
         "copying_nursery": {
             "copied_objects": 1,
             "copied_bytes": 16,
             "promoted_objects": 0,
             "promoted_bytes": 0,
             "malloc_registry_rebuilds": malloc_registry_rebuilds,
+            "ineligible_cycles": ineligible_cycles,
+        },
+        "non_minor_cycles": non_minor_cycles,
+        "phase_us": {
+            "sweep": phase_sweep_us,
+            "block_persistence": phase_block_persistence_us,
+            "root_marking": phase_root_marking_us,
+            "trace_worklist": phase_trace_worklist_us,
+            "reference_rewrite": phase_reference_rewrite_us,
+        },
+        "block_persist": {
+            "iterations": block_persist_iterations,
+            "candidate_blocks": block_persist_candidate_blocks,
+            "live_blocks": block_persist_live_blocks,
+            "marked_objects": block_persist_marked_objects,
+        },
+        "root_growth": {
+            "mutable_slots_scanned": {
+                "first": root_growth_mutable_first,
+                "last": root_growth_mutable_max,
+                "min": root_growth_mutable_first,
+                "max": root_growth_mutable_max,
+            },
+            "mutable_registered_slots_scanned": {
+                "first": root_growth_registered_first,
+                "last": root_growth_registered_max,
+                "min": root_growth_registered_first,
+                "max": root_growth_registered_max,
+            },
+        },
+        "pause_us": pause_us,
+        "remembered_set": {
+            "stale_entries": remembered_set_stale_entries,
+            "dirty_old_pages_before": 0,
+            "external_dirty_slot_pages_before": 0,
+            "external_dirty_entries_before": 0,
+            "dirty_pages_scanned": dirty_pages_scanned,
+            "dirty_slots_scanned": dirty_slots_scanned,
+            "old_objects_considered": old_objects_considered,
+        },
+        "external_memory": {
+            "live_bytes": {
+                "first": external_live_bytes_last,
+                "last": external_live_bytes_last,
+                "min": 0,
+                "max": external_live_bytes_max,
+            },
+            "cache_reserved_bytes": {
+                "first": external_cache_reserved_bytes_last,
+                "last": external_cache_reserved_bytes_last,
+                "min": 0,
+                "max": external_cache_reserved_bytes_last,
+            },
+            "young_owner_count": {
+                "first": external_young_owner_count_max,
+                "last": external_young_owner_count_max,
+                "min": 0,
+                "max": external_young_owner_count_max,
+            },
+            "registered_bytes": external_registered_bytes,
+            "finalized_bytes": external_finalized_bytes,
+            "owner_moves": external_owner_moves,
+            "copied_minor_young_owner_checks": external_young_owner_checks,
+            "kinds": {},
+        },
+        "mutable_roots": {
+            "slots_scanned": mutable_root_slots_scanned,
+            "nonzero_slots": 1 if mutable_root_slots_scanned else 0,
+            "pointer_roots": 1 if mutable_root_slots_scanned else 0,
+            "rewritten_slots": 1 if mutable_root_slots_scanned else 0,
+            "shadow_slots_scanned": 1 if mutable_root_slots_scanned else 0,
+            "global_slots_scanned": 0,
+            "registered_slots_scanned": mutable_registered_slots_scanned,
+            "metadata_slots_scanned": 0,
         },
     }
 
@@ -57,12 +181,59 @@ def copied_report(**overrides):
         for name in REPORT.STRICT_COPIED_MINOR_WORKLOADS
     }
     workloads.update(overrides)
+    external_registered_bytes = sum(
+        REPORT.nested(workload, "external_memory", "registered_bytes", default=0)
+        for workload in workloads.values()
+    )
+    external_finalized_bytes = sum(
+        REPORT.nested(workload, "external_memory", "finalized_bytes", default=0)
+        for workload in workloads.values()
+    )
+    external_owner_moves = sum(
+        REPORT.nested(workload, "external_memory", "owner_moves", default=0)
+        for workload in workloads.values()
+    )
+    external_young_owner_checks = sum(
+        REPORT.nested(
+            workload,
+            "external_memory",
+            "copied_minor_young_owner_checks",
+            default=0,
+        )
+        for workload in workloads.values()
+    )
+    external_live_bytes_last = max(
+        REPORT.nested(workload, "external_memory", "live_bytes", "last", default=0)
+        for workload in workloads.values()
+    )
+    external_live_bytes_max = max(
+        REPORT.nested(workload, "external_memory", "live_bytes", "max", default=0)
+        for workload in workloads.values()
+    )
+    external_cache_reserved_bytes_last = max(
+        REPORT.nested(workload, "external_memory", "cache_reserved_bytes", "last", default=0)
+        for workload in workloads.values()
+    )
+    external_young_owner_count_max = max(
+        REPORT.nested(workload, "external_memory", "young_owner_count", "max", default=0)
+        for workload in workloads.values()
+    )
     return {
         "summary": {
             "cycles": len(workloads),
             "fallback_reason_counts": {"none": len(workloads)},
             "conservative_pinned_bytes": 0,
-            "legacy_copy_only_scanner_pinned": {"bytes": 0},
+            "compiled_frame_conservative_pinned_bytes": 0,
+            "conservative_stack": {
+                "truncated_cycles": 0,
+                "unbounded_cycles": 0,
+            },
+            "legacy_copy_only_scanner_pinned": {
+                "bytes": 0,
+                "emitted_young_roots": 0,
+                "emitted_malloc_roots": 0,
+                "sources": {"unattributed": {"emitted_roots": 0}},
+            },
             "copying_nursery": {
                 "copied_objects": len(workloads),
                 "copied_bytes": len(workloads) * 16,
@@ -70,7 +241,45 @@ def copied_report(**overrides):
                 "promoted_bytes": 0,
                 "malloc_registry_rebuilds": 0,
             },
+            "external_memory": {
+                "live_bytes": {
+                    "first": 0,
+                    "last": external_live_bytes_last,
+                    "min": 0,
+                    "max": external_live_bytes_max,
+                },
+                "cache_reserved_bytes": {
+                    "first": 0,
+                    "last": external_cache_reserved_bytes_last,
+                    "min": 0,
+                    "max": external_cache_reserved_bytes_last,
+                },
+                "young_owner_count": {
+                    "first": 0,
+                    "last": external_young_owner_count_max,
+                    "min": 0,
+                    "max": external_young_owner_count_max,
+                },
+                "registered_bytes": external_registered_bytes,
+                "finalized_bytes": external_finalized_bytes,
+                "owner_moves": external_owner_moves,
+                "copied_minor_young_owner_checks": external_young_owner_checks,
+            },
+            "remembered_set": {
+                "stale_entries": 0,
+                "dirty_old_pages_before": 0,
+                "external_dirty_slot_pages_before": 0,
+                "external_dirty_entries_before": 0,
+                "dirty_pages_scanned": 0,
+                "dirty_slots_scanned": 0,
+                "old_objects_considered": 0,
+            },
+            "mutable_roots": {
+                "slots_scanned": len(workloads),
+                "registered_slots_scanned": 0,
+            },
         },
+        "scaling": {},
         "workloads": workloads,
     }
 
@@ -138,8 +347,94 @@ def perf_frontier_packet():
     }
 
 
+def gc_store_inventory_packet(**summary_overrides):
+    summary = {
+        "annotations": 61,
+        "audited_sites": 76,
+        "files_scanned": 333,
+        "unaudited_sites": 0,
+        "invalid_annotations": 0,
+        "stale_annotations": 0,
+        "missing_gc_type_metadata": 0,
+        "duplicate_gc_type_metadata": 0,
+    }
+    summary.update(summary_overrides)
+    return {
+        "schema_version": 1,
+        "status": "pass" if all(
+            summary.get(field, 0) == 0
+            for field in (
+                "unaudited_sites",
+                "invalid_annotations",
+                "stale_annotations",
+                "missing_gc_type_metadata",
+                "duplicate_gc_type_metadata",
+            )
+        ) else "fail",
+        "summary": summary,
+        "errors": [],
+    }
+
+
+def old_page_policy_packet(
+    *,
+    base_peak_kb=120_000,
+    head_peak_kb=90_000,
+    base_retained_kb=120_000,
+    head_retained_kb=90_000,
+    checksum=42,
+    structural=True,
+    churn_samples=None,
+):
+    if churn_samples is None:
+        churn_samples = [100_000, 104_000, 106_000, 107_000, 108_000, 109_000]
+    old_page = {
+        "selected_pages": 1 if structural else 0,
+        "old_page_scanned_objects": 2 if structural else 0,
+        "old_page_moved_objects": 1 if structural else 0,
+        "old_page_moved_bytes": 64 if structural else 0,
+        "released_original_bytes": 64 if structural else 0,
+        "released_original_reusable_bytes": 128 if structural else 0,
+        "released_original_returned_bytes": 0,
+        "reusable_bytes": 128 if structural else 0,
+        "returned_bytes": 0,
+    }
+    return {
+        "schema_version": 1,
+        "bench_json_roundtrip_retained": {
+            "base": {
+                "checksum": checksum,
+                "peak_rss_kb": base_peak_kb,
+                "retained_rss_kb": base_retained_kb,
+                "trace_path": "base.trace",
+                "old_page": {},
+            },
+            "head": {
+                "checksum": checksum,
+                "peak_rss_kb": head_peak_kb,
+                "retained_rss_kb": head_retained_kb,
+                "trace_path": "head.trace",
+                "old_page": old_page,
+            },
+        },
+        "old_gen_churn_retained": {
+            "samples_rss_kb": churn_samples,
+            "warmup_samples": 2,
+            "plateau_allowance_kb": REPORT.OLD_GEN_CHURN_PLATEAU_ALLOWANCE_KB,
+            "old_page": {},
+        },
+    }
+
+
 class Gc1090EvidenceReportTests(unittest.TestCase):
-    def make_root(self, *, head_copied=None, head_benchmarks=None, head_memory_failed=0):
+    def make_root(
+        self,
+        *,
+        head_copied=None,
+        base_benchmarks=None,
+        head_benchmarks=None,
+        head_memory_failed=0,
+    ):
         temp = tempfile.TemporaryDirectory()
         root = Path(temp.name)
         metadata = {
@@ -181,20 +476,41 @@ class Gc1090EvidenceReportTests(unittest.TestCase):
             )
             write_json(
                 root / label / "benchmarks" / "full.json",
-                head_benchmarks
-                if label == "head" and head_benchmarks is not None
-                else benchmark_report(),
+                (
+                    head_benchmarks
+                    if label == "head" and head_benchmarks is not None
+                    else base_benchmarks
+                    if label == "base" and base_benchmarks is not None
+                    else benchmark_report()
+                ),
             )
         return temp, root
 
-    def add_perf_frontier(self, root):
+    def add_perf_frontier(self, root, *, old_page_policy=True, old_page_policy_data=None):
         metadata = json.loads((root / "metadata.json").read_text(encoding="utf-8"))
         metadata.setdefault("commands", {}).setdefault("packet", {})["perf_frontier"] = {
             "status": "pass",
             "exit_code": 0,
         }
+        metadata.setdefault("commands", {}).setdefault("packet", {})["gc_store_inventory"] = {
+            "status": "pass",
+            "exit_code": 0,
+        }
+        if old_page_policy:
+            metadata.setdefault("commands", {}).setdefault("packet", {})["old_page_policy"] = {
+                "status": "pass",
+                "exit_code": 0,
+            }
         write_json(root / "metadata.json", metadata)
         write_json(root / "perf-frontier" / "perf-frontier-packet.json", perf_frontier_packet())
+        write_json(root / "gc-store-site-inventory.json", gc_store_inventory_packet())
+        if old_page_policy:
+            write_json(
+                root / "old-page-policy.json",
+                old_page_policy_data
+                if old_page_policy_data is not None
+                else old_page_policy_packet(),
+            )
 
     def collect(self, **kwargs):
         temp, root = self.make_root(**kwargs)
@@ -245,6 +561,51 @@ class Gc1090EvidenceReportTests(unittest.TestCase):
             any("conservative_pinned_bytes=8" in error for error in packet["errors"])
         )
 
+    def test_fails_compiled_frame_pinned_bytes(self):
+        packet = self.collect(
+            head_copied=copied_report(
+                json_roundtrip=copied_workload(
+                    compiled_frame_conservative_pinned_bytes=8
+                )
+            )
+        )
+        self.assertEqual(packet["status"], "fail")
+        self.assertTrue(
+            any(
+                "compiled_frame_conservative_pinned_bytes=8" in error
+                for error in packet["errors"]
+            )
+        )
+
+    def test_fails_truncated_unbounded_or_unattributed_roots(self):
+        packet = self.collect(
+            head_copied=copied_report(
+                json_roundtrip=copied_workload(
+                    conservative_stack_truncated_cycles=1,
+                    conservative_stack_unbounded_cycles=1,
+                    unattributed_roots=1,
+                    copy_only_young_roots=1,
+                    copy_only_malloc_roots=1,
+                )
+            )
+        )
+        self.assertEqual(packet["status"], "fail")
+        self.assertTrue(
+            any("conservative_stack_truncated cycles=1" in error for error in packet["errors"])
+        )
+        self.assertTrue(
+            any("conservative_stack_unbounded cycles=1" in error for error in packet["errors"])
+        )
+        self.assertTrue(
+            any("unattributed root scanner emitted roots=1" in error for error in packet["errors"])
+        )
+        self.assertTrue(
+            any("emitted_young_roots=1" in error for error in packet["errors"])
+        )
+        self.assertTrue(
+            any("emitted_malloc_roots=1" in error for error in packet["errors"])
+        )
+
     def test_fails_benchmark_correctness(self):
         packet = self.collect(head_benchmarks=benchmark_report(correctness="fail"))
         self.assertEqual(packet["status"], "fail")
@@ -259,11 +620,139 @@ class Gc1090EvidenceReportTests(unittest.TestCase):
         packet = self.collect_gate()
         self.assertEqual(packet["status"], "pass")
         self.assertIn("tool_versions", packet)
+        self.assertEqual(packet["gc_store_inventory"]["status"], "pass")
+        self.assertEqual(packet["gc_store_inventory"]["summary"]["unaudited_sites"], 0)
+        self.assertEqual(packet["old_page_policy"]["status"], "pass")
+        self.assertEqual(
+            packet["old_page_policy"]["bench_json_roundtrip"]["rss_gate"],
+            "pass",
+        )
         self.assertEqual(packet["perf_frontier"]["status"], "pass")
         self.assertIn("bench_json_roundtrip", packet["perf_frontier"]["classification"])
         self.assertEqual(
             packet["perf_frontier"]["baseline"]["input_path"],
             "tmp/perf-frontier-baseline.json",
+        )
+
+    def test_old_page_policy_retained_rss_improvement_can_pass_when_peak_does_not(self):
+        temp, root = self.make_root()
+        self.addCleanup(temp.cleanup)
+        self.add_perf_frontier(
+            root,
+            old_page_policy_data=old_page_policy_packet(
+                base_peak_kb=120_000,
+                head_peak_kb=119_000,
+                base_retained_kb=120_000,
+                head_retained_kb=90_000,
+            ),
+        )
+
+        packet = REPORT.collect_report(root, "base", "head", gate=True)
+
+        self.assertEqual(packet["status"], "pass")
+        old_page = packet["old_page_policy"]["bench_json_roundtrip"]
+        self.assertEqual(old_page["peak_gate"], "fail")
+        self.assertEqual(old_page["retained_gate"], "pass")
+        self.assertEqual(old_page["rss_gate"], "pass")
+        self.assertEqual(old_page["gate_reason"], "retained_improved")
+
+    def test_old_page_policy_fails_without_peak_or_retained_threshold(self):
+        temp, root = self.make_root()
+        self.addCleanup(temp.cleanup)
+        self.add_perf_frontier(
+            root,
+            old_page_policy_data=old_page_policy_packet(
+                base_peak_kb=120_000,
+                head_peak_kb=112_000,
+                base_retained_kb=120_000,
+                head_retained_kb=111_000,
+            ),
+        )
+
+        packet = REPORT.collect_report(root, "base", "head", gate=True)
+
+        self.assertEqual(packet["status"], "fail")
+        self.assertTrue(
+            any("neither peak RSS nor retained RSS" in error for error in packet["errors"])
+        )
+
+    def test_old_page_policy_small_baseline_uses_non_regression_with_structural_proof(self):
+        temp, root = self.make_root()
+        self.addCleanup(temp.cleanup)
+        self.add_perf_frontier(
+            root,
+            old_page_policy_data=old_page_policy_packet(
+                base_peak_kb=60_000,
+                head_peak_kb=59_000,
+                base_retained_kb=58_000,
+                head_retained_kb=57_000,
+            ),
+        )
+
+        packet = REPORT.collect_report(root, "base", "head", gate=True)
+
+        self.assertEqual(packet["status"], "pass")
+        old_page = packet["old_page_policy"]["bench_json_roundtrip"]
+        self.assertTrue(old_page["small_baseline"])
+        self.assertEqual(old_page["rss_gate"], "pass")
+        self.assertEqual(old_page["gate_reason"], "small_baseline_non_regression")
+
+    def test_old_page_policy_accepts_reclaimable_returned_pages(self):
+        temp, root = self.make_root()
+        self.addCleanup(temp.cleanup)
+        packet_data = old_page_policy_packet(
+            base_peak_kb=120_000,
+            head_peak_kb=119_000,
+            base_retained_kb=120_000,
+            head_retained_kb=90_000,
+        )
+        old_page = packet_data["bench_json_roundtrip_retained"]["head"]["old_page"]
+        old_page.update({
+            "reclaimable_bytes": 256 * 1024,
+            "old_page_moved_bytes": 0,
+            "released_original_bytes": 0,
+            "released_original_reusable_bytes": 0,
+            "reusable_bytes": 0,
+            "returned_bytes": 256 * 1024,
+        })
+        self.add_perf_frontier(root, old_page_policy_data=packet_data)
+
+        packet = REPORT.collect_report(root, "base", "head", gate=True)
+
+        self.assertEqual(packet["status"], "pass")
+        structural = packet["old_page_policy"]["structural_old_page"]
+        self.assertEqual(structural["status"], "pass")
+        self.assertTrue(
+            structural["requirements"]["moved_or_reclaimable_returned_pages"]
+        )
+
+    def test_old_page_policy_missing_evidence_fails_gate(self):
+        temp, root = self.make_root()
+        self.addCleanup(temp.cleanup)
+        self.add_perf_frontier(root, old_page_policy=False)
+
+        packet = REPORT.collect_report(root, "base", "head", gate=True)
+
+        self.assertEqual(packet["status"], "fail")
+        self.assertTrue(
+            any("old-page policy evidence is missing" in error for error in packet["errors"])
+        )
+
+    def test_old_page_policy_fails_old_gen_churn_plateau(self):
+        temp, root = self.make_root()
+        self.addCleanup(temp.cleanup)
+        self.add_perf_frontier(
+            root,
+            old_page_policy_data=old_page_policy_packet(
+                churn_samples=[100_000, 101_000, 102_000, 190_000, 250_000],
+            ),
+        )
+
+        packet = REPORT.collect_report(root, "base", "head", gate=True)
+
+        self.assertEqual(packet["status"], "fail")
+        self.assertTrue(
+            any("old_gen_churn_retained RSS did not plateau" in error for error in packet["errors"])
         )
 
     def test_gate_requires_exact_sha_and_perf_frontier(self):
@@ -276,6 +765,109 @@ class Gc1090EvidenceReportTests(unittest.TestCase):
         self.assertEqual(packet["status"], "fail")
         self.assertTrue(any("exact 40-char SHA" in error for error in packet["errors"]))
         self.assertTrue(any("perf frontier packet is missing" in error for error in packet["errors"]))
+        self.assertTrue(any("GC store-site inventory is missing" in error for error in packet["errors"]))
+
+    def test_gate_fails_unaudited_store_sites(self):
+        temp, root = self.make_root()
+        self.addCleanup(temp.cleanup)
+        self.add_perf_frontier(root)
+        metadata = json.loads((root / "metadata.json").read_text(encoding="utf-8"))
+        metadata["commands"]["packet"]["gc_store_inventory"] = {
+            "status": "fail",
+            "exit_code": 1,
+        }
+        write_json(root / "metadata.json", metadata)
+        write_json(
+            root / "gc-store-site-inventory.json",
+            gc_store_inventory_packet(unaudited_sites=2),
+        )
+        packet = REPORT.collect_report(root, "base", "head", gate=True)
+        self.assertEqual(packet["status"], "fail")
+        self.assertTrue(any("gc_store_inventory command status is fail" in error for error in packet["errors"]))
+        self.assertTrue(any("unaudited_sites=2" in error for error in packet["errors"]))
+
+    def test_fails_remembered_set_stale_entries(self):
+        packet = self.collect(
+            head_copied=copied_report(
+                json_roundtrip=copied_workload(remembered_set_stale_entries=1)
+            )
+        )
+        self.assertEqual(packet["status"], "fail")
+        self.assertTrue(
+            any("remembered_set.stale_entries=1" in error for error in packet["errors"])
+        )
+
+    def test_reports_external_memory_and_allows_young_owner_checks(self):
+        packet = self.collect(
+            head_copied=copied_report(
+                buffer_churn=copied_workload(
+                    external_live_bytes_last=1024,
+                    external_live_bytes_max=2048,
+                    external_registered_bytes=4096,
+                    external_finalized_bytes=3072,
+                    external_owner_moves=2,
+                    external_young_owner_count_max=2,
+                    external_young_owner_checks=3,
+                )
+            )
+        )
+
+        self.assertEqual(packet["status"], "pass")
+        summary = packet["copied_minor"]["head"]["summary"]
+        self.assertEqual(summary["external_live_bytes_last"], 1024)
+        self.assertEqual(summary["external_registered_bytes"], 4096)
+        self.assertEqual(summary["external_finalized_bytes"], 3072)
+        self.assertEqual(summary["external_owner_moves"], 2)
+        self.assertEqual(summary["external_copied_minor_young_owner_checks"], 3)
+        self.assertEqual(
+            packet["strict_head_workloads"]["buffer_churn"][
+                "external_copied_minor_young_owner_checks"
+            ],
+            3,
+        )
+
+    def test_fails_external_checks_without_young_owners(self):
+        packet = self.collect(
+            head_copied=copied_report(
+                buffer_churn=copied_workload(
+                    external_young_owner_count_max=0,
+                    external_young_owner_checks=1,
+                )
+            )
+        )
+
+        self.assertEqual(packet["status"], "fail")
+        self.assertTrue(
+            any(
+                "copied-minor external young-owner checks=1 with no young external owners"
+                in error
+                for error in packet["errors"]
+            )
+        )
+
+    def test_fails_non_minor_and_full_old_gen_work(self):
+        packet = self.collect(
+            head_copied=copied_report(
+                json_roundtrip=copied_workload(
+                    non_minor_cycles=1,
+                    phase_sweep_us=5,
+                    phase_block_persistence_us=7,
+                    phase_root_marking_us=11,
+                    phase_trace_worklist_us=13,
+                    phase_reference_rewrite_us=17,
+                    block_persist_iterations=1,
+                    root_growth_mutable_first=1,
+                    root_growth_mutable_max=10000,
+                )
+            )
+        )
+
+        self.assertEqual(packet["status"], "fail")
+        self.assertTrue(any("non-minor gc cycles=1" in error for error in packet["errors"]))
+        self.assertTrue(any("phase_us.sweep=5" in error for error in packet["errors"]))
+        self.assertTrue(any("broad old-gen walk phase_us=41" in error for error in packet["errors"]))
+        self.assertTrue(any("block_persistence work=" in error for error in packet["errors"]))
+        self.assertTrue(any("root_growth.mutable_slots_scanned.max=10000" in error for error in packet["errors"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_gc_1090_evidence_report.py
+++ b/tests/test_gc_1090_evidence_report.py
@@ -108,6 +108,36 @@ def benchmark_report(multiplier=1, correctness="pass"):
     return {"commit": "abc", "benchmarks": benchmarks}
 
 
+def perf_frontier_packet():
+    classifications = {
+        name: {
+            "class": "numeric-representation-bound",
+            "reasons": ["synthetic"],
+            "evidence": {},
+        }
+        for name in REQUIRED_BENCHMARKS
+    }
+    return {
+        "schema_version": 1,
+        "status": "pass",
+        "errors": [],
+        "warnings": [],
+        "classification": classifications,
+        "profile_summary": {
+            "status": "pass",
+            "row": "class_method_no_field_access",
+            "top_non_gc_costs": [
+                {"symbol": "js_object_get_own_field_or_undef", "samples": 10}
+            ],
+        },
+        "baseline": {
+            "input_path": "tmp/perf-frontier-baseline.json",
+            "baseline_sha": "c" * 40,
+            "present": True,
+        },
+    }
+
+
 class Gc1090EvidenceReportTests(unittest.TestCase):
     def make_root(self, *, head_copied=None, head_benchmarks=None, head_memory_failed=0):
         temp = tempfile.TemporaryDirectory()
@@ -157,10 +187,25 @@ class Gc1090EvidenceReportTests(unittest.TestCase):
             )
         return temp, root
 
+    def add_perf_frontier(self, root):
+        metadata = json.loads((root / "metadata.json").read_text(encoding="utf-8"))
+        metadata.setdefault("commands", {}).setdefault("packet", {})["perf_frontier"] = {
+            "status": "pass",
+            "exit_code": 0,
+        }
+        write_json(root / "metadata.json", metadata)
+        write_json(root / "perf-frontier" / "perf-frontier-packet.json", perf_frontier_packet())
+
     def collect(self, **kwargs):
         temp, root = self.make_root(**kwargs)
         self.addCleanup(temp.cleanup)
         return REPORT.collect_report(root, "base", "head")
+
+    def collect_gate(self, **kwargs):
+        temp, root = self.make_root(**kwargs)
+        self.addCleanup(temp.cleanup)
+        self.add_perf_frontier(root)
+        return REPORT.collect_report(root, "base", "head", gate=True)
 
     def test_pass_case(self):
         packet = self.collect()
@@ -209,6 +254,28 @@ class Gc1090EvidenceReportTests(unittest.TestCase):
         packet = self.collect(head_memory_failed=1)
         self.assertEqual(packet["status"], "fail")
         self.assertTrue(any("memory stability failed=1" in error for error in packet["errors"]))
+
+    def test_gate_includes_perf_frontier_fields(self):
+        packet = self.collect_gate()
+        self.assertEqual(packet["status"], "pass")
+        self.assertIn("tool_versions", packet)
+        self.assertEqual(packet["perf_frontier"]["status"], "pass")
+        self.assertIn("bench_json_roundtrip", packet["perf_frontier"]["classification"])
+        self.assertEqual(
+            packet["perf_frontier"]["baseline"]["input_path"],
+            "tmp/perf-frontier-baseline.json",
+        )
+
+    def test_gate_requires_exact_sha_and_perf_frontier(self):
+        temp, root = self.make_root()
+        self.addCleanup(temp.cleanup)
+        metadata = json.loads((root / "metadata.json").read_text(encoding="utf-8"))
+        metadata["head_sha"] = "b" * 39
+        write_json(root / "metadata.json", metadata)
+        packet = REPORT.collect_report(root, "base", "head", gate=True)
+        self.assertEqual(packet["status"], "fail")
+        self.assertTrue(any("exact 40-char SHA" in error for error in packet["errors"]))
+        self.assertTrue(any("perf frontier packet is missing" in error for error in packet["errors"]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend the #1090 exact-head evidence command with stricter SHA/tool metadata and optional perf-frontier gating
- add old-page policy evidence workloads and reporting for retained JSON RSS, old-gen churn plateau, structural old-page reuse/return proof, and store-inventory status
- teach gc_store_site_inventory.py to emit JSON/gate output while preserving the existing scanner semantics

## Verification
- python3 tests/test_gc_1090_evidence_report.py
- python3 tests/test_perf_frontier_report.py
- bash -n scripts/gc_1090_evidence_packet.sh
- python3 -m py_compile scripts/gc_1090_evidence_report.py scripts/gc_store_site_inventory.py scripts/perf_frontier_report.py
- python3 scripts/gc_store_site_inventory.py --self-test
- python3 scripts/gc_store_site_inventory.py --json-out tmp/gc-store-site-inventory-final.json --gate
- tests/test_gc_1090_evidence_packet_smoke.sh tmp/gc-1090-evidence-smoke-port2-20260524 (completed; packet generated, store inventory and old-page policy passed; final packet was fail only because the gate-mode perf-frontier slice intentionally preserved existing perf-frontier failures)

Refs #1090