### PR TITLE
test(parity): stream — batch of 8 tier-13 tests (iter-130..131) (3 free pass, 5 #1532/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3109,5 +3109,35 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-set-of-strings": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Set) — iteration order or count wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/emit-different-events-isolated": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: emit different events — count interference across event keys. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/cancel-with-undefined-reason": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: cancel(undefined) explicit — fails to compile or reason isn't undefined. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/end-true-explicit-still-ends": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe(dst,{end:true}) — dst not ended after source ends. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipeline/sync-iterable-source": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline(array, dst, cb) — sync iterable source not wired. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/emit-different-events-isolated.ts
+++ b/test-parity/node-suite/stream/events/emit-different-events-isolated.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Listeners for different events don't interfere.
+const r = new Readable({ read() {} });
+let a = 0, b = 0;
+r.on("eventA", () => a++);
+r.on("eventB", () => b++);
+r.emit("eventA");
+r.emit("eventB");
+r.emit("eventA");
+console.log("a:", a, "b:", b);
+console.log("isolated:", a === 2 && b === 1);

--- a/test-parity/node-suite/stream/events/listener-count-numeric-event.ts
+++ b/test-parity/node-suite/stream/events/listener-count-numeric-event.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// listenerCount with a numeric event key (Node EE accepts strings only;
+// non-string coerces / works as-is depending on impl).
+const r = new Readable({ read() {} });
+console.log("numeric:", r.listenerCount(42 as any));
+console.log("string:", r.listenerCount("42"));
+console.log("both 0:", r.listenerCount(42 as any) === 0 && r.listenerCount("42") === 0);

--- a/test-parity/node-suite/stream/pipe/end-true-explicit-still-ends.ts
+++ b/test-parity/node-suite/stream/pipe/end-true-explicit-still-ends.ts
@@ -1,0 +1,11 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe(dst, {end: true}) — same as default; dst is ended.
+const r = Readable.from(["a"]);
+const dst = new PassThrough();
+let dstEnded = false;
+dst.on("end", () => (dstEnded = true));
+dst.on("data", () => {});
+r.pipe(dst, { end: true });
+setImmediate(() => {
+  setImmediate(() => console.log("dst ended (end:true explicit):", dstEnded));
+});

--- a/test-parity/node-suite/stream/pipeline/sync-iterable-source.ts
+++ b/test-parity/node-suite/stream/pipeline/sync-iterable-source.ts
@@ -1,0 +1,9 @@
+import { PassThrough, pipeline } from "node:stream";
+// pipeline(syncIterable, dst, cb) — array source (not stream, not async).
+const dst = new PassThrough();
+const out: string[] = [];
+dst.on("data", (c) => out.push(String(c)));
+pipeline(["a", "b", "c"], dst, (err: any) => {
+  console.log("err:", err);
+  console.log("out:", out.join(","));
+});

--- a/test-parity/node-suite/stream/readable/from-set-of-strings.ts
+++ b/test-parity/node-suite/stream/readable/from-set-of-strings.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// Readable.from(Set) — iterates Set values in insertion order.
+const s = new Set(["alpha", "beta", "gamma"]);
+const r = Readable.from(s);
+const out: string[] = [];
+for await (const v of r) out.push(String(v));
+console.log("order:", out.join(","));

--- a/test-parity/node-suite/stream/readable/read-empty-objectmode-null.ts
+++ b/test-parity/node-suite/stream/readable/read-empty-objectmode-null.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// objectMode read on empty stream returns null.
+const r = new Readable({ objectMode: true, read() {} });
+console.log("read:", r.read());
+console.log("is null:", r.read() === null);

--- a/test-parity/node-suite/stream/web/cancel-with-undefined-reason.ts
+++ b/test-parity/node-suite/stream/web/cancel-with-undefined-reason.ts
@@ -1,0 +1,10 @@
+import { ReadableStream } from "node:stream/web";
+// cancel(undefined) explicitly — reason is undefined in cancel hook.
+let seen: any = "untouched";
+const rs = new ReadableStream({
+  start(c) { c.enqueue("x"); },
+  cancel(reason) { seen = reason; },
+});
+await rs.cancel(undefined);
+console.log("seen:", seen);
+console.log("is undefined:", seen === undefined);

--- a/test-parity/node-suite/stream/web/tee-array-shape.ts
+++ b/test-parity/node-suite/stream/web/tee-array-shape.ts
@@ -1,0 +1,8 @@
+import { ReadableStream } from "node:stream/web";
+// tee() returns an Array of length 2.
+const rs = new ReadableStream({ start(c) { c.close(); } });
+const result = rs.tee();
+console.log("isArray:", Array.isArray(result));
+console.log("length:", result.length);
+console.log("[0] is RS:", result[0] instanceof ReadableStream);
+console.log("[1] is RS:", result[1] instanceof ReadableStream);


### PR DESCRIPTION
### Stream parity batch — 8 tests aggregated (iter-130..131)

**3 free passes + 5 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Readable shape | from-set-of-strings, read-empty-objectmode-null ✅ | #1532 |
| Stream events | emit-different-events-isolated, listener-count-numeric-event ✅ | #1532 |
| Web stream surface | cancel-with-undefined-reason, tee-array-shape ✅ | #1545 |
| Pipe / pipeline | end-true-explicit-still-ends, sync-iterable-source | #1532 |

Free passes:
- `events/listener-count-numeric-event` (numeric event key returns 0)
- `web/tee-array-shape` (returns 2-element array of RS instances)
- `readable/read-empty-objectmode-null` (read on empty objectMode → null)

All 5 failures tracked in `known_failures.json`. Initially iter-131 was deferred due to a transient perry-stdlib build issue in worktrees that the symlinked-target trick couldn't bypass; cold-building perry-runtime in a fresh non-symlinked target resolved it.