### PR TITLE
test(parity): stream — batch of 8 tier-13 tests (iter-132..133) (1 free pass, 7 #1532/#1545/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3109,5 +3109,47 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/transform-stream-instanceof-check": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: TransformStream instance — fails instanceof checks vs RS/WS for readable/writable sides. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/from-arguments-object": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(arguments) — Array-like iteration fails. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/setMaxListeners-stays-applied": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: setMaxListeners(50) — value not preserved across operations. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/reduce-with-initial": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: reduce(fn, initial) — initial value not used or wrong sum. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/iter-helpers/for-each-empty-stream": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: forEach() on empty — calls non-zero or result not undefined. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/events/set-max-listeners-chainable": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: setMaxListeners returns wrong value (should return emitter). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/readable-stream-id-properties": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: distinct Readable instances — same identity or wrong prototype shared. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/set-max-listeners-chainable.ts
+++ b/test-parity/node-suite/stream/events/set-max-listeners-chainable.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// setMaxListeners(N) — should return the emitter (chainable).
+const r = new Readable({ read() {} });
+const returned = r.setMaxListeners(20);
+console.log("returns self:", returned === r);
+console.log("max set:", r.getMaxListeners() === 20);

--- a/test-parity/node-suite/stream/events/setMaxListeners-stays-applied.ts
+++ b/test-parity/node-suite/stream/events/setMaxListeners-stays-applied.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// setMaxListeners(N) — value sticks across operations.
+const r = new Readable({ read() {} });
+r.setMaxListeners(50);
+r.on("data", () => {});
+r.on("end", () => {});
+console.log("after ops:", r.getMaxListeners());
+console.log("still 50:", r.getMaxListeners() === 50);

--- a/test-parity/node-suite/stream/iter-helpers/for-each-empty-stream.ts
+++ b/test-parity/node-suite/stream/iter-helpers/for-each-empty-stream.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// forEach on empty stream — no calls, resolves to undefined.
+const r = Readable.from([]);
+let calls = 0;
+const result = await (r as any).forEach((_x: any) => { calls++; });
+console.log("calls:", calls);
+console.log("result:", result);

--- a/test-parity/node-suite/stream/iter-helpers/reduce-with-initial.ts
+++ b/test-parity/node-suite/stream/iter-helpers/reduce-with-initial.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// reduce(fn, initial) with explicit initial value.
+const r = Readable.from([1, 2, 3, 4]);
+const result = await (r as any).reduce((acc: number, x: number) => acc + x, 100);
+console.log("result:", result);
+console.log("is 110:", result === 110);

--- a/test-parity/node-suite/stream/readable/from-arguments-object.ts
+++ b/test-parity/node-suite/stream/readable/from-arguments-object.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// arguments object is iterable (Array-like) — Readable.from yields each arg.
+function test() {
+  return Readable.from(arguments as any);
+}
+const r = test("a", "b", "c");
+const out: string[] = [];
+for await (const v of r) out.push(String(v));
+console.log("from arguments:", out.join(","));

--- a/test-parity/node-suite/stream/readable/readable-stream-id-properties.ts
+++ b/test-parity/node-suite/stream/readable/readable-stream-id-properties.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// Stream constructor exposes a fresh object — each new() makes distinct instances.
+const r1 = new Readable({ read() {} });
+const r2 = new Readable({ read() {} });
+console.log("distinct instances:", r1 !== r2);
+console.log("both readable:", r1.readable && r2.readable);
+console.log("not same proto:", Object.getPrototypeOf(r1) === Object.getPrototypeOf(r2));

--- a/test-parity/node-suite/stream/web/from-empty-array.ts
+++ b/test-parity/node-suite/stream/web/from-empty-array.ts
@@ -1,0 +1,7 @@
+import { ReadableStream } from "node:stream/web";
+// RS.from([]) — yields no data; reader gets {done:true} immediately.
+const rs = (ReadableStream as any).from([]);
+const reader = rs.getReader();
+const result = await reader.read();
+console.log("value:", result.value);
+console.log("done:", result.done);

--- a/test-parity/node-suite/stream/web/transform-stream-instanceof-check.ts
+++ b/test-parity/node-suite/stream/web/transform-stream-instanceof-check.ts
@@ -1,0 +1,8 @@
+import { TransformStream, ReadableStream, WritableStream } from "node:stream/web";
+// TransformStream — not instanceof RS or WS; readable/writable ARE.
+const ts = new TransformStream();
+console.log("ts instanceof TS:", ts instanceof TransformStream);
+console.log("ts instanceof RS:", ts instanceof ReadableStream);
+console.log("ts instanceof WS:", ts instanceof WritableStream);
+console.log("readable RS:", ts.readable instanceof ReadableStream);
+console.log("writable WS:", ts.writable instanceof WritableStream);


### PR DESCRIPTION
### Stream parity batch — 8 tests aggregated (iter-132..133)

**1 free pass + 7 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | transform-stream-instanceof-check, from-empty-array ✅ | #1545 |
| Readable shape | from-arguments-object, readable-stream-id-properties | #1532 |
| Stream events | setMaxListeners-stays-applied, set-max-listeners-chainable | #1532 |
| Iter helpers | reduce-with-initial, for-each-empty-stream | #1558 |

Free pass: `web/from-empty-array` (RS.from([]) yields {done:true}).

All 7 failures tracked in `known_failures.json`.