### PR TITLE
fix(gc): barrier Promise pointer stores for async resumption

### DIFF
--- a/crates/perry-runtime/src/gc/tests/barrier.rs
+++ b/crates/perry-runtime/src/gc/tests/barrier.rs
@@ -1036,6 +1036,88 @@ fn test_dirty_page_promise_value_slot_marks_child() {
     remembered_set_clear();
 }
 
+fn assert_heap_child_marked(ptr: *const u8, label: &str) {
+    assert!(!ptr.is_null(), "{label} should not be null");
+    unsafe {
+        let header = header_from_user_ptr(ptr);
+        assert_ne!(
+            (*header).gc_flags & GC_FLAG_MARKED,
+            0,
+            "{label} should be marked through the Promise remembered-set edge"
+        );
+    }
+}
+
+#[test]
+fn test_promise_pointer_field_stores_dirty_old_page() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+    reset_remembered_set();
+    clear_marks();
+    let promise = unsafe { alloc_old_test_promise() };
+    let callback = crate::closure::js_closure_alloc(test_captured_singleton_func as *const u8, 0);
+    let next = crate::promise::js_promise_then(promise, callback, std::ptr::null());
+
+    assert!(
+        remembered_set_size() > 0,
+        "js_promise_then should dirty old Promise pointer fields"
+    );
+    let valid_ptrs = build_valid_pointer_set();
+    mark_remembered_set_roots(&valid_ptrs);
+    assert_heap_child_marked(callback as *const u8, "then fulfillment callback");
+    assert_heap_child_marked(next as *const u8, "then next promise");
+
+    reset_remembered_set();
+    clear_marks();
+    let inner = unsafe { alloc_old_test_promise() };
+    let outer = crate::promise::js_promise_new();
+    crate::promise::js_promise_resolve_with_promise(outer, inner);
+
+    assert!(
+        remembered_set_size() > 0,
+        "js_promise_resolve_with_promise should dirty old Promise next"
+    );
+    let valid_ptrs = build_valid_pointer_set();
+    mark_remembered_set_roots(&valid_ptrs);
+    assert_heap_child_marked(outer as *const u8, "resolved outer promise");
+
+    reset_remembered_set();
+    clear_marks();
+    let promise = unsafe { alloc_old_test_promise() };
+    let fulfill = crate::closure::js_closure_alloc(test_captured_singleton_func as *const u8, 0);
+    let reject = crate::closure::js_closure_alloc(test_captured_singleton_func as *const u8, 0);
+    crate::promise::js_promise_attach_handlers(promise, fulfill, reject);
+
+    assert!(
+        remembered_set_size() > 0,
+        "js_promise_attach_handlers should dirty old Promise callback fields"
+    );
+    let valid_ptrs = build_valid_pointer_set();
+    mark_remembered_set_roots(&valid_ptrs);
+    assert_heap_child_marked(fulfill as *const u8, "attached fulfillment callback");
+    assert_heap_child_marked(reject as *const u8, "attached rejection callback");
+
+    reset_remembered_set();
+    clear_marks();
+    let promise = unsafe { alloc_old_test_promise() };
+    let on_finally = crate::closure::js_closure_alloc(test_captured_singleton_func as *const u8, 0);
+    let _next = crate::promise::js_promise_finally(promise, on_finally);
+    let (fulfill_wrap, reject_wrap) = unsafe { ((*promise).on_fulfilled, (*promise).on_rejected) };
+
+    assert!(
+        remembered_set_size() > 0,
+        "js_promise_finally should dirty old Promise wrapper fields"
+    );
+    let valid_ptrs = build_valid_pointer_set();
+    mark_remembered_set_roots(&valid_ptrs);
+    assert_heap_child_marked(fulfill_wrap as *const u8, "finally fulfillment wrapper");
+    assert_heap_child_marked(reject_wrap as *const u8, "finally rejection wrapper");
+
+    clear_marks();
+    remembered_set_clear();
+}
+
 #[test]
 fn test_dirty_page_error_cause_slot_marks_child() {
     reset_remembered_set();

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -9,6 +9,26 @@ unsafe fn store_promise_jsvalue_slot(promise: *mut Promise, slot: *mut f64, valu
     crate::gc::runtime_store_gc_jsvalue_slot(promise as usize, slot as usize, value.to_bits());
 }
 
+#[inline]
+unsafe fn store_promise_closure_slot(
+    promise: *mut Promise,
+    slot: *mut ClosurePtr,
+    value: ClosurePtr,
+) {
+    // GC_STORE_AUDIT(BARRIERED): Promise raw closure fields are GC heap words.
+    crate::gc::runtime_store_gc_heap_word_slot(promise as usize, slot as usize, value as u64);
+}
+
+#[inline]
+unsafe fn store_promise_next_slot(
+    promise: *mut Promise,
+    slot: *mut *mut Promise,
+    value: *mut Promise,
+) {
+    // GC_STORE_AUDIT(BARRIERED): Promise raw next fields are GC heap words.
+    crate::gc::runtime_store_gc_heap_word_slot(promise as usize, slot as usize, value as u64);
+}
+
 /// Allocate a new Promise
 #[no_mangle]
 pub extern "C" fn js_promise_new() -> *mut Promise {
@@ -197,7 +217,7 @@ pub extern "C" fn js_promise_resolve_with_promise(outer: *mut Promise, inner: *m
                     && (*inner).on_rejected.is_null()
                     && (*inner).next.is_null()
                 {
-                    (*inner).next = outer;
+                    store_promise_next_slot(inner, std::ptr::addr_of_mut!((*inner).next), outer);
                     return;
                 }
 
@@ -217,9 +237,22 @@ pub extern "C" fn js_promise_resolve_with_promise(outer: *mut Promise, inner: *m
                 crate::closure::js_closure_set_capture_ptr(reject_closure, 0, outer_i64);
 
                 // Register the forwarding callbacks on the inner promise
-                (*inner).on_fulfilled = resolve_closure;
-                (*inner).on_rejected = reject_closure;
-                (*inner).next = ptr::null_mut(); // Don't chain, we handle resolution ourselves
+                store_promise_closure_slot(
+                    inner,
+                    std::ptr::addr_of_mut!((*inner).on_fulfilled),
+                    resolve_closure,
+                );
+                store_promise_closure_slot(
+                    inner,
+                    std::ptr::addr_of_mut!((*inner).on_rejected),
+                    reject_closure,
+                );
+                // Don't chain; the forwarding callbacks handle resolution.
+                store_promise_next_slot(
+                    inner,
+                    std::ptr::addr_of_mut!((*inner).next),
+                    ptr::null_mut(),
+                );
             }
         }
     }
@@ -306,9 +339,17 @@ pub extern "C" fn js_promise_then(
     let next = js_promise_new();
 
     unsafe {
-        (*promise).on_fulfilled = on_fulfilled;
-        (*promise).on_rejected = on_rejected;
-        (*promise).next = next;
+        store_promise_closure_slot(
+            promise,
+            std::ptr::addr_of_mut!((*promise).on_fulfilled),
+            on_fulfilled,
+        );
+        store_promise_closure_slot(
+            promise,
+            std::ptr::addr_of_mut!((*promise).on_rejected),
+            on_rejected,
+        );
+        store_promise_next_slot(promise, std::ptr::addr_of_mut!((*promise).next), next);
         set_promise_callback_context(promise);
 
         // If already settled, schedule callback immediately. Same propagation
@@ -364,8 +405,16 @@ pub(crate) fn js_promise_attach_handlers(
         return;
     }
     unsafe {
-        (*promise).on_fulfilled = on_fulfilled;
-        (*promise).on_rejected = on_rejected;
+        store_promise_closure_slot(
+            promise,
+            std::ptr::addr_of_mut!((*promise).on_fulfilled),
+            on_fulfilled,
+        );
+        store_promise_closure_slot(
+            promise,
+            std::ptr::addr_of_mut!((*promise).on_rejected),
+            on_rejected,
+        );
         set_promise_callback_context(promise);
         // No next — caller doesn't want a chained promise.
 
@@ -449,9 +498,22 @@ pub extern "C" fn js_promise_finally(
     // the wrapper — each wrapper handles `next` settlement itself via the
     // extra-tick passthrough pattern.
     unsafe {
-        (*promise).on_fulfilled = fulfill_wrap;
-        (*promise).on_rejected = reject_wrap;
-        (*promise).next = ptr::null_mut(); // wrappers own next; runner must not touch it
+        store_promise_closure_slot(
+            promise,
+            std::ptr::addr_of_mut!((*promise).on_fulfilled),
+            fulfill_wrap,
+        );
+        store_promise_closure_slot(
+            promise,
+            std::ptr::addr_of_mut!((*promise).on_rejected),
+            reject_wrap,
+        );
+        // Wrappers own next; runner must not touch it.
+        store_promise_next_slot(
+            promise,
+            std::ptr::addr_of_mut!((*promise).next),
+            ptr::null_mut(),
+        );
         set_promise_callback_context(promise);
 
         // If the promise is already settled, push its task now.

--- a/scripts/gc_store_site_inventory.py
+++ b/scripts/gc_store_site_inventory.py
@@ -41,6 +41,9 @@ CODEGEN_EMIT_RAW_STORE_RE = re.compile(r'emit_raw\(format!\("store\b')
 RUST_FIELD_STORE_RE = re.compile(
     r"\(\*[^)\n]+\)\.(?P<field>keys_array|entries|elements)\s*="
 )
+RUST_PROMISE_FIELD_STORE_RE = re.compile(
+    r"\(\*[^)\n]+\)\.(?P<field>on_fulfilled|on_rejected|next)\s*="
+)
 RUST_POINTER_FIELD_STORE_RE = re.compile(
     r"\b(?P<owner>[A-Za-z_][A-Za-z0-9_]*)\.(?P<field>string_ptr)\s*="
 )
@@ -73,7 +76,7 @@ SCAN_PATHS = [
     Path("crates/perry-runtime/src/regex.rs"),
     Path("crates/perry-runtime/src/plugin.rs"),
     Path("crates/perry-runtime/src/thread.rs"),
-    Path("crates/perry-runtime/src/promise.rs"),
+    Path("crates/perry-runtime/src/promise"),
     Path("crates/perry-runtime/src/map.rs"),
     Path("crates/perry-runtime/src/set.rs"),
     Path("crates/perry-runtime/src/string.rs"),
@@ -270,6 +273,10 @@ def classify_rust_store(path: Path, lines: list[str], index: int) -> str | None:
 
     if RUST_TLS_INDEX_STORE_RE.search(line) and is_risky_tls_index_store(window):
         return "raw TLS cache pointer table store"
+
+    if "crates/perry-runtime/src/promise/" in path.as_posix():
+        if RUST_PROMISE_FIELD_STORE_RE.search(line):
+            return "raw Promise heap pointer field store"
 
     pointer_field = RUST_POINTER_FIELD_STORE_RE.search(line)
     if pointer_field:
@@ -501,6 +508,16 @@ def run_self_tests() -> int:
         "crates/perry-runtime/src/promise.rs",
         ["*fields.add(0) = promise_box_handle.get_nanbox_f64();"],
         "raw direct slot assignment",
+    )
+    check(
+        "crates/perry-runtime/src/promise/then.rs",
+        ["(*promise).on_fulfilled = callback;"],
+        "raw Promise heap pointer field store",
+    )
+    check(
+        "crates/perry-runtime/src/promise/then.rs",
+        ["(*promise).next = next;"],
+        "raw Promise heap pointer field store",
     )
 
     if failures:

--- a/tests/test_async_selective_evacuation_1597.ts
+++ b/tests/test_async_selective_evacuation_1597.ts
@@ -1,0 +1,32 @@
+// Regression test for #1597: selective generational evacuation must keep
+// Promise async-resumption edges up to date after young closures/promises move.
+//
+// Expected output:
+//   await: ok
+//   outer post: ok
+//   AFTER nested - reached
+
+async function runCb(cb: () => Promise<void>) {
+  await cb();
+}
+
+async function viaAwait() {
+  await Promise.resolve();
+  console.log("await: ok");
+}
+
+async function nested() {
+  await runCb(async () => {
+    await runCb(async () => {
+      await Promise.resolve();
+    });
+    await Promise.resolve();
+    console.log("outer post: ok");
+  });
+}
+
+(async () => {
+  await runCb(viaAwait);
+  await nested();
+  console.log("AFTER nested - reached");
+})();


### PR DESCRIPTION
## Summary
- Route Promise raw heap pointer stores (`on_fulfilled`, `on_rejected`, `next`) through the GC runtime heap-word store barrier.
- Add a focused remembered-set canary for Promise pointer stores used by `then`, `resolve_with_promise`, `attach_handlers`, and `finally`.
- Add a #1597 async regression fixture and teach the GC store-site inventory to scan Promise raw pointer fields.

## Verification
- `cargo fmt`
- `python3 scripts/gc_store_site_inventory.py --json-out tmp/gc-store-site-inventory-1597-pr.json --gate`
- `cargo test -p perry-runtime gc::tests::barrier::test_promise_pointer_field_stores_dirty_old_page`
- `cargo build --release -p perry`
- `./target/release/perry run tests/test_async_selective_evacuation_1597.ts`
- `PERRY_GC_VERIFY_EVACUATION=1 ./test_async_selective_evacuation_1597`
- `PERRY_GC_TRACE=1 ./test_async_selective_evacuation_1597`

Fixes #1597.