### PR TITLE
test(parity): stream — batch of 8 tier-13 tests (iter-136..137) (2 free pass, 6 #1532/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3109,5 +3109,41 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-string-as-iterable-single-chunk": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from('text') — chunk shape/count wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/eventNames-with-symbols": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: eventNames does not include Symbol event keys. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/map-async-with-concurrency": {
+    "issue": "1558",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: map(asyncFn, {concurrency}) — toArray output wrong. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/readable/from-set-deduplicates": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Set with duplicates) — count or order wrong (Set should dedup). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/get-event-listeners-count": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: getEventListeners(emitter, event) — wrong count/array shape. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/readable-flag-after-end": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: readable boolean — wrong value before/after end. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/eventNames-with-symbols.ts
+++ b/test-parity/node-suite/stream/events/eventNames-with-symbols.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+import { errorMonitor } from "node:events";
+// eventNames includes Symbol event keys.
+const r = new Readable({ read() {} });
+r.on("data", () => {});
+r.on(errorMonitor, () => {});
+const names = r.eventNames();
+console.log("length:", names.length);
+console.log("has data:", names.includes("data"));
+console.log("has symbol:", names.includes(errorMonitor));

--- a/test-parity/node-suite/stream/events/get-event-listeners-count.ts
+++ b/test-parity/node-suite/stream/events/get-event-listeners-count.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+import { getEventListeners } from "node:events";
+// getEventListeners — returns array with all listeners for the event.
+const r = new Readable({ read() {} });
+r.on("custom", () => {});
+r.on("custom", () => {});
+r.on("custom", () => {});
+const arr = getEventListeners(r, "custom");
+console.log("isArray:", Array.isArray(arr));
+console.log("length:", arr.length);

--- a/test-parity/node-suite/stream/iter-helpers/map-async-with-concurrency.ts
+++ b/test-parity/node-suite/stream/iter-helpers/map-async-with-concurrency.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// map(asyncFn, {concurrency:2}) — supports concurrency option.
+const r = Readable.from([1, 2, 3, 4]);
+const result = await (r as any).map(
+  async (x: number) => {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    return x * 10;
+  },
+  { concurrency: 2 },
+).toArray();
+console.log("result:", result.join(","));

--- a/test-parity/node-suite/stream/readable/from-set-deduplicates.ts
+++ b/test-parity/node-suite/stream/readable/from-set-deduplicates.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Set automatically deduplicates; Readable.from(Set) preserves that.
+const s = new Set(["a", "b", "a", "c", "b"]);
+const r = Readable.from(s);
+const out: string[] = [];
+for await (const v of r) out.push(String(v));
+console.log("count:", out.length);
+console.log("values:", out.join(","));

--- a/test-parity/node-suite/stream/readable/from-string-as-iterable-single-chunk.ts
+++ b/test-parity/node-suite/stream/readable/from-string-as-iterable-single-chunk.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Readable.from("text") — Node short-circuits: single chunk, NOT char-by-char.
+const r = Readable.from("text");
+const chunks: any[] = [];
+r.on("data", (c) => chunks.push(c));
+r.on("end", () => {
+  console.log("chunks:", chunks.length);
+  console.log("first:", chunks[0]);
+});

--- a/test-parity/node-suite/stream/readable/readable-flag-after-end.ts
+++ b/test-parity/node-suite/stream/readable/readable-flag-after-end.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// After 'end', readable flag becomes false.
+const r = Readable.from(["a"]);
+console.log("initial readable:", r.readable);
+r.on("data", () => {});
+r.on("end", () => {
+  console.log("after end readable:", r.readable);
+});

--- a/test-parity/node-suite/stream/web/enqueue-object-chunks.ts
+++ b/test-parity/node-suite/stream/web/enqueue-object-chunks.ts
@@ -1,0 +1,18 @@
+import { ReadableStream } from "node:stream/web";
+// Default RS accepts arbitrary value types in enqueue.
+const rs = new ReadableStream({
+  start(c) {
+    c.enqueue(42);
+    c.enqueue({ a: 1 });
+    c.enqueue([1, 2, 3]);
+    c.close();
+  },
+});
+const reader = rs.getReader();
+const out: any[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(typeof value);
+}
+console.log("types:", out.join(","));

--- a/test-parity/node-suite/stream/web/transform-with-only-flush.ts
+++ b/test-parity/node-suite/stream/web/transform-with-only-flush.ts
@@ -1,0 +1,14 @@
+import { TransformStream } from "node:stream/web";
+// TransformStream with only flush() (no transform fn) — identity transform
+// + flush emits final value.
+const ts = new TransformStream({
+  flush(c) { c.enqueue("FINAL"); },
+});
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("x");
+await writer.close();
+const a = await reader.read();
+const b = await reader.read();
+console.log("a:", a.value);
+console.log("b:", b.value);


### PR DESCRIPTION
### Stream parity batch — 8 tests aggregated (iter-136..137)

**2 free passes + 6 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | transform-with-only-flush ✅, enqueue-object-chunks ✅ | #1545 |
| Readable shape | from-string-as-iterable-single-chunk, from-set-deduplicates, readable-flag-after-end | #1532 |
| Stream events | eventNames-with-symbols, get-event-listeners-count | #1532 |
| Iter helpers | map-async-with-concurrency | #1558 |

Free passes:
- `web/transform-with-only-flush` (flush-only TS works)
- `web/enqueue-object-chunks` (default RS accepts arbitrary value types)

All 6 failures tracked in `known_failures.json`.