### PR TITLE
test(parity): stream — batch of 8 tier-14 tests (iter-138..139) (1 free pass, 7 #1532/#1539/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3109,5 +3109,47 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/from-bigint-throws": {
+    "issue": "1545",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream/web: RS.from(bigint) — should throw TypeError. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/push-empty-string-no-end": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: push('') — treats empty string as end signal. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/write-encoded-buffer": {
+    "issue": "1539",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: write(Buffer) — encoding arg not 'buffer'. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/events/listener-fires-with-this-emitter": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: 'data' listener `this` not bound to emitter (non-arrow fn). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-gen-with-early-return": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: generator with explicit return — values yielded after return statement aren't reached. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/listener-closure-counter": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: listener with closure counter — count wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/four-stage-chain-v2": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: 4-stage pipe — wrong output. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/listener-closure-counter.ts
+++ b/test-parity/node-suite/stream/events/listener-closure-counter.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Listener uses outer-scope counter; counter increments on each fire.
+const r = new Readable({ read() {} });
+let counter = 0;
+r.on("ping", () => counter++);
+r.emit("ping");
+r.emit("ping");
+r.emit("ping");
+console.log("count:", counter);

--- a/test-parity/node-suite/stream/events/listener-fires-with-this-emitter.ts
+++ b/test-parity/node-suite/stream/events/listener-fires-with-this-emitter.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// 'data' listener with `this` — binds to the emitter (in non-arrow fn).
+const r = new Readable({ read() {} });
+let thisIsEmitter = false;
+r.on("data", function (this: any) {
+  thisIsEmitter = this === r;
+});
+r.push("x");
+r.push(null);
+r.on("end", () => console.log("this===r:", thisIsEmitter));

--- a/test-parity/node-suite/stream/pipe/four-stage-chain-v2.ts
+++ b/test-parity/node-suite/stream/pipe/four-stage-chain-v2.ts
@@ -1,0 +1,10 @@
+import { Readable, Transform, PassThrough } from "node:stream";
+// 4-stage pipe: src → t1 → t2 → sink.
+const src = Readable.from(["a"]);
+const t1 = new Transform({ transform(c, _e, cb) { cb(null, String(c) + "1"); } });
+const t2 = new Transform({ transform(c, _e, cb) { cb(null, String(c) + "2"); } });
+const sink = new PassThrough();
+const out: string[] = [];
+sink.on("data", (c) => out.push(String(c)));
+sink.on("end", () => console.log("piped:", out.join(",")));
+src.pipe(t1).pipe(t2).pipe(sink);

--- a/test-parity/node-suite/stream/readable/from-gen-with-early-return.ts
+++ b/test-parity/node-suite/stream/readable/from-gen-with-early-return.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Generator that returns early via `return` — stream ends at that point.
+function* gen() {
+  yield 1;
+  yield 2;
+  return; // explicit return
+  yield 3; // never reached
+}
+const r = Readable.from(gen());
+const out: number[] = [];
+for await (const v of r) out.push(v as number);
+console.log("count:", out.length);
+console.log("values:", out.join(","));

--- a/test-parity/node-suite/stream/readable/push-empty-string-no-end.ts
+++ b/test-parity/node-suite/stream/readable/push-empty-string-no-end.ts
@@ -1,0 +1,17 @@
+import { Readable } from "node:stream";
+// push('') — empty string is a valid chunk, NOT an end signal.
+// Only push(null) signals end.
+const r = new Readable({ read() {} });
+let dataCount = 0;
+let endFired = false;
+r.on("data", () => dataCount++);
+r.on("end", () => (endFired = true));
+r.push("");
+r.push("x");
+r.push(null);
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("data count:", dataCount);
+    console.log("end fired:", endFired);
+  });
+});

--- a/test-parity/node-suite/stream/web/from-arraybuffer-typed-array.ts
+++ b/test-parity/node-suite/stream/web/from-arraybuffer-typed-array.ts
@@ -1,0 +1,13 @@
+import { ReadableStream } from "node:stream/web";
+// RS.from(Uint16Array) — typed array is iterable; yields each element.
+const arr = new Uint16Array([100, 200, 300]);
+const rs = (ReadableStream as any).from(arr);
+const reader = rs.getReader();
+const out: number[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(value as number);
+}
+console.log("count:", out.length);
+console.log("values:", out.join(","));

--- a/test-parity/node-suite/stream/web/from-bigint-throws.ts
+++ b/test-parity/node-suite/stream/web/from-bigint-throws.ts
@@ -1,0 +1,10 @@
+import { ReadableStream } from "node:stream/web";
+// RS.from(bigint) — bigint is not iterable → TypeError.
+let caught: string | null = null;
+try {
+  (ReadableStream as any).from(42n);
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/writable/write-encoded-buffer.ts
+++ b/test-parity/node-suite/stream/writable/write-encoded-buffer.ts
@@ -1,0 +1,17 @@
+import { Writable } from "node:stream";
+// write(Buffer) — sink receives the Buffer; encoding arg is 'buffer'.
+let receivedEnc: any = null;
+let receivedBuf: any = null;
+const w = new Writable({
+  write(c, enc, cb) {
+    receivedEnc = enc;
+    receivedBuf = c;
+    cb();
+  },
+});
+w.write(Buffer.from("hi"));
+w.end();
+w.on("finish", () => {
+  console.log("enc:", receivedEnc);
+  console.log("isBuffer:", Buffer.isBuffer(receivedBuf));
+});


### PR DESCRIPTION
### Stream parity batch — 8 tests aggregated (iter-138..139)

**1 free pass + 7 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | from-bigint-throws, from-arraybuffer-typed-array ✅ | #1545 |
| Readable shape | push-empty-string-no-end, from-gen-with-early-return | #1532 |
| Writable buffering | write-encoded-buffer | #1539 |
| Stream events | listener-fires-with-this-emitter, listener-closure-counter | #1532 |
| Pipe | four-stage-chain-v2 | #1532 |

Free pass: `web/from-arraybuffer-typed-array` (RS.from(Uint16Array) yields elements).

All 7 failures tracked in `known_failures.json`.