### PR TITLE
test(parity): stream — batch of 8 tier-14 tests (iter-140..141) (4 free pass, 4 #1531/#1532)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3109,5 +3109,29 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/listener-added-fires-on-emit": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: listener after add — does not fire on emit. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/many-listeners-on-dst": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: multi 'data' listeners on dst — count or values wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-gen-return-value-ignored": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: gen 'return value' included as chunk (should be ignored). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/composite-end-event": {
+    "issue": "1531",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: composite 'end' event does not fire after src exhausts. Flips to PASS when #1531 lands."
   }
 }

--- a/test-parity/node-suite/stream/compose/composite-end-event.ts
+++ b/test-parity/node-suite/stream/compose/composite-end-event.ts
@@ -1,0 +1,11 @@
+import { compose, Readable, Transform } from "node:stream";
+// Composite stream fires 'end' after upstream exhausts.
+const src = Readable.from(["a", "b"]);
+const t = new Transform({ transform(c, _e, cb) { cb(null, c); } });
+const composed: any = compose(src, t);
+let endFired = false;
+composed.on("end", () => (endFired = true));
+composed.on("data", () => {});
+setImmediate(() => {
+  setImmediate(() => console.log("end fired:", endFired));
+});

--- a/test-parity/node-suite/stream/events/listener-added-fires-on-emit.ts
+++ b/test-parity/node-suite/stream/events/listener-added-fires-on-emit.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// Add listener, emit, listener fires.
+const r = new Readable({ read() {} });
+let fired = false;
+r.on("trigger", () => (fired = true));
+r.emit("trigger");
+console.log("fired:", fired);

--- a/test-parity/node-suite/stream/flow/data-listener-resumes-paused-source.ts
+++ b/test-parity/node-suite/stream/flow/data-listener-resumes-paused-source.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Source paused; adding 'data' listener should NOT auto-resume (per Node docs).
+const r = Readable.from(["a", "b"]);
+r.pause();
+console.log("paused before listener:", !r.readableFlowing);
+let dataCount = 0;
+r.on("data", () => dataCount++);
+setImmediate(() => {
+  console.log("data count while paused:", dataCount);
+});

--- a/test-parity/node-suite/stream/pipe/many-listeners-on-dst.ts
+++ b/test-parity/node-suite/stream/pipe/many-listeners-on-dst.ts
@@ -1,0 +1,13 @@
+import { Readable, PassThrough } from "node:stream";
+// Multiple 'data' listeners on dst — each receives every chunk.
+const r = Readable.from(["a", "b"]);
+const dst = new PassThrough();
+const a: string[] = [];
+const b: string[] = [];
+dst.on("data", (c) => a.push(String(c)));
+dst.on("data", (c) => b.push(String(c)));
+r.pipe(dst);
+dst.on("end", () => {
+  console.log("a:", a.join(","));
+  console.log("b:", b.join(","));
+});

--- a/test-parity/node-suite/stream/readable/from-gen-return-value-ignored.ts
+++ b/test-parity/node-suite/stream/readable/from-gen-return-value-ignored.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Generator with `return value` — the returned value is NOT yielded as a chunk.
+function* gen() {
+  yield 1;
+  yield 2;
+  return 999; // not yielded
+}
+const r = Readable.from(gen());
+const out: number[] = [];
+for await (const v of r) out.push(v as number);
+console.log("count:", out.length);
+console.log("values:", out.join(","));
+console.log("no 999:", !out.includes(999));

--- a/test-parity/node-suite/stream/readable/from-promise-iterating-once.ts
+++ b/test-parity/node-suite/stream/readable/from-promise-iterating-once.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Readable.from(Promise.resolve(value)) — treats Promise as iterable? No;
+// Node yields the resolved value as a single chunk.
+const r = Readable.from(Promise.resolve("resolved-value"));
+const out: any[] = [];
+r.on("data", (v) => out.push(v));
+r.on("end", () => {
+  console.log("count:", out.length);
+  console.log("first:", out[0]);
+});

--- a/test-parity/node-suite/stream/web/no-enqueue-empty-close.ts
+++ b/test-parity/node-suite/stream/web/no-enqueue-empty-close.ts
@@ -1,0 +1,7 @@
+import { ReadableStream } from "node:stream/web";
+// Stream that calls c.close() in start with no enqueue — empty stream.
+const rs = new ReadableStream({ start(c) { c.close(); } });
+const reader = rs.getReader();
+const result = await reader.read();
+console.log("value:", result.value);
+console.log("done:", result.done);

--- a/test-parity/node-suite/stream/web/pipe-to-without-options.ts
+++ b/test-parity/node-suite/stream/web/pipe-to-without-options.ts
@@ -1,0 +1,7 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// pipeTo() with no options arg — defaults work.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const ws = new WritableStream({ write() {} });
+await rs.pipeTo(ws);
+console.log("rs locked after:", rs.locked);
+console.log("ws locked after:", ws.locked);


### PR DESCRIPTION
### Stream parity batch — 8 tests aggregated (iter-140..141)

**4 free passes + 4 tracked failures — 50% pass rate.**

| Category | Tests | Issue |
|---|---|---|
| Readable shape | from-promise-iterating-once ✅, from-gen-return-value-ignored | #1532 |
| Web stream surface | pipe-to-without-options ✅, no-enqueue-empty-close ✅ | #1545 |
| Flow | data-listener-resumes-paused-source ✅ | — |
| Events | listener-added-fires-on-emit | #1532 |
| Pipe | many-listeners-on-dst | #1532 |
| Compose | composite-end-event | #1531 |

Free passes — Perry already matches Node:
- `readable/from-promise-iterating-once` (Promise yields resolved value as single chunk)
- `web/pipe-to-without-options` (default options work)
- `web/no-enqueue-empty-close` (close-only stream → {done:true})
- `flow/data-listener-resumes-paused-source` (paused source stays paused after adding listener)

All 4 failures tracked in `known_failures.json`.