### PR TITLE
test(parity): stream — batch of 12 tier-14 tests focused on consumers + promises (iter-142..144) (9 free pass, 3 #1532)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3109,5 +3109,23 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/promises/pipeline-five-stages": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: 5-stage promises-pipeline — final sink doesn't receive chunks. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/promises/pipeline-array-source-promise": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: promises.pipeline(array, dst) — sync iterable source not collected. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/promises/finished-abortable-signal-abort": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: promises.finished({signal}) — abort doesn't reject with AbortError. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/consumers/array-buffer-equals-buffer.ts
+++ b/test-parity/node-suite/stream/consumers/array-buffer-equals-buffer.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+import { arrayBuffer, buffer } from "node:stream/consumers";
+// arrayBuffer() and buffer() should yield equivalent byte content.
+const data = ["abc", "def"];
+const r1 = Readable.from(data);
+const r2 = Readable.from(data);
+const ab = await arrayBuffer(r1);
+const buf = await buffer(r2);
+console.log("ab byteLength:", ab.byteLength);
+console.log("buf length:", buf.length);
+console.log("match:", ab.byteLength === buf.length);

--- a/test-parity/node-suite/stream/consumers/blob-content-size.ts
+++ b/test-parity/node-suite/stream/consumers/blob-content-size.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+import { blob } from "node:stream/consumers";
+// blob() returns Blob with .size === total bytes.
+const r = Readable.from(["hello"]);
+const b = await blob(r);
+console.log("is Blob:", b instanceof Blob);
+console.log("size:", b.size);
+console.log("text:", await b.text());

--- a/test-parity/node-suite/stream/consumers/buffer-empty-stream.ts
+++ b/test-parity/node-suite/stream/consumers/buffer-empty-stream.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+import { buffer } from "node:stream/consumers";
+// buffer() on empty stream returns empty Buffer.
+const r = Readable.from([]);
+const result = await buffer(r);
+console.log("isBuffer:", Buffer.isBuffer(result));
+console.log("length:", result.length);
+console.log("is empty:", result.length === 0);

--- a/test-parity/node-suite/stream/consumers/buffer-multi-chunk-concat.ts
+++ b/test-parity/node-suite/stream/consumers/buffer-multi-chunk-concat.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { buffer } from "node:stream/consumers";
+// buffer() concatenates multiple chunks into one Buffer.
+const r = Readable.from([Buffer.from("ab"), Buffer.from("cd"), Buffer.from("ef")]);
+const result = await buffer(r);
+console.log("length:", result.length);
+console.log("content:", result.toString("utf8"));

--- a/test-parity/node-suite/stream/consumers/json-multi-chunk.ts
+++ b/test-parity/node-suite/stream/consumers/json-multi-chunk.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { json } from "node:stream/consumers";
+// JSON split across multiple chunks — reassembled correctly.
+const r = Readable.from([`{"name":`, `"perry","ver`, `sion":1}`]);
+const result = await json(r) as any;
+console.log("name:", result.name);
+console.log("version:", result.version);

--- a/test-parity/node-suite/stream/consumers/json-parses-array.ts
+++ b/test-parity/node-suite/stream/consumers/json-parses-array.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { json } from "node:stream/consumers";
+// json() parses a streamed JSON document into the corresponding JS value.
+const r = Readable.from([`[1, 2, 3]`]);
+const result = await json(r);
+console.log("isArray:", Array.isArray(result));
+console.log("values:", (result as number[]).join(","));

--- a/test-parity/node-suite/stream/consumers/text-empty-stream.ts
+++ b/test-parity/node-suite/stream/consumers/text-empty-stream.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { text } from "node:stream/consumers";
+// text() on an empty stream returns ''.
+const r = Readable.from([]);
+const result = await text(r);
+console.log("result:", JSON.stringify(result));
+console.log("is empty:", result === "");

--- a/test-parity/node-suite/stream/consumers/text-from-web-readable-stream.ts
+++ b/test-parity/node-suite/stream/consumers/text-from-web-readable-stream.ts
@@ -1,0 +1,9 @@
+import { ReadableStream } from "node:stream/web";
+import { text } from "node:stream/consumers";
+// text() works on Web ReadableStream too.
+const rs = new ReadableStream({
+  start(c) { c.enqueue("hello"); c.enqueue(" world"); c.close(); },
+});
+const result = await text(rs as any);
+console.log("result:", result);
+console.log("matches:", result === "hello world");

--- a/test-parity/node-suite/stream/consumers/text-multi-chunk-concat.ts
+++ b/test-parity/node-suite/stream/consumers/text-multi-chunk-concat.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { text } from "node:stream/consumers";
+// text() concatenates multiple chunks into one string.
+const r = Readable.from(["hello", " ", "world"]);
+const result = await text(r);
+console.log("result:", result);
+console.log("matches:", result === "hello world");

--- a/test-parity/node-suite/stream/promises/finished-abortable-signal-abort.ts
+++ b/test-parity/node-suite/stream/promises/finished-abortable-signal-abort.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
+// finished() with a signal — abort rejects the promise.
+const r = new Readable({ read() {} });
+const ctrl = new AbortController();
+r.on("error", () => {});
+setTimeout(() => ctrl.abort(), 10);
+let errName: string | null = null;
+try {
+  await finished(r, { signal: ctrl.signal });
+} catch (e: any) {
+  errName = e && e.name;
+}
+console.log("rejected:", errName);

--- a/test-parity/node-suite/stream/promises/pipeline-array-source-promise.ts
+++ b/test-parity/node-suite/stream/promises/pipeline-array-source-promise.ts
@@ -1,0 +1,8 @@
+import { PassThrough } from "node:stream";
+import { pipeline } from "node:stream/promises";
+// pipeline() promises form with array source.
+const dst = new PassThrough();
+const collected: string[] = [];
+dst.on("data", (c) => collected.push(String(c)));
+await pipeline(["a", "b", "c"], dst);
+console.log("collected:", collected.join(","));

--- a/test-parity/node-suite/stream/promises/pipeline-five-stages.ts
+++ b/test-parity/node-suite/stream/promises/pipeline-five-stages.ts
@@ -1,0 +1,13 @@
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+// 5-stage promises-pipeline.
+const src = Readable.from(["a"]);
+const t1 = new Transform({ transform(c, _e, cb) { cb(null, String(c) + "1"); } });
+const t2 = new Transform({ transform(c, _e, cb) { cb(null, String(c) + "2"); } });
+const t3 = new Transform({ transform(c, _e, cb) { cb(null, String(c) + "3"); } });
+const collected: string[] = [];
+async function* sink(source: AsyncIterable<any>) {
+  for await (const v of source) collected.push(String(v));
+}
+await pipeline(src, t1, t2, t3, sink as any);
+console.log("result:", collected.join(","));


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-142..144)

**9 free passes + 3 tracked failures — 75% pass rate, the highest of the run.**

Pivoted from the saturated main stream surface to the `stream/consumers` and `stream/promises` submodules; consumers is essentially at parity.

| Category | Tests | Issue |
|---|---|---|
| stream/consumers | text-empty ✅, buffer-empty ✅, arrayBuffer-equals-buffer ✅, text-multi-concat ✅, buffer-multi-concat ✅, json-array ✅, text-from-web-rs ✅, json-multi-chunk ✅, blob-size ✅ | — |
| stream/promises | pipeline-five-stages, pipeline-array-source, finished-abortable-signal | #1532 |

Free passes: every single `stream/consumers` test added passed. Failures isolated to promises-form pipeline/finished.

All 3 failures tracked in `known_failures.json`.