### PR TITLE
fix(json/fastify): empty-object JSON.stringify segfault (#1704) + req.url query string (#1705)

### DIFF
--- a/crates/perry-ext-fastify/src/context.rs
+++ b/crates/perry-ext-fastify/src/context.rs
@@ -221,12 +221,21 @@ pub unsafe extern "C" fn js_fastify_req_method(ctx_handle: Handle) -> *mut Strin
     std::ptr::null_mut()
 }
 
-/// `request.url` / `c.req.url` — the path (query string lives in
-/// `query_string`).
+/// `request.url` / `c.req.url` — the path **with** its query string, matching
+/// Node/Fastify where `req.url` is the raw request target (e.g. `/p?k=v`).
+/// `FastifyContext` splits the incoming target into `url` (path) and
+/// `query_string` for routing/`req.query`, so reconstruct the original here.
+/// #1705: returning the bare path dropped `?k=v`, so `@hono/perry-server`'s
+/// `new Request('http://' + host + req.url)` lost the query and
+/// `c.req.query()` / `new URL(c.req.url).searchParams` came back empty.
 #[no_mangle]
 pub unsafe extern "C" fn js_fastify_req_url(ctx_handle: Handle) -> *mut StringHeader {
     if let Some(ctx) = get_handle::<FastifyContext>(ctx_handle) {
-        return alloc_string(&ctx.url).as_raw();
+        if ctx.query_string.is_empty() {
+            return alloc_string(&ctx.url).as_raw();
+        }
+        let full = format!("{}?{}", ctx.url, ctx.query_string);
+        return alloc_string(&full).as_raw();
     }
     std::ptr::null_mut()
 }

--- a/crates/perry-ext-fastify/src/lib.rs
+++ b/crates/perry-ext-fastify/src/lib.rs
@@ -285,6 +285,40 @@ mod tests {
     }
 
     #[test]
+    fn req_url_includes_query_string() {
+        // #1705 — `c.req.url` / `req.url` must carry the query string like
+        // Node/Fastify (`@hono/perry-server` builds `new Request(host + req.url)`
+        // from it). The context splits the target internally, so the FFI getter
+        // reconstructs `path?query`.
+        let with_query = FastifyContext::new(
+            0,
+            "GET".to_string(),
+            "/u3?a=1&b=2".to_string(),
+            HashMap::new(),
+            None,
+            HashMap::new(),
+        );
+        let h = register_handle(with_query);
+        let got = unsafe { crate::context::string_from_header(super::js_fastify_req_url(h)) };
+        assert_eq!(got.as_deref(), Some("/u3?a=1&b=2"));
+        drop_handle(h);
+
+        // No query → bare path, no trailing '?'.
+        let no_query = FastifyContext::new(
+            0,
+            "GET".to_string(),
+            "/u3".to_string(),
+            HashMap::new(),
+            None,
+            HashMap::new(),
+        );
+        let h2 = register_handle(no_query);
+        let got2 = unsafe { crate::context::string_from_header(super::js_fastify_req_url(h2)) };
+        assert_eq!(got2.as_deref(), Some("/u3"));
+        drop_handle(h2);
+    }
+
+    #[test]
     fn ext_fastify_is_context_handle_membership() {
         // #1293 — the membership probe perry-stdlib's external-fastify
         // dispatch arms consult before forwarding `(request as any).json()`

--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -620,4 +620,36 @@ mod tests {
         expected.push('"');
         assert_eq!(unsafe { str_from_header(output).unwrap() }, expected);
     }
+
+    #[test]
+    fn stringify_empty_object_emits_braces_not_null() {
+        // #1704: an object straight out of `js_object_alloc` has a null
+        // `keys_array` (this is the shape of `Object.fromEntries([])`,
+        // `Object.fromEntries(emptyURLSearchParams)`, and a never-mutated
+        // `{}` literal). It must stringify to "{}" — pre-fix the top-level
+        // path emitted the literal "null".
+        let empty = crate::object::js_object_alloc(0, 0);
+        assert!(unsafe { (*empty).keys_array.is_null() });
+        let boxed = crate::value::js_nanbox_pointer(empty as i64);
+        let output = unsafe { js_json_stringify(boxed, TYPE_UNKNOWN) };
+        assert_eq!(unsafe { str_from_header(output).unwrap() }, "{}");
+    }
+
+    #[test]
+    fn stringify_nested_empty_object_does_not_segfault() {
+        // #1704: a nested empty object reaches `stringify_object_inner`
+        // directly via the `GC_TYPE_OBJECT` arm of `stringify_value_depth`
+        // (no `is_object_pointer` guard), so the null `keys_array` read
+        // would segfault. It must instead recurse to "{}" — the
+        // `@hono/perry-server` handler crash was `JSON.stringify({ url, o })`
+        // with `o = Object.fromEntries(emptyURLSearchParams)`.
+        let empty = crate::object::js_object_alloc(0, 0);
+        let outer = crate::object::js_object_alloc(0, 1);
+        let key = js_string_from_bytes(b"o".as_ptr(), 1);
+        let empty_boxed = crate::value::js_nanbox_pointer(empty as i64);
+        crate::object::js_object_set_field_by_name(outer, key, empty_boxed);
+        let outer_boxed = crate::value::js_nanbox_pointer(outer as i64);
+        let output = unsafe { js_json_stringify(outer_boxed, TYPE_UNKNOWN) };
+        assert_eq!(unsafe { str_from_header(output).unwrap() }, r#"{"o":{}}"#);
+    }
 }

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -397,6 +397,13 @@ pub(crate) unsafe fn stringify_value(value: f64, type_hint: u32, buf: &mut Strin
             crate::gc::GC_TYPE_OBJECT => {
                 if is_object_pointer(ptr) {
                     stringify_object(ptr, buf);
+                } else if (*(ptr as *const crate::ObjectHeader)).keys_array.is_null() {
+                    // #1704: a genuinely empty object (null keys_array, e.g.
+                    // `Object.fromEntries([])` / a never-mutated `{}`) fails
+                    // `is_object_pointer`'s `keys_len > 0` guard but is valid —
+                    // emit "{}" not "null". A non-empty object that fails the
+                    // check is treated as corrupted and still emits "null".
+                    buf.push_str("{}");
                 } else {
                     buf.push_str("null");
                 }
@@ -577,6 +584,21 @@ pub(crate) unsafe fn stringify_object(ptr: *const u8, buf: &mut String) {
 }
 
 pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, depth: u32) {
+    // #1704: an object with a null `keys_array` has no own enumerable
+    // properties — empty objects come out of `js_object_alloc` with
+    // `keys_array == null` and only get one once a field is set. This is the
+    // shape of `Object.fromEntries([])`, `Object.fromEntries(emptyURLSearchParams)`,
+    // and a never-mutated `{}` literal. Recursion into a nested empty object
+    // reaches here directly (the `GC_TYPE_OBJECT` arm in `stringify_value_depth`
+    // skips `is_object_pointer`), so the `(*keys_arr).length` read below would
+    // dereference null and segfault (the `Object.fromEntries(URL.searchParams)`
+    // crash inside a `@hono/perry-server` handler). Emit "{}" and return — an
+    // empty object has no children, so it can't be part of a cycle and the
+    // circular-reference tracking below is unnecessary.
+    if (*(ptr as *const crate::ObjectHeader)).keys_array.is_null() {
+        buf.push_str("{}");
+        return;
+    }
     if depth > MAX_FAST_DEPTH {
         // Deep nesting — switch to full circular detection
         if STRINGIFY_STACK.with(|s| s.borrow().contains(&(ptr as usize))) {


### PR DESCRIPTION
Fixes #1704 and #1705.

The reported "Fastify-specific segfault" was actually **two independent bugs**, and the crash is not Fastify-specific.

## #1704 — empty-object `JSON.stringify` segfault

`Object.fromEntries(new URL(c.req.url).searchParams)` crashed inside a `@hono/perry-server` handler. Root cause: an **empty object** straight out of `js_object_alloc` has `keys_array == null` (the shape of `Object.fromEntries([])`, `Object.fromEntries(emptyURLSearchParams)`, and a never-mutated `{}` literal). `JSON.stringify`'s nested-value path (`stringify_value_depth`, `GC_TYPE_OBJECT` arm) calls `stringify_object_inner` **without** the `is_object_pointer` guard, so the `(*keys_arr).length` read dereferenced null → SIGSEGV.

The handler hit this because the query was empty (due to #1705), so `Object.fromEntries` got an empty `URLSearchParams`. It reproduces in-process too: `JSON.stringify({ x: {} })` crashed and `JSON.stringify({})` wrongly returned `"null"`.

**Fix** (`crates/perry-runtime/src/json/stringify.rs`):
- Guard the top of `stringify_object_inner` for a null `keys_array` → emit `{}` (covers every recursion path).
- Route the top-level empty-object case to `{}` instead of `"null"`.

Output now matches Node byte-for-byte for empty / nested-empty objects from any source (literal, `fromEntries`, `Map`, `URLSearchParams`).

## #1705 — `req.url` dropped the query string

`FastifyContext` splits the incoming request target into `url` (path) + `query_string` for routing, and `js_fastify_req_url` returned only the path. `@hono/perry-server` builds `new Request('http://' + host + req.url)`, so the query was lost and `c.req.query()` / `new URL(c.req.url).searchParams` came back empty.

**Fix** (`crates/perry-ext-fastify/src/context.rs`): the getter reconstructs `path?query` to match Node/Fastify.

## Validation

End-to-end via `@hono/perry-server`:
```
GET /u3?a=1&b=2          -> {"url":".../u3?a=1&b=2","o":{"a":"1","b":"2"}}
GET /u3                  -> {"url":".../u3","o":{}}
GET /api/echo?name=ada&lang=ts -> {"url":".../api/echo?name=ada&lang=ts","o":{"name":"ada","lang":"ts"}}
```
Server stays alive (was SIGSEGV before). An 11-case `JSON.stringify` comparison is byte-identical to Node; the existing `serve_smoke` example still works.

## Tests

- `stringify_empty_object_emits_braces_not_null` (perry-runtime)
- `stringify_nested_empty_object_does_not_segfault` (perry-runtime)
- `req_url_includes_query_string` (perry-ext-fastify)
