### PR TITLE
fix(compile): const x = require('./user-module') binds undefined (#1721)

### DIFF
--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -246,6 +246,41 @@ module.exports = inner;
     }
 
     #[test]
+    fn issue_1721_blanks_adopted_alias_require_in_body() {
+        // #1721: `const c = require('./common')` adopts `c` as the import
+        // local name (so `import c from './common'`). The original body line
+        // MUST be blanked — otherwise it redeclares `c` inside the IIFE and
+        // the synthetic `require` (which returns `c`) resolves to that inner,
+        // not-yet-initialized binding, so the consumer's
+        // `const c = require('./common')` lands `undefined`. Regression:
+        // before the fix this only happened when hoisting classes.
+        let src = "const c = require('./common');\nconsole.log(c.x);";
+        let wrapped = wrap_commonjs(src, &PathBuf::from("/tmp/test.js"));
+        assert!(
+            wrapped.contains("import c from './common';"),
+            "expected hoisted import using the alias, got:\n{}",
+            wrapped
+        );
+        assert!(
+            !wrapped.contains("require('./common')") || !wrapped.contains("const c = require"),
+            "adopted-alias body line must be blanked so it can't shadow the \
+             import inside the IIFE, got:\n{}",
+            wrapped
+        );
+        assert!(
+            wrapped.contains("console.log(c.x);"),
+            "body references to the binding must survive, got:\n{}",
+            wrapped
+        );
+        // Sanity: the rewritten module still parses.
+        assert!(
+            perry_parser::parse_typescript(&wrapped, "test.js").is_ok(),
+            "wrapped module must parse, got:\n{}",
+            wrapped
+        );
+    }
+
+    #[test]
     fn wrap_falls_back_to_req_n_when_alias_unsafe() {
         // Reserved internal names (`_cjs`, `module`, `exports`, `require`)
         // and `_req_<N>` aliases must not become import locals — fall back

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -102,6 +102,27 @@ pub(in crate::commands::compile) fn wrap_commonjs(source: &str, source_path: &Pa
         chosen_alias_per_spec.insert(spec.clone());
     }
 
+    // #1721: ranges of `const <alias> = require(<spec>)` lines whose alias we
+    // ADOPTED as the import local name above (`import_local_names[idx] == alias`).
+    // The synthetic `require` returns that name, and the hoisted `import <alias>`
+    // already binds it at module scope — so the original body line would
+    // *redeclare* `<alias>` inside the IIFE and shadow the import. Under
+    // function scope the IIFE's `require` then returns the inner, not-yet-
+    // initialized binding → the consumer's `const x = require('./m')` lands
+    // `undefined`. We blank these body lines (below) so both the require-case
+    // return and the body references resolve to the module-scope import via
+    // closure. (Previously this blanking only happened when hoisting classes.)
+    let adopted_alias_strip_ranges: Vec<(usize, usize)> = raw_aliases
+        .iter()
+        .filter(|(alias, spec, _)| {
+            require_specs
+                .iter()
+                .position(|s| s == spec)
+                .is_some_and(|idx| import_local_names[idx] == *alias)
+        })
+        .map(|(_, _, range)| *range)
+        .collect();
+
     let imports = require_specs
         .iter()
         .zip(import_local_names.iter())
@@ -250,7 +271,11 @@ pub(in crate::commands::compile) fn wrap_commonjs(source: &str, source_path: &Pa
     // resolve via the outer `const import_X` through closure scope, so
     // non-hoisted code paths are unaffected.
     let (import_aliases, alias_strip_ranges) = if hoisted_class_block.is_empty() {
-        (String::new(), Vec::new())
+        // No hoisted classes: we don't need to surface module-scope `const
+        // alias = _req_N;` lines (body references resolve to the imports via
+        // closure), but we MUST still blank any adopted-alias `const alias =
+        // require(spec)` lines so they don't shadow the hoisted import (#1721).
+        (String::new(), adopted_alias_strip_ranges)
     } else {
         let aliases = extract_require_aliases_with_ranges(source);
         let lines = aliases
@@ -278,13 +303,17 @@ pub(in crate::commands::compile) fn wrap_commonjs(source: &str, source_path: &Pa
         (lines, ranges)
     };
 
-    let body_for_iife = if hoisted_class_block.is_empty() {
-        source.to_string()
-    } else {
-        // Start from the source with hoisted classes already blanked, then
-        // also blank the surfaced `var import_X = require(...)` lines so
-        // they don't shadow the module-scope aliases when the IIFE runs.
-        let mut s = source_without_hoists;
+    // Start from the source (with hoisted classes already blanked when there
+    // are any), then blank the `<kw> alias = require(...)` lines collected in
+    // `alias_strip_ranges` so they don't shadow the module-scope import/alias
+    // when the IIFE runs. Applies in both cases now: with classes it strips the
+    // surfaced aliases (#665), without classes it strips adopted aliases (#1721).
+    let body_for_iife = {
+        let mut s = if hoisted_class_block.is_empty() {
+            source.to_string()
+        } else {
+            source_without_hoists
+        };
         for (start, end) in alias_strip_ranges.into_iter().rev() {
             let original = &source[start..end];
             let blanked: String = original

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -1385,7 +1385,14 @@ pub(super) fn resolve_import(
                         false
                     }
                 });
-            let kind = if is_js_file(&canonical) && !in_compile_pkg {
+            // #1721 / #668: a *user* `.js` (outside node_modules) compiles
+            // natively now — mirrors collect_modules' `should_use_js_runtime`.
+            // Its import edge MUST be NativeCompiled so the importer wires
+            // `perry_fn_<prefix>__*` symbols; leaving it Interpreted routes to
+            // the (removed, post-#1696) V8 bridge and the default/named export
+            // symbols never link.
+            let in_node_modules = canonical.to_string_lossy().contains("node_modules");
+            let kind = if is_js_file(&canonical) && !in_compile_pkg && in_node_modules {
                 ModuleKind::Interpreted
             } else {
                 ModuleKind::NativeCompiled
@@ -1399,12 +1406,15 @@ pub(super) fn resolve_import(
     if import_source.starts_with('/') {
         let resolved = PathBuf::from(import_source);
         if let Some(path) = resolve_with_extensions(&resolved) {
-            let kind = if is_js_file(&path) {
+            let canonical = path.canonicalize().ok()?;
+            // #1721: same node_modules-gated rule as relative imports.
+            let in_node_modules = canonical.to_string_lossy().contains("node_modules");
+            let kind = if is_js_file(&canonical) && in_node_modules {
                 ModuleKind::Interpreted
             } else {
                 ModuleKind::NativeCompiled
             };
-            return Some((path.canonicalize().ok()?, kind));
+            return Some((canonical, kind));
         }
         return None;
     }
@@ -1525,12 +1535,13 @@ pub(super) fn resolve_import(
                         ));
                     }
                 }
-                // Same `.ts` / `.tsx` → NativeCompiled rule as the
-                // node_modules fallback above. Keeps `file:` deps that
-                // ship TypeScript source aligned with `collect_modules`'s
-                // recursive native walk.
+                // `.ts`/`.tsx` → NativeCompiled, as the node_modules fallback
+                // above. #1721: `file:` deps live outside node_modules (user
+                // code), so their `.js` also compiles natively; only genuine
+                // node_modules JS stays Interpreted.
                 let canonical = entry.canonicalize().ok()?;
-                let kind = if is_ts_file(&canonical) {
+                let in_node_modules = canonical.to_string_lossy().contains("node_modules");
+                let kind = if is_ts_file(&canonical) || !in_node_modules {
                     ModuleKind::NativeCompiled
                 } else {
                     ModuleKind::Interpreted


### PR DESCRIPTION
Fixes #1721. Follow-up to #668 / #1711 (require()/.js native compile).

## Problem

Binding a **user CommonJS module** via `const c = require('./m')` returned `undefined` under `perry compile`, so any `c.<prop>` threw. (Side-effect `require('../common')` and *builtin* binding `const path = require('path')` already worked.) This was the dominant `runtime-fail` in the #800 node-core radar — every test doing `const common = require('../common')` died.

## Root cause — two layers

**1. `cjs_wrap` self-shadowing.** The importer adopts the alias `c` as the hoisted import (`import c from './m'`) and the synthetic `require` returns `c`, intending the body's `const c = require('./m')` to be blanked. But that blanking only ran when the module hoisted classes. With no classes, the body line survived and redeclared `c` inside the IIFE — so `require('./m')` returned the shadowed, not-yet-initialized binding → `undefined`. Fix: blank adopted-alias body lines regardless of hoisted classes.

**2. Import-edge misclassification.** A relative/absolute/`file:` `.js` import was tagged `ModuleKind::Interpreted` purely by extension, routing it to the (removed, #1696) V8 bridge — so the default/named export symbols were never emitted and the binary failed to link (`_perry_fn___v8___..._default`). Fix: node_modules-gate the classification in `resolve.rs`, mirroring `collect_modules`' `should_use_js_runtime` — a user `.js` outside `node_modules` is `NativeCompiled`. node_modules `.js` (site 3) is unchanged.

## Validation

- New `cjs_wrap` regression unit test (`issue_1721_blanks_adopted_alias_require_in_body`); all 49 cjs_wrap unit tests pass.
- `const c = require('./common')` now binds the module object (`typeof c === "object"`, methods callable), matching Node.
- Raw Node `test/parallel` cases that use `const common = require('../common')` now run.

## Blast radius

Only changes classification for user `.js`/`.cjs` **outside** node_modules (previously routed to the dead V8 path). node_modules JS and compile-packages handling are unchanged.
