### PR TITLE
test(parity): stream — consolidated iter-115..144 batch (batches 16–27)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3109,5 +3109,515 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/readable-event-with-objectmode": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: objectMode 'readable' event — read() returns wrong object values. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/emit-with-arg-array": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: emit(event, a, b, c, d) — listeners receive wrong args. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/many-pushes-accumulate": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: many push() — readableLength does not match total bytes. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/drop-zero-yields-all": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: drop(0) — yields wrong items. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/web/from-async-gen-throws-mid": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: RS.from(asyncGen throws mid) — read() does not reject. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/listener-throw-does-not-stop-others": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: listener throw in emit — second listener may or may not fire (Perry differs from Node). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/cancel-during-pull": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: cancel() during pull — read() does not resolve {done:true}. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/iter-with-custom-return": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: for-await break — custom iterator.return() not invoked. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/events/captureRejections-constructor": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable({captureRejections}) — async listener throws not caught as 'error'. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/pipe-error-handler-on-source": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: src.on('error') during pipe — handler receives wrong error / not called. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/destroy-emits-error-event": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroy(err) — 'error' fires after 'close', or order wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/listener-count-by-symbol-event": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: listenerCount(Symbol) — count wrong for Symbol-keyed listeners. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/some-finds-match": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: some() — does not short-circuit at first match (calls > N). Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/pipeline/async-iter-source": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline(asyncIterable, dst, cb) — async-iterable source not handled. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-empty-string": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from('') — empty-string source iteration count wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/raw-listeners-empty": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: rawListeners(no-event) — should return empty array, doesn't. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/prepend-listener-returns-this": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: prependListener() does not return emitter (chainable). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/tee-mid-consume-throws": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: tee() after getReader+read — should throw TypeError. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/source-immediate-error": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe() src immediate error — error not fired on src listener. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-string-iterates-codepoints": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(string) — chunk count / shape wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/destroyed-after-finish": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Writable destroyed false after 'finish' (autoDestroy default true). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/multiple-events-event-names": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: eventNames does not include all registered event names. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/end-cb-fires-after-flush": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: end(cb) — cb fires before write callbacks or before finish. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/events/event-names-empty-array": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: fresh stream eventNames not empty array. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/writable-end-on-source-end": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe(dst) — dst not ended after src ends. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/encoding-via-constructor": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: encoding option in ctor — readableEncoding wrong or data not string. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/new-listener-fires-before-add": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'newListener' fires after the listener is added (should be before). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/pipe-to-plain-writable": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe() to plain Writable — collected wrong / empty. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/destroy-without-error": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroy() no arg — destroyed flag wrong or error event fires. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/byob-reader-method-shape": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: BYOB reader missing methods (read/releaseLock) or .closed prop. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/instance-method-bind-this": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: detached instance method called without `this` — wrong behavior (Perry should throw). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/dst-write-returns-false-pauses-src": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe() src pause/resume events on backpressure — wrong order/missing. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/remove-listener-after-removal": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'removeListener' meta-event fires before removal (should be after). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/three-stages-order": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose(src,t1,t2) — output transformation order wrong. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/duplex-acts-as-writable": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Duplex write side — received array empty / wrong order. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/remove-non-registered-listener": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: removeListener of non-registered fn — returns wrong value or eventNames non-empty. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipeline/async-source-throws-mid": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline(asyncGen src throws mid, dst, cb) — error not received in cb. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/compose-non-stream-throws": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose(string) — does not throw TypeError. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/static-from-with-options": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(iter, opts) — objectMode/hwm 2nd-arg not applied. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/multiple-pipes-from-same-source": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe to two dsts — each dst receives wrong chunks. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/two-stage-error-stops": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose 2-stage err — composite 'error' event not fired. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/from-buffer-emits-single": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Buffer) — not single Buffer chunk (iterates byte-by-byte). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/listener-cleanup-after-once-fires": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: once() — rawListeners count after fire not zero. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/push-string-with-encoding-set": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: setEncoding + push(string) — data not delivered as string. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/with-passthrough-mid": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose(src, t1, PassThrough, t2) — chain produces wrong output. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/from-set-of-strings": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Set) — iteration order or count wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/emit-different-events-isolated": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: emit different events — count interference across event keys. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/cancel-with-undefined-reason": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: cancel(undefined) explicit — fails to compile or reason isn't undefined. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/end-true-explicit-still-ends": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe(dst,{end:true}) — dst not ended after source ends. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipeline/sync-iterable-source": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline(array, dst, cb) — sync iterable source not wired. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/transform-stream-instanceof-check": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: TransformStream instance — fails instanceof checks vs RS/WS for readable/writable sides. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/from-arguments-object": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(arguments) — Array-like iteration fails. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/setMaxListeners-stays-applied": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: setMaxListeners(50) — value not preserved across operations. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/reduce-with-initial": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: reduce(fn, initial) — initial value not used or wrong sum. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/iter-helpers/for-each-empty-stream": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: forEach() on empty — calls non-zero or result not undefined. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/events/set-max-listeners-chainable": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: setMaxListeners returns wrong value (should return emitter). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/readable-stream-id-properties": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: distinct Readable instances — same identity or wrong prototype shared. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/writable-side-getters": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Duplex writable-side getters — wrong types or undefined. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/transform-piped-twice": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: pipeThrough().pipeThrough() — second transform output wrong. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/pipe-many-data-events": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe with 20 chunks — order or count wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/emit-error-multi-listener": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: emit('error') multi-listener — wrong call counts. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/strategy-size-non-number": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: strategy.size returning non-number — doesn't throw on enqueue. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/constructor-is-function": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: constructor.name / typeof not 'function' on stream classes. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-string-chunk-buffer": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from('hello') — chunk type/shape doesn't match Node. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/just-source-only": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose(src) — only source given, Duplex output empty. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/from-string-as-iterable-single-chunk": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from('text') — chunk shape/count wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/eventNames-with-symbols": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: eventNames does not include Symbol event keys. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/map-async-with-concurrency": {
+    "issue": "1558",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: map(asyncFn, {concurrency}) — toArray output wrong. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/readable/from-set-deduplicates": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Set with duplicates) — count or order wrong (Set should dedup). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/get-event-listeners-count": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: getEventListeners(emitter, event) — wrong count/array shape. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/readable-flag-after-end": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: readable boolean — wrong value before/after end. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/from-bigint-throws": {
+    "issue": "1545",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream/web: RS.from(bigint) — should throw TypeError. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/push-empty-string-no-end": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: push('') — treats empty string as end signal. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/write-encoded-buffer": {
+    "issue": "1539",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: write(Buffer) — encoding arg not 'buffer'. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/events/listener-fires-with-this-emitter": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: 'data' listener `this` not bound to emitter (non-arrow fn). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-gen-with-early-return": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: generator with explicit return — values yielded after return statement aren't reached. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/listener-closure-counter": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: listener with closure counter — count wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/four-stage-chain-v2": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: 4-stage pipe — wrong output. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/listener-added-fires-on-emit": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: listener after add — does not fire on emit. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/many-listeners-on-dst": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: multi 'data' listeners on dst — count or values wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-gen-return-value-ignored": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: gen 'return value' included as chunk (should be ignored). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/composite-end-event": {
+    "issue": "1531",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: composite 'end' event does not fire after src exhausts. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/promises/pipeline-five-stages": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: 5-stage promises-pipeline — final sink doesn't receive chunks. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/promises/pipeline-array-source-promise": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: promises.pipeline(array, dst) — sync iterable source not collected. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/promises/finished-abortable-signal-abort": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: promises.finished({signal}) — abort doesn't reject with AbortError. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/compose/composite-end-event.ts
+++ b/test-parity/node-suite/stream/compose/composite-end-event.ts
@@ -1,0 +1,11 @@
+import { compose, Readable, Transform } from "node:stream";
+// Composite stream fires 'end' after upstream exhausts.
+const src = Readable.from(["a", "b"]);
+const t = new Transform({ transform(c, _e, cb) { cb(null, c); } });
+const composed: any = compose(src, t);
+let endFired = false;
+composed.on("end", () => (endFired = true));
+composed.on("data", () => {});
+setImmediate(() => {
+  setImmediate(() => console.log("end fired:", endFired));
+});

--- a/test-parity/node-suite/stream/compose/just-source-only.ts
+++ b/test-parity/node-suite/stream/compose/just-source-only.ts
@@ -1,0 +1,7 @@
+import { compose, Readable } from "node:stream";
+// compose(src) — single-source compose returns Duplex wrapping it.
+const src = Readable.from(["a", "b"]);
+const composed: any = compose(src);
+const out: string[] = [];
+composed.on("data", (c: any) => out.push(String(c)));
+composed.on("end", () => console.log("data:", out.join(",")));

--- a/test-parity/node-suite/stream/compose/three-stages-order.ts
+++ b/test-parity/node-suite/stream/compose/three-stages-order.ts
@@ -1,0 +1,8 @@
+import { compose, Readable, Transform } from "node:stream";
+// compose(src, t1, t2) — order of transforms preserved.
+const src = Readable.from(["a"]);
+const upper = new Transform({ transform(c, _e, cb) { cb(null, String(c).toUpperCase()); } });
+const wrap = new Transform({ transform(c, _e, cb) { cb(null, "<" + String(c) + ">"); } });
+const composed: any = compose(src, upper, wrap);
+composed.on("data", (c: any) => console.log("got:", String(c)));
+composed.on("end", () => console.log("done"));

--- a/test-parity/node-suite/stream/compose/two-stage-error-stops.ts
+++ b/test-parity/node-suite/stream/compose/two-stage-error-stops.ts
@@ -1,0 +1,12 @@
+import { compose, Readable, Transform } from "node:stream";
+// compose(src, t1, t2) where t2 errors — composite emits error.
+const src = Readable.from(["a", "b"]);
+const t1 = new Transform({ transform(c, _e, cb) { cb(null, c); } });
+const t2 = new Transform({
+  transform(_c, _e, cb) { cb(new Error("t2-fail")); },
+});
+const composed: any = compose(src, t1, t2);
+let errMsg: string | null = null;
+composed.on("error", (e: any) => (errMsg = e && e.message));
+composed.on("data", () => {});
+composed.on("close", () => console.log("err:", errMsg));

--- a/test-parity/node-suite/stream/compose/with-passthrough-mid.ts
+++ b/test-parity/node-suite/stream/compose/with-passthrough-mid.ts
@@ -1,0 +1,9 @@
+import { compose, Readable, Transform, PassThrough } from "node:stream";
+// compose(src, t1, PassThrough, t2) — PassThrough in the middle.
+const src = Readable.from(["a"]);
+const upper = new Transform({ transform(c, _e, cb) { cb(null, String(c).toUpperCase()); } });
+const pt = new PassThrough();
+const wrap = new Transform({ transform(c, _e, cb) { cb(null, "<" + String(c) + ">"); } });
+const composed: any = compose(src, upper, pt, wrap);
+composed.on("data", (c: any) => console.log("got:", String(c)));
+composed.on("end", () => console.log("done"));

--- a/test-parity/node-suite/stream/consumers/array-buffer-equals-buffer.ts
+++ b/test-parity/node-suite/stream/consumers/array-buffer-equals-buffer.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+import { arrayBuffer, buffer } from "node:stream/consumers";
+// arrayBuffer() and buffer() should yield equivalent byte content.
+const data = ["abc", "def"];
+const r1 = Readable.from(data);
+const r2 = Readable.from(data);
+const ab = await arrayBuffer(r1);
+const buf = await buffer(r2);
+console.log("ab byteLength:", ab.byteLength);
+console.log("buf length:", buf.length);
+console.log("match:", ab.byteLength === buf.length);

--- a/test-parity/node-suite/stream/consumers/blob-content-size.ts
+++ b/test-parity/node-suite/stream/consumers/blob-content-size.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+import { blob } from "node:stream/consumers";
+// blob() returns Blob with .size === total bytes.
+const r = Readable.from(["hello"]);
+const b = await blob(r);
+console.log("is Blob:", b instanceof Blob);
+console.log("size:", b.size);
+console.log("text:", await b.text());

--- a/test-parity/node-suite/stream/consumers/buffer-empty-stream.ts
+++ b/test-parity/node-suite/stream/consumers/buffer-empty-stream.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+import { buffer } from "node:stream/consumers";
+// buffer() on empty stream returns empty Buffer.
+const r = Readable.from([]);
+const result = await buffer(r);
+console.log("isBuffer:", Buffer.isBuffer(result));
+console.log("length:", result.length);
+console.log("is empty:", result.length === 0);

--- a/test-parity/node-suite/stream/consumers/buffer-multi-chunk-concat.ts
+++ b/test-parity/node-suite/stream/consumers/buffer-multi-chunk-concat.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { buffer } from "node:stream/consumers";
+// buffer() concatenates multiple chunks into one Buffer.
+const r = Readable.from([Buffer.from("ab"), Buffer.from("cd"), Buffer.from("ef")]);
+const result = await buffer(r);
+console.log("length:", result.length);
+console.log("content:", result.toString("utf8"));

--- a/test-parity/node-suite/stream/consumers/json-multi-chunk.ts
+++ b/test-parity/node-suite/stream/consumers/json-multi-chunk.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { json } from "node:stream/consumers";
+// JSON split across multiple chunks — reassembled correctly.
+const r = Readable.from([`{"name":`, `"perry","ver`, `sion":1}`]);
+const result = await json(r) as any;
+console.log("name:", result.name);
+console.log("version:", result.version);

--- a/test-parity/node-suite/stream/consumers/json-parses-array.ts
+++ b/test-parity/node-suite/stream/consumers/json-parses-array.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { json } from "node:stream/consumers";
+// json() parses a streamed JSON document into the corresponding JS value.
+const r = Readable.from([`[1, 2, 3]`]);
+const result = await json(r);
+console.log("isArray:", Array.isArray(result));
+console.log("values:", (result as number[]).join(","));

--- a/test-parity/node-suite/stream/consumers/text-empty-stream.ts
+++ b/test-parity/node-suite/stream/consumers/text-empty-stream.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { text } from "node:stream/consumers";
+// text() on an empty stream returns ''.
+const r = Readable.from([]);
+const result = await text(r);
+console.log("result:", JSON.stringify(result));
+console.log("is empty:", result === "");

--- a/test-parity/node-suite/stream/consumers/text-from-web-readable-stream.ts
+++ b/test-parity/node-suite/stream/consumers/text-from-web-readable-stream.ts
@@ -1,0 +1,9 @@
+import { ReadableStream } from "node:stream/web";
+import { text } from "node:stream/consumers";
+// text() works on Web ReadableStream too.
+const rs = new ReadableStream({
+  start(c) { c.enqueue("hello"); c.enqueue(" world"); c.close(); },
+});
+const result = await text(rs as any);
+console.log("result:", result);
+console.log("matches:", result === "hello world");

--- a/test-parity/node-suite/stream/consumers/text-multi-chunk-concat.ts
+++ b/test-parity/node-suite/stream/consumers/text-multi-chunk-concat.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { text } from "node:stream/consumers";
+// text() concatenates multiple chunks into one string.
+const r = Readable.from(["hello", " ", "world"]);
+const result = await text(r);
+console.log("result:", result);
+console.log("matches:", result === "hello world");

--- a/test-parity/node-suite/stream/events/captureRejection-symbol-fn.ts
+++ b/test-parity/node-suite/stream/events/captureRejection-symbol-fn.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// Stream constructor with captureRejections — async handler errors caught.
+const r = new Readable({ read() {}, captureRejections: true } as any);
+let caught: any = null;
+r.on("error", (e) => (caught = e && (e as Error).message));
+r.on("data", async () => {
+  throw new Error("rejection-in-data");
+});
+r.push("x");
+r.push(null);
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("captured:", caught);
+  });
+});

--- a/test-parity/node-suite/stream/events/captureRejections-constructor.ts
+++ b/test-parity/node-suite/stream/events/captureRejections-constructor.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+// Readable({captureRejections: true}) — listener throws are caught.
+const r = new Readable({ read() {}, captureRejections: true } as any);
+let caughtErr: any = null;
+r.on("error", (e) => (caughtErr = e && (e as Error).message));
+r.on("custom", async () => {
+  throw new Error("listener-fail");
+});
+r.emit("custom");
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("caught:", caughtErr);
+  });
+});

--- a/test-parity/node-suite/stream/events/constructor-is-function.ts
+++ b/test-parity/node-suite/stream/events/constructor-is-function.ts
@@ -1,0 +1,7 @@
+import { Readable, Writable } from "node:stream";
+// Stream classes are functions.
+console.log("Readable typeof:", typeof Readable);
+console.log("Writable typeof:", typeof Writable);
+const r = new Readable({ read() {} });
+console.log("r.constructor typeof:", typeof r.constructor);
+console.log("r.constructor.name:", r.constructor.name);

--- a/test-parity/node-suite/stream/events/emit-different-events-isolated.ts
+++ b/test-parity/node-suite/stream/events/emit-different-events-isolated.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Listeners for different events don't interfere.
+const r = new Readable({ read() {} });
+let a = 0, b = 0;
+r.on("eventA", () => a++);
+r.on("eventB", () => b++);
+r.emit("eventA");
+r.emit("eventB");
+r.emit("eventA");
+console.log("a:", a, "b:", b);
+console.log("isolated:", a === 2 && b === 1);

--- a/test-parity/node-suite/stream/events/emit-error-multi-listener.ts
+++ b/test-parity/node-suite/stream/events/emit-error-multi-listener.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// emit('error', e) with multiple listeners — all fire.
+const r = new Readable({ read() {} });
+let counts = [0, 0, 0];
+r.on("error", () => counts[0]++);
+r.on("error", () => counts[1]++);
+r.on("error", () => counts[2]++);
+r.emit("error", new Error("multi"));
+console.log("counts:", counts.join(","));
+console.log("all 1:", counts.every((c) => c === 1));

--- a/test-parity/node-suite/stream/events/emit-with-arg-array.ts
+++ b/test-parity/node-suite/stream/events/emit-with-arg-array.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// emit(event, ...args) — multiple args passed to listeners individually.
+const r = new Readable({ read() {} });
+let captured: any = null;
+r.on("multi", (a: any, b: any, c: any, d: any) => {
+  captured = { a, b, c, d };
+});
+r.emit("multi", 1, "two", { three: 3 }, [4, 5]);
+console.log(JSON.stringify(captured));

--- a/test-parity/node-suite/stream/events/error-with-listener-no-throw.ts
+++ b/test-parity/node-suite/stream/events/error-with-listener-no-throw.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// emit('error', err) with a listener — does NOT throw synchronously.
+const r = new Readable({ read() {} });
+r.on("error", () => {});
+let thrown: any = null;
+try {
+  r.emit("error", new Error("with-listener"));
+} catch (e: any) {
+  thrown = e && e.message;
+}
+console.log("threw:", thrown !== null);

--- a/test-parity/node-suite/stream/events/event-names-empty-array.ts
+++ b/test-parity/node-suite/stream/events/event-names-empty-array.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// Fresh stream — eventNames returns empty array.
+const r = new Readable({ read() {} });
+const names = r.eventNames();
+console.log("is array:", Array.isArray(names));
+console.log("length:", names.length);
+console.log("empty:", names.length === 0);

--- a/test-parity/node-suite/stream/events/eventNames-with-symbols.ts
+++ b/test-parity/node-suite/stream/events/eventNames-with-symbols.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+import { errorMonitor } from "node:events";
+// eventNames includes Symbol event keys.
+const r = new Readable({ read() {} });
+r.on("data", () => {});
+r.on(errorMonitor, () => {});
+const names = r.eventNames();
+console.log("length:", names.length);
+console.log("has data:", names.includes("data"));
+console.log("has symbol:", names.includes(errorMonitor));

--- a/test-parity/node-suite/stream/events/get-event-listeners-count.ts
+++ b/test-parity/node-suite/stream/events/get-event-listeners-count.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+import { getEventListeners } from "node:events";
+// getEventListeners — returns array with all listeners for the event.
+const r = new Readable({ read() {} });
+r.on("custom", () => {});
+r.on("custom", () => {});
+r.on("custom", () => {});
+const arr = getEventListeners(r, "custom");
+console.log("isArray:", Array.isArray(arr));
+console.log("length:", arr.length);

--- a/test-parity/node-suite/stream/events/listener-added-fires-on-emit.ts
+++ b/test-parity/node-suite/stream/events/listener-added-fires-on-emit.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// Add listener, emit, listener fires.
+const r = new Readable({ read() {} });
+let fired = false;
+r.on("trigger", () => (fired = true));
+r.emit("trigger");
+console.log("fired:", fired);

--- a/test-parity/node-suite/stream/events/listener-cleanup-after-once-fires.ts
+++ b/test-parity/node-suite/stream/events/listener-cleanup-after-once-fires.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// once() — listener removed cleanly; rawListeners is empty after fire.
+const r = new Readable({ read() {} });
+r.once("custom", () => {});
+const beforeFire = r.rawListeners("custom").length;
+r.emit("custom");
+const afterFire = r.rawListeners("custom").length;
+console.log("before:", beforeFire);
+console.log("after:", afterFire);
+console.log("cleaned:", afterFire === 0);

--- a/test-parity/node-suite/stream/events/listener-closure-counter.ts
+++ b/test-parity/node-suite/stream/events/listener-closure-counter.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Listener uses outer-scope counter; counter increments on each fire.
+const r = new Readable({ read() {} });
+let counter = 0;
+r.on("ping", () => counter++);
+r.emit("ping");
+r.emit("ping");
+r.emit("ping");
+console.log("count:", counter);

--- a/test-parity/node-suite/stream/events/listener-count-by-symbol-event.ts
+++ b/test-parity/node-suite/stream/events/listener-count-by-symbol-event.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+import { errorMonitor } from "node:events";
+// listenerCount with a Symbol event name works.
+const r = new Readable({ read() {} });
+console.log("before:", r.listenerCount(errorMonitor));
+r.on(errorMonitor, () => {});
+r.on(errorMonitor, () => {});
+console.log("after 2:", r.listenerCount(errorMonitor));

--- a/test-parity/node-suite/stream/events/listener-count-numeric-event.ts
+++ b/test-parity/node-suite/stream/events/listener-count-numeric-event.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// listenerCount with a numeric event key (Node EE accepts strings only;
+// non-string coerces / works as-is depending on impl).
+const r = new Readable({ read() {} });
+console.log("numeric:", r.listenerCount(42 as any));
+console.log("string:", r.listenerCount("42"));
+console.log("both 0:", r.listenerCount(42 as any) === 0 && r.listenerCount("42") === 0);

--- a/test-parity/node-suite/stream/events/listener-fires-with-this-emitter.ts
+++ b/test-parity/node-suite/stream/events/listener-fires-with-this-emitter.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// 'data' listener with `this` — binds to the emitter (in non-arrow fn).
+const r = new Readable({ read() {} });
+let thisIsEmitter = false;
+r.on("data", function (this: any) {
+  thisIsEmitter = this === r;
+});
+r.push("x");
+r.push(null);
+r.on("end", () => console.log("this===r:", thisIsEmitter));

--- a/test-parity/node-suite/stream/events/listener-throw-does-not-stop-others.ts
+++ b/test-parity/node-suite/stream/events/listener-throw-does-not-stop-others.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// If one listener throws synchronously, OTHER listeners may still fire,
+// but EE actually throws the error. Verify behavior either way.
+const r = new Readable({ read() {} });
+let second = 0;
+r.on("custom", () => { throw new Error("first-fail"); });
+r.on("custom", () => second++);
+let outerErr: string | null = null;
+try {
+  r.emit("custom");
+} catch (e: any) {
+  outerErr = e && e.message;
+}
+console.log("outer caught:", outerErr);
+console.log("second listener fired:", second);

--- a/test-parity/node-suite/stream/events/multiple-events-event-names.ts
+++ b/test-parity/node-suite/stream/events/multiple-events-event-names.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Multiple events registered — eventNames returns all of them.
+const r = new Readable({ read() {} });
+r.on("data", () => {});
+r.on("end", () => {});
+r.on("error", () => {});
+r.on("close", () => {});
+const names = r.eventNames();
+console.log("count:", names.length);
+console.log("has data:", names.includes("data"));
+console.log("has end:", names.includes("end"));
+console.log("has error:", names.includes("error"));
+console.log("has close:", names.includes("close"));

--- a/test-parity/node-suite/stream/events/new-listener-fires-before-add.ts
+++ b/test-parity/node-suite/stream/events/new-listener-fires-before-add.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// 'newListener' fires BEFORE the listener is added to the list.
+const r = new Readable({ read() {} });
+r.on("newListener", (event) => {
+  if (event === "custom") {
+    console.log("count at newListener:", r.listenerCount("custom"));
+    // Should still be 0 (the listener hasn't been added yet)
+  }
+});
+r.on("custom", () => {});
+console.log("count after add:", r.listenerCount("custom"));

--- a/test-parity/node-suite/stream/events/prepend-listener-returns-this.ts
+++ b/test-parity/node-suite/stream/events/prepend-listener-returns-this.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// prependListener returns the emitter (chainable).
+const r = new Readable({ read() {} });
+const returned = r.prependListener("custom", () => {});
+console.log("returns self:", returned === r);

--- a/test-parity/node-suite/stream/events/raw-listeners-empty.ts
+++ b/test-parity/node-suite/stream/events/raw-listeners-empty.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// rawListeners(no-listeners-event) — returns empty array.
+const r = new Readable({ read() {} });
+const arr = r.rawListeners("never");
+console.log("is array:", Array.isArray(arr));
+console.log("length:", arr.length);
+console.log("is empty:", arr.length === 0);

--- a/test-parity/node-suite/stream/events/remove-listener-after-removal.ts
+++ b/test-parity/node-suite/stream/events/remove-listener-after-removal.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// 'removeListener' meta-event fires AFTER the listener is removed.
+const r = new Readable({ read() {} });
+const target = () => {};
+r.on("custom", target);
+let countAtMeta: number = -1;
+r.on("removeListener", (event) => {
+  if (event === "custom") countAtMeta = r.listenerCount("custom");
+});
+r.removeListener("custom", target);
+console.log("count at meta:", countAtMeta);
+console.log("count after:", r.listenerCount("custom"));

--- a/test-parity/node-suite/stream/events/remove-non-registered-listener.ts
+++ b/test-parity/node-suite/stream/events/remove-non-registered-listener.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// removeListener of a function never registered — safely no-op.
+const r = new Readable({ read() {} });
+const fn = () => {};
+const result = r.removeListener("never-registered", fn);
+console.log("returns self:", result === r);
+console.log("eventNames empty:", r.eventNames().length === 0);

--- a/test-parity/node-suite/stream/events/set-max-listeners-chainable.ts
+++ b/test-parity/node-suite/stream/events/set-max-listeners-chainable.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// setMaxListeners(N) — should return the emitter (chainable).
+const r = new Readable({ read() {} });
+const returned = r.setMaxListeners(20);
+console.log("returns self:", returned === r);
+console.log("max set:", r.getMaxListeners() === 20);

--- a/test-parity/node-suite/stream/events/setMaxListeners-stays-applied.ts
+++ b/test-parity/node-suite/stream/events/setMaxListeners-stays-applied.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// setMaxListeners(N) — value sticks across operations.
+const r = new Readable({ read() {} });
+r.setMaxListeners(50);
+r.on("data", () => {});
+r.on("end", () => {});
+console.log("after ops:", r.getMaxListeners());
+console.log("still 50:", r.getMaxListeners() === 50);

--- a/test-parity/node-suite/stream/events/symbol-for-rejection.ts
+++ b/test-parity/node-suite/stream/events/symbol-for-rejection.ts
@@ -1,0 +1,5 @@
+import { captureRejectionSymbol } from "node:events";
+// Symbol.for("nodejs.rejection") is captureRejectionSymbol.
+const builtIn = Symbol.for("nodejs.rejection");
+console.log("symbol matches:", builtIn === captureRejectionSymbol);
+console.log("is symbol:", typeof captureRejectionSymbol === "symbol");

--- a/test-parity/node-suite/stream/flow/data-listener-resumes-paused-source.ts
+++ b/test-parity/node-suite/stream/flow/data-listener-resumes-paused-source.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Source paused; adding 'data' listener should NOT auto-resume (per Node docs).
+const r = Readable.from(["a", "b"]);
+r.pause();
+console.log("paused before listener:", !r.readableFlowing);
+let dataCount = 0;
+r.on("data", () => dataCount++);
+setImmediate(() => {
+  console.log("data count while paused:", dataCount);
+});

--- a/test-parity/node-suite/stream/iter-helpers/drop-zero-yields-all.ts
+++ b/test-parity/node-suite/stream/iter-helpers/drop-zero-yields-all.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// drop(0) — yields all original items.
+const r = Readable.from([1, 2, 3, 4]);
+const out: number[] = [];
+for await (const v of (r as any).drop(0)) out.push(v as number);
+console.log("out:", out.join(","));

--- a/test-parity/node-suite/stream/iter-helpers/for-each-empty-stream.ts
+++ b/test-parity/node-suite/stream/iter-helpers/for-each-empty-stream.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// forEach on empty stream — no calls, resolves to undefined.
+const r = Readable.from([]);
+let calls = 0;
+const result = await (r as any).forEach((_x: any) => { calls++; });
+console.log("calls:", calls);
+console.log("result:", result);

--- a/test-parity/node-suite/stream/iter-helpers/map-async-with-concurrency.ts
+++ b/test-parity/node-suite/stream/iter-helpers/map-async-with-concurrency.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// map(asyncFn, {concurrency:2}) — supports concurrency option.
+const r = Readable.from([1, 2, 3, 4]);
+const result = await (r as any).map(
+  async (x: number) => {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    return x * 10;
+  },
+  { concurrency: 2 },
+).toArray();
+console.log("result:", result.join(","));

--- a/test-parity/node-suite/stream/iter-helpers/reduce-with-initial.ts
+++ b/test-parity/node-suite/stream/iter-helpers/reduce-with-initial.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// reduce(fn, initial) with explicit initial value.
+const r = Readable.from([1, 2, 3, 4]);
+const result = await (r as any).reduce((acc: number, x: number) => acc + x, 100);
+console.log("result:", result);
+console.log("is 110:", result === 110);

--- a/test-parity/node-suite/stream/iter-helpers/some-finds-match.ts
+++ b/test-parity/node-suite/stream/iter-helpers/some-finds-match.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// some(fn) returns true on first match; stops early.
+let calls = 0;
+const r = Readable.from([1, 2, 3, 4, 5]);
+const result = await (r as any).some((x: number) => {
+  calls++;
+  return x === 3;
+});
+console.log("result:", result);
+console.log("stopped early (calls <= 3):", calls <= 3);

--- a/test-parity/node-suite/stream/iter-helpers/to-array-empty-stream.ts
+++ b/test-parity/node-suite/stream/iter-helpers/to-array-empty-stream.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// toArray() on empty stream — returns empty array.
+const r = Readable.from([]);
+const result = await (r as any).toArray();
+console.log("is array:", Array.isArray(result));
+console.log("length:", result.length);
+console.log("is empty:", result.length === 0);

--- a/test-parity/node-suite/stream/pipe/dst-write-returns-false-pauses-src.ts
+++ b/test-parity/node-suite/stream/pipe/dst-write-returns-false-pauses-src.ts
@@ -1,0 +1,15 @@
+import { Readable, Writable } from "node:stream";
+// When dst.write() returns false, src auto-pauses; resumes after 'drain'.
+let srcEvents: string[] = [];
+const src = new Readable({ highWaterMark: 1, read() {} });
+src.on("pause", () => srcEvents.push("pause"));
+src.on("resume", () => srcEvents.push("resume"));
+const w = new Writable({
+  highWaterMark: 1,
+  write(_c, _e, cb) { setImmediate(cb); },
+});
+src.pipe(w);
+src.push("aa");
+src.push("bb");
+src.push(null);
+w.on("finish", () => console.log("src events:", srcEvents.join(",")));

--- a/test-parity/node-suite/stream/pipe/end-true-explicit-still-ends.ts
+++ b/test-parity/node-suite/stream/pipe/end-true-explicit-still-ends.ts
@@ -1,0 +1,11 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe(dst, {end: true}) — same as default; dst is ended.
+const r = Readable.from(["a"]);
+const dst = new PassThrough();
+let dstEnded = false;
+dst.on("end", () => (dstEnded = true));
+dst.on("data", () => {});
+r.pipe(dst, { end: true });
+setImmediate(() => {
+  setImmediate(() => console.log("dst ended (end:true explicit):", dstEnded));
+});

--- a/test-parity/node-suite/stream/pipe/four-stage-chain-v2.ts
+++ b/test-parity/node-suite/stream/pipe/four-stage-chain-v2.ts
@@ -1,0 +1,10 @@
+import { Readable, Transform, PassThrough } from "node:stream";
+// 4-stage pipe: src → t1 → t2 → sink.
+const src = Readable.from(["a"]);
+const t1 = new Transform({ transform(c, _e, cb) { cb(null, String(c) + "1"); } });
+const t2 = new Transform({ transform(c, _e, cb) { cb(null, String(c) + "2"); } });
+const sink = new PassThrough();
+const out: string[] = [];
+sink.on("data", (c) => out.push(String(c)));
+sink.on("end", () => console.log("piped:", out.join(",")));
+src.pipe(t1).pipe(t2).pipe(sink);

--- a/test-parity/node-suite/stream/pipe/many-listeners-on-dst.ts
+++ b/test-parity/node-suite/stream/pipe/many-listeners-on-dst.ts
@@ -1,0 +1,13 @@
+import { Readable, PassThrough } from "node:stream";
+// Multiple 'data' listeners on dst — each receives every chunk.
+const r = Readable.from(["a", "b"]);
+const dst = new PassThrough();
+const a: string[] = [];
+const b: string[] = [];
+dst.on("data", (c) => a.push(String(c)));
+dst.on("data", (c) => b.push(String(c)));
+r.pipe(dst);
+dst.on("end", () => {
+  console.log("a:", a.join(","));
+  console.log("b:", b.join(","));
+});

--- a/test-parity/node-suite/stream/pipe/multiple-pipes-from-same-source.ts
+++ b/test-parity/node-suite/stream/pipe/multiple-pipes-from-same-source.ts
@@ -1,0 +1,20 @@
+import { Readable, PassThrough } from "node:stream";
+// Two pipes from same source — each dst sees all data.
+const r = Readable.from(["x", "y"]);
+const a = new PassThrough();
+const b = new PassThrough();
+let aGot: string[] = [];
+let bGot: string[] = [];
+a.on("data", (c) => aGot.push(String(c)));
+b.on("data", (c) => bGot.push(String(c)));
+r.pipe(a);
+r.pipe(b);
+let endCount = 0;
+const checkDone = () => {
+  if (++endCount === 2) {
+    console.log("a:", aGot.join(","));
+    console.log("b:", bGot.join(","));
+  }
+};
+a.on("end", checkDone);
+b.on("end", checkDone);

--- a/test-parity/node-suite/stream/pipe/pipe-error-handler-on-source.ts
+++ b/test-parity/node-suite/stream/pipe/pipe-error-handler-on-source.ts
@@ -1,0 +1,13 @@
+import { Readable, PassThrough } from "node:stream";
+// Error handler on source — when src errors, the handler fires.
+let srcErrMsg: string | null = null;
+const src = new Readable({ read() {} });
+src.on("error", (e) => (srcErrMsg = e && e.message));
+const dst = new PassThrough();
+dst.on("data", () => {});
+dst.on("error", () => {});
+src.pipe(dst);
+src.destroy(new Error("src-error"));
+setImmediate(() => {
+  setImmediate(() => console.log("src err:", srcErrMsg));
+});

--- a/test-parity/node-suite/stream/pipe/pipe-many-data-events.ts
+++ b/test-parity/node-suite/stream/pipe/pipe-many-data-events.ts
@@ -1,0 +1,13 @@
+import { Readable, PassThrough } from "node:stream";
+// Pipe many chunks — all reach destination in order.
+const items = Array.from({ length: 20 }, (_, i) => `chunk${i}`);
+const r = Readable.from(items);
+const dst = new PassThrough();
+const out: string[] = [];
+dst.on("data", (c) => out.push(String(c)));
+r.pipe(dst);
+dst.on("end", () => {
+  console.log("count:", out.length);
+  console.log("first:", out[0]);
+  console.log("last:", out[out.length - 1]);
+});

--- a/test-parity/node-suite/stream/pipe/pipe-to-plain-writable.ts
+++ b/test-parity/node-suite/stream/pipe/pipe-to-plain-writable.ts
@@ -1,0 +1,9 @@
+import { Readable, Writable } from "node:stream";
+// pipe to a Writable instance directly.
+const r = Readable.from(["a", "b"]);
+const collected: string[] = [];
+const w = new Writable({
+  write(c, _e, cb) { collected.push(String(c)); cb(); },
+});
+r.pipe(w);
+w.on("finish", () => console.log("collected:", collected.join(",")));

--- a/test-parity/node-suite/stream/pipe/source-immediate-error.ts
+++ b/test-parity/node-suite/stream/pipe/source-immediate-error.ts
@@ -1,0 +1,17 @@
+import { Readable, PassThrough } from "node:stream";
+// Source emits error before any data — pipe handler still fires.
+const src = new Readable({ read() {} });
+const dst = new PassThrough();
+let dstDataCount = 0;
+let srcErrCount = 0;
+dst.on("data", () => dstDataCount++);
+src.on("error", () => srcErrCount++);
+dst.on("error", () => {});
+src.pipe(dst);
+src.destroy(new Error("immediate"));
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("dst data:", dstDataCount);
+    console.log("src error fired:", srcErrCount);
+  });
+});

--- a/test-parity/node-suite/stream/pipe/writable-end-on-source-end.ts
+++ b/test-parity/node-suite/stream/pipe/writable-end-on-source-end.ts
@@ -1,0 +1,13 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe() — destination receives end() when source ends (autoEnd default).
+const r = Readable.from(["a"]);
+const dst = new PassThrough();
+let dstEnded = false;
+dst.on("end", () => (dstEnded = true));
+dst.on("data", () => {});
+r.pipe(dst);
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("dst ended on src end:", dstEnded);
+  });
+});

--- a/test-parity/node-suite/stream/pipeline/async-iter-source.ts
+++ b/test-parity/node-suite/stream/pipeline/async-iter-source.ts
@@ -1,0 +1,13 @@
+import { PassThrough, pipeline } from "node:stream";
+// pipeline(asyncIterable, dst, cb) — async iterable as the source (not a stream).
+async function* gen() {
+  yield "x";
+  yield "y";
+}
+const dst = new PassThrough();
+const out: string[] = [];
+dst.on("data", (c) => out.push(String(c)));
+pipeline(gen(), dst, (err: any) => {
+  console.log("err:", err);
+  console.log("out:", out.join(","));
+});

--- a/test-parity/node-suite/stream/pipeline/async-source-throws-mid.ts
+++ b/test-parity/node-suite/stream/pipeline/async-source-throws-mid.ts
@@ -1,0 +1,13 @@
+import { PassThrough, pipeline } from "node:stream";
+// pipeline(asyncGenSrc, dst, cb) — asyncGen throws mid → cb receives error.
+async function* gen() {
+  yield "a";
+  throw new Error("src-fail");
+}
+const dst = new PassThrough();
+dst.on("data", () => {});
+let errMsg: string | null = null;
+pipeline(gen(), dst, (err: any) => {
+  errMsg = err && err.message;
+  console.log("err:", errMsg);
+});

--- a/test-parity/node-suite/stream/pipeline/sync-iterable-source.ts
+++ b/test-parity/node-suite/stream/pipeline/sync-iterable-source.ts
@@ -1,0 +1,9 @@
+import { PassThrough, pipeline } from "node:stream";
+// pipeline(syncIterable, dst, cb) — array source (not stream, not async).
+const dst = new PassThrough();
+const out: string[] = [];
+dst.on("data", (c) => out.push(String(c)));
+pipeline(["a", "b", "c"], dst, (err: any) => {
+  console.log("err:", err);
+  console.log("out:", out.join(","));
+});

--- a/test-parity/node-suite/stream/promises/finished-abortable-signal-abort.ts
+++ b/test-parity/node-suite/stream/promises/finished-abortable-signal-abort.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
+// finished() with a signal — abort rejects the promise.
+const r = new Readable({ read() {} });
+const ctrl = new AbortController();
+r.on("error", () => {});
+setTimeout(() => ctrl.abort(), 10);
+let errName: string | null = null;
+try {
+  await finished(r, { signal: ctrl.signal });
+} catch (e: any) {
+  errName = e && e.name;
+}
+console.log("rejected:", errName);

--- a/test-parity/node-suite/stream/promises/pipeline-array-source-promise.ts
+++ b/test-parity/node-suite/stream/promises/pipeline-array-source-promise.ts
@@ -1,0 +1,8 @@
+import { PassThrough } from "node:stream";
+import { pipeline } from "node:stream/promises";
+// pipeline() promises form with array source.
+const dst = new PassThrough();
+const collected: string[] = [];
+dst.on("data", (c) => collected.push(String(c)));
+await pipeline(["a", "b", "c"], dst);
+console.log("collected:", collected.join(","));

--- a/test-parity/node-suite/stream/promises/pipeline-five-stages.ts
+++ b/test-parity/node-suite/stream/promises/pipeline-five-stages.ts
@@ -1,0 +1,13 @@
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+// 5-stage promises-pipeline.
+const src = Readable.from(["a"]);
+const t1 = new Transform({ transform(c, _e, cb) { cb(null, String(c) + "1"); } });
+const t2 = new Transform({ transform(c, _e, cb) { cb(null, String(c) + "2"); } });
+const t3 = new Transform({ transform(c, _e, cb) { cb(null, String(c) + "3"); } });
+const collected: string[] = [];
+async function* sink(source: AsyncIterable<any>) {
+  for await (const v of source) collected.push(String(v));
+}
+await pipeline(src, t1, t2, t3, sink as any);
+console.log("result:", collected.join(","));

--- a/test-parity/node-suite/stream/readable/compose-non-stream-throws.ts
+++ b/test-parity/node-suite/stream/readable/compose-non-stream-throws.ts
@@ -1,0 +1,10 @@
+import { compose } from "node:stream";
+// compose(non-stream) — should throw TypeError.
+let caught: string | null = null;
+try {
+  (compose as any)("just a string");
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/readable/destroy-emits-error-event.ts
+++ b/test-parity/node-suite/stream/readable/destroy-emits-error-event.ts
@@ -1,0 +1,20 @@
+import { Readable } from "node:stream";
+// destroy(err) emits 'error' event with the supplied error before 'close'.
+const r = new Readable({ read() {} });
+let errFired = false;
+let closeFired = false;
+let order = "";
+r.on("error", () => {
+  errFired = true;
+  order += "E";
+});
+r.on("close", () => {
+  closeFired = true;
+  order += "C";
+});
+r.destroy(new Error("boom"));
+setImmediate(() => {
+  console.log("err fired:", errFired);
+  console.log("close fired:", closeFired);
+  console.log("order:", order);
+});

--- a/test-parity/node-suite/stream/readable/destroy-without-error.ts
+++ b/test-parity/node-suite/stream/readable/destroy-without-error.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// destroy() (no arg) — destroyed becomes true; no 'error' fired.
+const r = new Readable({ read() {} });
+let errFired = false;
+let closeFired = false;
+r.on("error", () => (errFired = true));
+r.on("close", () => (closeFired = true));
+r.destroy();
+setImmediate(() => {
+  console.log("destroyed:", r.destroyed);
+  console.log("error fired:", errFired);
+  console.log("close fired:", closeFired);
+});

--- a/test-parity/node-suite/stream/readable/destroyed-after-finish.ts
+++ b/test-parity/node-suite/stream/readable/destroyed-after-finish.ts
@@ -1,0 +1,9 @@
+import { Writable } from "node:stream";
+// After 'finish', destroyed should be true (autoDestroy default).
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+w.on("finish", () => {
+  setImmediate(() => {
+    console.log("destroyed after finish:", w.destroyed);
+  });
+});
+w.end("done");

--- a/test-parity/node-suite/stream/readable/duplex-acts-as-writable.ts
+++ b/test-parity/node-suite/stream/readable/duplex-acts-as-writable.ts
@@ -1,0 +1,11 @@
+import { Duplex } from "node:stream";
+// A Duplex stream has both read and write sides.
+const received: string[] = [];
+const d = new Duplex({
+  read() { this.push(null); }, // empty readable
+  write(c, _e, cb) { received.push(String(c)); cb(); },
+});
+d.on("data", () => {});
+d.write("x");
+d.end("y");
+d.on("finish", () => console.log("received:", received.join(",")));

--- a/test-parity/node-suite/stream/readable/encoding-via-constructor.ts
+++ b/test-parity/node-suite/stream/readable/encoding-via-constructor.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// encoding option in constructor sets readableEncoding.
+const r = new Readable({ encoding: "utf8", read() {} });
+console.log("encoding:", r.readableEncoding);
+r.push(Buffer.from("xyz"));
+r.push(null);
+r.on("data", (c) => {
+  console.log("data is string:", typeof c === "string");
+  console.log("value:", c);
+});

--- a/test-parity/node-suite/stream/readable/from-arguments-object.ts
+++ b/test-parity/node-suite/stream/readable/from-arguments-object.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// arguments object is iterable (Array-like) — Readable.from yields each arg.
+function test() {
+  return Readable.from(arguments as any);
+}
+const r = test("a", "b", "c");
+const out: string[] = [];
+for await (const v of r) out.push(String(v));
+console.log("from arguments:", out.join(","));

--- a/test-parity/node-suite/stream/readable/from-buffer-emits-single.ts
+++ b/test-parity/node-suite/stream/readable/from-buffer-emits-single.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Readable.from(Buffer) — Node short-circuits and emits the whole buffer
+// as a single chunk.
+const r = Readable.from(Buffer.from("abc"));
+const chunks: any[] = [];
+r.on("data", (c) => chunks.push(c));
+r.on("end", () => {
+  console.log("count:", chunks.length);
+  console.log("first is buffer:", Buffer.isBuffer(chunks[0]));
+});

--- a/test-parity/node-suite/stream/readable/from-empty-string.ts
+++ b/test-parity/node-suite/stream/readable/from-empty-string.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Readable.from("") — empty string is iterable but yields nothing.
+const r = Readable.from("");
+const out: string[] = [];
+r.on("data", (c) => out.push(String(c)));
+r.on("end", () => {
+  console.log("count:", out.length);
+  console.log("is empty:", out.length === 0);
+});

--- a/test-parity/node-suite/stream/readable/from-gen-return-value-ignored.ts
+++ b/test-parity/node-suite/stream/readable/from-gen-return-value-ignored.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Generator with `return value` — the returned value is NOT yielded as a chunk.
+function* gen() {
+  yield 1;
+  yield 2;
+  return 999; // not yielded
+}
+const r = Readable.from(gen());
+const out: number[] = [];
+for await (const v of r) out.push(v as number);
+console.log("count:", out.length);
+console.log("values:", out.join(","));
+console.log("no 999:", !out.includes(999));

--- a/test-parity/node-suite/stream/readable/from-gen-with-early-return.ts
+++ b/test-parity/node-suite/stream/readable/from-gen-with-early-return.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Generator that returns early via `return` — stream ends at that point.
+function* gen() {
+  yield 1;
+  yield 2;
+  return; // explicit return
+  yield 3; // never reached
+}
+const r = Readable.from(gen());
+const out: number[] = [];
+for await (const v of r) out.push(v as number);
+console.log("count:", out.length);
+console.log("values:", out.join(","));

--- a/test-parity/node-suite/stream/readable/from-promise-iterating-once.ts
+++ b/test-parity/node-suite/stream/readable/from-promise-iterating-once.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Readable.from(Promise.resolve(value)) — treats Promise as iterable? No;
+// Node yields the resolved value as a single chunk.
+const r = Readable.from(Promise.resolve("resolved-value"));
+const out: any[] = [];
+r.on("data", (v) => out.push(v));
+r.on("end", () => {
+  console.log("count:", out.length);
+  console.log("first:", out[0]);
+});

--- a/test-parity/node-suite/stream/readable/from-set-deduplicates.ts
+++ b/test-parity/node-suite/stream/readable/from-set-deduplicates.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Set automatically deduplicates; Readable.from(Set) preserves that.
+const s = new Set(["a", "b", "a", "c", "b"]);
+const r = Readable.from(s);
+const out: string[] = [];
+for await (const v of r) out.push(String(v));
+console.log("count:", out.length);
+console.log("values:", out.join(","));

--- a/test-parity/node-suite/stream/readable/from-set-of-strings.ts
+++ b/test-parity/node-suite/stream/readable/from-set-of-strings.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// Readable.from(Set) — iterates Set values in insertion order.
+const s = new Set(["alpha", "beta", "gamma"]);
+const r = Readable.from(s);
+const out: string[] = [];
+for await (const v of r) out.push(String(v));
+console.log("order:", out.join(","));

--- a/test-parity/node-suite/stream/readable/from-string-as-iterable-single-chunk.ts
+++ b/test-parity/node-suite/stream/readable/from-string-as-iterable-single-chunk.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Readable.from("text") — Node short-circuits: single chunk, NOT char-by-char.
+const r = Readable.from("text");
+const chunks: any[] = [];
+r.on("data", (c) => chunks.push(c));
+r.on("end", () => {
+  console.log("chunks:", chunks.length);
+  console.log("first:", chunks[0]);
+});

--- a/test-parity/node-suite/stream/readable/from-string-chunk-buffer.ts
+++ b/test-parity/node-suite/stream/readable/from-string-chunk-buffer.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Readable.from(string) — single chunk; check whether it's string or Buffer.
+const r = Readable.from("hello");
+r.on("data", (c) => {
+  console.log("type:", typeof c);
+  console.log("isBuffer:", Buffer.isBuffer(c));
+  console.log("value:", c.toString ? c.toString() : c);
+});

--- a/test-parity/node-suite/stream/readable/from-string-iterates-codepoints.ts
+++ b/test-parity/node-suite/stream/readable/from-string-iterates-codepoints.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Documented Node behavior: Readable.from(string) treats the string as a single
+// chunk (string-as-iterable shortcut). Validates whole-chunk emission.
+const r = Readable.from("abc");
+const chunks: string[] = [];
+r.on("data", (c) => chunks.push(String(c)));
+r.on("end", () => {
+  console.log("chunk count:", chunks.length);
+  console.log("first:", chunks[0]);
+});

--- a/test-parity/node-suite/stream/readable/instance-method-bind-this.ts
+++ b/test-parity/node-suite/stream/readable/instance-method-bind-this.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Instance method extracted and called — `this` no longer set; should throw.
+const r = Readable.from(["a"]);
+const detachedPush = r.push;
+let caught: string | null = null;
+try {
+  detachedPush("x");
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("detached push threw:", caught !== null);

--- a/test-parity/node-suite/stream/readable/iter-with-custom-return.ts
+++ b/test-parity/node-suite/stream/readable/iter-with-custom-return.ts
@@ -1,0 +1,25 @@
+import { Readable } from "node:stream";
+// When for-await breaks early, the iterator's return() is invoked.
+let returnCalled = false;
+const customIter = {
+  [Symbol.asyncIterator]() {
+    let i = 0;
+    return {
+      next: async () => ({ value: i++, done: i > 5 }),
+      return: async () => {
+        returnCalled = true;
+        return { value: undefined, done: true };
+      },
+    };
+  },
+};
+const r = Readable.from(customIter as any);
+let count = 0;
+for await (const _v of r) {
+  count++;
+  if (count === 2) break;
+}
+setImmediate(() => {
+  console.log("count:", count);
+  console.log("return called:", returnCalled);
+});

--- a/test-parity/node-suite/stream/readable/many-pushes-accumulate.ts
+++ b/test-parity/node-suite/stream/readable/many-pushes-accumulate.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// Many push() calls accumulate; final readableLength = sum.
+const r = new Readable({ read() {} });
+let totalBytes = 0;
+for (let i = 0; i < 10; i++) {
+  const s = "x".repeat(i + 1);
+  r.push(s);
+  totalBytes += s.length;
+}
+console.log("expected:", totalBytes);
+console.log("readableLength:", r.readableLength);
+console.log("match:", r.readableLength === totalBytes);

--- a/test-parity/node-suite/stream/readable/push-empty-string-no-end.ts
+++ b/test-parity/node-suite/stream/readable/push-empty-string-no-end.ts
@@ -1,0 +1,17 @@
+import { Readable } from "node:stream";
+// push('') — empty string is a valid chunk, NOT an end signal.
+// Only push(null) signals end.
+const r = new Readable({ read() {} });
+let dataCount = 0;
+let endFired = false;
+r.on("data", () => dataCount++);
+r.on("end", () => (endFired = true));
+r.push("");
+r.push("x");
+r.push(null);
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("data count:", dataCount);
+    console.log("end fired:", endFired);
+  });
+});

--- a/test-parity/node-suite/stream/readable/push-string-with-encoding-set.ts
+++ b/test-parity/node-suite/stream/readable/push-string-with-encoding-set.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// setEncoding then push(string) — string is delivered as string, not Buffer.
+const r = new Readable({ read() {} });
+r.setEncoding("utf8");
+r.push("hello");
+r.push(null);
+r.on("data", (c) => {
+  console.log("is string:", typeof c === "string");
+  console.log("value:", c);
+});

--- a/test-parity/node-suite/stream/readable/read-empty-objectmode-null.ts
+++ b/test-parity/node-suite/stream/readable/read-empty-objectmode-null.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// objectMode read on empty stream returns null.
+const r = new Readable({ objectMode: true, read() {} });
+console.log("read:", r.read());
+console.log("is null:", r.read() === null);

--- a/test-parity/node-suite/stream/readable/readable-event-with-objectmode.ts
+++ b/test-parity/node-suite/stream/readable/readable-event-with-objectmode.ts
@@ -1,0 +1,18 @@
+import { Readable } from "node:stream";
+// 'readable' event with objectMode — each read() returns one object.
+const r = new Readable({
+  objectMode: true,
+  read() {
+    this.push({ id: 1 });
+    this.push({ id: 2 });
+    this.push(null);
+  },
+});
+r.on("readable", () => {
+  const a = r.read();
+  const b = r.read();
+  const c = r.read();
+  console.log("a:", a && a.id);
+  console.log("b:", b && b.id);
+  console.log("c:", c);
+});

--- a/test-parity/node-suite/stream/readable/readable-flag-after-end.ts
+++ b/test-parity/node-suite/stream/readable/readable-flag-after-end.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// After 'end', readable flag becomes false.
+const r = Readable.from(["a"]);
+console.log("initial readable:", r.readable);
+r.on("data", () => {});
+r.on("end", () => {
+  console.log("after end readable:", r.readable);
+});

--- a/test-parity/node-suite/stream/readable/readable-stream-id-properties.ts
+++ b/test-parity/node-suite/stream/readable/readable-stream-id-properties.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// Stream constructor exposes a fresh object — each new() makes distinct instances.
+const r1 = new Readable({ read() {} });
+const r2 = new Readable({ read() {} });
+console.log("distinct instances:", r1 !== r2);
+console.log("both readable:", r1.readable && r2.readable);
+console.log("not same proto:", Object.getPrototypeOf(r1) === Object.getPrototypeOf(r2));

--- a/test-parity/node-suite/stream/readable/static-from-with-options.ts
+++ b/test-parity/node-suite/stream/readable/static-from-with-options.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Readable.from(iter, {objectMode: true}) — explicit objectMode.
+const r = Readable.from(["a"], { objectMode: true });
+console.log("objectMode:", r.readableObjectMode);
+console.log("hwm:", r.readableHighWaterMark);
+const out: any[] = [];
+r.on("data", (c) => out.push(c));
+r.on("end", () => console.log("count:", out.length));

--- a/test-parity/node-suite/stream/readable/writable-side-getters.ts
+++ b/test-parity/node-suite/stream/readable/writable-side-getters.ts
@@ -1,0 +1,7 @@
+import { Duplex } from "node:stream";
+// Duplex exposes writable getters: writableEnded, writableHighWaterMark.
+const d = new Duplex({ read() {}, write(_c, _e, cb) { cb(); } });
+console.log("writableEnded initial:", d.writableEnded);
+console.log("writableHighWaterMark:", typeof d.writableHighWaterMark);
+console.log("writableLength:", typeof d.writableLength);
+console.log("writableObjectMode:", d.writableObjectMode);

--- a/test-parity/node-suite/stream/web/byob-reader-method-shape.ts
+++ b/test-parity/node-suite/stream/web/byob-reader-method-shape.ts
@@ -1,0 +1,7 @@
+import { ReadableStream } from "node:stream/web";
+// BYOB reader should have read(view) and releaseLock methods.
+const rs = new ReadableStream({ type: "bytes" } as any);
+const reader = (rs as any).getReader({ mode: "byob" });
+console.log("has read:", typeof reader.read);
+console.log("has releaseLock:", typeof reader.releaseLock);
+console.log("has closed:", "closed" in reader);

--- a/test-parity/node-suite/stream/web/cancel-during-pull.ts
+++ b/test-parity/node-suite/stream/web/cancel-during-pull.ts
@@ -1,0 +1,14 @@
+import { ReadableStream } from "node:stream/web";
+// Cancel during an active pull — pull is interrupted; further reads see done.
+const rs = new ReadableStream({
+  async pull(c) {
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    c.enqueue("x");
+  },
+});
+const reader = rs.getReader();
+const readPromise = reader.read();
+// Cancel before pull resolves
+setTimeout(() => reader.cancel("interrupt"), 5);
+const result = await readPromise;
+console.log("done:", result.done);

--- a/test-parity/node-suite/stream/web/cancel-with-undefined-reason.ts
+++ b/test-parity/node-suite/stream/web/cancel-with-undefined-reason.ts
@@ -1,0 +1,10 @@
+import { ReadableStream } from "node:stream/web";
+// cancel(undefined) explicitly — reason is undefined in cancel hook.
+let seen: any = "untouched";
+const rs = new ReadableStream({
+  start(c) { c.enqueue("x"); },
+  cancel(reason) { seen = reason; },
+});
+await rs.cancel(undefined);
+console.log("seen:", seen);
+console.log("is undefined:", seen === undefined);

--- a/test-parity/node-suite/stream/web/enqueue-object-chunks.ts
+++ b/test-parity/node-suite/stream/web/enqueue-object-chunks.ts
@@ -1,0 +1,18 @@
+import { ReadableStream } from "node:stream/web";
+// Default RS accepts arbitrary value types in enqueue.
+const rs = new ReadableStream({
+  start(c) {
+    c.enqueue(42);
+    c.enqueue({ a: 1 });
+    c.enqueue([1, 2, 3]);
+    c.close();
+  },
+});
+const reader = rs.getReader();
+const out: any[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(typeof value);
+}
+console.log("types:", out.join(","));

--- a/test-parity/node-suite/stream/web/from-arraybuffer-typed-array.ts
+++ b/test-parity/node-suite/stream/web/from-arraybuffer-typed-array.ts
@@ -1,0 +1,13 @@
+import { ReadableStream } from "node:stream/web";
+// RS.from(Uint16Array) — typed array is iterable; yields each element.
+const arr = new Uint16Array([100, 200, 300]);
+const rs = (ReadableStream as any).from(arr);
+const reader = rs.getReader();
+const out: number[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(value as number);
+}
+console.log("count:", out.length);
+console.log("values:", out.join(","));

--- a/test-parity/node-suite/stream/web/from-async-gen-throws-mid.ts
+++ b/test-parity/node-suite/stream/web/from-async-gen-throws-mid.ts
@@ -1,0 +1,17 @@
+import { ReadableStream } from "node:stream/web";
+// RS.from(asyncGen) where gen throws mid-iteration — read() rejects.
+async function* gen() {
+  yield "a";
+  throw new Error("mid-fail");
+}
+const rs = (ReadableStream as any).from(gen());
+const reader = rs.getReader();
+const first = await reader.read();
+let secondErr: string | null = null;
+try {
+  await reader.read();
+} catch (e: any) {
+  secondErr = e && e.message;
+}
+console.log("first value:", first.value);
+console.log("second err:", secondErr);

--- a/test-parity/node-suite/stream/web/from-bigint-throws.ts
+++ b/test-parity/node-suite/stream/web/from-bigint-throws.ts
@@ -1,0 +1,10 @@
+import { ReadableStream } from "node:stream/web";
+// RS.from(bigint) — bigint is not iterable → TypeError.
+let caught: string | null = null;
+try {
+  (ReadableStream as any).from(42n);
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/web/from-empty-array.ts
+++ b/test-parity/node-suite/stream/web/from-empty-array.ts
@@ -1,0 +1,7 @@
+import { ReadableStream } from "node:stream/web";
+// RS.from([]) — yields no data; reader gets {done:true} immediately.
+const rs = (ReadableStream as any).from([]);
+const reader = rs.getReader();
+const result = await reader.read();
+console.log("value:", result.value);
+console.log("done:", result.done);

--- a/test-parity/node-suite/stream/web/identity-with-strategies.ts
+++ b/test-parity/node-suite/stream/web/identity-with-strategies.ts
@@ -1,0 +1,11 @@
+import { TransformStream, CountQueuingStrategy } from "node:stream/web";
+// new TransformStream(undefined, ws, rs) — Identity with explicit HWMs.
+const ws = new CountQueuingStrategy({ highWaterMark: 5 });
+const rs = new CountQueuingStrategy({ highWaterMark: 3 });
+const ts = new TransformStream(undefined, ws, rs);
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("x");
+await writer.close();
+const result = await reader.read();
+console.log("value:", result.value);

--- a/test-parity/node-suite/stream/web/no-enqueue-empty-close.ts
+++ b/test-parity/node-suite/stream/web/no-enqueue-empty-close.ts
@@ -1,0 +1,7 @@
+import { ReadableStream } from "node:stream/web";
+// Stream that calls c.close() in start with no enqueue — empty stream.
+const rs = new ReadableStream({ start(c) { c.close(); } });
+const reader = rs.getReader();
+const result = await reader.read();
+console.log("value:", result.value);
+console.log("done:", result.done);

--- a/test-parity/node-suite/stream/web/pipe-through-then-cancel.ts
+++ b/test-parity/node-suite/stream/web/pipe-through-then-cancel.ts
@@ -1,0 +1,16 @@
+import { ReadableStream, TransformStream } from "node:stream/web";
+// pipeThrough → then cancel the output. Source upstream should be cancelled too.
+const rs = new ReadableStream({
+  pull(c) { setTimeout(() => c.enqueue("x"), 30); },
+});
+const ts = new TransformStream();
+const result = rs.pipeThrough(ts);
+let cancelOk = false;
+try {
+  await result.cancel("downstream");
+  cancelOk = true;
+} catch {
+  cancelOk = false;
+}
+console.log("cancel ok:", cancelOk);
+console.log("result locked:", result.locked);

--- a/test-parity/node-suite/stream/web/pipe-to-failing-sink.ts
+++ b/test-parity/node-suite/stream/web/pipe-to-failing-sink.ts
@@ -1,0 +1,15 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// pipeTo() to a sink whose write() throws — Promise rejects.
+const rs = new ReadableStream({
+  start(c) { c.enqueue("x"); c.close(); },
+});
+const ws = new WritableStream({
+  write() { throw new Error("sink-fail"); },
+});
+let errMsg: string | null = null;
+try {
+  await rs.pipeTo(ws);
+} catch (e: any) {
+  errMsg = e && e.message;
+}
+console.log("rejected with:", errMsg);

--- a/test-parity/node-suite/stream/web/pipe-to-without-options.ts
+++ b/test-parity/node-suite/stream/web/pipe-to-without-options.ts
@@ -1,0 +1,7 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// pipeTo() with no options arg — defaults work.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const ws = new WritableStream({ write() {} });
+await rs.pipeTo(ws);
+console.log("rs locked after:", rs.locked);
+console.log("ws locked after:", ws.locked);

--- a/test-parity/node-suite/stream/web/pull-called-per-read.ts
+++ b/test-parity/node-suite/stream/web/pull-called-per-read.ts
@@ -1,0 +1,16 @@
+import { ReadableStream } from "node:stream/web";
+// pull() is called each time the queue is empty + read requested.
+let pullCount = 0;
+const rs = new ReadableStream({
+  pull(c) {
+    pullCount++;
+    if (pullCount <= 3) c.enqueue(pullCount);
+    else c.close();
+  },
+});
+const reader = rs.getReader();
+while (true) {
+  const { done } = await reader.read();
+  if (done) break;
+}
+console.log("pull count:", pullCount);

--- a/test-parity/node-suite/stream/web/readable-cancel-multi.ts
+++ b/test-parity/node-suite/stream/web/readable-cancel-multi.ts
@@ -1,0 +1,7 @@
+import { ReadableStream } from "node:stream/web";
+// Multiple cancel() calls — second is a no-op (resolves).
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); } });
+await rs.cancel("first");
+const second = await rs.cancel("second");
+console.log("second resolved:", second);
+console.log("is undefined:", second === undefined);

--- a/test-parity/node-suite/stream/web/readable-no-init-constructor.ts
+++ b/test-parity/node-suite/stream/web/readable-no-init-constructor.ts
@@ -1,0 +1,7 @@
+import { ReadableStream } from "node:stream/web";
+// new ReadableStream() — no args; constructs an empty stream.
+const rs = new ReadableStream();
+console.log("constructed:", rs instanceof ReadableStream);
+console.log("locked:", rs.locked);
+// Cancel to clean up
+await rs.cancel();

--- a/test-parity/node-suite/stream/web/readable-stream-async-iter-flowing.ts
+++ b/test-parity/node-suite/stream/web/readable-stream-async-iter-flowing.ts
@@ -1,0 +1,12 @@
+import { ReadableStream } from "node:stream/web";
+// Web RS supports Symbol.asyncIterator — iteration drains all chunks.
+const rs = new ReadableStream({
+  start(c) {
+    c.enqueue("p");
+    c.enqueue("q");
+    c.close();
+  },
+});
+const out: string[] = [];
+for await (const v of rs as any) out.push(String(v));
+console.log("collected:", out.join(","));

--- a/test-parity/node-suite/stream/web/release-lock-after-close.ts
+++ b/test-parity/node-suite/stream/web/release-lock-after-close.ts
@@ -1,0 +1,8 @@
+import { ReadableStream } from "node:stream/web";
+// releaseLock after the stream closes — should still work.
+const rs = new ReadableStream({ start(c) { c.close(); } });
+const reader = rs.getReader();
+const { done } = await reader.read();
+console.log("done:", done);
+reader.releaseLock();
+console.log("locked after release:", rs.locked);

--- a/test-parity/node-suite/stream/web/strategy-size-non-number.ts
+++ b/test-parity/node-suite/stream/web/strategy-size-non-number.ts
@@ -1,0 +1,21 @@
+import { ReadableStream } from "node:stream/web";
+// Strategy.size returning non-number — should error on enqueue.
+const strategy = {
+  size: () => "not-a-number" as any,
+  highWaterMark: 1,
+};
+let enqueueErr: string | null = null;
+const rs = new ReadableStream(
+  {
+    start(c) {
+      try {
+        c.enqueue("x");
+      } catch (e: any) {
+        enqueueErr = e && e.name;
+      }
+    },
+  },
+  strategy,
+);
+console.log("enqueue err:", enqueueErr);
+console.log("constructed:", rs instanceof ReadableStream);

--- a/test-parity/node-suite/stream/web/tee-array-shape.ts
+++ b/test-parity/node-suite/stream/web/tee-array-shape.ts
@@ -1,0 +1,8 @@
+import { ReadableStream } from "node:stream/web";
+// tee() returns an Array of length 2.
+const rs = new ReadableStream({ start(c) { c.close(); } });
+const result = rs.tee();
+console.log("isArray:", Array.isArray(result));
+console.log("length:", result.length);
+console.log("[0] is RS:", result[0] instanceof ReadableStream);
+console.log("[1] is RS:", result[1] instanceof ReadableStream);

--- a/test-parity/node-suite/stream/web/tee-drain-only-one-branch.ts
+++ b/test-parity/node-suite/stream/web/tee-drain-only-one-branch.ts
@@ -1,0 +1,23 @@
+import { ReadableStream } from "node:stream/web";
+// tee() then drain only one branch — the other accumulates in queue (HWM allows).
+const rs = new ReadableStream({
+  start(c) {
+    c.enqueue("a");
+    c.enqueue("b");
+    c.close();
+  },
+});
+const [a, b] = rs.tee();
+// Drain a only
+const reader = a.getReader();
+const out: string[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(String(value));
+}
+console.log("a:", out.join(","));
+// b is still readable
+const bReader = b.getReader();
+const first = await bReader.read();
+console.log("b first:", first.value);

--- a/test-parity/node-suite/stream/web/tee-mid-consume-throws.ts
+++ b/test-parity/node-suite/stream/web/tee-mid-consume-throws.ts
@@ -1,0 +1,15 @@
+import { ReadableStream } from "node:stream/web";
+// Get a reader, read once, then try tee() — should throw (stream locked).
+const rs = new ReadableStream({
+  start(c) { c.enqueue("a"); c.enqueue("b"); c.close(); },
+});
+const reader = rs.getReader();
+await reader.read(); // partial consume
+let caught: string | null = null;
+try {
+  rs.tee();
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/web/transform-backpressure-write-blocks.ts
+++ b/test-parity/node-suite/stream/web/transform-backpressure-write-blocks.ts
@@ -1,0 +1,10 @@
+import { TransformStream } from "node:stream/web";
+// Without reading from the readable, the writable should backpressure.
+const ts = new TransformStream({ transform(c, ctrl) { ctrl.enqueue(c); } });
+const writer = ts.writable.getWriter();
+// Write more than buffer can hold without reading
+await writer.write("a");
+await writer.write("b");
+// desiredSize should be ≤ 0 (backpressured)
+console.log("desiredSize:", writer.desiredSize);
+console.log("backpressure active:", (writer.desiredSize ?? 0) <= 0);

--- a/test-parity/node-suite/stream/web/transform-piped-twice.ts
+++ b/test-parity/node-suite/stream/web/transform-piped-twice.ts
@@ -1,0 +1,10 @@
+import { ReadableStream, TransformStream } from "node:stream/web";
+// pipeThrough then pipeThrough again.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const t1 = new TransformStream({ transform(c, ctrl) { ctrl.enqueue(String(c) + "1"); } });
+const t2 = new TransformStream({ transform(c, ctrl) { ctrl.enqueue(String(c) + "2"); } });
+const result = rs.pipeThrough(t1).pipeThrough(t2);
+const reader = result.getReader();
+const { value } = await reader.read();
+console.log("result:", value);
+console.log("is x12:", value === "x12");

--- a/test-parity/node-suite/stream/web/transform-stream-identity-roundtrip.ts
+++ b/test-parity/node-suite/stream/web/transform-stream-identity-roundtrip.ts
@@ -1,0 +1,15 @@
+import { TransformStream } from "node:stream/web";
+// Empty TransformStream is identity — written chunks come out unchanged.
+const ts = new TransformStream();
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("hello");
+await writer.write("world");
+await writer.close();
+const out: string[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(String(value));
+}
+console.log("roundtrip:", out.join("|"));

--- a/test-parity/node-suite/stream/web/transform-stream-instanceof-check.ts
+++ b/test-parity/node-suite/stream/web/transform-stream-instanceof-check.ts
@@ -1,0 +1,8 @@
+import { TransformStream, ReadableStream, WritableStream } from "node:stream/web";
+// TransformStream — not instanceof RS or WS; readable/writable ARE.
+const ts = new TransformStream();
+console.log("ts instanceof TS:", ts instanceof TransformStream);
+console.log("ts instanceof RS:", ts instanceof ReadableStream);
+console.log("ts instanceof WS:", ts instanceof WritableStream);
+console.log("readable RS:", ts.readable instanceof ReadableStream);
+console.log("writable WS:", ts.writable instanceof WritableStream);

--- a/test-parity/node-suite/stream/web/transform-with-only-flush.ts
+++ b/test-parity/node-suite/stream/web/transform-with-only-flush.ts
@@ -1,0 +1,14 @@
+import { TransformStream } from "node:stream/web";
+// TransformStream with only flush() (no transform fn) — identity transform
+// + flush emits final value.
+const ts = new TransformStream({
+  flush(c) { c.enqueue("FINAL"); },
+});
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("x");
+await writer.close();
+const a = await reader.read();
+const b = await reader.read();
+console.log("a:", a.value);
+console.log("b:", b.value);

--- a/test-parity/node-suite/stream/writable/end-cb-fires-after-flush.ts
+++ b/test-parity/node-suite/stream/writable/end-cb-fires-after-flush.ts
@@ -1,0 +1,17 @@
+import { Writable } from "node:stream";
+// end(cb) — cb fires after all pending writes flush + finish event.
+const order: string[] = [];
+const w = new Writable({
+  write(_c, _e, cb) {
+    setImmediate(() => {
+      order.push("write");
+      cb();
+    });
+  },
+});
+w.on("finish", () => order.push("finish"));
+w.write("a");
+w.end(() => {
+  order.push("end-cb");
+  console.log("order:", order.join(","));
+});

--- a/test-parity/node-suite/stream/writable/write-encoded-buffer.ts
+++ b/test-parity/node-suite/stream/writable/write-encoded-buffer.ts
@@ -1,0 +1,17 @@
+import { Writable } from "node:stream";
+// write(Buffer) — sink receives the Buffer; encoding arg is 'buffer'.
+let receivedEnc: any = null;
+let receivedBuf: any = null;
+const w = new Writable({
+  write(c, enc, cb) {
+    receivedEnc = enc;
+    receivedBuf = c;
+    cb();
+  },
+});
+w.write(Buffer.from("hi"));
+w.end();
+w.on("finish", () => {
+  console.log("enc:", receivedEnc);
+  console.log("isBuffer:", Buffer.isBuffer(receivedBuf));
+});


### PR DESCRIPTION
## Consolidation

Aggregates the 12 open `test(parity): stream` PRs into one. They each added **disjoint** new test files under `test-parity/node-suite/stream/` and all conflicted on the single shared file `test-parity/known_failures.json` — so merging them one-by-one means re-resolving the same conflict 12 times. This rolls them up.

Superseded PRs (close on merge):

| PR | branch | tests |
|----|--------|-------|
| #1697 | feat/stream-iter-batch16 | iter-115..117 |
| #1699 | feat/stream-iter-batch17 | iter-118..120 |
| #1702 | feat/stream-iter-batch18 | iter-121..123 |
| #1706 | feat/stream-iter-batch19 | iter-124..126 |
| #1707 | feat/stream-iter-batch20 | iter-127..129 |
| #1710 | feat/stream-iter-batch21 | iter-130..131 |
| #1713 | feat/stream-iter-batch22 | iter-132..133 |
| #1714 | feat/stream-iter-batch23 | iter-134..135 |
| #1716 | feat/stream-iter-batch24 | iter-136..137 |
| #1717 | feat/stream-iter-batch25 | iter-138..139 |
| #1718 | feat/stream-iter-batch26 | iter-140..141 |
| #1719 | feat/stream-iter-batch27 | iter-142..144 |

## Contents

- **120 new tests** under `test-parity/node-suite/stream/` (events, readable, writable, pipe, pipeline, compose, flow, web, iter-helpers, consumers, promises). No filename collisions across branches; none pre-existing on main.
- **35 free-pass** — match `node --experimental-strip-types` byte-for-byte today.
- **85 skip-listed** in `known_failures.json`, tracked behind #1531 / #1532 / #1539 / #1545 / #1558. Each flips to PASS when its tracking issue lands.

`known_failures.json` union adds only each branch's **own** additions (keys present in the branch tip but not its merge-base), so no entry that a fix PR already removed from main gets re-added. The existing 518 keys are byte-identical (510 insertions, 0 deletions).

No Rust changes — test files + skip-list only.
