### PR TITLE
fix(node): dispatch .apply()/.call() on stdlib namespace methods (#1722)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -178,6 +178,117 @@ pub(super) fn try_iife_call_rewrite(
     Ok(None)
 }
 
+/// Issue #1722 — `<stdlibNamespace>.<method>.apply(thisArg, args)` /
+/// `<stdlibNamespace>.<method>.call(thisArg, ...args)`.
+///
+/// Stdlib namespace methods (`path.join`, `fs.existsSync`, `os.platform`,
+/// …) are dispatched by dedicated HIR lowerings keyed on the
+/// `<namespace>.<method>(...)` *direct-call* shape — `path.join(a, b)`
+/// folds to `Expr::PathJoin`, etc. The bare value `path.join` lowers to a
+/// runtime namespace-property read that returns `undefined` for methods
+/// not on the callable-export whitelist, so invoking it *indirectly* via
+/// `Function.prototype.apply` / `.call` never reaches the native impl and
+/// silently evaluates to `undefined` (Node returns the real result).
+/// Surfaced by the #800 node-core radar (`test-path-join.js` uses
+/// `path.join.apply(...)`).
+///
+/// Fix: when the callee is exactly `<ns>.<method>.{apply,call}` and `<ns>`
+/// is a known native-module namespace binding (so `this` is irrelevant —
+/// these are plain free functions), rewrite the AST to the equivalent
+/// direct call and re-dispatch through `lower_call`, reusing every
+/// existing per-method lowering. `thisArg` is dropped (correct for
+/// namespace functions, which ignore `this`).
+///
+/// Conservative scope:
+///   - `.call(thisArg, a, b, …)`         → `ns.method(a, b, …)`
+///   - `.apply(thisArg)` / `.apply()`    → `ns.method()`
+///   - `.apply(thisArg, [a, b, …])`      → `ns.method(a, b, …)` — only for
+///     a clean array *literal* (no holes, no element spreads).
+/// A non-literal apply-args array (a variable / call result) can't be
+/// statically expanded into positional args, so it falls through
+/// unchanged (the runtime spread path `ns.method(...arr)` is a separate
+/// gap). The namespace-binding guard keeps this away from `obj.fn.call(…)`
+/// method dispatch, function-literal IIFEs (`try_iife_call_rewrite`), and
+/// `Object.prototype.<m>.call(…)` (`try_object_prototype_call`).
+pub(super) fn try_native_module_method_apply_call(
+    ctx: &mut LoweringContext,
+    call: &ast::CallExpr,
+    has_spread: bool,
+) -> Result<Option<Expr>> {
+    if has_spread {
+        return Ok(None);
+    }
+    let ast::Callee::Expr(callee_expr) = &call.callee else {
+        return Ok(None);
+    };
+    // Outer member: `<inner>.apply` / `<inner>.call`.
+    let ast::Expr::Member(outer) = callee_expr.as_ref() else {
+        return Ok(None);
+    };
+    let ast::MemberProp::Ident(outer_prop) = &outer.prop else {
+        return Ok(None);
+    };
+    let is_apply = match outer_prop.sym.as_ref() {
+        "apply" => true,
+        "call" => false,
+        _ => return Ok(None),
+    };
+    // Inner member: `<ns>.<method>` where `<ns>` is a native-module
+    // namespace ident and `<method>` is a plain (non-computed) name.
+    let ast::Expr::Member(inner) = outer.obj.as_ref() else {
+        return Ok(None);
+    };
+    if !matches!(&inner.prop, ast::MemberProp::Ident(_)) {
+        return Ok(None);
+    }
+    let ast::Expr::Ident(ns_id) = inner.obj.as_ref() else {
+        return Ok(None);
+    };
+    let ns_name = ns_id.sym.as_ref();
+    // Namespace bindings register both an alias (require / `import * as`)
+    // and a `(module, None)` native-module entry; named imports register
+    // `(module, Some(symbol))` and must NOT match here.
+    let is_module_ns = ctx.lookup_builtin_module_alias(ns_name).is_some()
+        || matches!(ctx.lookup_native_module(ns_name), Some((_, None)));
+    if !is_module_ns {
+        return Ok(None);
+    }
+
+    // Build the synthesized direct-call argument list at the AST level.
+    let synth_args: Vec<ast::ExprOrSpread> = if is_apply {
+        match call.args.get(1) {
+            // `.apply(thisArg)` / `.apply()` → no positional args.
+            None => Vec::new(),
+            Some(arr_arg) => match arr_arg.expr.as_ref() {
+                ast::Expr::Array(arr) => {
+                    // Only a clean literal (no holes, no element spreads)
+                    // can be expanded into positional args statically.
+                    let clean = arr
+                        .elems
+                        .iter()
+                        .all(|e| matches!(e, Some(eos) if eos.spread.is_none()));
+                    if !clean {
+                        return Ok(None);
+                    }
+                    arr.elems.iter().filter_map(|e| e.clone()).collect()
+                }
+                // Non-literal args array — can't statically expand.
+                _ => return Ok(None),
+            },
+        }
+    } else {
+        // `.call(thisArg, a, b, …)` → drop thisArg, keep the rest.
+        call.args.iter().skip(1).cloned().collect()
+    };
+
+    // Synthesize `<ns>.<method>(synth_args)` and re-dispatch. The new
+    // callee carries no `.apply`/`.call`, so this hook can't re-match it.
+    let mut synth_call = call.clone();
+    synth_call.callee = ast::Callee::Expr(Box::new(ast::Expr::Member(inner.clone())));
+    synth_call.args = synth_args;
+    Ok(Some(super::lower_call(ctx, &synth_call)?))
+}
+
 /// Followup to #957 / PR #959 — `Function('return this')()`.
 ///
 /// Every CJS/UMD-shaped library (lodash, underscore, Effect, …)

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -57,7 +57,7 @@ use imported_array_methods::try_imported_array_methods;
 use inline_array_methods::try_inline_array_methods;
 use intrinsics::{
     try_bare_regexp_call, try_embed_wasm, try_function_return_this, try_iife_call_rewrite,
-    try_require_literal_bail,
+    try_native_module_method_apply_call, try_require_literal_bail,
 };
 use local_array_methods::try_local_array_methods;
 use module_class_static::try_module_class_static;
@@ -139,6 +139,13 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
         return Ok(expr);
     }
     if let Some(expr) = try_iife_call_rewrite(ctx, call, has_spread)? {
+        return Ok(expr);
+    }
+    // #1722: `path.join.apply(null, [a, b])` / `.call(null, a, b)` and the
+    // same shape on any stdlib namespace — rewrite to the direct call so
+    // the dedicated per-method lowering runs (indirect invocation
+    // otherwise reads the method value as `undefined`).
+    if let Some(expr) = try_native_module_method_apply_call(ctx, call, has_spread)? {
         return Ok(expr);
     }
     if let Some(expr) = try_function_return_this(ctx, call, has_spread) {

--- a/test-parity/node-suite/os/methods/apply-call.ts
+++ b/test-parity/node-suite/os/methods/apply-call.ts
@@ -1,0 +1,12 @@
+// #1722: indirect invocation of stdlib namespace methods via
+// Function.prototype.apply / .call must reach the native impl. Use
+// deterministic shape-only assertions so the output matches Node on any
+// host (the actual platform/arch strings vary by machine).
+import * as os from "node:os";
+
+console.log("platform apply is string:", typeof os.platform.apply(null, []) === "string");
+console.log("platform call matches direct:", os.platform.call(null) === os.platform());
+console.log("arch apply matches direct:", os.arch.apply(null, []) === os.arch());
+console.log("endianness call known:", ["LE", "BE"].includes(os.endianness.call(null)));
+console.log("type apply nonempty:", os.type.apply(null, []).length > 0);
+console.log("totalmem call is number:", typeof os.totalmem.call(null) === "number");

--- a/test-parity/node-suite/path/apply-call/basic.ts
+++ b/test-parity/node-suite/path/apply-call/basic.ts
@@ -1,0 +1,25 @@
+// #1722: stdlib namespace methods invoked indirectly via
+// Function.prototype.apply / .call must reach the native impl (they used
+// to read as `undefined`). Surfaced by the #800 node-core radar
+// (test-path-join.js uses `path.join.apply(...)`).
+import * as path from "node:path";
+
+// typeof is "function" both directly and after capture.
+console.log("typeof join:", typeof path.join);
+
+// .apply with a literal args array (the radar shape).
+console.log("apply 2:", path.join.apply(null, ["a", "b"]));
+console.log("apply 3:", path.join.apply(null, ["a", "b", "c"]));
+console.log("apply empty:", path.join.apply(null, []));
+
+// .call with positional args.
+console.log("call 2:", path.join.call(null, "x", "y"));
+console.log("call none:", path.join.call(null));
+
+// Other single-arg path methods via apply / call.
+console.log("dirname apply:", path.dirname.apply(null, ["/a/b/c.txt"]));
+console.log("basename call:", path.basename.call(null, "/a/b/c.txt"));
+console.log("extname apply:", path.extname.apply(null, ["/a/b/c.txt"]));
+console.log("isAbsolute call:", path.isAbsolute.call(null, "/foo"));
+console.log("isAbsolute apply:", path.isAbsolute.apply(null, ["foo"]));
+console.log("resolve apply:", path.resolve.apply(null, ["/a", "b"]));


### PR DESCRIPTION
## Summary

Closes #1722.

Calling a stdlib namespace method **indirectly** via `Function.prototype.apply` / `.call` returned `undefined` instead of dispatching to the native implementation:

```js
const path = require('path');
typeof path.join;                  // "function"   ✓ (both before and after)
path.join.apply(null, ['a','b']);  // before: undefined   after: "a/b"  (Node: "a/b")
path.join.call(null, 'a', 'b');    // before: undefined   after: "a/b"  (Node: "a/b")
```

Surfaced by the #800 node-core radar (`test-path-join.js` uses `path.join.apply(...)`).

## Root cause

Stdlib namespace methods (`path.join`, `fs.existsSync`, `os.platform`, …) are lowered by dedicated HIR rules keyed on the **direct-call** shape `ns.method(...)` (e.g. `path.join(a, b)` folds to `Expr::PathJoin`). The bare method *value* `path.join` lowers to a runtime namespace-property read that returns `undefined` for methods not on the callable-export whitelist — so invoking it through `.apply`/`.call` evaluated `.apply` on `undefined` and silently produced `undefined`.

## Fix

A new AST hook `try_native_module_method_apply_call` recognises `ns.method.{apply,call}(...)` where `ns` is a native-module namespace binding (`import * as`, `require`, default import), rewrites it to the equivalent direct call, and re-dispatches through `lower_call` so every existing per-method lowering runs. `thisArg` is dropped — correct for namespace functions, which ignore `this`.

Conservative scope:
- `.call(thisArg, a, b, …)` → `ns.method(a, b, …)`
- `.apply(thisArg)` / `.apply()` → `ns.method()`
- `.apply(thisArg, [a, b, …])` → `ns.method(a, b, …)` (clean array literal only)

A non-literal `apply` args array (a variable / call result) can't be statically expanded, so it falls through unchanged (the runtime spread path `ns.method(...arr)` is a separate, pre-existing gap). The namespace-binding guard keeps the rewrite away from `obj.fn.call()` method dispatch, function-literal IIFEs (`try_iife_call_rewrite`), and `Object.prototype.<m>.call()` (`try_object_prototype_call`).

## Testing

- New parity coverage (byte-for-byte vs `node --experimental-strip-types`):
  - `test-parity/node-suite/path/apply-call/basic.ts` — join/dirname/basename/extname/isAbsolute/resolve via apply + call
  - `test-parity/node-suite/os/methods/apply-call.ts` — platform/arch/endianness/type/totalmem via apply + call
- Re-ran the full `path` + `os` node-suite locally: no new failures (the pre-existing failures don't use `.apply`/`.call`, so this change provably can't affect them).
- Existing `test-files/test_function_apply_call.ts` and `test-files/test_gap_node_path.ts` still match Node.
- `cargo test -p perry-hir` green; `cargo fmt --all -- --check` clean.

## Note for maintainer

Per the worktree-PR convention this branch intentionally omits the `Cargo.toml`/`CLAUDE.md` version bump and the `CHANGELOG.md` entry — fold those in at merge.
