### PR TITLE
test(parity): stream — batch of 8 consumers/promises tests (iter-145..146) (6 free pass, 2 #1532)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3109,5 +3109,17 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/consumers/text-from-buffer-chunks": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream/consumers: text() on Buffer chunks with multibyte UTF-8 — decode boundary wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/promises/pipeline-with-transform-collect": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream/promises: pipeline(src, transform, asyncFnSink) — collected output wrong/empty. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/consumers/array-buffer-from-web-rs.ts
+++ b/test-parity/node-suite/stream/consumers/array-buffer-from-web-rs.ts
@@ -1,0 +1,9 @@
+import { ReadableStream } from "node:stream/web";
+import { arrayBuffer } from "node:stream/consumers";
+// arrayBuffer() works with Web ReadableStream.
+const rs = new ReadableStream({
+  start(c) { c.enqueue("abc"); c.close(); },
+});
+const ab = await arrayBuffer(rs as any);
+console.log("is ArrayBuffer:", ab instanceof ArrayBuffer);
+console.log("byteLength:", ab.byteLength);

--- a/test-parity/node-suite/stream/consumers/blob-from-web-rs.ts
+++ b/test-parity/node-suite/stream/consumers/blob-from-web-rs.ts
@@ -1,0 +1,9 @@
+import { ReadableStream } from "node:stream/web";
+import { blob } from "node:stream/consumers";
+// blob() works with Web ReadableStream.
+const rs = new ReadableStream({
+  start(c) { c.enqueue("hi"); c.close(); },
+});
+const b = await blob(rs as any);
+console.log("is Blob:", b instanceof Blob);
+console.log("size:", b.size);

--- a/test-parity/node-suite/stream/consumers/buffer-from-web-rs.ts
+++ b/test-parity/node-suite/stream/consumers/buffer-from-web-rs.ts
@@ -1,0 +1,9 @@
+import { ReadableStream } from "node:stream/web";
+import { buffer } from "node:stream/consumers";
+// buffer() works on Web ReadableStream.
+const rs = new ReadableStream({
+  start(c) { c.enqueue("ab"); c.enqueue("cd"); c.close(); },
+});
+const buf = await buffer(rs as any);
+console.log("isBuffer:", Buffer.isBuffer(buf));
+console.log("content:", buf.toString("utf8"));

--- a/test-parity/node-suite/stream/consumers/json-from-web-rs.ts
+++ b/test-parity/node-suite/stream/consumers/json-from-web-rs.ts
@@ -1,0 +1,8 @@
+import { ReadableStream } from "node:stream/web";
+import { json } from "node:stream/consumers";
+// json() works on Web ReadableStream.
+const rs = new ReadableStream({
+  start(c) { c.enqueue(`{"ok":`); c.enqueue(`true}`); c.close(); },
+});
+const result = await json(rs as any) as any;
+console.log("ok:", result.ok);

--- a/test-parity/node-suite/stream/consumers/json-object-multi-key.ts
+++ b/test-parity/node-suite/stream/consumers/json-object-multi-key.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+import { json } from "node:stream/consumers";
+// JSON object with nested keys/values.
+const r = Readable.from([`{"a":1,"b":"two","c":[3,4,5]}`]);
+const result = await json(r) as any;
+console.log("a:", result.a);
+console.log("b:", result.b);
+console.log("c[2]:", result.c[2]);

--- a/test-parity/node-suite/stream/consumers/text-from-buffer-chunks.ts
+++ b/test-parity/node-suite/stream/consumers/text-from-buffer-chunks.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { text } from "node:stream/consumers";
+// text() decodes Buffer chunks as UTF-8.
+const r = Readable.from([Buffer.from("hé"), Buffer.from("llo")]);
+const result = await text(r);
+console.log("result:", result);
+console.log("length:", result.length);

--- a/test-parity/node-suite/stream/promises/finished-resolves-on-normal-end.ts
+++ b/test-parity/node-suite/stream/promises/finished-resolves-on-normal-end.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
+// finished() resolves (no value) on normal end.
+const r = Readable.from(["a", "b"]);
+r.on("data", () => {});
+const result = await finished(r);
+console.log("resolved to:", result);
+console.log("is undefined:", result === undefined);

--- a/test-parity/node-suite/stream/promises/pipeline-with-transform-collect.ts
+++ b/test-parity/node-suite/stream/promises/pipeline-with-transform-collect.ts
@@ -1,0 +1,10 @@
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+// promises.pipeline with a transform + collecting async-fn sink.
+const src = Readable.from(["a", "b"]);
+const upper = new Transform({ transform(c, _e, cb) { cb(null, String(c).toUpperCase()); } });
+const collected: string[] = [];
+await pipeline(src, upper, async function (source: AsyncIterable<any>) {
+  for await (const v of source) collected.push(String(v));
+});
+console.log("collected:", collected.join(","));


### PR DESCRIPTION
### Stream parity batch — 8 tests aggregated (iter-145..146)

**6 free passes + 2 tracked failures — 75% pass rate.**

Continued focus on `stream/consumers` + `stream/promises`. consumers is essentially at full parity (every web-RS-source variant passes).

| Category | Tests | Issue |
|---|---|---|
| stream/consumers | blob-from-web-rs ✅, array-buffer-from-web-rs ✅, json-object-multi-key ✅, json-from-web-rs ✅, buffer-from-web-rs ✅, text-from-buffer-chunks | #1532 |
| stream/promises | finished-resolves-on-normal-end ✅, pipeline-with-transform-collect | #1532 |

Free passes: all 5 consumers web-RS-source variants + finished-resolves.

2 failures tracked in `known_failures.json` (multibyte text decode boundary + promises pipeline collection).