### PR TITLE
fix(regex): dynamic regex.test()/exec() dispatch on untyped receiver (#1731)

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -210,6 +210,20 @@ pub unsafe extern "C" fn js_native_call_method(
         return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
     }
 
+    // `regex.test(str)` / `regex.exec(str)` on an *untyped* receiver — e.g.
+    // hono's RegExpRouter does `buildWildcardRegExp(k).test(path)`, a call on a
+    // function result the codegen `Expr::RegExpTest` fast path can't see; without
+    // this it throws `test is not a function`, breaking Hono `app.use('*', …)`
+    // (#1731). The helper returns None for non-regex so generic dispatch resumes.
+    if matches!(method_name, "test" | "exec") && jsval.is_pointer() {
+        let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+        let arg0 = refreshed_args().first().copied().unwrap_or(undef);
+        let p = jsval.as_pointer::<u8>();
+        if let Some(r) = crate::regex::dispatch_regex_receiver_method(p, method_name, arg0) {
+            return r;
+        }
+    }
+
     // Node timer handles are represented in Perry as small integer ids
     // NaN-boxed as pointers. Provide the common Timeout/Immediate methods
     // directly so `timeout.ref().unref().hasRef()` style probes behave like

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -955,6 +955,41 @@ pub extern "C" fn js_regexp_exec(
     }
 }
 
+/// Dynamic-receiver dispatch for `regex.test(str)` / `regex.exec(str)` when
+/// codegen couldn't prove the receiver is a RegExp (e.g. hono's RegExpRouter
+/// does `buildWildcardRegExp(k).test(path)`, where the receiver is the result
+/// of a function call). Returns `Some(result)` only when `ptr` is a live regex
+/// AND `method` is `test`/`exec`; `None` otherwise so the generic method
+/// dispatch in `js_native_call_method` continues. The argument is coerced to a
+/// string (`re.test(123)` tests against `"123"`). (#1731)
+pub(crate) fn dispatch_regex_receiver_method(
+    ptr: *const u8,
+    method: &str,
+    arg0: f64,
+) -> Option<f64> {
+    if !is_regex_pointer(ptr) {
+        return None;
+    }
+    let re = ptr as *mut RegExpHeader;
+    let s_ptr = crate::value::js_jsvalue_to_string(arg0);
+    match method {
+        "test" => {
+            let matched = js_regexp_test(re, s_ptr) != 0;
+            Some(f64::from_bits(crate::value::JSValue::bool(matched).bits()))
+        }
+        // exec: the match array, or `null` on no match (spec-correct).
+        "exec" => {
+            let arr = js_regexp_exec(re, s_ptr);
+            Some(if arr.is_null() {
+                f64::from_bits(crate::value::TAG_NULL)
+            } else {
+                f64::from_bits(crate::value::JSValue::pointer(arr as *const u8).bits())
+            })
+        }
+        _ => None,
+    }
+}
+
 /// Get the .index from the last exec() call
 #[no_mangle]
 pub extern "C" fn js_regexp_exec_get_index() -> f64 {


### PR DESCRIPTION
Fixes #1731.

## Root cause

hono's `RegExpRouter` matches wildcard middleware with `buildWildcardRegExp(k).test(path)` — a method call on the **untyped result of a function call**. Codegen's `Expr::RegExpTest` / `Expr::RegExpExec` fast path only fires when the receiver's static type is provably a `RegExp` (`const re = /…/; re.test(x)`). The dynamic-receiver form fell through to `js_native_call_method`, which had arms for `string.match/search/replace(regex)` (regex as *argument*) but **none for a regex *receiver*** with `test`/`exec` — so it hit the catch-all and threw `TypeError: test is not a function`.

That broke **every** Hono `app.use('*', …)` wildcard middleware — including `logger()`, which was the last line blocking the #1655 acceptance program.

## Fix

A regex-receiver arm in `js_native_call_method`: when `method ∈ {test, exec}` and the receiver is a live regex (`is_regex_pointer`), dispatch to `js_regexp_test` / `js_regexp_exec` (argument coerced to a string; `exec` returns `null` on no match, per spec). The body lives in `regex::dispatch_regex_receiver_method`; it returns `None` for non-regex receivers so the generic dispatch continues unchanged.

## Testing

- Minimal repro `app.use('*', async (c,next)=>{await next()})` + `app.get('/')` now returns `status 200`.
- The **complete literal #1655 acceptance program** (real `hono@4.10` + `@hono/perry-server`, `app.use('*', logger())` included) now serves all routes end-to-end through `serve()` + live `curl`:
  - `GET /` → `<html>…<h1>hello</h1>…</html>`
  - `GET /api/echo?k=v&a=b` → `{"q":{"k":"v","a":"b"}}`
  - `POST /api/echo` → `{"body":{"x":1}}`
  - `logger()` logs `--> GET / 200 0ms` (with color)
- `cargo test -p perry-runtime`: 560 passed, 0 failed. `cargo fmt --all --check` clean; file-size gate clean.

## Note (out of scope)

`typeof re.test` on a regex value still reports `undefined` (the method-as-value form via the property-get path) — hono doesn't rely on it. Left for a separate follow-up if needed.
