### PR TITLE
fix(dynamic-import): resolve import('pkg') when pkg is also statically imported (#1672)

### DIFF
--- a/crates/perry-hir/src/ir/decl.rs
+++ b/crates/perry-hir/src/ir/decl.rs
@@ -104,6 +104,18 @@ pub struct Import {
     /// but do NOT pin the target as eager — if no static edge reaches it
     /// the target is `Deferred`. `specifiers` is empty for these.
     pub is_dynamic: bool,
+    /// Issue #1672: this source is the target of at least one dynamic
+    /// `import()` site in the module, but the edge could NOT be a
+    /// dedicated `is_dynamic` synthetic edge because a *static* import of
+    /// the same source already exists (the fold in `collect_modules`
+    /// keeps the static edge for binding materialization + init order).
+    /// The static edge therefore stays `is_dynamic = false`, and this
+    /// flag is set on it so the driver still registers the source in the
+    /// dynamic-import dispatch map (`dynamic_import_path_to_prefix`) and
+    /// marks the target module as a namespace-emitting dynamic target.
+    /// Always `false` on `is_dynamic` synthetic edges (those are already
+    /// dynamic targets by virtue of `is_dynamic`).
+    pub is_dynamic_target: bool,
 }
 
 /// Import specifier

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -150,6 +150,7 @@ pub fn lower_module_full(
             resolved_path: None,
             type_only: false,
             is_dynamic: false,
+            is_dynamic_target: false,
         });
     }
 

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -211,6 +211,7 @@ pub(crate) fn lower_module_decl(
                 resolved_path: None, // Will be set by compiler driver during module resolution
                 type_only: whole_decl_type_only,
                 is_dynamic: false,
+                is_dynamic_target: false,
             });
         }
         ast::ModuleDecl::ExportDecl(export) => {

--- a/crates/perry-hir/src/stable_hash/module.rs
+++ b/crates/perry-hir/src/stable_hash/module.rs
@@ -92,6 +92,7 @@ impl SH for Import {
             resolved_path,
             type_only,
             is_dynamic,
+            is_dynamic_target,
         } = self;
         source.hash(h);
         specifiers.hash(h);
@@ -100,6 +101,7 @@ impl SH for Import {
         resolved_path.hash(h);
         type_only.hash(h);
         is_dynamic.hash(h);
+        is_dynamic_target.hash(h);
     }
 }
 

--- a/crates/perry-hir/src/stable_hash/tests.rs
+++ b/crates/perry-hir/src/stable_hash/tests.rs
@@ -115,6 +115,7 @@ fn module_metadata_affects_hash() {
         resolved_path: None,
         type_only: false,
         is_dynamic: false,
+        is_dynamic_target: false,
     });
     assert_ne!(base_hash, hash_module(&m_imp));
 

--- a/crates/perry-transform/src/inline/mod.rs
+++ b/crates/perry-transform/src/inline/mod.rs
@@ -489,6 +489,7 @@ pub fn inline_functions(
                     resolved_path: Some(path),
                     type_only: false,
                     is_dynamic: false,
+                    is_dynamic_target: false,
                 });
             }
         }

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -1480,7 +1480,11 @@ pub fn run_with_parse_cache(
     let mut dyn_target_paths: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
     for (_path, hir_module) in &ctx.native_modules {
         for import in &hir_module.imports {
-            if !import.is_dynamic {
+            // `is_dynamic` covers dynamic-only synthetic edges;
+            // `is_dynamic_target` (#1672) covers a static edge that is
+            // ALSO the target of a dynamic `import()` in the same module.
+            // Both need the target to emit `@__perry_ns_<prefix>`.
+            if !(import.is_dynamic || import.is_dynamic_target) {
                 continue;
             }
             if let Some(rp) = &import.resolved_path {
@@ -1599,13 +1603,15 @@ pub fn run_with_parse_cache(
     // For each consumer module, map every `Expr::DynamicImport` arg-path
     // string (as resolved in `collect_modules`) to the target's
     // sanitized prefix. Built by scanning the consumer's imports for
-    // `is_dynamic == true` and reading the `source` + `resolved_path`.
+    // `is_dynamic == true` (dynamic-only edges) or `is_dynamic_target ==
+    // true` (#1672: a static edge that is also a dynamic-import target)
+    // and reading the `source` + `resolved_path`.
     let mut per_module_dyn_import_targets: HashMap<PathBuf, HashMap<String, String>> =
         HashMap::new();
     for (path, hir_module) in &ctx.native_modules {
         let mut local_map: HashMap<String, String> = HashMap::new();
         for import in &hir_module.imports {
-            if !import.is_dynamic {
+            if !(import.is_dynamic || import.is_dynamic_target) {
                 continue;
             }
             let rp = match &import.resolved_path {

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -548,15 +548,23 @@ pub(super) fn collect_modules(
     }
     for source in new_dyn_imports {
         // A dynamic edge to the same source as a static import is folded
-        // into the existing edge (just flip is_dynamic off — the static
-        // edge already gives us full namespace materialization). A
-        // dynamic-only target appears as a new import with empty
+        // into the existing static edge: that edge already gives us full
+        // namespace materialization + the eager init-order pin, both of
+        // which depend on it staying `is_dynamic = false`. But the
+        // dynamic `import()` dispatch still needs the source registered
+        // as a dynamic-import target (#1672) — otherwise
+        // `dynamic_import_path_to_prefix` has no entry for it and the
+        // dispatch falls through to `js_promise_rejected(undefined)` even
+        // though the module is compiled in. So mark the static edge with
+        // `is_dynamic_target` instead of dropping the information.
+        // A dynamic-only target appears as a new import with empty
         // specifiers and `is_dynamic = true`.
-        if hir_module
+        if let Some(existing) = hir_module
             .imports
-            .iter()
-            .any(|i| i.source == source && !i.is_dynamic)
+            .iter_mut()
+            .find(|i| i.source == source && !i.is_dynamic)
         {
+            existing.is_dynamic_target = true;
             continue;
         }
         let is_native = perry_hir::is_native_module(&source);
@@ -573,6 +581,7 @@ pub(super) fn collect_modules(
             resolved_path: None,
             type_only: false,
             is_dynamic: true,
+            is_dynamic_target: false,
         });
     }
 

--- a/test-files/test_gap_dynamic_import_static_overlap.ts
+++ b/test-files/test_gap_dynamic_import_static_overlap.ts
@@ -1,0 +1,22 @@
+// Test (#1672): a module that BOTH statically imports a source AND
+// dynamically `import()`s the same source must still resolve the dynamic
+// import to the module namespace.
+//
+// The fold in collect_modules keeps the *static* edge (it provides binding
+// materialization + the eager init-order pin, both requiring is_dynamic =
+// false) and suppresses the synthetic dynamic edge. Before the fix, that
+// dropped the source from the dynamic-import dispatch map entirely, so
+// `await import("./dynamic_import_helper_a.ts")` rejected with `undefined`
+// even though the module was compiled in. The static edge now carries an
+// `is_dynamic_target` flag so the dispatch map is still populated.
+
+import { x } from "./dynamic_import_helper_a.ts";
+
+async function main(): Promise<void> {
+  console.log("static x:", x);
+  const m = await import("./dynamic_import_helper_a.ts");
+  console.log("dynamic x:", m.x);
+  console.log("dynamic greet:", m.greet());
+}
+
+main();


### PR DESCRIPTION
## Summary

Fixes #1672. A dynamic `import()` whose specifier is **also statically imported** in the same module rejected with `undefined` at runtime, even when the module is compiled in (relative path or `compilePackages` bare specifier). Node returns the namespace.

The pure dynamic-only case the issue describes (`await import('chalk')` with no static import) already resolved on `main` via the generic import-resolution loop. This PR closes the remaining **static + dynamic overlap** gap.

## Root cause

The fold in `collect_modules` suppresses the synthetic dynamic import edge when a static edge to the same source already exists — the static edge provides binding materialization + the eager init-order pin, both of which require `is_dynamic = false`. But the two dynamic-import dispatch maps in the driver were built **only** from `is_dynamic` edges:

- `dyn_target_paths` — makes the target module emit `@__perry_ns_<prefix>`.
- `per_module_dyn_import_targets` → `dynamic_import_path_to_prefix` — the dispatch-site path→prefix lookup.

So the folded source had no entry in either map, and the `Expr::DynamicImport` dispatch fell through to `js_promise_rejected(undefined)`.

## Fix

Add an `is_dynamic_target` flag to `Import`. The fold now sets it on the **retained static edge** instead of discarding the dynamic-target information, and both dispatch-map builders gate on `is_dynamic || is_dynamic_target`. The static edge stays `is_dynamic = false`, so init order and bindings are unaffected; the `__init` call the dispatch emits is idempotent.

## Testing

- New gap test `test-files/test_gap_dynamic_import_static_overlap.ts` — byte-equal to `node --experimental-strip-types`.
- All 9 `test_gap_dynamic_import_*` gap tests pass (no regression).
- Verified manually for a bare-specifier `compilePackages` package imported both statically and dynamically (now matches Node), plus dynamic-only named/default/scoped/subpath and the optional-dependency reject idiom.
- `perry-hir` `stable_hash` tests pass; `cargo fmt --all -- --check` clean.

> Per the external-contributor / worktree convention, no version bump or CHANGELOG entry — to be folded in at merge.
