### PR TITLE
fix(windows): #1542 black areas on window resize + restore Windows source build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1027 — fix(windows): #1542 black areas on window resize + restore Windows source build
+
+Two Windows-only fixes.
+
+**#1542 — black areas after enlarging a `perry/ui` window.** Enlarging an `App` window beyond its initial size left the newly-exposed client area (and the gaps between intrinsic-sized children) rendering solid black, with stale/torn copies of the original layout left behind. Root cause: the main `App` window class (`crates/perry-ui-windows/src/app.rs`) and the `PerryVStack` / `PerryHStack` container classes (`widgets/vstack.rs`, `widgets/hstack.rs`) all registered `hbrBackground: HBRUSH(null)`. Their `WM_ERASEBKGND` handlers only fill a background when an explicit `.background()` color or gradient is set on the widget (or an ancestor); with no background set they fall through to `DefWindowProcW`, which — with a null class brush — erases *nothing*. Combined with `CS_HREDRAW | CS_VREDRAW` invalidating the whole client area on every resize, the unpainted regions showed black and intermediate paints were never cleared. Fix: register those three classes with the idiomatic default window-color brush `HBRUSH((COLOR_WINDOW.0 + 1))` — the same brush the secondary-window class in `window.rs` already used. Explicit colors/gradients are unaffected because their handlers still return before the class brush is consulted; only the no-background case changes from "black" to the system window color. Verified on Windows 11 @ 100% DPI: black coverage of the enlarged window dropped from ~51% to ~1% (residual is the window frame edge), content fills correctly, and the stale duplicate render is gone.
+
+**Restore Windows source build.** `crates/perry-runtime/src/fs/cp.rs`'s `copy_preserve_timestamps` called `set_path_times`, which is `#[cfg(unix)]` (`fs/mod.rs`), unconditionally — so `perry-runtime` failed to compile on Windows (`error[E0425]: cannot find function set_path_times`). CI did not catch this because `cargo-test` runs on Linux/macOS. Gated the call behind `#[cfg(unix)]` with a non-unix no-op, matching the existing convention used by the `utimesSync` / `lutimesSync` callers (timestamp preservation on `cpSync` is best-effort and already a no-op on non-unix targets).
+
 ## v0.5.1026 — release sweep: timers epic + perf_hooks fan-out + lazy-tape fixes
 
 Rolls up 22 PRs that merged to `main` post-v0.5.1025 without version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1026
+**Current Version:** 0.5.1027
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4773,7 +4773,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "anyhow",
  "base64",
@@ -4828,14 +4828,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "anyhow",
  "log",
@@ -4850,7 +4850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4859,7 +4859,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4867,7 +4867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "anyhow",
  "base64",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4907,7 +4907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "serde",
  "serde_json",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1026"
+version = "0.5.1027"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4926,7 +4926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "anyhow",
  "clap",
@@ -4941,14 +4941,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "chrono",
  "cron",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5015,7 +5015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5047,14 +5047,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5082,7 +5082,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "base64",
  "image",
@@ -5239,14 +5239,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5302,7 +5302,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "anyhow",
  "base64",
@@ -5357,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5444,7 +5444,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5452,11 +5452,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1026"
+version = "0.5.1027"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "base64",
  "itoa",
@@ -5472,7 +5472,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "base64",
  "block2",
@@ -5519,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "base64",
  "block2",
@@ -5538,11 +5538,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1026"
+version = "0.5.1027"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "base64",
  "block2",
@@ -5558,7 +5558,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "base64",
  "block2",
@@ -5574,7 +5574,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "block2",
  "libc",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "base64",
  "libc",
@@ -5602,7 +5602,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1026"
+version = "0.5.1027"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1026"
+version = "0.5.1027"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/fs/cp.rs
+++ b/crates/perry-runtime/src/fs/cp.rs
@@ -65,7 +65,12 @@ pub(crate) fn copy_preserve_timestamps(src: &Path, dst: &Path, follow: bool) {
     };
     let (atime, mtime, _, _) = metadata_times_ms(&meta);
     let dst_string = dst.to_string_lossy();
+    // `set_path_times` is unix-only (utimensat); on other targets timestamp
+    // preservation is a no-op, matching the cfg-gated callers in fs/mod.rs.
+    #[cfg(unix)]
     let _ = set_path_times(&dst_string, atime / 1000.0, mtime / 1000.0, !follow);
+    #[cfg(not(unix))]
+    let _ = (&dst_string, atime, mtime, follow);
 }
 
 pub(crate) fn lexical_normalize_path(path: PathBuf) -> PathBuf {

--- a/crates/perry-ui-windows/src/app.rs
+++ b/crates/perry-ui-windows/src/app.rs
@@ -194,7 +194,13 @@ pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
                 lpfnWndProc: Some(wnd_proc),
                 hInstance: HINSTANCE::from(hinstance),
                 hCursor: LoadCursorW(None, IDC_ARROW).unwrap_or_default(),
-                hbrBackground: HBRUSH(std::ptr::null_mut()),
+                // Default window-color class brush (matches the secondary-window
+                // class in window.rs). A null brush erases nothing, so any client
+                // area not covered by a child renders black after a resize (#1542).
+                // The WM_ERASEBKGND handler still returns early for explicit
+                // .background() colors/gradients, so this only affects the
+                // no-background case.
+                hbrBackground: HBRUSH((COLOR_WINDOW.0 + 1) as *mut _),
                 lpszClassName: windows::core::PCWSTR(class_name.as_ptr()),
                 ..Default::default()
             };

--- a/crates/perry-ui-windows/src/widgets/hstack.rs
+++ b/crates/perry-ui-windows/src/widgets/hstack.rs
@@ -4,7 +4,7 @@
 use windows::Win32::Foundation::*;
 #[cfg(target_os = "windows")]
 use windows::Win32::Graphics::Gdi::{
-    CreateSolidBrush, FillRect, SetBkMode, HBRUSH, HDC, TRANSPARENT,
+    CreateSolidBrush, FillRect, SetBkMode, COLOR_WINDOW, HBRUSH, HDC, TRANSPARENT,
 };
 #[cfg(target_os = "windows")]
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
@@ -31,7 +31,10 @@ fn ensure_class_registered() {
             style: CS_HREDRAW | CS_VREDRAW,
             lpfnWndProc: Some(container_wnd_proc),
             hInstance: HINSTANCE::from(hinstance),
-            hbrBackground: HBRUSH(std::ptr::null_mut()),
+            // Default window-color class brush — see vstack.rs / #1542. A null
+            // brush leaves uncovered/exposed area black; the WM_ERASEBKGND
+            // handler still returns early for an explicit background color.
+            hbrBackground: HBRUSH((COLOR_WINDOW.0 + 1) as *mut _),
             lpszClassName: windows::core::PCWSTR(class_name.as_ptr()),
             ..Default::default()
         };

--- a/crates/perry-ui-windows/src/widgets/vstack.rs
+++ b/crates/perry-ui-windows/src/widgets/vstack.rs
@@ -4,7 +4,7 @@
 use windows::Win32::Foundation::*;
 #[cfg(target_os = "windows")]
 use windows::Win32::Graphics::Gdi::{
-    CreateSolidBrush, FillRect, SetBkMode, HBRUSH, HDC, TRANSPARENT,
+    CreateSolidBrush, FillRect, SetBkMode, COLOR_WINDOW, HBRUSH, HDC, TRANSPARENT,
 };
 #[cfg(target_os = "windows")]
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
@@ -32,7 +32,13 @@ fn ensure_class_registered() {
                 style: CS_HREDRAW | CS_VREDRAW,
                 lpfnWndProc: Some(container_wnd_proc),
                 hInstance: HINSTANCE::from(hinstance),
-                hbrBackground: HBRUSH(std::ptr::null_mut()), // transparent
+                // Default window-color class brush. With a null brush, the
+                // gaps between intrinsic-sized children and any area exposed by
+                // enlarging the window erase to nothing → black (#1542). The
+                // WM_ERASEBKGND handler below still fills an explicit/ancestor
+                // .background() color or gradient and returns early, so this
+                // class brush is only used when no background is set anywhere.
+                hbrBackground: HBRUSH((COLOR_WINDOW.0 + 1) as *mut _),
                 lpszClassName: windows::core::PCWSTR(class_name.as_ptr()),
                 ..Default::default()
             };


### PR DESCRIPTION
## Summary

Two Windows-only fixes (closes #1542, plus a build regression found along the way).

### 1. #1542 — black areas after enlarging a `perry/ui` window
Enlarging an `App` window beyond its initial size left the newly-exposed client area (and the gaps between intrinsic-sized children) rendering **solid black**, with stale/torn copies of the original layout left behind.

**Root cause:** the main `App` window class (`app.rs`) and the `PerryVStack` / `PerryHStack` container classes (`widgets/vstack.rs`, `widgets/hstack.rs`) all registered `hbrBackground: HBRUSH(null)`. Their `WM_ERASEBKGND` handlers only fill a background when an explicit `.background()` color/gradient is set on the widget or an ancestor; with none set they fall through to `DefWindowProcW`, which — with a null class brush — erases *nothing*. With `CS_HREDRAW | CS_VREDRAW` invalidating the whole client area on every resize, the unpainted regions showed black and intermediate paints were never cleared.

**Fix:** register those three classes with the idiomatic default window-color brush `HBRUSH((COLOR_WINDOW.0 + 1))` — the same brush the secondary-window class in `window.rs` already uses. Explicit colors/gradients are unaffected (their handlers still return before the class brush is consulted); only the no-background case changes from "black" to the system window color.

### 2. Restore the Windows source build
`fs/cp.rs::copy_preserve_timestamps` called `set_path_times` (which is `#[cfg(unix)]` in `fs/mod.rs`) unconditionally, so `perry-runtime` failed to compile on Windows:
```
error[E0425]: cannot find function `set_path_times` in this scope
```
CI doesn't catch this because `cargo-test` runs on Linux/macOS. cfg-gated the call with a non-unix no-op, matching the existing `utimesSync` / `lutimesSync` convention (cp timestamp preservation is already a no-op on non-unix).

## Verification
Compiled the exact repro from #1542, launched it, enlarged the window 800×600 → 1200×900, and captured via `PrintWindow` (window's own pixels, z-order independent) on Windows 11 @ 100% DPI:

- **Before:** ~51% of the enlarged window is solid black + a stale duplicate render.
- **After:** ~1% black (just the window frame edge); content fills the window, no stale render.

## Files
- `crates/perry-ui-windows/src/app.rs`, `widgets/vstack.rs`, `widgets/hstack.rs` — default class brush
- `crates/perry-runtime/src/fs/cp.rs` — cfg-gate `set_path_times`
- `Cargo.toml` / `Cargo.lock` / `CLAUDE.md` — version bump 0.5.1026 → 0.5.1027
- `CHANGELOG.md` — entry