### PR TITLE
feat(compile): add --trace/--focus debugging flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ benchmarks/suite/assets/
 # SIGILL at runtime. Always machine-local, always regenerable.)
 .perry-cache/
 
+# `perry compile --trace llvm` dumps per-module .ll files here.
+.perry-trace/
+
 # Compiled test executables in the project root (no extension)
 /test_*
 /test-*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,11 @@ cargo test --release --workspace \
   --exclude perry-ui-gtk4   # Run tests (exclude cross-host UI crates on macOS)
 cargo run --release -- file.ts -o output && ./output    # Compile and run TypeScript
 cargo run --release -- file.ts --print-hir              # Debug: print HIR
+cargo run --release -- file.ts --trace hir --focus fnName  # Debug: focused HIR for one fn (use to localize a miscompile)
+cargo run --release -- file.ts --trace llvm             # Debug: dump per-module LLVM IR to .perry-trace/llvm/
 ```
+
+When debugging a "compiled to the wrong thing" bug, reach for `--trace hir --focus <name>` to dump just the offending function's lowered HIR (functions/methods/classes matching the substring; import/init noise suppressed) instead of scrolling a full `--print-hir`. `--trace llvm` writes per-module `.ll` (it forces a no-cache rebuild so codegen actually runs). See `docs/src/cli/flags.md`.
 
 ## Architecture
 

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -145,6 +145,53 @@ pub fn run_with_parse_cache(
         std::env::set_var("PERRY_DEBUG_SYMBOLS", "1");
     }
 
+    // `--trace <stages>` consolidates the scattered debug-dump knobs into one
+    // flag. Parse it up-front (single-threaded, before codegen spawns rayon
+    // workers) so the `llvm` stage can promote itself to the env vars the
+    // codegen + linker already honor, exactly like `--debug-symbols` above.
+    // `--focus NAME` alone implies `hir` — asking to focus something with no
+    // stage selected obviously means "show me that function's HIR".
+    let trace_stages: std::collections::HashSet<String> = args
+        .trace
+        .as_deref()
+        .map(|s| {
+            s.split(',')
+                .map(|t| t.trim().to_ascii_lowercase())
+                .filter(|t| !t.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    let trace_all = trace_stages.contains("all");
+    let trace_hir = trace_all
+        || trace_stages.contains("hir")
+        || args.print_hir
+        || (trace_stages.is_empty() && args.focus.is_some());
+    let trace_llvm = trace_all || trace_stages.contains("llvm");
+    if trace_llvm {
+        // Land .ll files in a predictable per-build directory so the user
+        // doesn't have to remember PERRY_SAVE_LL / PERRY_LLVM_KEEP_IR. Don't
+        // clobber an explicit env override.
+        if std::env::var_os("PERRY_SAVE_LL").is_none() {
+            // Absolute path: codegen runs the .ll write on rayon workers whose
+            // cwd we don't want to depend on. Join against cwd up-front.
+            let dir = std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(".perry-trace")
+                .join("llvm");
+            let _ = std::fs::create_dir_all(&dir);
+            std::env::set_var("PERRY_SAVE_LL", &dir);
+            std::env::set_var("PERRY_LLVM_KEEP_IR", "1");
+            // The per-module object cache short-circuits codegen for unchanged
+            // modules — which means `emit_module` (and thus the .ll write)
+            // never runs and the trace dir comes up empty. Force a full
+            // recompile for this build, exactly like --verify-native-regions.
+            std::env::set_var("PERRY_NO_CACHE", "1");
+            if matches!(format, OutputFormat::Text) {
+                println!("[trace] LLVM IR → {}", dir.display());
+            }
+        }
+    }
+
     match format {
         OutputFormat::Text => println!("Collecting modules..."),
         OutputFormat::Json => {}
@@ -258,8 +305,8 @@ pub fn run_with_parse_cache(
 
     let i18n_table = apply_i18n_pass(&mut ctx, i18n_config.as_ref(), &i18n_translations, format);
 
-    if args.print_hir {
-        dump_hir_for_debug(&ctx);
+    if trace_hir {
+        dump_hir_for_debug(&ctx, args.focus.as_deref());
     }
 
     write_i18n_key_registry(&ctx, i18n_table.as_ref());

--- a/crates/perry/src/commands/compile/bootstrap.rs
+++ b/crates/perry/src/commands/compile/bootstrap.rs
@@ -832,39 +832,89 @@ pub(super) fn apply_i18n_pass(
 }
 
 /// Debug dump triggered by `--print-hir`.
-pub(super) fn dump_hir_for_debug(ctx: &CompilationContext) {
+/// Print one HIR function's signature + lowered body. Shared between the
+/// top-level-function and class-method dump paths so focus mode renders
+/// methods identically to free functions.
+fn dump_hir_function(func: &perry_hir::Function, indent: &str) {
+    println!(
+        "{}- {} (params: {}, type_params: {}, async: {}, exported: {})",
+        indent,
+        func.name,
+        func.params.len(),
+        func.type_params.len(),
+        func.is_async,
+        func.is_exported
+    );
+    for p in &func.params {
+        println!("{}    param {} (id={}): {:?}", indent, p.name, p.id, p.ty);
+    }
+    for (i, stmt) in func.body.iter().enumerate() {
+        println!("{}    [{}] {:?}", indent, i, stmt);
+    }
+}
+
+/// Debug dump triggered by `--print-hir` (focus `None`) or
+/// `--trace hir` / `--trace hir --focus NAME`.
+///
+/// When `focus` is `Some(needle)`, only functions, class methods, and
+/// classes whose name contains `needle` are printed — and the
+/// imports/exports/init-statement sections are suppressed — so a single
+/// function's lowered body is readable instead of buried in a full-module
+/// dump. When `focus` is `None`, behaves exactly like the historical
+/// full dump.
+pub(super) fn dump_hir_for_debug(ctx: &CompilationContext, focus: Option<&str>) {
+    let matches = |name: &str| focus.map(|f| name.contains(f)).unwrap_or(true);
+
     for (path, hir_module) in &ctx.native_modules {
-        println!("\n=== HIR (after monomorphization): {} ===", path.display());
+        // In focus mode, skip whole modules that contain no match so the
+        // output isn't a wall of empty module headers.
+        if focus.is_some() {
+            let any = hir_module.functions.iter().any(|f| matches(&f.name))
+                || hir_module
+                    .classes
+                    .iter()
+                    .any(|c| matches(&c.name) || c.methods.iter().any(|m| matches(&m.name)));
+            if !any {
+                continue;
+            }
+        }
+
+        match focus {
+            Some(f) => println!("\n=== HIR trace (focus: {:?}): {} ===", f, path.display()),
+            None => println!("\n=== HIR (after monomorphization): {} ===", path.display()),
+        }
         println!("Module: {}", hir_module.name);
-        println!("Imports: {}", hir_module.imports.len());
-        for import in &hir_module.imports {
-            println!(
-                "  - {} ({} specifiers, kind: {:?})",
-                import.source,
-                import.specifiers.len(),
-                import.module_kind
-            );
-        }
-        println!("Exports: {}", hir_module.exports.len());
-        println!("Functions: {}", hir_module.functions.len());
-        for func in &hir_module.functions {
-            println!(
-                "  - {} (params: {}, type_params: {}, async: {}, exported: {})",
-                func.name,
-                func.params.len(),
-                func.type_params.len(),
-                func.is_async,
-                func.is_exported
-            );
-            for p in &func.params {
-                println!("      param {} (id={}): {:?}", p.name, p.id, p.ty);
+
+        if focus.is_none() {
+            println!("Imports: {}", hir_module.imports.len());
+            for import in &hir_module.imports {
+                println!(
+                    "  - {} ({} specifiers, kind: {:?})",
+                    import.source,
+                    import.specifiers.len(),
+                    import.module_kind
+                );
             }
-            for (i, stmt) in func.body.iter().enumerate() {
-                println!("      [{}] {:?}", i, stmt);
-            }
+            println!("Exports: {}", hir_module.exports.len());
         }
-        println!("Classes: {}", hir_module.classes.len());
-        for cls in &hir_module.classes {
+
+        let funcs: Vec<_> = hir_module
+            .functions
+            .iter()
+            .filter(|f| matches(&f.name))
+            .collect();
+        println!("Functions: {}", funcs.len());
+        for func in funcs {
+            dump_hir_function(func, "  ");
+        }
+
+        let classes: Vec<_> = hir_module
+            .classes
+            .iter()
+            .filter(|c| matches(&c.name) || c.methods.iter().any(|m| matches(&m.name)))
+            .collect();
+        println!("Classes: {}", classes.len());
+        for cls in classes {
             println!(
                 "  - {} (exported: {}, fields: {}, methods: {}, constructor: {})",
                 cls.name,
@@ -873,15 +923,31 @@ pub(super) fn dump_hir_for_debug(ctx: &CompilationContext) {
                 cls.methods.len(),
                 cls.constructor.is_some()
             );
+            // In focus mode, print the bodies of matching methods (and all
+            // methods when the class name itself matched). In full mode the
+            // historical output stops at the counts above, so keep it.
+            if focus.is_some() {
+                let class_matched = matches(&cls.name);
+                for m in cls
+                    .methods
+                    .iter()
+                    .filter(|m| class_matched || matches(&m.name))
+                {
+                    dump_hir_function(m, "    ");
+                }
+            }
         }
-        println!("Init statements: {}", hir_module.init.len());
-        for (i, stmt) in hir_module.init.iter().enumerate() {
-            println!("  [{}] {:?}", i, stmt);
+
+        if focus.is_none() {
+            println!("Init statements: {}", hir_module.init.len());
+            for (i, stmt) in hir_module.init.iter().enumerate() {
+                println!("  [{}] {:?}", i, stmt);
+            }
         }
         println!("===========\n");
     }
 
-    if !ctx.js_modules.is_empty() {
+    if focus.is_none() && !ctx.js_modules.is_empty() {
         println!("\n=== JavaScript Modules (interpreted) ===");
         for (specifier, module) in &ctx.js_modules {
             println!("  {} -> {}", specifier, module.path.display());

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -299,6 +299,32 @@ pub struct CompileArgs {
     /// built `WidgetExtension.appex` directory next to the sources.
     #[arg(long)]
     pub skip_swift_build: bool,
+
+    /// Dump the program's intermediate representation at one or more
+    /// pipeline stages, for debugging "compiled to the wrong thing"
+    /// bugs. Comma-separated stage list:
+    ///
+    ///   - `hir`  — post-transform HIR (same data as `--print-hir`,
+    ///              but honors `--focus`)
+    ///   - `llvm` — per-module LLVM IR `.ll` files (wires up the
+    ///              `PERRY_SAVE_LL` / `PERRY_LLVM_KEEP_IR` knobs so you
+    ///              don't have to remember the env vars). Written to
+    ///              `.perry-trace/llvm/`.
+    ///   - `all`  — every stage above
+    ///
+    /// Example: `perry compile foo.ts --trace hir,llvm --focus parseRow`
+    /// localizes which stage corrupted `parseRow` without scrolling a
+    /// 10k-line full dump.
+    #[arg(long, value_name = "STAGES")]
+    pub trace: Option<String>,
+
+    /// Restrict `--trace hir` output to functions, class methods, and
+    /// classes whose name contains this substring (case-sensitive).
+    /// Suppresses the imports/exports/init noise so a single function's
+    /// lowered body is ~40 lines instead of buried in the full module
+    /// dump. No effect unless `--trace hir` (or `--print-hir`) is set.
+    #[arg(long, value_name = "NAME")]
+    pub focus: Option<String>,
 }
 
 /// Information about a JavaScript module that will be interpreted at runtime

--- a/crates/perry/src/commands/dev.rs
+++ b/crates/perry/src/commands/dev.rs
@@ -313,6 +313,8 @@ fn build_once(
         harmonyos_profile: None,
         harmonyos_key_alias: None,
         skip_swift_build: false,
+        trace: None,
+        focus: None,
     };
     parse_cache.reset_counters();
     let result = super::compile::run_with_parse_cache(

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -234,6 +234,8 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
         harmonyos_profile: None,
         harmonyos_key_alias: None,
         skip_swift_build: false,
+        trace: None,
+        focus: None,
     };
 
     let result = super::compile::run(compile_args, format, use_color, verbose)?;

--- a/docs/src/cli/flags.md
+++ b/docs/src/cli/flags.md
@@ -50,8 +50,17 @@ Use `--output-type` to change what's produced:
 | Flag | Description |
 |------|-------------|
 | `--print-hir` | Print HIR (intermediate representation) to stdout |
+| `--trace <STAGES>` | Dump IR at one or more pipeline stages. Comma-separated: `hir` (post-transform HIR), `llvm` (per-module `.ll` into `.perry-trace/llvm/`), or `all` |
+| `--focus <NAME>` | Restrict `--trace hir` to functions/methods/classes whose name contains `NAME`, suppressing import/export/init noise. Implies `--trace hir` if no stage is given |
 | `--no-link` | Produce `.o` object file only, skip linking |
 | `--keep-intermediates` | Keep `.o` and `.asm` intermediate files |
+
+The `--trace`/`--focus` pair localizes "compiled to the wrong thing" bugs:
+`perry compile foo.ts --trace hir,llvm --focus parseRow` dumps just the
+`parseRow` function's lowered HIR and the module's LLVM IR, so you can see
+which stage corrupted it without scrolling a full-module dump. `--trace llvm`
+forces a full recompile (the object cache otherwise skips codegen for
+unchanged modules, leaving the trace dir empty).
 
 ## Output Optimization
 


### PR DESCRIPTION
## What

Adds `--trace`/`--focus` debug flags that consolidate the scattered
compiler-introspection knobs (`--print-hir`, `PERRY_SAVE_LL`,
`PERRY_LLVM_KEEP_IR`) into one CLI surface, plus a **focus filter** for
localizing "compiled to the wrong thing" bugs — the dominant Perry debug
workflow.

- **`--trace <stages>`** — comma-separated `hir`, `llvm`, or `all`.
  - `hir`: post-transform HIR dump (same data as `--print-hir`).
  - `llvm`: writes per-module `.ll` into `.perry-trace/llvm/` by promoting
    the `PERRY_SAVE_LL`/`PERRY_LLVM_KEEP_IR` env vars, and forces
    `PERRY_NO_CACHE` so the per-module object cache can't skip codegen and
    leave the trace dir empty (the same cache-bypass `--verify-native-regions`
    already does).
- **`--focus <name>`** — substring filter on `--trace hir`: only matching
  functions, class methods, and classes are printed, and the
  imports/exports/init sections are suppressed. One function's lowered body
  is ~40 lines instead of buried in a 10k-line full-module dump. Implies
  `hir` when no stage is given.

`--print-hir` keeps its exact historical full-dump behavior (it maps to
`focus = None`).

## Why

When a TypeScript program compiles to the wrong result, ~30% of debug time
is just *localizing which stage corrupted a value*. The pipeline has clean
stage boundaries but the introspection for them was a scattered set of
undocumented env vars. This makes "dump stage X, focused on function Y" a
one-liner.

## Test evidence

```
$ perry compile demo.ts --trace hir --focus parseRow
=== HIR trace (focus: "parseRow"): demo.ts ===
Functions: 1
  - parseRow (params: 1, ...)
      [0] Let { id: 2, name: "n", ... PropertyGet { ... "length" } }
      [1] Return(Some(Binary { op: Mul, left: LocalGet(2), right: Integer(2) }))
Classes: 1
  - Parser (...)
    - parseRowImpl (params: 1, ...)
        [0] Return(Some(PropertyGet { object: LocalGet(5), property: "length" }))
```

Verified manually:
- `--trace hir --focus NAME` → focused dump (functions + matching class methods)
- `--focus NAME` alone → implies hir
- `--trace llvm` → `.perry-trace/llvm/*.ll` written (cache-bypass confirmed)
- `--trace all` → full HIR + llvm
- `--print-hir` → unchanged full dump (imports/exports/init present)

`cargo fmt --all -- --check` clean; new code clippy-clean; `cargo build -p perry --tests` clean.

## Scope / follow-ups (deliberately out of this slice)

- `--focus` on the LLVM stage (extract just the matching `define`s post-codegen)
- An `ast` stage (pre-lowering SWC dump)
- `--timings` (per-stage wall time)

Per worktree-PR convention this PR omits the version bump + CHANGELOG entry;
fold those in at merge.
