### PR TITLE
test(parity): stream — 4 consumers/promises tests (iter-148) (4 free pass, 0 failures)

### DIFF
--- a/test-parity/node-suite/stream/consumers/json-number-literal.ts
+++ b/test-parity/node-suite/stream/consumers/json-number-literal.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { json } from "node:stream/consumers";
+// json() of a bare number literal.
+const r = Readable.from(["42"]);
+const result = await json(r);
+console.log("result:", result);
+console.log("is 42:", result === 42);

--- a/test-parity/node-suite/stream/consumers/json-string-literal.ts
+++ b/test-parity/node-suite/stream/consumers/json-string-literal.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { json } from "node:stream/consumers";
+// json() of a quoted string literal.
+const r = Readable.from([`"hello"`]);
+const result = await json(r);
+console.log("result:", result);
+console.log("is hello:", result === "hello");

--- a/test-parity/node-suite/stream/consumers/text-single-chunk.ts
+++ b/test-parity/node-suite/stream/consumers/text-single-chunk.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { text } from "node:stream/consumers";
+// text() on a single-chunk string stream.
+const r = Readable.from(["solo"]);
+const result = await text(r);
+console.log("result:", result);
+console.log("matches:", result === "solo");

--- a/test-parity/node-suite/stream/promises/finished-on-duplex.ts
+++ b/test-parity/node-suite/stream/promises/finished-on-duplex.ts
@@ -1,0 +1,12 @@
+import { Duplex } from "node:stream";
+import { finished } from "node:stream/promises";
+// finished() on a Duplex resolves once both sides settle.
+const d = new Duplex({
+  read() { this.push(null); },
+  write(_c, _e, cb) { cb(); },
+});
+d.on("data", () => {});
+const p = finished(d);
+d.end("x");
+const result = await p;
+console.log("resolved:", result === undefined);


### PR DESCRIPTION
### Stream parity batch — 4 tests (iter-148)

**4 free passes, 0 failures — 100% pass rate.**

All in `stream/consumers` + `stream/promises`, both now effectively at full parity:

| Test | Status |
|---|---|
| promises/finished-on-duplex | ✅ PASS |
| consumers/text-single-chunk | ✅ PASS |
| consumers/json-number-literal | ✅ PASS |
| consumers/json-string-literal | ✅ PASS |

No `known_failures.json` changes needed. Verified directly with prebuilt binary + node.