### PR TITLE
fix(lockdown): #503 guard must allow auditable ns[dynamicKey].staticMember (#1723)

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -70,6 +70,7 @@ impl LoweringContext {
             module_native_instances: Vec::new(),
             uses_fetch: false,
             uses_webassembly: false,
+            suppress_stdlib_dispatch_guard_once: false,
             var_hoisted_ids: HashSet::new(),
             functions_index: HashMap::new(),
             classes_index: HashMap::new(),

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -109,7 +109,14 @@ use wasm_exports::try_wasm_instance_exports;
 /// `(res)` for any later use in the outer body.
 pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<Expr> {
     let ni_mark = ctx.native_instances.len();
+    // #1723: snapshot/restore the one-shot #503 suppression flag around the
+    // whole call. `lower_call_inner` may set it (for a `ns[dynamicKey].method()`
+    // receiver) but a dispatch arm could `return` before the receiver is
+    // lowered, leaving the flag set. Restoring here keeps it from leaking into
+    // a sibling expression.
+    let prev_suppress = ctx.suppress_stdlib_dispatch_guard_once;
     let result = lower_call_inner(ctx, call);
+    ctx.suppress_stdlib_dispatch_guard_once = prev_suppress;
     // Restore: drop any native-instance tags this call's pre-scans
     // added (and anything nested calls left above the mark — those
     // are likewise out of scope once we unwind past their owning
@@ -153,6 +160,29 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
         .iter()
         .map(|arg| lower_expr(ctx, &arg.expr))
         .collect::<Result<Vec<_>>>()?;
+
+    // #1723: `<stdlib-ns>[dynamicKey].method(args)` — a method call whose
+    // receiver is a dynamic stdlib SUB-namespace selection (`path.win32` /
+    // `path.posix`) and whose method is a source-visible static name. The
+    // method-call dispatch below lowers the receiver `ns[dynamicKey]` directly
+    // — it never routes the `.method` part through `lower_member` — so the #503
+    // guard would fire on the receiver. Mark the *next* `ns[dynamicKey]`
+    // lowering auditable (same carve-out as the member-access form: the method
+    // name is in plaintext, not the `ns[runtimeVar]()` obfuscation). The flag
+    // is set AFTER the arguments above are lowered, so a dynamic stdlib key in
+    // an ARGUMENT (`ns[dyn].m(fs[evil])`) is still refused; it is consumed by
+    // the first guarded access (the receiver) and restored by `lower_call`.
+    if let ast::Callee::Expr(callee_expr) = &call.callee {
+        let mut callee = callee_expr.as_ref();
+        while let ast::Expr::Paren(p) = callee {
+            callee = p.expr.as_ref();
+        }
+        if let ast::Expr::Member(callee_member) = callee {
+            if super::expr_member::stdlib_ns_subnamespace_static_access(ctx, callee_member) {
+                ctx.suppress_stdlib_dispatch_guard_once = true;
+            }
+        }
+    }
 
     // Post-args dispatch hooks: proxy apply/revoke, `Object.<static>`
     // aliased calls, and `Object.prototype.<method>.call(...)` rewrites.

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -18,6 +18,32 @@ use crate::ir::Expr;
 use super::{lower_expr, LoweringContext};
 
 pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Result<Expr> {
+    // #1723: when THIS access is the auditable `ns[dynamicKey].staticMember`
+    // shape — a dynamic stdlib SUB-namespace selection (`path.win32` /
+    // `path.posix`) followed by a source-visible static member — mark the
+    // immediately-nested `ns[dynamicKey]` computed access as auditable so the
+    // #503 refusal does not fire on it (the method/property name is in
+    // plaintext, not the `ns[runtimeVar]()` obfuscation the guard targets). The
+    // flag must be set HERE, before the many early-return arms below that lower
+    // `member.obj` themselves — otherwise the receiver `ns[dynamicKey]` is
+    // lowered through one of those arms and trips the guard. It is a one-shot
+    // consumed by the first guarded access, so a dynamic key *inside the index*
+    // (`ns[fs[evil]].x`) is still refused. Save/restore the prior value so the
+    // flag never leaks past this member, and only touch it when our own
+    // detection fires (a method-call receiver sets the flag via `lower_call`
+    // instead, and that must survive into the bare `ns[dynamicKey]` lowering).
+    let suppress_for_obj = stdlib_ns_subnamespace_static_access(ctx, member);
+    if !suppress_for_obj {
+        return lower_member_inner(ctx, member);
+    }
+    let prev_suppress = ctx.suppress_stdlib_dispatch_guard_once;
+    ctx.suppress_stdlib_dispatch_guard_once = true;
+    let result = lower_member_inner(ctx, member);
+    ctx.suppress_stdlib_dispatch_guard_once = prev_suppress;
+    result
+}
+
+fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Result<Expr> {
     // Issue #444: `import.meta.<prop>` folds directly to a literal at
     // lowering time. Routing through the bare-`import.meta` Object
     // synthesis hits a long-standing module-level NaN-boxing bug where
@@ -1167,7 +1193,12 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
             //     package on the per-package allow-list, and
             //   - there is no `// @perry-allow-dynamic` line annotation on
             //     or immediately above the offending site.
-            if crate::ir::refuse_dynamic_stdlib_dispatch_enabled() {
+            // #1723: an enclosing `ns[dynamicKey].staticMember` access may have
+            // marked THIS computed access as auditable sub-namespace selection.
+            // Consume the one-shot flag (so a dynamic key in the index position
+            // is still refused) and skip the refusal for exactly this access.
+            let suppressed_by_parent = std::mem::take(&mut ctx.suppress_stdlib_dispatch_guard_once);
+            if !suppressed_by_parent && crate::ir::refuse_dynamic_stdlib_dispatch_enabled() {
                 if let Some(ns) = stdlib_namespace_receiver(ctx, member.obj.as_ref()) {
                     if !matches!(*computed.expr, ast::Expr::Lit(ast::Lit::Str(_))) {
                         let pkg = crate::ir::package_name_for_source_path(&ctx.source_file_path);
@@ -1298,6 +1329,69 @@ const STDLIB_NAMESPACE_NAMES: &[&str] = &[
     "tty",
     "worker_threads",
 ];
+
+/// #1723 — is `member` the auditable `ns[dynamicKey].staticMember` shape, where
+/// the dynamic index merely selects a stdlib SUB-namespace (e.g. `path.win32` /
+/// `path.posix`) and the member actually used is a *source-visible* static name?
+///
+/// This is the legit counterpart of the #503 obfuscation pattern
+/// `ns[runtimeVar]()` — which HIDES the called method behind a runtime string.
+/// Here the method name is in plaintext (`.matchesGlob`, or a literal-string
+/// key that folds to a static property), and the dynamic index only picks among
+/// a namespace's tiny, known set of sub-namespaces, every one of which exposes
+/// the same API surface the static member already names. So nothing is hidden,
+/// and the #503 refusal should not fire on the nested `ns[dynamicKey]`. The
+/// discriminator is the *enclosing access shape*, not the binding origin, so
+/// `require()`, `import * as`, and default-import forms all behave identically.
+///
+/// Returns true only when:
+///   - `member.prop` is static — an `Ident` or a computed STRING-LITERAL key
+///     (a numeric/dynamic key would not be auditable), AND
+///   - `member.obj` (transparent TS/paren wrappers peeled) is `recv[<nonLiteral>]`
+///     where `recv` resolves to a stdlib namespace.
+///
+/// `ns[d1][d2]` (chained dynamic — the enclosing prop is a non-literal computed
+/// key) is NOT matched and stays refused. Surfaced by the #800 node-core radar:
+/// `test-path-glob.js` does `path[platform].matchesGlob(path, glob)`.
+pub(super) fn stdlib_ns_subnamespace_static_access(
+    ctx: &super::LoweringContext,
+    member: &ast::MemberExpr,
+) -> bool {
+    // Enclosing access must name a STATIC (auditable) property.
+    let prop_is_static = match &member.prop {
+        ast::MemberProp::Ident(_) => true,
+        ast::MemberProp::Computed(c) => matches!(*c.expr, ast::Expr::Lit(ast::Lit::Str(_))),
+        _ => false,
+    };
+    if !prop_is_static {
+        return false;
+    }
+    // Object must be `<stdlib-ns>[<nonLiteralKey>]`.
+    let mut obj = member.obj.as_ref();
+    loop {
+        match obj {
+            ast::Expr::Paren(p) => obj = p.expr.as_ref(),
+            ast::Expr::TsAs(a) => obj = a.expr.as_ref(),
+            ast::Expr::TsNonNull(a) => obj = a.expr.as_ref(),
+            ast::Expr::TsTypeAssertion(a) => obj = a.expr.as_ref(),
+            ast::Expr::TsConstAssertion(a) => obj = a.expr.as_ref(),
+            ast::Expr::TsSatisfies(a) => obj = a.expr.as_ref(),
+            _ => break,
+        }
+    }
+    let inner = match obj {
+        ast::Expr::Member(m) => m,
+        _ => return false,
+    };
+    let inner_is_dynamic = match &inner.prop {
+        ast::MemberProp::Computed(c) => !matches!(*c.expr, ast::Expr::Lit(ast::Lit::Str(_))),
+        _ => false,
+    };
+    if !inner_is_dynamic {
+        return false;
+    }
+    stdlib_namespace_receiver(ctx, inner.obj.as_ref()).is_some()
+}
 
 /// #503 — does the given AST receiver expression resolve to a known
 /// stdlib namespace? Recognised shapes:

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -180,6 +180,15 @@ pub struct LoweringContext {
     pub(crate) uses_fetch: bool,
     /// Issue #76 — set when any `WebAssembly.*` HIR variant is lowered.
     pub(crate) uses_webassembly: bool,
+    /// #1723 — one-shot flag set by an enclosing `ns[dynamicKey].staticMember`
+    /// access to tell the *immediately-nested* computed-member lowering to skip
+    /// the #503 dynamic-stdlib-dispatch refusal. The dynamic index there only
+    /// selects a stdlib SUB-namespace (e.g. `path.win32` / `path.posix`) and the
+    /// actual member is a source-visible static name, so it is auditable — not
+    /// the `ns[runtimeVar]()` obfuscation #503 targets. The guard consumes
+    /// (clears) it on read so a dynamic key *inside the index* (`ns[fs[evil]]`)
+    /// is still refused.
+    pub(crate) suppress_stdlib_dispatch_guard_once: bool,
     pub(crate) var_hoisted_ids: HashSet<LocalId>,
     /// Shadow index: function name -> index in `functions` Vec (last entry for shadowing)
     pub(crate) functions_index: HashMap<String, usize>,

--- a/crates/perry-hir/tests/dynamic_stdlib_dispatch.rs
+++ b/crates/perry-hir/tests/dynamic_stdlib_dispatch.rs
@@ -210,6 +210,93 @@ fn package_name_extraction() {
 }
 
 #[test]
+fn allows_stdlib_subnamespace_static_method() {
+    // #1723: `path[platform].matchesGlob(...)` — the dynamic key selects a
+    // stdlib SUB-namespace (`path.win32` / `path.posix`) and the method is a
+    // source-visible static ident. The method name is in plaintext, so this is
+    // NOT the `ns[runtimeVar]()` obfuscation #503 targets (which HIDES the
+    // method). Must compile. This is exactly Node's own `test-path-glob.js`
+    // shape, the #800 node-core radar's only compile-fail.
+    let src = r#"
+        import * as path from "path";
+        const platform: string = "win32";
+        const r = path[platform].matchesGlob("foo/bar", "foo/*");
+    "#;
+    try_lower(src, "/tmp/host.ts").expect("auditable sub-namespace dispatch must compile");
+}
+
+#[test]
+fn allows_stdlib_subnamespace_literal_key_method() {
+    // `path[platform]["matchesGlob"](...)` — the terminal key is a string
+    // literal (folds to a static property), so the method name is still
+    // auditable. Allowed for the same reason as the dotted form.
+    let src = r#"
+        import * as path from "path";
+        const platform: string = "posix";
+        const r = path[platform]["matchesGlob"]("foo/bar", "foo/*");
+    "#;
+    try_lower(src, "/tmp/host.ts").expect("literal-key method on sub-namespace must compile");
+}
+
+#[test]
+fn refuses_chained_dynamic_dispatch() {
+    // `fs[a][b]` — BOTH keys dynamic, so the terminal member name is hidden:
+    // the #1723 carve-out only covers a STATIC enclosing member, so this stays
+    // refused as the obfuscation pattern.
+    let src = r#"
+        import fs from "fs";
+        const a: string = "promises";
+        const b: string = "readFile";
+        // @ts-ignore
+        (fs as any)[a][b]("/tmp/x");
+    "#;
+    let err = try_lower(src, "/tmp/host.ts").expect_err("chained dynamic dispatch must be refused");
+    assert!(
+        err.contains("dynamic dispatch on stdlib namespace `fs`"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn refuses_dynamic_key_inside_subnamespace_index() {
+    // `path[fs[evil]].matchesGlob(...)` — the OUTER access is the auditable
+    // `ns[dyn].static` shape, but the INDEX hides an `fs[runtimeVar]` dispatch.
+    // The one-shot suppression must NOT leak into the index, so `fs[evil]` is
+    // still refused (regression guard for the flag's scoping).
+    let src = r#"
+        import * as path from "path";
+        import fs from "fs";
+        const evil: string = "readFileSync";
+        // @ts-ignore
+        const r = path[(fs as any)[evil]].matchesGlob("a", "b");
+    "#;
+    let err = try_lower(src, "/tmp/host.ts").expect_err("dynamic key inside index must be refused");
+    assert!(
+        err.contains("dynamic dispatch on stdlib namespace `fs`"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn refuses_terminal_dynamic_subselect() {
+    // `const sub = path[platform];` — no static member follows, so the
+    // dynamically-selected value is bound opaquely (you can't tell from source
+    // what gets read off it later). Stays refused.
+    let src = r#"
+        import * as path from "path";
+        const platform: string = "win32";
+        // @ts-ignore
+        const sub = (path as any)[platform];
+    "#;
+    let err =
+        try_lower(src, "/tmp/host.ts").expect_err("terminal dynamic sub-select must be refused");
+    assert!(
+        err.contains("dynamic dispatch on stdlib namespace `path`"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
 fn diagnostic_names_the_namespace() {
     // The error message must name the offending namespace so reviewers
     // grepping CI logs can attribute the failure without reading the

--- a/test-files/test_issue_1723_require_stdlib_subnamespace.ts
+++ b/test-files/test_issue_1723_require_stdlib_subnamespace.ts
@@ -1,0 +1,38 @@
+// #1723 — the #503 dynamic-stdlib-dispatch guard must NOT refuse the auditable
+// `ns[dynamicKey].staticMember` shape: the dynamic key selects a stdlib
+// SUB-namespace (path.win32 / path.posix) and the member is a source-visible
+// static name, so nothing is hidden (unlike the `ns[runtimeVar]()` obfuscation
+// the guard targets). Before the fix this file was a hard `(#503)` compile
+// error; the #800 node-core radar hit the same guard on Node's own
+// test-path-glob.js (`path[platform].matchesGlob(...)`).
+//
+// This file is pure CommonJS (no top-level import/export), so #1711's cjs_wrap
+// rewrites `require('path')` to a namespace binding — the exact path the radar
+// exercises. It asserts the dynamic SUB-namespace PROPERTY reads that the fix
+// unblocks (these match Node). Dynamic sub-namespace METHOD dispatch
+// (`path[v].matchesGlob(...)` returning the right value at runtime) is a
+// separate runtime-layer gap tracked in its own issue; this test stays on the
+// property surface so it is byte-for-byte correct against Node today (#1740).
+const path = require('path');
+
+const expected: Record<string, { sep: string; delimiter: string }> = {
+  win32: { sep: '\\', delimiter: ';' },
+  posix: { sep: '/', delimiter: ':' },
+};
+
+let checked = 0;
+for (const platform of ['win32', 'posix']) {
+  // path[platform] is the dynamic stdlib sub-namespace selection; .sep /
+  // .delimiter are the auditable static members.
+  const sep = path[platform].sep;
+  const delimiter = path[platform].delimiter;
+  if (sep !== expected[platform].sep) {
+    throw new Error(`${platform}.sep = ${JSON.stringify(sep)}`);
+  }
+  if (delimiter !== expected[platform].delimiter) {
+    throw new Error(`${platform}.delimiter = ${JSON.stringify(delimiter)}`);
+  }
+  checked++;
+}
+
+console.log('ok', checked);


### PR DESCRIPTION
## What

Fixes #1723. The #503 dynamic-stdlib-dispatch guard refused **every** computed
member access on a stdlib namespace, including the legit
`ns[dynamicKey].staticMember` shape where the dynamic index merely selects a
SUB-namespace (`path.win32` / `path.posix`) and the member actually used is a
**source-visible static name**.

That is not the obfuscation the guard targets. `ns[runtimeVar]()` hides the
called method behind a runtime string; here the method/property name is in
plaintext and fully auditable, and the dynamic index only picks among a
namespace's tiny, known set of sub-namespaces — every one of which exposes the
same API surface the static member already names. Nothing is hidden.

Discovered by the #800 node-core radar: Node's own `test/parallel/test-path-glob.js`
does `path[platform].matchesGlob(pathStr, glob)` and hit a hard `(#503)`
compile error (its only `path` compile-fail). The require()-imported form
(#1711 cjs_wrap → default import), `import * as`, and default-import forms were
all refused identically — the discriminator in this fix is the **enclosing
access shape, not the binding origin**, so the three forms now behave the same
(addressing the issue's "same handling as the ESM form" expectation).

## How

- New `stdlib_ns_subnamespace_static_access` recognizes
  `<stdlib-ns>[<nonLiteral>] . <staticName>` (static = `Ident` or
  literal-string key).
- A one-shot `suppress_stdlib_dispatch_guard_once` context flag tells the
  nested `ns[dynamicKey]` lowering to skip the refusal. The guard **consumes**
  the flag on read, so:
  - a dynamic key **inside the index** (`ns[fs[evil]].x`) is still refused, and
  - chained dynamic access (`ns[d1][d2]`) is still refused (the enclosing prop
    is a non-literal computed key, so the carve-out never matches).
- The flag is set in two places:
  - top of `lower_member` (before its early-return arms lower `member.obj`) —
    the property-access form `path[v].sep`;
  - after args in `lower_call` — the dot method-call form
    `path[v].matchesGlob(...)`, whose receiver never routes through
    `lower_member` for the `.method` part. Args are lowered **before** the flag
    is set, so a dynamic stdlib key in an argument (`ns[v].m(fs[evil])`) is
    still refused.

## Validation

- **Guard intact (negative):** terminal `ns[k]`, called `(fs as any)[k]()`,
  chained `(fs as any)[a][b]()`, dynamic-key-in-index `path[fs[evil]].m()`, and
  the node_modules self-annotation case all stay refused. All 12 pre-existing
  `crates/perry-hir/tests/dynamic_stdlib_dispatch.rs` tests pass unchanged.
- **Fix (positive):** `path[v].sep` / `path[v].delimiter` for both `win32` and
  `posix` compile and match `node --experimental-strip-types` byte-for-byte.
- 5 new unit tests + a `test-files/` integration test (pure-CommonJS so #1711's
  cjs_wrap exercises the require()→namespace path).
- Full `cargo test -p perry-hir` green; `cargo fmt --all -- --check` clean.

## Out of scope (tracked separately)

Dynamic sub-namespace **method dispatch** — `path[v].matchesGlob(...)` returning
the right value at runtime — is a runtime-layer gap (the sub-namespace object
exposes data properties but not callable methods). Filed as #1740. This PR is
the #503 guard fix only; it converts a loud over-refusal into correct behavior
for property access and unblocks the auditable shape per security policy.
