### PR TITLE
fix(dynamic-import): resolve literal node: builtin import('node:crypto') to native namespace (#1673)

### DIFF
--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -91,6 +91,26 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         let promise = blk.call(I64, "js_promise_resolved", &[(DOUBLE, &ns_val)]);
                         return Ok(nanbox_pointer_inline(blk, &promise));
                     }
+                    // #1673: a dynamic import of a general native builtin
+                    // (`await import('node:crypto')`) carries the sentinel
+                    // prefix `__native_mod__<name>`. Build its namespace via
+                    // `js_create_native_module_namespace` — the same
+                    // NATIVE_MODULE_CLASS_ID object `require('node:crypto')`
+                    // produces, whose member access dispatches natively at
+                    // runtime — and resolve the promise with it.
+                    if let Some(name) = prefix.strip_prefix("__native_mod__") {
+                        let name = name.to_string();
+                        let mod_label = emit_string_literal_global(ctx, &name);
+                        let mod_len = name.len();
+                        let blk = ctx.block();
+                        let ns_val = blk.call(
+                            DOUBLE,
+                            "js_create_native_module_namespace",
+                            &[(PTR, &mod_label), (I64, &mod_len.to_string())],
+                        );
+                        let promise = blk.call(I64, "js_promise_resolved", &[(DOUBLE, &ns_val)]);
+                        return Ok(nanbox_pointer_inline(blk, &promise));
+                    }
                 }
                 let blk = ctx.block();
                 let ns_val = match target_prefix {
@@ -192,6 +212,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         DOUBLE,
                         "js_node_submodule_namespace",
                         &[(PTR, &submod_label), (I32, &submod_len.to_string())],
+                    )
+                } else if let Some(name) = target_prefix.strip_prefix("__native_mod__") {
+                    // #1673: general native builtin target in a multi-path
+                    // (`import(cond ? 'node:crypto' : './local.ts')`) chain.
+                    let name = name.to_string();
+                    let mod_label = emit_string_literal_global(ctx, &name);
+                    let mod_len = name.len();
+                    ctx.block().call(
+                        DOUBLE,
+                        "js_create_native_module_namespace",
+                        &[(PTR, &mod_label), (I64, &mod_len.to_string())],
                     )
                 } else {
                     let blk = ctx.block();

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -1673,6 +1673,27 @@ pub fn run_with_parse_cache(
                         self::collect_modules::known_node_submodule_key(&import.source)
                     {
                         local_map.insert(import.source.clone(), format!("__node_submod__{}", key));
+                    } else if import.is_native {
+                        // #1673: a dynamic `import('node:crypto')` /
+                        // `import('node:util')` targets a general native builtin
+                        // that is NOT in the node-submodule table and has no
+                        // compiled-source backing. The runtime builds its
+                        // namespace object via `js_create_native_module_namespace`
+                        // (the same object `require('node:crypto')` and `import *
+                        // as` produce). Record a `__native_mod__<name>` sentinel,
+                        // keyed by the `node:`-stripped module name, that the
+                        // dynamic-import codegen routes to that builder. An
+                        // unsupported builtin never reaches here (`is_native` is
+                        // false for it → no map entry → the dispatch rejects,
+                        // matching Node's failure mode).
+                        let native_name = import
+                            .source
+                            .strip_prefix("node:")
+                            .unwrap_or(&import.source);
+                        local_map.insert(
+                            import.source.clone(),
+                            format!("__native_mod__{}", native_name),
+                        );
                     }
                     continue;
                 }

--- a/test-files/test_gap_dynamic_import_node_builtin.ts
+++ b/test-files/test_gap_dynamic_import_node_builtin.ts
@@ -1,0 +1,24 @@
+// Test (#1673): a dynamic `import()` of a literal `node:` builtin resolves to
+// the native-module namespace. Native builtins have no compiled-module backing
+// and no `@__perry_ns_<prefix>` global — the dynamic-import dispatch builds the
+// namespace object via `js_create_native_module_namespace` (the same object
+// `require('node:crypto')` / `import * as` produce) and resolves the promise
+// with it. An unsupported builtin still rejects, matching Node's failure mode.
+
+async function main(): Promise<void> {
+  const crypto = await import("node:crypto");
+  console.log("crypto.randomUUID is fn:", typeof crypto.randomUUID === "function");
+
+  const util = await import("node:util");
+  console.log("util.format:", util.format("%s=%d", "n", 7));
+
+  // Unsupported builtin → rejected promise → caught (Node parity).
+  try {
+    await import("node:this_builtin_does_not_exist");
+    console.log("unsupported unexpectedly resolved");
+  } catch {
+    console.log("unsupported rejected");
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Fixes #1673. A dynamic `import()` of a general `node:` builtin — `node:crypto`, `node:util`, `node:os`, … — rejected with `undefined` at runtime even for builtins Perry fully supports. Native modules have no compiled-source backing and no `@__perry_ns_<prefix>` global, and the dynamic-import dispatch only knew how to load a compiled-module namespace or a fixed node-submodule namespace.

## Root cause

Known node-submodules (`node:fs/promises`, `node:stream/promises`, …) already resolved via the `__node_submod__` sentinel → `js_node_submodule_namespace` (#1671). General native builtins are **not** in that submodule table, so a dynamic `import('node:crypto')` had no map entry and fell through to `js_promise_rejected(undefined)`.

## Fix

Reuse the same sentinel mechanism. When a dynamic-import target is a native module with no submodule-table entry, the driver records a `__native_mod__<name>` sentinel (keyed by the `node:`-stripped module name), and the dispatch builds the namespace via `js_create_native_module_namespace` — the same `NATIVE_MODULE_CLASS_ID` object that `require('node:crypto')` and `import * as ns from 'node:crypto'` produce, whose member access dispatches natively at runtime — then resolves the promise with it. Handled in both the single-path fast path and the multi-path `js_string_equals` chain.

An **unsupported** builtin keeps rejecting: `is_native_module` is false for it, so no sentinel is recorded and the dispatch falls through to `js_promise_rejected`, matching Node's failure mode (caught by `try/catch`).

## Testing

- New gap test `test-files/test_gap_dynamic_import_node_builtin.ts` — byte-equal to `node --experimental-strip-types`: `node:crypto` + `node:util` resolve, unsupported builtin rejects.
- Verified manually: `node:crypto` (`randomUUID`), `node:util` (`format`), `node:os` (`platform`/`EOL`), `node:fs/promises` (already-working submodule — no regression), multi-path ternary between two `node:` builtins, and unsupported-builtin reject.
- All 10 `test_gap_dynamic_import_*` gap tests pass; `cargo fmt --all -- --check` clean.

### Note on `test_parity_zlib.ts`

The acceptance criteria mention `test_parity_zlib.ts:77`'s `await import("node:util")`. That whole test currently fails to **compile** on an unrelated `zlib.Deflate` not-implemented gap (#463), so its `node:util` line can't be exercised through it. The dedicated gap test above provides the `await import("node:util")` coverage instead; the zlib-surface gaps are out of scope for this issue.

> Sibling of #1672 (merged). No version bump / CHANGELOG entry — folded in at merge.
