### PR TITLE
test(parity): stream — 4 static-helper tests (iter-150) (2 free pass, 2 #1532)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3619,5 +3619,17 @@
     "added": "2026-05-25",
     "category": "bug-open",
     "reason": "node:stream: promises.finished({signal}) — abort doesn't reject with AbortError. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/static/is-errored-after-destroy": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: isErrored(stream) stays false after destroy(err) (should be true). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/static/get-default-hwm-objectmode": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: getDefaultHighWaterMark(true) returns undefined (objectMode default should be 16). Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/static/add-abort-signal-returns-stream.ts
+++ b/test-parity/node-suite/stream/static/add-abort-signal-returns-stream.ts
@@ -1,0 +1,7 @@
+import { Readable, addAbortSignal } from "node:stream";
+// addAbortSignal(signal, stream) returns the stream.
+const ctrl = new AbortController();
+const r = new Readable({ read() {} });
+const returned = addAbortSignal(ctrl.signal, r);
+console.log("returns stream:", returned === r);
+r.on("error", () => {});

--- a/test-parity/node-suite/stream/static/get-default-hwm-objectmode.ts
+++ b/test-parity/node-suite/stream/static/get-default-hwm-objectmode.ts
@@ -1,0 +1,5 @@
+import { getDefaultHighWaterMark } from "node:stream";
+// getDefaultHighWaterMark(true) — objectMode default is 16.
+const objHwm = getDefaultHighWaterMark(true);
+console.log("objectMode hwm:", objHwm);
+console.log("is 16:", objHwm === 16);

--- a/test-parity/node-suite/stream/static/is-errored-after-destroy.ts
+++ b/test-parity/node-suite/stream/static/is-errored-after-destroy.ts
@@ -1,0 +1,9 @@
+import { Readable, isErrored } from "node:stream";
+// isErrored(stream) — true after destroy(err).
+const r = new Readable({ read() {} });
+r.on("error", () => {});
+console.log("before:", isErrored(r));
+r.destroy(new Error("boom"));
+setImmediate(() => {
+  console.log("after:", isErrored(r));
+});

--- a/test-parity/node-suite/stream/static/is-errored-false-initially.ts
+++ b/test-parity/node-suite/stream/static/is-errored-false-initially.ts
@@ -1,0 +1,7 @@
+import { Readable, Writable, isErrored } from "node:stream";
+// isErrored is false on a fresh, error-free stream.
+const r = new Readable({ read() {} });
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+console.log("R:", isErrored(r));
+console.log("W:", isErrored(w));
+console.log("both false:", isErrored(r) === false && isErrored(w) === false);


### PR DESCRIPTION
### Stream parity batch — 4 static-helper tests (iter-150)

**2 free passes + 2 tracked failures.**

| Test | Status | Issue |
|---|---|---|
| static/add-abort-signal-returns-stream | ✅ PASS | — |
| static/is-errored-false-initially | ✅ PASS | — |
| static/is-errored-after-destroy | parity-fail | #1532 (isErrored stays false post-destroy) |
| static/get-default-hwm-objectmode | parity-fail | #1532 (getDefaultHighWaterMark(true) → undefined) |

Both failures are tight impl targets on #1532. Tracked in `known_failures.json`.