### PR TITLE
test(parity): stream — 4 static-helper tests (iter-151) (2 free pass, 2 #1532)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3619,5 +3619,17 @@
     "added": "2026-05-25",
     "category": "bug-open",
     "reason": "node:stream: promises.finished({signal}) — abort doesn't reject with AbortError. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/static/is-writable-after-end-false": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: isWritable() returns undefined (unimplemented). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/static/get-default-hwm-byte-mode": {
+    "issue": "1532",
+    "added": "2026-05-25",
+    "category": "bug-open",
+    "reason": "node:stream: getDefaultHighWaterMark(false) returns undefined (byte-mode default should be 65536). Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/static/get-default-hwm-byte-mode.ts
+++ b/test-parity/node-suite/stream/static/get-default-hwm-byte-mode.ts
@@ -1,0 +1,5 @@
+import { getDefaultHighWaterMark } from "node:stream";
+// getDefaultHighWaterMark(false) — byte-mode default is 65536 (64KB).
+const byteHwm = getDefaultHighWaterMark(false);
+console.log("byte hwm:", byteHwm);
+console.log("is 65536:", byteHwm === 65536);

--- a/test-parity/node-suite/stream/static/is-disturbed-fresh-false.ts
+++ b/test-parity/node-suite/stream/static/is-disturbed-fresh-false.ts
@@ -1,0 +1,5 @@
+import { Readable, isDisturbed } from "node:stream";
+// isDisturbed is false on a fresh, unread stream.
+const r = new Readable({ read() {} });
+console.log("isDisturbed:", isDisturbed(r));
+console.log("is false:", isDisturbed(r) === false);

--- a/test-parity/node-suite/stream/static/is-readable-fresh-true.ts
+++ b/test-parity/node-suite/stream/static/is-readable-fresh-true.ts
@@ -1,0 +1,5 @@
+import { Readable, isReadable } from "node:stream";
+// isReadable is true on a fresh Readable.
+const r = new Readable({ read() {} });
+console.log("isReadable:", isReadable(r));
+console.log("is true:", isReadable(r) === true);

--- a/test-parity/node-suite/stream/static/is-writable-after-end-false.ts
+++ b/test-parity/node-suite/stream/static/is-writable-after-end-false.ts
@@ -1,0 +1,8 @@
+import { Writable, isWritable } from "node:stream";
+// isWritable becomes false after end().
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+console.log("before end:", isWritable(w));
+w.end();
+w.on("finish", () => {
+  setImmediate(() => console.log("after end:", isWritable(w)));
+});


### PR DESCRIPTION
### Stream parity batch — 4 static-helper tests (iter-151)

**2 free passes + 2 tracked failures.**

| Test | Status | Issue |
|---|---|---|
| static/is-disturbed-fresh-false | ✅ PASS | — |
| static/is-readable-fresh-true | ✅ PASS | — |
| static/is-writable-after-end-false | parity-fail | #1532 (`isWritable` undefined — unimplemented, confirmed across batches) |
| static/get-default-hwm-byte-mode | parity-fail | #1532 (`getDefaultHighWaterMark(false)` → undefined) |

The `isWritable` and `getDefaultHighWaterMark` gaps are reproducible across batch31/32/33 — they appear genuinely unimplemented in node:stream. Tracked in `known_failures.json`.