### PR TITLE
fix(node): #1724 URL.revokeObjectURL/Blob globals link-fail — trigger http-client stdlib feature

### DIFF
--- a/crates/perry-codegen/src/ext_registry.rs
+++ b/crates/perry-codegen/src/ext_registry.rs
@@ -186,6 +186,26 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
     ("js_net_server_close",                         OwnerKind::WellKnown("net")),
     ("js_net_server_address",                       OwnerKind::WellKnown("net")),
     ("js_net_server_on",                            OwnerKind::WellKnown("net")),
+
+    // ── #1724: global Blob/File + URL object-URL helpers ──────────────
+    // `new Blob([...])`, `new File([...], name)`, `URL.createObjectURL`,
+    // `URL.revokeObjectURL`, and `resolveObjectURL` (node:buffer) are all
+    // global / built-in entry points — a program can use them without
+    // any `import` that maps to the `http-client` feature. Their FFI
+    // definitions live in `perry-stdlib::fetch_blob`, which is gated
+    // behind `#[cfg(feature = "http-client")]` (it shares the Blob
+    // registry + handle ABI with `fetch.rs`). Without a feature hint the
+    // auto-optimize stdlib rebuild drops the module entirely and the link
+    // fails with "Undefined symbols: _js_url_revoke_object_url" (and the
+    // companion `_js_blob_new` / `_js_url_create_object_url`). Tagging the
+    // constructor + object-URL entry points pulls in `http-client` so the
+    // module — and every Blob/File instance method reachable from a
+    // constructed value — is compiled into libperry_stdlib.a.
+    ("js_blob_new",                                 OwnerKind::Stdlib { feature: Some("http-client") }),
+    ("js_file_new",                                 OwnerKind::Stdlib { feature: Some("http-client") }),
+    ("js_url_create_object_url",                    OwnerKind::Stdlib { feature: Some("http-client") }),
+    ("js_url_revoke_object_url",                    OwnerKind::Stdlib { feature: Some("http-client") }),
+    ("js_buffer_resolve_object_url",                OwnerKind::Stdlib { feature: Some("http-client") }),
 ];
 
 /// Process-wide collector of provider keys observed during codegen.
@@ -245,6 +265,10 @@ mod tests {
         record_ffi_call("js_readable_stream_new");
         // Repro #846: server FFI should bind to WellKnown("http").
         record_ffi_call("js_node_http_create_server");
+        // Repro #1724: global Blob/URL object-URL FFI should bind to
+        // Stdlib { feature: Some("http-client") } so the auto-optimize
+        // stdlib rebuild compiles the `fetch_blob` module in.
+        record_ffi_call("js_url_revoke_object_url");
         // Non-registered FFI: must NOT cause an insert.
         record_ffi_call("js_definitely_not_a_real_ffi_symbol_zzz");
 
@@ -254,6 +278,13 @@ mod tests {
                 feature: Some("bundled-streams")
             }),
             "expected Stdlib(bundled-streams) in providers, got {:?}",
+            got
+        );
+        assert!(
+            got.contains(&OwnerKind::Stdlib {
+                feature: Some("http-client")
+            }),
+            "expected Stdlib(http-client) in providers (Blob/URL object-URL), got {:?}",
             got
         );
         assert!(


### PR DESCRIPTION
## Summary

Fixes #1724. `URL.revokeObjectURL(...)` (and its companions `URL.createObjectURL`, `new Blob`, `new File`, `resolveObjectURL`) failed to **link**:

```
Undefined symbols for architecture arm64:
  "_js_blob_new", referenced from: _main
  "_js_url_create_object_url", referenced from: _main
  "_js_url_revoke_object_url", referenced from: _main
```

## Root cause

The issue framed it as a missing `perry-runtime` symbol, but `js_url_revoke_object_url` *is* defined — in `perry-stdlib::fetch_blob`, alongside `createObjectURL`/`Blob`/`File`. That whole module is gated behind `#[cfg(feature = "http-client")]` (it shares the Blob registry + handle ABI with `fetch.rs`).

The auto-optimizer (`build_optimized_libs`) rebuilds `perry-stdlib` with `--no-default-features` plus only the features it derives from the program's **imports**. `URL`, `Blob`, `File`, and `URL.createObjectURL`/`revokeObjectURL` are *globals* — a program can use them with no `import` at all. So `http-client` was never enabled, `fetch_blob` was `#[cfg]`-ed out, and `needs_stdlib` stayed `false` (so `libperry_stdlib.a` wasn't even on the link line — the compile printed `Linking (runtime-only)...`).

## Fix

Register the constructor + object-URL entry points in the codegen FFI provenance registry (`ext_registry.rs`, the same mechanism that handles `#835`/`#846` Stream/http-server FFIs) as `Stdlib { feature: Some("http-client") }`:

- `js_blob_new`, `js_file_new`
- `js_url_create_object_url`, `js_url_revoke_object_url`
- `js_buffer_resolve_object_url`

Emitting any one of them now flips `needs_stdlib` and injects `http-client` into `extra_stdlib_features`, so the module — and every Blob/File instance method reachable from a constructed value — is compiled into `libperry_stdlib.a`.

## Validation

```ts
const u = URL.createObjectURL(new Blob(['x']));
URL.revokeObjectURL(u);
console.log('ok');                          // → ok
```

Broader shape also verified:
```ts
import { resolveObjectURL } from "node:buffer";
const b = new Blob(['hello']);
const u = URL.createObjectURL(b);
resolveObjectURL(u).size;                   // → 5
URL.revokeObjectURL(u);
resolveObjectURL(u);                        // → undefined
new File(['abc'], 'x.txt');                 // → name x.txt, size 3
```

- `cargo fmt --all -- --check` clean.
- Extended `registry_dispatch_routes_to_correct_owner` to assert the new `http-client` routing; passes.

Surfaced by the #800 node-core radar (`test-url-revokeobjecturl.js`).
