### PR TITLE
fix(node:path): dispatch methods on a path sub-namespace bound to a local (#1750)

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -49,6 +49,7 @@ impl LoweringContext {
             imported_functions: Vec::new(),
             native_modules: Vec::new(),
             builtin_module_aliases: Vec::new(),
+            subns_path_aliases: HashMap::new(),
             type_param_scopes: Vec::new(),
             native_instances: Vec::new(),
             ui_widget_type_aliases: HashMap::new(),
@@ -907,6 +908,22 @@ impl LoweringContext {
         self.builtin_module_aliases_index
             .get(name)
             .map(|&idx| self.builtin_module_aliases[idx].1.as_str())
+    }
+
+    /// #1750: record `const w = <root>.win32` / `.posix` so that later
+    /// `w.<method>(...)` calls dispatch like `path.<sub>.<method>(...)`. The
+    /// root identifier is stored unresolved (imports aren't processed yet at
+    /// pre-scan time); the `path` check happens when the call is lowered.
+    pub(crate) fn register_subns_path_alias(&mut self, local: String, root: String, sub: String) {
+        self.subns_path_aliases.insert(local, (root, sub));
+    }
+
+    /// Look up a local recorded by `register_subns_path_alias`, returning
+    /// `(root_identifier_name, sub_namespace)`.
+    pub(crate) fn lookup_subns_path_alias(&self, name: &str) -> Option<(&str, &str)> {
+        self.subns_path_aliases
+            .get(name)
+            .map(|(root, sub)| (root.as_str(), sub.as_str()))
     }
 
     pub(crate) fn register_native_instance(

--- a/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
+++ b/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
@@ -354,206 +354,211 @@ pub(super) fn try_util_types_namespace(
 ///   so the result uses `\` separators. Other path.win32.<method>
 ///   calls route to the generic `Expr::PathWin32` carrier, which
 ///   codegen dispatches to `js_path_win32_*` (issue #1162).
+/// True when `root_name` refers to the `node:path` module — directly, via a
+/// builtin-module alias, or via a namespace import (`import * as p from
+/// "node:path"`).
+fn is_path_root(ctx: &LoweringContext, root_name: &str) -> bool {
+    root_name == "path"
+        || ctx.lookup_builtin_module_alias(root_name) == Some("path")
+        || ctx
+            .lookup_native_module(root_name)
+            .map(|(m, _)| m == "path")
+            .unwrap_or(false)
+}
+
+/// Core dispatch for `path.<sub>.<method>(...)` where `sub` is `"win32"` or
+/// `"posix"`. Shared by the direct member form and the aliased-local form
+/// (`const w = path.win32; w.<method>(...)`, #1750). Returns `Err(args)` when
+/// no method matches so the caller can fall through to generic lowering.
+fn dispatch_path_subnamespace(sub: &str, method: &str, args: Vec<Expr>) -> Result<Expr, Vec<Expr>> {
+    // path.<sub>.join(...)
+    if method == "join" {
+        if args.is_empty() {
+            return Ok(Expr::String(".".to_string()));
+        }
+        if sub == "win32" {
+            let mut iter = args.into_iter();
+            let mut result = iter.next().unwrap();
+            for next_arg in iter {
+                result = Expr::PathWin32Join(Box::new(result), Box::new(next_arg));
+            }
+            return Ok(result);
+        } else {
+            // posix.join → existing PathJoin
+            if args.len() == 1 {
+                return Ok(Expr::PathNormalize(Box::new(
+                    args.into_iter().next().unwrap(),
+                )));
+            }
+            let mut iter = args.into_iter();
+            let mut result = iter.next().unwrap();
+            for next_arg in iter {
+                result = Expr::PathJoin(Box::new(result), Box::new(next_arg));
+            }
+            return Ok(result);
+        }
+    }
+
+    // path.win32.<method> — issue #1162. Route every supported method to the
+    // generic `Expr::PathWin32` carrier; codegen dispatches to the matching
+    // `js_path_win32_*` runtime function.
+    if sub == "win32" {
+        use crate::ir::PathWin32Method as M;
+        let m = match method {
+            "dirname" if !args.is_empty() => Some(M::Dirname),
+            "basename" if args.len() >= 2 => Some(M::BasenameExt),
+            "basename" if !args.is_empty() => Some(M::Basename),
+            "extname" if !args.is_empty() => Some(M::Extname),
+            "isAbsolute" if !args.is_empty() => Some(M::IsAbsolute),
+            "normalize" if !args.is_empty() => Some(M::Normalize),
+            "parse" if !args.is_empty() => Some(M::Parse),
+            "format" if !args.is_empty() => Some(M::Format),
+            "relative" if args.len() >= 2 => Some(M::Relative),
+            "toNamespacedPath" if !args.is_empty() => Some(M::ToNamespacedPath),
+            "matchesGlob" if args.len() >= 2 => Some(M::MatchesGlob),
+            _ => None,
+        };
+        if let Some(m) = m {
+            return Ok(Expr::PathWin32 { method: m, args });
+        }
+        // resolve has multi-arg chaining like POSIX — first arg seeds,
+        // remaining fold via ResolveJoin, final via Resolve.
+        if method == "resolve" {
+            if args.is_empty() {
+                return Ok(Expr::PathWin32 {
+                    method: M::Resolve,
+                    args: vec![Expr::String(String::new())],
+                });
+            }
+            let mut it = args.into_iter();
+            let first = it.next().unwrap();
+            let mut joined = first;
+            for next_arg in it {
+                joined = Expr::PathWin32 {
+                    method: M::ResolveJoin,
+                    args: vec![joined, next_arg],
+                };
+            }
+            return Ok(Expr::PathWin32 {
+                method: M::Resolve,
+                args: vec![joined],
+            });
+        }
+    }
+    // The remaining methods route to the existing POSIX Expr::Path* variants
+    // only for the `posix` sub-namespace.
+    if sub == "posix" {
+        match method {
+            "dirname" if !args.is_empty() => {
+                return Ok(Expr::PathDirname(Box::new(
+                    args.into_iter().next().unwrap(),
+                )));
+            }
+            "basename" if args.len() >= 2 => {
+                let mut it = args.into_iter();
+                let p = it.next().unwrap();
+                let e = it.next().unwrap();
+                return Ok(Expr::PathBasenameExt(Box::new(p), Box::new(e)));
+            }
+            "basename" if !args.is_empty() => {
+                return Ok(Expr::PathBasename(Box::new(
+                    args.into_iter().next().unwrap(),
+                )));
+            }
+            "extname" if !args.is_empty() => {
+                return Ok(Expr::PathExtname(Box::new(
+                    args.into_iter().next().unwrap(),
+                )));
+            }
+            "isAbsolute" if !args.is_empty() => {
+                return Ok(Expr::PathIsAbsolute(Box::new(
+                    args.into_iter().next().unwrap(),
+                )));
+            }
+            "normalize" if !args.is_empty() => {
+                return Ok(Expr::PathNormalize(Box::new(
+                    args.into_iter().next().unwrap(),
+                )));
+            }
+            "parse" if !args.is_empty() => {
+                return Ok(Expr::PathParse(Box::new(args.into_iter().next().unwrap())));
+            }
+            "format" if !args.is_empty() => {
+                return Ok(Expr::PathFormat(Box::new(args.into_iter().next().unwrap())));
+            }
+            "toNamespacedPath" if !args.is_empty() => {
+                return Ok(Expr::PathToNamespacedPath(Box::new(
+                    args.into_iter().next().unwrap(),
+                )));
+            }
+            "relative" if args.len() >= 2 => {
+                let mut it = args.into_iter();
+                let from = it.next().unwrap();
+                let to = it.next().unwrap();
+                return Ok(Expr::PathRelative(Box::new(from), Box::new(to)));
+            }
+            "resolve" if args.is_empty() => {
+                return Ok(Expr::PathResolve(Box::new(Expr::String(String::new()))));
+            }
+            "resolve" if !args.is_empty() => {
+                let mut it = args.into_iter();
+                let first = it.next().unwrap();
+                let mut joined = first;
+                for next_arg in it {
+                    joined = Expr::PathResolveJoin(Box::new(joined), Box::new(next_arg));
+                }
+                return Ok(Expr::PathResolve(Box::new(joined)));
+            }
+            "matchesGlob" if args.len() >= 2 => {
+                let mut it = args.into_iter();
+                let p = it.next().unwrap();
+                let pat = it.next().unwrap();
+                return Ok(Expr::PathMatchesGlob(Box::new(p), Box::new(pat)));
+            }
+            _ => {}
+        }
+    }
+    Err(args)
+}
+
 pub(super) fn try_path_subnamespace(
     ctx: &LoweringContext,
     expr: &ast::Expr,
     args: Vec<Expr>,
 ) -> Result<Expr, Vec<Expr>> {
-    if let ast::Expr::Member(outer_member) = expr {
-        if let ast::Expr::Member(inner_member) = outer_member.obj.as_ref() {
-            if let ast::Expr::Ident(root_ident) = inner_member.obj.as_ref() {
-                let root_name = root_ident.sym.as_ref();
-                let is_path_root = root_name == "path"
-                    || ctx.lookup_builtin_module_alias(root_name) == Some("path")
-                    || ctx
-                        .lookup_native_module(root_name)
-                        .map(|(m, _)| m == "path")
-                        .unwrap_or(false);
-                if is_path_root {
-                    if let (ast::MemberProp::Ident(sub_prop), ast::MemberProp::Ident(method_prop)) =
-                        (&inner_member.prop, &outer_member.prop)
-                    {
-                        let sub = sub_prop.sym.as_ref();
-                        let method = method_prop.sym.as_ref();
-                        if sub == "posix" || sub == "win32" {
-                            // path.<sub>.join(...)
-                            if method == "join" {
-                                if args.is_empty() {
-                                    return Ok(Expr::String(".".to_string()));
-                                }
-                                if sub == "win32" {
-                                    let mut iter = args.into_iter();
-                                    let mut result = iter.next().unwrap();
-                                    for next_arg in iter {
-                                        result = Expr::PathWin32Join(
-                                            Box::new(result),
-                                            Box::new(next_arg),
-                                        );
-                                    }
-                                    return Ok(result);
-                                } else {
-                                    // posix.join → existing PathJoin
-                                    if args.len() == 1 {
-                                        return Ok(Expr::PathNormalize(Box::new(
-                                            args.into_iter().next().unwrap(),
-                                        )));
-                                    }
-                                    let mut iter = args.into_iter();
-                                    let mut result = iter.next().unwrap();
-                                    for next_arg in iter {
-                                        result =
-                                            Expr::PathJoin(Box::new(result), Box::new(next_arg));
-                                    }
-                                    return Ok(result);
-                                }
-                            }
+    let ast::Expr::Member(outer_member) = expr else {
+        return Err(args);
+    };
+    let ast::MemberProp::Ident(method_prop) = &outer_member.prop else {
+        return Err(args);
+    };
+    let method = method_prop.sym.as_ref();
 
-                            // path.win32.<method> — issue #1162. Route
-                            // every supported method to the generic
-                            // `Expr::PathWin32` carrier; codegen
-                            // dispatches to the matching
-                            // `js_path_win32_*` runtime function.
-                            if sub == "win32" {
-                                use crate::ir::PathWin32Method as M;
-                                let m = match method {
-                                    "dirname" if !args.is_empty() => Some(M::Dirname),
-                                    "basename" if args.len() >= 2 => Some(M::BasenameExt),
-                                    "basename" if !args.is_empty() => Some(M::Basename),
-                                    "extname" if !args.is_empty() => Some(M::Extname),
-                                    "isAbsolute" if !args.is_empty() => Some(M::IsAbsolute),
-                                    "normalize" if !args.is_empty() => Some(M::Normalize),
-                                    "parse" if !args.is_empty() => Some(M::Parse),
-                                    "format" if !args.is_empty() => Some(M::Format),
-                                    "relative" if args.len() >= 2 => Some(M::Relative),
-                                    "toNamespacedPath" if !args.is_empty() => {
-                                        Some(M::ToNamespacedPath)
-                                    }
-                                    "matchesGlob" if args.len() >= 2 => Some(M::MatchesGlob),
-                                    _ => None,
-                                };
-                                if let Some(m) = m {
-                                    return Ok(Expr::PathWin32 { method: m, args });
-                                }
-                                // resolve has multi-arg chaining like
-                                // POSIX — first arg seeds, remaining
-                                // fold via ResolveJoin, final via
-                                // Resolve.
-                                if method == "resolve" {
-                                    if args.is_empty() {
-                                        return Ok(Expr::PathWin32 {
-                                            method: M::Resolve,
-                                            args: vec![Expr::String(String::new())],
-                                        });
-                                    }
-                                    let mut it = args.into_iter();
-                                    let first = it.next().unwrap();
-                                    let mut joined = first;
-                                    for next_arg in it {
-                                        joined = Expr::PathWin32 {
-                                            method: M::ResolveJoin,
-                                            args: vec![joined, next_arg],
-                                        };
-                                    }
-                                    return Ok(Expr::PathWin32 {
-                                        method: M::Resolve,
-                                        args: vec![joined],
-                                    });
-                                }
-                            }
-                            // The remaining methods route to the
-                            // existing POSIX Expr::Path* variants
-                            // only for the `posix` sub-namespace.
-                            if sub == "posix" {
-                                match method {
-                                    "dirname" if !args.is_empty() => {
-                                        return Ok(Expr::PathDirname(Box::new(
-                                            args.into_iter().next().unwrap(),
-                                        )));
-                                    }
-                                    "basename" if args.len() >= 2 => {
-                                        let mut it = args.into_iter();
-                                        let p = it.next().unwrap();
-                                        let e = it.next().unwrap();
-                                        return Ok(Expr::PathBasenameExt(Box::new(p), Box::new(e)));
-                                    }
-                                    "basename" if !args.is_empty() => {
-                                        return Ok(Expr::PathBasename(Box::new(
-                                            args.into_iter().next().unwrap(),
-                                        )));
-                                    }
-                                    "extname" if !args.is_empty() => {
-                                        return Ok(Expr::PathExtname(Box::new(
-                                            args.into_iter().next().unwrap(),
-                                        )));
-                                    }
-                                    "isAbsolute" if !args.is_empty() => {
-                                        return Ok(Expr::PathIsAbsolute(Box::new(
-                                            args.into_iter().next().unwrap(),
-                                        )));
-                                    }
-                                    "normalize" if !args.is_empty() => {
-                                        return Ok(Expr::PathNormalize(Box::new(
-                                            args.into_iter().next().unwrap(),
-                                        )));
-                                    }
-                                    "parse" if !args.is_empty() => {
-                                        return Ok(Expr::PathParse(Box::new(
-                                            args.into_iter().next().unwrap(),
-                                        )));
-                                    }
-                                    "format" if !args.is_empty() => {
-                                        return Ok(Expr::PathFormat(Box::new(
-                                            args.into_iter().next().unwrap(),
-                                        )));
-                                    }
-                                    "toNamespacedPath" if !args.is_empty() => {
-                                        return Ok(Expr::PathToNamespacedPath(Box::new(
-                                            args.into_iter().next().unwrap(),
-                                        )));
-                                    }
-                                    "relative" if args.len() >= 2 => {
-                                        let mut it = args.into_iter();
-                                        let from = it.next().unwrap();
-                                        let to = it.next().unwrap();
-                                        return Ok(Expr::PathRelative(
-                                            Box::new(from),
-                                            Box::new(to),
-                                        ));
-                                    }
-                                    "resolve" if args.is_empty() => {
-                                        return Ok(Expr::PathResolve(Box::new(Expr::String(
-                                            String::new(),
-                                        ))));
-                                    }
-                                    "resolve" if !args.is_empty() => {
-                                        let mut it = args.into_iter();
-                                        let first = it.next().unwrap();
-                                        let mut joined = first;
-                                        for next_arg in it {
-                                            joined = Expr::PathResolveJoin(
-                                                Box::new(joined),
-                                                Box::new(next_arg),
-                                            );
-                                        }
-                                        return Ok(Expr::PathResolve(Box::new(joined)));
-                                    }
-                                    "matchesGlob" if args.len() >= 2 => {
-                                        let mut it = args.into_iter();
-                                        let p = it.next().unwrap();
-                                        let pat = it.next().unwrap();
-                                        return Ok(Expr::PathMatchesGlob(
-                                            Box::new(p),
-                                            Box::new(pat),
-                                        ));
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
+    // Direct form: `path.<sub>.<method>(...)` — a 3-level member where the
+    // root identifier resolves to the path module.
+    if let ast::Expr::Member(inner_member) = outer_member.obj.as_ref() {
+        if let ast::Expr::Ident(root_ident) = inner_member.obj.as_ref() {
+            if is_path_root(ctx, root_ident.sym.as_ref()) {
+                if let ast::MemberProp::Ident(sub_prop) = &inner_member.prop {
+                    let sub = sub_prop.sym.as_ref();
+                    if sub == "posix" || sub == "win32" {
+                        return dispatch_path_subnamespace(sub, method, args);
                     }
                 }
             }
         }
     }
+
+    // Aliased form (#1750): `const w = path.<sub>; w.<method>(...)` — a 2-level
+    // member whose receiver is a local recorded as a path sub-namespace alias.
+    if let ast::Expr::Ident(recv) = outer_member.obj.as_ref() {
+        if let Some((root, sub)) = ctx.lookup_subns_path_alias(recv.sym.as_ref()) {
+            let (root, sub) = (root.to_string(), sub.to_string());
+            if is_path_root(ctx, &root) {
+                return dispatch_path_subnamespace(&sub, method, args);
+            }
+        }
+    }
+
     Err(args)
 }

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -198,6 +198,12 @@ pub struct LoweringContext {
     pub(crate) imported_functions_index: HashMap<String, usize>,
     /// Shadow index: local alias name -> index in `builtin_module_aliases` Vec
     pub(crate) builtin_module_aliases_index: HashMap<String, usize>,
+    /// Local names bound to a `path` sub-namespace (`const w = path.win32`).
+    /// Maps the local name -> (root identifier name, sub "win32"|"posix").
+    /// Resolution of the root identifier to the `path` module is deferred to
+    /// call-lowering time because imports aren't registered yet during the
+    /// pre-scan that populates this; see `try_path_subnamespace`. #1750.
+    pub(crate) subns_path_aliases: HashMap<String, (String, String)>,
     /// Local names whose value is a `WeakRef` instance (so `x.deref()` routes to
     /// `Expr::WeakRefDeref`). Pragmatic tracking — populated when lowering
     /// `let/const x = new WeakRef(...)`. Cleared on scope exit.

--- a/crates/perry-hir/src/lower/pre_scan.rs
+++ b/crates/perry-hir/src/lower/pre_scan.rs
@@ -78,6 +78,23 @@ pub(crate) fn pre_scan_weakref_locals(ast_module: &ast::Module, ctx: &mut Loweri
                     }
                     _ => {}
                 }
+            } else if let ast::Expr::Member(member) = init_unwrapped {
+                // #1750: `const w = path.win32` / `const p = path.posix`.
+                // Record the alias so `w.normalize(...)` later dispatches like
+                // `path.win32.normalize(...)`. The root ident is stored
+                // unresolved; the `path` check is deferred to call lowering.
+                if let (ast::Expr::Ident(root), ast::MemberProp::Ident(sub_prop)) =
+                    (member.obj.as_ref(), &member.prop)
+                {
+                    let sub = sub_prop.sym.as_ref();
+                    if sub == "win32" || sub == "posix" {
+                        ctx.register_subns_path_alias(
+                            ident.id.sym.to_string(),
+                            root.sym.to_string(),
+                            sub.to_string(),
+                        );
+                    }
+                }
             }
         }
     }

--- a/test-parity/node-suite/path/subnamespace/local-alias.ts
+++ b/test-parity/node-suite/path/subnamespace/local-alias.ts
@@ -1,0 +1,27 @@
+import * as path from "node:path";
+
+// #1750: a path sub-namespace bound to a local must dispatch its methods
+// exactly like the direct `path.win32.<m>(...)` / `path.posix.<m>(...)` form
+// (previously segfaulted). Only deterministic, host-independent inputs here.
+const w = path.win32;
+console.log("w.normalize bare-drive:", w.normalize("C:"));
+console.log("w.normalize trailing:", w.normalize(".\\"));
+console.log("w.basename:", w.basename("C:\\foo\\bar\\baz.txt"));
+console.log("w.basename unc:", w.basename("\\\\server\\share\\"));
+console.log("w.dirname:", w.dirname("C:\\foo\\bar\\baz.txt"));
+console.log("w.extname:", w.extname("C:\\foo\\bar.txt"));
+console.log("w.isAbsolute:", w.isAbsolute("C:\\foo"));
+console.log("w.join:", w.join("C:\\a", "b", "c"));
+console.log("w.toNamespacedPath:", w.toNamespacedPath("C:\\foo"));
+
+const p = path.posix;
+console.log("p.normalize:", p.normalize("/a/./b/../c"));
+console.log("p.basename:", p.basename("/a/b/c.txt"));
+console.log("p.dirname:", p.dirname("/a/b/c.txt"));
+console.log("p.extname:", p.extname("/a/b.txt"));
+console.log("p.isAbsolute:", p.isAbsolute("/a"));
+console.log("p.join:", p.join("/a", "b", "c"));
+
+// direct forms must still work (regression guard for the refactor).
+console.log("direct win32:", path.win32.normalize("C:\\x\\..\\y"));
+console.log("direct posix:", path.posix.normalize("/x//y"));


### PR DESCRIPTION
## Summary

Fixes #1750 — binding a `node:path` sub-namespace to a local and then calling a method on it segfaulted:

```ts
import * as path from "node:path";
const w = path.win32;
console.log(w.normalize("C:")); // was: SIGSEGV (exit 139)
```

The direct form `path.win32.normalize(...)` always worked. The bug also hit `path.posix`. Root cause: the nested-namespace detector (`try_path_subnamespace`) only matched the direct 3-level member shape `path.win32.normalize(...)`. When the sub-namespace was aliased, the RHS lowered to a meaningless `PropertyGet { NativeModuleRef("path"), "win32" }` value, and the later `w.normalize(...)` dispatched on garbage.

## Fix (perry-hir, lowering only)

1. **`pre_scan.rs`** — `record_var` now records `const w = path.win32` / `.posix` as a sub-namespace alias. The root identifier is stored *unresolved* because imports aren't processed yet at pre-scan time.
2. **`context.rs` / `lowering_context.rs`** — new `subns_path_aliases` map + `register_/lookup_subns_path_alias` helpers.
3. **`nested_namespace.rs`** — refactored `try_path_subnamespace`: extracted `is_path_root` + `dispatch_path_subnamespace` helpers (no behavior change to the direct path), then added an **aliased-receiver branch** for the 2-level `w.<method>(...)` shape. The `path` check is applied at call-lowering time (imports now exist), so `const w = notPath.win32` is safely ignored.

The alias now dispatches *identically* to the direct form — verified: `w.resolve("C:foo")` and `path.win32.resolve("C:foo")` both produce `C:\C:foo`.

## Validation

- New parity fixture `test-parity/node-suite/path/subnamespace/local-alias.ts` — byte-for-byte with Node v25 (17/17 lines), covering `win32`/`posix` normalize/basename/dirname/extname/isAbsolute/join/toNamespacedPath via a local alias, plus direct-form regression guards.
- All 102+ `perry-hir` unit tests pass; `cargo fmt --all --check` clean.
- The pre-existing `path/win32/unc-and-drive-relative.ts` fixture (which used `const w = path.win32`) **no longer segfaults** — it now runs and matches Node on 5/6 lines.

## Out of scope

- The remaining `unc-and-drive-relative.ts` divergence is `w.resolve("C:foo")` — Node resolves a drive-relative path against the cwd on that drive (`C:\Users\...\foo`), which is cwd-dependent. Perry's `win32.resolve` uses a synthetic `C:\` root regardless of host. This is the same cwd-dependency #1728 flagged as out of scope and is unrelated to the alias fix (the direct form diverges identically).
- Destructured sub-namespace aliases (`const { win32 } = path`) and arrow/closure-body aliases are not covered by this pre-scan pass; they fall back to current behavior (no regression). Can be a follow-up if needed.
