### PR TITLE
release: v0.5.1028 — post-v0.5.1027 catch-up batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1028 — release sweep: tag the post-v0.5.1027 catch-up batch
+
+Captures the 7 PRs that landed on `main` after the v0.5.1027 version
+bump (`50c391ff`) without their own per-PR tags. Neither v0.5.1026 nor
+v0.5.1027 were tagged on the remote — v0.5.1028 is the first tag in
+this window. CHANGELOG entries for v0.5.1027 and v0.5.1026 below remain
+authoritative for the prior batches; this entry covers only what's new
+since `50c391ff`.
+
+- **#1738** `feat(compile)`: add `--trace` / `--focus` debugging flags
+  to the compile driver. Lets contributors narrow the compile trace to
+  a specific module/function without recompiling the whole tree.
+- **#1723 / #1741** `fix(lockdown)`: #503 guard must allow auditable
+  `ns[dynamicKey].staticMember` accesses (closure-local dynamic key
+  reads + manifest-static member). Pre-fix the lockdown gate
+  conservative-failed on legit codepaths in fastify request adapters.
+- **#1673 / #1742** `fix(dynamic-import)`: a literal `node:` builtin
+  specifier like `import('node:crypto')` now resolves to the native
+  namespace path instead of falling through to V8-shim resolution.
+- **#1724 / #1747** `fix(node)`: referencing `Blob` / `URL` (or
+  `URL.createObjectURL`) at the global scope now triggers the
+  http-client stdlib feature gate so the object-URL helper landing
+  side is available at link time.
+- **#1728 / #1749** `fix(node:path)`: win32 `normalize` / `basename` /
+  `toNamespacedPath` edge cases (bare drive refs, mixed separators,
+  trailing-slash collapsing).
+- **#1751** `test(parity)`: stream — consolidated consumers / promises
+  / static batch (batches 28–34, iter-145..152).
+- **#1754** `test(node-core)`: enrich the `common` shim to raise the
+  #800 radar denominator.
+
 ## v0.5.1027 — fix(windows): #1542 black areas on window resize + restore Windows source build
 
 Two Windows-only fixes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1027
+**Current Version:** 0.5.1028
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4773,7 +4773,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "anyhow",
  "base64",
@@ -4828,14 +4828,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "anyhow",
  "log",
@@ -4850,7 +4850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4859,7 +4859,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4867,7 +4867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "anyhow",
  "base64",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4907,7 +4907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "serde",
  "serde_json",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1027"
+version = "0.5.1028"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4926,7 +4926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "anyhow",
  "clap",
@@ -4941,14 +4941,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "chrono",
  "cron",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5015,7 +5015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5047,14 +5047,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5082,7 +5082,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "base64",
  "image",
@@ -5239,14 +5239,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5302,7 +5302,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "anyhow",
  "base64",
@@ -5357,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5444,7 +5444,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5452,11 +5452,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1027"
+version = "0.5.1028"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "base64",
  "itoa",
@@ -5472,7 +5472,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "base64",
  "block2",
@@ -5519,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "base64",
  "block2",
@@ -5538,11 +5538,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1027"
+version = "0.5.1028"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "base64",
  "block2",
@@ -5558,7 +5558,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "base64",
  "block2",
@@ -5574,7 +5574,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "block2",
  "libc",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "base64",
  "libc",
@@ -5602,7 +5602,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1027"
+version = "0.5.1028"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1027"
+version = "0.5.1028"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"


### PR DESCRIPTION
## Summary

7 PRs landed on `main` after the v0.5.1027 bump (`50c391ff`) without per-PR tags. Neither v0.5.1026 nor v0.5.1027 were tagged on the remote — **v0.5.1028 is the first tag in this window**, so it's also implicitly shipping v0.5.1026 + v0.5.1027.

**This batch's deltas (post-1027 bump):**
- **#1738** `feat(compile)`: `--trace` / `--focus` flags
- **#1723 / #1741** `fix(lockdown)`: #503 `ns[dynamicKey].staticMember`
- **#1673 / #1742** `fix(dynamic-import)`: literal `node:` builtin
- **#1724 / #1747** `fix(node)`: Blob/URL globals → http-client feature
- **#1728 / #1749** `fix(node:path)`: win32 normalize/basename/toNamespacedPath edges
- **#1751** stream parity consolidation
- **#1754** node-core common shim coverage

(See `git log v0.5.1025..HEAD` and the v0.5.1026 / v0.5.1027 CHANGELOG entries for the prior 166 commits also shipping in this tag.)

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo check -p perry` clean
- [ ] PR CI: lint + cargo-test + api-docs-drift + security-audit + harmonyos-smoke pass
- [ ] After merge: tag v0.5.1028 → release-packages.yml all-green