### PR TITLE
fix(hir,runtime): namespace-member call invocation + keys_array guard (toward Effect #321)

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -80,6 +80,7 @@ impl LoweringContext {
             finreg_locals: HashSet::new(),
             weakmap_locals: HashSet::new(),
             weakset_locals: HashSet::new(),
+            namespace_import_locals: HashSet::new(),
             generator_func_names: HashSet::new(),
             async_generator_func_names: HashSet::new(),
             iterator_func_for_class: std::collections::HashMap::new(),

--- a/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
@@ -34,7 +34,17 @@ pub(super) fn try_static_method_and_instance(
             // ClosureHeader.  See compile.rs::imported_classes for the
             // backing dispatch table that resolves these calls at
             // codegen time.
+            // A wildcard namespace import (`import * as Effect from "mod"`) is
+            // a module namespace, not a class — even when uppercase. Its
+            // members must be resolved and CALLED (`Effect.succeed(42)`), not
+            // lowered to a StaticMethodCall (which, post-V8-removal, returns
+            // the member function uncalled — the Effect #321 blocker).
+            // Excluding namespaces here lets `Effect.succeed(42)` fall through
+            // to the namespace-member-call path. Named/default imports of real
+            // classes (`import { MongoClient }`) are not namespace locals and
+            // keep this static-method path.
             let is_imported_upper = ctx.lookup_imported_func(&obj_name).is_some()
+                && !ctx.namespace_import_locals.contains(&obj_name)
                 && obj_name
                     .chars()
                     .next()

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -211,6 +211,16 @@ pub struct LoweringContext {
     pub(crate) weakmap_locals: HashSet<String>,
     /// Local names whose value is a `WeakSet` instance.
     pub(crate) weakset_locals: HashSet<String>,
+    /// Local names bound by a wildcard namespace import (`import * as X from
+    /// "mod"`). These are module namespaces, NOT classes — so `X.member(args)`
+    /// must resolve+call the namespace member, never lower to a
+    /// `StaticMethodCall`. The uppercase-imported-identifier class heuristic in
+    /// `expr_call::static_and_instance` consults this set to skip namespaces
+    /// (an uppercase `import * as Effect` would otherwise be mistaken for a
+    /// class and the member call would return the function uncalled). Named /
+    /// default imports of actual classes (`import { MongoClient }`) are NOT in
+    /// this set and keep the static-method path.
+    pub(crate) namespace_import_locals: HashSet<String>,
     /// Names of functions declared with `function*` — used to detect generator
     /// calls in `for...of` so the iterator protocol loop is emitted instead of
     /// the array-index loop.

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -188,6 +188,11 @@ pub(crate) fn lower_module_decl(
                         } else {
                             // Namespace import from JS module - register so calls resolve to ExternFuncRef
                             ctx.register_imported_func(local.clone(), local.clone());
+                            // Record that `local` is a module namespace (not a
+                            // class). `local.member(args)` must call the member,
+                            // not lower to StaticMethodCall — see the heuristic
+                            // in expr_call::static_and_instance.
+                            ctx.namespace_import_locals.insert(local.clone());
                         }
                         specifiers.push(ImportSpecifier::Namespace { local });
                     }

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -500,9 +500,16 @@ unsafe fn ensure_key_in_keys_array(obj: *mut ObjectHeader, key: *const crate::St
         }
         return;
     }
-    // Validate keys array pointer
+    // Validate keys array pointer. The bare high-bits/low-address checks let
+    // through values that are non-null and tag-free yet still not real heap
+    // pointers (e.g. a stray `0x20_0000_0203` left in a miscompiled object's
+    // keys_array slot), which then fault inside `js_array_length`'s GC-header
+    // read. Gate on the arena-bounds predicate (same one `js_object_create`
+    // uses for prototype validation) so a garbage slot is treated as "no keys
+    // array" instead of crashing the process. (#321: defends against the
+    // Effect `makeGenericTag` mis-tagged-receiver corruption.)
     let keys_ptr = keys as usize;
-    if (keys_ptr as u64) >> 48 != 0 || keys_ptr < 0x10000 {
+    if (keys_ptr as u64) >> 48 != 0 || keys_ptr < 0x10000 || !is_valid_obj_ptr(keys as *const u8) {
         return;
     }
     // Check if key already exists


### PR DESCRIPTION
## Summary

Two correct, regression-safe fixes toward Effect end-to-end (#321), now that V8/`perry-jsruntime` is gone and the only path is native AOT.

### 1. `fix(hir)` — namespace-member call on uppercase `import * as X` invokes the member

`import * as Effect from "effect/Effect"; Effect.succeed(42)` returned the `succeed` **function itself** instead of calling it. The "uppercase imported identifier = class" heuristic in `expr_call::static_and_instance` lowered `X.member(args)` to a `StaticMethodCall`, which post-#1696 (V8 removal) returns the resolved member uncalled. Wildcard namespace-import locals are now tracked and excluded from that heuristic, so `X.member(args)` falls through to the namespace-member-call path (lowercase namespaces already worked). Named/default imports of real classes (`import { MongoClient }`) keep the static-method path.

Minimal repro now passes:
```ts
// mod.ts
export const succeed = (v: number) => ({ _op: "Success", value: v });
// up.ts
import * as Up from "./mod";
console.log(typeof Up.succeed(42), (Up.succeed(42) as any)._op);
// before: "function" undefined   after: "object" "Success"  (matches node)
```

### 2. `fix(runtime)` — guard `ensure_key_in_keys_array` against a non-heap `keys_array`

A miscompiled object whose `keys_array` slot holds a tag-free non-null value that isn't a real heap pointer (e.g. a stray `0x20_0000_0203`) passed the bare high-bits/low-address validation and then faulted inside `js_array_length`'s GC-header read (SIGBUS). The deref is now gated on the arena-bounds predicate `is_valid_obj_ptr` (the same check `js_object_create` already uses for prototypes), so a garbage slot is treated as "no keys array" instead of crashing the process. Normal objects (null or valid-array `keys_array`) are unaffected; `Object.defineProperty` regressions verified passing.

## Effect #321 progress with these two fixes

The full Effect tree (effect@3.21.2) **compiles, links, boots, and runs all ~360 module inits**, and the core works: on the deep import, `eff.runSync(eff.succeed(42))` produces `result: 42` byte-for-byte with node. Fix #1 makes the idiomatic `Effect.succeed(42)` actually execute; fix #2 removes an incidental SIGBUS.

These do **not** yet close #321 — they expose the next latent layers (see filed sub-issues): a `makeGenericTag` `tag`-local codegen miscompile (`TypeError: has is not a function`) and the `Schema.ts` `_tag`-on-undefined crash on the barrel import. Those are pre-existing bugs that only surface once Effect's namespace calls actually run.

## Test plan

- [x] Minimal namespace-member-call repro (uppercase vs lowercase) matches node.
- [x] Lowercase and uppercase deep imports now lower identically.
- [x] `Object.defineProperty` / `Object.create` programs unaffected by the guard.
- [x] `cargo fmt --all -- --check` clean.

Refs #321.
