### PR TITLE
fix(runtime,hir): WeakMap/WeakSet dynamic dispatch + param-property defaults (toward Effect #321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1029 — Effect: WeakMap dynamic dispatch + TS param-property defaults (#1763)
+
+Two small, regression-safe correctness fixes toward Effect end-to-end (#321),
+continuing from #1756. With #1756 merged, the originally-filed symptoms of
+#1757 (makeGenericTag tag-local) and #1758 (Schema.ts `_tag`) no longer
+reproduced — both surfaced a shared deeper blocker instead. This batch fixes
+the real root cause and the next blocker after it. Net effect: the deep-import
+DoD `import * as Effect from "effect/Effect"; Effect.runSync(Effect.succeed(42))`
+now prints `42`, byte-for-byte with node.
+
+- **#1757 / #1758** `fix(runtime)`: WeakMap/WeakSet **dynamic** method
+  dispatch. `new WeakMap()` already builds a real `js_weakmap_new` object, and
+  a directly-declared `const w = new WeakMap()` dispatches `.has/.get/.set/
+  .delete` via the static `weakmap_locals` lowering. But a WeakMap reaching the
+  dynamic dispatcher `js_native_call_method` through an `any`-typed binding —
+  exactly effect's `globalValue(() => new WeakMap())`, whose generic return
+  type erases the WeakMap-ness — had no dispatch arm, so `randomHashCache.has(
+  self)` in `Hash.ts` threw `TypeError: has is not a function`. Unlike Map/Set
+  (plain-alloc, raw-pointer registries), WeakMap/WeakSet objects are
+  GcHeader-backed and movable, so a raw-pointer registry would dangle after a
+  GC evacuation; instead `js_weakmap_new`/`js_weakset_new` now stamp a
+  GC-stable reserved `class_id` (`0xFFFF0027`/`0xFFFF0028`, following the
+  `CLASS_ID_MAP`/`CLASS_ID_SET` convention) and `js_native_call_method` routes
+  `has/get/set/delete`/`add` to the existing `js_weakmap_*`/`js_weakset_*`
+  helpers via `weakref::try_weak_method_dispatch` (extracted to `weakref.rs` to
+  keep `native_call_method.rs` — a dispatch tower already at the file-size
+  gate — readable; the file is allowlisted with a split note under #1435).
+- **#1757 / #1758** `fix(hir)`: TS constructor **parameter-property default
+  values**. `constructor(readonly tags: ReadonlyArray<X> = [])` dropped the
+  default during lowering (`class_members.rs` forced `default: None` on every
+  `TsParamProp`), leaving `this.tags` null when the argument was omitted;
+  effect's `MetricKeyImpl` then threw `Cannot read properties of null (reading
+  'length')` in `Hash.array(this.tags)`. The `TsParamProp` arms now capture the
+  default (lowering `assign.right`, and treating `x?` optional as `undefined`)
+  so the existing `build_default_param_stmts` pass applies it before the
+  synthesized `this.field = param` assignment.
+- New gap test `test-files/test_gap_weakmap_dynamic.ts` covers `any`-typed
+  WeakMap/WeakSet dispatch (byte-for-byte parity with node).
+
+Remaining toward #321 (not in this batch): the barrel import `import { Effect }
+from "effect"` (which additionally drags in `Schema.ts`/`SchemaAST.ts`) now
+advances past these two blockers and reaches the original #1758 symptom —
+`Cannot read properties of undefined (reading '_tag')` in `SchemaAST_ts__239 ←
+Schema_ts__211/__227` during Schema init — tracked under #1758. A statically
+`WeakMap`-typed receiver (e.g. a function return type) still mis-dispatches as
+Map (`local_array_methods.rs` treats `WeakMap` like `Map`) onto a
+`js_weakmap_new` object; effect doesn't hit this (its WeakMap is `any`-typed),
+tracked as #1766.
+
 ## v0.5.1028 — release sweep: tag the post-v0.5.1027 catch-up batch
 
 Captures the 7 PRs that landed on `main` after the v0.5.1027 version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1028
+**Current Version:** 0.5.1029
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4773,7 +4773,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "anyhow",
  "base64",
@@ -4828,14 +4828,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "anyhow",
  "log",
@@ -4850,7 +4850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4859,7 +4859,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4867,7 +4867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "anyhow",
  "base64",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4907,7 +4907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "serde",
  "serde_json",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1028"
+version = "0.5.1029"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4926,7 +4926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "anyhow",
  "clap",
@@ -4941,14 +4941,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "chrono",
  "cron",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5015,7 +5015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5047,14 +5047,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5082,7 +5082,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "base64",
  "image",
@@ -5239,14 +5239,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5302,7 +5302,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "anyhow",
  "base64",
@@ -5357,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5444,7 +5444,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5452,11 +5452,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1028"
+version = "0.5.1029"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "base64",
  "itoa",
@@ -5472,7 +5472,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "base64",
  "block2",
@@ -5519,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "base64",
  "block2",
@@ -5538,11 +5538,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1028"
+version = "0.5.1029"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "base64",
  "block2",
@@ -5558,7 +5558,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "base64",
  "block2",
@@ -5574,7 +5574,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "block2",
  "libc",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "base64",
  "libc",
@@ -5602,7 +5602,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1028"
+version = "0.5.1029"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1028"
+version = "0.5.1029"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-hir/src/lower_decl/class_members.rs
+++ b/crates/perry-hir/src/lower_decl/class_members.rs
@@ -63,7 +63,15 @@ pub fn lower_constructor(
             }
             ast::ParamOrTsParamProp::TsParamProp(ts_prop) => {
                 // Handle parameter properties (e.g., constructor(public x: number))
-                let (param_name, param_type) = match &ts_prop.param {
+                // Capture the default like a plain param: `build_default_param_stmts`
+                // (below) turns it into `if (p === undefined) p = <default>` so the
+                // synthesized `this.field = p` assignment stores the default rather
+                // than `undefined` when the arg is omitted. Without this, a defaulted
+                // parameter property such as effect's MetricKeyImpl
+                // `readonly tags: ReadonlyArray<...> = []` left `this.tags` null, and
+                // `Hash.array(this.tags)` then threw "Cannot read properties of null
+                // (reading 'length')". Issue #1757/#1758 (toward #321).
+                let (param_name, param_type, param_default) = match &ts_prop.param {
                     ast::TsParamPropParam::Ident(ident) => {
                         let name = ident.id.sym.to_string();
                         let ty = ident
@@ -71,12 +79,22 @@ pub fn lower_constructor(
                             .as_ref()
                             .map(|ann| extract_ts_type_with_ctx(&ann.type_ann, Some(ctx)))
                             .unwrap_or(Type::Any);
-                        (name, ty)
+                        // `constructor(public x?: T)` — optional param props
+                        // default to undefined, mirroring get_param_default.
+                        let default = if ident.id.optional {
+                            Some(Expr::Undefined)
+                        } else {
+                            None
+                        };
+                        (name, ty, default)
                     }
                     ast::TsParamPropParam::Assign(assign) => {
                         let name = get_pat_name(&assign.left)?;
                         let ty = extract_param_type_with_ctx(&assign.left, Some(ctx));
-                        (name, ty)
+                        // Lower the default before defining this param's local,
+                        // matching the plain-`Param` ordering at get_param_default.
+                        let default = Some(lower_expr(ctx, &assign.right)?);
+                        (name, ty, default)
                     }
                 };
                 let param_id = ctx.define_local(param_name.clone(), param_type.clone());
@@ -86,7 +104,7 @@ pub fn lower_constructor(
                     id: param_id,
                     name: param_name,
                     ty: param_type,
-                    default: None,
+                    default: param_default,
                     decorators: lower_decorators(ctx, &ts_prop.decorators),
                     is_rest: false, // TsParamProp cannot be a rest parameter
                 });

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1759,6 +1759,18 @@ pub unsafe extern "C" fn js_native_call_method(
             return crate::perf_hooks::perf_entry_to_json(object);
         }
 
+        // WeakMap/WeakSet dynamic method dispatch (issue #1757/#1758): these
+        // are GcHeader-backed objects stamped with a reserved class_id, so a
+        // WeakMap reaching here through an `any`-typed binding (effect's
+        // `globalValue(() => new WeakMap())`) still routes has/get/set/delete/
+        // add to the js_weak* helpers instead of throwing "has is not a
+        // function". The class_id guard + routing live in weakref.rs.
+        if let Some(r) =
+            crate::weakref::try_weak_method_dispatch(obj, object, method_name, args_ptr, args_len)
+        {
+            return r;
+        }
+
         if gc_type != crate::gc::GC_TYPE_OBJECT {
             // Only accept object_type == 1 (OBJECT_TYPE_REGULAR)
             let object_type = (*obj).object_type;

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -148,6 +148,60 @@ pub extern "C" fn js_finreg_unregister(registry: f64, token: f64) -> f64 {
 const WEAKMAP_SHAPE_ID: u32 = 0x7FFF_FE12;
 const WEAKSET_SHAPE_ID: u32 = 0x7FFF_FE13;
 
+// Reserved `ObjectHeader.class_id` markers for WeakMap/WeakSet instances.
+// These follow the same `0xFFFF00xx` reserved-builtin convention as
+// CLASS_ID_MAP/CLASS_ID_SET (see object/instanceof.rs). Unlike Map/Set —
+// which are plain-alloc and tracked in raw-pointer registries — WeakMap/
+// WeakSet objects are GcHeader-backed and movable, so a registry of raw
+// pointers would dangle after a GC evacuation. The class_id travels with
+// the object across GC moves, so `js_native_call_method` can recognise a
+// WeakMap/WeakSet held in an `any`-typed binding (e.g. effect's
+// `globalValue(() => new WeakMap())`) and dispatch .has/.get/.set/.delete/
+// .add through to these helpers. 0x27/0x28 are the next free slots after
+// CLASS_ID_BLOB (0x26). Issue #1757/#1758.
+pub const CLASS_ID_WEAKMAP: u32 = 0xFFFF_0027;
+pub const CLASS_ID_WEAKSET: u32 = 0xFFFF_0028;
+
+/// Dynamic-dispatch entry point for WeakMap/WeakSet method calls (issue
+/// #1757/#1758). `js_native_call_method` calls this for any heap object;
+/// it returns `Some(result)` only when `obj` carries the reserved
+/// WeakMap/WeakSet `class_id` and `method_name` is one of their methods,
+/// and `None` otherwise so the caller falls through to its normal
+/// dispatch. `receiver` is the NaN-boxed f64 the `js_weak*` helpers expect.
+///
+/// Unknown methods on a known WeakMap/WeakSet resolve to `undefined`,
+/// mirroring the Map/Set registry arms in the dynamic dispatcher.
+///
+/// # Safety
+/// `obj` must be a valid, readable `ObjectHeader` pointer (the caller has
+/// already validated it as a live heap object).
+pub unsafe fn try_weak_method_dispatch(
+    obj: *const ObjectHeader,
+    receiver: f64,
+    method_name: &str,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> Option<f64> {
+    let class_id = (*obj).class_id;
+    if class_id != CLASS_ID_WEAKMAP && class_id != CLASS_ID_WEAKSET {
+        return None;
+    }
+    let args: &[f64] = if !args_ptr.is_null() && args_len > 0 {
+        std::slice::from_raw_parts(args_ptr, args_len)
+    } else {
+        &[]
+    };
+    let result = match method_name {
+        "set" if args.len() >= 2 => js_weakmap_set(receiver, args[0], args[1]),
+        "add" if !args.is_empty() => js_weakset_add(receiver, args[0]),
+        "get" if !args.is_empty() => js_weakmap_get(receiver, args[0]),
+        "has" if !args.is_empty() => js_weakmap_has(receiver, args[0]),
+        "delete" if !args.is_empty() => js_weakmap_delete(receiver, args[0]),
+        _ => f64::from_bits(TAG_UNDEFINED),
+    };
+    Some(result)
+}
+
 unsafe fn entries_array(reg: *mut ObjectHeader) -> *mut ArrayHeader {
     let entries_key = crate::string::js_string_from_bytes(b"entries".as_ptr(), 7);
     let entries_val = js_object_get_field_by_name(reg, entries_key);
@@ -160,6 +214,11 @@ pub extern "C" fn js_weakmap_new() -> *mut ObjectHeader {
     let obj = js_object_alloc_with_shape(WEAKMAP_SHAPE_ID, 1, packed.as_ptr(), packed.len() as u32);
     let entries_arr = js_array_alloc(0);
     js_object_set_field(obj, 0, JSValue::array_ptr(entries_arr));
+    // Stamp the GC-stable kind marker so dynamic method dispatch
+    // (js_native_call_method) recognises this as a WeakMap. Issue #1757.
+    unsafe {
+        (*obj).class_id = CLASS_ID_WEAKMAP;
+    }
     obj
 }
 
@@ -294,6 +353,10 @@ pub extern "C" fn js_weakset_new() -> *mut ObjectHeader {
     let obj = js_object_alloc_with_shape(WEAKSET_SHAPE_ID, 1, packed.as_ptr(), packed.len() as u32);
     let entries_arr = js_array_alloc(0);
     js_object_set_field(obj, 0, JSValue::array_ptr(entries_arr));
+    // Stamp the GC-stable kind marker (see js_weakmap_new). Issue #1757.
+    unsafe {
+        (*obj).class_id = CLASS_ID_WEAKSET;
+    }
     obj
 }
 

--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -78,6 +78,10 @@ crates/perry-runtime/src/object/field_get_set.rs
 # fast-path gate refinements + main's process / fs / perf_hooks Expr
 # additions. Splitting per-builtin family tracked alongside #1435.
 crates/perry-codegen/src/expr/calls.rs
+# Dynamic method-call dispatch tower (js_native_call_method); crossed the
+# limit by the 7-line WeakMap/WeakSet dispatch hook in #1757/#1758. Splitting
+# per receiver-kind family tracked alongside #1435.
+crates/perry-runtime/src/object/native_call_method.rs
 EOF
 )
 

--- a/test-files/test_gap_weakmap_dynamic.ts
+++ b/test-files/test_gap_weakmap_dynamic.ts
@@ -1,0 +1,37 @@
+// Issue #1757/#1758: WeakMap/WeakSet methods must dispatch when the receiver
+// flows through an `any`-typed binding (not a directly-declared
+// `const w = new WeakMap()` local). This is the shape effect uses via
+// `globalValue(() => new WeakMap())`, whose generic return type erases the
+// WeakMap-ness so `.has(...)` lands in the dynamic method dispatcher. Before
+// the fix this threw `TypeError: has is not a function`.
+//
+// Expected output:
+// wm has(a): false
+// wm set/has(a): true
+// wm get(a): 1
+// wm has(b): false
+// wm delete(a): true
+// wm has(a) after delete: false
+// ws has(a): false
+// ws add/has(a): true
+// ws delete(a): true
+// ws has(a) after delete: false
+
+// `any`-typed binding defeats static WeakMap tracking → dynamic dispatch.
+const wm: any = new WeakMap<object, number>();
+const a = {};
+const b = {};
+console.log("wm has(a): " + wm.has(a));
+wm.set(a, 1);
+console.log("wm set/has(a): " + wm.has(a));
+console.log("wm get(a): " + wm.get(a));
+console.log("wm has(b): " + wm.has(b));
+console.log("wm delete(a): " + wm.delete(a));
+console.log("wm has(a) after delete: " + wm.has(a));
+
+const ws: any = new WeakSet<object>();
+console.log("ws has(a): " + ws.has(a));
+ws.add(a);
+console.log("ws add/has(a): " + ws.has(a));
+console.log("ws delete(a): " + ws.delete(a));
+console.log("ws has(a) after delete: " + ws.has(a));


### PR DESCRIPTION
## Summary

Two small, regression-safe correctness fixes that unblock Effect end-to-end (toward #321), continuing from PR #1756. With #1756 merged, both #1757 and #1758 stopped manifesting their originally-filed symptoms (makeGenericTag tag-local / Schema `_tag`) and instead surfaced a shared, deeper blocker; this PR fixes the real root cause and the next blocker after it.

**Result:** the deep import DoD now passes —
`import * as Effect from "effect/Effect"; Effect.runSync(Effect.succeed(42))` prints `42`, byte-for-byte with node.

### 1. `fix(runtime)` — WeakMap/WeakSet dynamic method dispatch (#1757, #1758)

`new WeakMap()` already builds a real runtime object (`js_weakmap_new`, with an `entries` array), and a directly-declared `const w = new WeakMap()` dispatches `.has/.get/.set/.delete` via the static `weakmap_locals` lowering. But when a WeakMap flows through an **`any`-typed binding** — exactly effect's `globalValue(() => new WeakMap())`, whose generic return type erases the WeakMap-ness — `.has(...)` lands in the dynamic method dispatcher (`js_native_call_method`), which had no arm for WeakMap/WeakSet objects. So `randomHashCache.has(self)` in `Hash.ts` threw `TypeError: has is not a function`.

Unlike Map/Set (plain-alloc, tracked in raw-pointer registries), WeakMap/WeakSet objects are GcHeader-backed and movable, so a raw-pointer registry would dangle after a GC evacuation. Instead `js_weakmap_new`/`js_weakset_new` now stamp a reserved `class_id` (`0xFFFF0027`/`0xFFFF0028`, following the existing `CLASS_ID_MAP`/`CLASS_ID_SET` convention) that travels with the object across GC moves, and `js_native_call_method` recognises it and routes `has/get/set/delete`/`add` to the existing `js_weakmap_*`/`js_weakset_*` helpers.

### 2. `fix(hir)` — TS parameter-property default values (toward #321)

A constructor parameter property with a default — `constructor(readonly tags: ReadonlyArray<X> = [])` — dropped the default during lowering (`class_members.rs` always pushed `default: None`), so when the arg was omitted `this.tags` stayed `null`. effect's `MetricKeyImpl` does exactly this; `Hash.array(this.tags)` then threw `Cannot read properties of null (reading 'length')`. The `TsParamProp` arms now capture the default (lowering `assign.right`, and treating `x?` optional as `undefined`) so the existing `build_default_param_stmts` pass applies it before the synthesized `this.field = param` assignment.

## Validation

- New gap test `test-files/test_gap_weakmap_dynamic.ts` — `any`-typed WeakMap/WeakSet dispatch, byte-for-byte parity with node.
- Minimal repros + a combined smoke test (reference-identity keys, delete, WeakSet, multiple/optional/mixed param-property defaults) all match node exactly.
- `import * as Effect from "effect/Effect"` → `result: 42` (was `TypeError: has is not a function`).
- `cargo test -p perry-runtime -p perry-hir` green; `cargo fmt --all -- --check` clean.

## Remaining (not in this PR)

The barrel import `import { Effect } from "effect"` (which additionally drags in `Schema.ts` / `SchemaAST.ts`, ~360 modules) now advances past these two blockers and reaches the original #1758 symptom — `Cannot read properties of undefined (reading '_tag')` inside `SchemaAST_ts__239 ← Schema_ts__211/__227` during `Schema.ts` init. That is a separate, deeper miscompile in effect's 11k-line generics/factory-class module and is tracked as follow-up work under #321.

Also surfaced but out of scope: a statically `WeakMap`-typed receiver (e.g. a function return type) routes through the Map-method lowering (`local_array_methods.rs` treats `WeakMap` like `Map`) onto a `js_weakmap_new` object and fails; effect doesn't hit this (its WeakMap is `any`-typed). Worth a follow-up to unify the three WeakMap dispatch paths.

Refs #1757, #1758, #321. Follows #1756.
