### PR TITLE
Add guarded raw numeric heap layouts

### DIFF
--- a/benchmarks/compare.sh
+++ b/benchmarks/compare.sh
@@ -68,7 +68,7 @@ if [[ $QUICK_MODE -eq 1 ]]; then
   BENCHMARKS="02_loop_overhead.ts 05_fibonacci.ts 06_math_intensive.ts 10_nested_loops.ts 13_factorial.ts"
 elif [[ $FULL_MODE -eq 1 ]]; then
   # Full suite including the regression-probe benchmarks added for performance tracking
-  BENCHMARKS="02_loop_overhead.ts 03_array_write.ts 04_array_read.ts 05_fibonacci.ts 06_math_intensive.ts 07_object_create.ts 08_string_concat.ts 09_method_calls.ts 10_nested_loops.ts 11_prime_sieve.ts 12_binary_trees.ts 13_factorial.ts 14_closure.ts 15_mandelbrot.ts 16_matrix_multiply.ts bench_gc_pressure.ts bench_json_roundtrip.ts bench_object_property.ts bench_int_arithmetic.ts bench_buffer_readwrite.ts bench_array_grow.ts bench_string_heavy.ts"
+  BENCHMARKS="02_loop_overhead.ts 03_array_write.ts 04_array_read.ts 05_fibonacci.ts 06_math_intensive.ts 07_object_create.ts 08_string_concat.ts 09_method_calls.ts 10_nested_loops.ts 11_prime_sieve.ts 12_binary_trees.ts 13_factorial.ts 14_closure.ts 15_mandelbrot.ts 16_matrix_multiply.ts bench_gc_pressure.ts bench_json_roundtrip.ts bench_object_property.ts bench_int_arithmetic.ts bench_buffer_readwrite.ts bench_array_grow.ts bench_string_heavy.ts bench_numeric_array_numeric.ts bench_numeric_array_downgrade.ts"
 else
   BENCHMARKS="02_loop_overhead.ts 03_array_write.ts 04_array_read.ts 05_fibonacci.ts 06_math_intensive.ts 07_object_create.ts 08_string_concat.ts 09_method_calls.ts 10_nested_loops.ts 11_prime_sieve.ts 12_binary_trees.ts 13_factorial.ts 14_closure.ts 15_mandelbrot.ts 16_matrix_multiply.ts"
 fi
@@ -553,6 +553,7 @@ cd "$SUITE_DIR" && rm -f 01_startup 02_loop_overhead 03_array_write 04_array_rea
   06_math_intensive 07_object_create 08_string_concat 09_method_calls 10_nested_loops \
   11_prime_sieve 12_binary_trees 13_factorial 14_closure 15_mandelbrot 16_matrix_multiply \
   bench_gc_pressure bench_json_roundtrip bench_object_property bench_int_arithmetic \
-  bench_buffer_readwrite bench_array_grow bench_string_heavy 2>/dev/null
+  bench_buffer_readwrite bench_array_grow bench_string_heavy bench_numeric_array_numeric \
+  bench_numeric_array_downgrade 2>/dev/null
 
 exit ${COMPARE_EXIT:-0}

--- a/benchmarks/suite/bench_numeric_array_downgrade.ts
+++ b/benchmarks/suite/bench_numeric_array_downgrade.ts
@@ -1,0 +1,52 @@
+// Benchmark: Numeric array downgrade path
+// Measures arrays that start numeric, receive pointer/string slots, then keep
+// mutating numeric regions without losing JS semantics for the downgraded slots.
+
+const SIZE = 250000;
+const ITERATIONS = 25;
+const OBJECT_INDEX = 125000;
+const STRING_INDEX = 125001;
+
+function buildDowngradedArray(): any[] {
+  const arr: any[] = [];
+  for (let i = 0; i < SIZE; i++) {
+    arr.push(i);
+  }
+
+  arr[OBJECT_INDEX] = { value: 7 };
+  arr[STRING_INDEX] = "numeric-array-downgrade-payload";
+  return arr;
+}
+
+function runDowngradedArray(): number {
+  const arr = buildDowngradedArray();
+  let checksum = 0;
+
+  for (let iter = 0; iter < ITERATIONS; iter++) {
+    for (let i = 0; i < OBJECT_INDEX; i++) {
+      arr[i] = arr[i] + 1;
+    }
+    for (let i = STRING_INDEX + 1; i < arr.length; i++) {
+      arr[i] = arr[i] + 1;
+    }
+
+    checksum = checksum + arr[0] + arr[arr.length - 1] + arr[OBJECT_INDEX].value;
+    if (arr[STRING_INDEX] !== "") {
+      checksum = checksum + 3;
+    }
+  }
+
+  return checksum + arr.length;
+}
+
+// Warmup
+for (let i = 0; i < 3; i++) {
+  runDowngradedArray();
+}
+
+const start = Date.now();
+const checksum = runDowngradedArray();
+const elapsed = Date.now() - start;
+
+console.log("numeric_array_downgrade:" + elapsed);
+console.log("checksum:" + checksum);

--- a/benchmarks/suite/bench_numeric_array_numeric.ts
+++ b/benchmarks/suite/bench_numeric_array_numeric.ts
@@ -1,0 +1,40 @@
+// Benchmark: Numeric array pointer-free layout
+// Measures push + indexed mutation/read on arrays that remain numeric-only.
+// This is the positive path for the typed-runtime numeric-array metadata slice.
+
+const SIZE = 250000;
+const ITERATIONS = 25;
+
+function buildNumericArray(): number[] {
+  const arr: number[] = [];
+  for (let i = 0; i < SIZE; i++) {
+    arr.push(i);
+  }
+  return arr;
+}
+
+function runNumericArray(): number {
+  const arr = buildNumericArray();
+  let checksum = 0;
+
+  for (let iter = 0; iter < ITERATIONS; iter++) {
+    for (let i = 0; i < arr.length; i++) {
+      arr[i] = arr[i] + 1;
+    }
+    checksum = checksum + arr[0] + arr[arr.length - 1];
+  }
+
+  return checksum + arr.length;
+}
+
+// Warmup
+for (let i = 0; i < 3; i++) {
+  runNumericArray();
+}
+
+const start = Date.now();
+const checksum = runNumericArray();
+const elapsed = Date.now() - start;
+
+console.log("numeric_array_numeric:" + elapsed);
+console.log("checksum:" + checksum);

--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -70,7 +70,7 @@ pub(super) struct ModuleArtifactsCtx<'a> {
     pub closure_synthetic_arguments: &'a std::collections::HashSet<u32>,
     pub closure_arities: &'a HashMap<u32, u32>,
     pub closures: &'a [(perry_types::FuncId, perry_hir::Expr)],
-    pub class_keys_init_data: &'a [(String, String, u32, Vec<u64>)],
+    pub class_keys_init_data: &'a [(String, String, u32, Vec<u64>, Vec<u64>)],
     pub imported_class_stubs: &'a [perry_hir::Class],
     pub cross_module: &'a CrossModuleCtx,
 }

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -444,9 +444,10 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
     // allocation path.
     //
     // Per-class init data:
-    // (global_name, packed_keys_string, total_field_count, pointer_mask_words).
+    // (global_name, packed_keys_string, total_field_count, raw_f64_mask_words,
+    // pointer_mask_words).
     // Used by emit_string_pool to emit the build-call sequence.
-    let mut class_keys_init_data: Vec<(String, String, u32, Vec<u64>)> = Vec::new();
+    let mut class_keys_init_data: Vec<(String, String, u32, Vec<u64>, Vec<u64>)> = Vec::new();
     let mut class_keys_globals_map: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
     for c in &hir.classes {
@@ -531,13 +532,13 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                 .entry(alias.clone())
                 .or_insert_with(|| global_name.clone());
         }
-        let (_typed_slot_count, typed_mask_words) =
-            crate::typed_shape::class_typed_layout(&class_table, &c.name);
+        let typed_layout = crate::typed_shape::class_typed_layout(&class_table, &c.name);
         class_keys_init_data.push((
             global_name,
             packed_keys,
             total_field_count,
-            typed_mask_words,
+            typed_layout.raw_f64_mask_words,
+            typed_layout.pointer_mask_words,
         ));
     }
     // Same naming convention for IMPORTED class stubs. Pack the field
@@ -610,13 +611,13 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             packed_keys.push_str(&f.name);
             packed_keys.push('\0');
         }
-        let (_typed_slot_count, typed_mask_words) =
-            crate::typed_shape::class_typed_layout(&class_table, &c.name);
+        let typed_layout = crate::typed_shape::class_typed_layout(&class_table, &c.name);
         class_keys_init_data.push((
             global_name,
             packed_keys,
             total_field_count,
-            typed_mask_words,
+            typed_layout.raw_f64_mask_words,
+            typed_layout.pointer_mask_words,
         ));
     }
 

--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -19,7 +19,7 @@ pub(super) fn emit_string_pool(
     llmod: &mut LlModule,
     strings: &StringPool,
     module_prefix: &str,
-    class_keys_init_data: &[(String, String, u32, Vec<u64>)],
+    class_keys_init_data: &[(String, String, u32, Vec<u64>, Vec<u64>)],
     class_ids: &HashMap<String, u32>,
     classes: &HashMap<String, &perry_hir::Class>,
     closure_rest_params: &HashMap<u32, usize>,
@@ -70,7 +70,9 @@ pub(super) fn emit_string_pool(
     // Naming: `@perry_class_keys_packed_<modprefix>__<idx>` so we
     // don't collide with anything else.
     let mut packed_global_names: Vec<String> = Vec::with_capacity(class_keys_init_data.len());
-    for (idx, (_global_name, packed, _fc, _mask_words)) in class_keys_init_data.iter().enumerate() {
+    for (idx, (_global_name, packed, _fc, _raw_mask_words, _pointer_mask_words)) in
+        class_keys_init_data.iter().enumerate()
+    {
         if packed.is_empty() {
             packed_global_names.push(String::new());
             continue;
@@ -132,27 +134,43 @@ pub(super) fn emit_string_pool(
         }
     }
 
-    // Emit per-class typed-shape pointer-mask globals. Empty mask = nothing
-    // to emit (no typed slots in this class shape). Must run BEFORE
+    // Emit per-class typed-shape raw-f64 and pointer-mask globals. Empty masks
+    // emit no storage. Must run BEFORE
     // `init_fn = llmod.define_function(...)` because that call holds a
     // mutable borrow of `llmod` for the lifetime of the function/block
     // used by everything below.
-    for (global_name, _packed, _field_count, mask_words) in class_keys_init_data.iter() {
-        if mask_words.is_empty() {
-            continue;
+    for (global_name, _packed, _field_count, raw_mask_words, pointer_mask_words) in
+        class_keys_init_data.iter()
+    {
+        if !raw_mask_words.is_empty() {
+            let mask_global =
+                crate::typed_shape::raw_f64_mask_global_name_from_keys_global(global_name);
+            let words = raw_mask_words
+                .iter()
+                .map(|word| format!("i64 {}", word))
+                .collect::<Vec<_>>()
+                .join(", ");
+            llmod.add_raw_global(format!(
+                "@{} = private unnamed_addr constant [{} x i64] [{}]",
+                mask_global,
+                raw_mask_words.len(),
+                words
+            ));
         }
-        let mask_global = crate::typed_shape::mask_global_name_from_keys_global(global_name);
-        let words = mask_words
-            .iter()
-            .map(|word| format!("i64 {}", word))
-            .collect::<Vec<_>>()
-            .join(", ");
-        llmod.add_raw_global(format!(
-            "@{} = private unnamed_addr constant [{} x i64] [{}]",
-            mask_global,
-            mask_words.len(),
-            words
-        ));
+        if !pointer_mask_words.is_empty() {
+            let mask_global = crate::typed_shape::mask_global_name_from_keys_global(global_name);
+            let words = pointer_mask_words
+                .iter()
+                .map(|word| format!("i64 {}", word))
+                .collect::<Vec<_>>()
+                .join(", ");
+            llmod.add_raw_global(format!(
+                "@{} = private unnamed_addr constant [{} x i64] [{}]",
+                mask_global,
+                pointer_mask_words.len(),
+                words
+            ));
+        }
     }
 
     let init_name = format!("__perry_init_strings_{}", module_prefix);
@@ -198,7 +216,7 @@ pub(super) fn emit_string_pool(
     // module init; every `new ClassName()` call from then on does a
     // single global load + inline allocator call (no SHAPE_CACHE
     // lookup, no js_build_class_keys_array overhead).
-    for (idx, (global_name, packed, field_count, _mask_words)) in
+    for (idx, (global_name, packed, field_count, _raw_mask_words, _pointer_mask_words)) in
         class_keys_init_data.iter().enumerate()
     {
         // Resolve class id from the global name. The global name is

--- a/crates/perry-codegen/src/expr/array_literal.rs
+++ b/crates/perry-codegen/src/expr/array_literal.rs
@@ -8,6 +8,7 @@ use super::{
     emit_jsvalue_slot_store_on_block, expr_produces_non_pointer_bits_by_construction, lower_expr,
     nanbox_pointer_inline, FnCtx,
 };
+use crate::type_analysis::is_numeric_expr;
 use crate::types::{I32, I64, I8, PTR};
 
 /// Lower an array literal `[a, b, c, …]`.
@@ -36,6 +37,7 @@ use crate::types::{I32, I64, I8, PTR};
 /// allocations lower to SSA values pinned by conservative stack scanning.
 pub(crate) fn lower_array_literal(ctx: &mut FnCtx<'_>, elements: &[Expr]) -> Result<String> {
     let n = elements.len();
+    let all_numeric_elements = elements.iter().all(|e| is_numeric_expr(ctx, e));
 
     // Empty literal: no elements to worry about, keep the simple path.
     if n == 0 {
@@ -181,6 +183,14 @@ pub(crate) fn lower_array_literal(ctx: &mut FnCtx<'_>, elements: &[Expr]) -> Res
             );
         }
 
+        if all_numeric_elements {
+            blk.call(
+                I32,
+                "js_array_mark_numeric_f64_layout",
+                &[(I64, &user_ptr_as_i64)],
+            );
+        }
+
         return Ok(nanbox_pointer_inline(ctx.block(), &user_ptr_as_i64));
     }
 
@@ -213,6 +223,11 @@ pub(crate) fn lower_array_literal(ctx: &mut FnCtx<'_>, elements: &[Expr]) -> Res
             &elem_addr,
             layout_notes_needed[i],
         );
+    }
+
+    if all_numeric_elements {
+        ctx.block()
+            .call(I32, "js_array_mark_numeric_f64_layout", &[(I64, &arr)]);
     }
 
     Ok(nanbox_pointer_inline(ctx.block(), &arr))

--- a/crates/perry-codegen/src/expr/array_push.rs
+++ b/crates/perry-codegen/src/expr/array_push.rs
@@ -32,10 +32,12 @@ use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 #[allow(unused_imports)]
 use super::{
     array_store_needs_layout_note, array_store_needs_write_barrier, buffer_alias_metadata_suffix,
-    can_lower_expr_as_i32, emit_jsvalue_slot_store_on_block, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
+    can_lower_expr_as_i32, emit_array_numeric_write_note_on_block,
+    emit_jsvalue_slot_store_on_block, emit_layout_note_slot_on_block, emit_shadow_slot_clear,
+    emit_shadow_slot_update_for_expr, emit_string_literal_global,
+    emit_typed_feedback_register_site, emit_v8_export_call, emit_v8_member_method_call,
+    emit_write_barrier, emit_write_barrier_slot_on_block,
+    expr_has_numeric_pointer_free_array_layout, expr_is_known_non_pointer_shadow_value,
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
     lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
@@ -44,7 +46,7 @@ use super::{
     nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
     try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
     unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
+    I18nLowerCtx, TypedFeedbackContract, TypedFeedbackKind,
 };
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
@@ -57,8 +59,77 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let array_expr = Expr::LocalGet(*array_id);
             let layout_note_needed = array_store_needs_layout_note(ctx, &array_expr, value);
             let write_barrier_needed = array_store_needs_write_barrier(ctx, value);
+            let value_is_numeric = is_numeric_expr(ctx, value);
+            let require_numeric_layout =
+                value_is_numeric && expr_has_numeric_pointer_free_array_layout(ctx, &array_expr);
             let v = lower_expr(ctx, value)?;
             let arr_box = lower_expr(ctx, &array_expr)?;
+
+            if require_numeric_layout
+                && !ctx.boxed_vars.contains(array_id)
+                && !ctx.closure_captures.contains_key(array_id)
+                && ctx.locals.contains_key(array_id)
+            {
+                let slot = ctx.locals.get(array_id).cloned().unwrap();
+                let feedback_site_id = emit_typed_feedback_register_site(
+                    ctx,
+                    TypedFeedbackKind::ArrayElement,
+                    "array.push",
+                    TypedFeedbackContract::numeric_array_push(),
+                );
+                let fast_idx = ctx.new_block("apush.numeric_fast");
+                let fallback_idx = ctx.new_block("apush.numeric_fallback");
+                let merge_idx = ctx.new_block("apush.numeric_merge");
+                let fast_label = ctx.block_label(fast_idx);
+                let fallback_label = ctx.block_label(fallback_idx);
+                let merge_label = ctx.block_label(merge_idx);
+
+                let guard_ok = {
+                    let blk = ctx.block();
+                    let guard_i32 = blk.call(
+                        I32,
+                        "js_typed_feedback_numeric_array_push_guard",
+                        &[(I64, &feedback_site_id), (DOUBLE, &arr_box), (DOUBLE, &v)],
+                    );
+                    blk.icmp_ne(I32, &guard_i32, "0")
+                };
+                ctx.block().cond_br(&guard_ok, &fast_label, &fallback_label);
+
+                ctx.current_block = fast_idx;
+                {
+                    let blk = ctx.block();
+                    let arr_handle = unbox_to_i64(blk, &arr_box);
+                    let new_handle = blk.call(
+                        I64,
+                        "js_array_numeric_push_f64_unboxed",
+                        &[(I64, &arr_handle), (DOUBLE, &v)],
+                    );
+                    let new_box = nanbox_pointer_inline(blk, &new_handle);
+                    blk.store(DOUBLE, &new_box, &slot);
+                    blk.br(&merge_label);
+                }
+
+                ctx.current_block = fallback_idx;
+                {
+                    let blk = ctx.block();
+                    blk.call_void(
+                        "js_typed_feedback_record_fallback_call",
+                        &[(I64, &feedback_site_id)],
+                    );
+                    let arr_handle = unbox_to_i64(blk, &arr_box);
+                    let new_handle = blk.call(
+                        I64,
+                        "js_array_push_f64",
+                        &[(I64, &arr_handle), (DOUBLE, &v)],
+                    );
+                    let new_box = nanbox_pointer_inline(blk, &new_handle);
+                    blk.store(DOUBLE, &new_box, &slot);
+                    blk.br(&merge_label);
+                }
+
+                ctx.current_block = merge_idx;
+                return Ok(arr_box);
+            }
 
             // Fast path: local-bound, non-captured, non-boxed array.
             // This is the canonical hot shape — `out.push(...)` over a
@@ -158,7 +229,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     let with_header = blk.add(I64, &byte_offset, "8");
                     let element_addr = blk.add(I64, &arr_handle, &with_header);
                     let element_ptr = blk.inttoptr(I64, &element_addr);
-                    emit_jsvalue_slot_store_on_block(
+                    let value_bits = emit_jsvalue_slot_store_on_block(
                         blk,
                         &element_ptr,
                         &v,
@@ -169,6 +240,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &element_addr,
                         write_barrier_needed,
                     );
+                    if !value_is_numeric {
+                        let value_bits =
+                            value_bits.unwrap_or_else(|| blk.bitcast_double_to_i64(&v));
+                        emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
+                    }
                     let new_length = blk.add(I32, &length, "1");
                     let arr_ptr = blk.inttoptr(I64, &arr_handle);
                     // GC_STORE_AUDIT(POINTER_FREE): array length header update has no child pointer.

--- a/crates/perry-codegen/src/expr/array_push.rs
+++ b/crates/perry-codegen/src/expr/array_push.rs
@@ -60,12 +60,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let layout_note_needed = array_store_needs_layout_note(ctx, &array_expr, value);
             let write_barrier_needed = array_store_needs_write_barrier(ctx, value);
             let value_is_numeric = is_numeric_expr(ctx, value);
+            let value_is_plain_number = is_plain_number_value_expr(ctx, value);
             let require_numeric_layout =
                 value_is_numeric && expr_has_numeric_pointer_free_array_layout(ctx, &array_expr);
             let v = lower_expr(ctx, value)?;
             let arr_box = lower_expr(ctx, &array_expr)?;
+            let skip_guarded_numeric_push = !ctx.loop_targets.is_empty() && value_is_plain_number;
 
             if require_numeric_layout
+                && !skip_guarded_numeric_push
                 && !ctx.boxed_vars.contains(array_id)
                 && !ctx.closure_captures.contains_key(array_id)
                 && ctx.locals.contains_key(array_id)
@@ -408,5 +411,57 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // (`perry_closure_<modprefix>__<func_id>`) earlier in
         // `compile_module` via the `compile_closure` pass.
         _ => unreachable!("expr/mod.rs dispatched a variant not handled by this submodule"),
+    }
+}
+
+fn is_plain_number_value_expr(ctx: &FnCtx<'_>, expr: &Expr) -> bool {
+    match expr {
+        Expr::Integer(_) | Expr::Number(_) | Expr::DateNow => true,
+        Expr::Uint8ArrayGet { .. }
+        | Expr::BufferIndexGet { .. }
+        | Expr::Uint8ArrayLength(_)
+        | Expr::BufferLength(_) => true,
+        Expr::LocalGet(id) | Expr::Update { id, .. } => {
+            ctx.integer_locals.contains(id) || ctx.unsigned_i32_locals.contains(id)
+        }
+        Expr::MathImul(_, _) => true,
+        Expr::Binary { op, left, right } => match op {
+            BinaryOp::Add
+            | BinaryOp::Sub
+            | BinaryOp::Mul
+            | BinaryOp::BitAnd
+            | BinaryOp::BitOr
+            | BinaryOp::BitXor
+            | BinaryOp::Shl
+            | BinaryOp::Shr
+            | BinaryOp::UShr => {
+                is_plain_number_value_expr(ctx, left) && is_plain_number_value_expr(ctx, right)
+            }
+            BinaryOp::Div => {
+                is_plain_number_value_expr(ctx, left)
+                    && match right.as_ref() {
+                        Expr::Integer(n) => *n != 0,
+                        Expr::Number(n) => n.is_finite() && n.abs() >= 1.0,
+                        other => is_plain_number_value_expr(ctx, other),
+                    }
+            }
+            BinaryOp::Mod => {
+                is_plain_number_value_expr(ctx, left)
+                    && match right.as_ref() {
+                        Expr::Integer(n) => *n != 0,
+                        Expr::Number(n) => n.is_finite() && *n != 0.0,
+                        other => is_plain_number_value_expr(ctx, other),
+                    }
+            }
+            _ => false,
+        },
+        Expr::Conditional {
+            then_expr,
+            else_expr,
+            ..
+        } => {
+            is_plain_number_value_expr(ctx, then_expr) && is_plain_number_value_expr(ctx, else_expr)
+        }
+        _ => false,
     }
 }

--- a/crates/perry-codegen/src/expr/index.rs
+++ b/crates/perry-codegen/src/expr/index.rs
@@ -4,8 +4,8 @@
 use anyhow::{anyhow, Result};
 
 use super::{
-    emit_jsvalue_slot_store_on_block, emit_write_barrier_slot_on_block, nanbox_pointer_inline,
-    FnCtx,
+    emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
+    emit_write_barrier_slot_on_block, nanbox_pointer_inline, FnCtx,
 };
 use crate::block::LlBlock;
 use crate::nanbox::POINTER_MASK_I64;
@@ -70,6 +70,8 @@ pub(crate) fn lower_index_set_fast(
     local_id: u32,
     layout_note_needed: bool,
     write_barrier_needed: bool,
+    value_is_numeric: bool,
+    require_numeric_layout: bool,
     feedback_site_id: &str,
 ) -> Result<()> {
     // Capture the local slot for the realloc path.
@@ -107,9 +109,14 @@ pub(crate) fn lower_index_set_fast(
     // semantics and writes the returned receiver back to the local slot.
     let guard_ok = {
         let blk = ctx.block();
+        let guard_fn = if require_numeric_layout {
+            "js_typed_feedback_numeric_array_index_set_guard"
+        } else {
+            "js_typed_feedback_plain_array_index_set_guard"
+        };
         let guard_i32 = blk.call(
             I32,
-            "js_typed_feedback_plain_array_index_set_guard",
+            guard_fn,
             &[
                 (I64, feedback_site_id),
                 (DOUBLE, arr_box),
@@ -160,18 +167,30 @@ pub(crate) fn lower_index_set_fast(
     ctx.current_block = inbounds_idx;
     {
         let blk = ctx.block();
-        let (element_addr, element_ptr) = element_slot(blk, &arr_handle, &idx_i32);
-        emit_jsvalue_slot_store_on_block(
-            blk,
-            &element_ptr,
-            val_double,
-            &arr_handle,
-            &idx_i32,
-            layout_note_needed,
-            &arr_handle,
-            &element_addr,
-            write_barrier_needed,
-        );
+        if require_numeric_layout {
+            blk.call(
+                I32,
+                "js_array_numeric_set_f64_unboxed",
+                &[(I64, &arr_handle), (I32, &idx_i32), (DOUBLE, val_double)],
+            );
+        } else {
+            let (element_addr, element_ptr) = element_slot(blk, &arr_handle, &idx_i32);
+            let value_bits = emit_jsvalue_slot_store_on_block(
+                blk,
+                &element_ptr,
+                val_double,
+                &arr_handle,
+                &idx_i32,
+                layout_note_needed,
+                &arr_handle,
+                &element_addr,
+                write_barrier_needed,
+            )
+            .unwrap_or_else(|| blk.bitcast_double_to_i64(val_double));
+            if !value_is_numeric {
+                emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
+            }
+        }
         blk.br(&merge_label);
     }
 
@@ -193,7 +212,7 @@ pub(crate) fn lower_index_set_fast(
     {
         let blk = ctx.block();
         let (element_addr, element_ptr) = element_slot(blk, &arr_handle, &idx_i32);
-        emit_jsvalue_slot_store_on_block(
+        let value_bits = emit_jsvalue_slot_store_on_block(
             blk,
             &element_ptr,
             val_double,
@@ -203,7 +222,11 @@ pub(crate) fn lower_index_set_fast(
             &arr_handle,
             &element_addr,
             write_barrier_needed,
-        );
+        )
+        .unwrap_or_else(|| blk.bitcast_double_to_i64(val_double));
+        if !value_is_numeric {
+            emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
+        }
         // Bump length: store idx+1 to arr_ptr+0.
         let new_len = blk.add(I32, &idx_i32, "1");
         let len_ptr = blk.inttoptr(I64, &arr_handle); // length is at offset 0

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -34,7 +34,8 @@ use super::{
     buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
     emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
     emit_typed_feedback_register_site, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
+    emit_write_barrier, emit_write_barrier_slot_on_block,
+    expr_has_numeric_pointer_free_array_layout, expr_is_known_non_pointer_shadow_value,
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
     lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
@@ -52,12 +53,18 @@ fn lower_guarded_array_index_get(
     idx_box: &str,
     idx_i32: &str,
     block_prefix: &str,
+    require_numeric_layout: bool,
 ) -> Result<String> {
+    let contract = if require_numeric_layout {
+        TypedFeedbackContract::numeric_array_get_index()
+    } else {
+        TypedFeedbackContract::array_get_index()
+    };
     let feedback_site_id = emit_typed_feedback_register_site(
         ctx,
         TypedFeedbackKind::ArrayElement,
         "array[index]",
-        TypedFeedbackContract::array_get_index(),
+        contract,
     );
     let fast_idx = ctx.new_block(&format!("{}.fast", block_prefix));
     let fallback_idx = ctx.new_block(&format!("{}.fallback", block_prefix));
@@ -68,9 +75,14 @@ fn lower_guarded_array_index_get(
 
     let guard_ok = {
         let blk = ctx.block();
+        let guard_fn = if require_numeric_layout {
+            "js_typed_feedback_numeric_array_index_get_guard"
+        } else {
+            "js_typed_feedback_plain_array_index_get_guard"
+        };
         let guard_i32 = blk.call(
             I32,
-            "js_typed_feedback_plain_array_index_get_guard",
+            guard_fn,
             &[
                 (I64, &feedback_site_id),
                 (DOUBLE, arr_box),
@@ -100,18 +112,26 @@ fn lower_guarded_array_index_get(
     let fast_blk = ctx.block();
     let arr_bits = fast_blk.bitcast_double_to_i64(arr_box);
     let arr_handle = fast_blk.and(I64, &arr_bits, POINTER_MASK_I64);
-    let idx_i64 = fast_blk.zext(I32, idx_i32, I64);
-    let byte_offset = fast_blk.shl(I64, &idx_i64, "3");
-    let with_header = fast_blk.add(I64, &byte_offset, "8");
-    let element_addr = fast_blk.add(I64, &arr_handle, &with_header);
-    let element_ptr = fast_blk.inttoptr(I64, &element_addr);
-    let fast_raw = fast_blk.load(DOUBLE, &element_ptr);
-    // `new Array(n)` slots are TAG_HOLE internally; JavaScript reads expose
-    // `undefined`.
-    let fast_raw_bits = fast_blk.bitcast_double_to_i64(&fast_raw);
-    let is_hole = fast_blk.icmp_eq(I64, &fast_raw_bits, crate::nanbox::TAG_HOLE_I64);
-    let undef_d = fast_blk.bitcast_i64_to_double(crate::nanbox::TAG_UNDEFINED_I64);
-    let fast_val = fast_blk.select(I1, &is_hole, DOUBLE, &undef_d, &fast_raw);
+    let fast_val = if require_numeric_layout {
+        fast_blk.call(
+            DOUBLE,
+            "js_array_numeric_get_f64_unboxed",
+            &[(I64, &arr_handle), (I32, idx_i32)],
+        )
+    } else {
+        let idx_i64 = fast_blk.zext(I32, idx_i32, I64);
+        let byte_offset = fast_blk.shl(I64, &idx_i64, "3");
+        let with_header = fast_blk.add(I64, &byte_offset, "8");
+        let element_addr = fast_blk.add(I64, &arr_handle, &with_header);
+        let element_ptr = fast_blk.inttoptr(I64, &element_addr);
+        let fast_raw = fast_blk.load(DOUBLE, &element_ptr);
+        // `new Array(n)` slots are TAG_HOLE internally; JavaScript reads expose
+        // `undefined`.
+        let fast_raw_bits = fast_blk.bitcast_double_to_i64(&fast_raw);
+        let is_hole = fast_blk.icmp_eq(I64, &fast_raw_bits, crate::nanbox::TAG_HOLE_I64);
+        let undef_d = fast_blk.bitcast_i64_to_double(crate::nanbox::TAG_UNDEFINED_I64);
+        fast_blk.select(I1, &is_hole, DOUBLE, &undef_d, &fast_raw)
+    };
     let fast_end_label = fast_blk.label.clone();
     fast_blk.br(&merge_label);
 
@@ -405,6 +425,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             //   3. Anything else → fall back to dynamic object field
             //      access by stringifying the index at runtime
             if is_array_expr(ctx, object) {
+                let require_numeric_layout =
+                    expr_has_numeric_pointer_free_array_layout(ctx, object);
                 // Bounded-index fast path (mirrors the IndexSet
                 // optimization in the same file): if the surrounding
                 // for-loop registered `(counter_id, arr_id)` as
@@ -437,7 +459,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 if !matches!(index.as_ref(), Expr::Integer(_) | Expr::Number(_)) {
                     return lower_legacy_array_index_get(ctx, &arr_box, &idx_i32);
                 }
-                return lower_guarded_array_index_get(ctx, &arr_box, &idx_double, &idx_i32, "arr");
+                return lower_guarded_array_index_get(
+                    ctx,
+                    &arr_box,
+                    &idx_double,
+                    &idx_i32,
+                    "arr",
+                    require_numeric_layout,
+                );
             }
             // Generic dynamic object access: stringify the index (no-op
             // for already-string keys, format for numeric keys) and

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -32,10 +32,12 @@ use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 #[allow(unused_imports)]
 use super::{
     array_store_needs_layout_note, array_store_needs_write_barrier, buffer_alias_metadata_suffix,
-    can_lower_expr_as_i32, emit_jsvalue_slot_store_on_block, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
+    can_lower_expr_as_i32, emit_array_numeric_write_note_on_block,
+    emit_jsvalue_slot_store_on_block, emit_layout_note_slot_on_block, emit_shadow_slot_clear,
+    emit_shadow_slot_update_for_expr, emit_string_literal_global,
     emit_typed_feedback_register_site, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
+    emit_write_barrier, emit_write_barrier_slot_on_block,
+    expr_has_numeric_pointer_free_array_layout, expr_is_known_non_pointer_shadow_value,
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
     lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
@@ -216,6 +218,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     }) {
                         let layout_note_needed = array_store_needs_layout_note(ctx, object, value);
                         let write_barrier_needed = array_store_needs_write_barrier(ctx, value);
+                        let value_is_numeric = is_numeric_expr(ctx, value);
+                        let require_numeric_layout = value_is_numeric
+                            && expr_has_numeric_pointer_free_array_layout(ctx, object);
                         let arr_box = lower_expr(ctx, object)?;
                         let val_double = lower_expr(ctx, value)?;
                         // Grab i32 slot name before mutably borrowing ctx for block().
@@ -229,29 +234,45 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         let blk = ctx.block();
                         let arr_bits = blk.bitcast_double_to_i64(&arr_box);
                         let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
-                        // ptr = arr_handle + 8 + idx*8
-                        let idx_i64 = blk.zext(I32, &idx_i32, I64);
-                        let byte_offset = blk.shl(I64, &idx_i64, "3");
-                        let with_header = blk.add(I64, &byte_offset, "8");
-                        let element_addr = blk.add(I64, &arr_handle, &with_header);
-                        let element_ptr = blk.inttoptr(I64, &element_addr);
-                        emit_jsvalue_slot_store_on_block(
-                            blk,
-                            &element_ptr,
-                            &val_double,
-                            &arr_handle,
-                            &idx_i32,
-                            layout_note_needed,
-                            &arr_handle,
-                            &element_addr,
-                            write_barrier_needed,
-                        );
+                        if require_numeric_layout {
+                            blk.call(
+                                I32,
+                                "js_array_numeric_set_f64_unboxed",
+                                &[(I64, &arr_handle), (I32, &idx_i32), (DOUBLE, &val_double)],
+                            );
+                        } else {
+                            // ptr = arr_handle + 8 + idx*8
+                            let idx_i64 = blk.zext(I32, &idx_i32, I64);
+                            let byte_offset = blk.shl(I64, &idx_i64, "3");
+                            let with_header = blk.add(I64, &byte_offset, "8");
+                            let element_addr = blk.add(I64, &arr_handle, &with_header);
+                            let element_ptr = blk.inttoptr(I64, &element_addr);
+                            let value_bits = emit_jsvalue_slot_store_on_block(
+                                blk,
+                                &element_ptr,
+                                &val_double,
+                                &arr_handle,
+                                &idx_i32,
+                                layout_note_needed,
+                                &arr_handle,
+                                &element_addr,
+                                write_barrier_needed,
+                            );
+                            if !value_is_numeric {
+                                let value_bits =
+                                    value_bits.unwrap_or_else(|| blk.bitcast_double_to_i64(&val_double));
+                                emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
+                            }
+                        }
                         return Ok(val_double);
                     }
                 }
 
                 let layout_note_needed = array_store_needs_layout_note(ctx, object, value);
                 let write_barrier_needed = array_store_needs_write_barrier(ctx, value);
+                let value_is_numeric = is_numeric_expr(ctx, value);
+                let require_numeric_layout =
+                    value_is_numeric && expr_has_numeric_pointer_free_array_layout(ctx, object);
                 let arr_box = lower_expr(ctx, object)?;
                 let idx_double = lower_expr(ctx, index)?;
                 let val_double = lower_expr(ctx, value)?;
@@ -264,7 +285,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     ctx,
                     TypedFeedbackKind::ArrayElement,
                     "array[index]=",
-                    TypedFeedbackContract::array_set_index(),
+                    if require_numeric_layout {
+                        TypedFeedbackContract::numeric_array_set_index()
+                    } else {
+                        TypedFeedbackContract::array_set_index()
+                    },
                 );
                 // Use the fast inlined IndexSet path only when the
                 // receiver is a local that's actually in ctx.locals
@@ -288,6 +313,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             id,
                             layout_note_needed,
                             write_barrier_needed,
+                            value_is_numeric,
+                            require_numeric_layout,
                             &feedback_site_id,
                         )?;
                     } else if let Some(global_name) = ctx.module_globals.get(&id).cloned() {

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -259,9 +259,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                 write_barrier_needed,
                             );
                             if !value_is_numeric {
-                                let value_bits =
-                                    value_bits.unwrap_or_else(|| blk.bitcast_double_to_i64(&val_double));
-                                emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
+                                let value_bits = value_bits
+                                    .unwrap_or_else(|| blk.bitcast_double_to_i64(&val_double));
+                                emit_array_numeric_write_note_on_block(
+                                    blk,
+                                    &arr_handle,
+                                    &value_bits,
+                                );
                             }
                         }
                         return Ok(val_double);

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -92,8 +92,9 @@ pub(crate) use v8_interop::{
     emit_v8_export_call, emit_v8_member_method_call, import_origin_suffix, try_static_class_name,
 };
 pub(crate) use write_barrier::{
-    emit_jsvalue_slot_store_on_block, emit_layout_note_slot_on_block, emit_write_barrier,
-    emit_write_barrier_slot_on_block, lower_stream_super_init,
+    emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
+    emit_layout_note_slot_on_block, emit_write_barrier, emit_write_barrier_slot_on_block,
+    lower_stream_super_init,
 };
 
 /// Per-function codegen context. Held briefly during lowering, never stored.
@@ -1080,6 +1081,13 @@ impl TypedFeedbackContract {
         )
     }
 
+    pub(crate) const fn numeric_array_get_index() -> Self {
+        Self::new(
+            "numeric_array_index_get_guard",
+            "js_typed_feedback_array_index_get_fallback_boxed",
+        )
+    }
+
     pub(crate) const fn array_set_index() -> Self {
         Self::new("plain_array_index_set_guard", "js_array_set_f64_extend")
     }
@@ -1089,6 +1097,21 @@ impl TypedFeedbackContract {
             "plain_array_index_set_guard",
             "js_typed_feedback_array_index_set_fallback_boxed",
         )
+    }
+
+    pub(crate) const fn numeric_array_set_index() -> Self {
+        Self::new("numeric_array_index_set_guard", "js_array_set_f64_extend")
+    }
+
+    pub(crate) const fn bounded_numeric_array_set_index() -> Self {
+        Self::new(
+            "numeric_array_index_set_guard",
+            "js_typed_feedback_array_index_set_fallback_boxed",
+        )
+    }
+
+    pub(crate) const fn numeric_array_push() -> Self {
+        Self::new("numeric_array_push_guard", "js_array_push_f64")
     }
 
     pub(crate) const fn array_set_string_key() -> Self {

--- a/crates/perry-codegen/src/expr/object_literal.rs
+++ b/crates/perry-codegen/src/expr/object_literal.rs
@@ -88,23 +88,32 @@ fn typed_object_literal_layout(
     ctx: &FnCtx<'_>,
     props: &[(String, Expr)],
     expected_ty: Option<&HirType>,
-) -> Option<(u32, Vec<u64>)> {
+) -> Option<crate::typed_shape::TypedShapeLayout> {
     let expected_ty = expected_ty?;
-    let mut words = Vec::new();
+    let mut raw_f64_mask_words = Vec::new();
+    let mut pointer_mask_words = Vec::new();
     for (slot, (key, _)) in props.iter().enumerate() {
         let prop_ty = expected_object_property_type(ctx, expected_ty, key, 0)?;
+        if crate::typed_shape::type_is_raw_f64_candidate(&prop_ty) {
+            let word = slot / 64;
+            if raw_f64_mask_words.len() <= word {
+                raw_f64_mask_words.resize(word + 1, 0);
+            }
+            raw_f64_mask_words[word] |= 1u64 << (slot % 64);
+        }
         if crate::typed_shape::type_is_pointer_bearing(&prop_ty) {
             let word = slot / 64;
-            if words.len() <= word {
-                words.resize(word + 1, 0);
+            if pointer_mask_words.len() <= word {
+                pointer_mask_words.resize(word + 1, 0);
             }
-            words[word] |= 1u64 << (slot % 64);
+            pointer_mask_words[word] |= 1u64 << (slot % 64);
         }
     }
-    Some((
-        props.len() as u32,
-        crate::typed_shape::trim_mask_words(words),
-    ))
+    Some(crate::typed_shape::TypedShapeLayout {
+        slot_count: props.len() as u32,
+        raw_f64_mask_words: crate::typed_shape::trim_mask_words(raw_f64_mask_words),
+        pointer_mask_words: crate::typed_shape::trim_mask_words(pointer_mask_words),
+    })
 }
 
 fn unboxed_object_fields_enabled() -> bool {
@@ -188,45 +197,54 @@ fn unboxed_xy_object_literal(
             .all(|(_, value_expr)| is_numeric_expr(ctx, value_expr))
 }
 
+fn emit_object_mask_global(ctx: &mut FnCtx<'_>, kind: &str, mask_words: &[u64]) -> String {
+    if mask_words.is_empty() {
+        return "null".to_string();
+    }
+    let site_id = ctx.ic_site_counter;
+    ctx.ic_site_counter += 1;
+    let prefix = ctx.strings.module_prefix().to_string();
+    let global_name = if prefix.is_empty() {
+        format!("perry_typed_obj_shape_{}_mask_{}", kind, site_id)
+    } else {
+        format!(
+            "perry_typed_obj_shape_{}_mask_{}__{}",
+            kind, prefix, site_id
+        )
+    };
+    let words = mask_words
+        .iter()
+        .map(|word| format!("i64 {}", word))
+        .collect::<Vec<_>>()
+        .join(", ");
+    ctx.typed_parse_rodata.push(format!(
+        "@{} = private unnamed_addr constant [{} x i64] [{}]",
+        global_name,
+        mask_words.len(),
+        words
+    ));
+    format!("@{}", global_name)
+}
+
 fn emit_object_typed_shape_init(
     ctx: &mut FnCtx<'_>,
     obj_handle: &str,
-    slot_count: u32,
-    mask_words: &[u64],
+    layout: &crate::typed_shape::TypedShapeLayout,
 ) {
-    let slot_count_str = slot_count.to_string();
-    let mask_word_count_str = mask_words.len().to_string();
-    let mask_ref = if mask_words.is_empty() {
-        "null".to_string()
-    } else {
-        let site_id = ctx.ic_site_counter;
-        ctx.ic_site_counter += 1;
-        let prefix = ctx.strings.module_prefix().to_string();
-        let global_name = if prefix.is_empty() {
-            format!("perry_typed_obj_shape_mask_{}", site_id)
-        } else {
-            format!("perry_typed_obj_shape_mask_{}__{}", prefix, site_id)
-        };
-        let words = mask_words
-            .iter()
-            .map(|word| format!("i64 {}", word))
-            .collect::<Vec<_>>()
-            .join(", ");
-        ctx.typed_parse_rodata.push(format!(
-            "@{} = private unnamed_addr constant [{} x i64] [{}]",
-            global_name,
-            mask_words.len(),
-            words
-        ));
-        format!("@{}", global_name)
-    };
+    let slot_count_str = layout.slot_count.to_string();
+    let raw_mask_word_count_str = layout.raw_f64_mask_words.len().to_string();
+    let pointer_mask_word_count_str = layout.pointer_mask_words.len().to_string();
+    let raw_mask_ref = emit_object_mask_global(ctx, "raw_f64", &layout.raw_f64_mask_words);
+    let pointer_mask_ref = emit_object_mask_global(ctx, "ptr", &layout.pointer_mask_words);
     ctx.block().call_void(
         "js_gc_init_typed_shape_layout",
         &[
             (I64, obj_handle),
             (I32, &slot_count_str),
-            (PTR, &mask_ref),
-            (I32, &mask_word_count_str),
+            (PTR, &raw_mask_ref),
+            (I32, &raw_mask_word_count_str),
+            (PTR, &pointer_mask_ref),
+            (I32, &pointer_mask_word_count_str),
         ],
     );
 }
@@ -392,8 +410,8 @@ pub(crate) fn lower_object_literal(
                 &[(I64, &obj_handle), (I32, &idx_str), (I64, &v_bits)],
             );
         }
-        if let Some((slot_count, mask_words)) = typed_layout.as_ref() {
-            emit_object_typed_shape_init(ctx, &obj_handle, *slot_count, mask_words);
+        if let Some(layout) = typed_layout.as_ref() {
+            emit_object_typed_shape_init(ctx, &obj_handle, layout);
         }
         return Ok(nanbox_pointer_inline(ctx.block(), &obj_handle));
     }
@@ -471,8 +489,8 @@ pub(crate) fn lower_object_literal(
         }
     }
 
-    if let Some((slot_count, mask_words)) = typed_layout.as_ref() {
-        emit_object_typed_shape_init(ctx, &obj_handle, *slot_count, mask_words);
+    if let Some(layout) = typed_layout.as_ref() {
+        emit_object_typed_shape_init(ctx, &obj_handle, layout);
     }
 
     Ok(nanbox_pointer_inline(ctx.block(), &obj_handle))

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -909,6 +909,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         );
                         let field_idx_str = field_index.to_string();
                         let expected_class_id_str = expected_class_id.to_string();
+                        let requires_raw_f64 = crate::type_analysis::class_field_declared_type(
+                            ctx,
+                            &class_name,
+                            property,
+                        )
+                        .as_ref()
+                        .is_some_and(crate::typed_shape::type_is_raw_f64_candidate);
+                        let requires_raw_f64_str = if requires_raw_f64 { "1" } else { "0" };
                         let (obj_bits, obj_handle, key_raw, guard_ok) = {
                             let blk = ctx.block();
                             let obj_bits = blk.bitcast_double_to_i64(&recv_box);
@@ -927,6 +935,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                     (I64, &expected_keys),
                                     (I64, &key_raw),
                                     (I32, &field_idx_str),
+                                    (I32, requires_raw_f64_str),
                                 ],
                             );
                             (obj_bits, obj_handle, key_raw, guard_ok)

--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -147,19 +147,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     return Ok(val_double);
                 }
                 // Fast path: known class instance + plain instance field.
-                // Mirrors the PropertyGet fast path. NOTE: this bypasses
-                // the runtime's `Object.freeze` / per-key writable: false
-                // check that `js_object_set_field_by_name` does. That's
-                // OK for class methods on user types because:
-                //   1. The fast path only fires when the receiver type
-                //      is statically known to be a Named class — which
-                //      means the user has typed it as such.
-                //   2. Object.freeze on user-class instances is rare in
-                //      practice; freezing a Counter and then calling
-                //      .increment() would silently succeed instead of
-                //      silently failing — both are non-standard.
-                //   3. The dynamic `obj["foo"] = ...` path still goes
-                //      through the runtime helper and honors freeze.
+                // The runtime guard checks the receiver's class/shape and
+                // descriptor state before this block touches the raw slot.
                 if let Some(field_index) =
                     crate::type_analysis::class_field_global_index(ctx, &class_name, property)
                 {
@@ -180,6 +169,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         );
                         let field_idx_str = field_index.to_string();
                         let expected_class_id_str = expected_class_id.to_string();
+                        let requires_raw_f64 = crate::type_analysis::class_field_declared_type(
+                            ctx,
+                            &class_name,
+                            property,
+                        )
+                        .as_ref()
+                        .is_some_and(crate::typed_shape::type_is_raw_f64_candidate);
+                        let requires_raw_f64_str = if requires_raw_f64 { "1" } else { "0" };
                         let (key_raw, guard_ok) = {
                             let blk = ctx.block();
                             let key_box = blk.load(DOUBLE, &key_handle_global);
@@ -197,6 +194,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                     (I64, &key_raw),
                                     (I32, &field_idx_str),
                                     (DOUBLE, &val_double),
+                                    (I32, requires_raw_f64_str),
                                 ],
                             );
                             (key_raw, guard_ok)
@@ -219,18 +217,25 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         let header_skip = "24".to_string();
                         let fields_base = blk.gep(I8, &obj_ptr, &[(I64, &header_skip)]);
                         let field_ptr = blk.gep(DOUBLE, &fields_base, &[(I64, &field_idx_str)]);
-                        let field_addr = blk.ptrtoint(&field_ptr, I64);
-                        emit_jsvalue_slot_store_on_block(
-                            blk,
-                            &field_ptr,
-                            &val_double,
-                            &obj_handle,
-                            &field_idx_str,
-                            true,
-                            &obj_bits,
-                            &field_addr,
-                            true,
-                        );
+                        if requires_raw_f64 {
+                            // Guarded raw-f64 slots are pointer-free by typed
+                            // shape descriptor; non-number writes miss the
+                            // guard and use the boxed setter fallback.
+                            blk.store(DOUBLE, &val_double, &field_ptr);
+                        } else {
+                            let field_addr = blk.ptrtoint(&field_ptr, I64);
+                            emit_jsvalue_slot_store_on_block(
+                                blk,
+                                &field_ptr,
+                                &val_double,
+                                &obj_handle,
+                                &field_idx_str,
+                                true,
+                                &obj_bits,
+                                &field_addr,
+                                true,
+                            );
+                        }
                         blk.br(&merge_label);
 
                         ctx.current_block = fallback_idx;

--- a/crates/perry-codegen/src/expr/write_barrier.rs
+++ b/crates/perry-codegen/src/expr/write_barrier.rs
@@ -57,6 +57,17 @@ pub(crate) fn emit_layout_note_slot_on_block(
     );
 }
 
+pub(crate) fn emit_array_numeric_write_note_on_block(
+    blk: &mut LlBlock,
+    array_bits: &str,
+    value_bits: &str,
+) {
+    blk.call_void(
+        "js_array_note_numeric_write",
+        &[(I64, array_bits), (I64, value_bits)],
+    );
+}
+
 pub(crate) fn emit_jsvalue_slot_store_on_block(
     blk: &mut LlBlock,
     slot_ptr: &str,

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -789,11 +789,19 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
     }
 
     if let Some(keys_global_name) = ctx.class_keys_globals.get(class_name).cloned() {
-        let (typed_slot_count, typed_mask_words) =
-            crate::typed_shape::class_typed_layout(ctx.classes, class_name);
-        let slot_count_str = typed_slot_count.to_string();
-        let mask_word_count_str = typed_mask_words.len().to_string();
-        let mask_ref = if typed_mask_words.is_empty() {
+        let typed_layout = crate::typed_shape::class_typed_layout(ctx.classes, class_name);
+        let slot_count_str = typed_layout.slot_count.to_string();
+        let raw_mask_word_count_str = typed_layout.raw_f64_mask_words.len().to_string();
+        let pointer_mask_word_count_str = typed_layout.pointer_mask_words.len().to_string();
+        let raw_mask_ref = if typed_layout.raw_f64_mask_words.is_empty() {
+            "null".to_string()
+        } else {
+            format!(
+                "@{}",
+                crate::typed_shape::raw_f64_mask_global_name_from_keys_global(&keys_global_name)
+            )
+        };
+        let pointer_mask_ref = if typed_layout.pointer_mask_words.is_empty() {
             "null".to_string()
         } else {
             format!(
@@ -806,8 +814,10 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
             &[
                 (I64, &obj_handle),
                 (I32, &slot_count_str),
-                (PTR, &mask_ref),
-                (I32, &mask_word_count_str),
+                (PTR, &raw_mask_ref),
+                (I32, &raw_mask_word_count_str),
+                (PTR, &pointer_mask_ref),
+                (I32, &pointer_mask_word_count_str),
             ],
         );
     }

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -33,15 +33,22 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // alloc + N×push_f64. See `js_array_alloc_literal` in perry-runtime/src/array.rs.
     module.declare_function("js_array_alloc_literal", I64, &[I32]);
     module.declare_function("js_array_push_f64", I64, &[I64, DOUBLE]);
+    module.declare_function("js_array_numeric_push_f64_unboxed", I64, &[I64, DOUBLE]);
     // Refs #488: bulk push for `arr.push(...src)` spread call.
     module.declare_function("js_array_push_spread_f64", I64, &[I64, I64]);
     module.declare_function("js_array_get_f64", DOUBLE, &[I64, I32]);
+    module.declare_function("js_array_numeric_get_f64_unboxed", DOUBLE, &[I64, I32]);
     module.declare_function("js_array_set_f64", VOID, &[I64, I32, DOUBLE]);
+    module.declare_function("js_array_numeric_set_f64_unboxed", I32, &[I64, I32, DOUBLE]);
     // Extending variant: returns a possibly-realloc'd pointer that the
     // caller must write back to the local slot.
     module.declare_function("js_array_set_f64_extend", I64, &[I64, I32, DOUBLE]);
     module.declare_function("js_array_set_string_key", I64, &[I64, I64, DOUBLE]);
     module.declare_function("js_array_set_index_or_string", I64, &[I64, DOUBLE, DOUBLE]);
+    module.declare_function("js_array_mark_numeric_f64_layout", I32, &[I64]);
+    module.declare_function("js_array_is_numeric_f64_layout", I32, &[I64]);
+    module.declare_function("js_array_clear_numeric_layout", VOID, &[I64]);
+    module.declare_function("js_array_note_numeric_write", VOID, &[I64, I64]);
     module.declare_function("js_array_length", I32, &[I64]);
     // Array.isArray runtime dispatch for values with indeterminate
     // static type (e.g. JSON.parse results, closure captures, any/
@@ -74,12 +81,16 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     //   js_write_barrier(parent_bits: u64, child_bits: u64)
     //   js_write_barrier_slot(parent_bits: u64, slot_addr: u64, child_bits: u64)
     //   js_gc_note_slot_layout(parent_bits: u64, slot_index: u32, value_bits: u64)
-    //   js_gc_init_typed_shape_layout(obj: u64, slot_count: u32, mask_words: *const u64, mask_word_count: u32)
+    //   js_gc_init_typed_shape_layout(obj: u64, slot_count: u32, raw_f64_mask_words: *const u64, raw_f64_mask_word_count: u32, pointer_mask_words: *const u64, pointer_mask_word_count: u32)
     //   js_gc_init_unboxed_object_layout(obj: u64, slot_count: u32, raw_f64_mask: u64, pointer_mask: u64)
     module.declare_function("js_write_barrier", VOID, &[I64, I64]);
     module.declare_function("js_write_barrier_slot", VOID, &[I64, I64, I64]);
     module.declare_function("js_gc_note_slot_layout", VOID, &[I64, I32, I64]);
-    module.declare_function("js_gc_init_typed_shape_layout", VOID, &[I64, I32, PTR, I32]);
+    module.declare_function(
+        "js_gc_init_typed_shape_layout",
+        VOID,
+        &[I64, I32, PTR, I32, PTR, I32],
+    );
     module.declare_function(
         "js_gc_init_unboxed_object_layout",
         VOID,

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -84,12 +84,12 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     module.declare_function(
         "js_typed_feedback_class_field_set_guard",
         I32,
-        &[I64, DOUBLE, I32, I64, I64, I32, DOUBLE],
+        &[I64, DOUBLE, I32, I64, I64, I32, DOUBLE, I32],
     );
     module.declare_function(
         "js_typed_feedback_class_field_get_guard",
         I32,
-        &[I64, DOUBLE, I32, I64, I64, I32],
+        &[I64, DOUBLE, I32, I64, I64, I32, I32],
     );
     module.declare_function(
         "js_typed_feedback_native_call_method",
@@ -165,6 +165,11 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
         &[I64, DOUBLE, DOUBLE, I32, I32],
     );
     module.declare_function(
+        "js_typed_feedback_numeric_array_index_get_guard",
+        I32,
+        &[I64, DOUBLE, DOUBLE, I32, I32],
+    );
+    module.declare_function(
         "js_typed_feedback_array_index_get_fallback_boxed",
         DOUBLE,
         &[I64, DOUBLE, DOUBLE],
@@ -183,6 +188,16 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
         "js_typed_feedback_plain_array_index_set_guard",
         I32,
         &[I64, DOUBLE, I32, DOUBLE, I32],
+    );
+    module.declare_function(
+        "js_typed_feedback_numeric_array_index_set_guard",
+        I32,
+        &[I64, DOUBLE, I32, DOUBLE, I32],
+    );
+    module.declare_function(
+        "js_typed_feedback_numeric_array_push_guard",
+        I32,
+        &[I64, DOUBLE, DOUBLE],
     );
     module.declare_function(
         "js_typed_feedback_array_index_set_fallback_boxed",

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -1400,6 +1400,28 @@ pub(crate) fn class_field_global_index(
     walk(ctx, class_name, property, 0)
 }
 
+pub(crate) fn class_field_declared_type(
+    ctx: &FnCtx<'_>,
+    class_name: &str,
+    property: &str,
+) -> Option<HirType> {
+    let mut current = ctx.classes.get(class_name).copied();
+    while let Some(cls) = current {
+        if let Some(field) = cls
+            .fields
+            .iter()
+            .find(|field| field.key_expr.is_none() && field.name == property)
+        {
+            return Some(field.ty.clone());
+        }
+        current = cls
+            .extends_name
+            .as_deref()
+            .and_then(|parent| ctx.classes.get(parent).copied());
+    }
+    None
+}
+
 /// If the expression is a known instance of a Named class type, return
 /// the class name. Used by the class method dispatch in lower_call to
 /// pick the right `perry_method_<class>_<name>` function.

--- a/crates/perry-codegen/src/typed_shape.rs
+++ b/crates/perry-codegen/src/typed_shape.rs
@@ -20,6 +20,17 @@ pub(crate) fn type_is_pointer_bearing(ty: &Type) -> bool {
     }
 }
 
+pub(crate) fn type_is_raw_f64_candidate(ty: &Type) -> bool {
+    matches!(ty, Type::Number)
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TypedShapeLayout {
+    pub(crate) slot_count: u32,
+    pub(crate) raw_f64_mask_words: Vec<u64>,
+    pub(crate) pointer_mask_words: Vec<u64>,
+}
+
 pub(crate) fn trim_mask_words(mut words: Vec<u64>) -> Vec<u64> {
     while words.last().copied() == Some(0) {
         words.pop();
@@ -27,34 +38,12 @@ pub(crate) fn trim_mask_words(mut words: Vec<u64>) -> Vec<u64> {
     words
 }
 
-pub(crate) fn mask_words_for_fields<'a, I>(fields: I) -> Vec<u64>
-where
-    I: IntoIterator<Item = &'a perry_hir::ClassField>,
-{
-    let mut words = Vec::new();
-    let mut slot = 0usize;
-    for field in fields {
-        if field.key_expr.is_some() {
-            continue;
-        }
-        if type_is_pointer_bearing(&field.ty) {
-            let word = slot / 64;
-            if words.len() <= word {
-                words.resize(word + 1, 0);
-            }
-            words[word] |= 1u64 << (slot % 64);
-        }
-        slot += 1;
-    }
-    trim_mask_words(words)
-}
-
 pub(crate) fn class_typed_layout(
     classes: &std::collections::HashMap<String, &perry_hir::Class>,
     class_name: &str,
-) -> (u32, Vec<u64>) {
+) -> TypedShapeLayout {
     let Some(class) = classes.get(class_name).copied() else {
-        return (0, Vec::new());
+        return TypedShapeLayout::default();
     };
     let mut chain: Vec<&perry_hir::Class> = Vec::new();
     let mut cur = Some(class);
@@ -72,13 +61,36 @@ pub(crate) fn class_typed_layout(
     }
     chain.reverse();
 
-    let slot_count = chain
-        .iter()
-        .flat_map(|class| class.fields.iter())
-        .filter(|field| field.key_expr.is_none())
-        .count() as u32;
-    let mask_words = mask_words_for_fields(chain.iter().flat_map(|class| class.fields.iter()));
-    (slot_count, mask_words)
+    let mut raw_f64_mask_words = Vec::new();
+    let mut pointer_mask_words = Vec::new();
+    let mut slot_count = 0u32;
+    for field in chain.iter().flat_map(|class| class.fields.iter()) {
+        if field.key_expr.is_some() {
+            continue;
+        }
+        let slot = slot_count as usize;
+        if type_is_raw_f64_candidate(&field.ty) {
+            let word = slot / 64;
+            if raw_f64_mask_words.len() <= word {
+                raw_f64_mask_words.resize(word + 1, 0);
+            }
+            raw_f64_mask_words[word] |= 1u64 << (slot % 64);
+        }
+        if type_is_pointer_bearing(&field.ty) {
+            let word = slot / 64;
+            if pointer_mask_words.len() <= word {
+                pointer_mask_words.resize(word + 1, 0);
+            }
+            pointer_mask_words[word] |= 1u64 << (slot % 64);
+        }
+        slot_count += 1;
+    }
+
+    TypedShapeLayout {
+        slot_count,
+        raw_f64_mask_words: trim_mask_words(raw_f64_mask_words),
+        pointer_mask_words: trim_mask_words(pointer_mask_words),
+    }
 }
 
 pub(crate) fn mask_global_name_from_keys_global(keys_global_name: &str) -> String {
@@ -86,4 +98,11 @@ pub(crate) fn mask_global_name_from_keys_global(keys_global_name: &str) -> Strin
         .strip_prefix("perry_class_keys_")
         .map(|suffix| format!("perry_typed_shape_mask_{}", suffix))
         .unwrap_or_else(|| format!("perry_typed_shape_mask_{}", keys_global_name))
+}
+
+pub(crate) fn raw_f64_mask_global_name_from_keys_global(keys_global_name: &str) -> String {
+    keys_global_name
+        .strip_prefix("perry_class_keys_")
+        .map(|suffix| format!("perry_typed_shape_raw_f64_mask_{}", suffix))
+        .unwrap_or_else(|| format!("perry_typed_shape_raw_f64_mask_{}", keys_global_name))
 }

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -213,12 +213,15 @@ fn typed_feedback_guards_direct_class_field_specialization() {
 
     assert!(ir.contains("class_field_set_guard"));
     assert!(ir.contains("class_field_get_guard"));
+    assert!(ir.contains("@perry_typed_shape_raw_f64_mask_"));
     assert!(ir.contains("js_typed_feedback_class_field_set_guard"));
     assert!(ir.contains("js_typed_feedback_class_field_get_guard"));
     assert!(ir.contains("class_field_set.fast"));
     assert!(ir.contains("class_field_set.fallback"));
     assert!(ir.contains("class_field_get.fast"));
     assert!(ir.contains("class_field_get.fallback"));
+    assert!(ir.contains("store double"));
+    assert!(!ir.contains("call void @js_gc_note_slot_layout"));
     assert!(ir.contains("call void @js_typed_feedback_record_fallback_call"));
     assert!(ir.contains("call void @js_object_set_field_by_name"));
     assert!(ir.contains("call double @js_object_get_field_by_name_f64"));
@@ -332,12 +335,110 @@ fn typed_feedback_guards_array_index_specialization() {
         ],
     ));
 
-    assert!(ir.contains("plain_array_index_set_guard"));
-    assert!(ir.contains("plain_array_index_get_guard"));
-    assert!(ir.contains("js_typed_feedback_plain_array_index_set_guard"));
+    assert!(ir.contains("numeric_array_index_set_guard"));
+    assert!(ir.contains("numeric_array_index_get_guard"));
+    assert!(ir.contains("js_typed_feedback_numeric_array_index_set_guard"));
     assert!(ir.contains("js_typed_feedback_array_index_set_fallback_boxed"));
-    assert!(ir.contains("js_typed_feedback_plain_array_index_get_guard"));
+    assert!(ir.contains("js_typed_feedback_numeric_array_index_get_guard"));
     assert!(ir.contains("js_typed_feedback_array_index_get_fallback_boxed"));
+    assert!(ir.contains("js_array_numeric_set_f64_unboxed"));
+    assert!(ir.contains("js_array_numeric_get_f64_unboxed"));
+}
+
+#[test]
+fn typed_feedback_guards_numeric_array_push_specialization() {
+    let array_ty = Type::Array(Box::new(Type::Number));
+    let ir = ir_for(module(
+        "typed_feedback_array_push.ts",
+        vec![],
+        array_ty.clone(),
+        vec![
+            Stmt::Let {
+                id: 1,
+                name: "xs".to_string(),
+                ty: array_ty,
+                mutable: true,
+                init: Some(Expr::Array(Vec::new())),
+            },
+            Stmt::Expr(Expr::ArrayPush {
+                array_id: 1,
+                value: Box::new(Expr::Number(7.0)),
+            }),
+            Stmt::Return(Some(Expr::LocalGet(1))),
+        ],
+    ));
+
+    assert!(ir.contains("numeric_array_push_guard"));
+    assert!(ir.contains("js_typed_feedback_numeric_array_push_guard"));
+    assert!(ir.contains("js_array_numeric_push_f64_unboxed"));
+    assert!(ir.contains("js_typed_feedback_record_fallback_call"));
+    assert!(ir.contains("call i64 @js_array_push_f64"));
+}
+
+#[test]
+fn typed_feedback_marks_numeric_array_literals() {
+    let numeric_ir = ir_for(module(
+        "typed_feedback_numeric_array_literal.ts",
+        Vec::new(),
+        Type::Any,
+        vec![Stmt::Return(Some(Expr::Array(vec![
+            Expr::Number(1.0),
+            Expr::Integer(2),
+            Expr::Binary {
+                op: perry_hir::BinaryOp::Mul,
+                left: Box::new(Expr::Number(3.0)),
+                right: Box::new(Expr::Number(4.0)),
+            },
+        ])))],
+    ));
+
+    assert!(numeric_ir.contains("call i32 @js_array_mark_numeric_f64_layout"));
+
+    let mixed_ir = ir_for(module(
+        "typed_feedback_mixed_array_literal.ts",
+        Vec::new(),
+        Type::Any,
+        vec![Stmt::Return(Some(Expr::Array(vec![
+            Expr::Number(1.0),
+            Expr::String("x".to_string()),
+        ])))],
+    ));
+
+    assert!(!mixed_ir.contains("call i32 @js_array_mark_numeric_f64_layout"));
+}
+
+#[test]
+fn typed_feedback_inline_array_writes_note_numeric_downgrade() {
+    let array_ty = Type::Array(Box::new(Type::Number));
+    let ir = ir_for(module(
+        "typed_feedback_array_numeric_downgrade.ts",
+        Vec::new(),
+        Type::Any,
+        vec![
+            Stmt::Let {
+                id: 2,
+                name: "xs".to_string(),
+                ty: array_ty,
+                mutable: true,
+                init: Some(Expr::Array(vec![Expr::Number(1.0)])),
+            },
+            Stmt::Expr(Expr::IndexSet {
+                object: Box::new(Expr::LocalGet(2)),
+                index: Box::new(Expr::Number(0.0)),
+                value: Box::new(Expr::String("not-number".to_string())),
+            }),
+            Stmt::Expr(Expr::ArrayPush {
+                array_id: 2,
+                value: Box::new(Expr::String("still-not-number".to_string())),
+            }),
+            Stmt::Return(Some(Expr::LocalGet(2))),
+        ],
+    ));
+
+    assert!(ir.contains("call void @js_array_note_numeric_write"));
+    assert!(ir.contains("plain_array_index_set_guard"));
+    assert!(ir.contains("js_typed_feedback_plain_array_index_set_guard"));
+    assert!(!ir.contains("call i32 @js_typed_feedback_numeric_array_index_set_guard"));
 }
 
 #[test]

--- a/crates/perry-codegen/tests/typed_shape_descriptor.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptor.rs
@@ -148,8 +148,12 @@ fn typed_class_emits_pointer_mask_and_descriptor_install() {
     let ir = compile_ir(&module);
 
     assert!(ir.contains("@perry_typed_shape_mask_"));
+    assert!(ir.contains("@perry_typed_shape_raw_f64_mask_"));
+    assert!(ir.contains("private unnamed_addr constant [1 x i64] [i64 1]"));
     assert!(ir.contains("private unnamed_addr constant [1 x i64] [i64 6]"));
-    assert!(ir.contains("declare void @js_gc_init_typed_shape_layout(i64, i32, ptr, i32)"));
+    assert!(
+        ir.contains("declare void @js_gc_init_typed_shape_layout(i64, i32, ptr, i32, ptr, i32)")
+    );
     assert!(ir.contains("call void @js_gc_init_typed_shape_layout"));
 }
 
@@ -167,6 +171,8 @@ fn synthesized_closed_shape_emits_pointer_mask_and_descriptor_install() {
     let ir = compile_ir(&module);
 
     assert!(ir.contains("@perry_typed_shape_mask_"));
+    assert!(ir.contains("@perry_typed_shape_raw_f64_mask_"));
+    assert!(ir.contains("private unnamed_addr constant [1 x i64] [i64 1]"));
     assert!(ir.contains("private unnamed_addr constant [1 x i64] [i64 2]"));
     assert!(ir.contains("call void @js_gc_init_typed_shape_layout"));
 }

--- a/crates/perry-codegen/tests/typed_shape_descriptors.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptors.rs
@@ -265,22 +265,15 @@ fn number_typed_local_array_push_keeps_layout_note_and_barrier() {
     );
 
     let ir = ir_for(module);
-    let inbounds_pos = ir
-        .find("\napush.inbounds.")
-        .expect("local array push should emit an optimized in-bounds block");
-    let push_ir = &ir[inbounds_pos + 1..];
-    let inbounds_end = push_ir
-        .find("\napush.realloc.")
-        .expect("in-bounds push block should precede the realloc block");
-    let inbounds_ir = &push_ir[..inbounds_end];
 
     assert!(
-        inbounds_ir.contains("call void @js_gc_note_slot_layout"),
-        "number-typed LocalGet stores must keep runtime layout notes"
+        ir.contains("call i32 @js_typed_feedback_numeric_array_push_guard"),
+        "number-typed array pushes should validate the runtime value before the numeric path"
     );
     assert!(
-        inbounds_ir.contains("call void @js_write_barrier_slot"),
-        "number-typed LocalGet stores must keep write barriers"
+        ir.contains("call void @js_typed_feedback_record_fallback_call")
+            && ir.contains("call i64 @js_array_push_f64"),
+        "wrong runtime values must keep a boxed runtime push fallback"
     );
 }
 
@@ -333,11 +326,11 @@ fn bounded_integer_array_store_omits_layout_note_and_barrier() {
     );
 
     let ir = ir_for(module);
-    let body_ir = block_between(&ir, "\nfor.body.", "\nfor.update.");
+    let body_ir = block_between(&ir, "\nidxset.bounded_fast.", "\nidxset.bounded_fallback.");
 
     assert!(
-        body_ir.contains("store double"),
-        "bounded array store should emit a direct element store"
+        body_ir.contains("call i32 @js_array_numeric_set_f64_unboxed"),
+        "bounded numeric array store should route through the raw-f64 payload helper"
     );
     assert!(
         !body_ir.contains("call void @js_gc_note_slot_layout"),
@@ -394,11 +387,11 @@ fn integer_arithmetic_array_push_omits_inbounds_layout_note_and_barrier() {
     );
 
     let ir = ir_for(module);
-    let inbounds_ir = block_between(&ir, "\napush.inbounds.", "\napush.realloc.");
+    let inbounds_ir = block_between(&ir, "\napush.numeric_fast.", "\napush.numeric_fallback.");
 
     assert!(
-        inbounds_ir.contains("store double"),
-        "optimized push should emit a direct in-bounds store"
+        inbounds_ir.contains("call i64 @js_array_numeric_push_f64_unboxed"),
+        "optimized numeric push should route through the raw-f64 payload helper"
     );
     assert!(
         !inbounds_ir.contains("call void @js_gc_note_slot_layout"),
@@ -515,8 +508,16 @@ fn typed_object_literal_stable_path_installs_pointer_mask_descriptor() {
         "fixture should use the stable object-literal shape allocator"
     );
     assert!(
-        ir.contains("@perry_typed_obj_shape_mask_"),
+        ir.contains("@perry_typed_obj_shape_raw_f64_mask_"),
+        "typed object literal should emit a raw-f64 mask constant"
+    );
+    assert!(
+        ir.contains("@perry_typed_obj_shape_ptr_mask_"),
         "typed object literal should emit a pointer-mask constant"
+    );
+    assert!(
+        ir.contains("constant [1 x i64] [i64 1]"),
+        "only the id slot (slot 0) should be raw-f64"
     );
     assert!(
         ir.contains("constant [1 x i64] [i64 4]"),
@@ -524,7 +525,7 @@ fn typed_object_literal_stable_path_installs_pointer_mask_descriptor() {
     );
 
     let mask_call_pos = ir
-        .find("ptr @perry_typed_obj_shape_mask_")
+        .find("ptr @perry_typed_obj_shape_ptr_mask_")
         .expect("typed descriptor call should reference the object-literal mask");
     let before_mask_call = &ir[..mask_call_pos];
     let alloc_pos = before_mask_call
@@ -561,8 +562,12 @@ fn typed_object_literal_pointer_free_descriptor_precedes_dynamic_mutation() {
 
     let ir = ir_for(module);
     let descriptor_pos = ir
-        .find(", i32 1, ptr null, i32 0)")
+        .find("call void @js_gc_init_typed_shape_layout")
         .expect("number-only object type should install a pointer-free descriptor");
+    assert!(
+        ir.contains("@perry_typed_obj_shape_raw_f64_mask_"),
+        "number-only object type should install a raw-f64 descriptor mask"
+    );
     assert_typed_feedback_setter_after(
         &ir,
         descriptor_pos,
@@ -632,6 +637,8 @@ fn unboxed_point_literal_gate_off_uses_existing_typed_shape_path() {
     assert!(ir.contains("call i64 @js_object_alloc_with_shape"));
     assert!(ir.contains("call void @js_object_set_field"));
     assert!(ir.contains("call void @js_gc_init_typed_shape_layout"));
+    assert!(ir.contains("@perry_typed_obj_shape_raw_f64_mask_"));
+    assert!(ir.contains("constant [1 x i64] [i64 3]"));
     assert!(!ir.contains("call void @js_object_set_unboxed_f64_field"));
     assert!(!ir.contains("call void @js_gc_init_unboxed_object_layout"));
 }

--- a/crates/perry-codegen/tests/typed_shape_descriptors.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptors.rs
@@ -326,18 +326,25 @@ fn bounded_integer_array_store_omits_layout_note_and_barrier() {
     );
 
     let ir = ir_for(module);
-    let body_ir = block_between(&ir, "\nidxset.bounded_fast.", "\nidxset.bounded_fallback.");
 
     assert!(
-        body_ir.contains("call i32 @js_array_numeric_set_f64_unboxed"),
+        ir.contains("call i32 @js_array_numeric_set_f64_unboxed"),
         "bounded numeric array store should route through the raw-f64 payload helper"
     );
     assert!(
-        !body_ir.contains("call void @js_gc_note_slot_layout"),
+        !ir.contains("call i32 @js_typed_feedback_numeric_array_index_set_guard"),
+        "bounded numeric array stores should not reintroduce typed-feedback guards into hot loops"
+    );
+    assert!(
+        !ir.contains("call i32 @js_typed_feedback_plain_array_index_set_guard"),
+        "bounded numeric array stores should not fall back to plain typed-feedback guards"
+    );
+    assert!(
+        !ir.contains("call void @js_gc_note_slot_layout"),
         "integer LocalGet store into a numeric array should not update slot layout"
     );
     assert!(
-        !body_ir.contains("call void @js_write_barrier_slot"),
+        !ir.contains("call void @js_write_barrier_slot"),
         "integer LocalGet store into a numeric array should not emit a slot barrier"
     );
 }
@@ -387,11 +394,15 @@ fn integer_arithmetic_array_push_omits_inbounds_layout_note_and_barrier() {
     );
 
     let ir = ir_for(module);
-    let inbounds_ir = block_between(&ir, "\napush.numeric_fast.", "\napush.numeric_fallback.");
+    let inbounds_ir = block_between(&ir, "\napush.inbounds.", "\napush.realloc.");
 
     assert!(
-        inbounds_ir.contains("call i64 @js_array_numeric_push_f64_unboxed"),
-        "optimized numeric push should route through the raw-f64 payload helper"
+        !ir.contains("call i32 @js_typed_feedback_numeric_array_push_guard"),
+        "plain-number loop pushes should not reintroduce typed-feedback guards into hot loops"
+    );
+    assert!(
+        inbounds_ir.contains("store double"),
+        "plain-number loop pushes should keep the hot inbounds store inline"
     );
     assert!(
         !inbounds_ir.contains("call void @js_gc_note_slot_layout"),

--- a/crates/perry-runtime/src/array/alloc.rs
+++ b/crates/perry-runtime/src/array/alloc.rs
@@ -18,6 +18,7 @@ pub extern "C" fn js_array_alloc(capacity: u32) -> *mut ArrayHeader {
         // Initialize header
         (*ptr).length = 0;
         (*ptr).capacity = actual_capacity;
+        set_array_numeric_layout(ptr, NumericArrayLayout::RawF64);
         crate::gc::layout_init_pointer_free(ptr as *mut u8);
     }
 
@@ -62,6 +63,7 @@ pub extern "C" fn js_array_alloc_with_length(capacity: u32) -> *mut ArrayHeader 
         for i in 0..capacity as usize {
             std::ptr::write(elements_ptr.add(i), crate::value::TAG_HOLE);
         }
+        clear_array_numeric_layout(ptr);
         crate::gc::layout_init_pointer_free(ptr as *mut u8);
     }
 
@@ -88,6 +90,7 @@ pub extern "C" fn js_array_alloc_with_length_longlived(capacity: u32) -> *mut Ar
     unsafe {
         (*ptr).length = capacity;
         (*ptr).capacity = capacity;
+        clear_array_numeric_layout(ptr);
         crate::gc::layout_init_pointer_free(ptr as *mut u8);
     }
 
@@ -132,6 +135,7 @@ pub(crate) unsafe fn js_array_from_arraylike(
     };
     let arr = js_array_alloc(len);
     (*arr).length = len;
+    clear_array_numeric_layout(arr);
     let elements = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
     let undefined = f64::from_bits(TAG_UNDEFINED);
@@ -145,6 +149,7 @@ pub(crate) unsafe fn js_array_from_arraylike(
         *elements.add(i as usize) = v;
         note_array_slot(arr, i as usize, v.to_bits());
     }
+    refresh_array_numeric_layout(arr);
     arr
 }
 
@@ -173,6 +178,7 @@ pub(crate) unsafe fn js_array_from_string_codepoints(
     let cp_count = src.chars().count() as u32;
     let arr = js_array_alloc(cp_count);
     (*arr).length = cp_count;
+    clear_array_numeric_layout(arr);
     let elements = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
     for (i, ch) in src.chars().enumerate() {
         let mut buf = [0u8; 4];
@@ -209,6 +215,7 @@ pub extern "C" fn js_array_alloc_literal(capacity: u32) -> *mut ArrayHeader {
     unsafe {
         (*ptr).length = capacity;
         (*ptr).capacity = capacity;
+        clear_array_numeric_layout(ptr);
         crate::gc::layout_init_pointer_free(ptr as *mut u8);
     }
     ptr

--- a/crates/perry-runtime/src/array/flat_clone.rs
+++ b/crates/perry-runtime/src/array/flat_clone.rs
@@ -336,6 +336,7 @@ pub extern "C" fn js_array_entries(arr: *const ArrayHeader) -> *mut ArrayHeader 
         let len = (*arr).length;
         let result = js_array_alloc(len);
         (*result).length = len;
+        clear_array_numeric_layout(result);
         let src_elements = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
         let dst_elements = (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
         for i in 0..len as usize {

--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -15,6 +15,20 @@ thread_local! {
     /// Both pointers are GC-rooted via `scan_template_raw_roots`.
     static TEMPLATE_RAW_MAP: RefCell<HashMap<usize, *mut ArrayHeader>> =
         RefCell::new(HashMap::new());
+    static NUMERIC_ARRAY_LAYOUTS: RefCell<HashMap<usize, NumericArrayState>> =
+        RefCell::new(HashMap::new());
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NumericArrayLayout {
+    RawF64 = 1,
+}
+
+#[derive(Clone, Debug)]
+struct NumericArrayState {
+    layout: NumericArrayLayout,
+    raw_f64: Option<Vec<f64>>,
 }
 
 /// Register the (cooked, raw) pair for a tagged-template call. Returns
@@ -267,6 +281,338 @@ pub struct ArrayHeader {
     pub capacity: u32,
 }
 
+#[inline]
+pub(crate) fn value_bits_are_numeric(value_bits: u64) -> bool {
+    value_bits_to_number(value_bits).is_some()
+}
+
+#[inline]
+pub(crate) fn value_bits_to_number(value_bits: u64) -> Option<f64> {
+    if (value_bits & crate::value::TAG_MASK) == crate::value::INT32_TAG {
+        let lower = (value_bits & crate::value::INT32_MASK) as u32;
+        return Some((lower as i32) as f64);
+    }
+    let upper = value_bits >> 48;
+    if (0x7FF9..=0x7FFF).contains(&upper) {
+        return None;
+    }
+    Some(f64::from_bits(value_bits))
+}
+
+#[inline]
+unsafe fn array_slot_bits(arr: *const ArrayHeader, index: usize) -> u64 {
+    let slot = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const u64;
+    *slot.add(index)
+}
+
+#[inline]
+unsafe fn array_slots_are_numeric(arr: *const ArrayHeader) -> bool {
+    if arr.is_null() {
+        return false;
+    }
+    let length = (*arr).length as usize;
+    let capacity = (*arr).capacity as usize;
+    if length > capacity || length > 16_000_000 {
+        return false;
+    }
+    for i in 0..length {
+        if value_bits_to_number(array_slot_bits(arr, i)).is_none() {
+            return false;
+        }
+    }
+    true
+}
+
+unsafe fn rebuild_array_numeric_raw_f64(arr: *mut ArrayHeader) -> bool {
+    if arr.is_null() {
+        return false;
+    }
+    let length = (*arr).length as usize;
+    let capacity = (*arr).capacity as usize;
+    if length > capacity || length > 16_000_000 {
+        clear_array_numeric_layout(arr);
+        return false;
+    }
+
+    let mut raw = Vec::with_capacity(length);
+    for i in 0..length {
+        let Some(number) = value_bits_to_number(array_slot_bits(arr, i)) else {
+            clear_array_numeric_layout(arr);
+            return false;
+        };
+        raw.push(number);
+    }
+
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        m.borrow_mut().insert(
+            arr as usize,
+            NumericArrayState {
+                layout: NumericArrayLayout::RawF64,
+                raw_f64: Some(raw),
+            },
+        );
+    });
+    crate::gc::layout_init_pointer_free(arr as *mut u8);
+    true
+}
+
+#[inline]
+pub(crate) unsafe fn set_array_numeric_layout(arr: *mut ArrayHeader, layout: NumericArrayLayout) {
+    if arr.is_null() {
+        return;
+    }
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        m.borrow_mut().insert(
+            arr as usize,
+            NumericArrayState {
+                layout,
+                raw_f64: None,
+            },
+        );
+    });
+    crate::gc::layout_init_pointer_free(arr as *mut u8);
+}
+
+#[inline]
+pub(crate) unsafe fn clear_array_numeric_layout(arr: *const ArrayHeader) {
+    if arr.is_null() {
+        return;
+    }
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        m.borrow_mut().remove(&(arr as usize));
+    });
+}
+
+#[inline]
+pub(crate) fn clear_array_numeric_layout_ptr(user_ptr: usize) {
+    if user_ptr == 0 {
+        return;
+    }
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        m.borrow_mut().remove(&user_ptr);
+    });
+}
+
+#[inline]
+pub(crate) fn transfer_array_numeric_layout(old_user: usize, new_user: usize) {
+    if old_user == 0 || new_user == 0 || old_user == new_user {
+        return;
+    }
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        let mut layouts = m.borrow_mut();
+        layouts.remove(&new_user);
+        if let Some(state) = layouts.remove(&old_user) {
+            layouts.insert(new_user, state);
+        }
+    });
+}
+
+#[inline]
+pub(crate) unsafe fn array_numeric_layout(arr: *const ArrayHeader) -> Option<NumericArrayLayout> {
+    let arr = clean_arr_ptr(arr);
+    if arr.is_null() {
+        return None;
+    }
+    NUMERIC_ARRAY_LAYOUTS.with(|m| m.borrow().get(&(arr as usize)).map(|state| state.layout))
+}
+
+#[inline]
+pub(crate) unsafe fn note_array_numeric_write(arr: *mut ArrayHeader, value_bits: u64) {
+    if !value_bits_are_numeric(value_bits) {
+        clear_array_numeric_layout(arr);
+        return;
+    }
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        if let Some(state) = m.borrow_mut().get_mut(&(arr as usize)) {
+            state.raw_f64 = None;
+        }
+    });
+}
+
+#[inline]
+pub(crate) unsafe fn note_array_numeric_index_write(
+    arr: *mut ArrayHeader,
+    index: usize,
+    value_bits: u64,
+) {
+    let Some(number) = value_bits_to_number(value_bits) else {
+        clear_array_numeric_layout(arr);
+        return;
+    };
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        if let Some(state) = m.borrow_mut().get_mut(&(arr as usize)) {
+            if let Some(raw) = state.raw_f64.as_mut() {
+                if index < raw.len() {
+                    raw[index] = number;
+                } else {
+                    state.raw_f64 = None;
+                }
+            }
+        }
+    });
+}
+
+#[inline]
+pub(crate) unsafe fn ensure_array_numeric_raw_f64(arr: *mut ArrayHeader) -> bool {
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() {
+        return false;
+    }
+    let length = (*arr).length as usize;
+    let capacity = (*arr).capacity as usize;
+    if length > capacity || length > 16_000_000 {
+        clear_array_numeric_layout(arr);
+        return false;
+    }
+    let ready = NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        m.borrow()
+            .get(&(arr as usize))
+            .and_then(|state| state.raw_f64.as_ref())
+            .is_some_and(|raw| raw.len() == length)
+    });
+    if ready {
+        return true;
+    }
+    rebuild_array_numeric_raw_f64(arr)
+}
+
+#[inline]
+pub(crate) unsafe fn array_numeric_raw_f64_get(arr: *mut ArrayHeader, index: u32) -> Option<f64> {
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() {
+        return None;
+    }
+    if index >= (*arr).length {
+        return None;
+    }
+    if !ensure_array_numeric_raw_f64(arr) {
+        return None;
+    }
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        m.borrow()
+            .get(&(arr as usize))
+            .and_then(|state| state.raw_f64.as_ref())
+            .and_then(|raw| raw.get(index as usize).copied())
+    })
+}
+
+#[inline]
+pub(crate) unsafe fn array_numeric_raw_f64_set_inbounds(
+    arr: *mut ArrayHeader,
+    index: u32,
+    value: f64,
+) -> bool {
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() || index >= (*arr).length {
+        return false;
+    }
+    let value_bits = value.to_bits();
+    let elements_ptr = array_elements_ptr(arr) as *mut f64;
+    std::ptr::write(elements_ptr.add(index as usize), value);
+    note_array_numeric_index_write(arr, index as usize, value_bits);
+    crate::gc::layout_note_slot(arr as usize, index as usize, value_bits);
+    value_bits_are_numeric(value_bits)
+}
+
+#[inline]
+pub(crate) unsafe fn array_numeric_raw_f64_push_inbounds(
+    arr: *mut ArrayHeader,
+    value: f64,
+) -> bool {
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() || !ensure_array_numeric_raw_f64(arr) {
+        return false;
+    }
+    let length = (*arr).length;
+    let capacity = (*arr).capacity;
+    if length >= capacity || length > 16_000_000 || capacity > 16_000_000 {
+        return false;
+    }
+
+    let value_bits = value.to_bits();
+    let Some(number) = value_bits_to_number(value_bits) else {
+        return false;
+    };
+    let elements_ptr = array_elements_ptr(arr) as *mut f64;
+    std::ptr::write(elements_ptr.add(length as usize), value);
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        if let Some(state) = m.borrow_mut().get_mut(&(arr as usize)) {
+            match state.raw_f64.as_mut() {
+                Some(raw) if raw.len() == length as usize => raw.push(number),
+                Some(_) => state.raw_f64 = None,
+                None => {}
+            }
+        }
+    });
+    crate::gc::layout_note_slot(arr as usize, length as usize, value_bits);
+    (*arr).length = length + 1;
+    true
+}
+
+#[inline]
+pub(crate) unsafe fn refresh_array_numeric_layout(arr: *mut ArrayHeader) {
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() {
+        return;
+    }
+    if array_slots_are_numeric(arr) {
+        rebuild_array_numeric_raw_f64(arr);
+    } else {
+        clear_array_numeric_layout(arr);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_mark_numeric_f64_layout(arr: *mut ArrayHeader) -> i32 {
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() {
+        return 0;
+    }
+    unsafe {
+        if !array_slots_are_numeric(arr) {
+            clear_array_numeric_layout(arr);
+            return 0;
+        }
+        rebuild_array_numeric_raw_f64(arr);
+    }
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_clear_numeric_layout(arr: *mut ArrayHeader) {
+    let arr = clean_arr_ptr_mut(arr);
+    unsafe {
+        clear_array_numeric_layout(arr);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_note_numeric_write(arr: *mut ArrayHeader, value_bits: u64) {
+    let arr = clean_arr_ptr_mut(arr);
+    unsafe {
+        note_array_numeric_write(arr, value_bits);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_is_numeric_f64_layout(arr: *const ArrayHeader) -> i32 {
+    let arr = clean_arr_ptr(arr);
+    if arr.is_null() {
+        return 0;
+    }
+    unsafe {
+        if array_numeric_layout(arr) == Some(NumericArrayLayout::RawF64) {
+            return 1;
+        }
+        if array_slots_are_numeric(arr) {
+            rebuild_array_numeric_raw_f64(arr as *mut ArrayHeader);
+            return 1;
+        }
+        clear_array_numeric_layout(arr);
+    }
+    0
+}
+
 /// Calculate the byte size for an array with N elements capacity
 #[inline]
 pub(crate) fn array_byte_size(capacity: usize) -> usize {
@@ -297,13 +643,25 @@ pub(crate) unsafe fn gc_element_slot_range(
 
 #[inline]
 pub(crate) unsafe fn note_array_slot(arr: *mut ArrayHeader, index: usize, value_bits: u64) {
+    note_array_numeric_index_write(arr, index, value_bits);
     crate::gc::layout_note_slot(arr as usize, index, value_bits);
     let slot = array_elements_ptr(arr).add(index) as usize;
     crate::gc::runtime_write_barrier_slot(arr as usize, slot, value_bits);
 }
 
 #[inline]
+pub(crate) unsafe fn note_array_slot_layout_only(
+    arr: *mut ArrayHeader,
+    index: usize,
+    value_bits: u64,
+) {
+    note_array_numeric_index_write(arr, index, value_bits);
+    crate::gc::layout_note_slot(arr as usize, index, value_bits);
+}
+
+#[inline]
 pub(crate) unsafe fn store_array_slot(arr: *mut ArrayHeader, index: usize, value_bits: u64) {
+    note_array_numeric_index_write(arr, index, value_bits);
     let slot = array_elements_ptr(arr).add(index) as usize;
     crate::gc::runtime_store_jsvalue_slot(arr as usize, slot, index, value_bits);
 }
@@ -316,10 +674,12 @@ pub(crate) unsafe fn rebuild_array_layout(arr: *mut ArrayHeader) {
     let length = (*arr).length as usize;
     let capacity = (*arr).capacity as usize;
     if length > capacity || length > 16_000_000 {
+        clear_array_numeric_layout(arr);
         crate::gc::layout_mark_unknown(arr as *mut u8);
         return;
     }
     crate::gc::layout_rebuild_from_slots(arr as *mut u8, array_elements_ptr(arr), length);
+    refresh_array_numeric_layout(arr);
     if crate::arena::pointer_in_old_gen(arr as usize) {
         let slots = array_elements_ptr(arr);
         for i in 0..length {
@@ -337,10 +697,12 @@ pub(crate) unsafe fn rebuild_array_layout_exact(arr: *mut ArrayHeader) {
     let length = (*arr).length as usize;
     let capacity = (*arr).capacity as usize;
     if length > capacity || length > 16_000_000 {
+        clear_array_numeric_layout(arr);
         crate::gc::layout_mark_unknown(arr as *mut u8);
         return;
     }
     crate::gc::layout_rebuild_exact_from_slots(arr as *mut u8, array_elements_ptr(arr), length);
+    refresh_array_numeric_layout(arr);
     if crate::arena::pointer_in_old_gen(arr as usize) {
         let slots = array_elements_ptr(arr);
         for i in 0..length {
@@ -377,6 +739,7 @@ pub(crate) unsafe fn replay_array_growth_write_barriers(arr: *mut ArrayHeader) {
 
 #[inline]
 pub(crate) unsafe fn mark_array_layout_unknown(arr: *mut ArrayHeader) {
+    clear_array_numeric_layout(arr);
     crate::gc::layout_mark_unknown(arr as *mut u8);
 }
 

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -85,7 +85,7 @@ pub extern "C" fn js_array_get_f64_unchecked(arr: *const ArrayHeader, index: u32
         if index >= length {
             return TAG_UNDEFINED_F64;
         }
-        if length > 100000 {
+        if length > 100_000_000 {
             return TAG_UNDEFINED_F64;
         }
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
@@ -98,6 +98,16 @@ pub extern "C" fn js_array_get_f64_unchecked(arr: *const ArrayHeader, index: u32
         }
         raw
     }
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_numeric_get_f64_unboxed(arr: *mut ArrayHeader, index: u32) -> f64 {
+    unsafe {
+        if let Some(value) = array_numeric_raw_f64_get(arr, index) {
+            return value;
+        }
+    }
+    js_array_get_f64(arr, index)
 }
 
 /// Get an element from an array by index (returns f64)
@@ -191,7 +201,7 @@ pub extern "C" fn js_array_get_f64(arr: *const ArrayHeader, index: u32) -> f64 {
             return TAG_UNDEFINED_F64;
         }
         // Guard: corrupted arrays with unreasonably large length
-        if length > 100000 {
+        if length > 100_000_000 {
             return TAG_UNDEFINED_F64;
         }
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
@@ -223,6 +233,20 @@ pub extern "C" fn js_array_set_f64_unchecked(arr: *mut ArrayHeader, index: u32, 
         ptr::write(elements_ptr.add(index as usize), value);
         note_array_slot(arr, index as usize, value.to_bits());
     }
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_numeric_set_f64_unboxed(
+    arr: *mut ArrayHeader,
+    index: u32,
+    value: f64,
+) -> i32 {
+    unsafe {
+        if array_numeric_raw_f64_set_inbounds(arr, index, value) {
+            return 1;
+        }
+    }
+    0
 }
 
 /// Set an element in an array by index

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -76,7 +76,7 @@ pub extern "C" fn js_array_map(
                 // allocating), this path needs the full barrier helper
                 // because subsequent stores would miss the remembered
                 // set. The 64-element cap keeps that probability low.
-                crate::gc::layout_note_slot(result as usize, i, mapped_bits);
+                note_array_slot_layout_only(result, i, mapped_bits);
             } else {
                 note_array_slot(result, i, mapped_bits);
             }

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -30,8 +30,9 @@ pub use self::flat_clone::{
     js_array_values,
 };
 pub use self::header::{
-    js_tagged_template_register_raw, js_template_raw, scan_template_raw_roots,
-    scan_template_raw_roots_mut, ArrayHeader,
+    js_array_clear_numeric_layout, js_array_is_numeric_f64_layout,
+    js_array_mark_numeric_f64_layout, js_array_note_numeric_write, js_tagged_template_register_raw,
+    js_template_raw, scan_template_raw_roots, scan_template_raw_roots_mut, ArrayHeader,
 };
 pub use self::immutable::{
     js_array_copy_within, js_array_to_reversed, js_array_to_sorted_default,
@@ -39,7 +40,8 @@ pub use self::immutable::{
 };
 pub use self::indexing::{
     js_array_get_element, js_array_get_element_f64, js_array_get_f64, js_array_get_f64_unchecked,
-    js_array_get_length, js_array_length, js_array_set_f64, js_array_set_f64_extend,
+    js_array_get_length, js_array_length, js_array_numeric_get_f64_unboxed,
+    js_array_numeric_set_f64_unboxed, js_array_set_f64, js_array_set_f64_extend,
     js_array_set_f64_unchecked, js_array_set_index_or_string, js_array_set_string_key,
 };
 pub use self::is_array::js_array_is_array;
@@ -54,8 +56,9 @@ pub use self::jsvalue_api::{
     js_array_push_jsvalue, js_array_set, js_array_set_jsvalue, js_array_set_jsvalue_extend,
 };
 pub use self::push_pop::{
-    js_array_delete, js_array_grow, js_array_pop_f64, js_array_push_f64, js_array_push_spread_f64,
-    js_array_set_length, js_array_shift_f64, js_array_unshift_f64, js_array_unshift_jsvalue,
+    js_array_delete, js_array_grow, js_array_numeric_push_f64_unboxed, js_array_pop_f64,
+    js_array_push_f64, js_array_push_spread_f64, js_array_set_length, js_array_shift_f64,
+    js_array_unshift_f64, js_array_unshift_jsvalue,
 };
 pub use self::reduce_right::js_array_reduce_right;
 pub use self::search::{
@@ -67,9 +70,13 @@ pub use self::splice_slice::{js_array_slice, js_array_splice};
 
 pub(crate) use self::alloc::{js_array_from_arraylike, js_array_from_string_codepoints};
 pub(crate) use self::header::{
-    array_byte_size, clean_arr_ptr, clean_arr_ptr_mut, gc_element_slot_range,
-    mark_array_layout_unknown, note_array_slot, rebuild_array_layout, rebuild_array_layout_exact,
-    replay_array_growth_write_barriers, store_array_slot, MIN_ARRAY_CAPACITY,
+    array_byte_size, array_numeric_raw_f64_get, array_numeric_raw_f64_push_inbounds,
+    array_numeric_raw_f64_set_inbounds, clean_arr_ptr, clean_arr_ptr_mut,
+    clear_array_numeric_layout, clear_array_numeric_layout_ptr, gc_element_slot_range,
+    mark_array_layout_unknown, note_array_slot, note_array_slot_layout_only, rebuild_array_layout,
+    rebuild_array_layout_exact, refresh_array_numeric_layout, replay_array_growth_write_barriers,
+    set_array_numeric_layout, store_array_slot, transfer_array_numeric_layout, NumericArrayLayout,
+    MIN_ARRAY_CAPACITY,
 };
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -117,6 +117,23 @@ pub extern "C" fn js_array_push_f64(arr: *mut ArrayHeader, value: f64) -> *mut A
     }
 }
 
+#[no_mangle]
+pub extern "C" fn js_array_numeric_push_f64_unboxed(
+    arr: *mut ArrayHeader,
+    value: f64,
+) -> *mut ArrayHeader {
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() {
+        return js_array_alloc(0);
+    }
+    unsafe {
+        if array_numeric_raw_f64_push_inbounds(arr, value) {
+            return arr;
+        }
+    }
+    js_array_push_f64(arr, value)
+}
+
 #[cold]
 unsafe fn js_array_push_f64_grow(
     arr: *mut ArrayHeader,
@@ -249,6 +266,7 @@ pub extern "C" fn js_array_set_length(arr: *mut ArrayHeader, new_length: f64) {
                 note_array_slot(arr, i as usize, TAG_UNDEFINED_F64.to_bits());
             }
             (*arr).length = n;
+            refresh_array_numeric_layout(arr);
         } else if n > cur {
             // Extend: pad with TAG_UNDEFINED. Past-capacity extensions go
             // through `js_array_grow` which installs a forwarding pointer at

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -4,10 +4,27 @@ use std::ptr;
 
 use super::*;
 
+extern "C" fn test_map_to_string(
+    _closure: *const crate::closure::ClosureHeader,
+    _element: f64,
+    _index: f64,
+) -> f64 {
+    let str_ptr = crate::string::js_string_from_bytes(b"mapped".as_ptr(), 6);
+    f64::from_bits(crate::value::STRING_TAG | (str_ptr as u64 & crate::value::POINTER_MASK))
+}
+
 fn gc_collection_count_for_tests() -> u64 {
     let mut collections = 0;
     crate::gc::js_gc_stats(&mut collections, ptr::null_mut(), ptr::null_mut());
     collections
+}
+
+fn assert_numeric_raw_values(arr: *mut ArrayHeader, expected: &[f64]) {
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 1);
+    assert_eq!(js_array_length(arr), expected.len() as u32);
+    for (index, value) in expected.iter().enumerate() {
+        assert_eq!(js_array_numeric_get_f64_unboxed(arr, index as u32), *value);
+    }
 }
 
 #[test]
@@ -205,6 +222,363 @@ fn test_array_push_f64_grow_path_preserves_value_and_forwarding() {
     assert_eq!(
         js_array_get_f64(initial, capacity).to_bits(),
         str_value.to_bits()
+    );
+}
+
+#[test]
+fn test_numeric_array_layout_metadata_preserves_and_downgrades_on_writes() {
+    let mut arr = js_array_alloc(4);
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 1);
+
+    arr = js_array_push_f64(arr, 1.25);
+    arr = js_array_push_f64(arr, f64::NAN);
+    arr = js_array_push_f64(arr, -0.0);
+
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 1);
+    assert_eq!(
+        crate::gc::test_layout_pointer_slot_count(arr as usize, 3),
+        Some(0)
+    );
+
+    let str_ptr = crate::string::js_string_from_bytes(b"not-number".as_ptr(), 10);
+    let str_value =
+        f64::from_bits(crate::value::STRING_TAG | (str_ptr as u64 & crate::value::POINTER_MASK));
+    arr = js_array_push_f64(arr, str_value);
+
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 0);
+    assert_eq!(
+        crate::gc::test_layout_pointer_slot_count(arr as usize, 4),
+        Some(1)
+    );
+
+    js_array_set_f64(arr, 0, 99.0);
+    assert_eq!(
+        js_array_is_numeric_f64_layout(arr),
+        0,
+        "numeric writes do not silently re-specialize a downgraded mixed array"
+    );
+}
+
+#[test]
+fn test_numeric_array_layout_mark_rejects_holes_and_accepts_dense_numbers() {
+    let arr = js_array_alloc_with_length(2);
+
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 0);
+    assert_eq!(
+        js_array_mark_numeric_f64_layout(arr),
+        0,
+        "hole-filled arrays cannot be treated as dense numeric payloads"
+    );
+
+    js_array_set_f64(arr, 0, 3.5);
+    js_array_set_f64(arr, 1, -0.0);
+
+    assert_eq!(js_array_mark_numeric_f64_layout(arr), 1);
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 1);
+    assert_eq!(
+        crate::gc::test_layout_pointer_slot_count(arr as usize, 2),
+        Some(0)
+    );
+
+    let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+    js_array_set_f64(arr, 1, undefined);
+
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 0);
+    assert_eq!(
+        crate::gc::test_layout_pointer_slot_count(arr as usize, 2),
+        Some(0),
+        "undefined downgrades numeric metadata but remains pointer-free for GC"
+    );
+}
+
+#[test]
+fn test_numeric_array_raw_f64_payload_tracks_sets_and_downgrades() {
+    let mut arr = js_array_alloc(2);
+    arr = js_array_push_f64(arr, 1.5);
+    arr = js_array_push_f64(arr, 2.5);
+
+    assert_eq!(js_array_mark_numeric_f64_layout(arr), 1);
+    assert_eq!(js_array_numeric_get_f64_unboxed(arr, 0), 1.5);
+    assert_eq!(js_array_numeric_set_f64_unboxed(arr, 1, 7.25), 1);
+    assert_eq!(js_array_get_f64(arr, 1), 7.25);
+    assert_eq!(js_array_numeric_get_f64_unboxed(arr, 1), 7.25);
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 1);
+
+    let str_ptr = crate::string::js_string_from_bytes(b"boxed".as_ptr(), 5);
+    let str_value =
+        f64::from_bits(crate::value::STRING_TAG | (str_ptr as u64 & crate::value::POINTER_MASK));
+    js_array_set_f64(arr, 1, str_value);
+
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 0);
+    assert_eq!(
+        js_array_numeric_get_f64_unboxed(arr, 1).to_bits(),
+        str_value.to_bits(),
+        "unboxed helper falls back to boxed slots after downgrade"
+    );
+}
+
+#[test]
+fn test_numeric_array_raw_f64_payload_push_helper_preserves_and_downgrades() {
+    let mut arr = js_array_alloc(2);
+
+    assert_eq!(js_array_mark_numeric_f64_layout(arr), 1);
+    arr = js_array_numeric_push_f64_unboxed(arr, 1.0);
+    arr = js_array_numeric_push_f64_unboxed(arr, 2.0);
+
+    assert_eq!(js_array_length(arr), 2);
+    assert_eq!(js_array_numeric_get_f64_unboxed(arr, 0), 1.0);
+    assert_eq!(js_array_numeric_get_f64_unboxed(arr, 1), 2.0);
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 1);
+
+    let grown = js_array_numeric_push_f64_unboxed(arr, 3.0);
+    assert_eq!(js_array_length(grown), 3);
+    assert_eq!(js_array_numeric_get_f64_unboxed(grown, 2), 3.0);
+    assert_eq!(js_array_is_numeric_f64_layout(grown), 1);
+
+    let str_ptr = crate::string::js_string_from_bytes(b"push-boxed".as_ptr(), 10);
+    let str_value =
+        f64::from_bits(crate::value::STRING_TAG | (str_ptr as u64 & crate::value::POINTER_MASK));
+    let mixed = js_array_numeric_push_f64_unboxed(grown, str_value);
+
+    assert_eq!(js_array_get_f64(mixed, 3).to_bits(), str_value.to_bits());
+    assert_eq!(js_array_is_numeric_f64_layout(mixed), 0);
+}
+
+#[test]
+fn test_numeric_array_layout_transfers_across_growth_forwarding() {
+    let mut arr = js_array_alloc(0);
+    let original = arr;
+    let capacity = unsafe { (*arr).capacity };
+
+    for i in 0..capacity {
+        arr = js_array_push_f64(arr, i as f64);
+    }
+
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 1);
+
+    let grown = js_array_push_f64(arr, capacity as f64);
+
+    assert_ne!(grown, arr);
+    assert_eq!(js_array_is_numeric_f64_layout(grown), 1);
+    assert_eq!(
+        js_array_is_numeric_f64_layout(original),
+        1,
+        "stale pointers should follow growth forwarding before checking metadata"
+    );
+    assert_eq!(
+        crate::gc::test_layout_pointer_slot_count(grown as usize, (capacity + 1) as usize),
+        Some(0)
+    );
+}
+
+#[test]
+fn test_numeric_array_raw_f64_payload_rebuilds_after_growth_forwarding() {
+    let mut arr = js_array_alloc(0);
+    let original = arr;
+    let capacity = unsafe { (*arr).capacity };
+
+    for i in 0..capacity {
+        arr = js_array_push_f64(arr, i as f64);
+    }
+
+    assert_eq!(js_array_mark_numeric_f64_layout(arr), 1);
+    assert_eq!(
+        js_array_numeric_get_f64_unboxed(arr, capacity - 1),
+        (capacity - 1) as f64
+    );
+
+    let grown = js_array_push_f64(arr, capacity as f64);
+
+    assert_ne!(grown, arr);
+    assert_eq!(
+        js_array_numeric_get_f64_unboxed(grown, capacity),
+        capacity as f64
+    );
+    assert_eq!(
+        js_array_numeric_get_f64_unboxed(original, capacity),
+        capacity as f64,
+        "stale forwarded handles rebuild the moved raw payload before reading"
+    );
+}
+
+#[test]
+fn test_numeric_array_layout_query_recovers_dense_numeric_metadata() {
+    let mut arr = js_array_alloc(0);
+    arr = js_array_push_f64(arr, 1.0);
+    arr = js_array_push_f64(arr, 2.0);
+
+    js_array_clear_numeric_layout(arr);
+
+    assert_eq!(
+        js_array_is_numeric_f64_layout(arr),
+        1,
+        "numeric layout metadata can be rebuilt from dense numeric slots"
+    );
+}
+
+#[test]
+fn test_array_get_f64_large_dense_array_preserves_values() {
+    let arr = js_array_alloc_with_length(100_001);
+    js_array_set_f64(arr, 100_000, 42.0);
+
+    assert_eq!(js_array_get_f64(arr, 100_000), 42.0);
+    assert_eq!(js_array_get_f64_unchecked(arr, 100_000), 42.0);
+}
+
+#[test]
+fn test_numeric_array_layout_bulk_rebuild_preserves_and_downgrades() {
+    let values = [1.0, 2.0, 3.0, 4.0];
+    let src = js_array_from_f64(values.as_ptr(), values.len() as u32);
+
+    assert_eq!(js_array_is_numeric_f64_layout(src), 1);
+
+    let sliced = js_array_slice(src, 1, 3);
+    assert_numeric_raw_values(sliced, &[2.0, 3.0]);
+    assert_eq!(
+        crate::gc::test_layout_pointer_slot_count(sliced as usize, 2),
+        Some(0)
+    );
+
+    let concatenated = js_array_concat(js_array_alloc(0), src);
+    assert_numeric_raw_values(concatenated, &values);
+    assert_eq!(
+        crate::gc::test_layout_pointer_slot_count(concatenated as usize, values.len()),
+        Some(0)
+    );
+
+    let str_ptr = crate::string::js_string_from_bytes(b"bulk-mixed".as_ptr(), 10);
+    let str_value =
+        f64::from_bits(crate::value::STRING_TAG | (str_ptr as u64 & crate::value::POINTER_MASK));
+    js_array_fill(concatenated, str_value);
+
+    assert_eq!(js_array_is_numeric_f64_layout(concatenated), 0);
+    assert_eq!(
+        crate::gc::test_layout_pointer_slot_count(concatenated as usize, values.len()),
+        Some(values.len())
+    );
+}
+
+#[test]
+fn test_numeric_array_layout_length_and_delete_transitions() {
+    let mut arr = js_array_alloc(4);
+    arr = js_array_push_f64(arr, 1.0);
+    arr = js_array_push_f64(arr, 2.0);
+    arr = js_array_push_f64(arr, 3.0);
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 1);
+
+    js_array_set_length(arr, 2.0);
+
+    assert_eq!(js_array_length(arr), 2);
+    assert_eq!(
+        js_array_is_numeric_f64_layout(arr),
+        1,
+        "truncation should preserve dense numeric layout for the reachable prefix"
+    );
+
+    js_array_set_length(arr, 4.0);
+
+    assert_eq!(js_array_length(arr), 4);
+    assert_eq!(
+        js_array_is_numeric_f64_layout(arr),
+        0,
+        "extension pads with undefined and must downgrade numeric layout"
+    );
+    assert_eq!(
+        crate::gc::test_layout_pointer_slot_count(arr as usize, 4),
+        Some(0)
+    );
+
+    let mut dense = js_array_alloc(4);
+    dense = js_array_push_f64(dense, 10.0);
+    dense = js_array_push_f64(dense, 20.0);
+    assert_eq!(js_array_is_numeric_f64_layout(dense), 1);
+
+    assert_eq!(js_array_delete(dense, 0), 1);
+    assert_eq!(
+        js_array_is_numeric_f64_layout(dense),
+        0,
+        "delete creates an undefined slot and downgrades dense numeric layout"
+    );
+}
+
+#[test]
+fn test_numeric_array_layout_immutable_helpers_preserve_or_downgrade() {
+    let values = [10.0, 2.0, 30.0];
+    let src = js_array_from_f64(values.as_ptr(), values.len() as u32);
+    assert_numeric_raw_values(src, &values);
+
+    let reversed = js_array_to_reversed(src);
+    assert_numeric_raw_values(reversed, &[30.0, 2.0, 10.0]);
+
+    let sorted = js_array_to_sorted_default(src);
+    assert_numeric_raw_values(sorted, &[10.0, 2.0, 30.0]);
+
+    let numeric_replaced = js_array_with(src, 1.0, 99.0);
+    assert_numeric_raw_values(numeric_replaced, &[10.0, 99.0, 30.0]);
+
+    let insert = [7.0, 8.0];
+    let spliced = js_array_to_spliced(src, 1.0, 1.0, insert.as_ptr(), insert.len() as u32);
+    assert_numeric_raw_values(spliced, &[10.0, 7.0, 8.0, 30.0]);
+
+    let str_ptr = crate::string::js_string_from_bytes(b"immutable-mixed".as_ptr(), 15);
+    let str_value =
+        f64::from_bits(crate::value::STRING_TAG | (str_ptr as u64 & crate::value::POINTER_MASK));
+    let mixed = js_array_with(src, 1.0, str_value);
+
+    assert_eq!(js_array_is_numeric_f64_layout(mixed), 0);
+    assert_eq!(
+        crate::gc::test_layout_pointer_slot_count(mixed as usize, values.len()),
+        Some(1)
+    );
+}
+
+#[test]
+fn test_numeric_array_layout_map_fast_path_downgrades_mapped_pointers() {
+    let mut arr = js_array_alloc(4);
+    arr = js_array_push_f64(arr, 1.0);
+    arr = js_array_push_f64(arr, 2.0);
+    arr = js_array_push_f64(arr, 3.0);
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 1);
+
+    let callback = crate::closure::js_closure_alloc(test_map_to_string as *const u8, 0);
+    let mapped = js_array_map(arr, callback);
+
+    assert_eq!(js_array_length(mapped), 3);
+    assert_eq!(
+        js_array_is_numeric_f64_layout(mapped),
+        0,
+        "small map() results use a layout-only fast path and must still downgrade"
+    );
+    assert_eq!(
+        crate::gc::test_layout_pointer_slot_count(mapped as usize, 3),
+        Some(3)
+    );
+}
+
+#[test]
+fn test_numeric_array_layout_entries_outer_downgrades_inner_pairs_preserve() {
+    let values = [4.0, 5.0];
+    let src = js_array_from_f64(values.as_ptr(), values.len() as u32);
+    let entries = js_array_entries(src);
+
+    assert_eq!(
+        js_array_is_numeric_f64_layout(entries),
+        0,
+        "entries() outer array stores pair pointers, not raw numeric slots"
+    );
+    assert_eq!(
+        crate::gc::test_layout_pointer_slot_count(entries as usize, values.len()),
+        Some(values.len())
+    );
+
+    let pair_box = js_array_get_f64(entries, 0);
+    let pair = (pair_box.to_bits() & crate::value::POINTER_MASK) as *mut ArrayHeader;
+    assert_eq!(js_array_is_numeric_f64_layout(pair), 1);
+    assert_eq!(js_array_numeric_get_f64_unboxed(pair, 0), 0.0);
+    assert_eq!(js_array_numeric_get_f64_unboxed(pair, 1), 4.0);
+    assert_eq!(
+        crate::gc::test_layout_pointer_slot_count(pair as usize, 2),
+        Some(0)
     );
 }
 

--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -263,8 +263,8 @@ pub(super) fn layout_pointer_bearing_bits(bits: u64) -> bool {
 
 #[inline]
 pub(super) fn layout_raw_f64_bits(bits: u64) -> bool {
-    let upper = bits >> 48;
-    !(0x7FFC..=0x7FFF).contains(&upper)
+    let tag = bits & crate::value::TAG_MASK;
+    !(crate::value::SHORT_STRING_TAG..=crate::value::STRING_TAG).contains(&tag)
 }
 
 #[inline]

--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -314,17 +314,20 @@ pub(crate) unsafe fn layout_mark_unknown(user_ptr: *mut u8) {
         m.borrow_mut().remove(&(user_ptr as usize));
     });
     if state == GC_LAYOUT_POINTER_FREE {
+        crate::typed_feedback::invalidate_representation_change(user_ptr as usize);
         return;
     }
     LAYOUT_SLOT_MASKS.with(|m| {
         m.borrow_mut().remove(&(user_ptr as usize));
     });
+    crate::typed_feedback::invalidate_representation_change(user_ptr as usize);
 }
 
 pub(crate) fn layout_clear_for_ptr(user_ptr: usize) {
     if user_ptr == 0 {
         return;
     }
+    crate::array::clear_array_numeric_layout_ptr(user_ptr);
     LAYOUT_SLOT_MASKS.with(|m| {
         m.borrow_mut().remove(&user_ptr);
     });
@@ -348,6 +351,7 @@ pub(super) unsafe fn layout_set_typed_unknown(header: *mut GcHeader, user_ptr: u
     LAYOUT_SLOT_MASKS.with(|m| {
         m.borrow_mut().remove(&user_ptr);
     });
+    crate::typed_feedback::invalidate_representation_change(user_ptr);
 }
 
 pub(crate) fn layout_note_slot(parent_user: usize, slot_index: usize, value_bits: u64) {
@@ -417,12 +421,74 @@ pub extern "C" fn js_gc_note_slot_layout(parent: u64, slot_index: u32, value_bit
     layout_note_slot(parent_user, slot_index as usize, value_bits);
 }
 
+unsafe fn init_typed_shape_layout(
+    user_ptr: usize,
+    slot_count: usize,
+    raw_f64_words: &[u64],
+    pointer_words: &[u64],
+) {
+    let Some(header) = layout_header_for_user(user_ptr) else {
+        return;
+    };
+    if gc_type_layout_slot_kind((*header).obj_type) != GcLayoutSlotKind::ObjectFields {
+        return;
+    }
+    let obj_header = user_ptr as *const crate::object::ObjectHeader;
+    let object_slot_count = (*obj_header).field_count as usize;
+    if object_slot_count != slot_count {
+        layout_set_typed_unknown(header, user_ptr);
+        return;
+    }
+
+    let raw_f64_mask = LayoutSlotMask::from_words(raw_f64_words);
+    let pointer_mask = LayoutSlotMask::from_words(pointer_words);
+
+    if slot_count != 0 {
+        let fields = (obj_header as *const u8)
+            .add(std::mem::size_of::<crate::object::ObjectHeader>())
+            as *const u64;
+        for i in 0..slot_count {
+            let bits = *fields.add(i);
+            if raw_f64_mask.contains_slot(i) && !layout_raw_f64_bits(bits) {
+                layout_set_typed_unknown(header, user_ptr);
+                return;
+            }
+            if layout_pointer_bearing_bits(bits) && !pointer_mask.contains_slot(i) {
+                layout_set_typed_unknown(header, user_ptr);
+                return;
+            }
+        }
+    }
+
+    let descriptor = TypedLayoutDescriptor {
+        slot_count,
+        raw_f64_mask,
+        pointer_mask: pointer_mask.clone(),
+    };
+    TYPED_LAYOUTS.with(|m| {
+        m.borrow_mut().insert(user_ptr, descriptor);
+    });
+    if pointer_mask.is_empty() {
+        set_layout_state(header, GC_LAYOUT_POINTER_FREE);
+        LAYOUT_SLOT_MASKS.with(|m| {
+            m.borrow_mut().remove(&user_ptr);
+        });
+    } else {
+        set_layout_state(header, GC_LAYOUT_SIDE_MASK);
+        LAYOUT_SLOT_MASKS.with(|m| {
+            m.borrow_mut().insert(user_ptr, pointer_mask);
+        });
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn js_gc_init_typed_shape_layout(
     obj: u64,
     slot_count: u32,
-    mask_words: *const u64,
-    mask_word_count: u32,
+    raw_f64_mask_words: *const u64,
+    raw_f64_mask_word_count: u32,
+    pointer_mask_words: *const u64,
+    pointer_mask_word_count: u32,
 ) {
     let user_ptr = strip_nanbox_user_ptr(obj);
     let slot_count = slot_count as usize;
@@ -430,58 +496,18 @@ pub extern "C" fn js_gc_init_typed_shape_layout(
         return;
     }
     unsafe {
-        let Some(header) = layout_header_for_user(user_ptr) else {
-            return;
-        };
-        if gc_type_layout_slot_kind((*header).obj_type) != GcLayoutSlotKind::ObjectFields {
-            return;
-        }
-        let obj_header = user_ptr as *const crate::object::ObjectHeader;
-        let object_slot_count = (*obj_header).field_count as usize;
-        if object_slot_count != slot_count {
-            layout_set_typed_unknown(header, user_ptr);
-            return;
-        }
-
-        let words: &[u64] = if mask_words.is_null() || mask_word_count == 0 {
+        let raw_words: &[u64] = if raw_f64_mask_words.is_null() || raw_f64_mask_word_count == 0 {
             &[]
         } else {
-            std::slice::from_raw_parts(mask_words, mask_word_count as usize)
+            std::slice::from_raw_parts(raw_f64_mask_words, raw_f64_mask_word_count as usize)
         };
-        let pointer_mask = LayoutSlotMask::from_words(words);
-
-        if slot_count != 0 {
-            let fields = (obj_header as *const u8)
-                .add(std::mem::size_of::<crate::object::ObjectHeader>())
-                as *const u64;
-            for i in 0..slot_count {
-                let bits = *fields.add(i);
-                if layout_pointer_bearing_bits(bits) && !pointer_mask.contains_slot(i) {
-                    layout_set_typed_unknown(header, user_ptr);
-                    return;
-                }
-            }
-        }
-
-        let descriptor = TypedLayoutDescriptor {
-            slot_count,
-            raw_f64_mask: LayoutSlotMask::Inline(0),
-            pointer_mask: pointer_mask.clone(),
-        };
-        TYPED_LAYOUTS.with(|m| {
-            m.borrow_mut().insert(user_ptr, descriptor);
-        });
-        if pointer_mask.is_empty() {
-            set_layout_state(header, GC_LAYOUT_POINTER_FREE);
-            LAYOUT_SLOT_MASKS.with(|m| {
-                m.borrow_mut().remove(&user_ptr);
-            });
+        let pointer_words: &[u64] = if pointer_mask_words.is_null() || pointer_mask_word_count == 0
+        {
+            &[]
         } else {
-            set_layout_state(header, GC_LAYOUT_SIDE_MASK);
-            LAYOUT_SLOT_MASKS.with(|m| {
-                m.borrow_mut().insert(user_ptr, pointer_mask);
-            });
-        }
+            std::slice::from_raw_parts(pointer_mask_words, pointer_mask_word_count as usize)
+        };
+        init_typed_shape_layout(user_ptr, slot_count, raw_words, pointer_words);
     }
 }
 
@@ -625,6 +651,11 @@ pub(crate) unsafe fn layout_transfer(old_user: *mut u8, new_user: *mut u8) {
     };
     let state = (*old_header)._reserved & GC_LAYOUT_STATE_MASK;
     set_layout_state(new_header, state);
+    if (*old_header).obj_type == GC_TYPE_ARRAY && (*new_header).obj_type == GC_TYPE_ARRAY {
+        crate::array::transfer_array_numeric_layout(old_user as usize, new_user as usize);
+    } else {
+        crate::array::clear_array_numeric_layout_ptr(new_user as usize);
+    }
     TYPED_LAYOUTS.with(|m| {
         let mut typed = m.borrow_mut();
         typed.remove(&(new_user as usize));
@@ -672,6 +703,17 @@ pub(crate) fn layout_visit_pointer_slots_for_user<F: FnMut(usize)>(
     visit: F,
 ) -> bool {
     layout_visit_pointer_slots(user_ptr, slot_count, visit)
+}
+
+pub(crate) fn layout_typed_raw_f64_slot_for_user(user_ptr: usize, slot_index: usize) -> bool {
+    TYPED_LAYOUTS.with(|m| {
+        m.borrow()
+            .get(&user_ptr)
+            .map(|layout| {
+                slot_index < layout.slot_count && layout.raw_f64_mask.contains_slot(slot_index)
+            })
+            .unwrap_or(false)
+    })
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/perry-runtime/src/gc/tests/layout_trace.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace.rs
@@ -420,6 +420,56 @@ fn test_typed_shape_descriptor_tracks_raw_numeric_slots() {
 }
 
 #[test]
+fn test_typed_shape_descriptor_rejects_nanbox_non_number_tags() {
+    clear_marks();
+    clear_mark_seeds();
+
+    let raw_mask = [0b1u64];
+    let obj = crate::object::js_object_alloc(0, 1);
+    crate::object::js_object_set_unboxed_f64_field(obj, 0, 1.5);
+    js_gc_init_typed_shape_layout(
+        obj as u64,
+        1,
+        raw_mask.as_ptr(),
+        raw_mask.len() as u32,
+        std::ptr::null(),
+        0,
+    );
+    assert!(layout_typed_raw_f64_slot_for_user(obj as usize, 0));
+
+    let short = crate::value::JSValue::try_short_string(b"abc").unwrap();
+    crate::object::js_object_set_field(obj, 0, short);
+    assert!(
+        !layout_typed_raw_f64_slot_for_user(obj as usize, 0),
+        "SSO string tags must downgrade raw-f64 descriptors"
+    );
+    assert_eq!(test_layout_pointer_slot_count(obj as usize, 1), None);
+
+    let handle_obj = crate::object::js_object_alloc(0, 1);
+    crate::object::js_object_set_unboxed_f64_field(handle_obj, 0, 2.5);
+    js_gc_init_typed_shape_layout(
+        handle_obj as u64,
+        1,
+        raw_mask.as_ptr(),
+        raw_mask.len() as u32,
+        std::ptr::null(),
+        0,
+    );
+    assert!(layout_typed_raw_f64_slot_for_user(handle_obj as usize, 0));
+
+    let handle = crate::value::JSValue::from_bits(crate::value::JS_HANDLE_TAG | 0x1234);
+    crate::object::js_object_set_field(handle_obj, 0, handle);
+    assert!(
+        !layout_typed_raw_f64_slot_for_user(handle_obj as usize, 0),
+        "JS handle tags must downgrade raw-f64 descriptors"
+    );
+    assert_eq!(test_layout_pointer_slot_count(handle_obj as usize, 1), None);
+
+    clear_marks();
+    clear_mark_seeds();
+}
+
+#[test]
 fn test_typed_shape_descriptor_growing_new_field_falls_back() {
     clear_marks();
     clear_mark_seeds();

--- a/crates/perry-runtime/src/gc/tests/layout_trace.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace.rs
@@ -311,7 +311,14 @@ fn test_typed_shape_descriptor_preserves_pointer_slots_after_non_pointer_overwri
 
     let obj = crate::object::js_object_alloc(0, 2);
     let mask = [0b10u64];
-    js_gc_init_typed_shape_layout(obj as u64, 2, mask.as_ptr(), mask.len() as u32);
+    js_gc_init_typed_shape_layout(
+        obj as u64,
+        2,
+        std::ptr::null(),
+        0,
+        mask.as_ptr(),
+        mask.len() as u32,
+    );
 
     assert_eq!(test_layout_pointer_slot_count(obj as usize, 2), Some(1));
     assert_eq!(test_heap_child_slot_count(obj as *mut u8), 1);
@@ -334,7 +341,14 @@ fn test_typed_shape_descriptor_pointer_write_to_non_pointer_slot_falls_back() {
     let child_header = unsafe { header_from_user_ptr(child as *mut u8) };
     let obj = crate::object::js_object_alloc(0, 2);
     let mask = [0b10u64];
-    js_gc_init_typed_shape_layout(obj as u64, 2, mask.as_ptr(), mask.len() as u32);
+    js_gc_init_typed_shape_layout(
+        obj as u64,
+        2,
+        std::ptr::null(),
+        0,
+        mask.as_ptr(),
+        mask.len() as u32,
+    );
 
     crate::object::js_object_set_field(obj, 0, crate::value::JSValue::string_ptr(child));
 
@@ -360,6 +374,52 @@ fn test_typed_shape_descriptor_pointer_write_to_non_pointer_slot_falls_back() {
 }
 
 #[test]
+fn test_typed_shape_descriptor_tracks_raw_numeric_slots() {
+    clear_marks();
+    clear_mark_seeds();
+
+    let obj = crate::object::js_object_alloc(0, 2);
+    crate::object::js_object_set_unboxed_f64_field(obj, 0, 1.5);
+    crate::object::js_object_set_field(obj, 1, crate::value::JSValue::number(2.5));
+    let raw_mask = [0b01u64];
+    js_gc_init_typed_shape_layout(
+        obj as u64,
+        2,
+        raw_mask.as_ptr(),
+        raw_mask.len() as u32,
+        std::ptr::null(),
+        0,
+    );
+
+    assert!(layout_typed_raw_f64_slot_for_user(obj as usize, 0));
+    assert!(!layout_typed_raw_f64_slot_for_user(obj as usize, 1));
+    assert_eq!(test_layout_pointer_slot_count(obj as usize, 2), Some(0));
+
+    let child = crate::string::js_string_from_bytes(b"raw-child".as_ptr(), 9);
+    let child_header = unsafe { header_from_user_ptr(child as *mut u8) };
+    crate::object::js_object_set_field(obj, 0, crate::value::JSValue::string_ptr(child));
+
+    assert!(
+        !layout_typed_raw_f64_slot_for_user(obj as usize, 0),
+        "non-number writes must clear the exact raw-f64 descriptor"
+    );
+    assert_eq!(test_layout_pointer_slot_count(obj as usize, 2), None);
+
+    let valid_ptrs = build_valid_pointer_set();
+    assert!(try_mark_value(
+        POINTER_TAG | (obj as u64 & POINTER_MASK),
+        &valid_ptrs
+    ));
+    trace_marked_objects(&valid_ptrs);
+    unsafe {
+        assert_ne!((*child_header).gc_flags & GC_FLAG_MARKED, 0);
+    }
+
+    clear_marks();
+    clear_mark_seeds();
+}
+
+#[test]
 fn test_typed_shape_descriptor_growing_new_field_falls_back() {
     clear_marks();
     clear_mark_seeds();
@@ -372,7 +432,7 @@ fn test_typed_shape_descriptor_growing_new_field_falls_back() {
         packed_keys.len() as u32,
     );
     let obj = crate::object::js_object_alloc_class_inline_keys(65_001, 0, 1, keys);
-    js_gc_init_typed_shape_layout(obj as u64, 1, std::ptr::null(), 0);
+    js_gc_init_typed_shape_layout(obj as u64, 1, std::ptr::null(), 0, std::ptr::null(), 0);
 
     let extra_key = crate::string::js_string_from_bytes(b"extra".as_ptr(), 5);
     crate::object::js_object_set_field_by_name(obj, extra_key, 42.0);
@@ -394,7 +454,14 @@ fn test_typed_shape_descriptor_transfers_on_object_move() {
     let src = crate::object::js_object_alloc(0, 2);
     let dst = crate::object::js_object_alloc(0, 2);
     let mask = [0b10u64];
-    js_gc_init_typed_shape_layout(src as u64, 2, mask.as_ptr(), mask.len() as u32);
+    js_gc_init_typed_shape_layout(
+        src as u64,
+        2,
+        std::ptr::null(),
+        0,
+        mask.as_ptr(),
+        mask.len() as u32,
+    );
 
     unsafe {
         layout_transfer(src as *mut u8, dst as *mut u8);
@@ -914,6 +981,44 @@ fn test_numeric_array_push_heap_value_transitions_and_traces() {
 }
 
 #[test]
+fn test_numeric_array_layout_metadata_matches_gc_scan_state() {
+    clear_marks();
+    clear_mark_seeds();
+
+    let mut arr = crate::array::js_array_alloc(4);
+    arr = crate::array::js_array_push_f64(arr, 1.0);
+    arr = crate::array::js_array_push_f64(arr, 2.0);
+
+    assert_eq!(crate::array::js_array_is_numeric_f64_layout(arr), 1);
+    assert_numeric_array_trace_free(arr, 2);
+
+    let child = crate::string::js_string_from_bytes(b"layout-child".as_ptr(), 12) as *mut u8;
+    let child_header = unsafe { header_from_user_ptr(child) };
+    let child_box = f64::from_bits(STRING_TAG | (child as u64 & POINTER_MASK));
+    arr = crate::array::js_array_push_f64(arr, child_box);
+
+    assert_eq!(crate::array::js_array_is_numeric_f64_layout(arr), 0);
+    assert_eq!(test_layout_pointer_slot_count(arr as usize, 3), Some(1));
+
+    clear_marks();
+    clear_mark_seeds();
+    let valid_ptrs = build_valid_pointer_set();
+    assert!(try_mark_value(
+        POINTER_TAG | (arr as u64 & POINTER_MASK),
+        &valid_ptrs
+    ));
+    test_reset_trace_slot_reads();
+    trace_marked_objects(&valid_ptrs);
+    assert_eq!(test_trace_slot_reads(), 1);
+    unsafe {
+        assert_ne!((*child_header).gc_flags & GC_FLAG_MARKED, 0);
+    }
+
+    clear_marks();
+    clear_mark_seeds();
+}
+
+#[test]
 fn test_trace_object_uses_pointer_layout_mask() {
     clear_marks();
     clear_mark_seeds();
@@ -973,7 +1078,14 @@ fn test_typed_shape_descriptor_scans_only_declared_pointer_slots() {
     crate::object::js_object_set_field(obj, 2, crate::value::JSValue::number(3.0));
 
     let mask = [1u64 << 1];
-    js_gc_init_typed_shape_layout(obj as u64, 3, mask.as_ptr(), mask.len() as u32);
+    js_gc_init_typed_shape_layout(
+        obj as u64,
+        3,
+        std::ptr::null(),
+        0,
+        mask.as_ptr(),
+        mask.len() as u32,
+    );
 
     assert_eq!(test_layout_pointer_slot_count(obj as usize, 3), Some(1));
     assert_eq!(test_heap_child_slot_count(obj as *mut u8), 1);
@@ -1002,7 +1114,7 @@ fn test_typed_shape_descriptor_dynamic_pointer_mutation_falls_back_to_unknown_la
     let obj = crate::object::js_object_alloc(0, 2);
     crate::object::js_object_set_field(obj, 0, crate::value::JSValue::number(1.0));
     crate::object::js_object_set_field(obj, 1, crate::value::JSValue::number(2.0));
-    js_gc_init_typed_shape_layout(obj as u64, 2, std::ptr::null(), 0);
+    js_gc_init_typed_shape_layout(obj as u64, 2, std::ptr::null(), 0, std::ptr::null(), 0);
     assert_eq!(test_layout_pointer_slot_count(obj as usize, 2), Some(0));
 
     let child = crate::string::js_string_from_bytes(b"fallback-child".as_ptr(), 14);

--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -322,7 +322,7 @@ pub(crate) unsafe fn parse_shape_keys_array(
         for (i, &key_ptr) in keys.iter().enumerate() {
             let bits = crate::value::STRING_TAG | (key_ptr as u64 & crate::value::POINTER_MASK);
             *elements_ptr.add(i) = f64::from_bits(bits);
-            crate::gc::layout_note_slot(arr as usize, i, bits);
+            crate::array::note_array_slot_layout_only(arr, i, bits);
         }
         let header = (arr as *mut u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader;
         (*header).gc_flags |= crate::gc::GC_FLAG_SHAPE_SHARED;
@@ -547,6 +547,39 @@ mod tests {
         assert_eq!(
             unsafe { str_from_header(output).unwrap() },
             std::str::from_utf8(input).unwrap()
+        );
+    }
+
+    #[test]
+    fn direct_parse_array_numeric_layout_preserves_and_downgrades() {
+        let numeric_input = br#"[1,2,3]"#;
+        let numeric_text = js_string_from_bytes(numeric_input.as_ptr(), numeric_input.len() as u32);
+        let numeric_value = unsafe { js_json_parse(numeric_text) };
+        let numeric_arr = (numeric_value.bits() & POINTER_MASK) as *mut crate::ArrayHeader;
+
+        assert_eq!(crate::array::js_array_is_numeric_f64_layout(numeric_arr), 1);
+        assert_eq!(
+            crate::array::js_array_numeric_get_f64_unboxed(numeric_arr, 0),
+            1.0
+        );
+        assert_eq!(
+            crate::array::js_array_numeric_get_f64_unboxed(numeric_arr, 2),
+            3.0
+        );
+        assert_eq!(
+            crate::gc::test_layout_pointer_slot_count(numeric_arr as usize, 3),
+            Some(0)
+        );
+
+        let mixed_input = br#"[1,"longer",3]"#;
+        let mixed_text = js_string_from_bytes(mixed_input.as_ptr(), mixed_input.len() as u32);
+        let mixed_value = unsafe { js_json_parse(mixed_text) };
+        let mixed_arr = (mixed_value.bits() & POINTER_MASK) as *mut crate::ArrayHeader;
+
+        assert_eq!(crate::array::js_array_is_numeric_f64_layout(mixed_arr), 0);
+        assert_eq!(
+            crate::gc::test_layout_pointer_slot_count(mixed_arr as usize, 3),
+            Some(1)
         );
     }
 

--- a/crates/perry-runtime/src/json/parser.rs
+++ b/crates/perry-runtime/src/json/parser.rs
@@ -6,7 +6,8 @@
 
 use super::*;
 use crate::{
-    array::ArrayHeader, js_array_alloc, js_array_push, js_string_from_bytes, JSValue, StringHeader,
+    array::{note_array_slot_layout_only, ArrayHeader},
+    js_array_alloc, js_array_push, js_string_from_bytes, JSValue, StringHeader,
 };
 
 // ─── Direct JSON parser ────────────────────────────────────────────────────────
@@ -136,7 +137,7 @@ impl<'a> DirectParser<'a> {
             // JSON.parse suppresses GC and writes only into arrays allocated
             // by the same parse, so a generational write barrier is redundant.
             // Keep the layout note so tracing still sees the element slot.
-            crate::gc::layout_note_slot(arr as usize, length as usize, value_bits);
+            note_array_slot_layout_only(arr, length as usize, value_bits);
             (*arr).length = length + 1;
             arr
         } else {

--- a/crates/perry-runtime/src/json_tape.rs
+++ b/crates/perry-runtime/src/json_tape.rs
@@ -1023,6 +1023,52 @@ mod tests {
             "TapeEntry grew beyond 12 bytes — check padding"
         );
     }
+
+    #[test]
+    fn force_materialize_numeric_lazy_array_preserves_raw_payload() {
+        let input = br#"[1,2.5,3]"#;
+        let text = crate::string::js_string_from_bytes(input.as_ptr(), input.len() as u32);
+        let lazy = with_built_tape(input, |tape| unsafe {
+            alloc_lazy_array(tape, 0, count_array_length(tape, 0), text)
+        })
+        .expect("valid JSON should build a tape");
+
+        let arr = unsafe { force_materialize_lazy(lazy) };
+
+        assert_eq!(crate::array::js_array_is_numeric_f64_layout(arr), 1);
+        assert_eq!(crate::array::js_array_numeric_get_f64_unboxed(arr, 0), 1.0);
+        assert_eq!(crate::array::js_array_numeric_get_f64_unboxed(arr, 1), 2.5);
+        assert_eq!(crate::array::js_array_numeric_get_f64_unboxed(arr, 2), 3.0);
+        assert_eq!(
+            crate::gc::test_layout_pointer_slot_count(arr as usize, 3),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn force_materialize_lazy_array_cache_downgrades_for_pointer_values() {
+        let input = br#"[1,2,3]"#;
+        let text = crate::string::js_string_from_bytes(input.as_ptr(), input.len() as u32);
+        let lazy = with_built_tape(input, |tape| unsafe {
+            alloc_lazy_array(tape, 0, count_array_length(tape, 0), text)
+        })
+        .expect("valid JSON should build a tape");
+
+        unsafe {
+            let cached = crate::string::js_string_from_bytes(b"cached".as_ptr(), 6);
+            *(*lazy).materialized_elements.add(1) =
+                JSValue::string_ptr(cached as *mut crate::StringHeader);
+            *(*lazy).materialized_bitmap |= 1u64 << 1;
+        }
+
+        let arr = unsafe { force_materialize_lazy(lazy) };
+
+        assert_eq!(crate::array::js_array_is_numeric_f64_layout(arr), 0);
+        assert_eq!(
+            crate::gc::test_layout_pointer_slot_count(arr as usize, 3),
+            Some(1)
+        );
+    }
 }
 
 impl PartialEq for TapeEntry {

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -225,7 +225,7 @@ pub extern "C" fn js_build_class_keys_array(
         unsafe {
             // GC_STORE_AUDIT(BARRIERED): cached method-name array records layout immediately after.
             *elements_ptr.add(i) = nanboxed;
-            crate::gc::layout_note_slot(arr as usize, i, nanboxed.to_bits());
+            crate::array::note_array_slot_layout_only(arr, i, nanboxed.to_bits());
         }
     }
     shape_cache_insert(shape_id, arr);
@@ -303,7 +303,7 @@ pub extern "C" fn js_object_alloc_class_with_keys(
             unsafe {
                 // GC_STORE_AUDIT(BARRIERED): cached keys array slot is reflected into layout metadata.
                 *elements_ptr.add(i) = nanboxed;
-                crate::gc::layout_note_slot(arr as usize, i, nanboxed.to_bits());
+                crate::array::note_array_slot_layout_only(arr, i, nanboxed.to_bits());
             }
         }
         shape_cache_insert(shape_id, arr);
@@ -376,7 +376,7 @@ pub extern "C" fn js_object_alloc_with_shape(
             unsafe {
                 // GC_STORE_AUDIT(BARRIERED): cached keys array slot is reflected into layout metadata.
                 *elements_ptr.add(i) = nanboxed;
-                crate::gc::layout_note_slot(arr as usize, i, nanboxed.to_bits());
+                crate::array::note_array_slot_layout_only(arr, i, nanboxed.to_bits());
             }
         }
         shape_cache_insert(shape_id, arr);

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1721,7 +1721,7 @@ unsafe fn http_methods_array() -> f64 {
             crate::value::STRING_TAG | (str_ptr as u64 & crate::value::POINTER_MASK),
         );
         *elements_ptr.add(i) = nanboxed;
-        crate::gc::layout_note_slot(arr as usize, i, nanboxed.to_bits());
+        crate::array::note_array_slot_layout_only(arr, i, nanboxed.to_bits());
     }
     let value = crate::value::js_nanbox_pointer(arr as i64);
     // GC_STORE_AUDIT(ROOT): HTTP_METHODS_CACHE is a mutable root visited by scan_object_cache_roots_mut.

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -10,8 +10,8 @@ use std::sync::{LazyLock, Mutex};
 use crate::array::ArrayHeader;
 use crate::object::ObjectHeader;
 use crate::value::{
-    BIGINT_TAG, INT32_TAG, POINTER_MASK, POINTER_TAG, SHORT_STRING_TAG, STRING_TAG, TAG_FALSE,
-    TAG_HOLE, TAG_MASK, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,
+    BIGINT_TAG, INT32_TAG, JS_HANDLE_TAG, POINTER_MASK, POINTER_TAG, SHORT_STRING_TAG, STRING_TAG,
+    TAG_FALSE, TAG_HOLE, TAG_MASK, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,
 };
 
 const POLYMORPHIC_CAP: usize = 4;
@@ -395,6 +395,7 @@ const STABLE_VALUE_STRING: u16 = 7;
 const STABLE_VALUE_BIGINT: u16 = 8;
 const STABLE_VALUE_POINTER: u16 = 9;
 const STABLE_VALUE_INT32: u16 = 10;
+const STABLE_VALUE_JS_HANDLE: u16 = 11;
 
 const ARRAY_ACCESS_UNKNOWN: u8 = 0;
 const ARRAY_ACCESS_INDEXED_IN_BOUNDS: u8 = 1;
@@ -424,6 +425,7 @@ fn stable_value_kind(bits: u64) -> u16 {
         POINTER_TAG => STABLE_VALUE_POINTER,
         STRING_TAG => STABLE_VALUE_STRING,
         BIGINT_TAG => STABLE_VALUE_BIGINT,
+        JS_HANDLE_TAG => STABLE_VALUE_JS_HANDLE,
         SHORT_STRING_TAG => STABLE_VALUE_SHORT_STRING,
         INT32_TAG => STABLE_VALUE_INT32,
         _ => STABLE_VALUE_NUMBER,
@@ -1860,4 +1862,6 @@ pub(crate) fn reset_typed_feedback_for_tests() {
 
 #[path = "typed_feedback/tests.rs"]
 mod tests;
+
+
 

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -1083,8 +1083,6 @@ fn object_key_matches_field(
     }
 }
 
-
-
 fn shape_keyed_object_addr(source: ObservationSource, object_addr: usize) -> usize {
     if matches!(
         source,
@@ -1859,9 +1857,5 @@ pub(crate) fn reset_typed_feedback_for_tests() {
 }
 
 #[cfg(test)]
-
 #[path = "typed_feedback/tests.rs"]
 mod tests;
-
-
-

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -981,6 +981,13 @@ fn is_plain_number_bits(bits: u64) -> bool {
     stable_value_kind(bits) == STABLE_VALUE_NUMBER
 }
 
+fn is_numeric_value_bits(bits: u64) -> bool {
+    matches!(
+        stable_value_kind(bits),
+        STABLE_VALUE_NUMBER | STABLE_VALUE_INT32
+    )
+}
+
 fn gc_header_for_user_addr(addr: usize) -> Option<*const crate::gc::GcHeader> {
     if addr < crate::gc::GC_HEADER_SIZE + 0x1000
         || (addr as u64) >> 48 != 0
@@ -1011,6 +1018,33 @@ fn plain_array_index_guard(arr: *const ArrayHeader, index: u32, require_in_bound
             return false;
         }
         !require_in_bounds || index < len
+    }
+}
+
+fn numeric_array_index_guard(arr: *const ArrayHeader, index: u32, require_in_bounds: bool) -> bool {
+    plain_array_index_guard(arr, index, require_in_bounds)
+        && crate::array::js_array_is_numeric_f64_layout(arr) != 0
+}
+
+fn numeric_array_push_guard(arr: *const ArrayHeader, value: f64) -> bool {
+    let raw_addr = normalize_raw_object_addr(arr as u64);
+    let Some(header) = gc_header_for_user_addr(raw_addr) else {
+        return false;
+    };
+    unsafe {
+        if (*header).obj_type != crate::gc::GC_TYPE_ARRAY
+            || (*header).gc_flags & crate::gc::GC_FLAG_FORWARDED != 0
+        {
+            return false;
+        }
+        let arr = raw_addr as *const ArrayHeader;
+        let len = (*arr).length;
+        let cap = (*arr).capacity;
+        len <= 16_000_000
+            && cap <= 16_000_000
+            && len < cap
+            && is_numeric_value_bits(value.to_bits())
+            && crate::array::js_array_is_numeric_f64_layout(arr) != 0
     }
 }
 
@@ -1046,6 +1080,8 @@ fn object_key_matches_field(
             && crate::string::js_string_equals(key, stored.as_string_ptr()) != 0
     }
 }
+
+
 
 fn shape_keyed_object_addr(source: ObservationSource, object_addr: usize) -> usize {
     if matches!(
@@ -1131,6 +1167,47 @@ pub extern "C" fn js_typed_feedback_plain_array_index_get_guard(
     let contract_valid = is_plain_number_bits(index_value.to_bits())
         && index >= 0
         && plain_array_index_guard(
+            raw_addr as *const ArrayHeader,
+            index as u32,
+            require_in_bounds != 0,
+        );
+    let pass = guard_observe(
+        site_id,
+        TypedFeedbackSiteKind::ArrayElement,
+        observation,
+        contract_valid,
+    );
+    if pass {
+        1
+    } else {
+        0
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_typed_feedback_numeric_array_index_get_guard(
+    site_id: u64,
+    receiver: f64,
+    index_value: f64,
+    index: i32,
+    require_in_bounds: i32,
+) -> i32 {
+    let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
+    let (class_id, heap_type, aux, element_kind) = classify_array(raw_addr, Some(observed_index));
+    let observation = Observation {
+        source: ObservationSource::Array,
+        object_addr: 0,
+        shape_addr: 0,
+        key_hash: 0,
+        class_id,
+        heap_type,
+        aux,
+        value_tag: element_kind,
+    };
+    let contract_valid = is_plain_number_bits(index_value.to_bits())
+        && index >= 0
+        && numeric_array_index_guard(
             raw_addr as *const ArrayHeader,
             index as u32,
             require_in_bounds != 0,
@@ -1324,6 +1401,84 @@ pub extern "C" fn js_typed_feedback_plain_array_index_set_guard(
         TypedFeedbackSiteKind::ArrayElement,
         observation,
         contract_valid,
+    );
+    if pass {
+        1
+    } else {
+        0
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_typed_feedback_numeric_array_index_set_guard(
+    site_id: u64,
+    receiver: f64,
+    index: i32,
+    value: f64,
+    require_in_bounds: i32,
+) -> i32 {
+    let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
+    let (class_id, heap_type, aux, _element_kind) = classify_array(raw_addr, Some(observed_index));
+    let observation = Observation {
+        source: ObservationSource::Array,
+        object_addr: 0,
+        shape_addr: 0,
+        key_hash: 0,
+        class_id,
+        heap_type,
+        aux,
+        value_tag: stable_value_kind(value.to_bits()),
+    };
+    let contract_valid = index >= 0
+        && is_numeric_value_bits(value.to_bits())
+        && numeric_array_index_guard(
+            raw_addr as *const ArrayHeader,
+            index as u32,
+            require_in_bounds != 0,
+        );
+    let pass = guard_observe(
+        site_id,
+        TypedFeedbackSiteKind::ArrayElement,
+        observation,
+        contract_valid,
+    );
+    if pass {
+        1
+    } else {
+        0
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_typed_feedback_numeric_array_push_guard(
+    site_id: u64,
+    receiver: f64,
+    value: f64,
+) -> i32 {
+    let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    let push_index = match gc_header_for_user_addr(raw_addr) {
+        Some(header) if unsafe { (*header).obj_type == crate::gc::GC_TYPE_ARRAY } => unsafe {
+            (*(raw_addr as *const ArrayHeader)).length
+        },
+        _ => u32::MAX,
+    };
+    let (class_id, heap_type, aux, _element_kind) = classify_array(raw_addr, Some(push_index));
+    let observation = Observation {
+        source: ObservationSource::Array,
+        object_addr: 0,
+        shape_addr: 0,
+        key_hash: 0,
+        class_id,
+        heap_type,
+        aux,
+        value_tag: stable_value_kind(value.to_bits()),
+    };
+    let pass = guard_observe(
+        site_id,
+        TypedFeedbackSiteKind::ArrayElement,
+        observation,
+        numeric_array_push_guard(raw_addr as *const ArrayHeader, value),
     );
     if pass {
         1
@@ -1702,5 +1857,7 @@ pub(crate) fn reset_typed_feedback_for_tests() {
 }
 
 #[cfg(test)]
+
 #[path = "typed_feedback/tests.rs"]
 mod tests;
+

--- a/crates/perry-runtime/src/typed_feedback/guards.rs
+++ b/crates/perry-runtime/src/typed_feedback/guards.rs
@@ -245,6 +245,7 @@ fn class_field_get_contract(
     expected_keys: *const ArrayHeader,
     key: *const crate::StringHeader,
     expected_field_index: u32,
+    require_raw_f64: bool,
 ) -> (usize, u32, u16, bool) {
     let object_addr = normalize_raw_object_addr(receiver.to_bits());
     if object_addr == 0 || expected_class_id == 0 || expected_keys.is_null() {
@@ -276,6 +277,11 @@ fn class_field_get_contract(
             && expected_field_index < (*obj).field_count
             && plain_array_index_guard(expected_keys, expected_field_index, true)
             && object_key_matches_field(obj, key, expected_field_index)
+            && (!require_raw_f64
+                || crate::gc::layout_typed_raw_f64_slot_for_user(
+                    object_addr,
+                    expected_field_index as usize,
+                ))
             && !class_getter_in_chain(class_id, &key_name)
             && !descriptor_blocks_class_field_get(object_addr, class_id, &key_name);
         (shape_addr, class_id, gc_type, valid)
@@ -290,6 +296,7 @@ pub extern "C" fn js_typed_feedback_class_field_get_guard(
     expected_keys: *const ArrayHeader,
     key: *const crate::StringHeader,
     expected_field_index: u32,
+    require_raw_f64: i32,
 ) -> i32 {
     let (shape_addr, class_id, gc_type, contract_valid) = class_field_get_contract(
         receiver,
@@ -297,6 +304,7 @@ pub extern "C" fn js_typed_feedback_class_field_get_guard(
         expected_keys,
         key,
         expected_field_index,
+        require_raw_f64 != 0,
     );
     let object_addr = normalize_raw_object_addr(receiver.to_bits());
     let observation = Observation {
@@ -364,6 +372,8 @@ fn class_field_set_contract(
     expected_keys: *const ArrayHeader,
     key: *const crate::StringHeader,
     expected_field_index: u32,
+    require_raw_f64: bool,
+    value_bits: u64,
 ) -> (usize, u32, u16, bool) {
     let object_addr = normalize_raw_object_addr(receiver.to_bits());
     if object_addr == 0 || expected_class_id == 0 || expected_keys.is_null() {
@@ -398,6 +408,12 @@ fn class_field_set_contract(
             && expected_field_index < (*obj).field_count
             && plain_array_index_guard(expected_keys, expected_field_index, true)
             && object_key_matches_field(obj, key, expected_field_index)
+            && (!require_raw_f64
+                || (is_plain_number_bits(value_bits)
+                    && crate::gc::layout_typed_raw_f64_slot_for_user(
+                        object_addr,
+                        expected_field_index as usize,
+                    )))
             && !class_setter_in_chain(class_id, &key_name)
             && !descriptor_blocks_class_field_set(object_addr, class_id, &key_name);
         (shape_addr, class_id, gc_type, valid)
@@ -413,13 +429,17 @@ pub extern "C" fn js_typed_feedback_class_field_set_guard(
     key: *const crate::StringHeader,
     expected_field_index: u32,
     value: f64,
+    require_raw_f64: i32,
 ) -> i32 {
+    let value_bits = value.to_bits();
     let (shape_addr, class_id, gc_type, contract_valid) = class_field_set_contract(
         receiver,
         expected_class_id,
         expected_keys,
         key,
         expected_field_index,
+        require_raw_f64 != 0,
+        value_bits,
     );
     let object_addr = normalize_raw_object_addr(receiver.to_bits());
     let observation = Observation {
@@ -430,7 +450,7 @@ pub extern "C" fn js_typed_feedback_class_field_set_guard(
         class_id,
         heap_type: gc_type,
         aux: expected_field_index as u64,
-        value_tag: stable_value_kind(value.to_bits()),
+        value_tag: stable_value_kind(value_bits),
     };
     if guard_observe(
         site_id,

--- a/crates/perry-runtime/src/typed_feedback/tests.rs
+++ b/crates/perry-runtime/src/typed_feedback/tests.rs
@@ -515,7 +515,8 @@ fn typed_feedback_class_field_set_guard_fails_for_frozen_object() {
     crate::object::js_object_set_field(obj, 0, crate::JSValue::from_bits(1.0f64.to_bits()));
     crate::object::js_object_freeze(receiver);
 
-    let guard = js_typed_feedback_class_field_set_guard(31, receiver, class_id, keys, key, 0, 2.0, 0);
+    let guard =
+        js_typed_feedback_class_field_set_guard(31, receiver, class_id, keys, key, 0, 2.0, 0);
     assert_eq!(guard, 0);
     assert_eq!(
         crate::object::js_object_get_field(obj, 0).bits(),
@@ -548,7 +549,8 @@ fn typed_feedback_class_field_set_guard_falls_back_for_class_setter() {
         );
     }
 
-    let guard = js_typed_feedback_class_field_set_guard(32, receiver, class_id, keys, key, 0, 7.0, 0);
+    let guard =
+        js_typed_feedback_class_field_set_guard(32, receiver, class_id, keys, key, 0, 7.0, 0);
     assert_eq!(guard, 0);
     js_typed_feedback_record_fallback_call(32);
     crate::object::js_object_set_field_by_name(obj, key, 7.0);
@@ -657,8 +659,16 @@ fn typed_feedback_class_field_set_guard_requires_raw_f64_value_and_layout() {
         0,
     );
 
-    let first =
-        js_typed_feedback_class_field_set_guard(44, receiver, class_id, expected_keys, key_x, 0, 2.0, 1);
+    let first = js_typed_feedback_class_field_set_guard(
+        44,
+        receiver,
+        class_id,
+        expected_keys,
+        key_x,
+        0,
+        2.0,
+        1,
+    );
     assert_eq!(first, 1);
 
     let payload = crate::string::js_string_from_bytes(b"boxed".as_ptr(), 5);

--- a/crates/perry-runtime/src/typed_feedback/tests.rs
+++ b/crates/perry-runtime/src/typed_feedback/tests.rs
@@ -675,9 +675,35 @@ fn typed_feedback_class_field_set_guard_requires_raw_f64_value_and_layout() {
     );
     assert_eq!(second, 0);
 
+    let short = crate::value::JSValue::try_short_string(b"abc").unwrap();
+    let third = js_typed_feedback_class_field_set_guard(
+        44,
+        receiver,
+        class_id,
+        expected_keys,
+        key_x,
+        0,
+        f64::from_bits(short.bits()),
+        1,
+    );
+    assert_eq!(third, 0);
+
+    let handle_value = f64::from_bits(crate::value::JS_HANDLE_TAG | 0x1234);
+    let fourth = js_typed_feedback_class_field_set_guard(
+        44,
+        receiver,
+        class_id,
+        expected_keys,
+        key_x,
+        0,
+        handle_value,
+        1,
+    );
+    assert_eq!(fourth, 0);
+
     let site = &typed_feedback_snapshot().sites[0];
     assert_eq!(site.guard_passes, 1);
-    assert_eq!(site.guard_failures, 1);
+    assert_eq!(site.guard_failures, 3);
 }
 
 #[test]

--- a/crates/perry-runtime/src/typed_feedback/tests.rs
+++ b/crates/perry-runtime/src/typed_feedback/tests.rs
@@ -419,6 +419,92 @@ fn typed_feedback_non_bounded_array_set_guard_failure_uses_jsvalue_object_fallba
 }
 
 #[test]
+fn typed_feedback_numeric_array_get_guard_requires_numeric_layout() {
+    let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
+    reset_typed_feedback_for_tests();
+    register(26, TypedFeedbackSiteKind::ArrayElement, "arr[i]");
+
+    let values = [1.0, 2.0];
+    let arr = crate::array::js_array_from_f64(values.as_ptr(), values.len() as u32);
+    let arr_box = crate::value::js_nanbox_pointer(arr as i64);
+
+    let first = js_typed_feedback_numeric_array_index_get_guard(26, arr_box, 0.0, 0, 1);
+    assert_eq!(first, 1);
+
+    let payload = crate::string::js_string_from_bytes(b"downgraded".as_ptr(), 10);
+    let payload_value = crate::value::js_nanbox_string(payload as i64);
+    crate::array::js_array_set_f64(arr, 0, payload_value);
+    assert_eq!(crate::array::js_array_is_numeric_f64_layout(arr), 0);
+
+    let second = js_typed_feedback_numeric_array_index_get_guard(26, arr_box, 0.0, 0, 1);
+    assert_eq!(second, 0);
+
+    let site = &typed_feedback_snapshot().sites[0];
+    assert_eq!(site.guard_passes, 1);
+    assert_eq!(site.guard_failures, 1);
+    assert_eq!(site.fallback_calls, 0);
+}
+
+#[test]
+fn typed_feedback_numeric_array_set_guard_requires_numeric_value_and_layout() {
+    let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
+    reset_typed_feedback_for_tests();
+    register(27, TypedFeedbackSiteKind::ArrayElement, "arr[i]=");
+
+    let values = [1.0, 2.0];
+    let arr = crate::array::js_array_from_f64(values.as_ptr(), values.len() as u32);
+    let arr_box = crate::value::js_nanbox_pointer(arr as i64);
+
+    let first = js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1, 3.0, 1);
+    assert_eq!(first, 1);
+
+    let payload = crate::string::js_string_from_bytes(b"not-number".as_ptr(), 10);
+    let payload_value = crate::value::js_nanbox_string(payload as i64);
+    let nonnumeric =
+        js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1, payload_value, 1);
+    assert_eq!(nonnumeric, 0);
+
+    crate::array::js_array_set_f64(arr, 0, payload_value);
+    let downgraded = js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1, 4.0, 1);
+    assert_eq!(downgraded, 0);
+
+    let site = &typed_feedback_snapshot().sites[0];
+    assert_eq!(site.guard_passes, 1);
+    assert_eq!(site.guard_failures, 2);
+    assert_eq!(site.fallback_calls, 0);
+}
+
+#[test]
+fn typed_feedback_numeric_array_push_guard_requires_room_numeric_value_and_layout() {
+    let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
+    reset_typed_feedback_for_tests();
+    register(28, TypedFeedbackSiteKind::ArrayElement, "arr.push");
+
+    let arr = crate::array::js_array_alloc(0);
+    let arr_box = crate::value::js_nanbox_pointer(arr as i64);
+
+    let first = js_typed_feedback_numeric_array_push_guard(28, arr_box, 1.0);
+    assert_eq!(first, 1);
+
+    let payload = crate::string::js_string_from_bytes(b"not-number".as_ptr(), 10);
+    let payload_value = crate::value::js_nanbox_string(payload as i64);
+    let nonnumeric = js_typed_feedback_numeric_array_push_guard(28, arr_box, payload_value);
+    assert_eq!(nonnumeric, 0);
+
+    let capacity = unsafe { (*arr).capacity };
+    for i in 0..capacity {
+        crate::array::js_array_push_f64(arr, i as f64);
+    }
+    let full = js_typed_feedback_numeric_array_push_guard(28, arr_box, 2.0);
+    assert_eq!(full, 0);
+
+    let site = &typed_feedback_snapshot().sites[0];
+    assert_eq!(site.guard_passes, 1);
+    assert_eq!(site.guard_failures, 2);
+    assert_eq!(site.fallback_calls, 0);
+}
+
+#[test]
 fn typed_feedback_class_field_set_guard_fails_for_frozen_object() {
     let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
     reset_typed_feedback_for_tests();
@@ -429,7 +515,7 @@ fn typed_feedback_class_field_set_guard_fails_for_frozen_object() {
     crate::object::js_object_set_field(obj, 0, crate::JSValue::from_bits(1.0f64.to_bits()));
     crate::object::js_object_freeze(receiver);
 
-    let guard = js_typed_feedback_class_field_set_guard(31, receiver, class_id, keys, key, 0, 2.0);
+    let guard = js_typed_feedback_class_field_set_guard(31, receiver, class_id, keys, key, 0, 2.0, 0);
     assert_eq!(guard, 0);
     assert_eq!(
         crate::object::js_object_get_field(obj, 0).bits(),
@@ -462,7 +548,7 @@ fn typed_feedback_class_field_set_guard_falls_back_for_class_setter() {
         );
     }
 
-    let guard = js_typed_feedback_class_field_set_guard(32, receiver, class_id, keys, key, 0, 7.0);
+    let guard = js_typed_feedback_class_field_set_guard(32, receiver, class_id, keys, key, 0, 7.0, 0);
     assert_eq!(guard, 0);
     js_typed_feedback_record_fallback_call(32);
     crate::object::js_object_set_field_by_name(obj, key, 7.0);
@@ -496,7 +582,7 @@ fn typed_feedback_class_field_get_guard_falls_back_after_shape_transition() {
     let (obj, expected_keys, key_x, receiver) = class_instance(class_id, b"x");
     crate::object::js_object_set_field(obj, 0, crate::JSValue::from_bits(5.0f64.to_bits()));
     let first =
-        js_typed_feedback_class_field_get_guard(39, receiver, class_id, expected_keys, key_x, 0);
+        js_typed_feedback_class_field_get_guard(39, receiver, class_id, expected_keys, key_x, 0, 0);
     assert_eq!(first, 1);
 
     let key_y = crate::string::js_string_from_bytes(b"y".as_ptr(), 1);
@@ -504,7 +590,7 @@ fn typed_feedback_class_field_get_guard_falls_back_after_shape_transition() {
     assert_ne!(unsafe { (*obj).keys_array }, expected_keys);
 
     let second =
-        js_typed_feedback_class_field_get_guard(39, receiver, class_id, expected_keys, key_x, 0);
+        js_typed_feedback_class_field_get_guard(39, receiver, class_id, expected_keys, key_x, 0, 0);
     assert_eq!(second, 0);
     js_typed_feedback_record_fallback_call(39);
     let stored = crate::object::js_object_get_field_by_name_f64(obj, key_x);
@@ -514,6 +600,84 @@ fn typed_feedback_class_field_get_guard_falls_back_after_shape_transition() {
     assert_eq!(site.guard_passes, 1);
     assert_eq!(site.guard_failures, 1);
     assert_eq!(site.fallback_calls, 1);
+}
+
+#[test]
+fn typed_feedback_class_field_get_guard_requires_raw_f64_layout_when_requested() {
+    let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
+    reset_typed_feedback_for_tests();
+    register(43, TypedFeedbackSiteKind::PropertyGet, "obj.x");
+
+    let class_id = 0x7EED_0043;
+    let (obj, expected_keys, key_x, receiver) = class_instance(class_id, b"x");
+    crate::object::js_object_set_unboxed_f64_field(obj, 0, 5.0);
+    let raw_mask = [0b1u64];
+    crate::gc::js_gc_init_typed_shape_layout(
+        obj as u64,
+        1,
+        raw_mask.as_ptr(),
+        raw_mask.len() as u32,
+        std::ptr::null(),
+        0,
+    );
+
+    let first =
+        js_typed_feedback_class_field_get_guard(43, receiver, class_id, expected_keys, key_x, 0, 1);
+    assert_eq!(first, 1);
+
+    let payload = crate::string::js_string_from_bytes(b"boxed".as_ptr(), 5);
+    crate::object::js_object_set_field(obj, 0, crate::JSValue::string_ptr(payload));
+
+    let second =
+        js_typed_feedback_class_field_get_guard(43, receiver, class_id, expected_keys, key_x, 0, 1);
+    assert_eq!(second, 0);
+
+    let site = &typed_feedback_snapshot().sites[0];
+    assert_eq!(site.guard_passes, 1);
+    assert_eq!(site.guard_failures, 1);
+    assert!(site.representation_invalidations >= 1);
+}
+
+#[test]
+fn typed_feedback_class_field_set_guard_requires_raw_f64_value_and_layout() {
+    let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
+    reset_typed_feedback_for_tests();
+    register(44, TypedFeedbackSiteKind::PropertySet, "obj.x=");
+
+    let class_id = 0x7EED_0044;
+    let (obj, expected_keys, key_x, receiver) = class_instance(class_id, b"x");
+    crate::object::js_object_set_unboxed_f64_field(obj, 0, 1.0);
+    let raw_mask = [0b1u64];
+    crate::gc::js_gc_init_typed_shape_layout(
+        obj as u64,
+        1,
+        raw_mask.as_ptr(),
+        raw_mask.len() as u32,
+        std::ptr::null(),
+        0,
+    );
+
+    let first =
+        js_typed_feedback_class_field_set_guard(44, receiver, class_id, expected_keys, key_x, 0, 2.0, 1);
+    assert_eq!(first, 1);
+
+    let payload = crate::string::js_string_from_bytes(b"boxed".as_ptr(), 5);
+    let payload_value = crate::value::js_nanbox_string(payload as i64);
+    let second = js_typed_feedback_class_field_set_guard(
+        44,
+        receiver,
+        class_id,
+        expected_keys,
+        key_x,
+        0,
+        payload_value,
+        1,
+    );
+    assert_eq!(second, 0);
+
+    let site = &typed_feedback_snapshot().sites[0];
+    assert_eq!(site.guard_passes, 1);
+    assert_eq!(site.guard_failures, 1);
 }
 
 #[test]

--- a/crates/perry-runtime/src/value/jsvalue.rs
+++ b/crates/perry-runtime/src/value/jsvalue.rs
@@ -65,10 +65,11 @@ impl JSValue {
     /// Check if this is a number (not a tagged value)
     #[inline]
     pub fn is_number(&self) -> bool {
-        // A value is a number if upper 16 bits are not in our tagged range 0x7FFC-0x7FFF
-        // This allows IEEE NaN (0x7FF8), negative numbers, and all other f64 through
-        let upper = self.bits >> 48;
-        !(0x7FFC..=0x7FFF).contains(&upper)
+        // Perry-owned tags occupy the positive qNaN band 0x7FF9..=0x7FFF.
+        // Keep IEEE f64 values, including canonical qNaN 0x7FF8 and negative
+        // NaN payloads, classified as numbers.
+        let tag = self.bits & TAG_MASK;
+        !(SHORT_STRING_TAG..=STRING_TAG).contains(&tag)
     }
 
     /// Check if this is undefined

--- a/crates/perry-runtime/src/value/mod.rs
+++ b/crates/perry-runtime/src/value/mod.rs
@@ -17,6 +17,7 @@
 //! We use the top 16 bits for tagging:
 //! - 0x7FF9: short string (SSO, inline 5-byte payload)
 //! - 0x7FFA: bigint pointer
+//! - 0x7FFB: JS runtime handle
 //! - 0x7FFC + tag: singleton specials (undefined / null / true / false / hole)
 //! - 0x7FFD: object/array pointer (48-bit payload)
 //! - 0x7FFE: int32 (low 32 bits)

--- a/crates/perry-runtime/src/value/tests.rs
+++ b/crates/perry-runtime/src/value/tests.rs
@@ -109,6 +109,7 @@ fn test_short_string_encoding_roundtrip() {
         assert!(v.is_short_string(), "tag mismatch for {:?}", s);
         assert!(v.is_any_string(), "is_any_string should accept SSO");
         assert!(!v.is_string(), "legacy is_string should NOT accept SSO");
+        assert!(!v.is_number(), "SSO strings are Perry tags, not numbers");
         assert_eq!(v.short_string_len(), s.len(), "length mismatch for {:?}", s);
         let mut buf = [0u8; SHORT_STRING_MAX_LEN];
         let n = v.short_string_to_buf(&mut buf);
@@ -162,6 +163,17 @@ fn test_short_string_tag_distinct_from_others() {
     assert!(!pointer.is_any_string());
     assert!(!int32.is_any_string());
     assert!(!number.is_any_string());
+}
+
+#[test]
+fn test_tagged_values_are_not_numbers() {
+    assert!(!JSValue::try_short_string(b"abc").unwrap().is_number());
+    assert!(!JSValue::from_bits(BIGINT_TAG | 0x1234).is_number());
+    assert!(!JSValue::from_bits(JS_HANDLE_TAG | 0x5678).is_number());
+    assert!(!JSValue::undefined().is_number());
+    assert!(!JSValue::int32(42).is_number());
+    assert!(JSValue::from_bits(0x7FF8_0000_0000_0000).is_number());
+    assert!(JSValue::number(f64::NAN).is_number());
 }
 
 #[test]

--- a/scripts/run_memory_stability_tests.sh
+++ b/scripts/run_memory_stability_tests.sh
@@ -1530,6 +1530,8 @@ run_raw_numeric_object_fields_codegen_semantics() {
         '3.75' \
         '{"value":{"label":"class-transition"},"other":"boxed"}' \
         'class-transition' \
+        '{"value":"abc","other":"boxed"}' \
+        'abc' \
         'frozen-write-error' \
         '9.5' \
         'sealed-extra-error' \

--- a/scripts/run_memory_stability_tests.sh
+++ b/scripts/run_memory_stability_tests.sh
@@ -1491,15 +1491,14 @@ run_target_collector_pointer_free_trace() {
     return 1
 }
 
-run_unboxed_object_fields_codegen_semantics() {
-    local label="unboxed object field semantics"
-    local bin="$TMPDIR/unboxed_object_fields_codegen_semantics"
-    local compile_output="$TMPDIR/unboxed_object_fields_compile.$$.$RANDOM"
-    local expected_output="$TMPDIR/unboxed_object_fields_expected.$$.$RANDOM"
-    local diff_output="$TMPDIR/unboxed_object_fields_diff.$$.$RANDOM"
+run_raw_numeric_object_fields_codegen_semantics() {
+    local label="raw numeric object field semantics"
+    local bin="$TMPDIR/raw_numeric_object_fields_codegen_semantics"
+    local compile_output="$TMPDIR/raw_numeric_object_fields_compile.$$.$RANDOM"
+    local expected_output="$TMPDIR/raw_numeric_object_fields_expected.$$.$RANDOM"
+    local diff_output="$TMPDIR/raw_numeric_object_fields_diff.$$.$RANDOM"
 
-    if ! env PERRY_UNBOXED_OBJECT_FIELDS=1 \
-        $PERRY compile --no-cache tests/unboxed_object_fields.ts -o "$bin" \
+    if ! $PERRY compile --no-cache tests/raw_numeric_object_fields.ts -o "$bin" \
         >"$compile_output" 2>&1; then
         printf "  FAIL [target-gc] %-40s compile failed\n" "$label"
         sed 's/^/    /' "$compile_output"
@@ -1517,10 +1516,26 @@ run_unboxed_object_fields_codegen_semantics() {
     fi
 
     printf '%s\n' \
-        '{"x":3.5,"y":4.25}' \
-        '33.8125' \
-        '{"x":{"label":"heap"},"y":4.25}' \
-        'heap' >"$expected_output"
+        '{"x":3.5,"y":4.25,"negZero":0,"nan":null,"wide":2147483648.5}' \
+        'true' \
+        'true' \
+        '2147483648.5' \
+        '7.75' \
+        '{"x":3.5,"y":4.25,"negZero":0,"nan":null,"wide":2147483648.5}' \
+        '6.25' \
+        '{"x":{"label":"callback"},"y":6.25,"negZero":0,"nan":null,"wide":2147483648.5}' \
+        'callback' \
+        '{"value":7.75}' \
+        '{"value":{"label":"boxed"}}' \
+        '3.75' \
+        '{"value":{"label":"class-transition"},"other":"boxed"}' \
+        'class-transition' \
+        'frozen-write-error' \
+        '9.5' \
+        'sealed-extra-error' \
+        '{"value":12.5}' \
+        '44' \
+        '15.5' >"$expected_output"
 
     if ! diff -u "$expected_output" "$LAST_STDOUT_FILE" >"$diff_output"; then
         printf "  FAIL [target-gc] %-40s stdout mismatch\n" "$label"
@@ -1793,7 +1808,7 @@ run_canary "unboxed object canaries" \
     cargo test -p perry-runtime --release test_unboxed_object
 run_canary "typed/unboxed codegen layout installers" \
     cargo test -p perry-codegen --release --test typed_shape_descriptor --test typed_shape_descriptors -- --test-threads=1
-run_unboxed_object_fields_codegen_semantics
+run_raw_numeric_object_fields_codegen_semantics
 run_canary "managed string allocation" \
     cargo test -p perry-runtime --release test_small_js_string_alloc_uses_managed_nursery_page
 run_canary "managed closure allocation" \

--- a/tests/raw_numeric_object_fields.ts
+++ b/tests/raw_numeric_object_fields.ts
@@ -65,6 +65,11 @@ console.log(c.bump(2.25));
 console.log(JSON.stringify(c));
 console.log((c as any).value.label);
 
+const shortStringCounter = new Counter();
+(shortStringCounter as any).value = "abc";
+console.log(JSON.stringify(shortStringCounter));
+console.log((shortStringCounter as any).value);
+
 class GuardedCounter {
   value: number = 9.5;
 }

--- a/tests/raw_numeric_object_fields.ts
+++ b/tests/raw_numeric_object_fields.ts
@@ -1,0 +1,110 @@
+interface Point {
+  x: number;
+  y: number;
+  negZero: number;
+  nan: number;
+  wide: number;
+}
+
+interface AnyBox {
+  value: any;
+}
+
+function overwriteDynamic(p: any): void {
+  p["y"] = 6.25;
+}
+
+function mutateCallback(p: any): void {
+  p.x = { label: "callback" };
+}
+
+const p: Point = {
+  x: 3.5,
+  y: 4.25,
+  negZero: -0,
+  nan: NaN,
+  wide: 2147483648.5,
+};
+
+const before = JSON.stringify(p);
+const { x, y } = p;
+const spread = { ...p };
+
+console.log(before);
+console.log(Number.isNaN(p.nan));
+console.log(Object.is(p.negZero, -0));
+console.log(p.wide);
+console.log(x + y);
+console.log(JSON.stringify(spread));
+
+overwriteDynamic(p);
+console.log(p.y);
+
+mutateCallback(p);
+console.log(JSON.stringify(p));
+console.log((p as any).x.label);
+
+const anyBox: AnyBox = { value: 7.75 };
+console.log(JSON.stringify(anyBox));
+(anyBox as any).value = { label: "boxed" };
+console.log(JSON.stringify(anyBox));
+
+class Counter {
+  value: number = 1.5;
+  other: any = "boxed";
+
+  bump(delta: number): number {
+    this.value = this.value + delta;
+    return this.value;
+  }
+}
+
+const c = new Counter();
+console.log(c.bump(2.25));
+(c as any).value = { label: "class-transition" };
+console.log(JSON.stringify(c));
+console.log((c as any).value.label);
+
+class GuardedCounter {
+  value: number = 9.5;
+}
+
+const frozen = new GuardedCounter();
+Object.freeze(frozen);
+try {
+  frozen.value = 14.5;
+  console.log("frozen-write-ok");
+} catch (e) {
+  console.log("frozen-write-error");
+}
+console.log(frozen.value);
+
+const sealed = new GuardedCounter();
+Object.seal(sealed);
+sealed.value = 12.5;
+try {
+  (sealed as any).extra = 99;
+  console.log("sealed-extra-ok");
+} catch (e) {
+  console.log("sealed-extra-error");
+}
+console.log(JSON.stringify(sealed));
+
+let accessorSeen = 0;
+function readAccessor(): number {
+  return 44;
+}
+function writeAccessor(v: number): void {
+  accessorSeen = v;
+}
+
+const accessorBox = new GuardedCounter();
+Object.defineProperty(accessorBox, "value", {
+  get: readAccessor,
+  set: writeAccessor,
+  enumerable: true,
+  configurable: true,
+});
+console.log(accessorBox.value);
+accessorBox.value = 15.5;
+console.log(accessorSeen);


### PR DESCRIPTION
## Summary

Closes #1096.

This PR adds the guarded raw numeric heap-layout slice on top of the typed-feedback foundation and dispatch-specialization work that already landed in #1752 and #1762.

It includes:
- ABI-stable raw-f64 side payloads for numeric arrays with guarded get/set/push paths.
- Pointer-free GC proof for raw numeric array payloads.
- Raw-f64 typed-shape metadata for numeric object fields with guarded field access/fallback.
- Downgrade/rebuild behavior when array/object writes can no longer stay raw numeric.
- Rejection of Perry-owned NaN-box tags in raw numeric fields, including short-string/handle guard coverage.
- A proactive fix to keep typed-feedback numeric-array push guards out of hot loop bodies when the pushed value is already plainly numeric.

## Why this matters

This is the #1096 layout step: TypeScript/HIR numeric knowledge now helps shape runtime heap layout without changing Perry's JSValue/NaN-box ABI. Numeric data can stay raw and pointer-free where guarded safe, reducing GC scan surface and heap traffic while preserving JS-visible fallback behavior.

## Previous failure class checked

I checked the same kind of issue that broke the prior PR train: typed-feedback guard calls leaking into hot numeric loops. The compiler-output regression gate originally caught a `js_typed_feedback_numeric_array_push_guard` call in `loop_data_dependent`; this PR includes the fix and the gate is now green with hot-loop runtime calls `{}`.

## Verification

- `cargo test -p perry-codegen --test typed_shape_descriptors -- --test-threads=1`
- `cargo test -p perry-codegen --test typed_feedback -- --test-threads=1`
- `cargo test -p perry-runtime typed_feedback -- --test-threads=1`
- `cargo test -p perry-runtime raw_f64 -- --test-threads=1`
- `cargo test -p perry-codegen --test typed_shape_descriptor -- --test-threads=1`
- `cargo check -p perry-runtime -p perry-codegen`
- `cargo build -p perry`
- `python3.11 scripts/compiler_output_regression.py capture --perry target/debug/perry --workload loop_data_dependent --benchmark-mode smoke --runs 1 --perf-counters off --gate --print-summary`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
