### PR TITLE
fix(node:async_hooks): complete promise/await lifecycle + retain #1762 guard exports (#789, #788, #1423)

### DIFF
--- a/crates/perry-runtime/src/async_hooks.rs
+++ b/crates/perry-runtime/src/async_hooks.rs
@@ -131,6 +131,15 @@ fn box_ptr(ptr: *const u8) -> f64 {
     f64::from_bits(POINTER_TAG | (ptr as u64 & POINTER_MASK))
 }
 
+/// NaN-box a `StringHeader` pointer with `STRING_TAG` so JS sees a real
+/// string (#789): the `init` hook's `type` argument is a string like
+/// `"PROMISE"` — boxing it as a generic `POINTER_TAG` made the callback
+/// observe `[object Object]` instead.
+#[inline]
+fn box_string(ptr: *const u8) -> f64 {
+    f64::from_bits(STRING_TAG | (ptr as u64 & POINTER_MASK))
+}
+
 fn ptr_from_nanboxed(value: f64) -> *const u8 {
     let bits = value.to_bits();
     let tag = bits & TAG_MASK;
@@ -312,7 +321,7 @@ fn emit_init(async_id: u64, type_name: &str, trigger_async_id: u64, resource: f6
     let scope = crate::gc::RuntimeHandleScope::new();
     let resource_handle = scope.root_nanbox_f64(resource);
     let type_ptr = js_string_from_bytes(type_name.as_ptr(), type_name.len() as u32);
-    let type_value_handle = scope.root_nanbox_f64(box_ptr(type_ptr as *const u8));
+    let type_value_handle = scope.root_nanbox_f64(box_string(type_ptr as *const u8));
     with_hook_callbacks(|callbacks| {
         if !callbacks.init.is_null() {
             let callback_handle = scope.root_raw_const_ptr(callbacks.init);

--- a/crates/perry-runtime/src/promise/microtasks.rs
+++ b/crates/perry-runtime/src/promise/microtasks.rs
@@ -516,6 +516,26 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
                 } else {
                     f64::from_bits(0x7FFC_0000_0000_0003) // TAG_FALSE
                 };
+                // #789: bracket the await continuation with async_hooks
+                // before/after so `executionAsyncId()` reflects the async
+                // function's resource id during its resumed body and the
+                // before/after hooks fire — mirroring the `Task::Promise`
+                // arm above. Capture the result promise's ids as plain
+                // values BEFORE the callback (a re-entrant drain can move
+                // `next` via GC, #1663) and feed the same id to `after()`.
+                // `before`/`after` early-return on id 0, so this is a no-op
+                // when async_hooks are inactive.
+                let step_async_id = if next.is_null() {
+                    0
+                } else {
+                    unsafe { (*next).async_id }
+                };
+                let step_trigger_id = if next.is_null() {
+                    0
+                } else {
+                    unsafe { (*next).trigger_async_id }
+                };
+                crate::async_hooks::before(step_async_id, step_trigger_id);
                 let result = call_async_step_direct(step_closure, value, is_error_bits);
                 CURRENT_MICROTASK_VALUE.with(|c| c.set(result));
                 if let Some(t) = t1 {
@@ -530,6 +550,9 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
                             as usize,
                     })
                 });
+                // #789: pair the `before()` above — fires the after hook and
+                // pops the execution-id stack using the captured id.
+                crate::async_hooks::after(step_async_id);
                 CURRENT_MICROTASK_CALLBACK.with(|c| c.set(std::ptr::null()));
 
                 let t2 = if prof {

--- a/crates/perry-runtime/src/typed_feedback/guards.rs
+++ b/crates/perry-runtime/src/typed_feedback/guards.rs
@@ -655,3 +655,23 @@ pub extern "C" fn js_typed_feedback_closure_direct_call_guard(
         0
     }
 }
+
+// #1764 (follow-up): the guard helpers in this submodule are codegen-emitted
+// `#[no_mangle]` exports with no Rust-side caller, so the auto-optimize
+// whole-program thin-LTO + `strip=true` build internalizes + dead-strips them
+// — dangling the codegen call at final link (`Undefined symbols:
+// _js_typed_feedback_class_field_set_guard` for any class-field program).
+// `typed_feedback.rs`'s `#[used]` block covers the helpers defined there;
+// these typed fn-pointer statics extend the same `@llvm.used` retention to the
+// guard helpers defined here. (A `usize`/`*const()` cast does NOT survive
+// thin-LTO — only individual typed fn-pointer statics keep the symbol
+// external.) The statics must mirror each guard's exact signature, so keep
+// them in sync if a guard's parameter list changes.
+#[rustfmt::skip]
+mod keep_guard_symbols {
+    use super::*;
+    #[used] static G0: extern "C" fn(u64, f64, u32, *const ArrayHeader, *const crate::StringHeader, u32, i32) -> i32 = js_typed_feedback_class_field_get_guard;
+    #[used] static G1: extern "C" fn(u64, f64, u32, *const ArrayHeader, *const crate::StringHeader, u32, f64, i32) -> i32 = js_typed_feedback_class_field_set_guard;
+    #[used] static G2: unsafe extern "C" fn(u64, f64, u32, *const ArrayHeader, *const i8, usize, *const u8) -> i32 = js_typed_feedback_method_direct_call_guard;
+    #[used] static G3: extern "C" fn(u64, f64, *const u8, u32, u32) -> i32 = js_typed_feedback_closure_direct_call_guard;
+}

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -44,12 +44,6 @@
     "category": "gap-categorical",
     "reason": "Lookbehind regex assertions — Rust's `regex` crate doesn't support `(?<=)` / `(?<!)`. Documented in CLAUDE.md as a known categorical gap. Unblocking requires swapping the regex backend or implementing a separate matcher for lookbehind."
   },
-  "test_harness_async_context": {
-    "issue": "788",
-    "added": "2026-05-24",
-    "category": "bug-stale",
-    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #788 is closed. Deliberate failing repro/harness — kept as a regression canary. #807 harness for AsyncLocalStorage propagation through await/microtask/timer and async_hooks.createHook lifecycle. Perry now preserves ALS context across await chains, queueMicrotask, setTimeout, nested runs, and concurrent Promise.all branches (#788). Remaining failure is section 8: createHook returns undefined / lacks lifecycle + asyncId tracking, tracked by #789."
-  },
   "test_harness_class_mixins": {
     "issue": "806",
     "added": "2026-05-24",
@@ -103,12 +97,6 @@
     "added": "2026-05-24",
     "category": "bug-stale",
     "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #922 is closed. Deliberate failing repro/harness — kept as a regression canary. Regression test from #922 (P0 production /api crash). Deliberate failing repro until the underlying codegen bug is fixed; #934 added a circuit breaker that converts the runaway loop into [PERRY ABORT] (so test fails by design — the abort message diverges from Node's success output)."
-  },
-  "test_async_local_storage_context": {
-    "issue": "1423",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "AsyncLocalStorage `.enterWith()` / `.exit()` aren't implemented end-to-end — the test prints the first 10 lines (await/then/catch/nextTick/timer/immediate/interval contexts + nested outer) and then exits silently when `enterWith()` is invoked, missing the last 7 lines covering enterWith semantics + exit/restore mechanics. Sibling slice of #788 #789 (real AsyncLocalStorage tracking across await/microtasks/timers + real `async_hooks.createHook` lifecycle). Surfaced as a NEW failure on v0.5.1024 release-packages parity. Flips to PASS when `.enterWith` / `.exit` land."
   },
   "test_jsruntime_mixed_async_ordering_matrix": {
     "issue": "1635",
@@ -1633,12 +1621,6 @@
     "added": "2026-05-17",
     "category": "bug-open",
     "reason": "Regression test from #911 (express map undefined / http.METHODS). The METHODS property is now in the manifest (PR adding it alongside this entry); the test may still diverge from Node in the exact METHODS list shape. Re-evaluate once express compiles cleanly."
-  },
-  "test_parity_async_hooks": {
-    "issue": "789",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:async_hooks` createHook lifecycle + asyncId tracking missing. Tracked in #789. Flips to PASS once createHook fires."
   },
   "test_parity_stream_promises": {
     "issue": "793",


### PR DESCRIPTION
## Summary

Finishes the async-context work. The core landed earlier (#852 AsyncLocalStorage propagation, #865 async_hooks foundation); this closes the remaining `node:async_hooks` lifecycle gaps and a retention follow-up that kept it from working in release builds.

**Closes #789, #788, #1423.**

## #789 — async_hooks lifecycle on promise/await

Two bugs made the hook lifecycle diverge from Node:

1. **`init` hook `type` was `[object Object]`** — `emit_init` boxed the type string with `POINTER_TAG` instead of `STRING_TAG`, so `init(asyncId, type, …)` handed the callback a generic object rather than the string `"PROMISE"`. Fixed with a `box_string` helper.
2. **`executionAsyncId()` stayed 0 across `await`; the `after` hook never fired** — the `Task::Promise` (`.then`) arm already brackets its callback with `async_hooks::before`/`after`, but the `Task::AsyncStep` (await-continuation) arm didn't. It now does, using the result promise's `async_id` (captured as a plain value before the callback per the #1663 GC-reentrancy lesson; `before`/`after` early-return on id 0, so it's a no-op when async_hooks are inactive).

Probe vs `node --experimental-strip-types` now matches: `executionAsyncId()` is non-zero inside an awaited continuation, `init` reports `"PROMISE"`, and `before`+`after` both fire.

## #1764 follow-up — retain #1762's guard exports

#1762 added class-field / direct-call guard helpers in `typed_feedback/guards.rs` (`js_typed_feedback_class_field_set_guard`, `…_get_guard`, `method_direct_call_guard`, `closure_direct_call_guard`) with no `#[used]` anchors — after my #1765 retention block (which covered the helpers in `typed_feedback.rs`). The auto-optimize thin-LTO + `strip=true` build dead-stripped them, so **any class-field program** (including the async harness) failed to link under the default build. Added typed fn-pointer retention anchors for the four new guards (same `@llvm.used` mechanism as #1765).

## Verification

- All four async tests (`test_harness_async_context`, `test_async_local_storage_context`, `test_parity_async_hooks`, `test_parity_async_local_storage`) pass byte-for-byte vs Node under **both** `PERRY_NO_AUTO_OPTIMIZE=1` and the default auto-optimize build (they previously failed to link under auto-optimize).
- Removed their now-stale `known_failures.json` entries.

Note: the four async tests' `known_failures` reasons cited Linux-specific failures (one was already flagged `bug-stale`); verified passing on macOS in both build modes — worth a Linux re-check at merge since the parity gate is tag-gated.
