### PR TITLE
fix(hir): assign derived-class TS parameter properties after super() (toward Effect #321)

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_members.rs
+++ b/crates/perry-hir/src/lower_decl/class_members.rs
@@ -151,17 +151,38 @@ pub fn lower_constructor(
     // In TypeScript, `constructor(public name: string)` automatically assigns
     // `this.name = name` at the start of the constructor body.
     if !param_prop_assignments.is_empty() {
-        let mut synthetic_stmts: Vec<Stmt> = Vec::new();
-        for (param_id, field_name) in &param_prop_assignments {
-            synthetic_stmts.push(Stmt::Expr(Expr::PropertySet {
-                object: Box::new(Expr::This),
-                property: field_name.clone(),
-                value: Box::new(Expr::LocalGet(*param_id)),
-            }));
+        let assignments: Vec<Stmt> = param_prop_assignments
+            .iter()
+            .map(|(param_id, field_name)| {
+                Stmt::Expr(Expr::PropertySet {
+                    object: Box::new(Expr::This),
+                    property: field_name.clone(),
+                    value: Box::new(Expr::LocalGet(*param_id)),
+                })
+            })
+            .collect();
+        // For a derived class, `this` is unusable until `super()` runs, so TS
+        // emits the param-property assignments immediately AFTER the super()
+        // call — not at the top. Prepending them (the historical behavior)
+        // dropped the derived class's own param-props: e.g. SchemaAST's
+        // `class OptionalType extends Type { constructor(type, readonly
+        // isOptional, ...) { super(type, ...) } }` left `this.isOptional`
+        // undefined, which cascaded into `typeAST(undefined)` reading `._tag`
+        // during effect Schema init (#1758). Base classes (no super() call)
+        // keep prepending. The default-param / destructuring prologues below
+        // touch only params (not `this`), so they stay at the very top.
+        if let Some(super_pos) = body
+            .iter()
+            .position(|s| matches!(s, Stmt::Expr(Expr::SuperCall(_))))
+        {
+            let tail = body.split_off(super_pos + 1);
+            body.extend(assignments);
+            body.extend(tail);
+        } else {
+            let mut synthetic_stmts = assignments;
+            synthetic_stmts.append(&mut body);
+            body = synthetic_stmts;
         }
-        // Prepend synthetic assignments before the user-written constructor body
-        synthetic_stmts.append(&mut body);
-        body = synthetic_stmts;
     }
 
     // Issue #572: prepend destructuring extractions for ctor params (the

--- a/test-files/test_gap_derived_param_props.ts
+++ b/test-files/test_gap_derived_param_props.ts
@@ -1,0 +1,48 @@
+// Issue #1758/#321: a derived-class constructor's own TS parameter properties
+// must be assigned AFTER the super() call (TS semantics: `this` is unusable
+// before super). Perry previously prepended `this.field = param` to the top of
+// the constructor body, so for a class that calls super() the derived class's
+// own param-props were dropped (left undefined) — e.g. effect's SchemaAST
+// `class OptionalType extends Type { constructor(type, readonly isOptional) {
+// super(type) } }` lost `this.isOptional`.
+//
+// Node's --experimental-strip-types can't run parameter properties, so this is
+// a perry-only expected-output test.
+//
+// Expected output:
+// base: 1 def
+// mid: 2 mid true [9]
+// leaf: 3 mid false [1,2] leaf
+// withBody: 5 T init-T
+
+class Base {
+  constructor(public a: number, readonly b: string = "def") {}
+}
+const base = new Base(1);
+console.log("base:", base.a, base.b);
+
+class Mid extends Base {
+  constructor(a: number, public c: boolean, readonly d: number[] = [9]) {
+    super(a, "mid");
+  }
+}
+const mid = new Mid(2, true);
+console.log("mid:", mid.a, mid.b, mid.c, JSON.stringify(mid.d));
+
+class Leaf extends Mid {
+  constructor(public e: string) {
+    super(3, false, [1, 2]);
+  }
+}
+const leaf = new Leaf("leaf");
+console.log("leaf:", leaf.a, leaf.b, leaf.c, JSON.stringify(leaf.d), leaf.e);
+
+class WithBody extends Base {
+  log: string;
+  constructor(a: number, readonly tag: string) {
+    super(a);
+    this.log = "init-" + this.tag;
+  }
+}
+const wb = new WithBody(5, "T");
+console.log("withBody:", wb.a, wb.tag, wb.log);


### PR DESCRIPTION
## Summary

A derived-class constructor's own TS **parameter properties** were dropped, leaving the fields `undefined`. Found while pursuing Effect end-to-end (#321) — it's one of the blockers behind the barrel-import `Schema.ts` failure tracked in #1758.

Param-property assignments (`this.x = x` for `constructor(readonly x: T)`) were synthesized by **prepending** them to the top of the constructor body. In a *derived* class the body starts with the `super(...)` call, and per JS/TS semantics `this` is unusable before `super()` runs — so the prepended assignments were dropped, and only base-class param-props (assigned inside the base constructor, reached via `super()`) survived.

effect's `SchemaAST` hits this directly:

```ts
class Type {
  constructor(readonly type: AST, readonly annotations: Annotations = {}) {}
}
class OptionalType extends Type {
  constructor(type: AST, readonly isOptional: boolean, annotations: Annotations = {}) {
    super(type, annotations)   // this.type via super: OK
  }                            // this.isOptional: was dropped → undefined
}
```

## Fix

`crates/perry-hir/src/lower_decl/class_members.rs`: when the constructor body contains a `SuperCall`, splice the synthesized `this.field = param` assignments in immediately **after** it (matching TypeScript's emit order); base classes with no `super()` keep prepending. The default-param and destructuring prologues touch only params (not `this`), so they stay at the top and still run before `super()`.

## Validation

- New perry-validated test `test-files/test_gap_derived_param_props.ts` (Node `--experimental-strip-types` can't run parameter properties): base class, derived + own param-props + defaults, three-level chain, and a derived ctor whose post-`super()` body reads its own param-prop (`this.log = "init-" + this.tag`).

```
base: 1 def
mid: 2 mid true [9]
leaf: 3 mid false [1,2] leaf
withBody: 5 T init-T
```

- `import * as Effect from "effect/Effect"; Effect.runSync(Effect.succeed(42))` still prints `42` (no regression).

## Note on #1758

This is one layer of #1758. After it, the barrel import still fails: the deeper blocker is that perry hoists a **class expression to a single shared class** (so `make(a) === make(b)`), which means effect's `make(ast)` factory can't give each schema its own `static ast` — every schema's `.ast` is `undefined`/clobbered. That architectural item (per-evaluation class identity for class expressions) is tracked separately under #1758/#321.

Refs #1758, #321.
