### PR TITLE
fix(runtime): Buffer.from() handles inline SSO short strings (#1767)

### DIFF
--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -15,7 +15,16 @@ pub extern "C" fn js_buffer_from_string(
         let len = (*str_ptr).byte_len as usize;
         let data_ptr = (str_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
         let str_bytes = std::slice::from_raw_parts(data_ptr, len);
+        buffer_from_str_bytes(str_bytes, encoding)
+    }
+}
 
+/// Decode a raw string byte-slice into a Buffer according to the encoding
+/// tag (see `js_buffer_from_string` for the tag legend). Shared by the heap
+/// `StringHeader` path and the inline SSO short-string path so both honor
+/// the same hex / base64 / latin1 / utf8 semantics.
+fn buffer_from_str_bytes(str_bytes: &[u8], encoding: i32) -> *mut BufferHeader {
+    unsafe {
         match encoding {
             // v0.5.772 perf: decode directly into the BufferHeader instead of
             // routing through `decode_hex(&[u8]) -> Vec<u8>` + a follow-up
@@ -27,6 +36,7 @@ pub extern "C" fn js_buffer_from_string(
             4 | 5 => latin1_string_to_buffer(str_bytes),
             _ => {
                 // UTF-8 (default)
+                let len = str_bytes.len();
                 let buf = buffer_alloc(len as u32);
                 (*buf).length = len as u32;
                 ptr::copy_nonoverlapping(str_bytes.as_ptr(), buffer_data_mut(buf), len);
@@ -121,10 +131,25 @@ pub extern "C" fn js_buffer_from_value(value: i64, encoding: i32) -> *mut Buffer
     let bits = value as u64;
     let jsval = crate::JSValue::from_bits(bits);
 
-    // Check if it's a NaN-boxed string
+    // Check if it's a NaN-boxed heap string
     if jsval.is_string() {
         let str_ptr = jsval.as_string_ptr();
         return js_buffer_from_string(str_ptr as *const crate::string::StringHeader, encoding);
+    }
+
+    // Inline SSO short string (SHORT_STRING_TAG = 0x7FF9): strings of length
+    // 0..=5 carry their bytes inside the NaN-box payload instead of a heap
+    // `StringHeader`. `is_string()` above is STRING_TAG-only and rejects
+    // these, so without this branch the SSO value would fall through to the
+    // pointer-extraction path below, where its inline bytes (e.g. the ASCII
+    // of a 5-char `apiKey`) are misread as an array/buffer pointer and
+    // dereferenced — the #1767 SIGSEGV in `Buffer.from(shortString)` reached
+    // from `@perryts/mysql`'s prepared-statement param encoder. Decode the
+    // inline bytes and route through the shared encoder.
+    if jsval.is_short_string() {
+        let mut tmp = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+        let len = jsval.short_string_to_buf(&mut tmp);
+        return buffer_from_str_bytes(&tmp[..len], encoding);
     }
 
     // Extract the raw pointer

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -216,4 +216,50 @@ mod tests {
         let decoded = decode_base64(&encoded);
         assert_eq!(decoded, original);
     }
+
+    /// #1767: `Buffer.from(shortString)` must handle inline SSO strings.
+    /// A string of length 0..=5 lives in the NaN-box payload (tag 0x7FF9),
+    /// not behind a heap `StringHeader`. `js_buffer_from_value` only checked
+    /// the strict `is_string()` (STRING_TAG 0x7FFF) predicate, so an SSO
+    /// value fell through to the pointer/array path and its inline bytes
+    /// (e.g. the ASCII of a 5-char `apiKey` like "mango") were dereferenced
+    /// as an `ArrayHeader*` — SIGSEGV. Reached from `@perryts/mysql`'s
+    /// prepared-statement param encoder (`Buffer.from(v, 'utf8')`).
+    #[test]
+    fn buffer_from_value_decodes_sso_short_string_utf8() {
+        for s in ["", "a", "id", "p1", "mango"] {
+            let v = crate::JSValue::try_short_string(s.as_bytes())
+                .expect("len<=5 encodes as inline SSO");
+            assert!(v.is_short_string(), "{s:?} should be an inline SSO value");
+            let buf = js_buffer_from_value(v.bits() as i64, 0 /* utf8 */);
+            assert!(!buf.is_null(), "null buffer for {s:?}");
+            assert_eq!(
+                js_buffer_length(buf) as usize,
+                s.len(),
+                "length mismatch for {s:?}"
+            );
+            for (i, &b) in s.as_bytes().iter().enumerate() {
+                assert_eq!(
+                    js_buffer_get(buf, i as i32) as u8,
+                    b,
+                    "byte {i} mismatch for {s:?}"
+                );
+            }
+        }
+    }
+
+    /// Same SSO value, but decoded under the `hex` encoding tag (1): the
+    /// short string holds hex digits and must produce the decoded bytes,
+    /// proving the SSO branch routes through the shared encoding helper
+    /// rather than a utf8-only fast path.
+    #[test]
+    fn buffer_from_value_decodes_sso_short_string_hex() {
+        // "ff00" is 4 bytes (<= 5) → SSO; hex-decodes to [0xff, 0x00].
+        let v = crate::JSValue::try_short_string(b"ff00").expect("SSO");
+        let buf = js_buffer_from_value(v.bits() as i64, 1 /* hex */);
+        assert!(!buf.is_null());
+        assert_eq!(js_buffer_length(buf), 2);
+        assert_eq!(js_buffer_get(buf, 0) as u8, 0xff);
+        assert_eq!(js_buffer_get(buf, 1) as u8, 0x00);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #1767 — SIGSEGV in `js_buffer_from_value` reached from `@perryts/mysql`'s `executePreparedNow` on the first parameterized query.

## Root cause

Perry's Small String Optimization stores strings of length 0..=5 **inline** in the NaN-box payload under `SHORT_STRING_TAG` (`0x7FF9`) instead of a heap `StringHeader`.

`js_buffer_from_value` gated the string path on `is_string()`, which is **STRING_TAG-only (`0x7FFF`)** and returns `false` for inline SSO values. So a short-string argument fell through to the pointer-extraction path (`bits >> 48 >= 0x7FF8` matches `0x7FF9`), where its inline bytes were masked to 48 bits and dereferenced as an `ArrayHeader*`.

The fault address from the repro was `0x056f676e616d` — literally the bytes `m a n g o` plus the SSO length byte `0x05`, i.e. the 5-char `apiKey` "mango" interpreted as a pointer.

This is a regression: before SSO, "mango" was a heap `StringHeader` and `Buffer.from` handled it. It became reachable in `@perryts/mysql`'s prepared-statement param encoder (`Buffer.from(v, 'utf8')`) once the #1663 microtask fix let execution get that far.

## Fix

- Extract the byte-slice → buffer encoding match from `js_buffer_from_string` into a shared `buffer_from_str_bytes(bytes, encoding)` helper.
- Add an `is_short_string()` branch to `js_buffer_from_value` that decodes the inline bytes via `short_string_to_buf` and routes them through that helper, so heap and inline strings share identical hex/base64/latin1/utf8 semantics.

## Testing

- Two new runtime unit tests (`buffer_from_value_decodes_sso_short_string_{utf8,hex}`) covering empty + 1..=5-byte SSO values.
- Full `buffer::` test module green (15 tests); `cargo fmt --all -- --check` clean.
- End-to-end: compiled the issue's `repro4.ts` against `@perryts/mysql@0.1.4` + a local MySQL. Before the fix it SIGSEGVs on the first POST (backtrace matches the issue exactly); after the fix it survives repeated sequential POSTs, inserts rows, and the 401 / non-SSO-key paths still work — verified with both default (auto-optimize) and `--no-auto-optimize` builds.
