### PR TITLE
fix(codegen): don't mis-lower String/Number methods on a dynamic native-module sub-namespace receiver (#1760)

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -10,8 +10,8 @@ use crate::lower_array_method::lower_array_method;
 use crate::lower_string_method::lower_string_method;
 use crate::nanbox::double_literal;
 use crate::type_analysis::{
-    is_array_expr, is_global_constructor_expr, is_map_expr, is_promise_expr, is_set_expr,
-    is_string_expr, is_url_search_params_expr, receiver_class_name,
+    is_array_expr, is_global_constructor_expr, is_map_expr, is_native_module_dynamic_index,
+    is_promise_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
 };
 use crate::types::{DOUBLE, I32, I64};
 
@@ -44,6 +44,7 @@ pub fn try_lower_property_get_method_call(
         && args.len() == 1
         && !is_string_expr(ctx, object)
         && !is_array_expr(ctx, object)
+        && !is_native_module_dynamic_index(object)
     {
         let v = lower_expr(ctx, object)?;
         let dec = lower_expr(ctx, &args[0])?;
@@ -56,6 +57,7 @@ pub fn try_lower_property_get_method_call(
         && args.len() == 1
         && !is_string_expr(ctx, object)
         && !is_array_expr(ctx, object)
+        && !is_native_module_dynamic_index(object)
     {
         let v = lower_expr(ctx, object)?;
         let prec = lower_expr(ctx, &args[0])?;
@@ -72,6 +74,7 @@ pub fn try_lower_property_get_method_call(
         && args.len() <= 1
         && !is_string_expr(ctx, object)
         && !is_array_expr(ctx, object)
+        && !is_native_module_dynamic_index(object)
     {
         let v = lower_expr(ctx, object)?;
         let dec = if args.is_empty() {
@@ -279,7 +282,17 @@ pub fn try_lower_property_get_method_call(
             crate::type_analysis::static_type_of(ctx, object),
             Some(perry_types::Type::Named(ref n)) if n == "Uint8Array" || n == "Buffer"
         );
-        if is_string_only_method && !is_array_expr(ctx, object) && !is_buffer {
+        // #1760: a dynamic native-module sub-namespace receiver
+        // (`(path as any)[k]` → `path.win32`) is NOT a string, even though a
+        // method like `normalize` collides with a String.prototype name.
+        // Falling through here routes it to the generic `js_native_call_method`
+        // dispatch (→ `dispatch_native_module_method`); forcing the string path
+        // hands the namespace pointer to a string FFI and SIGSEGVs.
+        if is_string_only_method
+            && !is_array_expr(ctx, object)
+            && !is_buffer
+            && !is_native_module_dynamic_index(object)
+        {
             return Ok(Some(lower_string_method(ctx, object, property, args)?));
         }
     }

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -1523,6 +1523,32 @@ pub(crate) fn is_array_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     }
 }
 
+/// True when `e` is a *dynamic* index into a native-module namespace —
+/// the auditable `ns[dynamicKey]` sub-namespace-selection shape (#1740,
+/// e.g. `(path as any)[k]` resolving to `path.win32` / `path.posix`).
+///
+/// Such a receiver evaluates to a native-module sub-object at runtime,
+/// never a primitive, so a method call on it must route through the
+/// generic `js_native_call_method` dispatch (which reaches
+/// `dispatch_native_module_method`) rather than being mis-classified as
+/// a `String`/`Number` prototype method by its name alone. Without this,
+/// a prototype-colliding name like `normalize` is lowered as a string
+/// method and the namespace pointer is handed to a string FFI → SIGSEGV
+/// (#1760).
+///
+/// Gated on a *non-literal* index: `(path as any)["sep"]` (a literal
+/// string property) can legitimately resolve to a string and must keep
+/// its string-method lowering, whereas `(path as any)[k]` is the dynamic
+/// sub-namespace form this targets.
+pub(crate) fn is_native_module_dynamic_index(e: &Expr) -> bool {
+    matches!(
+        e,
+        Expr::IndexGet { object, index }
+            if matches!(object.as_ref(), Expr::NativeModuleRef(_))
+                && !matches!(index.as_ref(), Expr::String(_) | Expr::WtfString(_))
+    )
+}
+
 /// Best-effort static type lookup for an expression. Returns the HIR
 /// type when it's cheap to determine (literals, locals, field accesses
 /// on known classes). Returns `None` when computing the type would

--- a/test-parity/node-suite/path/dynamic-subns/method-dispatch.ts
+++ b/test-parity/node-suite/path/dynamic-subns/method-dispatch.ts
@@ -8,10 +8,9 @@ import * as path from "node:path";
 // `undefined` until the runtime dispatch table learned `path.win32` /
 // `path.posix`. Surfaced by the #800 node-core radar (`test-path-glob.js`).
 //
-// (`.normalize`/`.format`/`.resolve` are intentionally not exercised here:
-// `normalize` collides with a String.prototype method name and is mis-lowered
-// by codegen on an `any`-typed receiver — a separate codegen gap — and
-// `resolve` is cwd-dependent.)
+// (`.normalize`/`.format` — the prototype-name-colliding methods that #1760
+// fixed — are exercised in the companion `normalize-format.ts`. `.resolve` is
+// still omitted here because it is cwd-dependent.)
 const w = "win32";
 console.log("win32 sep:", (path as any)[w].sep, "delim:", (path as any)[w].delimiter);
 console.log("win32 join:", (path as any)[w].join("a", "b"));

--- a/test-parity/node-suite/path/dynamic-subns/normalize-format.ts
+++ b/test-parity/node-suite/path/dynamic-subns/normalize-format.ts
@@ -1,0 +1,19 @@
+import * as path from "node:path";
+
+// #1760: prototype-name-colliding methods on a dynamic sub-namespace receiver.
+// `(path as any)[k].normalize(...)` resolves `path[k]` to a runtime
+// sub-namespace object (`path.win32` / `path.posix`), so the `.normalize`
+// call must route through the generic native-module dispatch. Codegen used
+// to classify `normalize` as a `String.prototype` method purely by name and
+// emit a string-method lowering — handing the namespace pointer to a string
+// FFI and SIGSEGV-ing. This is the companion to #1740's method-dispatch.ts,
+// which deliberately omitted these names while the codegen gap was open.
+const w = "win32";
+console.log("win32 normalize:", (path as any)[w].normalize("a\\..\\b"));
+console.log("win32 normalize2:", (path as any)[w].normalize("C:\\foo\\..\\bar\\.\\baz"));
+console.log("win32 format:", (path as any)[w].format({ dir: "C:\\a", base: "b.txt" }));
+
+const po = "posix";
+console.log("posix normalize:", (path as any)[po].normalize("a/./b/../c"));
+console.log("posix normalize2:", (path as any)[po].normalize("/foo/bar//baz/../qux"));
+console.log("posix format:", (path as any)[po].format({ dir: "/a", base: "b.txt" }));


### PR DESCRIPTION
## Summary

Fixes #1760. `(path as any)[k].normalize("a\\..\\b")` SIGSEGV'd instead of returning `"b"`.

`path[k]` resolves to a runtime sub-namespace object (`path.win32` / `path.posix`), so the `.normalize` call must route through the generic `js_native_call_method` dispatch (→ `dispatch_native_module_method`, the #1740 runtime arms). But codegen's *String-method fallback for Any-typed receivers* (`lower_call/property_get.rs`) classified `normalize` — and other prototype-name-colliding methods — as a `String.prototype` method purely by name, emitting a string-method lowering that handed the namespace-object pointer to a string FFI → crash.

## Fix

- New predicate `is_native_module_dynamic_index()` in `type_analysis.rs` matches the auditable `ns[dynamicKey]` shape: `IndexGet { object: NativeModuleRef(_), index: <non-literal> }`.
- Gate the String-method fallback **and** the `toFixed`/`toPrecision`/`toExponential` Number branches on `!is_native_module_dynamic_index(object)`, so such receivers fall through to generic native dispatch.

Scoped to a **non-literal** index on purpose: `(path as any)["sep"]` lowers to a `PropertyGet` (literal `obj["x"]` ≡ `obj.x`) and can legitimately resolve to a string, so it keeps its string-method lowering. Only the dynamic `[k]` form produces `IndexGet`, which is exactly #1760's scope.

## Validation (`PERRY_NO_AUTO_OPTIMIZE=1`)

- `(path as any)[k].normalize(...)`: exit 139 → `b` (matches `node --experimental-strip-types`)
- win32 + posix `normalize`/`format` via `[k]`: byte-for-byte parity
- No regression: `(path as any)["sep"].toUpperCase()`, `path.sep`, and direct `path.win32.normalize()` all still correct
- `path` node-suite parity: 73 pass / 8 fail / 0 compile-fail — the 8 are pre-existing, unrelated gaps (TypeError parity for `null` args, glob/UNC/dotfile edge cases); the two `dynamic-subns/*` tests pass
- `cargo fmt --all -- --check`: clean

## Tests

- Adds `test-parity/node-suite/path/dynamic-subns/normalize-format.ts` (exercises `normalize`/`format` on both sub-namespaces via `[k]`).
- Updates the companion `method-dispatch.ts` comment — the codegen gap it called out is now closed.
