### PR TITLE
test(node-core): shim must not use [].slice.call(arguments)/.apply (#1777)

### DIFF
--- a/test-compat/node-core/shim/fixtures.js
+++ b/test-compat/node-core/shim/fixtures.js
@@ -10,14 +10,16 @@ const path = require('path');
 
 const fixturesDir = process.env.PERRY_NODE_CORE_FIXTURES || '/nonexistent-fixtures';
 
-function fixturesPath() {
-  const parts = Array.prototype.slice.call(arguments);
-  return path.join.apply(path, [fixturesDir].concat(parts));
+// Rest params + iterative join instead of `Array.prototype.slice.call` +
+// `.apply` (both trip Perry's #1777 gap).
+function fixturesPath(...parts) {
+  let p = fixturesDir;
+  for (const part of parts) p = path.join(p, part);
+  return p;
 }
 
-function readSync() {
-  const args = Array.prototype.slice.call(arguments);
-  return fs.readFileSync(fixturesPath.apply(null, args));
+function readSync(...parts) {
+  return fs.readFileSync(fixturesPath(...parts));
 }
 
 function readKey(name, enc) {

--- a/test-compat/node-core/shim/index.js
+++ b/test-compat/node-core/shim/index.js
@@ -71,9 +71,9 @@ function _mustCall(fn, criteria, field) {
   if (mustCallChecks.length === 0) process.on('exit', runCallChecks);
   mustCallChecks.push(context);
 
-  return function () {
+  return function (...args) {
     context.actual++;
-    return fn.apply(this, arguments);
+    return fn(...args);
   };
 }
 
@@ -86,18 +86,20 @@ function mustCallAtLeast(fn, minimum) {
 }
 
 function mustSucceed(fn, exact) {
-  return mustCall(function (err) {
+  // Rest params + spread instead of `Array.prototype.slice.call(arguments, 1)`
+  // — the latter trips Perry's #1777 gap (builtin prototype methods aren't
+  // first-class values, so `.call` on `Array.prototype.slice` is undefined),
+  // which would fail this scaffolding before the API under test even runs.
+  return mustCall(function (err, ...rest) {
     assert.ifError(err);
     if (typeof fn === 'function') {
-      const rest = Array.prototype.slice.call(arguments, 1);
-      return fn.apply(this, rest);
+      return fn(...rest);
     }
   }, exact);
 }
 
 function mustNotCall(msg) {
-  return function () {
-    const args = Array.prototype.slice.call(arguments);
+  return function (...args) {
     let info = '';
     if (args.length > 0) info = ' with arguments: ' + args.join(', ');
     assert.fail((msg || 'function should not have been called') + info);

--- a/test-compat/node-core/shim/tmpdir.js
+++ b/test-compat/node-core/shim/tmpdir.js
@@ -19,9 +19,12 @@ function refresh() {
   fs.mkdirSync(tmpPath, { recursive: true });
 }
 
-function resolve() {
-  const parts = Array.prototype.slice.call(arguments);
-  return path.join.apply(path, [tmpPath].concat(parts));
+function resolve(...parts) {
+  // Avoid `Array.prototype.slice.call(arguments)` + `path.join.apply` — both
+  // trip Perry's #1777 gap (builtin/stdlib methods aren't first-class values).
+  let p = tmpPath;
+  for (const part of parts) p = path.join(p, part);
+  return p;
 }
 
 module.exports = {


### PR DESCRIPTION
Tooling fix for the #800 radar (no compiler change). The common/tmpdir/fixtures shims used `Array.prototype.slice.call(arguments)` + `path.join.apply(...)`, which trip Perry's #1777 gap — so the scaffolding threw `Cannot read properties of undefined (reading 'call')` before the API under test ran. That was the radar's largest runtime-fail cluster (~117 tests, fs-heavy). Rewritten to rest params + spread / iterative join. Verified the fs tests now run real fs ops under Perry (surfacing genuine gaps) instead of failing in the harness. Underlying Perry gap tracked in #1777.