### PR TITLE
feat(hir): const-fold literal new Function bodies to native functions (#1679)

### DIFF
--- a/crates/perry-hir/Cargo.toml
+++ b/crates/perry-hir/Cargo.toml
@@ -9,6 +9,11 @@ description = "High-level intermediate representation for Perry"
 perry-types.workspace = true
 perry-diagnostics.workspace = true
 perry-api-manifest.workspace = true
+# #1679: HIR lowering parses synthesized function-literal source for
+# const-foldable `new Function(...)` bodies, so the parser is a regular
+# (not dev-only) dependency. No cycle: perry-parser does not depend on
+# perry-hir.
+perry-parser.workspace = true
 swc_ecma_ast.workspace = true
 swc_common.workspace = true
 
@@ -16,6 +21,3 @@ thiserror.workspace = true
 anyhow.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
-
-[dev-dependencies]
-perry-parser.workspace = true

--- a/crates/perry-hir/src/eval_classifier.rs
+++ b/crates/perry-hir/src/eval_classifier.rs
@@ -176,7 +176,10 @@ impl EvalClassification {
 /// Peel parens and return the constant string value of `expr` if it is a
 /// string literal or a substitution-free template literal. `None` for any
 /// other shape (a variable, concatenation, call result, …).
-fn const_string_of(expr: &ast::Expr) -> Option<String> {
+///
+/// Public so Phase 1 (#1679) const-folding decides constness the *same*
+/// way the Phase 0 classifier does — the fold must agree with the bucket.
+pub fn const_string_of(expr: &ast::Expr) -> Option<String> {
     let mut e = expr;
     while let ast::Expr::Paren(p) = e {
         e = p.expr.as_ref();

--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -1,0 +1,225 @@
+//! #1679 (Phase 1 of #1677) — const-fold literal `new Function` /
+//! `Function(...)` bodies into real native functions, plus the
+//! `(0, eval)('this')` indirect-eval `globalThis` idiom.
+//!
+//! When the Phase 0 classifier ([`crate::eval_classifier`]) would bucket a
+//! site as **const-foldable** (every argument is a compile-time-constant
+//! string), an ahead-of-time compiler should turn it into a genuine
+//! function rather than refuse it — this is true AOT eval. We synthesize
+//! the equivalent function-literal source, parse it, and lower it through
+//! the normal function-expression path, exactly as if the user had written
+//! `function (a, b) { return a + b }`.
+//!
+//! `new Function` has no access to the enclosing lexical scope (globals
+//! only), so the realistic const-foldable body references only its own
+//! parameters plus globals and lowers to a capture-free closure. (A body
+//! that happens to reference an enclosing local will capture it — a benign
+//! deviation from strict `new Function` global-only scope, and the literal
+//! function-equivalent lowering #1679 asks for.)
+//!
+//! Out of scope here (→ Phase 3, #1681): library-generated *non-literal*
+//! body strings. Those stay in the classifier's runtime-unknown /
+//! known-library buckets.
+
+use anyhow::Result;
+use swc_ecma_ast as ast;
+
+use crate::error::LowerError;
+use crate::eval_classifier::{const_string_of, eval_diag_enabled, EvalSurface};
+use crate::ir::Expr;
+
+use super::expr_function::lower_fn_expr;
+use super::LoweringContext;
+
+/// Fold a `new Function(...)` / `Function(...)` whose arguments are *all*
+/// compile-time-constant strings into a native function (`Expr::Closure`).
+///
+/// Returns `Ok(None)` when not every argument is a constant string — the
+/// caller then falls back to the Phase 0 classifier (which refuses the
+/// runtime-unknown bucket and logs the rest). Returns `Err` (span-tagged)
+/// when the synthesized body is not valid JavaScript or uses a feature
+/// Perry can't compile yet — both are genuine, localized compile errors.
+pub(crate) fn try_const_fold_function_construct(
+    ctx: &mut LoweringContext,
+    args: &[ast::ExprOrSpread],
+    surface: EvalSurface,
+    span: swc_common::Span,
+) -> Result<Option<Expr>> {
+    // A spread argument can't be expanded into a static param/body list.
+    if args.iter().any(|a| a.spread.is_some()) {
+        return Ok(None);
+    }
+    // Every argument must be a constant string (params *and* body).
+    let mut consts: Vec<String> = Vec::with_capacity(args.len());
+    for a in args {
+        match const_string_of(&a.expr) {
+            Some(s) => consts.push(s),
+            None => return Ok(None),
+        }
+    }
+
+    // Node treats the last argument as the body and every earlier argument
+    // as a (possibly comma-joined) parameter list: `new Function('a','b',
+    // 'return a+b')` ≡ `new Function('a, b', 'return a+b')`. Joining the
+    // param args with `,` reproduces either spelling.
+    let (body_src, params_src) = match consts.split_last() {
+        Some((body, params)) => (body.clone(), params.join(", ")),
+        // `new Function()` / `Function()` — empty params, empty body.
+        None => (String::new(), String::new()),
+    };
+
+    let synth = format!("(function ({params_src}) {{\n{body_src}\n}});\n");
+    let module = perry_parser::parse_typescript(&synth, "<new Function body>").map_err(|e| {
+        anyhow::Error::new(LowerError::new(
+            format!(
+                "`{}` body is not valid JavaScript and cannot be compiled: {} \
+                 (#1679)\n  body: {:?}",
+                surface.label(),
+                e,
+                body_src,
+            ),
+            span,
+        ))
+    })?;
+
+    let fn_expr = extract_fn_expr(&module).ok_or_else(|| {
+        anyhow::Error::new(LowerError::new(
+            format!(
+                "`{}` body could not be parsed as a function body (#1679)\n  body: {:?}",
+                surface.label(),
+                body_src,
+            ),
+            span,
+        ))
+    })?;
+
+    let lowered = lower_fn_expr(ctx, fn_expr).map_err(|e| {
+        // The synthesized body parsed but couldn't lower (an unsupported
+        // feature inside the generated function). Surface it as a clear
+        // error at the original call site rather than the broken
+        // placeholder the pre-#1679 fall-through produced.
+        anyhow::Error::new(LowerError::new(
+            format!(
+                "`{}` body uses a feature Perry can't compile yet: {} (#1679)\n  body: {:?}",
+                surface.label(),
+                e,
+                body_src,
+            ),
+            span,
+        ))
+    })?;
+
+    if eval_diag_enabled() {
+        eprintln!(
+            "[perry-eval-diag] {} -> const-foldable: compiled to native function (#1679)",
+            surface.label()
+        );
+    }
+    Ok(Some(lowered))
+}
+
+/// Fold the indirect-eval `globalThis` idiom — `(0, eval)('this')` /
+/// `(0, eval)('globalThis')` (and parenthesized variants) — to
+/// [`Expr::GlobalThisExpr`], the same singleton `Function('return this')()`
+/// folds to (#957/#959). Indirect `eval` runs in global scope, so
+/// `eval('this')` yields the global object.
+///
+/// Conservative: requires the comma-sequence callee whose last element is
+/// the *unshadowed* `eval` builtin, a single non-spread argument, and a
+/// constant body that trims to exactly `this` / `globalThis`. Anything
+/// else returns `None`.
+pub(crate) fn try_indirect_eval_globalthis(
+    ctx: &LoweringContext,
+    call: &ast::CallExpr,
+) -> Option<Expr> {
+    if call.args.len() != 1 || call.args[0].spread.is_some() {
+        return None;
+    }
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let mut c = callee.as_ref();
+    while let ast::Expr::Paren(p) = c {
+        c = p.expr.as_ref();
+    }
+    // Indirect eval is spelled as a comma sequence: `(0, eval)`.
+    let ast::Expr::Seq(seq) = c else {
+        return None;
+    };
+    let mut last = seq.exprs.last()?.as_ref();
+    while let ast::Expr::Paren(p) = last {
+        last = p.expr.as_ref();
+    }
+    let ast::Expr::Ident(id) = last else {
+        return None;
+    };
+    if id.sym.as_ref() != "eval"
+        || ctx.lookup_local("eval").is_some()
+        || ctx.lookup_func("eval").is_some()
+    {
+        return None;
+    }
+    let body = const_string_of(&call.args[0].expr)?;
+    let trimmed = body.trim().trim_end_matches(';').trim();
+    if matches!(trimmed, "this" | "globalThis") {
+        if eval_diag_enabled() {
+            eprintln!("[perry-eval-diag] (0, eval)({trimmed:?}) -> globalThis (#1679)");
+        }
+        Some(Expr::GlobalThisExpr)
+    } else {
+        None
+    }
+}
+
+/// Combined fold entry for the call form, run from `lower_call_inner`
+/// before the Phase 0 refusal: the `(0, eval)('this')` idiom first, then a
+/// bare-ident `Function(...)` const-fold. `Ok(None)` → fall through to the
+/// classifier.
+pub(crate) fn try_eval_function_call_fold(
+    ctx: &mut LoweringContext,
+    call: &ast::CallExpr,
+) -> Result<Option<Expr>> {
+    if let Some(expr) = try_indirect_eval_globalthis(ctx, call) {
+        return Ok(Some(expr));
+    }
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return Ok(None);
+    };
+    let mut c = callee.as_ref();
+    while let ast::Expr::Paren(p) = c {
+        c = p.expr.as_ref();
+    }
+    let ast::Expr::Ident(id) = c else {
+        return Ok(None);
+    };
+    if id.sym.as_ref() == "Function"
+        && ctx.lookup_local("Function").is_none()
+        && ctx.lookup_func("Function").is_none()
+        && ctx.lookup_imported_func("Function").is_none()
+    {
+        return try_const_fold_function_construct(
+            ctx,
+            &call.args,
+            EvalSurface::FunctionCall,
+            call.span,
+        );
+    }
+    Ok(None)
+}
+
+/// Pull the `FnExpr` out of a synthesized `(function (...) { ... });`
+/// module (a single expression statement wrapping a parenthesized
+/// function expression).
+fn extract_fn_expr(module: &ast::Module) -> Option<&ast::FnExpr> {
+    let ast::ModuleItem::Stmt(ast::Stmt::Expr(expr_stmt)) = module.body.first()? else {
+        return None;
+    };
+    let mut e = expr_stmt.expr.as_ref();
+    while let ast::Expr::Paren(p) = e {
+        e = p.expr.as_ref();
+    }
+    match e {
+        ast::Expr::Fn(fn_expr) => Some(fn_expr),
+        _ => None,
+    }
+}

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -158,9 +158,15 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
     if let Some(expr) = try_function_return_this(ctx, call, has_spread) {
         return Ok(expr);
     }
-    // #1678: classify `Function(...)` / `eval(...)` (after the
-    // `Function('return this')()` fold above has had its chance). Bails on
-    // the runtime-unknown bucket; otherwise logs + falls through.
+    // #1679 (Phase 1): const-fold a literal `Function(...)` body into a
+    // native function, and fold the `(0, eval)('this')` globalThis idiom.
+    // Runs after the `Function('return this')()` fold; before the Phase 0
+    // refusal so const-foldable sites compile instead of being classified.
+    if let Some(expr) = super::const_fold_fn::try_eval_function_call_fold(ctx, call)? {
+        return Ok(expr);
+    }
+    // #1678: classify `Function(...)` / `eval(...)`. Bails on the
+    // runtime-unknown bucket; otherwise logs + falls through.
     check_eval_function_call(ctx, call)?;
     if let Some(expr) = try_bare_regexp_call(ctx, call, has_spread)? {
         return Ok(expr);

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -186,25 +186,30 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
         ast::Expr::Ident(ident) => {
             let class_name = ident.sym.to_string();
 
-            // #1678 (Phase 0 of #1677): classify `new Function(...)` before
-            // it reaches the unknown-class fall-through (which silently
-            // lowers to a class_id=0 empty-object placeholder). The
-            // runtime-unknown bucket is refused with a precise diagnostic;
-            // const-foldable / known-codegen sites are logged under
-            // `PERRY_EVAL_DIAG` and keep their existing placeholder lowering
-            // for later phases of #1677. Skip when `Function` is shadowed.
+            // #1677 `new Function(...)` handling, when `Function` is not
+            // shadowed. Phase 1 (#1679) first: when every argument is a
+            // compile-time-constant string, fold the call into a real
+            // native function. Otherwise Phase 0 (#1678): refuse the
+            // runtime-unknown bucket with a precise diagnostic; log the
+            // const/known-codegen buckets and fall through to the existing
+            // placeholder lowering.
             if class_name == "Function"
                 && ctx.lookup_local("Function").is_none()
                 && ctx.lookup_func("Function").is_none()
                 && ctx.lookup_class("Function").is_none()
             {
-                // Body is the last argument (`new Function(p1, p2, body)`);
-                // earlier args are parameter names.
-                let body_arg = new_expr
-                    .args
-                    .as_ref()
-                    .and_then(|args| args.last())
-                    .map(|a| a.expr.as_ref());
+                let args_slice = new_expr.args.as_deref().unwrap_or(&[]);
+                if let Some(folded) = super::const_fold_fn::try_const_fold_function_construct(
+                    ctx,
+                    args_slice,
+                    crate::eval_classifier::EvalSurface::NewFunction,
+                    new_expr.span,
+                )? {
+                    return Ok(folded);
+                }
+                // Not fully const-foldable — body is the last argument
+                // (`new Function(p1, p2, body)`); earlier args are param names.
+                let body_arg = args_slice.last().map(|a| a.expr.as_ref());
                 crate::eval_classifier::check_site(
                     crate::eval_classifier::EvalSurface::NewFunction,
                     body_arg,

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -55,6 +55,7 @@ pub(crate) use misc::*;
 mod pre_scan;
 pub(crate) use pre_scan::*;
 mod closure_analysis;
+mod const_fold_fn;
 pub(crate) use closure_analysis::*;
 mod decorators;
 pub(crate) use decorators::*;

--- a/test-files/test_indirect_eval_globalthis.ts
+++ b/test-files/test_indirect_eval_globalthis.ts
@@ -1,0 +1,9 @@
+// #1679 (Phase 1 of #1677) — the indirect-eval `globalThis` idiom
+// `(0, eval)("this")` folds to the global object (it runs in global scope).
+const a = (0, eval)("this");
+console.log("indirect_this_type:", typeof a);
+
+const b = (0, eval)("globalThis");
+console.log("indirect_globalthis_type:", typeof b);
+
+console.log("indirect_same:", a === b);

--- a/test-files/test_new_function_const_fold.ts
+++ b/test-files/test_new_function_const_fold.ts
@@ -1,0 +1,27 @@
+// #1679 (Phase 1 of #1677) — literal `new Function` / `Function(...)` bodies
+// are compiled to native functions instead of refused. Output must match
+// `node --experimental-strip-types` byte-for-byte.
+
+// single-expression body, two params
+const add = new Function("a", "b", "return a + b");
+console.log("add:", add(2, 3));
+
+// multi-arg param names (three params)
+const sum3 = new Function("a", "b", "c", "return a + b + c");
+console.log("sum3:", sum3(1, 2, 3));
+
+// comma-joined param list — Node treats this identically to separate args
+const sub = new Function("a, b", "return a - b");
+console.log("sub:", sub(10, 4));
+
+// no params
+const five = new Function("return 5");
+console.log("five:", five());
+
+// multi-statement body referencing a global (Math)
+const hyp = new Function("x", "y", "const s = x * x + y * y; return Math.sqrt(s)");
+console.log("hyp:", hyp(3, 4));
+
+// the call form (no `new`) is equivalent
+const mul = Function("a", "b", "return a * b");
+console.log("mul:", mul(6, 7));


### PR DESCRIPTION
## Phase 1 of #1677 — const-fold literal `new Function` bodies to native functions

Closes #1679. Stacked on #1678 (Phase 0, merged).

### What

When the Phase 0 classifier buckets a `new Function(...)` / `Function(...)`
site as **const-foldable** (every argument is a compile-time-constant
string), compile it to a **real native function** instead of leaving it to
the placeholder fall-through. This is true ahead-of-time eval and builds the
`string → HIR` plumbing Phase 3 will reuse.

**How:** synthesize the equivalent `(function (<params>) { <body> })`
source (all-but-last args = the param list, last arg = body, matching
Node's `new Function` semantics including the comma-joined `'a, b'` form),
parse it via `perry-parser`, and lower it through the normal `lower_fn_expr`
path — *exactly as if the user had written the function literal* (the
issue's wording). The body references only its own params + globals, so it
lowers to a capture-free closure.

Also folds the **`(0, eval)('this')` / `(0, eval)('globalThis')`**
indirect-eval idiom to `Expr::GlobalThisExpr` (indirect eval runs in global
scope) — the same singleton `Function('return this')()` already folds to
(#957/#959).

### Where

New module `crates/perry-hir/src/lower/const_fold_fn.rs`, hooked at both
Function-shape sites **before** the Phase 0 refusal:
- `expr_new.rs` — `new Function(...)`
- `expr_call/mod.rs` — `Function(...)` and the indirect-eval idiom

The `Function('return this')()` fold runs first and is unaffected.
`perry-parser` promoted from dev- to regular dependency of `perry-hir` (no
cycle; only adds `swc_ecma_parser` to the build).

### Behaviour

- **const-foldable** → compiled to a native function (was: broken placeholder).
- **runtime-unknown** → still the Phase 0 refusal (no regression).
- A const body that **parses but can't lower** (unsupported feature inside
  the generated function) → a clear, span-tagged compile error at the call
  site, instead of the old silent broken placeholder.

### Tests / verification

Two new parity test-files, both **byte-for-byte vs `node --experimental-strip-types`**:
- `test_new_function_const_fold.ts` — single-expression body, multi-arg
  param names, comma-joined param list, no-param, multi-statement body
  referencing a global (`Math`), and the `Function(...)` call form.
- `test_indirect_eval_globalthis.ts` — `(0, eval)('this')` /
  `(0, eval)('globalThis')`.

Regression-checked locally: runtime-unknown `new Function`/`eval` still
refused; `Function('return this')()` and the lodash return-this test-file
still parity-clean. `perry-hir` suite green (111 tests); `cargo fmt --all
--check` + `cargo clippy -p perry-hir` clean.

Note: `parity`/`compile-smoke` are tag-gated (don't run on PRs) — the
release sweep is the real Phase-1 gate before #1680 starts.
