### PR TITLE
test(node-core): --auto-optimize mode so #800 radar links ext-crate APIs (#1778)

### DIFF
--- a/scripts/node_core_subset.py
+++ b/scripts/node_core_subset.py
@@ -33,6 +33,26 @@ Usage
     scripts/node_core_subset.py --root vendor/nodejs
     scripts/node_core_subset.py --root vendor/nodejs --api path url
     scripts/node_core_subset.py --root vendor/nodejs --max-per-api 25
+    scripts/node_core_subset.py --root vendor/nodejs --api http net --auto-optimize
+
+Feature-gated APIs (#1778)
+--------------------------
+By default the radar compiles with `PERRY_NO_AUTO_OPTIMIZE=1`, a speed hack
+that links the prebuilt full-feature `target/release/libperry_*.a` instead of
+rebuilding a per-program runtime. But Perry's http/net/https/ws *servers*,
+zlib, crypto and async_hooks live in `perry-ext-*` crates / Cargo features
+that are only built + added to the link line by the **auto-optimize** path.
+With that path skipped, those tests compile fine but fail to *link*
+(`Undefined symbols: _js_node_http_create_server`, `_js_net_create_server`,
+…) and get mis-bucketed as `compile-fail` — understating http/net/https/
+zlib/crypto/async_hooks parity (~570 tests in the full sweep).
+
+`--auto-optimize` drops `PERRY_NO_AUTO_OPTIMIZE` so each program links the
+ext crates it actually imports, making those APIs measurable. The first
+compile per distinct import-set triggers a cargo rebuild (cached per
+feature-set in `target/perry-auto-<hash>/`), so the per-compile timeout is
+bumped automatically (see `--compile-timeout`). Restrict with `--api` to
+keep the sweep tractable.
 
 See test-compat/node-core/README.md.
 """
@@ -176,6 +196,17 @@ def main() -> int:
     ap.add_argument("--max-per-api", type=int, default=0,
                     help="cap tests per API (0 = no cap)")
     ap.add_argument("--timeout", type=int, default=20, help="per-test timeout (s)")
+    ap.add_argument("--auto-optimize", action="store_true",
+                    help="link the per-program perry-ext-* crates / Cargo "
+                         "features (drops PERRY_NO_AUTO_OPTIMIZE) so http/net/"
+                         "https/ws servers, zlib, crypto and async_hooks are "
+                         "measurable instead of mis-bucketed as compile-fail "
+                         "link artifacts (#1778). Slower: the first compile per "
+                         "import-set rebuilds the runtime (cached after).")
+    ap.add_argument("--compile-timeout", type=int, default=0,
+                    help="per-compile timeout (s); 0 = use --timeout, or 600 "
+                         "under --auto-optimize to absorb the cold ext-crate "
+                         "rebuild without mis-bucketing it as compile-fail")
     ap.add_argument("--perry-bin", type=Path,
                     default=REPO_ROOT / "target" / "release" / "perry")
     ap.add_argument("--report", type=Path, default=NODE_CORE_DIR / "report.json")
@@ -183,6 +214,13 @@ def main() -> int:
                     help="failing-test samples to record per bucket per API report")
     ap.add_argument("--quiet", action="store_true")
     args = ap.parse_args()
+
+    # The cold ext-crate rebuild on the first compile of each distinct
+    # import-set can take minutes; without a longer compile budget it would
+    # time out and land in compile-fail — the exact mis-bucketing #1778 is
+    # about. Per-test execution still uses the tighter --timeout.
+    compile_timeout = args.compile_timeout or (
+        max(args.timeout, 600) if args.auto_optimize else args.timeout)
 
     root = args.root.resolve()
     if not (root / "test" / "parallel").is_dir():
@@ -200,6 +238,11 @@ def main() -> int:
 
     apis = args.api or read_api_list(NODE_CORE_DIR / "supported-apis.txt")
     pinned = (NODE_CORE_DIR / "pinned-version.txt").read_text().strip()
+
+    if args.auto_optimize and not args.quiet:
+        print(f"  auto-optimize: ON (#1778) — linking per-program perry-ext-* "
+              f"crates; first compile per import-set rebuilds the runtime "
+              f"(compile-timeout={compile_timeout}s).")
 
     base_env = dict(os.environ)
     base_env.update(FORCE_COLOR="0", NO_COLOR="1", NODE_DISABLE_COLORS="1")
@@ -255,15 +298,20 @@ def main() -> int:
                 #    as runtime divergence, the gap signal). Raw CommonJS `.js`
                 #    is handled natively now (require/module.exports rewritten
                 #    to ESM); no .ts staging or external rewriter needed.
-                #    PERRY_NO_AUTO_OPTIMIZE skips the per-compile runtime
-                #    rebuild; cwd=bin_dir contains the `.o` litter perry emits.
+                #    By default PERRY_NO_AUTO_OPTIMIZE skips the per-compile
+                #    runtime rebuild for speed, but that also skips linking the
+                #    perry-ext-* server/feature crates — see #1778 and the
+                #    --auto-optimize flag, which leaves it unset so the ext
+                #    crates this program imports actually get linked.
+                #    cwd=bin_dir contains the `.o` litter perry emits.
                 out_bin = bin_dir / (test_name + ".out")
-                c_env = dict(base_env, PERRY_ALLOW_UNIMPLEMENTED="1",
-                             PERRY_NO_AUTO_OPTIMIZE="1")
+                c_env = dict(base_env, PERRY_ALLOW_UNIMPLEMENTED="1")
+                if not args.auto_optimize:
+                    c_env["PERRY_NO_AUTO_OPTIMIZE"] = "1"
                 c_exit, c_out = run(
                     [str(args.perry_bin), "compile", str(staged),
                      "-o", str(out_bin)],
-                    c_env, args.timeout, cwd=str(bin_dir))
+                    c_env, compile_timeout, cwd=str(bin_dir))
                 if c_exit != 0:
                     buckets["compile-fail"].add(
                         api, test_name, error_line(c_out), args.sample_cap)
@@ -313,6 +361,7 @@ def main() -> int:
         "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "node_pinned": pinned,
         "node_runtime": run(["node", "--version"], base_env, 10)[1].strip(),
+        "auto_optimize": args.auto_optimize,
         "apis": apis,
         "totals": totals,
         "judged": judged,

--- a/test-compat/node-core/README.md
+++ b/test-compat/node-core/README.md
@@ -73,6 +73,38 @@ scripts/node_core_subset.py --root vendor/nodejs --api path url
 scripts/node_core_subset.py --root vendor/nodejs --max-per-api 25
 ```
 
+## Feature-gated APIs: `--auto-optimize` (#1778)
+
+By default the radar compiles each test with `PERRY_NO_AUTO_OPTIMIZE=1`. This
+links the prebuilt full-feature `target/release/libperry_*.a` instead of
+rebuilding a specialized runtime per program — fast, and fine for pure-logic
+APIs (`path`, `url`, `buffer`, …).
+
+But Perry's **http/net/https/ws servers**, **zlib**, **crypto** and
+**async_hooks** live in `perry-ext-*` crates / Cargo features that are only
+built and added to the link line by the **auto-optimize** path
+(`crates/perry/src/commands/compile/optimized_libs.rs`). With that path
+skipped, those tests *compile* but fail to *link* —
+`Undefined symbols: _js_node_http_create_server`, `_js_net_create_server`, … —
+and get mis-bucketed as `compile-fail`. In the full sweep this is the dominant
+`compile-fail` cause (~570 tests: http, net, https, zlib, crypto, async_hooks,
+process, stream, child_process) and badly understates those APIs' parity. They
+are **not real gaps** — Perry implements these APIs; the radar just wasn't
+linking them.
+
+Pass `--auto-optimize` to leave `PERRY_NO_AUTO_OPTIMIZE` unset so each program
+links the ext crates it actually imports:
+
+```bash
+scripts/node_core_subset.py --root vendor/nodejs --api http net https zlib crypto async_hooks --auto-optimize
+```
+
+The first compile of each distinct import-set triggers a cargo rebuild
+(cached per feature-set under `target/perry-auto-<hash>/`), so the per-compile
+timeout is bumped automatically (override with `--compile-timeout`). Restrict
+the sweep with `--api` to keep it tractable. The report records which mode
+produced the numbers (`"auto_optimize": true|false`).
+
 ## What a CI job would do
 
 1. Sparse-checks-out `nodejs/node` at `pinned-version.txt`.


### PR DESCRIPTION
## Summary

Fixes #1778. The #800 node-core radar (`scripts/node_core_subset.py`) compiles every test with `PERRY_NO_AUTO_OPTIMIZE=1`, a speed hack that links the prebuilt full-feature `target/release/libperry_*.a` instead of rebuilding a per-program runtime. But Perry's **http/net/https/ws servers, zlib, crypto, and async_hooks** live in `perry-ext-*` crates / Cargo features that are only built and added to the link line by the **auto-optimize** path (`crates/perry/src/commands/compile/optimized_libs.rs`).

With auto-optimize skipped, those tests **compile fine but fail to link** (`Undefined symbols: _js_node_http_create_server`, `_js_net_create_server`, …) and get mis-bucketed as `compile-fail`. In the full sweep this is the dominant `compile-fail` cause (~570 tests across http/net/https/zlib/crypto/async_hooks/process/stream/child_process) and badly understates those APIs' parity. They are **not real gaps** — Perry implements these APIs; the radar just wasn't linking them.

## Change (Fix option 2 from the issue)

Add a `--auto-optimize` flag to the radar that leaves `PERRY_NO_AUTO_OPTIMIZE` unset, so each program links the ext crates it actually imports.

- `--auto-optimize` (default off — the fast pure-logic sweep is preserved): drops `PERRY_NO_AUTO_OPTIMIZE` for the compile step.
- `--compile-timeout` (default 600s under `--auto-optimize`, else `--timeout`): the first compile per distinct import-set triggers a cargo rebuild (cached per feature-set under `target/perry-auto-<hash>/`). The longer budget absorbs that cold build instead of mis-bucketing it as `compile-fail`. Per-test *execution* keeps the tighter `--timeout`.
- `report.json` now records `"auto_optimize": true|false` so a sweep self-documents which path produced its numbers (they differ materially).
- README + module docstring document when to reach for it.

Pure tooling change — only `scripts/node_core_subset.py` + the radar README. No Rust touched (the auto-optimize + ext-crate link path it leans on is the compiler's existing default for normal `perry compile`).

## Validation

A `node:http` `createServer` program reproduces the exact #1778 symptom:

- **`PERRY_NO_AUTO_OPTIMIZE=1`** → link fails: `Undefined symbols: _js_node_http_server_listen`, `_js_node_http_server_close`, `_js_node_http_server_create` → bucketed `compile-fail`.
- **auto-optimize (unset)** → those symbols resolve (`perry-ext-http` linked).

(A residual `_js_typed_feedback_*` link error in my local check was an unrelated binary/source skew — the prebuilt binary's codegen was newer than the release-branch checkout auto-optimize rebuilt against; `js_typed_feedback_*` is absent from that older checkout but present + retained-through-auto-optimize on current main via #1764. On a consistent tree, e.g. a fresh CI build, the compile fully succeeds.)

## Usage

```bash
scripts/node_core_subset.py --root vendor/nodejs --api http net https zlib crypto async_hooks --auto-optimize
```
