### PR TITLE
fix(hir,codegen): class expressions → heap class objects with per-evaluation own static fields (#1786)

### DIFF
--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -772,6 +772,19 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
             walk(key_expr, out);
             walk(value_expr, out);
         }
+        Expr::ClassExprFresh {
+            named_statics,
+            symbol_statics,
+            ..
+        } => {
+            for (_, v) in named_statics {
+                walk(v, out);
+            }
+            for (k, v) in symbol_statics {
+                walk(k, out);
+                walk(v, out);
+            }
+        }
         Expr::RegisterClassParentDynamic { parent_expr, .. } => {
             walk(parent_expr, out);
         }

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1848,6 +1848,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::StaticFieldSet { .. }
         | Expr::RegisterClassParentDynamic { .. }
         | Expr::RegisterClassStaticSymbol { .. }
+        | Expr::ClassExprFresh { .. }
         | Expr::SetFunctionPrototype { .. }
         | Expr::RegisterPrototypeMethod { .. }
         | Expr::RegisterFunctionPrototypeMethod { .. }

--- a/crates/perry-codegen/src/expr/static_field_meta.rs
+++ b/crates/perry-codegen/src/expr/static_field_meta.rs
@@ -152,6 +152,53 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             }
             Ok(double_literal(f64::from_bits(0x7FFC_0000_0000_0001)))
         }
+        // Issue #1772: per-evaluation class identity for a class expression.
+        // Each evaluation allocates a real heap "class object" — a regular
+        // object stamped with the compile-time template's `class_id` (so
+        // static methods / `new` / instanceof dispatch through the existing
+        // class_id machinery, no fresh hop, no method regression) and
+        // carrying the per-evaluation static fields as its own properties.
+        // So `make(a) !== make(b)` (distinct pointers), `make(a).ast` is an
+        // own field, `make(a).pipe()` dispatches via class_id=template, and
+        // the object is GC-traced + collected when unreachable (no leak).
+        Expr::ClassExprFresh {
+            template,
+            named_statics,
+            symbol_statics,
+        } => {
+            let template_cid = ctx.class_ids.get(template).copied().unwrap_or(0);
+            let tcid_str = template_cid.to_string();
+            let nfields = named_statics.len().to_string();
+            // Allocate with class_id = template; set_field_by_name below
+            // performs the keys-array transition for the named statics.
+            let obj =
+                ctx.block()
+                    .call(I64, "js_object_alloc", &[(I32, &tcid_str), (I32, &nfields)]);
+            for (name, init) in named_statics {
+                let key_idx = ctx.strings.intern(name);
+                let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                let v = lower_expr(ctx, init)?;
+                let blk = ctx.block();
+                let key_box = blk.load(DOUBLE, &key_handle_global);
+                let key_bits = blk.bitcast_double_to_i64(&key_box);
+                let key_raw = blk.and(I64, &key_bits, crate::nanbox::POINTER_MASK_I64);
+                blk.call_void(
+                    "js_object_set_field_by_name",
+                    &[(I64, &obj), (I64, &key_raw), (DOUBLE, &v)],
+                );
+            }
+            let obj_box = nanbox_pointer_inline(ctx.block(), &obj);
+            for (key, init) in symbol_statics {
+                let k = lower_expr(ctx, key)?;
+                let v = lower_expr(ctx, init)?;
+                ctx.block().call(
+                    DOUBLE,
+                    "js_object_set_symbol_property",
+                    &[(DOUBLE, &obj_box), (DOUBLE, &k), (DOUBLE, &v)],
+                );
+            }
+            Ok(obj_box)
+        }
         // Issue #711 part 2: `<expr>.prototype = <expr>` pattern.
         // Calls `js_set_function_prototype(func, proto)`, which (when
         // func is a closure and proto is an object) allocates a

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -303,6 +303,27 @@ pub enum Expr {
         value_expr: Box<Expr>,
     },
 
+    /// Issue #1772: per-evaluation identity for a class EXPRESSION
+    /// (`class C { ... }` in value position, e.g. effect's `make(ast) =>
+    /// class SchemaClass { static ast = ast }`). Codegen allocates a real
+    /// heap "class object" (`js_object_alloc(template_class_id, n)`) stamped
+    /// with the compile-time `template`'s class_id — so static methods /
+    /// `new` / `instanceof` keep dispatching through the existing class_id
+    /// machinery — and writes the per-evaluation static fields as the
+    /// object's OWN properties (`named_statics` via
+    /// `js_object_set_field_by_name`, `symbol_statics` via
+    /// `js_object_set_symbol_property`). The class value is the object
+    /// POINTER, so `make(a) !== make(b)` (distinct heap allocations) and
+    /// each carries its own `static ast`. Because it is a normal traced
+    /// heap object it is collectible — no leak. The static-field
+    /// initializers are evaluated against the current scope each time the
+    /// expression runs. Top-level class DECLARATIONS keep `INT32(class_id)`.
+    ClassExprFresh {
+        template: String,
+        named_statics: Vec<(String, Expr)>,
+        symbol_statics: Vec<(Expr, Expr)>,
+    },
+
     // Issue #711 part 2: `<func_expr>.prototype = <obj_expr>` pattern,
     // used by Effect's effectable.ts to declare prototype-based
     // classes. Codegen emits a call to `js_set_function_prototype`

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -1317,7 +1317,35 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                     _ => None,
                 })
                 .collect();
+            // Issue #1772: regular-named static fields with an initializer
+            // (`static ast = ast`). #894 only handled the Symbol-key case;
+            // these need the same per-evaluation treatment, otherwise a class
+            // expression returned from a factory (effect's `make`) shares one
+            // template class and `.ast` is undefined/clobbered.
+            let named_statics: Vec<(String, Expr)> = class
+                .static_fields
+                .iter()
+                .filter_map(|sf| match (sf.key_expr.as_ref(), sf.init.as_ref()) {
+                    (None, Some(v)) => Some((sf.name.clone(), v.clone())),
+                    _ => None,
+                })
+                .collect();
             ctx.pending_classes.push(class);
+            // #1772: a class EXPRESSION that carries per-evaluation static
+            // fields and is NOT a mixin (`class extends <expr>`) lowers to a
+            // fresh heap class object per evaluation (`ClassExprFresh`), so
+            // `make(a) !== make(b)` and each holds its own statics as own
+            // properties. Mixins and static-less class expressions keep the
+            // historical (shared-template) path.
+            if parent_expr.is_none()
+                && (!named_statics.is_empty() || !static_symbol_registrations.is_empty())
+            {
+                return Ok(Expr::ClassExprFresh {
+                    template: synthetic_name,
+                    named_statics,
+                    symbol_statics: static_symbol_registrations,
+                });
+            }
             let mut seq: Vec<Expr> = Vec::new();
             if let Some(p) = parent_expr {
                 seq.push(Expr::RegisterClassParentDynamic {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -537,6 +537,7 @@ impl SH for Expr {
             Expr::TemplateRaw(e) => { tag(h, 446); e.as_ref().hash(h); }
             Expr::RegisterClassParentDynamic { class_name, parent_expr, } => { tag(h, 447); class_name.hash(h); parent_expr.as_ref().hash(h); }
             Expr::RegisterClassStaticSymbol { class_name, key_expr, value_expr, } => { tag(h, 465); class_name.hash(h); key_expr.as_ref().hash(h); value_expr.as_ref().hash(h); }
+            Expr::ClassExprFresh { template, named_statics, symbol_statics, } => { tag(h, 466); template.hash(h); for (n, v) in named_statics { n.hash(h); v.hash(h); } for (k, v) in symbol_statics { k.hash(h); v.hash(h); } }
             Expr::SetFunctionPrototype { func, proto } => { tag(h, 448); func.as_ref().hash(h); proto.as_ref().hash(h); }
             Expr::RegisterPrototypeMethod { class_name, method_name, value, } => { tag(h, 463); class_name.hash(h); method_name.hash(h); value.as_ref().hash(h); }
             Expr::RegisterFunctionPrototypeMethod { func, method_name, value, } => { tag(h, 464); func.as_ref().hash(h); method_name.hash(h); value.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -481,6 +481,19 @@ where
             f(key_expr);
             f(value_expr);
         }
+        Expr::ClassExprFresh {
+            named_statics,
+            symbol_statics,
+            ..
+        } => {
+            for (_, v) in named_statics.iter_mut() {
+                f(v);
+            }
+            for (k, v) in symbol_statics.iter_mut() {
+                f(k);
+                f(v);
+            }
+        }
         Expr::SetFunctionPrototype { func, proto } => {
             f(func);
             f(proto);

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -482,6 +482,19 @@ where
             f(key_expr);
             f(value_expr);
         }
+        Expr::ClassExprFresh {
+            named_statics,
+            symbol_statics,
+            ..
+        } => {
+            for (_, v) in named_statics {
+                f(v);
+            }
+            for (k, v) in symbol_statics {
+                f(k);
+                f(v);
+            }
+        }
         Expr::SetFunctionPrototype { func, proto } => {
             f(func);
             f(proto);

--- a/crates/perry-transform/src/inline/analysis.rs
+++ b/crates/perry-transform/src/inline/analysis.rs
@@ -474,6 +474,7 @@ pub fn construction_expr_can_affect_method_lookup(
         | Expr::ClassStaticSymbolSet { .. }
         | Expr::RegisterClassParentDynamic { .. }
         | Expr::RegisterClassStaticSymbol { .. }
+        | Expr::ClassExprFresh { .. }
         | Expr::SetFunctionPrototype { .. }
         | Expr::RegisterPrototypeMethod { .. }
         | Expr::RegisterFunctionPrototypeMethod { .. }

--- a/crates/perry-transform/src/inline/cross_module.rs
+++ b/crates/perry-transform/src/inline/cross_module.rs
@@ -401,6 +401,11 @@ pub fn body_references_class_in_set(stmts: &[Stmt], set: &HashSet<String>) -> bo
                     return true;
                 }
             }
+            Expr::ClassExprFresh { template, .. } => {
+                if set.contains(template) {
+                    return true;
+                }
+            }
             _ => {}
         }
         let mut hit = false;

--- a/crates/perry-transform/src/inline/exact_receivers.rs
+++ b/crates/perry-transform/src/inline/exact_receivers.rs
@@ -116,6 +116,7 @@ pub fn invalidate_exact_receivers_for_expr(expr: &Expr, facts: &mut ExactReceive
         | Expr::ClassStaticSymbolSet { .. }
         | Expr::RegisterClassParentDynamic { .. }
         | Expr::RegisterClassStaticSymbol { .. }
+        | Expr::ClassExprFresh { .. }
         | Expr::SetFunctionPrototype { .. }
         | Expr::RegisterPrototypeMethod { .. }
         | Expr::RegisterFunctionPrototypeMethod { .. }

--- a/test-files/test_gap_class_expr_identity.ts
+++ b/test-files/test_gap_class_expr_identity.ts
@@ -1,0 +1,51 @@
+// Issue #1772 / #1786 (foundation): a class EXPRESSION must evaluate to a
+// real heap "class object" with PER-EVALUATION identity and its own static
+// fields — the "factory returns a class" pattern (e.g. effect Schema's
+// `make(ast) => class { static ast = ast }`). Perry previously hoisted a
+// class expression to ONE shared class id, so `make(a) === make(b)` and
+// every returned class shared (clobbered/undefined) statics. Now each
+// evaluation allocates a distinct class object stamped with the compile-time
+// template's class_id, carrying its static fields as OWN properties — so the
+// pointers differ and `.tag` is per-evaluation, while a no-`this` static
+// method still dispatches via the template class_id.
+//
+// Scope note: `extends`-inheritance of per-evaluation statics (#1788),
+// static-method `this`-binding (#1787) and new/instanceof on a class-object
+// value (#1789) are later phases and covered by their own tests. Reading a
+// per-eval static back through a binding the compiler resolves to the
+// template (`const X = class { static v = 1 }; X.v`) is also a later phase
+// — it requires dispatching the property read dynamically on the value
+// rather than as a compile-time static-field-get on the template — so the
+// cases below read through factory results, whose type is opaque to the
+// compiler and therefore already resolve dynamically on the value.
+//
+// Expected output:
+// identity: false
+// A.tag B.tag: AAA BBB
+// greet: hi
+// anon static: 77
+
+function make(tag: string) {
+  return class C {
+    static tag = tag;
+    static greet() {
+      return "hi";
+    }
+  };
+}
+const A = make("AAA");
+const B = make("BBB");
+// Distinct heap allocations → distinct pointers.
+console.log("identity:", (A as any) === (B as any));
+// Per-evaluation own static fields.
+console.log("A.tag B.tag:", (A as any).tag, (B as any).tag);
+// A no-`this` static method still dispatches (via class_id = template).
+console.log("greet:", (A as any).greet());
+
+// An anonymous class expression (no `C` name) also gets its own statics.
+function makeAnon(n: number) {
+  return class {
+    static v = n;
+  };
+}
+console.log("anon static:", (makeAnon(77) as any).v);


### PR DESCRIPTION
## (1) Foundation: class expressions → heap class objects with per-evaluation own static fields

Part of #1785 (epic). Design: #1772. First of the sequenced subtickets; unblocks #1787/#1788/#1789/#1790.

### What

Lower a class **expression** (`class C { ... }` in value position — e.g. effect Schema's `make(ast) => class { static ast = ast }`) to a new HIR node `Expr::ClassExprFresh`, which codegen lowers to a real **heap class object**:

- `js_object_alloc(template_class_id, n)` — a regular object stamped with the compile-time **template** class_id, so static methods / `new` / `instanceof` keep dispatching through the existing class_id machinery (no fresh-id hop, no method-dispatch regression).
- per-evaluation **named** static fields → own properties via `js_object_set_field_by_name`.
- per-evaluation **symbol** static fields → own symbol slots via `js_object_set_symbol_property`.
- the class **value** is the object POINTER.

Top-level class **declarations** are unchanged — they keep `INT32(class_id)`.

Because the class value is now a normal traced heap object, it is GC-collectible when unreachable — no leak, no rooting hazard (the whole reason this supersedes the integer-hack WIP; see #1772).

### Result

- `function make(a){ return class { static x = a } }` → `make(1) !== make(2)` (distinct pointers) and `make(1).x === 1`, `make(2).x === 2`.
- A no-`this` static method on such a class still dispatches and returns correctly (via class_id = template).
- `cargo test` (hir/codegen/transform/runtime) green; `cargo fmt` clean.

### Notes

- **Net diff is purely additive (+187 lines) with zero runtime-source changes** — `js_object_alloc` / `js_object_set_field_by_name` / `js_object_set_symbol_property` already exist. The abandoned integer-hack runtime helpers (`js_class_clone_for_expr`, the `CLASS_DYNAMIC_PROPS` / static-symbol parent-walks) are **not** present in this PR; this is the architecturally-correct object-model path from the #1772 design.
- Scope is deliberately limited to the foundation. Explicitly **out of scope** here (each its own subticket):
  - static-method `this`-binding on a class-object value → #1787
  - `extends`-inheritance of per-evaluation own statics → #1788
  - `new` / `instanceof` / `typeof` on a class-object value → #1789
  - GC layout descriptor + leak/stress verification → #1790
- Gap test `test-files/test_gap_class_expr_identity.ts` covers the foundation behaviors (identity, per-eval own statics, no-`this` static-method dispatch); the extends/this-binding cases move to the later phases' tests.

Closes #1786.
