### PR TITLE
fix: class-object value dispatch — static-method this-binding (#1787) + extends static-field inheritance (#1788)

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -779,6 +779,14 @@ pub fn try_lower_property_get_method_call(
     ) -> Option<String> {
         match expr {
             Expr::ClassRef(name) => Some(name.clone()),
+            // #1787: a class EXPRESSION value (`make(a) => class { ... }`,
+            // lowered to `ClassExprFresh`) is a heap class object stamped
+            // with the compile-time `template`'s class_id. A static-method
+            // call on it (`make(a).pipe()`, the inlined factory result)
+            // resolves the method through `template`'s static chain, and the
+            // receiver-box selection below uses the actual object so `this`
+            // carries the per-evaluation own static fields.
+            Expr::ClassExprFresh { template, .. } => Some(template.clone()),
             Expr::LocalGet(id) => local_id_to_name
                 .get(id)
                 .and_then(|name| local_class_aliases.get(name).cloned()),
@@ -854,6 +862,22 @@ pub fn try_lower_property_get_method_call(
                 Expr::ClassRef(_) => lower_expr(ctx, object)?,
                 Expr::Call { .. } => lower_expr(ctx, object)?,
                 Expr::Sequence(_) => lower_expr(ctx, object)?,
+                // #1787: a class-expression value is a real heap class
+                // object whose per-evaluation static fields are OWN
+                // properties. Use the actual lowered object as `this` (NOT a
+                // synthesized ClassRef) so `this.ast` inside the static body
+                // reads this evaluation's own field rather than the shared
+                // template's static-field global.
+                Expr::ClassExprFresh { .. } => lower_expr(ctx, object)?,
+                // #1787: `const C = make(...); C.staticMethod()`. The local
+                // holds the class-expression's heap object (or, for a
+                // top-level-class alias like `const F = Foo`, the same
+                // INT32 ClassRef the synthesized fallback would produce).
+                // Loading the actual stored value preserves the
+                // per-evaluation own static fields a synthesized ClassRef
+                // would discard, and is value-identical for the ClassRef
+                // case — so `this.<field>` resolves correctly either way.
+                Expr::LocalGet(_) => lower_expr(ctx, object)?,
                 _ => {
                     // Synthesize a ClassRef NaN-box from the resolved class.
                     let cid = ctx.class_ids.get(&cls_name).copied().unwrap_or(0);

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -60,6 +60,17 @@ pub(crate) fn lower_let(
             ctx.local_class_aliases
                 .insert(name.to_string(), class_name.clone());
         }
+        // #1787: `const C = make(...)` where the factory body is a class
+        // EXPRESSION (lowered to `ClassExprFresh`, often inlined into the
+        // Let init). Register `C` as an alias of the compile-time template
+        // so a later `C.staticMethod(...)` resolves through the template's
+        // static chain; the static-dispatch site uses the actual object
+        // value as `this`, so `this.<field>` reads this evaluation's own
+        // static field.
+        Some(perry_hir::Expr::ClassExprFresh { template, .. }) => {
+            ctx.local_class_aliases
+                .insert(name.to_string(), template.clone());
+        }
         Some(perry_hir::Expr::LocalGet(other_id)) => {
             if let Some(other_name) = ctx.local_id_to_name.get(other_id).cloned() {
                 if let Some(resolved) = ctx.local_class_aliases.get(&other_name).cloned() {

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1408,6 +1408,25 @@ pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, parent_value: 
     if parent_cid != 0 && parent_cid != class_id {
         register_class(class_id, parent_cid);
     }
+
+    // #1788: when the parent is a per-evaluation class OBJECT (a class
+    // expression value, POINTER-tagged), record it as `class_id`'s static
+    // prototype so static-field lookups on the subclass walk to the parent
+    // object's OWN per-evaluation static fields — effect's
+    // `class Number$ extends make(numberKeyword) {}` → `Number$.ast`. Reuses
+    // the CLASS_PROTOTYPE_OBJECTS map (the same #711/#809 vehicle), resolved
+    // via `resolve_proto_chain_field`; the class_id parent edge above keeps
+    // method/`new`/instanceof dispatch on the existing fast path.
+    if tag == POINTER_TAG {
+        let ptr = crate::value::js_nanbox_get_pointer(parent_value) as *mut ObjectHeader;
+        if !ptr.is_null() && js_object_get_class_id(ptr as *const ObjectHeader) != 0 {
+            let mut write = CLASS_PROTOTYPE_OBJECTS.write().unwrap();
+            if write.is_none() {
+                *write = Some(HashMap::new());
+            }
+            write.as_mut().unwrap().insert(class_id, ptr as usize);
+        }
+    }
 }
 
 /// Look up parent class ID from the registry

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -872,6 +872,18 @@ pub extern "C" fn js_object_get_field_by_name(
                     if let Some(v) = result {
                         return JSValue::from_bits(v.to_bits());
                     }
+                    // #1788: a subclass of a class-expression value
+                    // (`class Sub extends make("A") {}`) inherits the parent
+                    // class OBJECT's OWN per-evaluation static fields. The
+                    // parent object was recorded as `class_id`'s static
+                    // prototype at `extends` time; walk that chain (also
+                    // covering multi-level `class Leaf extends Mid {}`).
+                    if let Some(v) = super::class_registry::resolve_proto_chain_field(class_id, key)
+                    {
+                        if !v.is_undefined() && !v.is_null() {
+                            return v;
+                        }
+                    }
                 }
             }
             return JSValue::undefined();

--- a/test-files/test_gap_class_expr_extends_static.ts
+++ b/test-files/test_gap_class_expr_extends_static.ts
@@ -1,0 +1,34 @@
+// Issue #1788: a class DECLARATION that `extends` a class-expression value
+// (`class Sub extends make("A") {}`) must inherit the parent class object's
+// per-evaluation OWN static fields. effect's base schemas use exactly this
+// shape: `class Number$ extends make(numberKeyword) {}`, then read
+// `Number$.ast`. The parent class object is recorded as the subclass's
+// static prototype at `extends` time; static-field reads walk that chain
+// (also covering a multi-level `class Leaf extends Mid {}`).
+//
+// Scope: static FIELD inheritance (the primary criterion). Inherited static
+// METHODS through a dynamic parent are tracked as the remaining #1788
+// sub-item.
+//
+// Expected output:
+// Sub.ast: A
+// Other.ast: B
+// Leaf.ast (2-level): M
+
+function make(tag: string) {
+  return class {
+    static ast = tag;
+  };
+}
+
+class Sub extends make("A") {}
+console.log("Sub.ast:", (Sub as any).ast);
+
+// A second subclass off a distinct evaluation gets the distinct parent field.
+class Other extends make("B") {}
+console.log("Other.ast:", (Other as any).ast);
+
+// Two-level: Leaf inherits from Mid which extends the class object.
+class Mid extends make("M") {}
+class Leaf extends Mid {}
+console.log("Leaf.ast (2-level):", (Leaf as any).ast);

--- a/test-files/test_gap_class_expr_static_this.ts
+++ b/test-files/test_gap_class_expr_static_this.ts
@@ -1,0 +1,43 @@
+// Issue #1787: a static method called on a class-object VALUE (a class
+// expression returned from a factory, lowered to a heap class object) must
+// bind `this` to that value, so `this.<field>` reads this evaluation's own
+// static field — not the shared template's static-field global. Both the
+// inline factory-result form (`make(a).m()`) and the const-bound form
+// (`const C = make(a); C.m()`) dispatch through the template's static chain
+// with `this` = the actual object.
+//
+// Scope: the static-method CALL binding (acceptance criterion #1). The
+// method VALUE-read form (`typeof make(a).m === "function"`, criterion #2)
+// goes through the separate value-read path and is tracked as the remaining
+// #1787 sub-item.
+//
+// Expected output:
+// inline X: X
+// inline Y: Y
+// const Z: Z
+// two-arg: a|b X
+
+function make(tag: string) {
+  return class {
+    static ast = tag;
+    static viaThis() {
+      return this.ast;
+    }
+    static withArgs(a: string, b: string) {
+      return a + "|" + b + " " + this.ast;
+    }
+  };
+}
+
+// Inline factory-result static-method call binds `this` to the fresh object.
+console.log("inline X:", make("X").viaThis());
+console.log("inline Y:", make("Y").viaThis());
+
+// Const-bound class object: `C.viaThis()` binds `this` to C, reading C's
+// own per-evaluation `ast`.
+const C = make("Z");
+console.log("const Z:", C.viaThis());
+
+// Args are not corrupted by the receiver (static methods have no `this`
+// param; `this` arrives via the implicit-this slot).
+console.log("two-arg:", make("X").withArgs("a", "b"));


### PR DESCRIPTION
## Track A (epic #1785): class-object value dispatch — #1787 + #1788

Stacked progress on top of the merged #1786 foundation (#1792). Two self-contained increments, each validated byte-for-byte against node with zero regressions.

### #1787 — static-method `this`-binding on a class-object value (commit 1)
A static method called on a class-expression value (`make(a).pipe()`, effect Schema) now binds `this` to that value, so `this.<field>` reads this evaluation's OWN static field. Codegen-only (+35 lines): routes a `ClassExprFresh`/class-alias receiver through the existing static-dispatch path (which already sets the implicit-`this` slot and forwards real args without a receiver-prepend, so static methods with params aren't corrupted).
- `make("X").viaThis() === "X"`, `make("Y").viaThis() === "Y"` ✅
- `const C = make("Z"); C.viaThis() === "Z"` ✅
- own static-field value-reads (`make(a).ast`, `C.ast`) and const-bound method `typeof` already work ✅
- Gap test `test_gap_class_expr_static_this.ts`.
- **Remaining sub-item:** the *inline* method value-read `typeof make("X").m === "function"` (the receiver is an un-bound factory `Call`, resolved via the hot value-read path) — marginal pattern, deferred.

### #1788 — inherit per-evaluation own static fields through `extends` (commit 2)
A class declaration that `extends` a class-object value (`class Number$ extends make(numberKeyword) {}`) inherits the parent class object's per-evaluation OWN static fields. `js_register_class_parent_dynamic` now also records the parent OBJECT as the subclass's static prototype in the GC-traced `CLASS_PROTOTYPE_OBJECTS` (the #711/#809 vehicle); the INT32-ClassRef static-field read walks it via the existing `resolve_proto_chain_field` (N-level) on a `CLASS_DYNAMIC_PROPS` miss.
- `class Sub extends make("A") {}` → `Sub.ast === "A"` ✅
- distinct evaluations → distinct inherited fields ✅
- 2-level `class Leaf extends Mid {}` → `Leaf.ast === "M"` ✅
- Gap test `test_gap_class_expr_extends_static.ts`.
- **Remaining sub-item:** inherited static *methods* through a dynamic parent (`Sub.greet()`) — the codegen tower can't see a dynamic parent's methods and they aren't in the instance vtable; needs a runtime class_id static-method parent-walk with `this`-binding. Next #1788 step.

### Validation
Both gap tests byte-identical to node; the existing class suite + the #1786 gap test unchanged (15/15 spot-check). `cargo fmt` clean.

Refs #1787, #1788, #1785, #1772. Does not yet fully close #1787/#1788 (sub-items above) or #1789.
