### PR TITLE
fix(runtime): SSO-aware decoding at is_string()-then-fallback sites (#1781)

### DIFF
--- a/crates/perry-runtime/src/bigint.rs
+++ b/crates/perry-runtime/src/bigint.rs
@@ -159,9 +159,14 @@ pub extern "C" fn js_bigint_from_f64(value: f64) -> *mut BigIntHeader {
         return js_bigint_from_i64(int_value);
     }
 
-    // If it's a string, parse as BigInt (e.g., BigInt("1000000"))
-    if jsval.is_string() {
-        let ptr = jsval.as_string_ptr();
+    // If it's a string, parse as BigInt (e.g., BigInt("1000000")).
+    // #1781: accept inline SSO short strings too — `BigInt("123")` is a
+    // 3-byte SSO value that `is_string()` (STRING_TAG-only) would reject,
+    // dropping it to the `value as i64` fallback (NaN → 0n). Route through
+    // the unified decoder, which materializes SSO bytes onto the heap.
+    if jsval.is_any_string() {
+        let ptr = crate::value::js_get_string_pointer_unified(value)
+            as *const crate::string::StringHeader;
         if !ptr.is_null() {
             unsafe {
                 let len = (*ptr).byte_len;
@@ -1424,6 +1429,36 @@ mod tests {
                 fits_in_i64(&(*beyond).limbs).is_none(),
                 "i64::MAX + 1 should not fit in i64"
             );
+        }
+    }
+}
+
+#[cfg(test)]
+mod sso_tests_1781 {
+    use super::*;
+
+    /// #1781: `BigInt("123")` — a numeric string <= 5 bytes is an inline SSO
+    /// value (tag 0x7FF9). `is_string()` is STRING_TAG-only, so pre-fix it
+    /// fell through to the `value as i64` arm (the SSO f64 is NaN → 0), and
+    /// `BigInt("123")` produced `0n`. Route through the unified decoder.
+    #[test]
+    fn bigint_from_f64_parses_sso_numeric_strings() {
+        for s in ["0", "1", "42", "123", "12345"] {
+            let v = crate::value::JSValue::try_short_string(s.as_bytes())
+                .expect("numeric string <= 5 bytes encodes as inline SSO");
+            assert!(v.is_short_string(), "{s:?} should be an inline SSO value");
+            let bi = js_bigint_from_f64(f64::from_bits(v.bits()));
+            assert!(!bi.is_null(), "null BigInt for {s:?}");
+            let out = js_bigint_to_string(bi);
+            let got = unsafe {
+                let len = (*out).byte_len as usize;
+                let data =
+                    (out as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+                std::str::from_utf8(std::slice::from_raw_parts(data, len))
+                    .unwrap()
+                    .to_string()
+            };
+            assert_eq!(got, s, "BigInt({s:?}) mismatch");
         }
     }
 }

--- a/crates/perry-runtime/src/builtins/table.rs
+++ b/crates/perry-runtime/src/builtins/table.rs
@@ -28,17 +28,11 @@ fn format_table_cell(value: f64) -> String {
             "null".to_string()
         } else if jsval.is_bool() {
             jsval.as_bool().to_string()
-        } else if jsval.is_string() {
-            let ptr = jsval.as_string_ptr();
-            if ptr.is_null() {
-                "''".to_string()
-            } else {
-                let len = (*ptr).byte_len as usize;
-                let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-                let bytes = std::slice::from_raw_parts(data, len);
-                let s = std::str::from_utf8(bytes).unwrap_or("[invalid utf8]");
-                format!("'{}'", s)
-            }
+        } else if let Some(s) = read_string_from_jsvalue(jsval) {
+            // #1781: covers both heap STRING_TAG and inline SSO short
+            // strings — without the SSO branch a <=5-char cell fell through
+            // to the numeric arm and rendered as "NaN".
+            format!("'{}'", s)
         } else if jsval.is_int32() {
             jsval.as_int32().to_string()
         } else if jsval.is_pointer() {
@@ -69,8 +63,19 @@ fn format_table_cell(value: f64) -> String {
     }
 }
 
-/// Read a string out of a NaN-boxed string JSValue.
+/// Read a string out of a NaN-boxed string JSValue. SSO-aware (#1781):
+/// accepts both heap `STRING_TAG` pointers and inline `SHORT_STRING_TAG`
+/// values; returns `None` for non-strings.
 unsafe fn read_string_from_jsvalue(jsval: JSValue) -> Option<String> {
+    if jsval.is_short_string() {
+        let mut buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+        let n = jsval.short_string_to_buf(&mut buf);
+        return Some(
+            std::str::from_utf8(&buf[..n])
+                .unwrap_or("[invalid utf8]")
+                .to_string(),
+        );
+    }
     if !jsval.is_string() {
         return None;
     }
@@ -568,4 +573,31 @@ unsafe fn build_temp_string_header(s: &str) -> *const StringHeader {
 
 unsafe fn free_temp_string_header(_ptr: *const StringHeader) {
     // No-op: GC-allocated, will be collected.
+}
+
+#[cfg(test)]
+mod sso_tests_1781 {
+    use super::*;
+
+    /// #1781: `console.table` cells/headers that are strings <= 5 bytes are
+    /// inline SSO values. `is_string()` (STRING_TAG-only) missed them, so a
+    /// short cell fell through to the numeric arm and rendered as "NaN", and
+    /// a short header decoded to None.
+    #[test]
+    fn read_string_from_jsvalue_handles_sso() {
+        for s in ["", "a", "id", "abc", "hello"] {
+            let v = JSValue::try_short_string(s.as_bytes()).expect("len <= 5 -> SSO");
+            let got = unsafe { read_string_from_jsvalue(v) };
+            assert_eq!(got.as_deref(), Some(s), "header decode mismatch for {s:?}");
+        }
+    }
+
+    #[test]
+    fn format_table_cell_quotes_sso_string() {
+        let v = JSValue::try_short_string(b"abc").expect("SSO");
+        assert_eq!(format_table_cell(f64::from_bits(v.bits())), "'abc'");
+        // empty SSO string renders as ''
+        let empty = JSValue::try_short_string(b"").expect("SSO");
+        assert_eq!(format_table_cell(f64::from_bits(empty.bits())), "''");
+    }
 }

--- a/crates/perry-runtime/src/fs/callbacks.rs
+++ b/crates/perry-runtime/src/fs/callbacks.rs
@@ -606,6 +606,15 @@ pub(crate) unsafe fn open_flag_is_read_only(flags_value: f64) -> bool {
 
 pub(crate) unsafe fn decode_flags_string(value: f64) -> Option<String> {
     let jsval = crate::value::JSValue::from_bits(value.to_bits());
+    // #1781: fs flag strings ("r", "r+", "w", "a", "wx", …) are ALL
+    // <= 5 bytes, so they are inline SSO values and `is_string()`
+    // (STRING_TAG-only) rejects every one of them. Decode the inline
+    // bytes directly before falling through to the heap-string path.
+    if jsval.is_short_string() {
+        let mut buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+        let n = jsval.short_string_to_buf(&mut buf);
+        return std::str::from_utf8(&buf[..n]).ok().map(|s| s.to_string());
+    }
     if !jsval.is_string() {
         return None;
     }
@@ -952,4 +961,35 @@ pub extern "C" fn js_fs_copy_file_callback(
     let _ = js_fs_copy_file_sync_flags(from_value, to_value, flags);
     call_cb0(cb);
     f64::from_bits(TAG_UNDEFINED)
+}
+
+#[cfg(test)]
+mod sso_tests_1781 {
+    use super::*;
+
+    /// #1781: fs flag strings ("r", "r+", "w", "a", "wx", …) are all <= 5
+    /// bytes, so they are inline SSO values (tag 0x7FF9). `is_string()` is
+    /// STRING_TAG-only and rejected every one — `decode_flags_string`
+    /// returned None for all flags, breaking the read-only fast-path probe.
+    #[test]
+    fn decode_flags_string_handles_sso_flags() {
+        for flag in ["r", "r+", "w", "w+", "a", "a+", "wx", "ax", "as"] {
+            let v = crate::value::JSValue::try_short_string(flag.as_bytes())
+                .expect("flag <= 5 bytes encodes as inline SSO");
+            assert!(
+                v.is_short_string(),
+                "{flag:?} should be an inline SSO value"
+            );
+            let got = unsafe { decode_flags_string(f64::from_bits(v.bits())) };
+            assert_eq!(got.as_deref(), Some(flag), "decode mismatch for {flag:?}");
+        }
+    }
+
+    #[test]
+    fn open_flag_is_read_only_recognizes_sso_flags() {
+        let r = crate::value::JSValue::try_short_string(b"r").unwrap();
+        assert!(unsafe { open_flag_is_read_only(f64::from_bits(r.bits())) });
+        let w = crate::value::JSValue::try_short_string(b"w").unwrap();
+        assert!(!unsafe { open_flag_is_read_only(f64::from_bits(w.bits())) });
+    }
 }

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -689,6 +689,15 @@ fn chown_path_value(path_value: f64, uid_value: f64, gid_value: f64, follow: boo
 /// cost that follows.
 unsafe fn decode_path_value(path_value: f64) -> Option<String> {
     let jsval = crate::value::JSValue::from_bits(path_value.to_bits());
+    // #1781: a path <= 5 bytes ("a.ts", "x", ".", "..", "/tmp") is an
+    // inline SSO value that `is_string()` (STRING_TAG-only) misses,
+    // so short relative paths silently decoded to None. Read the inline
+    // bytes directly.
+    if jsval.is_short_string() {
+        let mut buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+        let n = jsval.short_string_to_buf(&mut buf);
+        return std::str::from_utf8(&buf[..n]).ok().map(|s| s.to_string());
+    }
     if jsval.is_string() {
         let path_ptr = jsval.as_string_ptr();
         if path_ptr.is_null() {
@@ -1602,5 +1611,24 @@ unsafe fn fs_callback_write_parent_error(path_value: f64, syscall: &'static str)
             Some(build_fs_error_value(&err, syscall, &path))
         }
         Err(err) => Some(build_fs_error_value(&err, syscall, &path)),
+    }
+}
+
+#[cfg(test)]
+mod sso_tests_1781 {
+    use super::*;
+
+    /// #1781: a path <= 5 bytes ("x", ".", "..", "a.ts", "/tmp") is an inline
+    /// SSO value that `is_string()` (STRING_TAG-only) misses, so short
+    /// relative paths silently decoded to None and the fs op failed.
+    #[test]
+    fn decode_path_value_handles_sso_short_paths() {
+        for p in ["x", ".", "..", "a.ts", "/tmp"] {
+            let v = crate::value::JSValue::try_short_string(p.as_bytes())
+                .expect("path <= 5 bytes encodes as inline SSO");
+            assert!(v.is_short_string(), "{p:?} should be an inline SSO value");
+            let got = unsafe { decode_path_value(f64::from_bits(v.bits())) };
+            assert_eq!(got.as_deref(), Some(p), "path decode mismatch for {p:?}");
+        }
     }
 }

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -133,9 +133,14 @@ pub extern "C" fn js_object_delete_field(
 pub extern "C" fn js_object_delete_dynamic(obj: *mut ObjectHeader, key: f64) -> i32 {
     let key_val = JSValue::from_bits(key.to_bits());
 
-    // If the key is a string, use js_object_delete_field
-    if key_val.is_string() {
-        let key_str = key_val.as_string_ptr();
+    // If the key is a string, use js_object_delete_field. #1781: accept
+    // inline SSO short keys — `delete obj["abc"]` for a <=5-char key arrives
+    // as a SHORT_STRING_TAG value that is_string() rejects, so the delete
+    // silently no-op'd (fell through to "succeeds vacuously"). Materialize
+    // the key to a heap header so js_object_delete_field can match it.
+    if key_val.is_any_string() {
+        let key_str =
+            crate::value::js_get_string_pointer_unified(key) as *const crate::StringHeader;
         return js_object_delete_field(obj, key_str);
     }
 
@@ -231,5 +236,48 @@ pub extern "C" fn js_object_rest(
         }
 
         rest_obj
+    }
+}
+
+#[cfg(test)]
+mod sso_tests_1781 {
+    use super::*;
+
+    /// #1781: `delete obj["id"]` for a key <= 5 bytes — the dynamic key
+    /// arrives as an inline SSO value that `is_string()` (STRING_TAG-only)
+    /// rejected, so the delete silently no-op'd (fell through to "succeeds
+    /// vacuously") and the property stayed put.
+    #[test]
+    fn delete_dynamic_removes_property_via_sso_key() {
+        unsafe {
+            let obj = crate::object::js_object_alloc(0, 0);
+            let key = crate::string::js_string_from_bytes(b"id".as_ptr(), 2);
+            crate::object::js_object_set_field_by_name(obj, key, 42.0);
+
+            let obj_box = crate::value::js_nanbox_pointer(obj as i64);
+            let sso = crate::value::JSValue::try_short_string(b"id").unwrap();
+            assert!(sso.is_short_string());
+            // present before delete
+            assert_ne!(
+                crate::value::js_is_truthy(crate::object::js_object_has_property(
+                    obj_box,
+                    f64::from_bits(sso.bits())
+                )),
+                0
+            );
+
+            let ok = js_object_delete_dynamic(obj, f64::from_bits(sso.bits()));
+            assert_eq!(ok, 1, "delete should report success");
+
+            // gone after delete
+            assert_eq!(
+                crate::value::js_is_truthy(crate::object::js_object_has_property(
+                    obj_box,
+                    f64::from_bits(sso.bits())
+                )),
+                0,
+                "SSO key should be removed after delete"
+            );
+        }
     }
 }

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -687,10 +687,15 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
     // handle property dispatcher whether the property resolves to a real
     // value.
     if obj_addr > 0 && obj_addr < 0x100000 {
-        if key_val.is_string() {
+        // #1781: accept inline SSO short keys (`"id" in handle`) — is_string()
+        // is STRING_TAG-only, so a <=5-char key skipped the handle dispatcher
+        // and `in` wrongly returned false. Materialize SSO bytes to a heap
+        // header before reading name_ptr/name_len.
+        if key_val.is_any_string() {
             unsafe {
                 if let Some(dispatch) = super::class_registry::handle_property_dispatch() {
-                    let key_ptr = key_val.as_string_ptr();
+                    let key_ptr = crate::value::js_get_string_pointer_unified(key)
+                        as *const crate::StringHeader;
                     let name_ptr =
                         (key_ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                     let name_len = (*key_ptr).byte_len as usize;
@@ -765,11 +770,15 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
         }
     }
 
-    if !key_val.is_string() {
+    // #1781: accept inline SSO short keys here too — `"abc" in obj` for a
+    // <=5-char key arrives as a SHORT_STRING_TAG value that is_string()
+    // rejects, so `in` wrongly returned false. Materialize to a heap header
+    // (stored keys in keys_array are always heap, so js_string_equals works).
+    if !key_val.is_any_string() {
         return nanbox_false;
     }
 
-    let key_str = key_val.as_string_ptr();
+    let key_str = crate::value::js_get_string_pointer_unified(key) as *const crate::StringHeader;
 
     unsafe {
         let keys = (*obj_ptr).keys_array;
@@ -2137,3 +2146,40 @@ pub extern "C" fn js_object_get_field_ic_miss(
 // than touching object field storage directly, so they were split out
 // of this module. See `polymorphic_index.rs` for the implementations
 // and the #471 fix notes.
+
+#[cfg(test)]
+mod sso_tests_1781 {
+    use super::*;
+
+    /// #1781: `"id" in obj` for a key <= 5 bytes — the lookup key arrives as
+    /// an inline SSO value (tag 0x7FF9). `is_string()` (STRING_TAG-only)
+    /// rejected it, so `js_object_has_property` returned false even though the
+    /// object had the key (stored keys are always heap, so materializing the
+    /// SSO lookup key lets js_string_equals match).
+    #[test]
+    fn in_operator_finds_object_key_via_sso_lookup() {
+        unsafe {
+            let obj = crate::object::js_object_alloc(0, 0);
+            let key = crate::string::js_string_from_bytes(b"id".as_ptr(), 2);
+            crate::object::js_object_set_field_by_name(obj, key, 42.0);
+
+            let obj_box = crate::value::js_nanbox_pointer(obj as i64);
+            let sso = crate::value::JSValue::try_short_string(b"id").unwrap();
+            assert!(sso.is_short_string());
+            let present = js_object_has_property(obj_box, f64::from_bits(sso.bits()));
+            assert_ne!(
+                crate::value::js_is_truthy(present),
+                0,
+                "SSO key 'id' should be found via `in`"
+            );
+
+            let missing = crate::value::JSValue::try_short_string(b"zz").unwrap();
+            let absent = js_object_has_property(obj_box, f64::from_bits(missing.bits()));
+            assert_eq!(
+                crate::value::js_is_truthy(absent),
+                0,
+                "absent SSO key 'zz' should not be found"
+            );
+        }
+    }
+}

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -219,11 +219,18 @@ pub extern "C" fn js_object_is(a: f64, b: f64) -> f64 {
         return f64::from_bits(TAG_FALSE);
     }
 
-    // For strings, do content comparison
-    if a_jsval.is_string() && b_jsval.is_string() {
+    // For strings, do content comparison. #1781: accept inline SSO short
+    // strings on either side. Two SSO operands with equal content already
+    // match via the bit-pattern fallback below, but a mixed SSO/heap pair
+    // (same content, different representation — e.g. a JSON-parsed value vs
+    // a heap literal) would not. Materialize via the unified decoder so the
+    // comparison is representation-independent.
+    if a_jsval.is_any_string() && b_jsval.is_any_string() {
         let result = crate::string::js_string_equals(
-            a_jsval.as_string_ptr() as *const crate::StringHeader,
-            b_jsval.as_string_ptr() as *const crate::StringHeader,
+            crate::value::js_get_string_pointer_unified(f64::from_bits(a_bits))
+                as *const crate::StringHeader,
+            crate::value::js_get_string_pointer_unified(f64::from_bits(b_bits))
+                as *const crate::StringHeader,
         );
         if result != 0 {
             return f64::from_bits(TAG_TRUE);
@@ -1276,5 +1283,47 @@ pub extern "C" fn js_create_namespace(
         obj = obj_handle.get_raw_mut_ptr::<ObjectHeader>();
         let bits = (obj as u64) | 0x7FFD_0000_0000_0000;
         f64::from_bits(bits)
+    }
+}
+
+#[cfg(test)]
+mod sso_tests_1781 {
+    use super::*;
+
+    /// #1781: `Object.is` content-compares strings only when both sides pass
+    /// `is_string()` (STRING_TAG-only). Two SSO operands match via the
+    /// bit-pattern fallback, but a mixed SSO/heap pair with equal content
+    /// (e.g. a JSON-parsed value vs a heap literal) did not — `Object.is`
+    /// wrongly returned false. Now representation-independent.
+    #[test]
+    fn object_is_compares_sso_and_mixed_strings() {
+        let truthy = |v: f64| crate::value::js_is_truthy(v) != 0;
+        let a = JSValue::try_short_string(b"abc").unwrap();
+        let b = JSValue::try_short_string(b"abc").unwrap();
+        assert!(
+            truthy(js_object_is(
+                f64::from_bits(a.bits()),
+                f64::from_bits(b.bits())
+            )),
+            "two equal SSO strings"
+        );
+
+        let heap = JSValue::string_ptr(crate::string::js_string_from_bytes(b"abc".as_ptr(), 3));
+        assert!(
+            truthy(js_object_is(
+                f64::from_bits(a.bits()),
+                f64::from_bits(heap.bits())
+            )),
+            "mixed SSO/heap, equal content"
+        );
+
+        let c = JSValue::try_short_string(b"xyz").unwrap();
+        assert!(
+            !truthy(js_object_is(
+                f64::from_bits(a.bits()),
+                f64::from_bits(c.bits())
+            )),
+            "different content"
+        );
     }
 }

--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -168,6 +168,26 @@ unsafe fn coerce_to_string(value: f64) -> String {
     header_to_string(ptr)
 }
 
+/// Decode a JSValue to an owned `String` iff it actually *is* a string,
+/// accepting BOTH heap `STRING_TAG` pointers and inline `SHORT_STRING_TAG`
+/// (SSO) values. Returns `None` for non-strings.
+///
+/// #1781: `is_string()` is STRING_TAG-only, so the old
+/// `v.is_string() { header_to_string(v.as_string_ptr()) }` shape silently
+/// dropped every short mark/measure/type name — and the common literals
+/// `"mark"` (4 bytes) and observer `entryTypes: ["mark"]` are inline SSO.
+unsafe fn string_of(v: JSValue) -> Option<String> {
+    if v.is_string() {
+        Some(header_to_string(v.as_string_ptr()))
+    } else if v.is_short_string() {
+        let mut buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+        let n = v.short_string_to_buf(&mut buf);
+        Some(std::str::from_utf8(&buf[..n]).unwrap_or("").to_string())
+    } else {
+        None
+    }
+}
+
 /// Read a JS value as an f64 if it is numeric, accepting both the int32 and
 /// double NaN-box representations (`is_number()` alone misses int32 since
 /// INT32_TAG falls inside the tagged range). Returns `None` otherwise.
@@ -253,8 +273,7 @@ unsafe fn resolve_option_endpoint(
 unsafe fn resolve_endpoint_value(v: JSValue) -> f64 {
     if let Some(n) = num_of(v) {
         n
-    } else if v.is_string() {
-        let name = header_to_string(v.as_string_ptr());
+    } else if let Some(name) = string_of(v) {
         lookup_mark_start(&name).unwrap_or(0.0)
     } else {
         0.0
@@ -268,8 +287,7 @@ unsafe fn resolve_endpoint_value(v: JSValue) -> f64 {
 unsafe fn resolve_positional_endpoint(v: JSValue) -> f64 {
     if let Some(n) = num_of(v) {
         n
-    } else if v.is_string() {
-        let name = header_to_string(v.as_string_ptr());
+    } else if let Some(name) = string_of(v) {
         match lookup_mark_start(&name) {
             Some(t) => t,
             None => throw_type_error(&format!("The \"{name}\" performance mark has not been set")),
@@ -414,11 +432,11 @@ pub extern "C" fn js_perf_measure(name_val: f64, arg2: f64, arg3: f64) -> f64 {
 
             let detail_bits = option_detail_bits(opts);
             return finish_measure(name, start_time, duration, detail_bits);
-        } else if arg2_jv.is_string() {
+        } else if arg2_jv.is_any_string() {
             // Positional form: measure(name, startMark, endMark?)
             let start = resolve_positional_endpoint(arg2_jv);
             let arg3_jv = JSValue::from_bits(arg3.to_bits());
-            let end = if arg3_jv.is_string() || arg3_jv.is_number() {
+            let end = if arg3_jv.is_any_string() || arg3_jv.is_number() {
                 resolve_positional_endpoint(arg3_jv)
             } else {
                 perf_now()
@@ -506,8 +524,8 @@ pub extern "C" fn js_perf_get_entries_by_name(name_val: f64, type_val: f64) -> f
     unsafe {
         let want_name = coerce_to_string(name_val);
         let type_jv = JSValue::from_bits(type_val.to_bits());
-        let want_type: Option<u8> = if type_jv.is_string() {
-            match header_to_string(type_jv.as_string_ptr()).as_str() {
+        let want_type: Option<u8> = if let Some(t) = string_of(type_jv) {
+            match t.as_str() {
                 "mark" => Some(ENTRY_TYPE_MARK),
                 "measure" => Some(ENTRY_TYPE_MEASURE),
                 _ => Some(255),
@@ -791,8 +809,8 @@ pub extern "C" fn js_perf_observer_observe(obs_val: f64, opts: f64) -> f64 {
                 let len = crate::array::js_array_length(arr);
                 for i in 0..len {
                     let el = crate::array::js_array_get(arr, i);
-                    if el.is_string() {
-                        if let Some(code) = entry_type_code(&header_to_string(el.as_string_ptr())) {
+                    if let Some(s) = string_of(el) {
+                        if let Some(code) = entry_type_code(&s) {
                             types.push(code);
                         }
                     }
@@ -802,8 +820,8 @@ pub extern "C" fn js_perf_observer_observe(obs_val: f64, opts: f64) -> f64 {
             let tkey = b"type";
             let tkp = crate::string::js_string_from_bytes(tkey.as_ptr(), tkey.len() as u32);
             let t_v = js_object_get_field_by_name(opts_obj, tkp);
-            if t_v.is_string() {
-                if let Some(code) = entry_type_code(&header_to_string(t_v.as_string_ptr())) {
+            if let Some(s) = string_of(t_v) {
+                if let Some(code) = entry_type_code(&s) {
                     types.push(code);
                 }
             }
@@ -1073,4 +1091,61 @@ pub extern "C" fn js_perf_histogram_noop() -> f64 {
 #[no_mangle]
 pub extern "C" fn js_perf_histogram_percentile(_p: f64) -> f64 {
     0.0
+}
+
+#[cfg(test)]
+mod sso_tests_1781 {
+    use super::*;
+
+    /// #1781: perf entry-type/name strings are frequently <= 5 bytes — the
+    /// literal `"mark"` (4 bytes) and observer `entryTypes: ["mark"]` are
+    /// inline SSO values. `is_string()` (STRING_TAG-only) missed them, so
+    /// mark/measure resolution, type filters and observer registration all
+    /// silently dropped short names. `string_of` is the shared SSO-aware
+    /// decoder every one of those sites now routes through.
+    #[test]
+    fn string_of_decodes_sso_and_heap_strings() {
+        unsafe {
+            let sso = JSValue::try_short_string(b"mark").unwrap();
+            assert!(sso.is_short_string());
+            assert_eq!(string_of(sso).as_deref(), Some("mark"));
+
+            let heap =
+                JSValue::string_ptr(crate::string::js_string_from_bytes(b"measure".as_ptr(), 7));
+            assert_eq!(string_of(heap).as_deref(), Some("measure"));
+
+            // non-strings (undefined / number) return None.
+            assert_eq!(
+                string_of(JSValue::from_bits(crate::value::TAG_UNDEFINED)),
+                None
+            );
+            assert_eq!(string_of(JSValue::from_bits(3.0f64.to_bits())), None);
+        }
+    }
+
+    /// End-to-end: `getEntriesByName(name, "mark")` with the SSO literal
+    /// `"mark"` must still filter to the mark entry (site #509).
+    #[test]
+    fn get_entries_by_name_filters_on_sso_type() {
+        unsafe {
+            let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+            let name =
+                JSValue::string_ptr(crate::string::js_string_from_bytes(b"phase".as_ptr(), 5));
+            let name_f = f64::from_bits(name.bits());
+            js_perf_mark(name_f, undef);
+
+            // "mark" (4 bytes) is an inline SSO type filter.
+            let ty = JSValue::try_short_string(b"mark").unwrap();
+            assert!(ty.is_short_string());
+            let arr = js_perf_get_entries_by_name(name_f, f64::from_bits(ty.bits()));
+            let arr_ptr =
+                crate::value::js_nanbox_get_pointer(arr) as *const crate::array::ArrayHeader;
+            assert!(!arr_ptr.is_null());
+            assert_eq!(
+                crate::array::js_array_length(arr_ptr),
+                1,
+                "SSO type filter 'mark' should match the mark entry"
+            );
+        }
+    }
 }

--- a/crates/perry-runtime/src/value/dynamic_array.rs
+++ b/crates/perry-runtime/src/value/dynamic_array.rs
@@ -14,10 +14,15 @@ pub extern "C" fn js_dynamic_array_get(value: f64, index: i32) -> f64 {
     let bits = value.to_bits();
     let jsval = JSValue::from_bits(bits);
 
-    // Check if this is a NaN-boxed string
-    if jsval.is_string() {
+    // Check if this is a NaN-boxed string. #1781: accept inline SSO short
+    // strings too — `is_string()` is STRING_TAG-only, so `(s as any)[0]`
+    // for a <=5-char `s` previously fell through to the pointer path
+    // (js_nanbox_get_pointer returns 0 for SSO) and yielded `undefined`
+    // instead of the character. Materialize SSO bytes to a heap header so
+    // the existing char-at logic applies unchanged.
+    if jsval.is_any_string() {
         // String character access
-        let str_ptr = jsval.as_string_ptr();
+        let str_ptr = js_get_string_pointer_unified(value) as *const crate::string::StringHeader;
         if !str_ptr.is_null() && index >= 0 {
             let result_ptr = crate::string::js_string_char_at(str_ptr, index);
             if !result_ptr.is_null() {
@@ -161,4 +166,34 @@ pub extern "C" fn js_dynamic_array_findIndex(
 
     // Use the native array findIndex and convert to f64
     crate::array::js_array_findIndex(ptr as *const crate::array::ArrayHeader, callback) as f64
+}
+
+#[cfg(test)]
+mod sso_tests_1781 {
+    use super::*;
+
+    /// #1781: `(s as any)[i]` for a string `s` of length <= 5 — `s` is an
+    /// inline SSO value that `is_string()` (STRING_TAG-only) misses, so it
+    /// fell past the char-access branch to the pointer path
+    /// (js_nanbox_get_pointer returns 0 for SSO) and yielded `undefined`
+    /// instead of the character at `i`.
+    #[test]
+    fn dynamic_array_get_indexes_sso_string_chars() {
+        let v = JSValue::try_short_string(b"abc").expect("len 3 -> inline SSO");
+        assert!(v.is_short_string());
+        let value = f64::from_bits(v.bits());
+        for (i, expect) in [(0i32, "a"), (1, "b"), (2, "c")] {
+            let r = js_dynamic_array_get(value, i);
+            let rj = JSValue::from_bits(r.to_bits());
+            assert!(rj.is_any_string(), "char {i} not a string");
+            let ptr = js_get_string_pointer_unified(r) as *const crate::string::StringHeader;
+            let got = unsafe {
+                let len = (*ptr).byte_len as usize;
+                let data =
+                    (ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+                std::str::from_utf8(std::slice::from_raw_parts(data, len)).unwrap()
+            };
+            assert_eq!(got, expect, "char at {i}");
+        }
+    }
 }

--- a/crates/perry-runtime/src/value/jsvalue.rs
+++ b/crates/perry-runtime/src/value/jsvalue.rs
@@ -109,6 +109,23 @@ impl JSValue {
     /// `*mut StringHeader`. Keeping this strict avoids a massive
     /// audit during the SSO rollout; use `is_any_string()` when
     /// you want to accept both representations.
+    ///
+    /// ⚠ #1781 footgun — do NOT write
+    /// `if v.is_string() { /* read ptr */ } else { /* treat as pointer
+    /// / number / array */ }`. An inline SSO short string (len 0..=5,
+    /// `SHORT_STRING_TAG = 0x7FF9`) fails this STRICT check and falls into
+    /// the else-branch, where its payload bytes get masked to 48 bits and
+    /// dereferenced (SIGSEGV — the fault address spells the string) or
+    /// silently produce a wrong result. This blind spot has been patched
+    /// piecemeal at least five times (Buffer.from, querystring, str.replace,
+    /// js_is_truthy, the #1781 batch). When a value can be *any* runtime
+    /// string, branch on [`is_any_string`](Self::is_any_string) +
+    /// [`is_short_string`](Self::is_short_string) (decode via
+    /// [`short_string_to_buf`](Self::short_string_to_buf)), or route the
+    /// whole value through `js_get_string_pointer_unified`, which
+    /// materializes SSO bytes onto the heap so downstream `*StringHeader`
+    /// code is unchanged. Reading keys out of a `keys_array` is the one
+    /// safe exception: stored keys are always heap `STRING_TAG`.
     #[inline]
     pub fn is_string(&self) -> bool {
         (self.bits & !POINTER_MASK) == STRING_TAG


### PR DESCRIPTION
## Summary

Audits and fixes the recurring SSO short-string blind spot tracked in #1781. `JSValue::is_string()` is STRING_TAG-only and returns `false` for inline SSO short strings (`SHORT_STRING_TAG`, len 0..=5). Any site shaped like `if v.is_string() { read ptr } else { treat as pointer/number/array }` mishandles a runtime-produced short string.

## Triage

Swept every `is_string()` call site in `crates/perry-runtime`. Two invariants make most candidates **safe by construction**:

1. **`keys_array` stored keys are always heap `STRING_TAG`** — pushed via `JSValue::string_ptr(key)` at every insert site.
2. **String literals are interned to heap** via `js_string_from_bytes` in codegen, so `exclude_keys`, native-module field-0 names, etc. are heap.

So SSO only arises from **runtime-computed** short strings (`concat` ≤5, `JSON.parse`, `slice`/`charAt`, buffer ops). Confirmed-safe (no change): all `keys_array`-loop sites (`field_get_set`, `object_ops`, `delete_rest`, `alloc`, `field_set_by_name`, `typed_feedback/guards`), `native_module` name reads, `stream_promises` raw-ptr decode, and `delete_rest` exclude_keys.

## Fixes (17 sites in 9 functions)

Each routes through `is_any_string()` + `short_string_to_buf`, or `js_get_string_pointer_unified` (materializes SSO bytes to heap so downstream `*StringHeader` code is unchanged):

| Site | Symptom before |
|------|----------------|
| `perf_hooks` (new `string_of` helper + 7 sites) | literal `"mark"` (4 bytes) is SSO → mark/measure resolution, `getEntriesByName` type filter, and `PerformanceObserver` `entryTypes` silently dropped it |
| `fs/callbacks` `decode_flags_string` | every flag (`"r"`,`"w"`,`"a"`,…) is ≤5 bytes → read-only probe never matched |
| `fs/mod` `decode_path_value` | short relative paths decoded to `None` |
| `bigint` `js_bigint_from_f64` | `BigInt("123")` returned `0n` |
| `builtins/table` cell + header | short `console.table` cells rendered `"NaN"` |
| `value/dynamic_array` `js_dynamic_array_get` | `(shortStr as any)[i]` → `undefined` |
| `object/field_get_set` `js_object_has_property` | `"id" in obj` → `false` |
| `object/object_ops` `js_object_is` | mixed SSO/heap content compare returned `false` |
| `object/delete_rest` `js_object_delete_dynamic` | `delete obj[shortKey]` silently no-op'd |

Note: none of these were a live SIGSEGV today — `js_nanbox_get_pointer`'s `bits <= POINTER_MASK` guard returns 0 for SSO (`0x7FF9...`), so the fallbacks bail rather than deref. They were silent wrong-results.

## Tests / docs

- 12 `sso_tests_1781` regression tests constructing SSO values via `JSValue::try_short_string` (template from the #1767 PR). All pass; the touched modules' full test sets pass (30/30, 0 regressions).
- Doc note on `is_string()` (`value/jsvalue.rs`) steering new code to `is_any_string()` / the unified decoder.
- `cargo fmt --all -- --check` clean.

Refs #1767, #833, #1151, #793.
