### PR TITLE
Fix diagnostics channel worker publishes

### DIFF
--- a/crates/perry-runtime/src/node_submodules/diagnostics.rs
+++ b/crates/perry-runtime/src/node_submodules/diagnostics.rs
@@ -5,10 +5,13 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::{LazyLock, Mutex};
+use std::thread::ThreadId;
 
 use crate::closure::ClosureHeader;
 use crate::object::ObjectHeader;
 use crate::string::{js_string_from_bytes, StringHeader};
+use crate::thread::SerializedValue;
 use crate::value::JSValue;
 
 use super::*;
@@ -49,7 +52,7 @@ pub(crate) const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
 pub(crate) const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
 
 #[derive(Hash, Eq, PartialEq, Clone)]
-enum DiagChannelKey {
+pub(crate) enum DiagChannelKey {
     String(String),
     Symbol(u64),
 }
@@ -66,6 +69,158 @@ pub(crate) struct DiagTracingState {
     pub(crate) events: [i64; 5],
 }
 
+/// Cross-thread activity count keyed by channel name.
+///
+/// The concrete JS channel objects and subscriber closures remain
+/// thread-local because they point into the allocating thread's arena. This
+/// map intentionally stores only Rust-owned keys + counts, so workers can
+/// observe process-global subscriber state without touching foreign JS
+/// pointers.
+static DIAG_GLOBAL_ACTIVE_COUNTS: LazyLock<Mutex<HashMap<DiagChannelKey, usize>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Publish events produced by `perry/thread` workers for subscribers owned
+/// by the main/event-loop thread. The payload is arena-independent; it is
+/// deserialized only when the event-loop pump drains this queue.
+static DIAG_PENDING_PUBLISHES: LazyLock<Mutex<Vec<PendingDiagPublish>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
+
+struct PendingDiagPublish {
+    key: DiagChannelKey,
+    data: SerializedValue,
+    origin_thread: ThreadId,
+    local_delivered: bool,
+}
+
+fn cross_thread_key(key: &DiagChannelKey) -> Option<DiagChannelKey> {
+    match key {
+        DiagChannelKey::String(_) => Some(key.clone()),
+        // Symbols are arena/runtime objects in Perry today. Treat them as
+        // thread-local until the runtime has a real cross-thread symbol table.
+        DiagChannelKey::Symbol(_) => None,
+    }
+}
+
+fn global_active_count(key: &DiagChannelKey) -> usize {
+    let Some(key) = cross_thread_key(key) else {
+        return 0;
+    };
+    DIAG_GLOBAL_ACTIVE_COUNTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&key)
+        .copied()
+        .unwrap_or(0)
+}
+
+fn adjust_global_active_count_for_name(name: f64, delta: isize) {
+    let Some(key) = channel_key(name).and_then(|k| cross_thread_key(&k)) else {
+        return;
+    };
+    let mut counts = DIAG_GLOBAL_ACTIVE_COUNTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let entry = counts.entry(key.clone()).or_insert(0);
+    if delta >= 0 {
+        *entry = entry.saturating_add(delta as usize);
+    } else {
+        *entry = entry.saturating_sub(delta.unsigned_abs());
+    }
+    if *entry == 0 {
+        counts.remove(&key);
+    }
+}
+
+fn adjust_global_active_count_for_channel(id: i64, delta: isize) {
+    let name = DIAG_CHANNELS.with(|m| m.borrow().get(&id).map(|c| c.name));
+    if let Some(name) = name {
+        adjust_global_active_count_for_name(name, delta);
+    }
+}
+
+fn enqueue_cross_thread_publish(key: DiagChannelKey, data: f64, local_delivered: bool) {
+    let Some(key) = cross_thread_key(&key) else {
+        return;
+    };
+    let data = unsafe { crate::thread::serialize_nanbox_for_thread(data.to_bits()) };
+    let origin_thread = std::thread::current().id();
+    {
+        let mut pending = DIAG_PENDING_PUBLISHES
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        pending.push(PendingDiagPublish {
+            key,
+            data,
+            origin_thread,
+            local_delivered,
+        });
+    }
+    crate::event_pump::js_notify_main_thread();
+}
+
+pub fn diagnostics_channel_has_pending_publishes() -> bool {
+    !DIAG_PENDING_PUBLISHES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .is_empty()
+}
+
+/// Drain worker-originated diagnostics publishes on the current event-loop
+/// thread. This must be called from a thread whose local diagnostics registry
+/// owns the subscriber closures; in the normal executable this is the main
+/// thread's microtask/event-loop pump.
+///
+/// TODO(#1310 follow-up): if a future persistent worker runtime can keep a
+/// worker-local subscriber alive, it also needs its own pump or destination
+/// routing. Today `perry/thread::spawn` workers do not run an event loop, so
+/// retained items for worker-only subscribers may remain pending until a
+/// broader cross-thread diagnostics registry exists.
+pub fn diagnostics_channel_process_pending() -> i32 {
+    let current_thread = std::thread::current().id();
+    let pending = {
+        let mut pending = DIAG_PENDING_PUBLISHES
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        std::mem::take(&mut *pending)
+    };
+    let mut delivered = 0i32;
+    let mut retained = Vec::new();
+    for item in pending {
+        if item.local_delivered && item.origin_thread == current_thread {
+            // The publishing thread already invoked its local subscribers
+            // synchronously. Dropping this copy prevents a later same-thread
+            // pump from delivering the event twice; any cross-thread delivery
+            // remains the responsibility of another thread's pump.
+            continue;
+        }
+        let id = DIAG_CHANNEL_BY_KEY.with(|m| m.borrow().get(&item.key).copied());
+        let Some(id) = id else {
+            // This thread does not own a channel object for the publish. Keep
+            // the item queued so a later main/event-loop-thread drain can
+            // deliver it instead of silently swallowing worker-originated
+            // publishes.
+            retained.push(item);
+            continue;
+        };
+        let data = unsafe { crate::thread::deserialize_nanbox_on_current_thread(&item.data) };
+        publish_channel_local(id, f64::from_bits(data));
+        delivered += 1;
+    }
+    if !retained.is_empty() {
+        let mut pending = DIAG_PENDING_PUBLISHES
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Preserve retained items ahead of publishes that arrived while this
+        // drain was running. There is no total ordering guarantee between
+        // producer threads; keeping undelivered items at the front avoids
+        // starving an older event that was merely observed by the wrong
+        // thread first.
+        retained.append(&mut *pending);
+        *pending = retained;
+    }
+    delivered
+}
+
 // Known follow-ups for the thread-local state below:
 //
 // * #1309 — channels used to be pinned for the process lifetime. A soft
@@ -76,10 +231,9 @@ pub(crate) struct DiagTracingState {
 //   channel the moment no user reference and no subscriber remain) still
 //   needs a GC post-sweep hook or a weak-ref primitive.
 //
-// * #1310 — these maps are `thread_local!`, so `parallelMap`/`spawn`
-//   workers see an empty world. A `publish` from a worker thread
-//   silently no-ops against subscribers registered on the main
-//   thread, diverging from Node's process-global model.
+// * #1310 — the JS-owning maps remain `thread_local!`, but worker publishes
+//   now enqueue arena-independent payloads for the main/event-loop thread
+//   when a process-global subscriber count exists for a string channel.
 thread_local! {
     pub(crate) static DIAG_CHANNEL_BY_KEY: RefCell<HashMap<DiagChannelKey, i64>> = RefCell::new(HashMap::new());
     pub(crate) static DIAG_CHANNELS: RefCell<HashMap<i64, DiagChannelState>> = RefCell::new(HashMap::new());
@@ -364,7 +518,11 @@ pub(crate) fn with_implicit_this<F: FnOnce() -> f64>(this_arg: f64, f: F) -> f64
 pub(crate) fn update_channel_active(id: i64) {
     DIAG_CHANNELS.with(|channels| {
         if let Some(ch) = channels.borrow_mut().get_mut(&id) {
-            let active = !ch.subscribers.is_empty() || !ch.stores.is_empty();
+            let active = !ch.subscribers.is_empty()
+                || !ch.stores.is_empty()
+                || channel_key(ch.name)
+                    .as_ref()
+                    .is_some_and(|key| global_active_count(key) > 0);
             set_field_value(ch.obj, "hasSubscribers", bool_value(active));
         }
     });
@@ -451,8 +609,9 @@ pub(crate) fn ensure_channel(name: f64) -> i64 {
     evict_inactive_diag_channels_if_needed();
     let id = next_diag_id();
     let obj = js_object_alloc(0, 9);
+    let has_global_subscribers = global_active_count(&key) > 0;
     set_field_value(obj, "name", name);
-    set_field_value(obj, "hasSubscribers", bool_value(false));
+    set_field_value(obj, "hasSubscribers", bool_value(has_global_subscribers));
     set_field_value(
         obj,
         "subscribe",
@@ -514,11 +673,16 @@ pub(crate) fn add_subscriber(id: i64, subscriber: f64) {
     if !valid_closure_value(subscriber) {
         throw_invalid_arg();
     }
+    let mut inserted = false;
     DIAG_CHANNELS.with(|m| {
         if let Some(c) = m.borrow_mut().get_mut(&id) {
             c.subscribers.push(subscriber);
+            inserted = true;
         }
     });
+    if inserted {
+        adjust_global_active_count_for_channel(id, 1);
+    }
     update_channel_active(id);
 }
 
@@ -534,12 +698,13 @@ pub(crate) fn remove_subscriber(id: i64, subscriber: f64) -> bool {
         false
     });
     if removed {
+        adjust_global_active_count_for_channel(id, -1);
         update_channel_active(id);
     }
     removed
 }
 
-pub(crate) fn publish_channel(id: i64, data: f64) {
+pub(crate) fn publish_channel_local(id: i64, data: f64) {
     // Fast path: no subscribers means publish is a no-op. Avoid the
     // Vec clone entirely. `console.*` hits this path on every call when
     // nobody is subscribed to a `console.{method}` channel.
@@ -561,6 +726,29 @@ pub(crate) fn publish_channel(id: i64, data: f64) {
         if let Err(err) = catch_js(|| js_closure_call2(cb, data, name)) {
             schedule_uncaught(err);
         }
+    }
+}
+
+pub(crate) fn publish_channel(id: i64, data: f64) {
+    let (name, local_active_count, has_local_subscribers) = DIAG_CHANNELS.with(|m| {
+        let m = m.borrow();
+        match m.get(&id) {
+            Some(c) => (
+                c.name,
+                c.subscribers.len().saturating_add(c.stores.len()),
+                !c.subscribers.is_empty(),
+            ),
+            None => (undefined(), 0, false),
+        }
+    });
+    if has_local_subscribers {
+        publish_channel_local(id, data);
+    }
+    let Some(key) = channel_key(name) else {
+        return;
+    };
+    if global_active_count(&key) > local_active_count {
+        enqueue_cross_thread_publish(key, data, has_local_subscribers);
     }
 }
 
@@ -683,6 +871,7 @@ pub(crate) extern "C" fn diag_channel_bind_store(
     } else {
         None
     };
+    let mut inserted = false;
     DIAG_CHANNELS.with(|m| {
         if let Some(c) = m.borrow_mut().get_mut(&id) {
             if let Some(slot) = c
@@ -693,9 +882,13 @@ pub(crate) extern "C" fn diag_channel_bind_store(
                 slot.1 = transform;
             } else {
                 c.stores.push((store, transform));
+                inserted = true;
             }
         }
     });
+    if inserted {
+        adjust_global_active_count_for_channel(id, 1);
+    }
     update_channel_active(id);
     undefined()
 }
@@ -719,6 +912,7 @@ pub(crate) extern "C" fn diag_channel_unbind_store(
         false
     });
     if removed {
+        adjust_global_active_count_for_channel(id, -1);
         update_channel_active(id);
     }
     bool_value(removed)
@@ -850,6 +1044,9 @@ pub(crate) extern "C" fn thunk_diag_has_subscribers(
         Some(k) => k,
         None => return bool_value(false),
     };
+    if global_active_count(&key) > 0 {
+        return bool_value(true);
+    }
     let active = DIAG_CHANNEL_BY_KEY.with(|by_key| {
         by_key
             .borrow()

--- a/crates/perry-runtime/src/promise/microtasks.rs
+++ b/crates/perry-runtime/src/promise/microtasks.rs
@@ -42,6 +42,9 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
     // Process any scheduled resolutions (simulates async completions)
     ran += super::combinators::process_scheduled_resolves();
 
+    // Process diagnostics_channel publishes queued by perry/thread workers.
+    ran += crate::node_submodules::diagnostics_channel_process_pending();
+
     // Process pending thread results (from perry/thread spawn)
     ran += crate::thread::js_thread_process_pending();
 

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -584,5 +584,11 @@ impl InlineTrap {
 /// microtask drain runs.
 #[no_mangle]
 pub extern "C" fn js_microtasks_pending() -> i32 {
+    if crate::node_submodules::diagnostics_channel_has_pending_publishes() {
+        return 1;
+    }
+    if crate::thread::js_thread_has_pending() != 0 {
+        return 1;
+    }
     TASK_QUEUE.with(|q| if q.borrow().is_empty() { 0 } else { 1 })
 }

--- a/crates/perry-runtime/src/thread.rs
+++ b/crates/perry-runtime/src/thread.rs
@@ -216,7 +216,7 @@ fn is_truthy_bits(bits: u64) -> bool {
 /// or malloc memory. These are read from the source thread's memory and stored
 /// as owned Rust data (`Vec<u8>`, `Vec<SerializedValue>`, etc.).
 #[derive(Debug)]
-enum SerializedValue {
+pub(crate) enum SerializedValue {
     /// A raw 64-bit value that needs no pointer fixup.
     /// Covers: f64 numbers, TAG_UNDEFINED, TAG_NULL, TAG_TRUE, TAG_FALSE, INT32_TAG.
     Inline(u64),
@@ -267,7 +267,7 @@ unsafe impl Sync for SerializedValue {}
 /// # Safety
 /// The `bits` must be a valid NaN-boxed JSValue. Pointer-tagged values must
 /// point to valid, live objects in the current thread's arena or malloc heap.
-unsafe fn serialize_jsvalue(bits: u64) -> SerializedValue {
+pub(crate) unsafe fn serialize_nanbox_for_thread(bits: u64) -> SerializedValue {
     let tag = bits & TAG_MASK;
 
     // Fast path: values that are just bit patterns (no pointers)
@@ -349,7 +349,7 @@ unsafe fn serialize_array(arr: *const crate::array::ArrayHeader) -> SerializedVa
     let mut elements = Vec::with_capacity(len);
     for i in 0..len {
         let elem_bits = (*elements_ptr.add(i)).to_bits();
-        elements.push(serialize_jsvalue(elem_bits));
+        elements.push(serialize_nanbox_for_thread(elem_bits));
     }
     SerializedValue::Array(elements)
 }
@@ -375,7 +375,7 @@ unsafe fn serialize_object(obj: *const crate::object::ObjectHeader) -> Serialize
     let mut fields = Vec::with_capacity(field_count);
     for i in 0..field_count {
         let field_bits = (*fields_ptr.add(i)).to_bits();
-        fields.push(serialize_jsvalue(field_bits));
+        fields.push(serialize_nanbox_for_thread(field_bits));
     }
 
     // Serialize keys array if present (plain objects have keys, class instances don't)
@@ -431,7 +431,7 @@ unsafe fn serialize_closure(closure: *const ClosureHeader) -> SerializedValue {
     let mut captures = Vec::with_capacity(actual_count);
     for i in 0..actual_count {
         let cap_bits = (*captures_base.add(i)).to_bits();
-        captures.push(serialize_jsvalue(cap_bits));
+        captures.push(serialize_nanbox_for_thread(cap_bits));
     }
 
     SerializedValue::Closure {
@@ -487,7 +487,7 @@ pub(crate) unsafe fn test_store_thread_object_field(
 ///
 /// # Returns
 /// The raw u64 bits of the NaN-boxed JSValue.
-unsafe fn deserialize_jsvalue(sv: &SerializedValue) -> u64 {
+pub(crate) unsafe fn deserialize_nanbox_on_current_thread(sv: &SerializedValue) -> u64 {
     match sv {
         SerializedValue::Inline(bits) => *bits,
 
@@ -508,7 +508,7 @@ unsafe fn deserialize_jsvalue(sv: &SerializedValue) -> u64 {
             let scope = crate::gc::RuntimeHandleScope::new();
             let arr_handle = scope.root_raw_mut_ptr(arr);
             for (i, elem) in elements.iter().enumerate() {
-                let bits = deserialize_jsvalue(elem);
+                let bits = deserialize_nanbox_on_current_thread(elem);
                 let arr = arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>();
                 // GC_STORE_AUDIT(BARRIERED): deserialized thread array slot uses the shared array slot-store helper.
                 store_thread_array_slot(arr, i, bits);
@@ -534,7 +534,7 @@ unsafe fn deserialize_jsvalue(sv: &SerializedValue) -> u64 {
 
             // Set field values
             for (i, field) in fields.iter().enumerate() {
-                let bits = deserialize_jsvalue(field);
+                let bits = deserialize_nanbox_on_current_thread(field);
                 let obj = obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
                 // GC_STORE_AUDIT(BARRIERED): deserialized thread object field uses the shared object slot-store helper.
                 store_thread_object_field(obj, i, bits);
@@ -575,7 +575,7 @@ unsafe fn deserialize_jsvalue(sv: &SerializedValue) -> u64 {
         } => {
             let closure = closure::js_closure_alloc(*func_ptr as *const u8, *capture_count);
             for (i, cap) in captures.iter().enumerate() {
-                let bits = deserialize_jsvalue(cap);
+                let bits = deserialize_nanbox_on_current_thread(cap);
                 crate::closure::js_closure_set_capture_f64(closure, i as u32, f64::from_bits(bits));
             }
             JSValue::pointer(closure as *const u8).bits()
@@ -591,7 +591,7 @@ unsafe fn deserialize_jsvalue(sv: &SerializedValue) -> u64 {
 
 #[cfg(test)]
 pub(crate) unsafe fn test_deserialize_bigint_limbs(limbs: [u64; BIGINT_LIMBS]) -> u64 {
-    deserialize_jsvalue(&SerializedValue::BigInt(limbs))
+    deserialize_nanbox_on_current_thread(&SerializedValue::BigInt(limbs))
 }
 
 // ============================================================================
@@ -683,7 +683,7 @@ unsafe fn parallel_map_impl(array_val: f64, closure_val: f64) -> i64 {
     let mut serialized_elements = Vec::with_capacity(len);
     for i in 0..len {
         let bits = (*elements_ptr.add(i)).to_bits();
-        serialized_elements.push(serialize_jsvalue(bits));
+        serialized_elements.push(serialize_nanbox_for_thread(bits));
     }
 
     // ── 5. Serialize closure captures (shared across all threads) ────
@@ -696,7 +696,7 @@ unsafe fn parallel_map_impl(array_val: f64, closure_val: f64) -> i64 {
                 (closure as *const u8).add(std::mem::size_of::<ClosureHeader>()) as *const f64;
             let mut caps = Vec::with_capacity(actual);
             for i in 0..actual {
-                caps.push(serialize_jsvalue((*base.add(i)).to_bits()));
+                caps.push(serialize_nanbox_for_thread((*base.add(i)).to_bits()));
             }
             Some((fp, cc, caps))
         } else {
@@ -749,7 +749,7 @@ unsafe fn parallel_map_impl(array_val: f64, closure_val: f64) -> i64 {
                     let (fp, cc, ref cap_vals) = **caps;
                     let c = closure::js_closure_alloc(fp as *const u8, cc);
                     for (i, cap) in cap_vals.iter().enumerate() {
-                        let bits = deserialize_jsvalue(cap);
+                        let bits = deserialize_nanbox_on_current_thread(cap);
                         crate::closure::js_closure_set_capture_f64(
                             c,
                             i as u32,
@@ -764,9 +764,9 @@ unsafe fn parallel_map_impl(array_val: f64, closure_val: f64) -> i64 {
                 let call_fn: ClosureCallFn = std::mem::transmute(func_usize);
 
                 for elem_sv in &chunk {
-                    let arg = f64::from_bits(deserialize_jsvalue(elem_sv));
+                    let arg = f64::from_bits(deserialize_nanbox_on_current_thread(elem_sv));
                     let result = call_fn(local_closure, arg);
-                    results.push(serialize_jsvalue(result.to_bits()));
+                    results.push(serialize_nanbox_for_thread(result.to_bits()));
                 }
 
                 (idx, results)
@@ -791,7 +791,7 @@ unsafe fn parallel_map_impl(array_val: f64, closure_val: f64) -> i64 {
     let mut write_idx = 0;
     for chunk_results in &all_results {
         for sv in chunk_results {
-            let bits = deserialize_jsvalue(sv);
+            let bits = deserialize_nanbox_on_current_thread(sv);
             let result_arr = result_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>();
             // GC_STORE_AUDIT(BARRIERED): parallelMap result slot uses the shared array slot-store helper.
             store_thread_array_slot(result_arr, write_idx, bits);
@@ -892,7 +892,7 @@ unsafe fn parallel_filter_impl(array_val: f64, closure_val: f64) -> i64 {
     let mut serialized_elements = Vec::with_capacity(len);
     for i in 0..len {
         let bits = (*elements_ptr.add(i)).to_bits();
-        serialized_elements.push(serialize_jsvalue(bits));
+        serialized_elements.push(serialize_nanbox_for_thread(bits));
     }
 
     // Serialize closure captures
@@ -903,7 +903,7 @@ unsafe fn parallel_filter_impl(array_val: f64, closure_val: f64) -> i64 {
         let base = (closure as *const u8).add(std::mem::size_of::<ClosureHeader>()) as *const f64;
         let mut caps = Vec::with_capacity(actual);
         for i in 0..actual {
-            caps.push(serialize_jsvalue((*base.add(i)).to_bits()));
+            caps.push(serialize_nanbox_for_thread((*base.add(i)).to_bits()));
         }
         Some((fp, cc, caps))
     };
@@ -947,7 +947,7 @@ unsafe fn parallel_filter_impl(array_val: f64, closure_val: f64) -> i64 {
                     let (fp, cc, ref cap_vals) = **caps;
                     let c = closure::js_closure_alloc(fp as *const u8, cc);
                     for (i, cap) in cap_vals.iter().enumerate() {
-                        let bits = deserialize_jsvalue(cap);
+                        let bits = deserialize_nanbox_on_current_thread(cap);
                         crate::closure::js_closure_set_capture_f64(
                             c,
                             i as u32,
@@ -962,11 +962,11 @@ unsafe fn parallel_filter_impl(array_val: f64, closure_val: f64) -> i64 {
                 let call_fn: ClosureCallFn = std::mem::transmute(func_usize);
 
                 for elem_sv in &chunk {
-                    let arg = f64::from_bits(deserialize_jsvalue(elem_sv));
+                    let arg = f64::from_bits(deserialize_nanbox_on_current_thread(elem_sv));
                     let result = call_fn(local_closure, arg);
                     let keep = is_truthy_bits(result.to_bits());
                     if keep {
-                        kept.push(serialize_jsvalue(arg.to_bits()));
+                        kept.push(serialize_nanbox_for_thread(arg.to_bits()));
                     }
                 }
 
@@ -991,7 +991,7 @@ unsafe fn parallel_filter_impl(array_val: f64, closure_val: f64) -> i64 {
     let mut write_idx = 0;
     for chunk_kept in &all_results {
         for sv in chunk_kept {
-            let bits = deserialize_jsvalue(sv);
+            let bits = deserialize_nanbox_on_current_thread(sv);
             let result_arr = result_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>();
             // GC_STORE_AUDIT(BARRIERED): parallelFilter result slot uses the shared array slot-store helper.
             store_thread_array_slot(result_arr, write_idx, bits);
@@ -1087,7 +1087,7 @@ unsafe fn spawn_impl(closure_val: f64) -> *mut crate::promise::Promise {
                 (closure as *const u8).add(std::mem::size_of::<ClosureHeader>()) as *const f64;
             let mut caps = Vec::with_capacity(actual);
             for i in 0..actual {
-                caps.push(serialize_jsvalue((*base.add(i)).to_bits()));
+                caps.push(serialize_nanbox_for_thread((*base.add(i)).to_bits()));
             }
             Some((cc, caps))
         } else {
@@ -1104,7 +1104,7 @@ unsafe fn spawn_impl(closure_val: f64) -> *mut crate::promise::Promise {
             let c = closure::js_closure_alloc(func_usize as *const u8, cc);
             for (i, cap) in cap_vals.iter().enumerate() {
                 unsafe {
-                    let bits = deserialize_jsvalue(cap);
+                    let bits = deserialize_nanbox_on_current_thread(cap);
                     crate::closure::js_closure_set_capture_f64(c, i as u32, f64::from_bits(bits));
                 }
             }
@@ -1123,7 +1123,7 @@ unsafe fn spawn_impl(closure_val: f64) -> *mut crate::promise::Promise {
         match call_result {
             Ok(result) => {
                 // Serialize result for transfer back to main thread
-                let serialized_result = unsafe { serialize_jsvalue(result.to_bits()) };
+                let serialized_result = unsafe { serialize_nanbox_for_thread(result.to_bits()) };
                 queue_thread_result(promise_usize, serialized_result);
             }
             Err(_) => {
@@ -1199,7 +1199,7 @@ pub extern "C" fn js_thread_process_pending() -> i32 {
             let promise = item.promise_ptr as *mut crate::promise::Promise;
 
             // Deserialize the result into the main thread's arena
-            let result_bits = deserialize_jsvalue(&item.result);
+            let result_bits = deserialize_nanbox_on_current_thread(&item.result);
 
             // Unpin the promise now that we're resolving it
             let promise_header = (promise as *mut u8).sub(gc::GC_HEADER_SIZE) as *mut gc::GcHeader;

--- a/test-files/test_issue_1310_diagnostics_channel_thread.ts
+++ b/test-files/test_issue_1310_diagnostics_channel_thread.ts
@@ -1,0 +1,69 @@
+// Regression for #1310: node:diagnostics_channel is process-global across
+// perry/thread workers. A subscriber registered on the main thread must see
+// publishes originating from a spawned worker; worker-side hasSubscribers
+// should also observe the main-thread subscription.
+import { subscribe, unsubscribe, channel } from "node:diagnostics_channel";
+import { spawn } from "perry/thread";
+
+let count = 0;
+let payloadValue = 0;
+let payloadText = "";
+let payloadArrayLen = 0;
+
+const cb = (message: any, name: string) => {
+  if (name === "worker-event") {
+    count++;
+    payloadValue = message.value;
+    payloadText = message.text;
+    payloadArrayLen = message.items.length;
+  }
+};
+
+subscribe("worker-event", cb);
+console.log("main has subscribers:", channel("worker-event").hasSubscribers);
+if (!channel("worker-event").hasSubscribers) {
+  throw new Error("main channel should report subscribers after subscribe()");
+}
+
+const workerSawSubscribers = await spawn(() => {
+  const ch = channel("worker-event");
+  const sawSubscribers = ch.hasSubscribers;
+  ch.publish({ value: 42, text: "from-worker", items: [1, 2, 3] });
+  return sawSubscribers;
+});
+
+console.log("worker saw subscribers:", workerSawSubscribers);
+console.log("main saw events:", count);
+console.log("payload value:", payloadValue);
+console.log("payload text:", payloadText);
+console.log("payload array len:", payloadArrayLen);
+if (!workerSawSubscribers) {
+  throw new Error("worker should observe the main-thread subscriber");
+}
+if (count !== 1) {
+  throw new Error(`expected exactly one worker publish delivery, got ${count}`);
+}
+if (payloadValue !== 42 || payloadText !== "from-worker" || payloadArrayLen !== 3) {
+  throw new Error("worker publish payload was not deserialized correctly on main");
+}
+
+const workerSubscribed = await spawn(() => {
+  let localHits = 0;
+  subscribe("worker-event", () => {
+    localHits++;
+  });
+  return channel("worker-event").hasSubscribers;
+});
+
+console.log("worker subscribed:", workerSubscribed);
+if (!workerSubscribed) {
+  throw new Error("worker channel should report subscribers after worker subscribe()");
+}
+channel("worker-event").publish({ value: 7, text: "from-main", items: [4] });
+await spawn(() => 0);
+console.log("main saw events after main publish:", count);
+if (count !== 2) {
+  throw new Error(`main publish should reach main subscriber exactly once, got ${count}`);
+}
+
+unsubscribe("worker-event", cb);


### PR DESCRIPTION
## Summary
- deliver `node:diagnostics_channel` publishes from `perry/thread` workers to main-thread subscribers
- share arena-independent diagnostics subscriber state across threads while keeping JS callbacks thread-local
- add a regression test for worker publish delivery and payload serialization

## Root cause
`diagnostics_channel` channel maps and subscribers were stored in thread-local cells. Worker threads therefore saw no main-thread subscribers, so `publish()` from a worker silently no-oped even though Node treats diagnostics channels as process-global.

## Validation
- `cargo check -p perry-runtime`
- `cargo check -p perry`
- `cargo build -p perry`
- `./target/debug/perry test-files/test_issue_1310_diagnostics_channel_thread.ts -o /tmp/perry_issue_1310 && /tmp/perry_issue_1310`
- `PERRY_BIN=./target/debug/perry ./run_parity_tests.sh --suite node-suite --module diagnostics_channel` (56 pass, 1 pre-existing tracing output mismatch: `tracing/trace-callback-error-first`)
