### PR TITLE
fix(runtime,codegen): inherit static methods through extends of a class-object value (#1788 follow-up)

### DIFF
--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -1106,6 +1106,13 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
         for method in &class.methods {
             let _ = strings.intern(&method.name);
         }
+        // #1788: intern static-method names too, so the
+        // `js_register_class_static_method` registration loop in
+        // emit_string_pool finds their bytes_global without re-running
+        // through the string pool's mutable interner.
+        for sm in &class.static_methods {
+            let _ = strings.intern(&sm.name);
+        }
         // Refs #486: also intern getter property names so the cross-module
         // `js_register_class_getter` registration loop in emit_string_pool
         // can find their bytes_global without re-running through the

--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -300,6 +300,11 @@ pub(super) fn emit_string_pool(
     // Each module's init registers its own classes; the linker
     // ensures all init functions run before main.
     let mut method_triples: Vec<(u32, String, String, u32)> = Vec::new();
+    // #1788: (cid, static-method name, perry_static_* symbol, param_count).
+    // Registered into the runtime CLASS_STATIC_METHODS table so a subclass
+    // whose parent is a class-expression value inherits the parent's static
+    // methods (`class Sub extends make(...) {}; Sub.greet()`).
+    let mut static_method_triples: Vec<(u32, String, String, u32)> = Vec::new();
     for (class_name, class) in classes.iter() {
         // Refs #486: skip alias keys (class_table now contains both the
         // canonical name and self-binding aliases like `_X` from
@@ -338,6 +343,17 @@ pub(super) fn emit_string_pool(
                 method.params.len() as u32,
             ));
         }
+        // #1788: static methods are emitted as `perry_static_*` (no `this`
+        // param). Collect them for the runtime CLASS_STATIC_METHODS table.
+        for sm in &class.static_methods {
+            let llvm_name = format!(
+                "perry_static_{}__{}__{}",
+                module_prefix,
+                sanitize(class_name),
+                sanitize(&sm.name),
+            );
+            static_method_triples.push((cid, sm.name.clone(), llvm_name, sm.params.len() as u32));
+        }
     }
     method_triples.sort_unstable();
     for (cid, method_name, llvm_name, param_count) in method_triples {
@@ -359,6 +375,31 @@ pub(super) fn emit_string_pool(
         let bytes_i64 = blk.ptrtoint(&bytes_global, I64);
         blk.call_void(
             "js_register_class_method",
+            &[
+                (I64, &cid.to_string()),
+                (I64, &bytes_i64),
+                (I64, &len_str),
+                (I64, &func_i64),
+                (I64, &param_count.to_string()),
+            ],
+        );
+    }
+    // #1788: register static methods into CLASS_STATIC_METHODS so inherited
+    // static methods (subclass extends a class-expression value) resolve at
+    // runtime via the class_id parent-chain walk.
+    static_method_triples.sort_unstable();
+    for (cid, method_name, llvm_name, param_count) in static_method_triples {
+        let entry = match strings.iter().find(|e| e.value == method_name) {
+            Some(e) => e,
+            None => continue,
+        };
+        let bytes_global = format!("@{}", entry.bytes_global);
+        let len_str = entry.byte_len.to_string();
+        let func_ref = format!("@{}", llvm_name);
+        let func_i64 = blk.ptrtoint(&func_ref, I64);
+        let bytes_i64 = blk.ptrtoint(&bytes_global, I64);
+        blk.call_void(
+            "js_register_class_static_method",
             &[
                 (I64, &cid.to_string()),
                 (I64, &bytes_i64),

--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -943,15 +943,58 @@ pub fn try_lower_property_get_method_call(
                 .call(DOUBLE, "js_implicit_this_set", &[(DOUBLE, &prev_this)]);
             return Ok(Some(result));
         }
-        // No static method resolved through the visible chain.
-        // Lower the args for side effects and return the ClassRef
-        // itself so chained `.pipe()` calls keep producing a
-        // typed-class-shaped value during module init.
+        // No static method resolved through the class's statically-visible
+        // chain. #1788: a subclass of a class-expression value
+        // (`class Sub extends make(...) {}`) inherits the parent's static
+        // methods at RUNTIME — dispatch through the class_id parent-chain
+        // walk in CLASS_STATIC_METHODS, binding `this` to the class ref so
+        // `this.<field>` resolves through the subclass's static-field chain.
+        // The helper returns the receiver unchanged on a genuine miss, which
+        // preserves the prior "yield the class ref for a chained `.pipe()`
+        // during module init" behavior for truly-absent methods.
         if matches!(object.as_ref(), Expr::ClassRef(_)) {
+            let recv_box = lower_expr(ctx, object)?;
+            let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());
             for a in args {
-                let _ = lower_expr(ctx, a)?;
+                lowered_args.push(lower_expr(ctx, a)?);
             }
-            return Ok(Some(lower_expr(ctx, object)?));
+            // Materialize the args into an entry-block `[N x double]` slot
+            // (see issue #167 — alloca must live in the entry block).
+            let (args_ptr, args_len) = if lowered_args.is_empty() {
+                ("null".to_string(), "0".to_string())
+            } else {
+                let n = lowered_args.len();
+                let buf_reg = ctx.func.alloca_entry_array(DOUBLE, n);
+                for (i, v) in lowered_args.iter().enumerate() {
+                    let slot = ctx
+                        .block()
+                        .gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", i))]);
+                    ctx.block().store(DOUBLE, v, &slot);
+                }
+                let ptr_reg = ctx.block().next_reg();
+                ctx.block().emit_raw(format!(
+                    "{} = getelementptr [{} x double], ptr {}, i64 0, i64 0",
+                    ptr_reg, n, buf_reg
+                ));
+                (ptr_reg, n.to_string())
+            };
+            let key_idx = ctx.strings.intern(property);
+            let entry = ctx.strings.entry(key_idx);
+            let bytes_global = format!("@{}", entry.bytes_global);
+            let name_len = entry.byte_len.to_string();
+            let blk = ctx.block();
+            let name_ptr_i64 = blk.ptrtoint(&bytes_global, I64);
+            return Ok(Some(blk.call(
+                DOUBLE,
+                "js_class_static_method_call",
+                &[
+                    (DOUBLE, &recv_box),
+                    (I64, &name_ptr_i64),
+                    (I64, &name_len),
+                    (crate::types::PTR, &args_ptr),
+                    (I64, &args_len),
+                ],
+            )));
         }
         // For LocalGet receivers that resolve to a class but the
         // method isn't a static — fall through to the normal

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1156,6 +1156,18 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // Refs #486: per-class setter dispatch — see object.rs::js_register_class_setter.
     module.declare_function("js_register_class_setter", VOID, &[I64, I64, I64, I64]);
     module.declare_function("js_register_class_method", VOID, &[I64, I64, I64, I64, I64]);
+    // #1788: register a class STATIC method + dispatch an inherited static
+    // method on a class value (subclass extends a class-expression value).
+    module.declare_function(
+        "js_register_class_static_method",
+        VOID,
+        &[I64, I64, I64, I64, I64],
+    );
+    module.declare_function(
+        "js_class_static_method_call",
+        DOUBLE,
+        &[DOUBLE, I64, I64, PTR, I64],
+    );
     // #446: bound-method closure for `obj.method` PropertyGet on a known class.
     // Lets `typeof obj.method === "function"` and `let f = obj.method; f(args)`
     // dispatch through CLASS_VTABLE_REGISTRY instead of returning undefined.

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -35,6 +35,16 @@ pub struct ClassVTable {
 /// Global vtable registry: class_id -> vtable
 pub static CLASS_VTABLE_REGISTRY: RwLock<Option<HashMap<u32, ClassVTable>>> = RwLock::new(None);
 
+/// #1788: per-class STATIC-method registry: class_id -> { name -> (func_ptr,
+/// param_count) }. Static methods are emitted as `perry_static_*` (no `this`
+/// param — they read `this` from the implicit-this slot) and are NOT in the
+/// instance vtable above, so a subclass whose parent is a class-expression
+/// value (`class Sub extends make(...) {}`) can't resolve an inherited static
+/// method (`Sub.greet()`) at compile time. This table is walked up the
+/// class_id parent chain at runtime by `js_class_static_method_call`.
+pub static CLASS_STATIC_METHODS: RwLock<Option<HashMap<u32, HashMap<String, (usize, u32)>>>> =
+    RwLock::new(None);
+
 /// Set of all registered class ids. Populated at module init by codegen
 /// emitting `js_register_class_id(cid)` for every user class — even
 /// classes without any methods. Refs #618 / #420 followup.
@@ -1481,6 +1491,146 @@ pub fn is_class_object_ptr(ptr: *const u8) -> bool {
 pub fn is_class_object_value(value: f64) -> bool {
     let jsval = crate::value::JSValue::from_bits(value.to_bits());
     jsval.is_pointer() && is_class_object_ptr(jsval.as_pointer::<u8>())
+}
+
+/// #1788: register a class STATIC method (`perry_static_*`, no `this` param)
+/// in `CLASS_STATIC_METHODS`, keyed by the (template) class_id. Emitted by
+/// codegen at module init alongside the instance-method vtable registration.
+#[no_mangle]
+pub unsafe extern "C" fn js_register_class_static_method(
+    class_id: i64,
+    name_ptr: *const u8,
+    name_len: i64,
+    func_ptr: i64,
+    param_count: i64,
+) {
+    if class_id == 0 || name_ptr.is_null() || name_len <= 0 {
+        return;
+    }
+    let name = match std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len as usize)) {
+        Ok(s) => s.to_string(),
+        Err(_) => return,
+    };
+    let mut guard = CLASS_STATIC_METHODS.write().unwrap();
+    if guard.is_none() {
+        *guard = Some(HashMap::new());
+    }
+    guard
+        .as_mut()
+        .unwrap()
+        .entry(class_id as u32)
+        .or_default()
+        .insert(name, (func_ptr as usize, param_count as u32));
+}
+
+/// Look up a static method by name in `CLASS_STATIC_METHODS`, walking the
+/// class_id parent chain (so a subclass inherits a parent's static method).
+fn lookup_static_method_in_chain(class_id: u32, name: &str) -> Option<(usize, u32)> {
+    let guard = CLASS_STATIC_METHODS.read().ok()?;
+    let map = guard.as_ref()?;
+    let mut cid = class_id;
+    let mut depth = 0usize;
+    while cid != 0 && depth < 32 {
+        if let Some(m) = map.get(&cid) {
+            if let Some(&entry) = m.get(name) {
+                return Some(entry);
+            }
+        }
+        match get_parent_class_id(cid) {
+            Some(p) if p != 0 && p != cid => {
+                cid = p;
+                depth += 1;
+            }
+            _ => break,
+        }
+    }
+    None
+}
+
+/// Call a static method func_ptr with `args` (no `this` prepend — static
+/// methods read `this` from the implicit-this slot, set by the caller).
+/// Mirrors the arity dispatch of `call_vtable_method` minus the receiver arg.
+unsafe fn call_static_method(
+    func_ptr: usize,
+    args_ptr: *const f64,
+    args_len: usize,
+    param_count: u32,
+) -> f64 {
+    #[inline(always)]
+    unsafe fn a(args_ptr: *const f64, args_len: usize, idx: usize) -> f64 {
+        if idx < args_len {
+            *args_ptr.add(idx)
+        } else {
+            f64::NAN
+        }
+    }
+    match param_count {
+        0 => (std::mem::transmute::<usize, extern "C" fn() -> f64>(func_ptr))(),
+        1 => (std::mem::transmute::<usize, extern "C" fn(f64) -> f64>(func_ptr))(a(
+            args_ptr, args_len, 0,
+        )),
+        2 => (std::mem::transmute::<usize, extern "C" fn(f64, f64) -> f64>(func_ptr))(
+            a(args_ptr, args_len, 0),
+            a(args_ptr, args_len, 1),
+        ),
+        3 => (std::mem::transmute::<usize, extern "C" fn(f64, f64, f64) -> f64>(func_ptr))(
+            a(args_ptr, args_len, 0),
+            a(args_ptr, args_len, 1),
+            a(args_ptr, args_len, 2),
+        ),
+        _ => (std::mem::transmute::<usize, extern "C" fn(f64, f64, f64, f64) -> f64>(func_ptr))(
+            a(args_ptr, args_len, 0),
+            a(args_ptr, args_len, 1),
+            a(args_ptr, args_len, 2),
+            a(args_ptr, args_len, 3),
+        ),
+    }
+}
+
+/// #1788: dispatch a static method on a class value (`Sub.greet()` where
+/// `Sub extends make(...)`, or a class-object value) by walking the class_id
+/// parent chain in `CLASS_STATIC_METHODS`. Binds `this` to the receiver (so
+/// `this.<field>` resolves through the subclass's static-field chain), calls
+/// the method, and restores the previous implicit-this. On miss returns the
+/// receiver unchanged — preserving the prior "yield the class ref for a
+/// chained call during module init" behavior for genuinely-absent methods.
+#[no_mangle]
+pub unsafe extern "C" fn js_class_static_method_call(
+    receiver: f64,
+    name_ptr: *const u8,
+    name_len: usize,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
+    if name_ptr.is_null() || name_len == 0 {
+        return receiver;
+    }
+    let name = match std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)) {
+        Ok(s) => s,
+        Err(_) => return receiver,
+    };
+    // Resolve the receiver's class_id: INT32 ClassRef payload, or the
+    // class_id stamped on a POINTER class object's ObjectHeader.
+    let bits = receiver.to_bits();
+    let top16 = bits >> 48;
+    let class_id = if top16 == 0x7FFE {
+        (bits & 0xFFFF_FFFF) as u32
+    } else if is_class_object_value(receiver) {
+        let obj = crate::value::JSValue::from_bits(bits).as_pointer::<ObjectHeader>();
+        js_object_get_class_id(obj)
+    } else {
+        0
+    };
+    if class_id == 0 {
+        return receiver;
+    }
+    if let Some((func_ptr, param_count)) = lookup_static_method_in_chain(class_id, name) {
+        let prev_this = crate::object::js_implicit_this_set(receiver);
+        let result = call_static_method(func_ptr, args_ptr, args_len, param_count);
+        crate::object::js_implicit_this_set(prev_this);
+        return result;
+    }
+    receiver
 }
 
 /// Look up parent class ID from the registry

--- a/test-files/test_gap_class_expr_inherited_static_method.ts
+++ b/test-files/test_gap_class_expr_inherited_static_method.ts
@@ -1,0 +1,39 @@
+// Issue #1788 (follow-up): a class DECLARATION that `extends` a
+// class-expression value inherits the parent's STATIC METHODS, not just
+// static fields. effect's base schemas do this: `class Number$ extends
+// make(numberKeyword) {}`, then `Number$.pipe(...)` / `Number$.annotations(...)`
+// dispatch to the inherited static method with `this` = the subclass.
+//
+// Static methods are emitted as `perry_static_*` (no `this` param) and live
+// in the runtime CLASS_STATIC_METHODS table keyed by the template class_id;
+// `Sub.greet()` walks Sub's class_id parent chain to find it and binds `this`
+// to Sub so `this.<field>` resolves through the subclass's static-field chain.
+//
+// Scope note: fixed-arity inherited static methods. Rest-param static methods
+// (`static pipe(...args)`) need arg-array bundling and are a tracked
+// refinement.
+//
+// Expected output:
+// Sub.greet: hi-A
+// Sub.withArgs: x+y:A
+// Leaf.greet (2-level): hi-M
+
+function make(tag: string) {
+  return class {
+    static ast = tag;
+    static greet() {
+      return "hi-" + this.ast;
+    }
+    static withArgs(a: string, b: string) {
+      return a + "+" + b + ":" + this.ast;
+    }
+  };
+}
+
+class Sub extends make("A") {}
+console.log("Sub.greet:", (Sub as any).greet());
+console.log("Sub.withArgs:", (Sub as any).withArgs("x", "y"));
+
+class Mid extends make("M") {}
+class Leaf extends Mid {}
+console.log("Leaf.greet (2-level):", (Leaf as any).greet());


### PR DESCRIPTION
## #1788 (follow-up) — inherit static **methods** through `extends` of a class-object value

Part of epic #1785 (design #1772). Completes #1788: the static-**field** half landed in #1793; this adds the static-**method** half. Validated byte-for-byte against node, zero regressions.

### What
`class Sub extends make("A") {}` (effect's `class Number$ extends make(numberKeyword) {}`) now inherits the parent's static **methods**. `Sub.greet()` / `Sub.withArgs(...)` dispatch to the inherited method with `this` bound to the subclass, so `this.<field>` resolves through the subclass's static-field chain (the #1788 prototype walk).

### Why it needed new machinery
Static methods are emitted as `perry_static_*` (no `this` param — they read `this` from the implicit-this slot) and are **not** in the instance vtable, so a subclass of a *dynamic* parent (`extends make(...)`) can't resolve an inherited static method at compile time. Added:

- runtime **`CLASS_STATIC_METHODS`** registry (`class_id → name → (func_ptr, param_count)`) + `js_register_class_static_method`, populated by a codegen loop in `emit_string_pool` mirroring the instance-vtable registration (static-method names added to the pre-intern pass).
- runtime **`js_class_static_method_call(receiver, name, args)`**: resolves the receiver's class_id (INT32 ClassRef or POINTER class object), walks the class_id parent chain in `CLASS_STATIC_METHODS`, binds `this` via the implicit-this slot, calls. **On a genuine miss it returns the receiver unchanged** — preserving the prior "yield the class ref for a chained call during module init" behavior for truly-absent methods (so non-inherited classes are unaffected).
- codegen routes a `ClassRef`-receiver static-method call that didn't resolve in the class's statically-visible chain to this helper.

### Validation
`test_gap_class_expr_inherited_static_method.ts` byte-identical to node (1-level + args + 2-level). 18/19 class spot-check — the one miss is the pre-existing known-failure #685 (a static-field *value-read*, unaffected by this method-call routing). `cargo fmt` clean.

### Scope
Fixed-arity inherited static methods. Rest-param static methods (`static pipe(...args)`) need arg-array bundling at the call site — tracked refinement (relevant to effect's `pipe`).

Refs #1788, #1785, #1772.
