### PR TITLE
fix(runtime,codegen): bundle rest args for inherited rest-param static methods (#1788)

### DIFF
--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -300,11 +300,12 @@ pub(super) fn emit_string_pool(
     // Each module's init registers its own classes; the linker
     // ensures all init functions run before main.
     let mut method_triples: Vec<(u32, String, String, u32)> = Vec::new();
-    // #1788: (cid, static-method name, perry_static_* symbol, param_count).
-    // Registered into the runtime CLASS_STATIC_METHODS table so a subclass
-    // whose parent is a class-expression value inherits the parent's static
-    // methods (`class Sub extends make(...) {}; Sub.greet()`).
-    let mut static_method_triples: Vec<(u32, String, String, u32)> = Vec::new();
+    // #1788: (cid, static-method name, perry_static_* symbol, param_count,
+    // has_rest). Registered into the runtime CLASS_STATIC_METHODS table so a
+    // subclass whose parent is a class-expression value inherits the parent's
+    // static methods (`class Sub extends make(...) {}; Sub.greet()`); has_rest
+    // tells the dispatcher to bundle trailing args for a `...rest` param.
+    let mut static_method_triples: Vec<(u32, String, String, u32, bool)> = Vec::new();
     for (class_name, class) in classes.iter() {
         // Refs #486: skip alias keys (class_table now contains both the
         // canonical name and self-binding aliases like `_X` from
@@ -352,7 +353,14 @@ pub(super) fn emit_string_pool(
                 sanitize(class_name),
                 sanitize(&sm.name),
             );
-            static_method_triples.push((cid, sm.name.clone(), llvm_name, sm.params.len() as u32));
+            let has_rest = sm.params.last().map(|p| p.is_rest).unwrap_or(false);
+            static_method_triples.push((
+                cid,
+                sm.name.clone(),
+                llvm_name,
+                sm.params.len() as u32,
+                has_rest,
+            ));
         }
     }
     method_triples.sort_unstable();
@@ -388,7 +396,7 @@ pub(super) fn emit_string_pool(
     // static methods (subclass extends a class-expression value) resolve at
     // runtime via the class_id parent-chain walk.
     static_method_triples.sort_unstable();
-    for (cid, method_name, llvm_name, param_count) in static_method_triples {
+    for (cid, method_name, llvm_name, param_count, has_rest) in static_method_triples {
         let entry = match strings.iter().find(|e| e.value == method_name) {
             Some(e) => e,
             None => continue,
@@ -398,6 +406,7 @@ pub(super) fn emit_string_pool(
         let func_ref = format!("@{}", llvm_name);
         let func_i64 = blk.ptrtoint(&func_ref, I64);
         let bytes_i64 = blk.ptrtoint(&bytes_global, I64);
+        let has_rest_str = if has_rest { "1" } else { "0" };
         blk.call_void(
             "js_register_class_static_method",
             &[
@@ -406,6 +415,7 @@ pub(super) fn emit_string_pool(
                 (I64, &len_str),
                 (I64, &func_i64),
                 (I64, &param_count.to_string()),
+                (I64, has_rest_str),
             ],
         );
     }

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1161,7 +1161,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function(
         "js_register_class_static_method",
         VOID,
-        &[I64, I64, I64, I64, I64],
+        &[I64, I64, I64, I64, I64, I64],
     );
     module.declare_function(
         "js_class_static_method_call",

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -36,13 +36,16 @@ pub struct ClassVTable {
 pub static CLASS_VTABLE_REGISTRY: RwLock<Option<HashMap<u32, ClassVTable>>> = RwLock::new(None);
 
 /// #1788: per-class STATIC-method registry: class_id -> { name -> (func_ptr,
-/// param_count) }. Static methods are emitted as `perry_static_*` (no `this`
-/// param — they read `this` from the implicit-this slot) and are NOT in the
-/// instance vtable above, so a subclass whose parent is a class-expression
-/// value (`class Sub extends make(...) {}`) can't resolve an inherited static
-/// method (`Sub.greet()`) at compile time. This table is walked up the
-/// class_id parent chain at runtime by `js_class_static_method_call`.
-pub static CLASS_STATIC_METHODS: RwLock<Option<HashMap<u32, HashMap<String, (usize, u32)>>>> =
+/// param_count, has_rest) }. Static methods are emitted as `perry_static_*`
+/// (no `this` param — they read `this` from the implicit-this slot) and are
+/// NOT in the instance vtable above, so a subclass whose parent is a
+/// class-expression value (`class Sub extends make(...) {}`) can't resolve an
+/// inherited static method (`Sub.greet()`) at compile time. This table is
+/// walked up the class_id parent chain at runtime by
+/// `js_class_static_method_call`. `has_rest` marks a trailing rest param
+/// (`static pipe(...args)`, effect's `pipe`/`dual`) so the dispatcher bundles
+/// the call args into an array for that slot.
+pub static CLASS_STATIC_METHODS: RwLock<Option<HashMap<u32, HashMap<String, (usize, u32, bool)>>>> =
     RwLock::new(None);
 
 /// Set of all registered class ids. Populated at module init by codegen
@@ -1503,6 +1506,7 @@ pub unsafe extern "C" fn js_register_class_static_method(
     name_len: i64,
     func_ptr: i64,
     param_count: i64,
+    has_rest: i64,
 ) {
     if class_id == 0 || name_ptr.is_null() || name_len <= 0 {
         return;
@@ -1520,12 +1524,12 @@ pub unsafe extern "C" fn js_register_class_static_method(
         .unwrap()
         .entry(class_id as u32)
         .or_default()
-        .insert(name, (func_ptr as usize, param_count as u32));
+        .insert(name, (func_ptr as usize, param_count as u32, has_rest != 0));
 }
 
 /// Look up a static method by name in `CLASS_STATIC_METHODS`, walking the
 /// class_id parent chain (so a subclass inherits a parent's static method).
-fn lookup_static_method_in_chain(class_id: u32, name: &str) -> Option<(usize, u32)> {
+fn lookup_static_method_in_chain(class_id: u32, name: &str) -> Option<(usize, u32, bool)> {
     let guard = CLASS_STATIC_METHODS.read().ok()?;
     let map = guard.as_ref()?;
     let mut cid = class_id;
@@ -1624,9 +1628,37 @@ pub unsafe extern "C" fn js_class_static_method_call(
     if class_id == 0 {
         return receiver;
     }
-    if let Some((func_ptr, param_count)) = lookup_static_method_in_chain(class_id, name) {
+    if let Some((func_ptr, param_count, has_rest)) = lookup_static_method_in_chain(class_id, name) {
         let prev_this = crate::object::js_implicit_this_set(receiver);
-        let result = call_static_method(func_ptr, args_ptr, args_len, param_count);
+        let result = if has_rest {
+            // `static foo(a, b, ...rest)` / `static pipe(...args)` (effect's
+            // `pipe`/`dual`): pass the first `param_count-1` positional args
+            // as-is, then bundle the remaining call args into a JS array for
+            // the rest slot — matching JS `arguments`/rest semantics and the
+            // direct-call (#1787 / #915) static-dispatch path.
+            let fixed = (param_count as usize).saturating_sub(1);
+            let arr = crate::array::js_array_alloc(args_len.saturating_sub(fixed) as u32);
+            let mut i = fixed;
+            while i < args_len {
+                crate::array::js_array_push_f64(arr, *args_ptr.add(i));
+                i += 1;
+            }
+            let rest_box = crate::value::js_nanbox_pointer(arr as i64);
+            // Build the [param_count]-slot effective-args buffer:
+            // positional fixed args, then the bundled rest array.
+            let mut buf: Vec<f64> = Vec::with_capacity(param_count as usize);
+            for j in 0..fixed {
+                buf.push(if j < args_len {
+                    *args_ptr.add(j)
+                } else {
+                    f64::from_bits(crate::value::TAG_UNDEFINED)
+                });
+            }
+            buf.push(rest_box);
+            call_static_method(func_ptr, buf.as_ptr(), buf.len(), param_count)
+        } else {
+            call_static_method(func_ptr, args_ptr, args_len, param_count)
+        };
         crate::object::js_implicit_this_set(prev_this);
         return result;
     }

--- a/test-files/test_gap_class_expr_inherited_rest_static.ts
+++ b/test-files/test_gap_class_expr_inherited_rest_static.ts
@@ -1,0 +1,30 @@
+// Issue #1788 (follow-up): a REST-param inherited static method through a
+// class-expression-value parent. effect's `pipe(...args)` / `dual` are
+// rest-param static methods called during Schema init; the inherited-static
+// dispatcher must bundle the trailing call args into the rest array rather
+// than dropping them.
+//
+// Expected output:
+// pipe 3: piped:3:X
+// pipe 0: piped:0:X
+// mixed: a|2:M
+
+function make(tag: string) {
+  return class {
+    static ast = tag;
+    static pipe(...args: number[]) {
+      return "piped:" + args.length + ":" + this.ast;
+    }
+    static mixed(first: string, ...rest: number[]) {
+      return first + "|" + rest.length + ":" + this.ast;
+    }
+  };
+}
+
+class Sub extends make("X") {}
+console.log("pipe 3:", (Sub as any).pipe(1, 2, 3));
+console.log("pipe 0:", (Sub as any).pipe());
+
+class Mid extends make("M") {}
+class Leaf extends Mid {}
+console.log("mixed:", (Leaf as any).mixed("a", 10, 20));


### PR DESCRIPTION
## #1788 follow-on — bundle rest args for inherited rest-param static methods

Follow-on to #1797. Found while driving the effect end-to-end probe (#1791): an inherited static method with a trailing rest param (`static pipe(...args)` — effect's `pipe`/`dual`) **dropped its call args** when dispatched through the class_id parent-chain walk. `Sub.pipe(1,2,3)` saw `args.length === 0` (perry) vs `3` (node), because the dispatcher passed args positionally but a rest-param method expects the trailing args bundled into an array for the rest slot.

### Fix
- `CLASS_STATIC_METHODS` now stores a `has_rest` flag (codegen reads `sm.params.last().is_rest`).
- `js_class_static_method_call` bundles `args[param_count-1..]` into a JS array for the rest slot and forwards the leading fixed params — matching the direct-call static-dispatch path (#1787/#915) and JS rest semantics.

### Validation
`test_gap_class_expr_inherited_rest_static.ts` byte-identical to node (`pipe(1,2,3)` → 3, `pipe()` → 0, and a mixed `first, ...rest` 2-level case). 16/16 class spot-check, zero regressions. `cargo fmt` clean.

### Note (effect e2e, #1791)
This is a real correctness fix and completes the rest-param half of inherited static-method dispatch, but it is **not sufficient on its own** to unblock `effect/Schema` — the barrel/Schema module init still throws `value is not a function` from a different site that needs localization (separate follow-up). `effect/Effect` deep import stays green (`= 42`).

Refs #1788, #1785, #1772.
