### PR TITLE
feat(runtime,codegen): Object.getOwnPropertyDescriptors (#1791/#1758)

### DIFF
--- a/crates/perry-codegen-js/src/emit/exprs_more.rs
+++ b/crates/perry-codegen-js/src/emit/exprs_more.rs
@@ -1288,6 +1288,11 @@ impl JsEmitter {
                 self.emit_expr(key);
                 self.output.push(')');
             }
+            Expr::ObjectGetOwnPropertyDescriptors(obj) => {
+                self.output.push_str("Object.getOwnPropertyDescriptors(");
+                self.emit_expr(obj);
+                self.output.push(')');
+            }
             Expr::ObjectGetOwnPropertyNames(obj) => {
                 self.output.push_str("Object.getOwnPropertyNames(");
                 self.emit_expr(obj);

--- a/crates/perry-codegen/src/expr/misc_methods.rs
+++ b/crates/perry-codegen/src/expr/misc_methods.rs
@@ -526,6 +526,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             ))
         }
 
+        // -------- Object.getOwnPropertyDescriptors(obj) --------
+        Expr::ObjectGetOwnPropertyDescriptors(obj) => {
+            let o = lower_expr(ctx, obj)?;
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_object_get_own_property_descriptors",
+                &[(DOUBLE, &o)],
+            ))
+        }
+
         // -------- Math.cbrt --------
         Expr::MathCbrt(operand) => {
             let v = lower_expr(ctx, operand)?;

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1647,6 +1647,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ArrayIndexOf { .. }
         | Expr::ArrayForEach { .. }
         | Expr::ObjectGetOwnPropertyDescriptor(..)
+        | Expr::ObjectGetOwnPropertyDescriptors(..)
         | Expr::MathCbrt(..)
         | Expr::DateGetFullYear(..)
         | Expr::DateGetMonth(..)

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1097,6 +1097,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, DOUBLE],
     );
+    module.declare_function("js_object_get_own_property_descriptors", DOUBLE, &[DOUBLE]);
     module.declare_function("js_object_get_own_property_names", DOUBLE, &[DOUBLE]);
     // Symbol runtime (perry-runtime/src/symbol.rs)
     module.declare_function("js_symbol_new", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -1312,6 +1312,7 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                     | "setPrototypeOf"
                                     | "getPrototypeOf"
                                     | "getOwnPropertyDescriptor"
+                                    | "getOwnPropertyDescriptors"
                                     | "getOwnPropertyNames"
                                     | "getOwnPropertySymbols"
                                     | "keys"

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -583,18 +583,19 @@ pub enum Expr {
     // Object property descriptor methods
     ObjectDefineProperty(Box<Expr>, Box<Expr>, Box<Expr>), // Object.defineProperty(obj, key, desc)
     ObjectGetOwnPropertyDescriptor(Box<Expr>, Box<Expr>), // Object.getOwnPropertyDescriptor(obj, key)
-    ObjectGetOwnPropertyNames(Box<Expr>), // Object.getOwnPropertyNames(obj) -> string[]
-    ObjectCreate(Box<Expr>),              // Object.create(proto)
-    ObjectFreeze(Box<Expr>),              // Object.freeze(obj)
-    ObjectSeal(Box<Expr>),                // Object.seal(obj)
-    ObjectPreventExtensions(Box<Expr>),   // Object.preventExtensions(obj)
-    ObjectIsFrozen(Box<Expr>),            // Object.isFrozen(obj)
-    ObjectIsSealed(Box<Expr>),            // Object.isSealed(obj)
-    ObjectIsExtensible(Box<Expr>),        // Object.isExtensible(obj)
-    ObjectGetPrototypeOf(Box<Expr>),      // Object.getPrototypeOf(obj)
+    ObjectGetOwnPropertyDescriptors(Box<Expr>), // Object.getOwnPropertyDescriptors(obj) -> { [k]: descriptor }
+    ObjectGetOwnPropertyNames(Box<Expr>),       // Object.getOwnPropertyNames(obj) -> string[]
+    ObjectCreate(Box<Expr>),                    // Object.create(proto)
+    ObjectFreeze(Box<Expr>),                    // Object.freeze(obj)
+    ObjectSeal(Box<Expr>),                      // Object.seal(obj)
+    ObjectPreventExtensions(Box<Expr>),         // Object.preventExtensions(obj)
+    ObjectIsFrozen(Box<Expr>),                  // Object.isFrozen(obj)
+    ObjectIsSealed(Box<Expr>),                  // Object.isSealed(obj)
+    ObjectIsExtensible(Box<Expr>),              // Object.isExtensible(obj)
+    ObjectGetPrototypeOf(Box<Expr>),            // Object.getPrototypeOf(obj)
     ObjectSetPrototypeOf(Box<Expr>, Box<Expr>), // Object.setPrototypeOf(obj, proto) -> obj
     ObjectDefineProperties(Box<Expr>, Box<Expr>), // Object.defineProperties(target, descriptors)
-    ObjectGetOwnPropertySymbols(Box<Expr>), // Object.getOwnPropertySymbols(obj) -> symbol[]
+    ObjectGetOwnPropertySymbols(Box<Expr>),     // Object.getOwnPropertySymbols(obj) -> symbol[]
 
     // Symbol operations
     SymbolNew(Option<Box<Expr>>), // Symbol() / Symbol(description)

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -723,6 +723,11 @@ pub(super) fn try_native_module_methods(
                                 Box::new(key),
                             )));
                         }
+                        "getOwnPropertyDescriptors" => {
+                            return Ok(Ok(Expr::ObjectGetOwnPropertyDescriptors(Box::new(
+                                args.into_iter().next().unwrap_or(Expr::Undefined),
+                            ))));
+                        }
                         "getOwnPropertyNames" => {
                             return Ok(Ok(Expr::ObjectGetOwnPropertyNames(Box::new(
                                 args.into_iter().next().unwrap_or(Expr::Undefined),

--- a/crates/perry-hir/src/lower/expr_call/object_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/object_static.rs
@@ -49,6 +49,9 @@ pub(super) fn build_object_static_method_call(method: &str, args: Vec<Expr>) -> 
             let key = iter.next().unwrap_or(Expr::Undefined);
             Expr::ObjectGetOwnPropertyDescriptor(Box::new(obj), Box::new(key))
         }
+        "getOwnPropertyDescriptors" => {
+            Expr::ObjectGetOwnPropertyDescriptors(Box::new(iter.next().unwrap_or(Expr::Undefined)))
+        }
         "getOwnPropertyNames" => {
             Expr::ObjectGetOwnPropertyNames(Box::new(iter.next().unwrap_or(Expr::Undefined)))
         }

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -145,6 +145,7 @@ impl SH for Expr {
             Expr::FinalizationRegistryUnregister { registry, token } => { tag(h, 107); registry.as_ref().hash(h); token.as_ref().hash(h); }
             Expr::ObjectDefineProperty(a, b, c) => { tag(h, 108); a.as_ref().hash(h); b.as_ref().hash(h); c.as_ref().hash(h); }
             Expr::ObjectGetOwnPropertyDescriptor(a, b) => { tag(h, 109); a.as_ref().hash(h); b.as_ref().hash(h); }
+            Expr::ObjectGetOwnPropertyDescriptors(e) => { tag(h, 11237); e.as_ref().hash(h); }
             Expr::ObjectGetOwnPropertyNames(e) => { tag(h, 110); e.as_ref().hash(h); }
             Expr::ObjectCreate(e) => { tag(h, 111); e.as_ref().hash(h); }
             Expr::ObjectFreeze(e) => { tag(h, 112); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -131,6 +131,7 @@ where
         | Expr::WeakRefDeref(v)
         | Expr::FinalizationRegistryNew(v)
         | Expr::ObjectGetOwnPropertyNames(v)
+        | Expr::ObjectGetOwnPropertyDescriptors(v)
         | Expr::ObjectCreate(v)
         | Expr::ObjectFreeze(v)
         | Expr::ObjectSeal(v)

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -132,6 +132,7 @@ where
         | Expr::WeakRefDeref(v)
         | Expr::FinalizationRegistryNew(v)
         | Expr::ObjectGetOwnPropertyNames(v)
+        | Expr::ObjectGetOwnPropertyDescriptors(v)
         | Expr::ObjectCreate(v)
         | Expr::ObjectFreeze(v)
         | Expr::ObjectSeal(v)

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -876,6 +876,49 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
     }
 }
 
+/// Object.getOwnPropertyDescriptors(obj) — returns a new object whose own
+/// property keys (the same set `Object.getOwnPropertyNames` reports, including
+/// non-enumerable keys and class-ref method names) each map to the property
+/// descriptor produced by `js_object_get_own_property_descriptor`. Spec:
+/// "for each own property key K of O, set result[K] = descriptor(O, K)".
+///
+/// effect's `SchemaAST.annotations` builds a fresh AST node via
+/// `Object.create(Object.getPrototypeOf(ast), Object.getOwnPropertyDescriptors(ast))`,
+/// so without this the plural call lowered to a null callee and Schema.ts
+/// module init threw `TypeError: value is not a function` (#1791/#1758).
+#[no_mangle]
+pub extern "C" fn js_object_get_own_property_descriptors(obj_value: f64) -> f64 {
+    const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+    unsafe {
+        // Enumerate own keys exactly like Object.getOwnPropertyNames — this
+        // handles class refs and plain objects, and includes non-enumerable
+        // keys, matching the spec's [[OwnPropertyKeys]] string-key set.
+        let names_value = js_object_get_own_property_names(obj_value);
+        let names_arr =
+            crate::value::js_nanbox_get_pointer(names_value) as *const crate::array::ArrayHeader;
+
+        // Fresh result object that collects { key: descriptor } entries.
+        // Like js_object_entries / js_object_get_own_property_names above, the
+        // intermediate allocations aren't rooted — Perry's builder helpers
+        // follow this convention.
+        let result = js_object_alloc(0, 0);
+
+        if !names_arr.is_null() {
+            let len = crate::array::js_array_length(names_arr) as usize;
+            for i in 0..len {
+                let key_val = crate::array::js_array_get(names_arr, i as u32);
+                let key_f64 = f64::from_bits(key_val.bits());
+                let desc = js_object_get_own_property_descriptor(obj_value, key_f64);
+                let key_str = crate::builtins::js_string_coerce(key_f64);
+                if !key_str.is_null() {
+                    js_object_set_field_by_name(result, key_str, desc);
+                }
+            }
+        }
+        f64::from_bits((result as u64) | POINTER_TAG)
+    }
+}
+
 /// Object.create(proto) — create empty object. Perry ignores prototype; Object.create(null) returns {}.
 #[no_mangle]
 pub extern "C" fn js_object_create(proto_value: f64) -> f64 {

--- a/test-files/test_gap_object_get_own_property_descriptors.ts
+++ b/test-files/test_gap_object_get_own_property_descriptors.ts
@@ -1,0 +1,51 @@
+// Object.getOwnPropertyDescriptors(obj) — the PLURAL form. The singular
+// `Object.getOwnPropertyDescriptor(obj, key)` already had a dedicated HIR
+// variant + runtime helper, but the plural had none: the literal-callee
+// recogniser in `lower/expr_call/native_module.rs` (and the esbuild-alias
+// recogniser in `destructuring/var_decl.rs`) silently fell through, so codegen
+// lowered the callee to a constant null and the call threw
+// `TypeError: value is not a function`.
+//
+// This is the first blocker on `import * as S from "effect/Schema"` (#1791 /
+// #1758 / #1785): effect's `SchemaAST.annotations` clones an AST node via
+//   Object.create(Object.getPrototypeOf(ast), Object.getOwnPropertyDescriptors(ast))
+// during module init, so Schema.ts threw before any user code ran.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+// 1. Plain data object — every key reports a full data descriptor.
+const o = { a: 1, b: "x", c: true };
+console.log(JSON.stringify(Object.getOwnPropertyDescriptors(o)));
+
+// 2. Empty object — empty descriptor map.
+console.log(JSON.stringify(Object.getOwnPropertyDescriptors({})));
+
+// 3. Alias / indirect-call form (esbuild CJS prelude shape).
+const gopds = Object.getOwnPropertyDescriptors;
+console.log(JSON.stringify(gopds({ z: 9 })));
+
+// 4. Accessor (getter) property — descriptor carries `get`, not `value`.
+const acc: any = {};
+Object.defineProperty(acc, "g", {
+  get() {
+    return 42;
+  },
+  enumerable: true,
+  configurable: true,
+});
+const d = Object.getOwnPropertyDescriptors(acc);
+console.log("has get:", typeof d.g.get, "enumerable:", d.g.enumerable);
+
+// 5. The exact effect shape: shallow-clone an object (own props as
+//    descriptors) while preserving the prototype chain.
+const proto = { kind: "base" };
+const src: any = Object.create(proto);
+src.val = 7;
+const clone: any = Object.create(
+  Object.getPrototypeOf(src),
+  Object.getOwnPropertyDescriptors(src),
+);
+console.log("clone.val:", clone.val, "proto.kind:", clone.kind);
+
+// 6. Result is a real object usable downstream.
+console.log("typeof result:", typeof Object.getOwnPropertyDescriptors(o));


### PR DESCRIPTION
## Summary

Implements `Object.getOwnPropertyDescriptors(obj)` (the **plural** form) — the
first blocker stopping `import * as S from "effect/Schema"` from initializing
(epic #1785 / #1772, capstone #1791 / #1758).

The singular `Object.getOwnPropertyDescriptor(obj, key)` was already wired end
to end, but the plural had **no dedicated HIR variant**. It fell through both
the literal-callee recogniser (`lower/expr_call/native_module.rs`) and the
esbuild-alias recogniser (`destructuring/var_decl.rs`), so codegen lowered the
callee to a constant `0.0` (null) and the call threw
`TypeError: value is not a function`.

effect's `SchemaAST.annotations` clones an AST node during Schema.ts **module
init** via:

```ts
Object.create(Object.getPrototypeOf(ast), Object.getOwnPropertyDescriptors(ast))
```

so the import threw before any user code ran.

## Localization

`PERRY_DEBUG_SYMBOLS=1` + `lldb` (break `js_throw_type_error_not_a_function`) +
`--trace llvm` pinned the throw to `AST.annotations` (SchemaAST closure
`__182`), where the callee lowered to `%r5 = bitcast double 0.0 to i64` →
`js_closure_call1(null, ast)`. Minimal repro: `Object.getOwnPropertyDescriptors({a:1})`.

## Changes (mirror the singular-descriptor path)

- **runtime** `js_object_get_own_property_descriptors` (`object_ops.rs`):
  enumerate own keys via `getOwnPropertyNames`, build a fresh object mapping
  each key to its descriptor (`js_object_get_own_property_descriptor`).
  Non-rooted builder allocations follow the existing `js_object_entries` /
  `getOwnPropertyNames` convention.
- new HIR `Expr::ObjectGetOwnPropertyDescriptors(Box<Expr>)`; lowered in both
  the **direct-call** and **`Object`-alias** paths; whitelisted in the alias gate.
- codegen arm (`misc_methods.rs`) + extern decl (`runtime_decls/strings.rs`) +
  the codegen dispatch list, the ref/mut walkers, a `stable_hash` tag, and the
  JS emitter (`perry-codegen-js`).

## Validation

- Byte-for-byte with `node --experimental-strip-types` across
  plain / empty / alias / accessor-descriptor / clone-via-`Object.create` shapes
  (new gap test `test_gap_object_get_own_property_descriptors.ts`).
- `effect/Effect` deep import stays green (`result: 42`).
- Class-expr epic gap suite (identity / static-this / extends-static /
  inherited-static-method / inherited-rest-static / new-instanceof /
  static-iife / static-symbol): **all pass**.
- Object-method tests (define-property, getPrototypeOf, indirect-define-property
  #886, accessor #450, etc.): **all pass**.
- **0 regressions.** `test_issue_685` remains the documented pre-existing
  class-object static-field value-read known-failure (`params type: string` vs
  `object`), unrelated to this change.

## Remaining (reported, not chained here)

Full `effect/Schema` init hits a **distinct second blocker** once this lands:
`TypeError: Cannot read properties of undefined (reading '_tag')` deeper in
Schema.ts init.

Backtrace:

```
js_throw_type_error_property_access
  perry_closure_..._SchemaAST_ts__239 (+39352, a ~5.8k-line recursive AST dispatcher)
  perry_closure_..._Schema_ts__211
  perry_closure_..._Schema_ts__227
  node_modules_..._Schema_ts__init_body
```

The simple class-object static-field value-read this *looked* like (the
deferred #1787 / #685 sub-item) reproduces **correctly** in isolation now
(`make(x).ast._tag` matches node), so the `_tag`-undefined is a more specific
data-flow issue in Schema's struct construction — to be localized in a
follow-up.

Refs #1791, #1758, #1785, #1772.
