### PR TITLE
fix(codegen,runtime): bind `this` for static-method calls on class-object values (#1758)

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -1113,6 +1113,16 @@ pub fn try_lower_property_get_method_call(
             for a in args {
                 lowered_args.push(lower_expr(ctx, a)?);
             }
+            // #1758 / epic #1785: capture the raw user args (no `this`, no
+            // issue-#235 padding, no rest-bundling) before any of the
+            // instance-calling-convention mangling below. A `perry_static_*`
+            // implementor (a class-object value reaching this instance-method
+            // tower — e.g. `class X extends (make(...)).annotations(y) {}`)
+            // must dispatch through `js_class_static_method_call`, which binds
+            // `this` and applies static arity/rest semantics; the
+            // instance-style `fname(recv, args…)` direct call would pass recv
+            // as arg0 and never set IMPLICIT_THIS (the #1787 broken-tower bug).
+            let static_user_args: Vec<String> = lowered_args[1..].to_vec();
             // Issue #235: pad lowered_args with TAG_UNDEFINED so the callee's
             // default-param desugaring fires when the call site passed fewer
             // args than the method declares. Pre-fix the dispatch tower
@@ -1321,7 +1331,46 @@ pub fn try_lower_property_get_method_call(
             let mut phi_inputs: Vec<(String, String)> = Vec::new();
             for ((_, fname), &case_idx) in implementors.iter().zip(case_idxs.iter()) {
                 ctx.current_block = case_idx;
-                let v = ctx.block().call(DOUBLE, fname, &arg_slices);
+                // #1758: a `perry_static_*` implementor is a STATIC method on a
+                // class-object receiver. Route it through the runtime
+                // `js_class_static_method_call` (binds `this`, walks the
+                // class_id parent chain, applies static arity/rest) instead of
+                // the instance-style direct call, which would pass recv as
+                // arg0 and leave `this` unset (#1787 broken-tower behavior).
+                let v = if fname.starts_with("perry_static_") {
+                    let n = static_user_args.len();
+                    let (sa_ptr, sa_len) = if n == 0 {
+                        ("null".to_string(), "0".to_string())
+                    } else {
+                        let buf_reg = ctx.func.alloca_entry_array(DOUBLE, n);
+                        for (i, a_val) in static_user_args.iter().enumerate() {
+                            let slot =
+                                ctx.block()
+                                    .gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", i))]);
+                            ctx.block().store(DOUBLE, a_val, &slot);
+                        }
+                        let ptr_reg = ctx.block().next_reg();
+                        ctx.block().emit_raw(format!(
+                            "{} = getelementptr [{} x double], ptr {}, i64 0, i64 0",
+                            ptr_reg, n, buf_reg
+                        ));
+                        (ptr_reg, n.to_string())
+                    };
+                    let name_ptr_i64 = ctx.block().ptrtoint(&probe_bytes_global, I64);
+                    ctx.block().call(
+                        DOUBLE,
+                        "js_class_static_method_call",
+                        &[
+                            (DOUBLE, &recv_box),
+                            (I64, &name_ptr_i64),
+                            (I64, &probe_name_len_str),
+                            (crate::types::PTR, &sa_ptr),
+                            (I64, &sa_len),
+                        ],
+                    )
+                } else {
+                    ctx.block().call(DOUBLE, fname, &arg_slices)
+                };
                 let after_label = ctx.block().label.clone();
                 if !ctx.block().is_terminated() {
                     ctx.block().br(&merge_label);

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1529,7 +1529,10 @@ pub unsafe extern "C" fn js_register_class_static_method(
 
 /// Look up a static method by name in `CLASS_STATIC_METHODS`, walking the
 /// class_id parent chain (so a subclass inherits a parent's static method).
-fn lookup_static_method_in_chain(class_id: u32, name: &str) -> Option<(usize, u32, bool)> {
+pub(crate) fn lookup_static_method_in_chain(
+    class_id: u32,
+    name: &str,
+) -> Option<(usize, u32, bool)> {
     let guard = CLASS_STATIC_METHODS.read().ok()?;
     let map = guard.as_ref()?;
     let mut cid = class_id;

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -140,6 +140,37 @@ pub unsafe extern "C" fn js_native_call_method(
 
     let jsval = JSValue::from_bits(object.to_bits());
 
+    // #1758 / epic #1785: a class-object VALUE reaching the *dynamic*
+    // dispatcher is a STATIC method call. This happens when the static
+    // analyzer couldn't prove the receiver is a class object — e.g.
+    // `class X extends (make(...) as any).annotations(y) {}` where the
+    // `make()` factory call wasn't inlined to a `ClassExprFresh` (so the
+    // `.annotations` receiver lowers to a generic Call result), or any
+    // `(expr-returning-a-class-object).staticMethod()`. The compile-time
+    // static-dispatch tower (property_get.rs) binds `this` via
+    // IMPLICIT_THIS; the generic field-scan path below does NOT, so
+    // `this.<staticField>` (effect's `annotations() { make(this.ast, ...) }`)
+    // read `undefined`. Route to `js_class_static_method_call`, which binds
+    // `this` to the receiver and walks the class_id parent chain — but only
+    // when the method actually resolves in the static chain, so an own
+    // function-valued static field still falls through to the generic path.
+    if crate::object::class_registry::is_class_object_value(object) {
+        let class_id = crate::object::js_object_get_class_id(jsval.as_pointer::<ObjectHeader>());
+        if class_id != 0
+            && crate::object::class_registry::lookup_static_method_in_chain(class_id, method_name)
+                .is_some()
+        {
+            let args = refreshed_args();
+            return crate::object::class_registry::js_class_static_method_call(
+                object_handle.get_nanbox_f64(),
+                method_name_ptr as *const u8,
+                method_name_len,
+                args.as_ptr(),
+                args.len(),
+            );
+        }
+    }
+
     // Issue #489 followup: Promise's `then` / `catch` / `finally` are
     // intrinsic — when the dynamic dispatch path lands a `.then(cb)` on
     // a Promise (drizzle's `mysql-proxy/session.js`:

--- a/test-files/test_gap_class_expr_extends_static_call_this.ts
+++ b/test-files/test_gap_class_expr_extends_static_call_this.ts
@@ -1,0 +1,61 @@
+// epic #1785 / #1758: a STATIC method call on a class-object VALUE reached
+// through the *dynamic* dispatch path must bind `this` to the receiver.
+//
+// The compile-time static-dispatch tower (property_get.rs ~757) handles a
+// `ClassExprFresh` / const-bound class-object receiver. But when the receiver
+// is an *un-inlined* factory-call result — e.g. the `extends` clause of
+//   `class X extends (make(...) as any).annotations(y) {}`
+// (effect's `class BigInt$ extends transformOrFail(...).annotations(...) {}`)
+// — the call fell into the instance-method dispatch tower, which passed the
+// receiver as arg0 and never set IMPLICIT_THIS. So a static method reading
+// `this.<staticField>` (effect's `annotations() { make(this.ast, ...) }`)
+// saw `undefined` and threw `Cannot read properties of undefined`.
+//
+// Fix: route `perry_static_*` implementors through `js_class_static_method_call`
+// (codegen tower) and detect class-object receivers in `js_native_call_method`
+// (runtime dynamic path) — both bind `this` + walk the class_id parent chain.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+function make(a: any) {
+  return class SchemaClass {
+    static ast = a;
+    static annotations(x: any) {
+      // reads `this.ast` (the receiver's static field) — requires `this` bound
+      return make({ base: this.ast, ann: x });
+    }
+  };
+}
+
+// (1) extends an inline static-method-call result (tower case0 path: the
+//     `make()` receiver's class is statically known, so the class-id switch
+//     fires and the case body must use the static calling convention).
+class Chained extends (make({ _tag: "C" }) as any).annotations({ id: 1 }) {}
+console.log("(1) Chained.ast:", JSON.stringify((Chained as any).ast));
+
+// (2) opaque (any-typed) receiver → the tower can't resolve the class, so the
+//     call goes through the runtime dynamic dispatcher `js_native_call_method`.
+function opaque(): any {
+  return make({ _tag: "O" });
+}
+class FromOpaque extends (opaque() as any).annotations({ id: 2 }) {}
+console.log("(2) FromOpaque.ast:", JSON.stringify((FromOpaque as any).ast));
+
+// (3) a static method that does NOT read `this` still works through the
+//     dynamic path (regression guard: don't break the non-this case).
+function makeNoThis(a: any) {
+  return class S2 {
+    static ast = a;
+    static fixed(x: any) {
+      return make({ fixed: "F", ann: x });
+    }
+  };
+}
+class FromNoThis extends (makeNoThis({ _tag: "N" }) as any).fixed({ id: 3 }) {}
+console.log("(3) FromNoThis.ast:", JSON.stringify((FromNoThis as any).ast));
+
+// (4) const-bound receiver (the already-working static-dispatch path) — guard
+//     that the new routing didn't regress it.
+const parent = (make({ _tag: "P" }) as any).annotations({ id: 4 });
+class FromConst extends parent {}
+console.log("(4) FromConst.ast:", JSON.stringify((FromConst as any).ast));


### PR DESCRIPTION
## Summary

Fixes `this`-binding for a **static** method call on a **class-object value**
reached through the *dynamic* dispatch path — the #1787 "broken dynamic-dispatch
tower" that the class-object epic (#1785) previously *avoided* but never fixed.

When the receiver of a static-method call is an **un-inlined factory-call
result** (so its class isn't statically known), the call fell into the
instance-method dispatch tower, which passed the receiver as `arg0` and never
set `IMPLICIT_THIS`. A static method reading `this.<staticField>` then saw
`undefined`.

This is the next `effect/Schema` init blocker after #1804:

```ts
class BigInt$ extends transformOrFail(...).annotations(...) {}
```

The `.annotations()` receiver is an un-inlined factory call, so
`static annotations(x) { return make(mergeSchemaAnnotations(this.ast, x)) }`
read `this.ast === undefined` and threw
`Cannot read properties of undefined (reading '_tag')` during Schema.ts init.

## Localization

`PERRY_DEBUG_SYMBOLS=1` + lldb (`b js_throw_type_error_property_access`) + an
effect-source probe pinned the failing field to `nanos` (`BigInt$`), then
`--trace llvm` showed the inline dispatch's `idispatch.case0` emitting
`perry_static_…__withThis(recv, arg)` — receiver as arg0, no `IMPLICIT_THIS`.

## Fix (two complementary dispatch paths)

Both delegate to the existing `js_class_static_method_call`, which binds `this`,
walks the class_id parent chain, and applies static arity/rest semantics:

- **codegen** (`lower_call/property_get.rs`): in the instance-method dispatch
  tower, a `perry_static_*` implementor routes to `js_class_static_method_call`
  instead of the instance-style `fname(recv, args…)` direct call. Raw user args
  are captured before the issue-#235 padding / rest-bundling mangling.
- **runtime** (`object/native_call_method.rs`): the dynamic dispatcher detects a
  class-object receiver (`is_class_object_value`) and, when the method resolves
  in the static chain, delegates; otherwise falls through to the generic
  own-field path. `lookup_static_method_in_chain` is now `pub(crate)`.

## Validation

- New gap test `test_gap_class_expr_extends_static_call_this.ts` — byte-for-byte
  with node across: statically-known receiver (tower), any-typed receiver
  (runtime dynamic path), a no-`this` static method, and the const-bound
  (already-working) path.
- Class-expr epic gap suite + Object/class dispatch tests: **0 regressions**.
- Broad 50-test class/method/inheritance sweep: the 8 failures
  (decorators / static-block / mixins / node-error-format / primitive-typeerror)
  **fail identically on origin/main** — confirmed pre-existing, not regressions.

## Remaining (continuing in a follow-up)

`effect/Schema` init still has further class-object blockers past this, in the
**symbol** subsystem (which breaks effect's `isSchema` → `dual` →
`transformOrFail`):

- `symbol in classObject` (the `in` operator / `Predicate.hasProperty`) returns
  `false` even for an own static symbol property.
- inherited static **symbol** reads (`Sub[TypeId]` where `Sub extends make(...)`)
  return `undefined`.

Refs #1758, #1785, #1772, #1791.
