### PR TITLE
fix(runtime): static symbol property lookup on class-object values (#1758)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -220,6 +220,38 @@ pub(crate) unsafe fn resolve_proto_chain_field(
     None
 }
 
+/// #1758: symbol-keyed analogue of [`resolve_proto_chain_field`]. Walks the
+/// `CLASS_PROTOTYPE_OBJECTS` / `get_parent_class_id` chain and, at each
+/// prototype object (a POINTER class-object), looks up its OWN symbol property
+/// via `js_object_get_symbol_property`. Lets a subclass whose parent is a
+/// class-expression value inherit the parent's static *symbol* statics — e.g.
+/// effect's `class BigIntFromSelf extends make(bigIntKeyword) {}` inheriting
+/// `static [TypeId]`, which `Predicate.hasProperty(.., TypeId)` (`isSchema`)
+/// and `u[TypeId]` both read. Returns the first defined value found.
+pub(crate) unsafe fn resolve_proto_chain_symbol(class_id: u32, sym_f64: f64) -> Option<f64> {
+    let mut cid = class_id;
+    let mut depth = 0usize;
+    while depth < 32 {
+        let proto_obj = class_prototype_object(cid);
+        if !proto_obj.is_null() {
+            let proto_f64 = f64::from_bits(JSValue::pointer(proto_obj as *const u8).bits());
+            // OWN lookup only — this fn IS the chain walk, so recursing into
+            // the full chain-walking getter would re-walk per prototype.
+            if let Some(v) = crate::symbol::own_symbol_property(proto_f64, sym_f64) {
+                return Some(v);
+            }
+        }
+        match get_parent_class_id(cid) {
+            Some(p) if p != 0 && p != cid => {
+                cid = p;
+                depth += 1;
+            }
+            _ => break,
+        }
+    }
+    None
+}
+
 /// Lookup the synthetic class id for a function value, if one was
 /// registered via `js_set_function_prototype`.
 #[inline]

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -654,6 +654,22 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
     let obj_val = JSValue::from_bits(obj.to_bits());
     let key_val = JSValue::from_bits(key.to_bits());
 
+    // #1758: a SYMBOL key. The class-ref path below + the keys_array scan
+    // (string keys only) can't see a class-object's static `[Sym]` props nor
+    // ones inherited from a class-expression parent. Delegate to the symbol
+    // resolver (handles INT32 class refs, POINTER class-objects, own +
+    // prototype-chain), mirroring the string-key "present-and-not-undefined"
+    // semantics. Fixes effect's `Predicate.hasProperty(classObj, TypeId)`
+    // (`isSchema` → `dual` → `transformOrFail`) and `Sym in obj` generally.
+    if unsafe { crate::symbol::js_is_symbol(key) } != 0 {
+        let v = unsafe { crate::symbol::js_object_get_symbol_property(obj, key) };
+        return if v.to_bits() != crate::value::TAG_UNDEFINED {
+            nanbox_true
+        } else {
+            nanbox_false
+        };
+    }
+
     // Refs #420 / #618: `Symbol in ClassRef` — drizzle's `entityKind in cls`.
     // Class refs are INT32-tagged. Check CLASS_STATIC_SYMBOLS for symbol
     // keys and CLASS_DYNAMIC_PROPS for string keys.

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -636,6 +636,30 @@ pub unsafe extern "C" fn js_object_has_own_symbol(obj_f64: f64, sym_f64: f64) ->
 /// init via `js_class_register_static_symbol`. Pre-fix the dispatch
 /// only looked at the per-instance `SYMBOL_PROPERTIES` map and class
 /// refs always returned undefined.
+/// #1758: the OWN symbol-property lookup — the raw `SYMBOL_PROPERTIES`
+/// side-table read keyed by the object's address (no class-ref / no prototype
+/// chain). Used by `js_object_get_symbol_property` and by
+/// `resolve_proto_chain_symbol`, which walks prototype objects itself and must
+/// therefore NOT recurse into the full chain-walking getter.
+pub(crate) unsafe fn own_symbol_property(obj_f64: f64, sym_f64: f64) -> Option<f64> {
+    let obj_key = obj_key_from_f64(obj_f64);
+    let sym_key = sym_key_from_f64(sym_f64);
+    if obj_key == 0 || sym_key == 0 {
+        return None;
+    }
+    let guard = SYMBOL_PROPERTIES.lock().unwrap();
+    if let Some(map) = guard.as_ref() {
+        if let Some(entries) = map.get(&obj_key) {
+            for &(sk, vb) in entries.iter() {
+                if sk == sym_key {
+                    return Some(f64::from_bits(vb));
+                }
+            }
+        }
+    }
+    None
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f64) -> f64 {
     // Check CLASS_STATIC_SYMBOLS first when receiver is a class ref
@@ -645,6 +669,12 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
         let class_id = (bits & 0xFFFF_FFFF) as u32;
         if let Some(vb) = class_static_symbol_lookup(class_id, sym_f64) {
             return f64::from_bits(vb);
+        }
+        // #1758: a class ref whose own static symbols miss may inherit the
+        // symbol from a class-expression parent (`class Sub extends make(...) {}`
+        // → `Sub[TypeId]`). Walk the CLASS_PROTOTYPE_OBJECTS chain.
+        if let Some(v) = crate::object::resolve_proto_chain_symbol(class_id, sym_f64) {
+            return v;
         }
         return f64::from_bits(TAG_UNDEFINED);
     }
@@ -670,17 +700,21 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
             }
         }
     }
-    let obj_key = obj_key_from_f64(obj_f64);
-    let sym_key = sym_key_from_f64(sym_f64);
-    if obj_key == 0 || sym_key == 0 {
-        return f64::from_bits(TAG_UNDEFINED);
+    if let Some(v) = own_symbol_property(obj_f64, sym_f64) {
+        return v;
     }
-    let guard = SYMBOL_PROPERTIES.lock().unwrap();
-    if let Some(map) = guard.as_ref() {
-        if let Some(entries) = map.get(&obj_key) {
-            for &(sk, vb) in entries.iter() {
-                if sk == sym_key {
-                    return f64::from_bits(vb);
+    // #1758: a POINTER class-object whose OWN symbol props miss may inherit
+    // the symbol through its class_id prototype chain. (The SYMBOL_PROPERTIES
+    // lock is released above before recursing into the resolver, which takes
+    // it again per prototype object.)
+    if (bits >> 48) == 0x7FFD {
+        let obj_ptr =
+            crate::value::JSValue::from_bits(bits).as_pointer::<crate::object::ObjectHeader>();
+        if !obj_ptr.is_null() {
+            let cid = crate::object::js_object_get_class_id(obj_ptr);
+            if cid != 0 {
+                if let Some(v) = crate::object::resolve_proto_chain_symbol(cid, sym_f64) {
+                    return v;
                 }
             }
         }

--- a/test-files/test_gap_class_object_static_symbol.ts
+++ b/test-files/test_gap_class_object_static_symbol.ts
@@ -1,0 +1,55 @@
+// epic #1785 / #1758: static SYMBOL property lookup on class-object values —
+// both the `in` operator (`Predicate.hasProperty`) and the read (`obj[Sym]`),
+// for OWN props and props INHERITED from a class-expression parent.
+//
+// Two bugs:
+//   (b) `Sym in classObject` returned false even for an OWN static `[Sym]`
+//       (the `in` operator's generic path rejected non-string keys outright).
+//   (c) `Sub[Sym]` where `class Sub extends make(...)` returned undefined
+//       (inherited static symbols weren't walked through the prototype chain).
+//
+// This breaks effect's `isSchema(u) = hasProperty(u, TypeId) && isObject(u[TypeId])`:
+// `BigIntFromSelf = class extends make(bigIntKeyword) {}` carries `[TypeId]`
+// only via inheritance, so `transformOrFail`'s `dual` predicate
+// (`isSchema(args[0]) && isSchema(args[1])`) returned false and `transformOrFail`
+// degraded to a curried function — never building the transformation class.
+//
+// Fix: `js_object_has_property` delegates symbol keys to the symbol resolver;
+// `js_object_get_symbol_property` walks the `CLASS_PROTOTYPE_OBJECTS` chain
+// (new `resolve_proto_chain_symbol`) for both class-ref (INT32) and
+// class-object (POINTER) receivers.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+const TypeId: unique symbol = Symbol.for("perry-test-TypeId") as any;
+const variance = { _A: 1 };
+
+function make(a: any) {
+  return class S {
+    [TypeId] = variance;
+    static ast = a;
+    static [TypeId] = variance;
+  };
+}
+
+// (1) OWN static symbol on a class-object value (POINTER class-object).
+const M = make({ _tag: "y" });
+console.log("(1) read  M[TypeId]:", typeof (M as any)[TypeId]);
+console.log("(1) in    TypeId in M:", (TypeId as any) in (M as any));
+
+// (2) INHERITED static symbol on a subclass (INT32 class ref extends make()).
+class Sub extends make({ _tag: "x" }) {}
+console.log("(2) read  Sub[TypeId]:", typeof (Sub as any)[TypeId]);
+console.log("(2) in    TypeId in Sub:", (TypeId as any) in (Sub as any));
+
+// (3) a symbol that is NOT present must report absent (no false positives).
+const Other: unique symbol = Symbol.for("perry-test-Other") as any;
+console.log("(3) read  M[Other]:", typeof (M as any)[Other]);
+console.log("(3) in    Other in M:", (Other as any) in (M as any));
+
+// (4) effect's `isSchema` shape: hasProperty(u, TypeId) && isObject(u[TypeId]).
+const isSchemaLike = (u: any) =>
+  u != null && (TypeId as any) in u && typeof u[TypeId] === "object";
+console.log("(4) isSchemaLike(M):", isSchemaLike(M));
+console.log("(4) isSchemaLike(Sub):", isSchemaLike(Sub));
+console.log("(4) isSchemaLike({}):", isSchemaLike({}));


### PR DESCRIPTION
## Summary

Fixes static **symbol**-keyed property access on class values — both the `in`
operator and the read — for OWN props and props **inherited** from a
class-expression parent. Toward `effect/Schema` init (epic #1785 / #1758).

Two bugs, both breaking effect's `isSchema`:

1. **`Sym in classObject`** (the `in` operator / `Predicate.hasProperty`)
   returned `false` even for an OWN static `[Sym]` — `js_object_has_property`'s
   generic path rejects non-string keys outright, and its INT32 class-ref path
   only checked own `CLASS_STATIC_SYMBOLS`.
2. **`Sub[Sym]`** where `class Sub extends make(...)` returned `undefined` —
   inherited static symbols weren't walked through the class-expression
   prototype chain.

## Why it blocks effect

`isSchema(u) = hasProperty(u, TypeId) && isObject(u[TypeId])`. With
`BigIntFromSelf = class extends make(bigIntKeyword) {}` (carries `[TypeId]`
only via inheritance), `isSchema(BigIntFromSelf)` returned `false`, so
`transformOrFail`'s `dual` predicate `isSchema(args[0]) && isSchema(args[1])`
was false → `transformOrFail` degraded to a curried function →
`makeTransformationClass` never ran → a downstream schema's `.ast` was
`undefined` → `Cannot read properties of undefined (reading '_tag')` during
Schema.ts init.

Localized with `PERRY_DEBUG_SYMBOLS=1` + lldb + an effect-source probe: the
failing field was `nanos` (`= BigInt$`), traced back through
`transformOrFail`/`dual` to `isSchema` → `hasProperty(.., TypeId)`.

## Fix (runtime only)

- new `resolve_proto_chain_symbol` (`class_registry.rs`) — symbol analogue of
  `resolve_proto_chain_field`; walks `CLASS_PROTOTYPE_OBJECTS` + the class_id
  parent chain, checking each prototype object's OWN symbol props via a new
  non-recursive `own_symbol_property` helper (`symbol.rs`).
- `js_object_get_symbol_property` — on an own miss, walk the chain (INT32 class
  refs **and** POINTER class-objects).
- `js_object_has_property` — delegate symbol keys to
  `js_object_get_symbol_property` (own + inherited), mirroring the existing
  string-key "present-and-not-undefined" semantics.

## Validation

- New gap test `test_gap_class_object_static_symbol.ts` — byte-for-byte with
  node across own / inherited / absent / `isSchema`-shape cases.
- Class / Object / symbol regression sweep: **0 regressions** (the pre-existing
  failures fail identically on origin/main).

## Relationship to #1809 and remaining work

Independent of #1809 (extends-static-method `this`-binding), but the full
`effect/Schema` flow needs **both**. With this + #1809, Schema init gets **past**
the `_tag`-of-undefined `TypeError` and now reaches a **distinct SIGSEGV** deeper
in effect's fiber runtime: `js_object_has_property` → `js_array_length` on a
malformed `keys_array`
(`effect/internal/core` → `…fiberRuntime`). Reported separately.

Refs #1758, #1785, #1772, #1791.
