### PR TITLE
fix(runtime): `in` operator on a closure value no longer SIGSEGVs (#1758)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -783,6 +783,31 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                 // false for now — out of scope for #323.
                 return nanbox_false;
             }
+            // #1758: a CLOSURE receiver (functions ARE objects in JS, so
+            // `key in fn` is valid). Pre-fix this fell through to the
+            // keys_array scan below, which read `(*obj_ptr).keys_array` at
+            // the closure's capture-slot offset — a NaN-boxed value, not a
+            // real *ArrayHeader — and SIGSEGV'd in `js_array_length`. effect's
+            // `dual`-wrapped helpers reach here (`<key> in someClosure` deep in
+            // the fiber runtime). Mirror the closure read path
+            // (`js_object_get_field_by_name`: `length` → arity, others →
+            // CLOSURE_DYNAMIC_PROPS): present-and-not-undefined ⇒ true.
+            if (*gc_header).obj_type == crate::gc::GC_TYPE_CLOSURE {
+                if !key_val.is_any_string() {
+                    return nanbox_false;
+                }
+                let key_str =
+                    crate::value::js_get_string_pointer_unified(key) as *const crate::StringHeader;
+                if key_str.is_null() {
+                    return nanbox_false;
+                }
+                let v = js_object_get_field_by_name(obj_ptr, key_str);
+                return if v.is_undefined() {
+                    nanbox_false
+                } else {
+                    nanbox_true
+                };
+            }
         }
     }
 

--- a/test-files/test_gap_in_operator_closure.ts
+++ b/test-files/test_gap_in_operator_closure.ts
@@ -1,0 +1,48 @@
+// epic #1785 / #1758: the `in` operator on a CLOSURE (function) value.
+//
+// Functions are objects in JS, so `key in fn` is valid. Pre-fix,
+// `js_object_has_property` treated the closure pointer as an `ObjectHeader`
+// and read `(*obj_ptr).keys_array` at the closure's capture-slot offset — a
+// NaN-boxed value, not a real `*ArrayHeader` — then SIGSEGV'd in
+// `js_array_length`. effect's `dual`-wrapped helpers reach this deep in the
+// fiber runtime (`<key> in someClosure`), crashing `import * as S from
+// "effect/Schema"` module init (after the #1804/#1809/#1810 fixes let init get
+// that far).
+//
+// Fix: `js_object_has_property` detects a `GC_TYPE_CLOSURE` receiver and
+// mirrors the closure read path (`js_object_get_field_by_name`: `length` →
+// arity, others → `CLOSURE_DYNAMIC_PROPS`): present-and-not-undefined ⇒ true.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+// (`'name' in fn` / `'prototype' in fn` are a separate pre-existing
+// closure-property-completeness gap — perry's `fn.name` also reads undefined —
+// so they're intentionally not asserted here.)
+
+const fn: any = () => 1;
+
+// (1) absent key — must be false, NOT a crash (this was the SIGSEGV).
+console.log("(1) 'foo' in fn:", "foo" in fn);
+
+// (2) `length` is intrinsic (perry returns the arity).
+console.log("(2) 'length' in fn:", "length" in fn);
+
+// (3) a dynamically-assigned property is present.
+fn.custom = 42;
+console.log("(3) 'custom' in fn:", "custom" in fn);
+console.log("(3) 'missing' in fn:", "missing" in fn);
+
+// (4) named function — absent key is false (no crash).
+function named() {
+  return 2;
+}
+console.log("(4) 'x' in named:", "x" in (named as any));
+
+// (5) the effect shape: `<key> in fn` where fn is the result of a wrapper.
+function makeWrapped(): any {
+  const w: any = (x: number) => x + 1;
+  w.tag = "wrapped";
+  return w;
+}
+const wrapped = makeWrapped();
+console.log("(5) 'tag' in wrapped:", "tag" in wrapped);
+console.log("(5) 'nope' in wrapped:", "nope" in wrapped);


### PR DESCRIPTION
## Summary

`key in fn` (the `in` operator on a **closure**/function value) SIGSEGV'd.
Functions are objects in JS, so `key in fn` is valid — but
`js_object_has_property` treated the closure pointer as an `ObjectHeader` and
read `(*obj_ptr).keys_array` at the closure's capture-slot offset (a NaN-boxed
value, not a real `*ArrayHeader`), then crashed in `js_array_length` →
`is_registered_set` dereferencing the tagged value.

**This is the last blocker on `import * as S from "effect/Schema"` MODULE INIT**
(after #1804 / #1809 / #1810): effect's `dual`-wrapped helpers do
`<key> in someClosure` deep in the fiber runtime. With this fix, the Schema
import **initializes byte-identical to node** (`ok object`).

## Localization

`PERRY_DEBUG_SYMBOLS=1` + lldb `-k` crash hooks pinned the fault to
`is_registered_set` deref'ing `0x7ffd…` (a NaN-boxed value). A conditional
breakpoint on `js_array_length` with a tagged arg captured the receiver: GC
type `0x04` (`GC_TYPE_CLOSURE`), first field a code pointer (a `fiberRuntime`
closure body) — i.e. a function, not an object.

## Fix

`js_object_has_property` detects a `GC_TYPE_CLOSURE` receiver (sibling to the
existing `GC_TYPE_ARRAY` fast path) and mirrors the closure *read* path
(`js_object_get_field_by_name`: `length` → arity, others →
`CLOSURE_DYNAMIC_PROPS`): present-and-not-undefined ⇒ true. Regular
object/array `in` is untouched.

## Validation

- New gap test `test_gap_in_operator_closure.ts` — byte-for-byte with node:
  absent key (false, **no crash**), `length`, dynamically-assigned props.
- `import * as S from "effect/Schema"` → `ok object` (exit 0). `effect/Effect`
  deep import stays green (42).
- 80-test object/array/closure/class/symbol regression sweep
  (`PERRY_NO_AUTO_OPTIMIZE=1`): **0 regressions** — every failing test is
  pre-existing and **none uses the `in` operator** (the fix's only blast
  radius). (`'name'`/`'prototype' in fn` remain a separate pre-existing
  closure-property gap — `fn.name` also reads undefined — intentionally not
  asserted.)

## Remaining (reported, not chained)

Schema *init* works now, but actually USING Schema and the barrel hit further
distinct blockers:
- `S.decodeUnknownSync(S.Number)(42)` → `_tag`-undefined in
  `ParseResult.ts__69` (the parse machinery).
- `import { Effect } from "effect"` barrel → `value is not a function`.

Refs #1758, #1785, #1772, #1791.
