### PR TITLE
feat(compiler): self-hosted build-time precompile() — Perry runs its own codegen, no node/V8 (#1681)

### DIFF
--- a/crates/perry-hir/src/ir/constants.rs
+++ b/crates/perry-hir/src/ir/constants.rs
@@ -102,6 +102,51 @@ thread_local! {
         const { std::cell::RefCell::new(None) };
 }
 
+// ---- #1681 build-time precompile (self-hosted codegen) ----
+
+thread_local! {
+    /// #1681: when true, this compile is the build-time *capture* stage —
+    /// each `precompile(EXPR)` site lowers to a `console.log` that emits its
+    /// build-time-evaluated source instead of substituting a compiled
+    /// function. Set (via the `PERRY_PRECOMPILE_CAPTURE` env var) only on the
+    /// Stage-1 subprocess the driver spawns with `current_exe`.
+    static PRECOMPILE_CAPTURE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+
+    /// #1681: results captured by the Stage-1 build-time run, keyed by the
+    /// `precompile` call site's `(source_file, span.lo)` so the key is stable
+    /// across the capture subprocess and the main compile (no dependence on
+    /// lowering order / parallelism). Value = the generated function source.
+    /// The driver installs this before the main `collect_modules`.
+    static PRECOMPILE_RESULTS: std::cell::RefCell<std::collections::HashMap<(String, u32), String>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+/// #1681: enter (true) / leave (false) build-time precompile capture mode.
+pub fn set_precompile_capture(on: bool) {
+    PRECOMPILE_CAPTURE.with(|c| c.set(on));
+}
+
+/// #1681: is this compile the build-time capture stage?
+pub fn precompile_capture_enabled() -> bool {
+    PRECOMPILE_CAPTURE.with(|c| c.get())
+}
+
+/// #1681: install the captured build-time results (driver → main compile).
+pub fn set_precompile_results(results: std::collections::HashMap<(String, u32), String>) {
+    PRECOMPILE_RESULTS.with(|c| *c.borrow_mut() = results);
+}
+
+/// #1681: look up the captured generated source for a `precompile` site.
+pub fn precompile_result_at(source_file: &str, span_lo: u32) -> Option<String> {
+    PRECOMPILE_RESULTS.with(|c| c.borrow().get(&(source_file.to_string(), span_lo)).cloned())
+}
+
+/// #1681: clear precompile state (symmetry with the other per-build resets).
+pub fn clear_precompile_state() {
+    PRECOMPILE_CAPTURE.with(|c| c.set(false));
+    PRECOMPILE_RESULTS.with(|c| c.borrow_mut().clear());
+}
+
 /// #503: enable (true) or disable (false) the dynamic-stdlib-dispatch
 /// refusal pass. Default is true (refusal active). The compile driver
 /// calls this once with the resolved configuration before kicking off

--- a/crates/perry-hir/src/ir/mod.rs
+++ b/crates/perry-hir/src/ir/mod.rs
@@ -20,16 +20,17 @@ mod widget;
 // ---- constants.rs ----
 pub use constants::{
     clear_allow_dynamic_stdlib_packages, clear_compile_packages_override,
-    clear_current_module_source, current_module_has_allow_dynamic_at, current_module_line_at,
-    determine_module_kind, dynamic_stdlib_allowed_for_package, is_native_module,
-    is_native_module_with_externals, package_name_for_source_path,
-    refuse_dynamic_stdlib_dispatch_enabled, requires_stdlib, set_allow_dynamic_stdlib_packages,
-    set_compile_packages_override, set_current_module_source, set_refuse_dynamic_stdlib_dispatch,
-    typed_array_kind_for_name, ClassId, EnumId, InterfaceId, ModuleInitKind, ModuleKind,
-    PosixCredentialKind, TypeAliasId, NATIVE_MODULES, TYPED_ARRAY_KIND_FLOAT32,
-    TYPED_ARRAY_KIND_FLOAT64, TYPED_ARRAY_KIND_INT16, TYPED_ARRAY_KIND_INT32,
-    TYPED_ARRAY_KIND_INT8, TYPED_ARRAY_KIND_UINT16, TYPED_ARRAY_KIND_UINT32,
-    TYPED_ARRAY_KIND_UINT8, TYPED_ARRAY_KIND_UINT8_CLAMPED,
+    clear_current_module_source, clear_precompile_state, current_module_has_allow_dynamic_at,
+    current_module_line_at, determine_module_kind, dynamic_stdlib_allowed_for_package,
+    is_native_module, is_native_module_with_externals, package_name_for_source_path,
+    precompile_capture_enabled, precompile_result_at, refuse_dynamic_stdlib_dispatch_enabled,
+    requires_stdlib, set_allow_dynamic_stdlib_packages, set_compile_packages_override,
+    set_current_module_source, set_precompile_capture, set_precompile_results,
+    set_refuse_dynamic_stdlib_dispatch, typed_array_kind_for_name, ClassId, EnumId, InterfaceId,
+    ModuleInitKind, ModuleKind, PosixCredentialKind, TypeAliasId, NATIVE_MODULES,
+    TYPED_ARRAY_KIND_FLOAT32, TYPED_ARRAY_KIND_FLOAT64, TYPED_ARRAY_KIND_INT16,
+    TYPED_ARRAY_KIND_INT32, TYPED_ARRAY_KIND_INT8, TYPED_ARRAY_KIND_UINT16,
+    TYPED_ARRAY_KIND_UINT32, TYPED_ARRAY_KIND_UINT8, TYPED_ARRAY_KIND_UINT8_CLAMPED,
 };
 
 // ---- module.rs ----

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -115,6 +115,150 @@ pub(super) fn check_eval_function_call(ctx: &LoweringContext, call: &ast::CallEx
     crate::eval_classifier::check_site(surface, body_arg, &ctx.source_file_path, call.span)
 }
 
+/// #1681 (Phase 3 of #1677) — `precompile(EXPR)` build-time intrinsic.
+///
+/// `precompile` marks a build-time-evaluable codegen expression: `EXPR` is
+/// run **at build time** (by Perry compiling and running its own output —
+/// no node, no embedded engine) and must produce a *function-source
+/// string*; that source is then compiled natively and substituted for the
+/// call. This is the self-hosted "evaporate dynamism at build time" path:
+/// the generated function ships native, with no `new Function`/engine in
+/// the binary.
+///
+/// Two lowering modes (set by the driver via `set_precompile_capture` /
+/// `set_precompile_results`):
+///   - **Capture stage** (the Stage-1 subprocess): lower to
+///     `console.log("<marker>…" + JSON.stringify(EXPR))` so running the
+///     produced binary emits `EXPR`'s build-time value, keyed by this call
+///     site's `(source_file, span.lo)`.
+///   - **Main compile**: look up the captured source for this `(file, lo)`,
+///     parse it as a function expression, and lower it in place. A missing
+///     result (the capture run never reached this site) is a hard error —
+///     no silent fallback (acceptance criterion of #1681).
+pub(super) fn try_precompile(
+    ctx: &mut LoweringContext,
+    call: &ast::CallExpr,
+) -> Result<Option<Expr>> {
+    // Bare unshadowed `precompile(<one non-spread arg>)`.
+    let ast::Callee::Expr(callee_expr) = &call.callee else {
+        return Ok(None);
+    };
+    let ast::Expr::Ident(ident) = callee_expr.as_ref() else {
+        return Ok(None);
+    };
+    if ident.sym.as_ref() != "precompile"
+        || ctx.lookup_local("precompile").is_some()
+        || ctx.lookup_func("precompile").is_some()
+        || ctx.lookup_imported_func("precompile").is_some()
+        || call.args.len() != 1
+        || call.args[0].spread.is_some()
+    {
+        return Ok(None);
+    }
+    let span = call.span;
+    let site_lo = span.lo.0;
+    let file = ctx.source_file_path.clone();
+
+    if crate::ir::precompile_capture_enabled() {
+        // Stage 1: emit `console.log("<marker>" + JSON.stringify(EXPR))`.
+        // Synthesize the AST and re-dispatch through `lower_call` so the
+        // normal console.log / JSON.stringify / string-concat lowerings do
+        // the work. The marker carries the site key so the driver can route
+        // the captured source back without depending on lowering order.
+        let marker = format!("\u{1}PERRY_PRECOMPILE\u{1}{file}\u{1}{site_lo}\u{1}");
+        let sctx = swc_common::SyntaxContext::empty();
+        let member = |obj: &str, prop: &str| {
+            ast::Expr::Member(ast::MemberExpr {
+                span,
+                obj: Box::new(ast::Expr::Ident(ast::Ident::new(obj.into(), span, sctx))),
+                prop: ast::MemberProp::Ident(ast::IdentName {
+                    span,
+                    sym: prop.into(),
+                }),
+            })
+        };
+        // JSON.stringify(EXPR)
+        let mut json_call = call.clone();
+        json_call.callee = ast::Callee::Expr(Box::new(member("JSON", "stringify")));
+        json_call.args = vec![call.args[0].clone()];
+        // "<marker>" + JSON.stringify(EXPR)
+        let concat = ast::Expr::Bin(ast::BinExpr {
+            span,
+            op: ast::BinaryOp::Add,
+            left: Box::new(ast::Expr::Lit(ast::Lit::Str(ast::Str {
+                span,
+                value: marker.into(),
+                raw: None,
+            }))),
+            right: Box::new(ast::Expr::Call(json_call)),
+        });
+        // console.log(<concat>)
+        let mut log_call = call.clone();
+        log_call.callee = ast::Callee::Expr(Box::new(member("console", "log")));
+        log_call.args = vec![ast::ExprOrSpread {
+            spread: None,
+            expr: Box::new(concat),
+        }];
+        return Ok(Some(super::lower_call(ctx, &log_call)?));
+    }
+
+    // Main compile: substitute the captured generated function.
+    match crate::ir::precompile_result_at(&file, site_lo) {
+        Some(src) => Ok(Some(lower_precompiled_source(ctx, &src, span)?)),
+        None => {
+            crate::lower_bail!(
+                span,
+                "`precompile(...)` produced no build-time result for this call site \
+                 ({}:{}). The build-time capture run did not reach it — its argument \
+                 must be evaluable at build time and produce a function-source string. \
+                 (#1681)",
+                file,
+                site_lo,
+            );
+        }
+    }
+}
+
+/// Parse a build-time-captured function-source string (e.g. `"(a) => a + 3"`
+/// or `"function (a) { return a }"`) and lower it as an ordinary function
+/// expression — the same path the Phase 1 const-fold uses.
+fn lower_precompiled_source(
+    ctx: &mut LoweringContext,
+    src: &str,
+    span: swc_common::Span,
+) -> Result<Expr> {
+    let wrapped = format!("({src});\n");
+    let module = perry_parser::parse_typescript(&wrapped, "<precompiled>").map_err(|e| {
+        anyhow::Error::new(crate::error::LowerError::new(
+            format!(
+                "build-time `precompile` result is not a valid function expression: {e} \
+                 (#1681)\n  source: {src:?}"
+            ),
+            span,
+        ))
+    })?;
+    let fn_expr = module
+        .body
+        .first()
+        .and_then(|item| match item {
+            ast::ModuleItem::Stmt(ast::Stmt::Expr(es)) => Some(es.expr.as_ref()),
+            _ => None,
+        })
+        .map(|mut e| {
+            while let ast::Expr::Paren(p) = e {
+                e = p.expr.as_ref();
+            }
+            e
+        });
+    match fn_expr {
+        Some(e @ (ast::Expr::Fn(_) | ast::Expr::Arrow(_))) => lower_expr(ctx, e),
+        _ => crate::lower_bail!(
+            span,
+            "build-time `precompile` result must be a function expression (#1681)\n  source: {src:?}"
+        ),
+    }
+}
+
 /// Issue #76 — `embedWasm("./file.wasm")` from `perry/build` is a
 /// compile-time intrinsic that bakes the file's bytes directly into the
 /// produced binary. Resolves the path relative to the current source

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -57,7 +57,8 @@ use imported_array_methods::try_imported_array_methods;
 use inline_array_methods::try_inline_array_methods;
 use intrinsics::{
     check_eval_function_call, try_bare_regexp_call, try_embed_wasm, try_function_return_this,
-    try_iife_call_rewrite, try_native_module_method_apply_call, try_require_literal_bail,
+    try_iife_call_rewrite, try_native_module_method_apply_call, try_precompile,
+    try_require_literal_bail,
 };
 use local_array_methods::try_local_array_methods;
 use module_class_static::try_module_class_static;
@@ -143,6 +144,11 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
     // (require/embedWasm/IIFE.call/Function('return this')/RegExp).
     try_require_literal_bail(ctx, call)?;
     if let Some(expr) = try_embed_wasm(ctx, call)? {
+        return Ok(expr);
+    }
+    // #1681: `precompile(EXPR)` build-time codegen — capture stage emits the
+    // build-time-evaluated source; main compile substitutes the compiled fn.
+    if let Some(expr) = try_precompile(ctx, call)? {
         return Ok(expr);
     }
     if let Some(expr) = try_iife_call_rewrite(ctx, call, has_spread)? {

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -35,6 +35,7 @@ mod object_cache;
 mod optimized_libs;
 mod parse_cache;
 mod post_link;
+mod precompile_capture;
 mod resolve;
 mod resources;
 mod sandbox_buildrs;
@@ -224,6 +225,13 @@ pub fn run_with_parse_cache(
     // the eval-free generated output is on disk for the normal compile path.
     let skip_codegen = args.no_codegen || codegen_steps::skip_from_env();
     codegen_steps::run_codegen_steps(&ctx, skip_codegen, format)?;
+
+    // #1681 (Phase 3 of #1677): self-hosted build-time `precompile(...)`.
+    // If this is the capture subprocess, enter capture mode; otherwise, when
+    // the entry uses `precompile(`, compile+run it via Perry itself (no node,
+    // no V8) to evaluate the codegen at build time and install the captured
+    // generated sources for the main compile below.
+    precompile_capture::prepare_precompile(&args, &mut ctx, format)?;
 
     maybe_init_type_checker(&args, &project_root, format, &mut ctx);
 

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -476,6 +476,13 @@ pub(super) fn collect_modules(
     // after the lower call so it can't leak to unrelated work on this
     // thread.
     perry_hir::set_current_module_source(source.clone());
+    // #1681: re-install build-time precompile state on the (possibly rayon
+    // worker) lowering thread — capture mode emits `precompile(EXPR)` source;
+    // otherwise the captured results are substituted. Cleared after the lower.
+    perry_hir::set_precompile_capture(ctx.precompile_capture);
+    if !ctx.precompile_results.is_empty() {
+        perry_hir::set_precompile_results(ctx.precompile_results.clone());
+    }
     let lower_result = perry_hir::lower_module_full(
         ast_module,
         &module_name,
@@ -488,6 +495,7 @@ pub(super) fn collect_modules(
     );
     perry_hir::clear_compile_packages_override();
     perry_hir::clear_current_module_source();
+    perry_hir::clear_precompile_state();
     let (mut hir_module, new_next_class_id) = lower_result?;
     *next_class_id = new_next_class_id; // Update the global class_id counter
 

--- a/crates/perry/src/commands/compile/precompile_capture.rs
+++ b/crates/perry/src/commands/compile/precompile_capture.rs
@@ -1,0 +1,187 @@
+//! #1681 (Phase 3 of #1677) — self-hosted build-time evaluation of
+//! `precompile(...)` codegen.
+//!
+//! Perry runs the codegen itself, with **no node and no embedded JS engine**:
+//! it compiles the entry program to a native binary in *capture mode* (each
+//! `precompile(EXPR)` site lowered to a `console.log` that prints `EXPR`'s
+//! build-time value), runs that binary — Perry executing its own compiled
+//! output — and parses the emitted generated sources back. The main compile
+//! then substitutes the natively-compiled generated function for each site
+//! (see `perry-hir`'s `try_precompile`).
+//!
+//! The capture binary is invoked via `current_exe`, so the "build-time
+//! evaluator" is just Perry compiling-and-running code — the same way the
+//! driver shells out to `cc` to link. The shipped binary contains no engine.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{anyhow, Result};
+
+use super::{CompilationContext, CompileArgs};
+use crate::OutputFormat;
+
+const CAPTURE_ENV: &str = "PERRY_PRECOMPILE_CAPTURE";
+const MARKER: &str = "\u{1}PERRY_PRECOMPILE\u{1}";
+
+/// Driver entry, run just before module collection. Records its result on
+/// `ctx` (`precompile_capture` / `precompile_results`); `collect_modules`
+/// re-installs those onto the lowering thread before each module (the
+/// thread-locals don't survive a hop to a rayon worker, so per-lower
+/// re-installation is required — same pattern as the `#665`/`#503` config).
+///
+/// - In the capture subprocess (`PERRY_PRECOMPILE_CAPTURE` set): mark this
+///   compile as the capture stage and return (no recursion).
+/// - Otherwise: if the entry source uses `precompile(`, run the build-time
+///   capture stage and stash its results for the main compile.
+pub(super) fn prepare_precompile(
+    args: &CompileArgs,
+    ctx: &mut CompilationContext,
+    format: OutputFormat,
+) -> Result<()> {
+    if std::env::var(CAPTURE_ENV).is_ok() {
+        ctx.precompile_capture = true;
+        return Ok(());
+    }
+    // Cheap gate: only pay for the capture stage when the entry mentions
+    // `precompile(` at all.
+    let entry_src = std::fs::read_to_string(&args.input).unwrap_or_default();
+    if !entry_src.contains("precompile(") {
+        return Ok(());
+    }
+    let results = run_capture(args, format)?;
+    if matches!(format, OutputFormat::Text) {
+        println!(
+            "  Precompile: evaluated {} build-time site(s)",
+            results.len()
+        );
+    }
+    ctx.precompile_results = results;
+    Ok(())
+}
+
+/// Compile the entry in capture mode via Perry's own binary, run the produced
+/// executable, and parse the emitted `(file, span) -> generated source` map.
+fn run_capture(args: &CompileArgs, format: OutputFormat) -> Result<HashMap<(String, u32), String>> {
+    let exe = std::env::current_exe()
+        .map_err(|e| anyhow!("precompile: cannot locate the Perry binary: {e}"))?;
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tmp_bin =
+        std::env::temp_dir().join(format!("perry_precompile_{}_{}", std::process::id(), stamp));
+
+    // Stage 1a — compile the entry in capture mode.
+    let compile = Command::new(&exe)
+        .arg("compile")
+        .arg(&args.input)
+        .arg("-o")
+        .arg(&tmp_bin)
+        .env(CAPTURE_ENV, "1")
+        // Keep the build-time helper fast and faithful to source.
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .output()
+        .map_err(|e| anyhow!("precompile: failed to spawn the capture compile: {e}"))?;
+    if !compile.status.success() {
+        let _ = cleanup(&tmp_bin);
+        return Err(anyhow!(
+            "precompile: build-time capture compile failed ({})\n--- stderr ---\n{}",
+            compile.status,
+            String::from_utf8_lossy(&compile.stderr).trim_end(),
+        ));
+    }
+
+    // Stage 1b — run the capture binary. Tolerate a non-zero exit: the
+    // `precompile` sites emit their source during module init, before any
+    // downstream use of the (now-undefined) result might fault; the markers
+    // are already on stdout.
+    let run = Command::new(&tmp_bin)
+        .output()
+        .map_err(|e| anyhow!("precompile: failed to run the capture binary: {e}"))?;
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    let map = parse_markers(&stdout);
+    if map.is_empty() && matches!(format, OutputFormat::Text) {
+        eprintln!(
+            "  Precompile: capture run emitted no results (exit {}). stderr:\n{}",
+            run.status,
+            String::from_utf8_lossy(&run.stderr).trim_end(),
+        );
+    }
+    let _ = cleanup(&tmp_bin);
+    Ok(map)
+}
+
+/// Parse `\x01PERRY_PRECOMPILE\x01<file>\x01<span_lo>\x01<json-encoded src>`
+/// lines from the capture binary's stdout.
+fn parse_markers(stdout: &str) -> HashMap<(String, u32), String> {
+    let mut map = HashMap::new();
+    for line in stdout.lines() {
+        let Some(pos) = line.find(MARKER) else {
+            continue;
+        };
+        // Everything from the marker on; split on the SOH delimiter. The
+        // JSON-encoded source can't contain a raw SOH (it'd be ``), so
+        // the field count is stable.
+        let parts: Vec<&str> = line[pos..].split('\u{1}').collect();
+        // parts == ["", "PERRY_PRECOMPILE", <file>, <lo>, <json src>]
+        if parts.len() < 5 || parts[1] != "PERRY_PRECOMPILE" {
+            continue;
+        }
+        let file = parts[2].to_string();
+        let Ok(lo) = parts[3].parse::<u32>() else {
+            continue;
+        };
+        if let Ok(src) = serde_json::from_str::<String>(parts[4]) {
+            map.insert((file, lo), src);
+        }
+    }
+    map
+}
+
+fn cleanup(path: &PathBuf) -> std::io::Result<()> {
+    if path.exists() {
+        std::fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_marker_line() {
+        let out = format!(
+            "some normal output\n{MARKER}/app/main.ts\u{1}42\u{1}{}\nmore output\n",
+            "\"(a) => a + 3\""
+        );
+        let map = parse_markers(&out);
+        assert_eq!(
+            map.get(&("/app/main.ts".to_string(), 42))
+                .map(String::as_str),
+            Some("(a) => a + 3")
+        );
+    }
+
+    #[test]
+    fn ignores_non_marker_output() {
+        let map = parse_markers("hello\nworld\n");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn handles_multiline_source_via_json_escaping() {
+        // JSON-encoded source with an escaped newline stays on one line.
+        let out = format!(
+            "{MARKER}/x.ts\u{1}7\u{1}{}\n",
+            "\"function (a) {\\n  return a\\n}\""
+        );
+        let map = parse_markers(&out);
+        assert_eq!(
+            map.get(&("/x.ts".to_string(), 7)).map(String::as_str),
+            Some("function (a) {\n  return a\n}")
+        );
+    }
+}

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -392,6 +392,16 @@ pub struct CompilationContext {
     pub package_aliases: HashMap<String, String>,
     /// Packages to compile natively instead of routing to V8 (from perry.compilePackages)
     pub compile_packages: HashSet<String>,
+    /// #1681 (Phase 3 of #1677): true when this is the build-time capture
+    /// stage (the `current_exe` subprocess), so `precompile(EXPR)` sites
+    /// emit their build-time value instead of substituting. Re-installed on
+    /// the lowering thread before each `lower_module_full` (rayon-safe),
+    /// like the `#665`/`#503` thread-locals.
+    pub precompile_capture: bool,
+    /// #1681: captured build-time `precompile` results, keyed by
+    /// `(source_file, span.lo)`, installed by the main compile after the
+    /// capture stage and re-installed on the lowering thread per module.
+    pub precompile_results: HashMap<(String, u32), String>,
     /// Resolved `--fast-math` setting for this build. Default false.
     /// Sources, last wins: `perry.fastMath` in package.json → env var
     /// `PERRY_FAST_MATH=1` → CLI `--fast-math`. Drives the per-instruction
@@ -614,6 +624,8 @@ impl CompilationContext {
             native_libraries: Vec::new(),
             package_aliases: HashMap::new(),
             compile_packages: HashSet::new(),
+            precompile_capture: false,
+            precompile_results: HashMap::new(),
             fast_math: false,
             fp_contract_mode: perry_codegen::FpContractMode::Off,
             app_metadata: perry_codegen::AppMetadata::default(),

--- a/test-files/test_precompile_basic.ts
+++ b/test-files/test_precompile_basic.ts
@@ -1,0 +1,19 @@
+// #1681 (Phase 3 of #1677) — `precompile(EXPR)` evaluates EXPR at BUILD TIME
+// by Perry compiling and running its own output (no node, no V8), captures
+// the generated function source, and compiles it natively. The shipped
+// binary contains no JS engine. (`precompile` is a Perry build-time
+// intrinsic with no Node equivalent — compared against a stored expected
+// output, not Node.)
+function makeAdder(n: number): string {
+  return "(a: number) => a + " + n;
+}
+function makeGreeter(greeting: string): string {
+  return "function (name: string) { return \"" + greeting + ", \" + name; }";
+}
+
+const addTen = precompile(makeAdder(10));
+const greet = precompile(makeGreeter("Hello"));
+
+console.log("addTen(5):", addTen(5));
+console.log("addTen(-3):", addTen(-3));
+console.log("greet:", greet("Ada"));

--- a/test-parity/expected/test_precompile_basic.txt
+++ b/test-parity/expected/test_precompile_basic.txt
@@ -1,0 +1,3 @@
+addTen(5): 15
+addTen(-3): 7
+greet: Hello, Ada


### PR DESCRIPTION
## Phase 3 of #1677 (prototype) — self-hosted build-time `precompile()`: Perry runs its own codegen, no node/V8

Part of #1677. Implements the self-hosted build-time evaluation discussed on #1681.

### Why the original framing changed

The issue says "demote `perry-jsruntime` to a build-time tool." That engine was **already removed** (no `deno_core`/`rusty_v8`/`quickjs` anywhere), and re-embedding one — or shelling out to node — contradicts the tracker's goal and adds an external dependency. **The architecturally correct answer: Perry evaluates the codegen itself** by compiling the program to native and running its own output. No node, no engine in the shipped binary.

### Surface

`precompile(EXPR)` — a build-time intrinsic. `EXPR` is evaluated at build time and must produce a **function-source string**; that source is compiled natively and substituted for the call.

```ts
function makeAdder(n: number): string { return "(a: number) => a + " + n; }
const addTen = precompile(makeAdder(10));   // makeAdder runs at build time
console.log(addTen(5));                       // 15 — addTen is a native function
```

### Two-stage mechanism (no node, no V8)

1. **Capture stage** — the driver compiles the entry via Perry's **own binary** (`current_exe`) with `PERRY_PRECOMPILE_CAPTURE=1`. In that mode each `precompile(EXPR)` lowers to `console.log("<marker>" + JSON.stringify(EXPR))`, keyed by the call site's `(source_file, span.lo)`. The driver **runs the produced binary** — Perry executing its own compiled output — and parses the emitted generated sources.
2. **Main compile** — each site is replaced by its captured source, parsed + lowered as a function (reusing the Phase 1 string→HIR path). A missing result, or a result that isn't a function expression, is a **hard compile error** (acceptance criterion: no silent fallback).

### Restrictions (by design — answers "does this cover all `new Function`?")

Only **build-time-knowable, deterministic** codegen is supported. Genuinely runtime-dynamic `new Function(runtimeData)` / `eval(userInput)` stays **refused by Phase 0** — there's nothing to evaluate at build time, and an AOT binary shouldn't fake it. Across the tracker: literal bodies → Phase 1; build-time-knowable codegen → this; runtime-dynamic → refused.

### Implementation

- **perry-hir**: `PRECOMPILE_CAPTURE` / `PRECOMPILE_RESULTS` thread-locals (`ir/constants.rs`); `try_precompile` + `lower_precompiled_source` (`expr_call/intrinsics.rs`), wired into `lower_call_inner`.
- **perry**: `precompile_capture.rs` driver (capture subprocess via `current_exe` + marker parser, 3 unit tests); `precompile_capture`/`precompile_results` on `CompilationContext`, **re-installed on the lowering thread before each `lower_module_full`** in `collect_modules` — rayon-safe, the same pattern as the `#665`/`#503` thread-locals (a set-once-on-main thread-local doesn't reach worker threads; that was a real bug caught during testing).

### Verification

- `test-files/test_precompile_basic.ts` (+ `test-parity/expected/...`) — Perry compiles+runs the capture helper itself, captures two generated functions, compiles them natively → expected output; binary links **0** V8 symbols. (`precompile` is a Perry build intrinsic with no Node equivalent, so it's compared to a stored expected output.)
- Normal programs (no `precompile(`) are unaffected (gated). Generators returning function sources, the not-a-function error path, and the no-result error path all checked. `cargo fmt`/`clippy` clean; marker-parser unit tests green.

### Follow-up (not this PR)

fast-json-stringify end-to-end additionally needs fjs's `Serializer` helpers compiled via `compilePackages` and the codegen-correctness fixes (#1802 closure-prop GC, #1803 type-guard miscompile) for byte-parity. This PR proves the self-hosted two-stage mechanism.

Note: `parity`/`compile-smoke` are tag-gated (don't run on PRs).
