### PR TITLE
fix(hir): nested local must not reuse a module const's forward-declared id (#1758/#321)

### DIFF
--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -1241,8 +1241,20 @@ pub(crate) fn lower_var_decl_with_destructuring(
             let init = decl.init.as_ref().map(|e| lower_expr(ctx, e)).transpose()?;
             let id = if let Some(pid) = pre_id {
                 pid
-            } else if ctx.pre_registered_module_vars.remove(&name) {
-                // Reuse pre-registered LocalId from module-level forward-declaration pass
+            } else if ctx.scope_depth == 0
+                && ctx.inside_block_scope == 0
+                && ctx.pre_registered_module_vars.remove(&name)
+            {
+                // Reuse pre-registered LocalId from module-level forward-declaration pass.
+                // #1758: gated on MODULE scope — a nested local of the same name
+                // (`function helper() { const zipWith = ... }` where the module also
+                // declares `const zipWith`) must NOT consume the module var's
+                // pre-registered id, or it conflates the two: the nested local and
+                // the module binding share one id, the real module value lands on a
+                // fresh id, and a sibling closure that referenced the module name
+                // resolves to the wrong (uninitialised) slot → `value is not a
+                // function`. effect's `layer.merge` (refs module `zipWith` at L1191)
+                // broke this way because a local `zipWith` (L1180) precedes it.
                 let id = ctx.lookup_local(&name).unwrap();
                 // Update the type now that we have full inference
                 if let Some((_, _, existing_ty)) =
@@ -1497,7 +1509,11 @@ pub(crate) fn lower_var_decl_with_destructuring(
             let name = get_binding_name(&decl.name)?;
             let ty = extract_binding_type(&decl.name);
             let init = decl.init.as_ref().map(|e| lower_expr(ctx, e)).transpose()?;
-            let id = if ctx.pre_registered_module_vars.remove(&name) {
+            let id = if ctx.scope_depth == 0
+                && ctx.inside_block_scope == 0
+                && ctx.pre_registered_module_vars.remove(&name)
+            {
+                // #1758: module-scope only — see the sibling guard above.
                 let id = ctx.lookup_local(&name).unwrap();
                 if let Some((_, _, existing_ty)) =
                     ctx.locals.iter_mut().rev().find(|(n, _, _)| n == &name)

--- a/test-files/test_gap_module_const_local_shadow.ts
+++ b/test-files/test_gap_module_const_local_shadow.ts
@@ -1,0 +1,56 @@
+// epic #1785 / #1758: a module-level closure that forward-references a
+// module-level `const`, where a *nested* local of the same name exists in
+// another function.
+//
+// The module-level forward-declaration pass pre-registers a LocalId for the
+// module `const`. The bug: a nested local of the same name
+// (`function helper() { const zipWith = ... }`) hit the same
+// `pre_registered_module_vars` reuse branch and CONSUMED the module var's id —
+// so the nested local and the module binding shared one id, the real module
+// value landed on a fresh id, and the sibling closure (`merge`) that
+// forward-referenced the module name resolved to the wrong (uninitialised)
+// slot → `value is not a function`.
+//
+// effect's `layer.merge` (`dual(2, (self, that) => zipWith(self, that, ...))`,
+// referencing the module `zipWith` exported later at L1191) broke this way
+// because a *local* `zipWith` (L1180, inside another fn) precedes it — which
+// blocked the entire `import { Effect } from "effect"` barrel.
+//
+// Fix: gate the `pre_registered_module_vars` id-reuse on MODULE scope
+// (`scope_depth == 0 && inside_block_scope == 0`); a nested local gets a fresh
+// id. Compared byte-for-byte against `node --experimental-strip-types`.
+
+// (1) the core shape: merge forward-refs module `zipWith`; helper has a local.
+const merge = (self: number, that: number) => zipWith(self, that);
+function helper() {
+  const zipWith = 5; // local shadow, declared BEFORE the module const
+  return zipWith;
+}
+const zipWith = (a: number, b: number) => a + b;
+console.log("(1) merge(1,2):", merge(1, 2));
+console.log("(1) helper():", helper());
+
+// (2) via a dual-style indirection (effect's exact shape).
+function dual(_arity: number, body: any): any {
+  return function (a: any, b: any) {
+    if (arguments.length >= 2) return body(a, b);
+    return (s: any) => body(s, a);
+  };
+}
+const combine = dual(2, (self: any, that: any) => joiner(self, that));
+function other() {
+  const joiner = "shadow";
+  return joiner;
+}
+const joiner = (a: any, b: any) => `${a}+${b}`;
+console.log("(2) combine(x,y):", combine("x", "y"));
+console.log("(2) combine(y) curried:", combine("y")("x"));
+console.log("(2) other():", other());
+
+// (3) the nested local still works independently (not clobbered).
+function scope3() {
+  const val = 99;
+  return val;
+}
+const val = (n: number) => n * 2;
+console.log("(3) scope3():", scope3(), "| module val(21):", val(21));


### PR DESCRIPTION
## Summary

A **nested local** binding could reuse a module-level `const`/`let`'s
forward-declared `LocalId`, conflating two distinct variables.

The module-level forward-declaration pass pre-registers a `LocalId` for each
module-level `const`/`let` (so forward references resolve). The var-decl
lowering reused that pre-registered id for *any* binding of the same name —
**including a nested local inside a function body**:

```ts
const merge = (s, t) => zipWith(s, t);        // forward-refs module zipWith
function helper() { const zipWith = 5; ... }   // local shadow (declared first)
const zipWith = (a, b) => a + b;               // module const
```

`helper`'s local `zipWith` consumed the module var's pre-registered id, so the
local and the module binding shared one id; the real `zipWith` function landed
on a fresh id; and `merge`'s closure — which forward-resolved `zipWith` to the
pre-registered id — pointed at the wrong (uninitialised) slot →
`TypeError: value is not a function`. Order-dependent: only triggers when the
local shadow precedes the module const.

## Why it matters — unblocks the `effect` barrel

`import { Effect } from "effect"` threw `value is not a function` in
`TestContext.ts` init. effect's `layer.merge = dual(2, (self, that) =>
zipWith(self, that, ...))` references the module `zipWith` (exported at
`internal/layer.ts:1191`), and a **local** `zipWith` (L1180, inside another
function) precedes it — exactly this shape.

## Localization

Probed pipe args (all defined) → narrowed to `layer.merge(a,b)` throwing →
`merge`'s body calls `zipWith(self,that,cb)` (the 3-arg `js_closure_call3` in
the backtrace) → HIR showed `merge` body `Call{callee: LocalGet(1)}` while the
module `zipWith` is `Let id:6` (id 1 = the shadow). An env-gated `define_local`
trace confirmed only two `zipWith` define_locals (both `scope_depth=0`) — the
nested local made none; it reused.

## Fix

Gate the `pre_registered_module_vars` id-reuse (both the simple-ident and
destructuring-fallback sites in `destructuring/var_decl.rs`) on **module scope**
(`scope_depth == 0 && inside_block_scope == 0`), mirroring `define_local`'s own
module-level tagging. A nested local of the same name now gets a fresh id.

## Validation

- New gap test `test_gap_module_const_local_shadow.ts` (core shape +
  dual-indirection + independent-nested-local guard) — byte-identical to node.
- **Full 578-test regression sweep** (`PERRY_NO_AUTO_OPTIMIZE=1`): **0
  regressions** — all 39 failures + 4 hangs fail/hang identically on the
  pre-fix baseline (decorators / crypto / fastify / sqlite / fs / date /
  class-field-layout / mixins — all pre-existing).
- With this **+ #1812** (renamed-class-export, in review), the full effect
  framework works end-to-end, byte-identical to node:
  `effect/Effect` deep import → 42, `effect/Schema` init → ok,
  `effect/Schema` decode → "hello", and the **`import { Effect } from "effect"`
  barrel → 42** (`Effect.runSync(Effect.succeed(42))`).

Refs #1758, #321, #1785, #1772, #1791.
