### PR TITLE
fix(hir,codegen,runtime): computed-key class methods + dynamic-key this-binding (#321)

### DIFF
--- a/crates/perry-codegen/src/lower_call/early_branches.rs
+++ b/crates/perry-codegen/src/lower_call/early_branches.rs
@@ -77,37 +77,47 @@ pub fn try_lower_index_get_call(
     // walks the class vtable chain (parent inheritance included). Refs
     // #420 / #618 followup.
     if let Expr::IndexGet { object, index } = callee {
-        if matches!(index.as_ref(), Expr::String(_))
+        // Don't intercept array/typed-array element calls keyed by a numeric
+        // expression — those have dedicated lowering and aren't method
+        // dispatch. Only string-ish or unknown (Any) keys route here.
+        if crate::type_analysis::is_numeric_expr(ctx, index) {
+            return Ok(None);
+        }
+        let is_static_string = matches!(index.as_ref(), Expr::String(_))
             || crate::type_analysis::is_string_expr(ctx, index)
-            || crate::type_analysis::is_definitely_string_expr(ctx, index)
-        {
-            let recv_box = lower_expr(ctx, object)?;
-            let name_box = lower_expr(ctx, index)?;
-            let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());
-            for a in args {
-                lowered_args.push(lower_expr(ctx, a)?);
+            || crate::type_analysis::is_definitely_string_expr(ctx, index);
+
+        let recv_box = lower_expr(ctx, object)?;
+        let key_box = lower_expr(ctx, index)?;
+        let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());
+        for a in args {
+            lowered_args.push(lower_expr(ctx, a)?);
+        }
+        let n = lowered_args.len();
+        let (args_ptr, args_len) = if n == 0 {
+            ("null".to_string(), "0".to_string())
+        } else {
+            let buf_reg = ctx.func.alloca_entry_array(DOUBLE, n);
+            for (i, v) in lowered_args.iter().enumerate() {
+                let slot = ctx
+                    .block()
+                    .gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", i))]);
+                ctx.block().store(DOUBLE, v, &slot);
             }
-            let n = lowered_args.len();
+            let ptr_reg = ctx.block().next_reg();
+            ctx.block().emit_raw(format!(
+                "{} = getelementptr [{} x double], ptr {}, i64 0, i64 0",
+                ptr_reg, n, buf_reg
+            ));
+            (ptr_reg, n.to_string())
+        };
+
+        if is_static_string {
+            // Statically-known string key: extract the string handle and use
+            // the str-key entry (`this` bound by the dispatch tower).
             let name_handle = {
                 let blk = ctx.block();
-                crate::expr::unbox_str_handle(blk, &name_box)
-            };
-            let (args_ptr, args_len) = if n == 0 {
-                ("null".to_string(), "0".to_string())
-            } else {
-                let buf_reg = ctx.func.alloca_entry_array(DOUBLE, n);
-                for (i, v) in lowered_args.iter().enumerate() {
-                    let slot = ctx
-                        .block()
-                        .gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", i))]);
-                    ctx.block().store(DOUBLE, v, &slot);
-                }
-                let ptr_reg = ctx.block().next_reg();
-                ctx.block().emit_raw(format!(
-                    "{} = getelementptr [{} x double], ptr {}, i64 0, i64 0",
-                    ptr_reg, n, buf_reg
-                ));
-                (ptr_reg, n.to_string())
+                crate::expr::unbox_str_handle(blk, &key_box)
             };
             return Ok(Some(ctx.block().call(
                 DOUBLE,
@@ -120,6 +130,23 @@ pub fn try_lower_index_get_call(
                 ],
             )));
         }
+
+        // Dynamic key (`this[(cur)._op](cur)`, `obj[k]()` where `k` is a
+        // runtime value): pass the key value through, the runtime branches on
+        // its type and binds `this = obj` either way. Refs #321 (effect
+        // FiberRuntime op dispatch) — pre-fix this fell through to a plain
+        // closure-call that dropped `this`, so a method stored as a class
+        // field reached by dynamic key read `this === undefined`.
+        return Ok(Some(ctx.block().call(
+            DOUBLE,
+            "js_native_call_method_value",
+            &[
+                (DOUBLE, &recv_box),
+                (DOUBLE, &key_box),
+                (crate::types::PTR, &args_ptr),
+                (I64, &args_len),
+            ],
+        )));
     }
     Ok(None)
 }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1552,6 +1552,15 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, I64, PTR, I64],
     );
+    // #321: dispatch obj[key](args) for a runtime-value key (not statically a
+    // string). Binds `this = obj` for any key type — string keys go through
+    // the full dispatch tower, symbol/other keys read the property then call
+    // with `this` bound. (object, key, args_ptr, args_len) -> result.
+    module.declare_function(
+        "js_native_call_method_value",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, PTR, I64],
+    );
     module.declare_function("js_promise_resolve", VOID, &[I64, DOUBLE]);
     module.declare_function("js_promise_reject", VOID, &[I64, DOUBLE]);
     module.declare_function("js_promise_resolved", I64, &[DOUBLE]);

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -271,7 +271,7 @@ pub(super) fn lower_arrow(ctx: &mut LoweringContext, arrow: &ast::ArrowExpr) -> 
     })
 }
 
-pub(super) fn lower_fn_expr(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Result<Expr> {
+pub(crate) fn lower_fn_expr(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Result<Expr> {
     // Lower function expression to a closure (similar to arrow but
     // without `this` capture — function expressions have their own
     // `this` binding determined by how they're called).

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -38,6 +38,7 @@ mod context;
 mod expr_assign;
 mod expr_call;
 mod expr_function;
+pub(crate) use expr_function::lower_fn_expr;
 mod expr_member;
 mod expr_misc;
 mod expr_new;

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -253,6 +253,27 @@ pub fn lower_class_decl(
                 if method.function.body.is_none() {
                     continue;
                 }
+                // Generic computed-key methods (`[OpCodes.OP_SYNC](op) {...}`,
+                // not a well-known symbol / iterator / inspect key) can't be
+                // reduced to a static vtable name — install them as a
+                // per-instance closure field keyed by the runtime-evaluated key
+                // (`this[expr] = function (...) {...}`). Refs #321 (effect
+                // FiberRuntime op dispatch `this[(cur)._op](cur)`). Scoped to
+                // instance methods: static computed-key *methods* need
+                // closure-valued static-field dispatch that codegen doesn't
+                // wire up yet, so they stay on the legacy path below.
+                if matches!(method.kind, ast::MethodKind::Method) && !method.is_static {
+                    if let ast::PropName::Computed(computed) = &method.key {
+                        if !is_symbol_iterator_key(&computed.expr)
+                            && !is_inspect_custom_key(ctx, &computed.expr)
+                            && symbol_well_known_key(&computed.expr).is_none()
+                        {
+                            let field = lower_computed_key_method_as_field(ctx, method, computed)?;
+                            fields.push(field);
+                            continue;
+                        }
+                    }
+                }
                 // Get the property name for getters/setters. Computed
                 // keys are accepted for `[Symbol.iterator]` (registered
                 // under `@@iterator`), and for `[Symbol.hasInstance]` /
@@ -933,6 +954,20 @@ pub fn lower_class_from_ast(
                 // Skip TypeScript overload declarations (no body)
                 if method.function.body.is_none() {
                     continue;
+                }
+                // Generic computed-key methods → per-instance closure field
+                // (see lower_class_decl above; instance-only). Refs #321.
+                if matches!(method.kind, ast::MethodKind::Method) && !method.is_static {
+                    if let ast::PropName::Computed(computed) = &method.key {
+                        if !is_symbol_iterator_key(&computed.expr)
+                            && !is_inspect_custom_key(ctx, &computed.expr)
+                            && symbol_well_known_key(&computed.expr).is_none()
+                        {
+                            let field = lower_computed_key_method_as_field(ctx, method, computed)?;
+                            fields.push(field);
+                            continue;
+                        }
+                    }
                 }
                 let prop_name = match &method.key {
                     ast::PropName::Ident(ident) => ident.sym.to_string(),

--- a/crates/perry-hir/src/lower_decl/class_members.rs
+++ b/crates/perry-hir/src/lower_decl/class_members.rs
@@ -778,6 +778,55 @@ pub fn lower_setter_method(
     })
 }
 
+/// Lower a generic computed-key method (`[expr](args) { body }`, where `expr`
+/// is *not* a well-known symbol or a key we special-case) into a per-instance
+/// closure field keyed by the runtime-evaluated key expression.
+///
+/// We can't reduce `expr` to a static vtable name at compile time — it may be a
+/// cross-module const (`[OpCodes.OP_ON_SUCCESS]` resolves to `"OnSuccess"` only
+/// at runtime). Instead we desugar to `this[expr] = function (args) { body }`:
+/// the field's `key_expr` is evaluated at construction and the method body is
+/// lowered as a plain function-expression closure so `this` binds dynamically
+/// to the receiver when called via `recv[k](...)`. This is exactly what
+/// effect's `FiberRuntime` op-dispatch (`this[(cur)._op](cur)`) needs. Refs
+/// #321 — the fiber-runtime op-handler dispatch was an infinite loop because
+/// these methods were silently dropped (`c["myOp"]` read `undefined`).
+pub fn lower_computed_key_method_as_field(
+    ctx: &mut LoweringContext,
+    method: &ast::ClassMethod,
+    computed: &ast::ComputedPropName,
+) -> Result<ClassField> {
+    // Key expression evaluated at construction time (e.g. `OpCodes.OP_SYNC`).
+    let key = lower_expr(ctx, &computed.expr)?;
+
+    // Lower the method's function as a function-expression closure: this
+    // reuses the full fn-expr path (params, default params, destructuring,
+    // synthetic `arguments`, capture analysis) and crucially leaves `this`
+    // dynamically bound (`captures_this: false`) so a `recv[k]()` call binds
+    // `this` to `recv` — matching how the method would behave on the vtable.
+    let fn_expr = ast::FnExpr {
+        ident: None,
+        function: method.function.clone(),
+    };
+    let closure = crate::lower::lower_fn_expr(ctx, &fn_expr)?;
+
+    // Synthetic name for HIR identity; the real key is `key_expr`.
+    let synth = format!(
+        "__computed_method_{}_{}",
+        computed.span.lo.0, computed.span.hi.0
+    );
+
+    Ok(ClassField {
+        name: synth,
+        key_expr: Some(key),
+        ty: Type::Any,
+        init: Some(closure),
+        is_private: false,
+        is_readonly: false,
+        decorators: Vec::new(),
+    })
+}
+
 pub fn lower_class_prop(ctx: &mut LoweringContext, prop: &ast::ClassProp) -> Result<ClassField> {
     // Computed property keys (`[Symbol.for("k")]`, `[Parent.Symbol.X]`, etc.)
     // can't be reduced to a string at compile time — the key expression is

--- a/crates/perry-hir/src/lower_decl/mod.rs
+++ b/crates/perry-hir/src/lower_decl/mod.rs
@@ -34,8 +34,9 @@ pub(crate) use body_stmt::{find_native_return_in_stmts, lower_body_stmt};
 pub(crate) use class_captures::synthesize_class_captures;
 pub(crate) use class_decl::{lower_class_decl, lower_class_from_ast};
 pub(crate) use class_members::{
-    collect_method_captures, lower_class_method, lower_class_prop, lower_constructor,
-    lower_getter_method, lower_setter_method,
+    collect_method_captures, lower_class_method, lower_class_prop,
+    lower_computed_key_method_as_field, lower_constructor, lower_getter_method,
+    lower_setter_method,
 };
 pub(crate) use class_validation::validate_legacy_decorator_surface;
 pub(crate) use enum_decl::lower_enum_decl;

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -44,6 +44,60 @@ pub unsafe extern "C" fn js_native_call_method_str_key(
     js_native_call_method(object, bytes_ptr, bytes_len, args_ptr, args_len)
 }
 
+/// Dispatch `obj[key](args)` where `key` is a *runtime value* whose static type
+/// is not provably a string (`cur._op`, `arr[i]`, a `let`-rebound key, etc.).
+///
+/// JS binds `this = obj` for any `obj[k](...)` call regardless of how `k` is
+/// computed. The static-string fast path (`js_native_call_method_str_key`)
+/// covers literal/typed-string keys; this is the dynamic-key sibling. Without
+/// it, codegen fell through to a plain closure-call that dropped `this`, so a
+/// method stored as a class *field* (or any property closure) reached via a
+/// dynamic key read `this === undefined`. This is the dispatch half of #321 —
+/// effect's `FiberRuntime` op loop is exactly `this[(cur)._op](cur)`.
+///
+/// String keys delegate to the full `js_native_call_method` dispatch tower
+/// (own-field scan + prototype/class-id chain, all `this`-binding). Symbol
+/// keys read the symbol property; other keys go through the polymorphic index
+/// read. In every case the resolved callable is invoked with `this` bound.
+#[no_mangle]
+pub unsafe extern "C" fn js_native_call_method_value(
+    object: f64,
+    key: f64,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
+    let key_jsval = JSValue::from_bits(key.to_bits());
+
+    // String key (incl. SSO short strings): forward to the dispatch tower,
+    // which both finds own-field closures and binds `this`.
+    if key_jsval.is_any_string() {
+        let str_ptr =
+            crate::value::js_get_string_pointer_unified(key) as *const crate::StringHeader;
+        if !str_ptr.is_null() {
+            let bytes_ptr = (str_ptr as *const i8).add(std::mem::size_of::<crate::StringHeader>());
+            let bytes_len = (*str_ptr).byte_len as usize;
+            return js_native_call_method(object, bytes_ptr, bytes_len, args_ptr, args_len);
+        }
+    }
+
+    // Non-string key: read the property value, then invoke it with `this`
+    // bound to the receiver (the codegen `Expr::This` fallback reads
+    // `IMPLICIT_THIS` when there's no lexical `this`).
+    let field = if crate::symbol::js_is_symbol(key) != 0 {
+        crate::symbol::js_object_get_symbol_property(object, key)
+    } else {
+        crate::object::js_object_get_index_polymorphic(object.to_bits() as i64, key)
+    };
+    let fv = JSValue::from_bits(field.to_bits());
+    if fv.is_undefined() || fv.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let prev_this = IMPLICIT_THIS.with(|c| c.replace(object.to_bits()));
+    let result = crate::closure::js_native_call_value(field, args_ptr, args_len);
+    IMPLICIT_THIS.with(|c| c.set(prev_this));
+    result
+}
+
 /// every regular + spread arg already concatenated by codegen), materialises
 /// the f64 elements into a temporary `Vec<f64>`, and forwards to
 /// `js_native_call_method`. Lets the caller use a single uniform shape for

--- a/test-files/test_gap_computed_key_method_def.ts
+++ b/test-files/test_gap_computed_key_method_def.ts
@@ -1,0 +1,86 @@
+// #321 / #1785: class methods defined with a *computed* key —
+// `[KEY](args) { ... }` where KEY is a string literal, a local const, or a
+// (cross-module) const member expression — were silently DROPPED during HIR
+// lowering (`return Err("Unsupported method key")` for any non-well-known
+// computed key). `instance["KEY"]` then read `undefined`.
+//
+// This was the root of effect's `FiberRuntime` op-dispatch hang (#321): the
+// fiber evaluation loop dispatches `this[(cur)._op](cur)` where `_op` is an op
+// code string ("OnSuccess", "Sync", ...) and the handlers are defined as
+// `[OpCodes.OP_ON_SUCCESS](op) {...}`. With the handlers missing, `cur` never
+// advanced and `Effect.map(...)` looped forever.
+//
+// Fix: a generic computed-key method lowers to a per-instance closure field
+// keyed by the runtime-evaluated key expression (`this[expr] = function (...)
+// {...}`), so `this` binds dynamically and dynamic dispatch `recv[k]()` finds
+// it. Compared byte-for-byte against `node --experimental-strip-types`.
+
+const KEY = "myOp";
+const SECOND = "second";
+
+class C {
+  base = 10;
+  // literal-string computed key
+  ["litKey"](x: number): number {
+    return x + 1;
+  }
+  // local-const computed key + `this` access
+  [KEY](x: number): number {
+    return this.base + x;
+  }
+  // another local-const key, calls a sibling computed-key method via `this[k]`
+  [SECOND](x: number): number {
+    return (this as any)["myOp"](x) * 2;
+  }
+  // a plain method must still work alongside computed-key methods
+  plain(x: number): number {
+    return x - 1;
+  }
+}
+
+const c: any = new C();
+console.log("typeof c[KEY]:", typeof c[KEY]);
+console.log("c.litKey(5):", c["litKey"](5));
+console.log("c.myOp(5):", c["myOp"](5)); // base(10) + 5 = 15
+console.log("c.second(5):", c["second"](5)); // myOp(5)=15, *2 = 30
+console.log("c.plain(5):", c.plain(5));
+
+// Dynamic dispatch by a runtime-chosen key (effect's `this[op]` shape).
+const op = "myOp";
+console.log("dynamic c[op](3):", c[op](3)); // 13
+
+// Truly-dynamic key (array-sourced, not const-foldable) — exercises the
+// dynamic-dispatch `this`-binding path (`js_native_call_method_value`). A
+// method stored as a per-instance closure field must still bind `this` when
+// reached via a runtime key, which is effect's `this[(cur)._op](cur)` shape.
+const dynKey = ["myOp"][0];
+console.log("array-key c[dynKey](4):", c[dynKey](4)); // base(10)+4 = 14
+
+// A custom Symbol used as a computed method key (effect's `[Hash.symbol]()` /
+// `[Equal.symbol]()` shape). The method installs under the symbol and is
+// callable with `this` bound.
+const TAG = Symbol("tag");
+class WithSym {
+  v = 42;
+  [TAG](): number {
+    return this.v;
+  }
+}
+const ws: any = new WithSym();
+console.log("symbol-key method:", ws[TAG]());
+
+// NOTE: *static* computed-key methods (`static [SKEY](n) {...}`) are a deferred
+// follow-up — they need closure-valued static-field dispatch in codegen that
+// isn't wired up yet, so this fix scopes to instance methods (what effect's
+// FiberRuntime op handlers are).
+
+// Class EXPRESSION with a computed-key method (the #1785 heap-object path).
+const EXPR_KEY = "run";
+const Klass = class {
+  mult = 3;
+  [EXPR_KEY](n: number): number {
+    return this.mult * n;
+  }
+};
+const k: any = new Klass();
+console.log("class-expr run(4):", k["run"](4)); // 12


### PR DESCRIPTION
## Summary

Fixes two coupled bugs that kept effect's `FiberRuntime` op-dispatch loop — `this[(cur)._op](cur)` — from working. Any `Effect.map` / `effect/Schema` use either **hung forever** or threw. With both fixed, **`effect/Schema` now initializes** (`S.String`, `S.Number`, `S.Struct(...)` all resolve), which was the #1758/#1785 capstone goal.

### Bug 1 — HIR silently dropped computed-key instance methods

A class method defined with a non-well-known computed key was discarded during lowering (`Err("Unsupported method key")`):

```ts
[OpCodes.OP_ON_SUCCESS](op) { ... }   // effect fiber op handlers
[Hash.symbol]() { ... }               // effect Hash/Equal
[KEY](x) { ... }                      // any const/computed key
```

So `inst["OnSuccess"]` read `undefined`, and effect's `runLoop` dispatch `this[(cur)._op](cur)` never advanced → **infinite loop**.

**Fix:** these now lower to a per-instance closure field keyed by the runtime-evaluated key expression — i.e. `this[expr] = function (...) {...}` — reusing the fn-expr lowering path so `this` binds dynamically. Wired into both `lower_class_decl` and `lower_class_from_ast` (the #1785 class-expression path). Instance methods only; static computed-key methods are a deferred follow-up (they need closure-valued static-field dispatch in codegen).

### Bug 2 — dynamic-key method dispatch dropped `this`

`obj[k](args)` where `k` is **not statically a string** (`cur._op`, `arr[i]`, a `let`-rebound key) fell through to a plain closure-call that didn't bind `this`. A method stored as a class **field** (incl. the closures from Bug 1) reached via a runtime key saw `this === undefined`.

**Fix:** new runtime entry `js_native_call_method_value` binds `this = obj` for any key type — string keys go through the full `js_native_call_method` dispatch tower (own-field scan + prototype/class-id chain), symbol/other keys read the property then call with `this` bound. Codegen routes non-static-string `IndexGet`-callee calls through it (numeric-keyed element calls excluded — those aren't method dispatch).

This is the dispatch half; it also turned out to fix the earlier `_hash` symptom (Hash/Equal methods were being called without `this`), so no special-casing is needed and all computed-key methods install uniformly.

## Validation

- `effect/Schema`: `import * as S from "effect/Schema"` → `S.String`/`S.Number` are functions, `S.Struct({...})` constructs. (Was: `TypeError ... reading '_hash'`.)
- `effect/Effect`: `runSync(succeed(42))` → `42` (stays green).
- New `test_gap_computed_key_method_def.ts` — literal/const/symbol computed keys, dynamic `obj[k]()` dispatch (array-sourced + cross-module-const keys), class-expression — byte-for-byte vs `node --experimental-strip-types`.
- Gap-suite sweep: no new regressions (pre-existing `class_advanced`, `console_methods`, `derived_param_props` confirmed unchanged vs baseline binary). Dispatch-sensitive tests (`issue_510`, `issue_645`, decorators, computed-method) byte-identical baseline-vs-fix.
- `cargo test` for perry-hir / perry-codegen / perry-runtime: all green. `cargo fmt --check`: clean.

## Next blocker (follow-up)

The fiber `runLoop` no longer hangs; `Effect.map(succeed(10), f)` via `runSync` now advances and throws an empty-object defect **before** the OnSuccess continuation runs (the mapping function never executes). Separate investigation — will file/track for the #321 cascade.

Refs #321, #1758, #1785.
