### PR TITLE
fix(hir): namespace-member call mis-lowered to Array intrinsic (#321)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/imported_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/imported_array_methods.rs
@@ -27,6 +27,19 @@ pub(super) fn try_imported_array_methods(
                 let method_name = method_ident.sym.as_ref();
                 if let ast::Expr::Ident(arr_ident) = member.obj.as_ref() {
                     let arr_name = arr_ident.sym.to_string();
+                    // A module namespace import (`import * as NS from "..."`) is
+                    // NOT an array — its `.map`/`.filter`/`.find`/... are member
+                    // functions, e.g. effect's `export const map = core.map`.
+                    // Folding `NS.map(x, f)` to `Expr::ArrayMap { array: NS,
+                    // callback: x }` dispatched `js_array_map(NS, x)` and
+                    // returned `[]` without ever calling the member (#321 —
+                    // `Effect.map(...)` never ran). Skip the fold for
+                    // namespaces; the generic call path invokes the member
+                    // correctly. Named-value imports (`import { CHAIN_NAMES }`)
+                    // are not namespaces, so real imported arrays still fold.
+                    if ctx.namespace_import_locals.contains(&arr_name) {
+                        return Ok(Err(args));
+                    }
                     // Check if this is an imported variable (not a local)
                     if ctx.lookup_local(&arr_name).is_none() {
                         if let Some(orig_name) = ctx.lookup_imported_func(&arr_name) {

--- a/test-files/_helpers/ns_member_fns_mod.ts
+++ b/test-files/_helpers/ns_member_fns_mod.ts
@@ -1,0 +1,11 @@
+// Helper for test_gap_namespace_member_not_array_method.ts (#321 / #24).
+// A module that happens to export functions named like array methods
+// (`map`, `filter`, ...) — exactly effect's `export const map = core.map`
+// shape — plus a real array export.
+
+export const map = (x: number, f: (n: number) => number): number => f(x);
+export const filter = (x: number, p: (n: number) => boolean): boolean => p(x);
+export const find = (x: number): number => x + 1;
+
+// A real exported array, to confirm `NS.items.map(cb)` still array-maps.
+export const items = [10, 20, 30];

--- a/test-files/test_gap_namespace_member_not_array_method.ts
+++ b/test-files/test_gap_namespace_member_not_array_method.ts
@@ -1,0 +1,29 @@
+// #321 / #24: a method call on a *module namespace* whose member happens to be
+// named `map` / `filter` / `find` / ... was mis-lowered to the Array intrinsic
+// (`NS.map(x, f)` → `Expr::ArrayMap { array: NS, callback: x }`), so it
+// returned `[]` and never called the member. This is exactly effect's
+// `import * as Effect from "effect/Effect"; Effect.map(eff, f)` — where
+// `Effect.map` is `export const map = core.map`.
+//
+// Fix: skip the array-intrinsic fold when the receiver identifier is a module
+// namespace import (`namespace_import_locals`). Real imported arrays (named
+// value imports, or `NS.items.map(...)`) still fold.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+import * as NS from "./_helpers/ns_member_fns_mod.ts";
+import { items } from "./_helpers/ns_member_fns_mod.ts";
+
+// (1) namespace member functions named like array methods — must call the
+//     member, NOT lower to an array op.
+console.log("NS.map(5, *2):", NS.map(5, (n) => n * 2)); // 10
+console.log("NS.filter(5, >3):", NS.filter(5, (n) => n > 3)); // true
+console.log("NS.find(7):", NS.find(7)); // 8
+
+// (2) a real array reached *through* the namespace (`NS.items`) still maps.
+console.log("NS.items.map(+1):", NS.items.map((n) => n + 1).join(",")); // 11,21,31
+
+// (3) a directly-imported array (named value import) still array-maps — guard
+//     must not over-fire on non-namespace imports.
+console.log("items.filter(>15):", items.filter((n) => n > 15).join(",")); // 20,30
+console.log("items.map(*2):", items.map((n) => n * 2).join(",")); // 20,40,60


### PR DESCRIPTION
## Summary

A method call on a **module namespace import** whose member happens to be named like an array method (`map`, `filter`, `find`, `forEach`, `reduce`, ...) was mis-lowered to the **Array intrinsic**:

```ts
import * as Effect from "effect/Effect";
Effect.map(eff, f)   // lowered to  Expr::ArrayMap { array: Effect, callback: eff }
```

→ dispatched as `js_array_map(Effect, eff)`, returned `[]`, and **never invoked the member**. `try_imported_array_methods` folds `<imported>.map(...)` to `ArrayMap` for any imported identifier; only the `join` case had a guard (#420). So `Effect.map` (which is `export const map = core.map`) produced an empty value instead of an `OnSuccess` effect, and the fiber never ran.

## Fix

Skip the array-intrinsic fold when the receiver identifier is a module namespace import (`ctx.namespace_import_locals` — populated for `import * as NS`). The generic call path then invokes the member correctly.

Named-value imports (`import { CHAIN_NAMES }`) are **not** namespaces, so genuinely-imported arrays still fold — confirmed by the gap test:
- `NS.map(5, f)` / `NS.filter(...)` / `NS.find(...)` → call the member function ✓
- `NS.items.map(cb)` (array reached through the namespace) → still array-maps ✓
- direct `items.map(cb)` (named array import) → still array-maps ✓

## Validation

- Minimal repro (`/tmp/dualmod`): `R.map(10, n=>n*2)` → `20` (was `[]`), closure now runs.
- effect: `Effect.map(succeed(10), f)` now produces a real `OnSuccess` effect (`_op="OnSuccess"`, full instruction fields) instead of `[]`.
- New `test_gap_namespace_member_not_array_method.ts` — byte-for-byte vs `node --experimental-strip-types`.
- Regression sweeps (array / map / import / namespace tests + first 45 gap tests): no new regressions — the 3 pre-existing fails (`class_advanced`, `console_methods`, `derived_param_props`) are byte-identical baseline-vs-fix.
- `cargo test -p perry-hir` green; `cargo fmt --check` clean.

Independent of #1818 (fails on baseline too). Together with #1818 (fiber-runtime dispatch), this unblocks `Effect.map`/`pipe` in the #321 cascade.

Refs #321, #1758, #1785.
