### PR TITLE
fix(codegen,runtime): static class field/method dispatch — same + cross module (#1787)

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -776,9 +776,30 @@ pub fn try_lower_property_get_method_call(
         local_id_to_name: &std::collections::HashMap<u32, String>,
         local_class_aliases: &std::collections::HashMap<String, String>,
         func_returns_class: &std::collections::HashMap<u32, String>,
+        class_ids: &std::collections::HashMap<String, u32>,
     ) -> Option<String> {
         match expr {
             Expr::ClassRef(name) => Some(name.clone()),
+            // #1787 / #321: a cross-module class accessed via a direct named
+            // import (`import { Union }; Union.make(...)`) lowers the receiver
+            // to `ExternFuncRef("Union")`. When the name is a known class,
+            // treat it as a static-dispatch receiver so `Class.staticMember(...)`
+            // routes through the static tower (the imported class's stub has
+            // empty static_methods/fields here, so it falls to the runtime
+            // `js_class_static_method_call`, which resolves via the class_id
+            // registries).
+            Expr::ExternFuncRef { name, .. } if class_ids.contains_key(name) => Some(name.clone()),
+            // ...and via a namespace import (`import * as AST; AST.Union.make(...)`),
+            // which lowers to `PropertyGet { object: <namespace>, property:
+            // "Union" }`. effect's `AST.Union.make([...])` is exactly this.
+            // Gate on the property being a known class to avoid intercepting
+            // ordinary instance method calls.
+            Expr::PropertyGet { object, property }
+                if matches!(object.as_ref(), Expr::ExternFuncRef { .. })
+                    && class_ids.contains_key(property) =>
+            {
+                Some(property.clone())
+            }
             // #1787: a class EXPRESSION value (`make(a) => class { ... }`,
             // lowered to `ClassExprFresh`) is a heap class object stamped
             // with the compile-time `template`'s class_id. A static-method
@@ -800,6 +821,7 @@ pub fn try_lower_property_get_method_call(
                     local_id_to_name,
                     local_class_aliases,
                     func_returns_class,
+                    class_ids,
                 )
             }),
             _ => None,
@@ -810,6 +832,7 @@ pub fn try_lower_property_get_method_call(
         &ctx.local_id_to_name,
         &ctx.local_class_aliases,
         ctx.func_returns_class,
+        &ctx.class_ids,
     );
     if let Some(cls_name) = static_dispatch_cls {
         // (fn_name, is_static, declared_param_count, has_rest, is_synthetic_arguments)
@@ -943,6 +966,75 @@ pub fn try_lower_property_get_method_call(
                 .call(DOUBLE, "js_implicit_this_set", &[(DOUBLE, &prev_this)]);
             return Ok(Some(result));
         }
+        // #1787 / #321: the call target is a static FIELD holding a callable,
+        // not a static METHOD — e.g. effect's
+        // `static make = (types) => ...` / `static unify = ...` on
+        // `SchemaAST.Union`. The static-method walk above misses it (it's a
+        // field), and the `js_class_static_method_call` fallback below returns
+        // the receiver class ref on a method miss (an INT32 class id, which is
+        // why `Union.make([...])` came back as `1`/undefined and Schema decode
+        // died reading `_tag`). Detect a string-named static field on the
+        // class's chain, read its value (the installed closure) via
+        // `StaticFieldGet`, and invoke it with the call args. Static-field
+        // arrows don't use dynamic `this`, so a plain closure call is correct.
+        {
+            let mut field_owner: Option<String> = None;
+            let mut fc = Some(cls_name.clone());
+            while let Some(c) = fc {
+                if let Some(ci) = ctx.classes.get(&c) {
+                    if ci
+                        .static_fields
+                        .iter()
+                        .any(|f| f.key_expr.is_none() && f.name == *property)
+                    {
+                        field_owner = Some(c.clone());
+                        break;
+                    }
+                }
+                fc = ctx.classes.get(&c).and_then(|cc| cc.extends_name.clone());
+            }
+            if let Some(owner) = field_owner {
+                let callee_val = lower_expr(
+                    ctx,
+                    &Expr::StaticFieldGet {
+                        class_name: owner,
+                        field_name: property.clone(),
+                    },
+                )?;
+                let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());
+                for a in args {
+                    lowered_args.push(lower_expr(ctx, a)?);
+                }
+                let (args_ptr_i64, args_len) = if lowered_args.is_empty() {
+                    ("0".to_string(), "0".to_string())
+                } else {
+                    let n = lowered_args.len();
+                    let buf_reg = ctx.func.alloca_entry_array(DOUBLE, n);
+                    for (i, v) in lowered_args.iter().enumerate() {
+                        let slot = ctx
+                            .block()
+                            .gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", i))]);
+                        ctx.block().store(DOUBLE, v, &slot);
+                    }
+                    let ptr_reg = ctx.block().next_reg();
+                    ctx.block().emit_raw(format!(
+                        "{} = getelementptr [{} x double], ptr {}, i64 0, i64 0",
+                        ptr_reg, n, buf_reg
+                    ));
+                    let ptr_i64 = ctx.block().ptrtoint(&ptr_reg, I64);
+                    (ptr_i64, n.to_string())
+                };
+                return Ok(Some(ctx.block().call(
+                    DOUBLE,
+                    "js_native_call_value",
+                    &[
+                        (DOUBLE, &callee_val),
+                        (I64, &args_ptr_i64),
+                        (I64, &args_len),
+                    ],
+                )));
+            }
+        }
         // No static method resolved through the class's statically-visible
         // chain. #1788: a subclass of a class-expression value
         // (`class Sub extends make(...) {}`) inherits the parent's static
@@ -952,7 +1044,20 @@ pub fn try_lower_property_get_method_call(
         // The helper returns the receiver unchanged on a genuine miss, which
         // preserves the prior "yield the class ref for a chained `.pipe()`
         // during module init" behavior for truly-absent methods.
-        if matches!(object.as_ref(), Expr::ClassRef(_)) {
+        //
+        // #1787 / #321: also route imported-class receivers
+        // (`ExternFuncRef("C")` from `import { C }`, or a `namespace.Class`
+        // PropertyGet — effect's `AST.Union.make`). Their class stub has empty
+        // compile-time static methods/fields, so resolution above misses; the
+        // runtime call resolves both static methods AND static fields from the
+        // class_id registries. `resolve_static_dispatch_cls` already gated
+        // these on known-class membership, so reaching here means the receiver
+        // really is a class.
+        let receiver_is_dispatchable_class = matches!(object.as_ref(), Expr::ClassRef(_))
+            || matches!(object.as_ref(), Expr::ExternFuncRef { name, .. } if ctx.class_ids.contains_key(name))
+            || matches!(object.as_ref(), Expr::PropertyGet { object: inner, property }
+                if matches!(inner.as_ref(), Expr::ExternFuncRef { .. }) && ctx.class_ids.contains_key(property));
+        if receiver_is_dispatchable_class {
             let recv_box = lower_expr(ctx, object)?;
             let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());
             for a in args {

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1697,6 +1697,32 @@ pub unsafe extern "C" fn js_class_static_method_call(
         crate::object::js_implicit_this_set(prev_this);
         return result;
     }
+    // #1787 / #321: not a static METHOD — try a static FIELD holding a
+    // callable (effect's `static make = (...) => ...` / `static unify = ...`
+    // on `SchemaAST.Union`). Walk the class_id chain in CLASS_DYNAMIC_PROPS
+    // (where `js_class_register_static_field` records each static field) and,
+    // if `name` resolves to a non-nullish value, invoke it as a closure with
+    // the call args. Static-field arrows capture lexical `this` (the class) and
+    // don't read dynamic `this`, so a plain closure call is correct. Without
+    // this, `Class.staticField(args)` fell through to `receiver` (the class
+    // ref / INT32 class id), which is why `Union.make([...])` returned `1`/
+    // undefined and Schema decode died reading `_tag`.
+    {
+        let mut cid = class_id;
+        let mut depth = 0u32;
+        while cid != 0 && depth < 64 {
+            let field_val = CLASS_DYNAMIC_PROPS
+                .with(|m| m.borrow().get(&cid).and_then(|f| f.get(name).copied()));
+            if let Some(v) = field_val {
+                let fv = crate::value::JSValue::from_bits(v.to_bits());
+                if !fv.is_undefined() && !fv.is_null() {
+                    return crate::closure::js_native_call_value(v, args_ptr, args_len);
+                }
+            }
+            cid = get_parent_class_id(cid).unwrap_or(0);
+            depth += 1;
+        }
+    }
     receiver
 }
 

--- a/test-files/_helpers/static_members_mod.ts
+++ b/test-files/_helpers/static_members_mod.ts
@@ -1,0 +1,19 @@
+// Helper for test_gap_static_member_call.ts (#1787 / #321).
+// A class exposing callable STATIC FIELDS (arrow + function expression) and a
+// static METHOD, plus a subclass that inherits them — mirrors effect's
+// `SchemaAST.Union` (`static make = (...) => ...`, `static unify = ...`).
+
+export class Factory {
+  static tag = "F";
+  static make = (n: number): number => n * 2;
+  static makeFn = function (n: number): number {
+    return n + 100;
+  };
+  static label(n: number): string {
+    return Factory.tag + ":" + n;
+  }
+}
+
+export class SubFactory extends Factory {
+  static extra = (n: number): number => n - 3;
+}

--- a/test-files/test_gap_static_member_call.ts
+++ b/test-files/test_gap_static_member_call.ts
@@ -1,0 +1,41 @@
+// #1787 / #321: calling a STATIC FIELD that holds a callable —
+// `Class.make(args)` where `static make = (x) => ...` (an arrow field, not a
+// static method) — mis-dispatched. The static-method vtable walk missed it
+// (it's a field), so the call fell through to `js_class_static_method_call`,
+// which returns the receiver class ref on a method miss → `Class.make(5)` came
+// back as `1` (the INT32 class id). Cross-module it was worse: even static
+// METHODS on an imported class returned `1`, because the importing module's
+// class stub has no compile-time static methods/fields and the receiver
+// (`ExternFuncRef` / `namespace.Class`) never reached the static-dispatch tower.
+//
+// This is effect's `SchemaAST.Union` shape: `static make = (...) => ...` called
+// as `AST.Union.make([...])` from `ParseResult.ts` — which returned undefined
+// and crashed Schema decode reading `_tag`.
+//
+// Fix: a static FIELD holding a callable is read and invoked as a closure
+// (compile-time for same-module `ClassRef`, runtime via the class_id
+// CLASS_DYNAMIC_PROPS registry for imported `ExternFuncRef` / `namespace.Class`
+// receivers). Compared byte-for-byte against `node --experimental-strip-types`.
+
+import * as NS from "./_helpers/static_members_mod.ts";
+import { Factory, SubFactory } from "./_helpers/static_members_mod.ts";
+
+// (1) static arrow field — direct import.
+console.log("Factory.make(5):", (Factory as any).make(5)); // 10
+// (2) static function-expression field.
+console.log("Factory.makeFn(5):", (Factory as any).makeFn(5)); // 105
+// (3) static method (regression guard).
+console.log("Factory.label(5):", Factory.label(5)); // F:5
+// (4) static arrow field — via namespace import (effect's `AST.Union.make`).
+console.log("NS.Factory.make(7):", (NS.Factory as any).make(7)); // 14
+console.log("NS.Factory.label(7):", NS.Factory.label(7)); // F:7
+// (5) inherited static field through a subclass.
+console.log("SubFactory.make(8):", (SubFactory as any).make(8)); // 16 (inherited)
+console.log("SubFactory.extra(8):", (SubFactory as any).extra(8)); // 5 (own)
+console.log("NS.SubFactory.make(9):", (NS.SubFactory as any).make(9)); // 18
+
+// Same-module class with a static arrow field.
+class Local {
+  static twice = (n: number): number => n + n;
+}
+console.log("Local.twice(6):", (Local as any).twice(6)); // 12


### PR DESCRIPTION
## Summary

`Class.staticMember(args)` mis-dispatched, returning `1` (the class id) instead of calling the member. Two distinct bugs, both on the path effect's Schema parser walks:

**1. Static FIELDS holding callables.** `static make = (x) => ...` (effect's `SchemaAST.Union.make` / `.unify`) is a *field*, not a static *method*. The static-method vtable walk missed it, so the call fell through to `js_class_static_method_call`, which returns the receiver class ref on a method miss → `Class.make(5)` → `1`.

**2. Cross-module static members.** Even static *methods* on an imported class returned `1`. `resolve_static_dispatch_cls` only recognised `ClassRef`/`ClassExprFresh`/factory receivers, so an imported-class receiver — `ExternFuncRef("C")` (`import { C }`) or `<namespace>.Class` (`import * as AST; AST.Union.make(...)`) — never reached the static-dispatch tower.

This is exactly effect's `AST.Union.make([...])` (called from `ParseResult.ts`): it returned undefined and crashed Schema decode with `reading '_tag'`.

## Fix

- **codegen** (`property_get.rs`): after the static-method walk misses, look for a string-named static **field** on the class chain, read its installed closure via `StaticFieldGet`, and invoke it (`js_native_call_value`). Extend `resolve_static_dispatch_cls` to recognise imported-class receivers (`ExternFuncRef(name)` and `<namespace>.<ClassName>`), gated on known-class membership (`ctx.class_ids`), and broaden the runtime-fallback gate to route them through the static tower.
- **runtime** (`class_registry.rs`): `js_class_static_method_call`, on a method miss, now walks the `class_id` chain in `CLASS_DYNAMIC_PROPS` (where `js_class_register_static_field` records static fields) and invokes a resolved callable field — covering imported classes whose compile-time stub has no static methods/fields.

Static-field arrows capture lexical `this` (the class), not dynamic `this`, so a plain closure call is correct.

## Validation

Byte-for-byte vs `node --experimental-strip-types` (new `test_gap_static_member_call.ts`):
- same-module static arrow field / fn field / method ✓
- cross-module via direct import **and** namespace (`NS.Factory.make`) ✓
- inherited static field through a subclass ✓; subclass's own static field ✓

Advances effect's `Schema.decodeUnknownSync` **past** the `AST.Union.make` blocker (`Union.make` now dispatches and returns a real `Union`); a deeper Schema-parser step remains (separate follow-up).

Zero regressions: class/static/computed/import sweep (23/24, the 1 fail pre-existing) + first-45 gap tests (3 pre-existing fails — `class_advanced`, `console_methods`, `derived_param_props` — byte-identical baseline-vs-fix). `cargo fmt --check` clean.

Part of the #1785 class-object epic (the #1787 static-member-dispatch central gap). Refs #1787, #1785, #1758, #321.
