### PR TITLE
fix(runtime,codegen): expose Symbol.iterator on arrays (#321)

### DIFF
--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -425,6 +425,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             //   3. Anything else → fall back to dynamic object field
             //      access by stringifying the index at runtime
             if is_array_expr(ctx, object) {
+                // #321: a symbol-keyed array read (`arr[Symbol.iterator]`) must
+                // NOT take the numeric fast path below — `fptosi` on the symbol
+                // value yields a garbage index (returned a number). Route symbol
+                // keys to the symbol-property resolver, which exposes the array
+                // iterator for `Symbol.iterator`.
+                if matches!(index.as_ref(), Expr::SymbolFor(_)) {
+                    let obj_box = lower_expr(ctx, object)?;
+                    let key_box = lower_expr(ctx, index)?;
+                    return Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_object_get_symbol_property",
+                        &[(DOUBLE, &obj_box), (DOUBLE, &key_box)],
+                    ));
+                }
                 let require_numeric_layout =
                     expr_has_numeric_pointer_free_array_layout(ctx, object);
                 // Bounded-index fast path (mirrors the IndexSet

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -703,6 +703,25 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
     if let Some(v) = own_symbol_property(obj_f64, sym_f64) {
         return v;
     }
+    // #321: arrays expose `Symbol.iterator`. perry has no standalone array
+    // iterator object (for-of is special-cased), but `arr[Symbol.iterator]`
+    // must resolve to a callable so `Symbol.iterator in arr` is true
+    // (effect's `Predicate.isIterable`) and `typeof arr[Symbol.iterator]` is
+    // "function". Bind the array's `values` method as that callable. Pre-fix
+    // the symbol key fell through to the numeric/string paths and read back a
+    // number, so `isIterable([...])` was false and `Effect.all`'s
+    // predicate-`dual` `forEach` went data-last (returned a function).
+    if crate::array::js_array_is_array(obj_f64).to_bits() == crate::value::TAG_TRUE {
+        let iter_wk = well_known_symbol("iterator");
+        if !iter_wk.is_null() {
+            let iter_f64 =
+                f64::from_bits(crate::value::JSValue::pointer(iter_wk as *const u8).bits());
+            if sym_key_from_f64(sym_f64) == sym_key_from_f64(iter_f64) {
+                let mname = b"values";
+                return crate::object::js_class_method_bind(obj_f64, mname.as_ptr(), mname.len());
+            }
+        }
+    }
     // #1758: a POINTER class-object whose OWN symbol props miss may inherit
     // the symbol through its class_id prototype chain. (The SYMBOL_PROPERTIES
     // lock is released above before recursing into the resolver, which takes

--- a/test-files/test_gap_array_symbol_iterator.ts
+++ b/test-files/test_gap_array_symbol_iterator.ts
@@ -1,0 +1,43 @@
+// #321 / #27: arrays did not expose `Symbol.iterator` as a property.
+// `Symbol.iterator in arr` was `false` and `arr[Symbol.iterator]` read back a
+// *number* (the symbol value `fptosi`'d to a garbage index on the array
+// numeric fast path). effect's `Predicate.isIterable(x)` is
+// `Symbol.iterator in x`, so `isIterable([...])` was false — which made
+// `Effect.all`'s predicate-`dual` `forEach` take its data-last branch and
+// return a function instead of the combined effect.
+//
+// Fix: the symbol resolver exposes the array's iterator for the well-known
+// iterator symbol (a bound callable), and the array IndexGet fast path routes
+// symbol keys to the resolver instead of the numeric load. So
+// `Symbol.iterator in arr` is true and `arr[Symbol.iterator]` is a function.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+const arr = [1, 2, 3];
+
+// (1) presence via `in` (effect's isIterable shape).
+console.log("Symbol.iterator in arr:", Symbol.iterator in arr);
+console.log("Symbol.iterator in []:", Symbol.iterator in ([] as number[]));
+
+// (2) the property is a function.
+console.log("typeof arr[Symbol.iterator]:", typeof arr[Symbol.iterator]);
+
+// (3) a hasProperty-style guard (effect's Predicate.hasProperty).
+const hasProperty = (self: any, key: any): boolean =>
+  (typeof self === "object" || typeof self === "function") &&
+  self !== null &&
+  key in self;
+console.log("hasProperty(arr, Symbol.iterator):", hasProperty(arr, Symbol.iterator));
+
+// (4) a string key is still absent (guard against over-broad `in`).
+console.log("'foo' in arr:", "foo" in arr);
+console.log("0 in arr:", 0 in arr);
+
+// (5) for-of and spread still work (no regression to array iteration).
+let sum = 0;
+for (const n of arr) sum += n;
+console.log("for-of sum:", sum);
+console.log("spread:", [...arr].join(","));
+
+// (6) a plain object without Symbol.iterator reports false.
+console.log("Symbol.iterator in {}:", Symbol.iterator in ({} as any));


### PR DESCRIPTION
## Summary

Arrays didn't expose the iterator protocol as a **property**: `Symbol.iterator in arr` was `false` and `arr[Symbol.iterator]` read back a *number* (the symbol value was `fptosi`'d to a garbage index on the array numeric fast path). for-of worked (it's special-cased), but the property/`in` exposure was missing.

This broke effect: `Predicate.isIterable(x)` is literally `Symbol.iterator in x`, so `isIterable([...])` returned false. `Effect.all` dispatches through `forEach`, a predicate-`dual` whose predicate is `(args) => isIterable(args[0])` — with it false, `forEach` took its **data-last** branch and returned a curried *function* instead of the combined effect, so `runSync` saw a non-effect and produced a `{}` defect.

## Fix (two halves of one gap)

- **runtime** (`symbol.rs`): `js_object_get_symbol_property`, for an array receiver + the well-known iterator symbol, returns the array's `values` method bound via `js_class_method_bind` (the same callable-binding path `Symbol.dispose` already uses). This makes both `Symbol.iterator in arr` (routes through `js_object_has_property` → the symbol resolver) and the property read resolve to a callable.
- **codegen** (`index_get.rs`): the array IndexGet fast path routes a `SymbolFor` key to `js_object_get_symbol_property` instead of `fptosi`-ing it to a numeric index.

## Result

`Symbol.iterator in arr` → `true`, `typeof arr[Symbol.iterator]` → `"function"`, `Predicate.isIterable([...])` → `true`, and `Effect.all([...])` now **constructs a real effect** (`_op: WithRuntime`) instead of a function.

`Effect.all`'s `runSync` still hits a deeper blocker (the bound iterator isn't yet a full `.next()` iterator object) — tracked separately.

## Validation

Byte-for-byte vs `node --experimental-strip-types` (new `test_gap_array_symbol_iterator.ts`): `in` presence, typeof, hasProperty guard, string/numeric `in` still correct, for-of + spread unchanged, plain-object negative.

Zero regressions: 30/30 array/iterator/for-of/spread/symbol tests + first-45 gap tests (the 3 fails — `class_advanced`, `console_methods`, `derived_param_props` — are pre-existing, byte-identical baseline-vs-fix). `cargo fmt --check` clean.

Broadly useful beyond effect — any `isIterable`/`Symbol.iterator`-presence check on arrays. Refs #321, #1785.
