### PR TITLE
feat(runtime): PERRY_DISPATCH_DIAG — surface silent dynamic-dispatch misses

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -313,6 +313,76 @@ pub fn class_name_for_id(class_id: u32) -> Option<String> {
     guard.as_ref()?.get(&class_id).cloned()
 }
 
+/// Whether dynamic-dispatch miss diagnostics are enabled (`PERRY_DISPATCH_DIAG`,
+/// any non-empty/non-falsey value). Cached on first read.
+///
+/// When a dynamic dispatch falls through every resolution tower (vtable,
+/// static-method, static-field, prototype, field-scan, namespace, symbol), the
+/// runtime returns a *silent placeholder* — the receiver class ref, an empty
+/// object, `undefined`, etc. — rather than throwing, because some of those
+/// placeholders are load-bearing (effect's `.pipe()` chains yield the class ref
+/// during module init, #687). The upside is no spurious crashes; the downside
+/// is a typo'd / unsupported member surfaces far downstream as a stray
+/// `{}`/`1`/`[]`/function, turning each one into a multi-hour localization.
+///
+/// This flag doesn't change behavior — it just prints a located, typed report
+/// at the moment of the miss, so the bug surfaces at its true call site.
+pub(crate) fn dispatch_diag_enabled() -> bool {
+    use std::sync::OnceLock;
+    static EN: OnceLock<bool> = OnceLock::new();
+    *EN.get_or_init(|| {
+        std::env::var("PERRY_DISPATCH_DIAG")
+            .map(|v| !v.is_empty() && v != "0" && v != "off" && v != "false")
+            .unwrap_or(false)
+    })
+}
+
+/// Best-effort one-line description of a dispatch receiver for diagnostics:
+/// class refs resolve to their registered name, pointers/primitives to a tag.
+fn describe_dispatch_receiver(recv: f64) -> String {
+    let bits = recv.to_bits();
+    let top16 = bits >> 48;
+    if top16 == 0x7FFE {
+        let cid = (bits & 0xFFFF_FFFF) as u32;
+        return match class_name_for_id(cid) {
+            Some(n) => format!("class-ref `{}` (id {})", n, cid),
+            None => format!("class-ref (id {})", cid),
+        };
+    }
+    if top16 == 0x7FFF || top16 == 0x7FF9 {
+        return "string".to_string();
+    }
+    if top16 == 0x7FFD {
+        return "object/pointer".to_string();
+    }
+    match bits {
+        x if x == crate::value::TAG_UNDEFINED => "undefined".to_string(),
+        0x7FFC_0000_0000_0002 => "null".to_string(),
+        0x7FFC_0000_0000_0003 => "false".to_string(),
+        0x7FFC_0000_0000_0004 => "true".to_string(),
+        _ if !recv.is_nan() => format!("number {}", recv),
+        _ => "value".to_string(),
+    }
+}
+
+/// Report a true dynamic-dispatch miss to stderr (only when
+/// `PERRY_DISPATCH_DIAG` is set). `tower` names which resolution path fell
+/// through; `returning` is the silent placeholder the runtime is about to hand
+/// back. No-op (and near-zero cost) when the flag is off.
+pub(crate) fn report_dispatch_miss(tower: &str, recv: f64, name: &str, returning: &str) {
+    if !dispatch_diag_enabled() {
+        return;
+    }
+    eprintln!(
+        "[perry dispatch-miss] {tower}: {}.{:?} did not resolve \u{2192} returning {returning}. \
+         A dynamic dispatch fell through every tower; downstream this usually surfaces as a stray \
+         {{}}/1/[]/function. Check the call site for {:?}.",
+        describe_dispatch_receiver(recv),
+        name,
+        name
+    );
+}
+
 /// Resolve a closure-typed JSValue back to a built-in constructor name
 /// (`"Date"`/`"Array"`/`"Object"`/...) when it matches one of the
 /// singleton-installed thunks. Returns `None` for closures that aren't
@@ -1723,6 +1793,16 @@ pub unsafe extern "C" fn js_class_static_method_call(
             depth += 1;
         }
     }
+    // True miss: no static method and no callable static field resolved on the
+    // class chain. We hand back the receiver (load-bearing for effect's
+    // `.pipe()`-during-init chains, #687) — but that silent class-ref is exactly
+    // what surfaces downstream as a stray `1`. Surface it at the call site.
+    report_dispatch_miss(
+        "static-member-call",
+        receiver,
+        name,
+        "the receiver (class ref)",
+    );
     receiver
 }
 

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -174,6 +174,12 @@ pub unsafe extern "C" fn js_native_call_method(
     let _depth_guard = match CallMethodDepthGuard::enter(method_name) {
         Some(g) => g,
         None => {
+            crate::object::class_registry::report_dispatch_miss(
+                "call-method (recursion-depth guard)",
+                object,
+                method_name,
+                "empty object",
+            );
             let null_obj_ptr = &NULL_OBJECT_BYTES as *const NullObjectBytes as *mut u8;
             return f64::from_bits(JSValue::pointer(null_obj_ptr).bits());
         }
@@ -2085,6 +2091,17 @@ pub unsafe extern "C" fn js_native_call_method(
     // the surrounding async path). Now we throw the standard `<prop>
     // is not a function` TypeError, which `try`/`catch` catches (per
     // #596's exception-routing fix).
+    // Even though this path throws a catchable TypeError, frameworks with broad
+    // `try`/`catch` (effect's fiber runtime) swallow it into a die defect that
+    // surfaces far downstream as a stray `{}` — hiding the real call site. Print
+    // a located report first so `PERRY_DISPATCH_DIAG=1` names the missing
+    // method+receiver before the throw is caught.
+    crate::object::class_registry::report_dispatch_miss(
+        "call-method (no method/field/proto match)",
+        object,
+        method_name,
+        "throws \"<m> is not a function\"",
+    );
     crate::error::js_throw_type_error_not_a_function(
         std::ptr::null(),
         0,


### PR DESCRIPTION
## Summary

Answers the "can we be better about the silent-placeholder problem?" question directly.

When a dynamic dispatch falls through **every** resolution tower (vtable, static-method, static-field, prototype, field-scan, namespace, symbol), the runtime returns a *silent placeholder* — the receiver class ref, an empty object, `undefined` — instead of throwing. That's deliberate (some placeholders are load-bearing: effect's `.pipe()` chains yield the class ref during module init, #687), and it avoids spurious crashes. But the cost is real: a typo'd / unsupported member surfaces far downstream as a stray `{}`/`1`/`[]`/function, so each one is a multi-hour localization. This is exactly what made the #321 effect bugs (`Union.make` → `1`, `Effect.all` → `{}`) so expensive to find.

## What this adds

An opt-in diagnostic — **`PERRY_DISPATCH_DIAG=1`** — that prints a located, typed report at the moment of a true miss: the tower that fell through, the receiver's type/class name, the member name, and the placeholder being returned. It surfaces the bug at its **real call site** instead of downstream.

**It does not change behavior** — print-only, gated on the env var, near-zero cost when off — so the load-bearing placeholders keep working and nothing throws that didn't before.

Wired into the silent / swallowed miss points:
- `js_class_static_method_call`'s receiver-return — the `1` from `Class.staticMember()` (the `Union.make` case).
- `js_native_call_method`'s recursion-depth-guard empty-object return.
- `js_native_call_method`'s catch-all `<m> is not a function` throw — printed **before** the throw, so frameworks with broad `try`/`catch` (effect's fiber runtime) can't swallow the call site into a `{}` defect.

## Example

```
$ PERRY_DISPATCH_DIAG=1 ./prog        # (C as any).doesNotExist(7)
[perry dispatch-miss] static-member-call: class-ref `C` (id 1)."doesNotExist" did not resolve
  → returning the receiver (class ref). A dynamic dispatch fell through every tower; downstream
  this usually surfaces as a stray {}/1/[]/function. Check the call site for "doesNotExist".
```

That one line would have collapsed today's multi-hour `Union.make` hunt to seconds.

## Validation

- Quiet (0 reports) on working effect programs (`Effect.map` → 20); program output unchanged with the flag on.
- Zero regressions across the gap sweep (only the 3 pre-existing fails — `class_advanced`, `console_methods`, `derived_param_props`).
- `cargo fmt --check` clean.

Scope note: this catches the silent-placeholder / swallowed-throw class (the expensive one). HIR-level mis-lowerings that emit *wrong-but-valid* code (e.g. a namespace `.map` folded to `ArrayMap`) aren't runtime misses and aren't caught here. The deeper consolidation toward a single dynamic path is a larger refactor, deliberately out of scope. Refs #321.
