### PR TITLE
fix(gc): root IMPLICIT_THIS so moving GC can't strand the dispatch receiver (#1813)

### DIFF
--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -679,6 +679,12 @@ pub fn gc_init() {
     gc_register_mutable_root_scanner(crate::perf_hooks::scan_perf_entries_roots_mut);
     gc_register_mutable_root_scanner(transition_cache_mutable_root_scanner);
     gc_register_mutable_root_scanner(crate::object::scan_object_cache_roots_mut);
+    // Issue #1813: the implicit-`this` cell holds the live receiver across a
+    // dynamically-dispatched method body. A moving GC triggered from inside
+    // that body (e.g. @perryts/mysql Pool.acquire → handshake → nativeScramble
+    // under concurrent load) must rewrite the cell, or the body's next
+    // `this`-derived dispatch derefs a relocated receiver → SIGSEGV.
+    gc_register_mutable_root_scanner(crate::object::scan_implicit_this_roots_mut);
     gc_register_mutable_root_scanner(json_parse_mutable_root_scanner);
     gc_register_mutable_root_scanner(intern_table_mutable_root_scanner);
     gc_register_mutable_root_scanner(small_int_cache_mutable_root_scanner);

--- a/crates/perry-runtime/src/gc/tests/runtime_roots.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots.rs
@@ -264,6 +264,62 @@ fn test_runtime_root_visitor_marks_and_rewrites_nanbox_slot() {
 }
 
 #[test]
+fn test_implicit_this_root_scanner_marks_and_rewrites() {
+    // Regression for #1813. The implicit-`this` cell holds the NaN-boxed
+    // receiver across a dynamically-dispatched non-arrow method body. Under a
+    // moving GC triggered from inside that body (the @perryts/mysql
+    // Pool.acquire → handshake → nativeScramble path under concurrent load)
+    // the receiver relocates. The scanner must (a) MARK it so it is not swept
+    // when the cell is its only root, and (b) REWRITE the cell to the moved
+    // copy so the body's next `this`-derived dispatch derefs live memory
+    // instead of the stale slot (the reported SIGSEGV in js_native_call_method).
+    clear_marks();
+    clear_mark_seeds();
+    let prev_this = crate::object::js_implicit_this_get();
+
+    let nursery_user = crate::arena::arena_alloc_gc(64, 8, GC_TYPE_OBJECT);
+    let valid_ptrs = build_valid_pointer_set();
+    let old_user = crate::arena::arena_alloc_gc_old(64, 8, GC_TYPE_OBJECT);
+    let nursery_hdr = unsafe { header_from_user_ptr(nursery_user) as *mut GcHeader };
+
+    crate::object::js_implicit_this_set(f64::from_bits(ptr_bits(nursery_user as usize)));
+
+    // Mark phase: the live receiver must be discovered as a root.
+    crate::object::scan_implicit_this_roots_mut(&mut RuntimeRootVisitor::for_mark(&valid_ptrs));
+    unsafe {
+        assert_ne!(
+            (*nursery_hdr).gc_flags & GC_FLAG_MARKED,
+            0,
+            "IMPLICIT_THIS scanner must mark the receiver so GC does not sweep `this`"
+        );
+    }
+
+    // Rewrite phase: the cell must follow the forwarding pointer.
+    unsafe {
+        set_forwarding_address(nursery_hdr, old_user);
+    }
+    crate::object::scan_implicit_this_roots_mut(&mut RuntimeRootVisitor::for_rewrite(&valid_ptrs));
+    assert_eq!(
+        crate::object::js_implicit_this_get().to_bits(),
+        ptr_bits(old_user as usize),
+        "IMPLICIT_THIS must be rewritten to the receiver's relocated copy (#1813)"
+    );
+
+    // Idle / undefined cell must be a no-op (the default state between calls).
+    crate::object::js_implicit_this_set(f64::from_bits(crate::value::TAG_UNDEFINED));
+    crate::object::scan_implicit_this_roots_mut(&mut RuntimeRootVisitor::for_rewrite(&valid_ptrs));
+    assert_eq!(
+        crate::object::js_implicit_this_get().to_bits(),
+        crate::value::TAG_UNDEFINED,
+        "scanning the idle implicit-`this` cell must leave TAG_UNDEFINED untouched"
+    );
+
+    crate::object::js_implicit_this_set(prev_this);
+    clear_marks();
+    clear_mark_seeds();
+}
+
+#[test]
 fn test_runtime_root_visitor_rewrites_raw_pointer_slots() {
     let nursery_user = crate::arena::arena_alloc_gc(64, 8, GC_TYPE_OBJECT);
     let valid_ptrs = build_valid_pointer_set();

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -277,6 +277,38 @@ pub extern "C" fn js_implicit_this_set(value: f64) -> f64 {
     IMPLICIT_THIS.with(|c| f64::from_bits(c.replace(value.to_bits())))
 }
 
+/// GC mutable-root scanner for the implicit-`this` cell (issue #1813).
+///
+/// `IMPLICIT_THIS` holds the NaN-boxed receiver for the duration of a
+/// dynamically-dispatched non-arrow method body — set then restored by
+/// `js_native_call_method` and by the codegen `js_implicit_this_set`
+/// save/restore around `js_native_call_value`. That receiver is a live
+/// heap object for the whole call, but the cell is plain thread-local
+/// storage, so before this scanner it was invisible to GC: not a root.
+///
+/// When a moving GC runs *during* the method body — e.g. a nested stdlib
+/// pump draining network IO for `@perryts/mysql`'s `Pool.acquire` →
+/// handshake → `nativeScramble` under concurrent load — the receiver is
+/// evacuated/copied. Without a root slot to rewrite, the cell kept the
+/// stale pre-move pointer and the body's next `this`-derived dispatch
+/// dereferenced freed/relocated memory: the concurrent-load SIGSEGV in
+/// `js_native_call_method` reported in #1813. (It only surfaced under
+/// memory pressure because nursery copying / old-gen evacuation only move
+/// objects then — hence the load-dependent heisenbug.)
+///
+/// Marking also keeps `this` reachable when the cell is its only root.
+/// Non-pointer tags (the `TAG_UNDEFINED` default, plus null/int/bool)
+/// flow through `visit_nanbox_bits` as no-ops, so scanning the idle cell
+/// is safe.
+pub fn scan_implicit_this_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    IMPLICIT_THIS.with(|c| {
+        let mut bits = c.get();
+        if visitor.visit_nanbox_u64_slot(&mut bits) {
+            c.set(bits);
+        }
+    });
+}
+
 /// Read the u64 bits stored at `field_index` for `obj`, or `None` if absent.
 /// Positions never written are stored as `TAG_UNDEFINED`; this helper reports
 /// them as `None` so callers can return JS `undefined` uniformly with the


### PR DESCRIPTION
## Summary

Fixes #1813 — the SIGSEGV race in `js_native_call_method` reached via `@perryts/mysql`'s `nativeScramble` during concurrent `Pool.acquire` handshakes.

**Root cause:** the implicit-`this` thread-local cell (`IMPLICIT_THIS` in `crates/perry-runtime/src/object/mod.rs`) holds the NaN-boxed receiver for the duration of a dynamically-dispatched non-arrow method body. It is set/restored around the call by both `js_native_call_method` and the codegen `js_implicit_this_set` save/restore that wraps `js_native_call_value`. The receiver is a live heap object for the whole call — but the cell was plain thread-local storage that **no GC root scanner visited**.

When a moving GC runs *during* that method body — and under this workload it does: `Pool.acquire` runs a nested stdlib pump (`js_run_stdlib_pump`) that drains the handshake network IO, and the auth path allocates while building the scramble — the receiver gets evacuated (old-gen) or copied (nursery). With no root slot to rewrite, the cell kept the stale pre-move pointer, and the body's next `this`-derived dispatch dereferenced freed/relocated memory → the reported fault inside `js_native_call_method`.

This explains every symptom:
- **Concurrency-only / heisenbug:** nursery copying and the C4b old-gen evacuation policy only *move* objects under nursery/RSS pressure, which only happens once the pool opens new connections under load. Sequential (`-c 1`) never moves the receiver mid-handshake.
- **Auth-plugin-agnostic** (`mysql_native_password` SIGSEGV, `caching_sha2_password` wedge): both paths share concurrent connection-establishment that runs the handshake under the nested pump.
- Sibling of #1663 (same Fastify + `@perryts/mysql` POST shape): that one was a stale TLS pointer in the *microtask* drain; this is a stale TLS pointer in the *implicit-`this`* slot. Same class, different cell.

## Fix

Register `IMPLICIT_THIS` as a GC mutable-root scanner (`scan_implicit_this_roots_mut`), wired into `gc_init()` alongside the other object scanners. The mark phase keeps `this` reachable when the cell is its only root; the rewrite phase follows the forwarding pointer so the cell tracks the receiver's relocation. Non-pointer tags (the `TAG_UNDEFINED` default, null/int/bool) flow through `visit_nanbox_bits` as no-ops, so scanning the idle cell between calls is free and safe.

Because every codegen and runtime dispatch site funnels through this one cell, a single scanner closes the gap for all of them.

## Testing

- New deterministic regression test `test_implicit_this_root_scanner_marks_and_rewrites` (in `gc/tests/runtime_roots.rs`): sets the cell to a nursery receiver, asserts the scanner **marks** it (not swept) and **rewrites** it to the relocated copy after `set_forwarding_address`, and that an idle `TAG_UNDEFINED` cell is left untouched. Mirrors the existing receiver-rewrite tests for `js_native_call_method` (split/replace/bigint).
- Full `gc::` module: **281 passed, 0 failed**.
- Re-ran `gc::tests::runtime_roots` + `gc::tests::evacuation` under `PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1` (real moving GC + post-move stale-reference verifier): all green.
- `cargo fmt --all -- --check` clean.

I couldn't reproduce the full MySQL-under-concurrency e2e locally (needs the server + package + load), so validation is via the unit tests that exercise the exact moving-GC + implicit-`this` interaction the crash depends on, plus the force-evacuate/verify stress mode.
