### PR TITLE
docs: correct 'types erased / no runtime type checking' claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ First-resolved directory cached in `compile_package_dirs`; subsequent imports re
 
 ## Known Limitations
 
-- **No runtime type checking**: Types erased at compile time. `typeof` via NaN-boxing tags. `instanceof` via class ID chain.
+- **No runtime type *validation***: declared TS types aren't enforced at runtime (a `string` param accepts a number, no throw). Annotations are mostly erased — the exception is `emitDecoratorMetadata`, which retains `design:type`/`design:paramtypes` from annotations on decorated members (see `docs/src/language/decorators.md`). Runtime type *discrimination* does exist: `typeof` via NaN-boxing tags, `instanceof` via class ID chain.
 - **No shared mutable state across threads**: No `SharedArrayBuffer` or `Atomics`.
 
 ## Common Pitfalls & Patterns

--- a/docs/src/language/limitations.md
+++ b/docs/src/language/limitations.md
@@ -2,15 +2,21 @@
 
 Perry compiles a practical subset of TypeScript. This page documents what's not supported or works differently from Node.js/tsc.
 
-## No Runtime Type Checking
+## No Runtime Type Validation
 
-Types are erased at compile time. There is no runtime type system — Perry doesn't generate type guards or runtime type metadata.
+Declared TypeScript types are not enforced at runtime — Perry doesn't generate
+type guards from annotations, so a parameter typed `string` will accept a number
+without throwing.
 
 ```typescript
 {{#include ../../examples/language/limitations.ts:erased-types}}
 ```
 
-Use explicit `typeof` checks where runtime type discrimination is needed.
+Annotations are mostly erased, with one exception: when `emitDecoratorMetadata`
+applies, the `design:type` / `design:paramtypes` reflection metadata is derived
+from the annotations on decorated members and survives to runtime (see
+[Decorators](decorators.md)). Runtime type *discrimination* is available via
+explicit `typeof` checks and `instanceof`.
 
 ## No eval() or Dynamic Code
 


### PR DESCRIPTION
## What

Corrects an inaccurate claim in `CLAUDE.md` and `docs/src/language/limitations.md` that TypeScript types are *fully erased* and that Perry does *no runtime type checking*.

## Why it was wrong

Two issues:

1. **"Types erased at compile time" is false when `emitDecoratorMetadata` applies.** `crates/perry-hir/src/lower/decorators.rs` derives `design:type` / `design:paramtypes` reflection metadata directly from the annotations on decorated members (`type_metadata_expr()` maps `Type::Named` → `Expr::ClassRef`). `test-files/test_decorators_legacy_property_metadata.ts` asserts the annotated type survives to runtime by identity. So annotations are demonstrably retained — not erased — for decorated members.

2. **The "No runtime type checking" header contradicted its own body**, which then described `typeof` (NaN-box tags) and `instanceof` (class ID chain) — both of which *are* runtime type discrimination. `docs/src/language/limitations.md:7` separately claimed Perry "doesn't generate ... runtime type metadata", directly contradicting the Decorators section on the same page.

## What changed

Reframed both as **"no runtime type *validation*"** — the genuinely-true fact: declared types aren't enforced at runtime (a `string` param accepts a number without throwing). The decorator-metadata exception is now called out with a pointer to `docs/src/language/decorators.md`, and runtime type *discrimination* (`typeof`/`instanceof`) is described as the capability it is.

Docs-only; no code or behavior change.
