### PR TITLE
fix(hir,runtime): builtin-prototype .call/.apply (#1777) + fs.readdir/child_process.exec callbacks (#1779, #1780)

### DIFF
--- a/crates/perry-codegen/src/expr/child_proc.rs
+++ b/crates/perry-codegen/src/expr/child_proc.rs
@@ -175,24 +175,31 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             options,
             callback,
         } => {
+            // `exec(cmd[, options], callback)` — runs synchronously and fires
+            // the callback with `(err, stdout, stderr)` (see
+            // `js_child_process_exec`). The callback may sit in the options
+            // slot (`exec(cmd, cb)`), so pass both `options` and `callback` as
+            // NaN-boxed f64 and let the runtime locate the closure. With no
+            // callback the runtime returns the stdout string (legacy shape).
+            let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
             let cmd_box = lower_expr(ctx, command)?;
-            let blk = ctx.block();
-            let cmd_str = unbox_to_i64(blk, &cmd_box);
-            let opts_str = if let Some(o) = options {
-                let v = lower_expr(ctx, o)?;
-                unbox_to_i64(ctx.block(), &v)
+            let cmd_str = unbox_to_i64(ctx.block(), &cmd_box);
+            let arg1 = if let Some(o) = options {
+                lower_expr(ctx, o)?
             } else {
-                "0".to_string()
+                undef.clone()
             };
-            if let Some(cb) = callback {
-                let _ = lower_expr(ctx, cb)?;
-            }
+            let arg2 = if let Some(cb) = callback {
+                lower_expr(ctx, cb)?
+            } else {
+                undef.clone()
+            };
             let result = ctx.block().call(
-                I64,
-                "js_child_process_exec_sync",
-                &[(I64, &cmd_str), (I64, &opts_str)],
+                DOUBLE,
+                "js_child_process_exec",
+                &[(I64, &cmd_str), (DOUBLE, &arg1), (DOUBLE, &arg2)],
             );
-            Ok(nanbox_string_inline(ctx.block(), &result))
+            Ok(result)
         }
 
         Expr::ChildProcessGetProcessStatus(handle) => {

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -378,6 +378,10 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
 
     // ========== child_process ==========
     module.declare_function("js_child_process_exec_sync", I64, &[I64, I64]);
+    // exec(cmd, options?, callback?): cmd string ptr (I64), options + callback
+    // as NaN-boxed f64 in either slot; returns undefined (callback form) or the
+    // stdout string (no-callback form). See `js_child_process_exec`.
+    module.declare_function("js_child_process_exec", DOUBLE, &[I64, DOUBLE, DOUBLE]);
     module.declare_function("js_child_process_get_process_status", I64, &[DOUBLE]);
     module.declare_function("js_child_process_kill_process", I32, &[DOUBLE]);
     module.declare_function(

--- a/crates/perry-hir/src/lower/array_fold.rs
+++ b/crates/perry-hir/src/lower/array_fold.rs
@@ -168,3 +168,23 @@ pub(crate) fn is_known_string_prototype_method(name: &str) -> bool {
         | "isWellFormed" | "toWellFormed"
     )
 }
+
+/// Names of `Array.prototype.<name>` instance methods that Perry's runtime
+/// implements (or short-circuits) — used by the `typeof Array.prototype.<m>`
+/// / `typeof [].<m>` AST fold (#1777) so feature detection and the indirect
+/// prototype-borrow idiom (`[].slice.call(args)`) see callable values.
+pub(crate) fn is_known_array_prototype_method(name: &str) -> bool {
+    matches!(
+        name,
+        // mutators
+        "push" | "pop" | "shift" | "unshift" | "splice" | "sort" | "reverse"
+        | "fill" | "copyWithin"
+        // accessors / iteration
+        | "concat" | "slice" | "join" | "indexOf" | "lastIndexOf" | "includes"
+        | "find" | "findIndex" | "findLast" | "findLastIndex" | "at"
+        | "forEach" | "map" | "filter" | "reduce" | "reduceRight" | "some"
+        | "every" | "flat" | "flatMap" | "keys" | "values" | "entries"
+        | "toString" | "toLocaleString" | "with" | "toReversed" | "toSorted"
+        | "toSpliced"
+    )
+}

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -479,6 +479,152 @@ pub(super) fn try_native_module_method_apply_call(
     Ok(Some(super::lower_call(ctx, &synth_call)?))
 }
 
+/// Issue #1777 — `<builtinProto>.<method>.{call,apply}(thisArg, …)` where the
+/// receiver is a **builtin prototype** (`Array.prototype`, `String.prototype`,
+/// …) or an array/string literal (`[].slice.call(…)`, `"".charAt.call(…)`).
+///
+/// This is the general case of #1722. A builtin prototype method read as a
+/// *value* — `Array.prototype.slice`, `[].slice` — lowers to `undefined`, so
+/// `Array.prototype.slice.call(arguments, 1)` / `[].slice.call(arguments)`
+/// throws `TypeError: Cannot read properties of undefined (reading 'call')`.
+/// The arguments-to-array idiom (`[].slice.call(arguments)`) and prototype
+/// borrowing (`Array.prototype.map.call(arrayLike, fn)`) are pervasive in
+/// real-world JS and in the node-core test harness (`mustCall`/`mustSucceed`),
+/// the single largest runtime-fail cluster in the #800 radar.
+///
+/// Unlike the namespace case (#1722, where `this` is irrelevant), here the
+/// first argument **is** the receiver: `Proto.method.call(thisArg, ...rest)`
+/// is semantically `thisArg.method(...rest)`. We rewrite to that direct
+/// member call and re-dispatch through `lower_call`, so the normal
+/// type-directed method dispatch picks the right native impl based on
+/// `thisArg`'s runtime value (perry materializes `arguments` as a real
+/// array, so `arguments.slice(1)` dispatches to Array.prototype.slice — the
+/// exact behavior the idiom wants).
+///
+/// Conservative scope:
+///   - `.call(thisArg, a, b, …)`        → `thisArg.method(a, b, …)`
+///   - `.apply(thisArg)` / `.apply()`   → `thisArg.method()`
+///   - `.apply(thisArg, [a, b, …])`     → `thisArg.method(a, b, …)` — only a
+///     clean array *literal* (no holes/spreads); a non-literal apply-args
+///     array can't be statically expanded, so it falls through unchanged.
+///
+/// `Object.prototype.{toString,hasOwnProperty}.call(…)` is intentionally NOT
+/// matched here — the post-args hooks `try_object_prototype_call` /
+/// `try_object_has_own_call` rewrite those to dedicated runtime helpers
+/// (`js_object_to_string` / `js_object_has_own`), so `Object.prototype` is
+/// excluded from the receiver guard below to preserve that path. This hook
+/// only ever fires on a shape that currently *throws* (the method value reads
+/// `undefined`), so it cannot regress working code.
+pub(super) fn try_builtin_prototype_method_apply_call(
+    ctx: &mut LoweringContext,
+    call: &ast::CallExpr,
+    has_spread: bool,
+) -> Result<Option<Expr>> {
+    if has_spread {
+        return Ok(None);
+    }
+    let ast::Callee::Expr(callee_expr) = &call.callee else {
+        return Ok(None);
+    };
+    // Outer member: `<inner>.apply` / `<inner>.call`.
+    let ast::Expr::Member(outer) = callee_expr.as_ref() else {
+        return Ok(None);
+    };
+    let ast::MemberProp::Ident(outer_prop) = &outer.prop else {
+        return Ok(None);
+    };
+    let is_apply = match outer_prop.sym.as_ref() {
+        "apply" => true,
+        "call" => false,
+        _ => return Ok(None),
+    };
+    // Inner member: `<recv>.<method>` where `<method>` is a plain name and
+    // `<recv>` is a builtin-prototype reference or array/string literal.
+    let ast::Expr::Member(inner) = outer.obj.as_ref() else {
+        return Ok(None);
+    };
+    if !matches!(&inner.prop, ast::MemberProp::Ident(_)) {
+        return Ok(None);
+    }
+    if !is_builtin_prototype_receiver(ctx, inner.obj.as_ref()) {
+        return Ok(None);
+    }
+
+    // `.call`/`.apply` need at least the `thisArg` (the new receiver). A
+    // spread in the `thisArg` slot can't be statically resolved to a receiver.
+    let Some(this_arg) = call.args.first() else {
+        return Ok(None);
+    };
+    if this_arg.spread.is_some() {
+        return Ok(None);
+    }
+    let this_arg = this_arg.clone();
+
+    // Build the synthesized positional argument list (everything after thisArg).
+    let rest_args: Vec<ast::ExprOrSpread> = if is_apply {
+        match call.args.get(1) {
+            None => Vec::new(),
+            Some(arr_arg) => match arr_arg.expr.as_ref() {
+                ast::Expr::Array(arr) => {
+                    let clean = arr
+                        .elems
+                        .iter()
+                        .all(|e| matches!(e, Some(eos) if eos.spread.is_none()));
+                    if !clean {
+                        return Ok(None);
+                    }
+                    arr.elems.iter().filter_map(|e| e.clone()).collect()
+                }
+                // Non-literal apply-args array — can't statically expand.
+                _ => return Ok(None),
+            },
+        }
+    } else {
+        call.args.iter().skip(1).cloned().collect()
+    };
+
+    // Synthesize `(thisArg).<method>(rest_args)`: keep the original method
+    // name, swap the prototype/literal receiver for the real `thisArg`, drop
+    // the `.apply`/`.call` wrapper, and re-dispatch.
+    let mut synth_member = inner.clone();
+    synth_member.obj = this_arg.expr.clone();
+    let mut synth_call = call.clone();
+    synth_call.callee = ast::Callee::Expr(Box::new(ast::Expr::Member(synth_member)));
+    synth_call.args = rest_args;
+    Ok(Some(super::lower_call(ctx, &synth_call)?))
+}
+
+/// True when `recv` is a builtin constructor's `.prototype` (and that
+/// constructor name is not shadowed by a local/function binding) or an
+/// array/string literal — the receiver shapes whose prototype-method *values*
+/// currently lower to `undefined`. `Object` is deliberately excluded; see
+/// `try_builtin_prototype_method_apply_call`.
+fn is_builtin_prototype_receiver(ctx: &LoweringContext, recv: &ast::Expr) -> bool {
+    match recv {
+        // `Array.prototype` / `String.prototype` / … (not `Object`).
+        ast::Expr::Member(m) => {
+            let ast::MemberProp::Ident(p) = &m.prop else {
+                return false;
+            };
+            if p.sym.as_ref() != "prototype" {
+                return false;
+            }
+            let ast::Expr::Ident(base) = m.obj.as_ref() else {
+                return false;
+            };
+            let name = base.sym.as_ref();
+            matches!(name, "Array" | "String" | "Number" | "Boolean" | "Function")
+                && ctx.lookup_local(name).is_none()
+                && ctx.lookup_func(name).is_none()
+        }
+        // `[].slice.call(…)` / `[1,2,3].map.call(…)`.
+        ast::Expr::Array(_) => true,
+        // `"".charAt.call(…)`.
+        ast::Expr::Lit(ast::Lit::Str(_)) => true,
+        _ => false,
+    }
+}
+
 /// Followup to #957 / PR #959 — `Function('return this')()`.
 ///
 /// Every CJS/UMD-shaped library (lodash, underscore, Effect, …)

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -56,9 +56,9 @@ use globals::try_global_builtins;
 use imported_array_methods::try_imported_array_methods;
 use inline_array_methods::try_inline_array_methods;
 use intrinsics::{
-    check_eval_function_call, try_bare_regexp_call, try_embed_wasm, try_function_return_this,
-    try_iife_call_rewrite, try_native_module_method_apply_call, try_precompile,
-    try_require_literal_bail,
+    check_eval_function_call, try_bare_regexp_call, try_builtin_prototype_method_apply_call,
+    try_embed_wasm, try_function_return_this, try_iife_call_rewrite,
+    try_native_module_method_apply_call, try_precompile, try_require_literal_bail,
 };
 use local_array_methods::try_local_array_methods;
 use module_class_static::try_module_class_static;
@@ -159,6 +159,13 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
     // the dedicated per-method lowering runs (indirect invocation
     // otherwise reads the method value as `undefined`).
     if let Some(expr) = try_native_module_method_apply_call(ctx, call, has_spread)? {
+        return Ok(expr);
+    }
+    // #1777: `Array.prototype.slice.call(arguments, 1)` / `[].slice.call(…)` and
+    // the same on any builtin prototype — rewrite `Proto.method.{call,apply}(
+    // thisArg, …)` to `thisArg.method(…)` so the indirect prototype-borrow
+    // dispatches (the bare method value otherwise reads `undefined`).
+    if let Some(expr) = try_builtin_prototype_method_apply_call(ctx, call, has_spread)? {
         return Ok(expr);
     }
     if let Some(expr) = try_function_return_this(ctx, call, has_spread) {

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -756,6 +756,57 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                             return Ok(Expr::String("function".to_string()));
                         }
                     }
+                    // #1777: `typeof Array.prototype.slice` / `typeof [].slice`
+                    // (and String/Number/Boolean prototypes). The method value
+                    // read lowers to `undefined` today, so typeof was
+                    // "undefined" — but these are real functions in Node and the
+                    // `.call`/`.apply` dispatch is now wired (see
+                    // `try_builtin_prototype_method_apply_call`). Fold to
+                    // "function" for known prototype methods so feature
+                    // detection (`typeof X.slice === "function"`) agrees.
+                    if let ast::MemberProp::Ident(prop_ident) = &member.prop {
+                        let prop_name = prop_ident.sym.as_ref();
+                        // `<Ctor>.prototype.<method>`
+                        if let ast::Expr::Member(proto) = member.obj.as_ref() {
+                            if let (ast::Expr::Ident(base), ast::MemberProp::Ident(proto_prop)) =
+                                (proto.obj.as_ref(), &proto.prop)
+                            {
+                                let ctor = base.sym.as_ref();
+                                if proto_prop.sym.as_ref() == "prototype"
+                                    && ctx.lookup_local(ctor).is_none()
+                                {
+                                    let is_fn = match ctor {
+                                        "Array" => is_known_array_prototype_method(prop_name),
+                                        "String" => is_known_string_prototype_method(prop_name),
+                                        // Number/Boolean prototypes: the handful of
+                                        // real methods are all functions in Node.
+                                        "Number" => matches!(
+                                            prop_name,
+                                            "toFixed"
+                                                | "toPrecision"
+                                                | "toExponential"
+                                                | "toString"
+                                                | "valueOf"
+                                                | "toLocaleString"
+                                        ),
+                                        "Boolean" => {
+                                            matches!(prop_name, "toString" | "valueOf")
+                                        }
+                                        _ => false,
+                                    };
+                                    if is_fn {
+                                        return Ok(Expr::String("function".to_string()));
+                                    }
+                                }
+                            }
+                        }
+                        // `[].<method>` — array-literal prototype borrow.
+                        if matches!(member.obj.as_ref(), ast::Expr::Array(_))
+                            && is_known_array_prototype_method(prop_name)
+                        {
+                            return Ok(Expr::String("function".to_string()));
+                        }
+                    }
                 }
             }
             let operand = Box::new(lower_expr(ctx, &unary.arg)?);

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -78,8 +78,8 @@ pub(crate) use typed_parse::{extract_typed_parse_source_order, resolve_typed_par
 
 mod array_fold;
 pub(crate) use array_fold::{
-    is_known_array_static_method, is_known_object_static_method, is_known_string_prototype_method,
-    try_fold_array_method_call,
+    is_known_array_prototype_method, is_known_array_static_method, is_known_object_static_method,
+    is_known_string_prototype_method, try_fold_array_method_call,
 };
 
 mod lower_module_fn;

--- a/crates/perry-runtime/src/child_process.rs
+++ b/crates/perry-runtime/src/child_process.rs
@@ -445,17 +445,84 @@ pub extern "C" fn js_child_process_spawn(
     std::ptr::null_mut()
 }
 
-/// Execute a command asynchronously with shell
-/// Note: This returns a simplified handle for now
+/// `child_process.exec(command[, options], callback)`.
+///
+/// In Node this runs on the libuv threadpool and fires the callback on a
+/// later tick. Perry has no subprocess streaming / event-loop integration for
+/// child_process yet (full `spawn` with piped stdout/stderr + EventEmitter is
+/// still unimplemented — see #1780), but the dominant
+/// `exec(cmd, (err, stdout, stderr) => …)` shape only needs the *buffered*
+/// result. Run the command synchronously through the shell (like `execSync`)
+/// and invoke the callback immediately with `(err, stdout, stderr)` — the same
+/// immediate-callback model the async fs wrappers use. `exec` defaults to utf8
+/// encoding, so stdout/stderr are passed as strings.
+///
+/// `arg1`/`arg2` carry `(options, callback)`. The callback can sit in either
+/// slot — `exec(cmd, cb)` puts it in `arg1`, `exec(cmd, options, cb)` in
+/// `arg2` — so it's located the same way the fs callbacks disambiguate. With
+/// no callback we preserve the legacy behavior of returning the stdout string.
 #[no_mangle]
-pub extern "C" fn js_child_process_exec(
-    _cmd_ptr: *const StringHeader,
-    _options_ptr: *const ObjectHeader,
-    _callback_ptr: *const crate::closure::ClosureHeader,
-) -> *mut ObjectHeader {
-    // TODO: Implement async exec with callback
-    // For now, return null - async child processes need event loop integration
-    std::ptr::null_mut()
+pub extern "C" fn js_child_process_exec(cmd_ptr: *const StringHeader, arg1: f64, arg2: f64) -> f64 {
+    use crate::fs::extract_closure_ptr;
+    // The callback is whichever argument is a closure; prefer the later slot.
+    let cb = {
+        let c2 = extract_closure_ptr(arg2);
+        if !c2.is_null() {
+            c2
+        } else {
+            extract_closure_ptr(arg1)
+        }
+    };
+
+    let box_string = |bytes: &[u8]| -> f64 {
+        let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+        crate::value::js_nanbox_string(ptr as i64)
+    };
+
+    if cmd_ptr.is_null() {
+        if cb.is_null() {
+            return box_string(b"");
+        }
+        crate::closure::js_closure_call3(cb, TAG_NULL_F64, box_string(b""), box_string(b""));
+        return f64::from_bits(TAG_UNDEFINED_BITS);
+    }
+
+    let (stdout_bytes, stderr_bytes, success) = unsafe {
+        let len = (*cmd_ptr).byte_len as usize;
+        let data_ptr = (cmd_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        let cmd_bytes = std::slice::from_raw_parts(data_ptr, len);
+        match std::str::from_utf8(cmd_bytes) {
+            Ok(cmd_str) => {
+                #[cfg(unix)]
+                let output = Command::new("sh").arg("-c").arg(cmd_str).output();
+                #[cfg(windows)]
+                let output = Command::new("cmd").arg("/C").arg(cmd_str).output();
+                match output {
+                    Ok(o) => (o.stdout, o.stderr, o.status.success()),
+                    Err(e) => (Vec::new(), e.to_string().into_bytes(), false),
+                }
+            }
+            Err(_) => (Vec::new(), Vec::new(), false),
+        }
+    };
+
+    let stdout_box = box_string(&stdout_bytes);
+    if cb.is_null() {
+        // Legacy no-callback shape — return the stdout string.
+        return stdout_box;
+    }
+
+    let stderr_box = box_string(&stderr_bytes);
+    let err_val = if success {
+        TAG_NULL_F64
+    } else {
+        let msg = "Command failed";
+        let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+        let err_ptr = crate::error::js_error_new_with_message(msg_ptr);
+        crate::value::js_nanbox_pointer(err_ptr as i64)
+    };
+    crate::closure::js_closure_call3(cb, err_val, stdout_box, stderr_box);
+    f64::from_bits(TAG_UNDEFINED_BITS)
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/fs/callbacks.rs
+++ b/crates/perry-runtime/src/fs/callbacks.rs
@@ -217,6 +217,17 @@ pub extern "C" fn js_fs_exists_callback(path_value: f64, callback: f64) -> f64 {
 pub extern "C" fn js_fs_readdir_callback(path_value: f64, arg1: f64, arg2: f64) -> f64 {
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
     const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
+    // `fs.readdir(path, callback)` puts the callback in `arg1`; only
+    // `fs.readdir(path, options, callback)` carries real options there. Passing
+    // the callback closure to `js_fs_readdir_sync` as `options` (the old bug)
+    // made it read garbage out of the closure object and halt the program
+    // before the callback ever fired. Disambiguate the same way the stat/lstat
+    // callbacks do: a closure in `arg1` means there are no options.
+    let options = if extract_closure_ptr(arg1).is_null() {
+        arg1
+    } else {
+        f64::from_bits(TAG_UNDEFINED)
+    };
     let cb = last_callback(&[arg1, arg2]);
     unsafe {
         if let Some(err_val) = fs_callback_read_error(path_value, "scandir") {
@@ -224,7 +235,7 @@ pub extern "C" fn js_fs_readdir_callback(path_value: f64, arg1: f64, arg2: f64) 
             return f64::from_bits(TAG_UNDEFINED);
         }
     }
-    let entries = js_fs_readdir_sync(path_value, arg1);
+    let entries = js_fs_readdir_sync(path_value, options);
     let entries =
         f64::from_bits(crate::value::JSValue::pointer(entries.to_bits() as *const u8).bits());
     if !cb.is_null() {

--- a/test-files/test_issue_1777_prototype_borrow.ts
+++ b/test-files/test_issue_1777_prototype_borrow.ts
@@ -1,0 +1,44 @@
+// Issue #1777: Function.prototype.call/.apply on builtin prototype methods.
+// `Array.prototype.slice.call(arguments, 1)` / `[].slice.call(arguments)` and
+// the same on String/Object prototypes must dispatch to the native impl (the
+// method value previously read `undefined` and `.call`/`.apply` threw).
+
+// typeof of a borrowed prototype method is "function" (feature detection).
+console.log(typeof Array.prototype.slice);
+console.log(typeof Array.prototype.map);
+console.log(typeof [].slice);
+console.log(typeof String.prototype.charAt);
+console.log(typeof "".slice);
+
+// Array.prototype borrowing on a real array.
+console.log(Array.prototype.slice.call([9, 8, 7], 1));
+console.log(Array.prototype.map.call([1, 2, 3], (x: number) => x * 2));
+console.log([].slice.call([5, 6, 7], 1));
+console.log([].concat.call([1], [2, 3]));
+
+// .apply with a clean literal args array.
+console.log(Array.prototype.slice.apply([1, 2, 3, 4], [1, 3]));
+
+// The classic arguments-to-array idiom (perry materializes `arguments` as a
+// real array, so the borrowed slice dispatches just like Node's intent).
+function args2arr() {
+  return [].slice.call(arguments);
+}
+console.log(args2arr(1, 2, 3));
+
+function tailArgs() {
+  return Array.prototype.slice.call(arguments, 1);
+}
+console.log(tailArgs("a", "b", "c"));
+
+// String.prototype borrowing.
+console.log("hello".slice.call("world", 1));
+console.log(String.prototype.toUpperCase.call("abc"));
+
+// Object.prototype.{toString,hasOwnProperty}.call must still route through the
+// existing runtime-helper rewrites (not regressed by the new hook).
+const o = { a: 1 };
+console.log(Object.prototype.hasOwnProperty.call(o, "a"));
+console.log(Object.prototype.hasOwnProperty.call(o, "b"));
+console.log(Object.prototype.toString.call([]));
+console.log(Object.prototype.toString.call({}));

--- a/test-files/test_issue_1779_readdir_callback.ts
+++ b/test-files/test_issue_1779_readdir_callback.ts
@@ -1,0 +1,23 @@
+// Issue #1779: fs.readdir(path, callback) (2-arg form) halted execution — the
+// callback closure was passed to readdir_sync as the `options` argument, so it
+// read garbage and the program stopped before the callback fired. readdir now
+// disambiguates options-vs-callback like the stat/lstat callbacks do.
+import * as fs from "fs";
+
+const dir = "/tmp/perry_issue_1779_dir";
+fs.rmSync(dir, { recursive: true, force: true });
+fs.mkdirSync(dir, { recursive: true });
+fs.writeFileSync(dir + "/a.txt", "");
+fs.writeFileSync(dir + "/b.txt", "");
+
+// path + callback (the form that previously halted).
+fs.readdir(dir, (err: any, files: string[]) => {
+  console.log("readdir(path,cb):", err, files.sort().join(","));
+
+  // path + options + callback.
+  fs.readdir(dir, { withFileTypes: true }, (err2: any, entries: any[]) => {
+    const names = entries.map((e) => e.name).sort().join(",");
+    console.log("readdir(path,opts,cb):", err2, names);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/test-files/test_issue_1780_exec_callback.ts
+++ b/test-files/test_issue_1780_exec_callback.ts
@@ -1,0 +1,16 @@
+// Issue #1780: child_process.exec(cmd[, options], callback) was a null stub —
+// the callback never fired (codegen lowered it then discarded it). Now exec
+// runs the command and invokes the callback with (err, stdout, stderr).
+// Chained so the ordering is deterministic across Node (deferred callbacks)
+// and Perry (immediate callbacks).
+import { exec } from "child_process";
+
+exec("echo first", (err: any, stdout: string, stderr: string) => {
+  console.log("1 err:", err, "out:", stdout.trim(), "errOut:", JSON.stringify(stderr));
+  exec("echo second", { encoding: "utf8" }, (err2: any, stdout2: string) => {
+    console.log("2 out:", stdout2.trim());
+    exec("exit 4", (err3: any) => {
+      console.log("3 err is null:", err3 === null);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three related "method value reads as undefined / stub never fires" fixes surfaced by the #800 node-core radar.

### #1777 — builtin prototype method `.call`/`.apply` (the headline; ~117 radar fails)
`Array.prototype.slice.call(arguments, 1)` / `[].slice.call(args)` (and the same on String/Number/Boolean/Function prototypes) read the method value as `undefined`, so `.call`/`.apply` threw *"Cannot read properties of undefined (reading 'call')"*. This is the general case of #1722 (which only covered stdlib namespace methods).

- New HIR hook `try_builtin_prototype_method_apply_call` rewrites `Proto.method.{call,apply}(thisArg, ...rest)` → `thisArg.method(...rest)` and re-dispatches. The normal type-directed method dispatch then picks the native impl from `thisArg`'s runtime value — and since perry materializes `arguments` as a real array, the borrowed `slice`/`map`/… dispatch exactly as the idiom intends.
- `Object.prototype.{toString,hasOwnProperty}.call` is intentionally excluded so the existing runtime-helper rewrites (`js_object_to_string` / `js_object_has_own`) still win.
- Also folds `typeof Array.prototype.slice` / `typeof [].slice` / `typeof "".charAt` → `"function"` for feature detection.
- The hook only ever matches a shape that currently *throws*, so it carries no regression risk for working code.

### #1779 — `fs.readdir(path, callback)` halted execution
The 2-arg callback form passed the callback **closure** to `js_fs_readdir_sync` as the `options` argument (every other fs callback disambiguates via `extract_closure_ptr`; readdir didn't), so it read garbage out of the closure object and stopped the program before the callback fired. readdir now disambiguates options-vs-callback like `stat`/`lstat`/`statfs`.

The other value-gaps listed in #1779 (`fs.open`/FileHandle/`fs.promises` surface, `access`/`writeFile`/`mkdtemp` as values) already resolve correctly on current `main`; `lchmod`/`lchown` remain a hard `#463` unimplemented-surface error (deprecated / macOS-only). #1779 stays open for the radar to re-measure the residual "value is not a function" long tail.

### #1780 — `child_process.exec(cmd[, options], callback)` callback never fired
`js_child_process_exec` was a `null` stub and the codegen lowered the callback then discarded it. exec now runs the command (shell, like `execSync`) and invokes the callback with `(err, stdout, stderr)` using the same immediate-callback model the async fs wrappers use; the no-callback form still returns the stdout string.

Full async `spawn` with piped `stdout`/`stderr` **Readable streams + EventEmitter** (`child.stdout.on('data', …)`, `'exit'`/`'close'`) is the larger remaining part of #1780 and is still unimplemented — #1780 stays open for that.

## Tests
- `test-files/test_issue_1777_prototype_borrow.ts`
- `test-files/test_issue_1779_readdir_callback.ts`
- `test-files/test_issue_1780_exec_callback.ts`

All byte-identical to `node --experimental-strip-types`. Regression sweeps: fs node-suite 166/170 (the 4 fails are pre-existing rmdir/cp recursive-options, use neither readdir-callbacks nor exec); `typeof` feature-detection sweep 57/57 relevant; the #1722 `path/os apply-call` tests still pass. `cargo test -p perry-hir` and the `perry-runtime` child_process/fs tests pass.

Closes #1777.
Refs #1779, #1780.
