### PR TITLE
docs: clarify weak-reference primitives work, only collection is missing

### DIFF
--- a/docs/src/language/limitations.md
+++ b/docs/src/language/limitations.md
@@ -94,12 +94,28 @@ Object.setPrototypeOf(obj, proto);
 for class/prototype inspection patterns, but `Object.setPrototypeOf(...)` /
 `Reflect.setPrototypeOf(...)` do not mutate Perry's fixed class layout.
 
-## Weak References Are Not GC-Accurate
+## Weak References Retain Their Targets
 
-`WeakMap`, `WeakSet`, `WeakRef`, and `FinalizationRegistry` expose the expected
-API shape, but their weak-reference semantics are pragmatic, not GC-accurate:
-`WeakRef` keeps a strong reference internally, and `FinalizationRegistry`
-records registrations but does not run cleanup callbacks after collection.
+`WeakMap`, `WeakSet`, `WeakRef`, and `FinalizationRegistry` are implemented and
+their APIs behave as expected — `set` / `get` / `has` / `delete`, `add`,
+`deref()`, and `register` / `unregister` all work and return the right values.
+`WeakMap` and `WeakSet` use **reference** equality, so two distinct objects
+never collide on the same slot.
+
+The one caveat is that Perry's garbage collector does not yet treat these
+references as *weak*, so targets are **retained rather than collected**. In
+practice:
+
+- `WeakRef.deref()` always returns the original target (it is never reported as
+  collected).
+- `FinalizationRegistry` records registrations but never fires its cleanup
+  callback.
+- `WeakMap` / `WeakSet` keep their keys alive (they behave like a
+  reference-keyed `Map` / `Set`).
+
+This is safe for **correctness** — code that reads through these APIs gets the
+right values. It only matters if you depend on collection *timing* to reclaim
+memory or to run finalizer side effects.
 
 ## Limited Proxy Trapping
 


### PR DESCRIPTION
## What

Reword the **"Weak References Are Not GC-Accurate"** section of `docs/src/language/limitations.md` so it leads with what works instead of what doesn't.

## Why

[@WebReflection (Andrea Giammarchi)](https://x.com/WebReflection) read this section and came away thinking the weak-reference primitives "are just misleading and not working." They're not — `WeakMap`/`WeakSet`/`WeakRef`/`FinalizationRegistry` are implemented and their APIs return correct values (reference equality, `deref()` always resolves, `register`/`unregister` are tracked). The *only* real limitation is that the GC doesn't collect through them, so nothing is ever finalized/collected.

The old wording front-loaded "not GC-accurate" and buried the "it works" part. The rewrite:
- States the APIs work and return correct values.
- Calls out reference equality for `WeakMap`/`WeakSet`.
- Scopes the single caveat (targets retained, never collected/finalized) with a concrete per-type bullet list.
- Clarifies it's correctness-safe; only collection *timing* is affected.

## Notes

- Docs prose only; no code fence, no behavior change.
- Version bump + changelog intentionally omitted — fold in at merge to avoid patch-collision with parallel `main` commits.
- Separately filed #1830 for the `gc()`-in-try/catch segfault the same user reported (minimal cases all pass on `main`; needs his repro).
