### PR TITLE
feat(hir): generator function expressions — const g = function*(){} (#321)

### DIFF
--- a/crates/perry-codegen-arkts/src/tests.rs
+++ b/crates/perry-codegen-arkts/src/tests.rs
@@ -62,6 +62,7 @@ fn closure_stub() -> Expr {
         captures_this: false,
         enclosing_class: None,
         is_async: false,
+        is_generator: false,
     }
 }
 
@@ -629,6 +630,7 @@ fn for_each_lowers_array_map_in_vstack() {
             captures_this: false,
             enclosing_class: None,
             is_async: false,
+            is_generator: false,
         }),
     };
     m.init.push(app_with_body(nmc(
@@ -885,6 +887,7 @@ fn navstack_set_in_closure_rewrites_to_settext() {
                 captures_this: false,
                 enclosing_class: None,
                 is_async: false,
+                is_generator: false,
             },
         ],
     );
@@ -993,6 +996,7 @@ fn state_set_in_closure_rewrites_to_settext() {
         captures_this: false,
         enclosing_class: None,
         is_async: false,
+        is_generator: false,
     };
     m.init.push(app_with_body(nmc(
         "Button",
@@ -1162,6 +1166,7 @@ fn lazyvstack_with_array_map_emits_lazy_for_each() {
             captures_this: false,
             enclosing_class: None,
             is_async: false,
+            is_generator: false,
         }),
     };
     m.init
@@ -1467,6 +1472,7 @@ fn media_call_inside_button_closure_also_triggers_glue() {
         captures_this: false,
         enclosing_class: None,
         is_async: false,
+        is_generator: false,
     };
     m.init.push(app_with_body(nmc(
         "Button",
@@ -1953,6 +1959,7 @@ fn phase2_v35_widget_set_hidden_in_closure_emits_state_binding() {
         captures_this: false,
         enclosing_class: None,
         is_async: false,
+        is_generator: false,
     };
     m.init.push(let_widget(
         body_id,

--- a/crates/perry-codegen-arkts/tests/phase2_full_app_smoke.rs
+++ b/crates/perry-codegen-arkts/tests/phase2_full_app_smoke.rs
@@ -76,6 +76,7 @@ fn closure(params: Vec<Param>, body: Vec<Stmt>) -> Expr {
         captures_this: false,
         enclosing_class: None,
         is_async: false,
+        is_generator: false,
     }
 }
 

--- a/crates/perry-codegen/tests/shadow_slot_hygiene.rs
+++ b/crates/perry-codegen/tests/shadow_slot_hygiene.rs
@@ -409,6 +409,7 @@ fn closure_captured_write_shadow_module() -> Module {
                         captures_this: false,
                         enclosing_class: None,
                         is_async: false,
+                        is_generator: false,
                     }),
                 },
                 Stmt::Return(Some(Expr::LocalGet(51))),

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -297,6 +297,7 @@ fn typed_feedback_guards_direct_closure_call_specialization() {
                     captures_this: false,
                     enclosing_class: None,
                     is_async: false,
+                    is_generator: false,
                 }),
             },
             Stmt::Return(Some(Expr::Call {

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -1239,6 +1239,23 @@ pub(crate) fn lower_var_decl_with_destructuring(
             };
 
             let init = decl.init.as_ref().map(|e| lower_expr(ctx, e)).transpose()?;
+            // #321: a generator function EXPRESSION bound to a name (`const g =
+            // function*(){}`) — register the name so `for (x of g())` / `[...g()]`
+            // take the iterator-protocol path, matching named `function* g(){}`
+            // declarations. (`.next()`-driving already works via the lifted
+            // generator transform; this covers the for-of/spread call sites,
+            // whose detection in stmt_loops.rs is name-based.)
+            if let Some(Expr::Closure {
+                is_generator: true,
+                is_async,
+                ..
+            }) = &init
+            {
+                ctx.generator_func_names.insert(name.clone());
+                if *is_async {
+                    ctx.async_generator_func_names.insert(name.clone());
+                }
+            }
             let id = if let Some(pid) = pre_id {
                 pid
             } else if ctx.scope_depth == 0
@@ -1509,6 +1526,23 @@ pub(crate) fn lower_var_decl_with_destructuring(
             let name = get_binding_name(&decl.name)?;
             let ty = extract_binding_type(&decl.name);
             let init = decl.init.as_ref().map(|e| lower_expr(ctx, e)).transpose()?;
+            // #321: a generator function EXPRESSION bound to a name (`const g =
+            // function*(){}`) — register the name so `for (x of g())` / `[...g()]`
+            // take the iterator-protocol path, matching named `function* g(){}`
+            // declarations. (`.next()`-driving works regardless via the lifted
+            // generator transform; this covers the for-of/spread call sites,
+            // whose detection in stmt_loops.rs is name-based.)
+            if let Some(Expr::Closure {
+                is_generator: true,
+                is_async,
+                ..
+            }) = &init
+            {
+                ctx.generator_func_names.insert(name.clone());
+                if *is_async {
+                    ctx.async_generator_func_names.insert(name.clone());
+                }
+            }
             let id = if ctx.scope_depth == 0
                 && ctx.inside_block_scope == 0
                 && ctx.pre_registered_module_vars.remove(&name)

--- a/crates/perry-hir/src/dynamic_import.rs
+++ b/crates/perry-hir/src/dynamic_import.rs
@@ -1126,6 +1126,7 @@ mod tests {
             captures_this: false,
             enclosing_class: None,
             is_async: true,
+            is_generator: false,
         };
         m.init.push(Stmt::Expr(closure));
 
@@ -1167,6 +1168,7 @@ mod tests {
             captures_this: false,
             enclosing_class: None,
             is_async: false,
+            is_generator: false,
         };
         m.init.push(Stmt::Expr(closure));
         let consts = collect_module_const_locals(&m);
@@ -1295,6 +1297,7 @@ mod tests {
             captures_this: false,
             enclosing_class: None,
             is_async: true,
+            is_generator: false,
         };
         m.init.push(Stmt::Expr(closure));
         detect_top_level_await(&mut m);

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1638,6 +1638,12 @@ pub enum Expr {
         enclosing_class: Option<String>,
         /// Whether this is an async closure
         is_async: bool,
+        /// Whether this is a generator closure (a `function*(){}` expression).
+        /// Set by `lower_fn_expr`; the generator transform rewrites the body of
+        /// such closures (reusing the captures-aware generator transform) so
+        /// calling the closure returns a `{next,return,throw}` generator, then
+        /// clears the flag. Refs #321 (effect's `Effect.gen(function*(){...})`).
+        is_generator: bool,
     },
 
     // RegExp operations

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -202,6 +202,7 @@ impl LoweringContext {
                     captures_this: false,
                     enclosing_class: None,
                     is_async: false,
+                    is_generator: false,
                 };
             }
         }

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -268,6 +268,7 @@ pub(super) fn lower_arrow(ctx: &mut LoweringContext, arrow: &ast::ArrowExpr) -> 
         captures_this,
         enclosing_class,
         is_async: arrow.is_async,
+        is_generator: false,
     })
 }
 
@@ -537,6 +538,7 @@ pub(crate) fn lower_fn_expr(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) ->
         captures_this: false,
         enclosing_class: None,
         is_async: fn_expr.function.is_async,
+        is_generator: fn_expr.function.is_generator,
     })
 }
 

--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -243,6 +243,7 @@ fn lower_method_prop(
             captures_this,
             enclosing_class,
             is_async: method.function.is_async,
+            is_generator: false,
         }
     };
     Ok(Some((method_key, value_expr, uses_this)))
@@ -561,6 +562,7 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
             captures_this: body_uses_this,
             enclosing_class: None,
             is_async: false,
+            is_generator: false,
         };
         return Ok(Expr::Call {
             callee: Box::new(closure),
@@ -739,6 +741,7 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
         captures_this: body_uses_this,
         enclosing_class: None,
         is_async: false,
+        is_generator: false,
     };
     Ok(Expr::Call {
         callee: Box::new(closure),

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -1588,6 +1588,7 @@ pub(crate) fn try_desugar_reactive_text(
             captures_this: false,
             enclosing_class: None,
             is_async: false,
+            is_generator: false,
         };
 
         outer_body.push(Stmt::Expr(Expr::NativeMethodCall {
@@ -1625,6 +1626,7 @@ pub(crate) fn try_desugar_reactive_text(
         captures_this: false,
         enclosing_class: None,
         is_async: false,
+        is_generator: false,
     };
 
     Ok(Some(Expr::Call {

--- a/crates/perry-hir/src/lower/misc.rs
+++ b/crates/perry-hir/src/lower/misc.rs
@@ -207,6 +207,17 @@ pub(super) fn is_generator_call_expr(ctx: &LoweringContext, expr: &Expr) -> bool
                 }
             }
         }
+        // #321: a generator function EXPRESSION bound to a name (`const range =
+        // function*(){}`) lowers `range()` to `Call { callee: LocalGet(id) }`,
+        // not a `FuncRef`. Resolve the local's name and check the same set the
+        // for-of path registers into (see destructuring/var_decl.rs).
+        if let Expr::LocalGet(local_id) = callee.as_ref() {
+            if let Some((name, _, _)) = ctx.locals.iter().find(|(_, id, _)| id == local_id) {
+                if ctx.generator_func_names.contains(name) {
+                    return true;
+                }
+            }
+        }
     }
     false
 }

--- a/crates/perry-hir/src/lower/widget_decl.rs
+++ b/crates/perry-hir/src/lower/widget_decl.rs
@@ -224,6 +224,7 @@ pub(super) fn try_desugar_reactive_animate(
             captures_this: false,
             enclosing_class: None,
             is_async: false,
+            is_generator: false,
         };
 
         outer_body.push(Stmt::Expr(Expr::NativeMethodCall {
@@ -261,6 +262,7 @@ pub(super) fn try_desugar_reactive_animate(
         captures_this: false,
         enclosing_class: None,
         is_async: false,
+        is_generator: false,
     };
 
     Ok(Some(Expr::Call {

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -473,6 +473,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     captures_this: false,
                     enclosing_class: None,
                     is_async: fn_decl.function.is_async,
+                    is_generator: false,
                 };
                 result.push(Stmt::Let {
                     id: local_id,

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -686,6 +686,7 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
             captures_this,
             enclosing_class,
             is_async,
+            is_generator,
         } => Expr::Closure {
             func_id: *func_id,
             params: params
@@ -709,6 +710,7 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
             captures_this: *captures_this,
             enclosing_class: enclosing_class.clone(),
             is_async: *is_async,
+            is_generator: *is_generator,
         },
 
         // RegExp operations

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -461,7 +461,7 @@ impl SH for Expr {
             Expr::UrlSearchParamsSort(e) => { tag(h, 703); e.as_ref().hash(h); }
             Expr::UrlSearchParamsForEach { params, callback } => { tag(h, 704); params.as_ref().hash(h); callback.as_ref().hash(h); }
             Expr::Delete(e) => { tag(h, 381); e.as_ref().hash(h); }
-            Expr::Closure { func_id, params, return_type, body, captures, mutable_captures, captures_this, enclosing_class, is_async, } => { tag(h, 382); func_id.hash(h); params.hash(h); return_type.hash(h); body.hash(h); captures.hash(h); mutable_captures.hash(h); captures_this.hash(h); enclosing_class.hash(h); is_async.hash(h); }
+            Expr::Closure { func_id, params, return_type, body, captures, mutable_captures, captures_this, enclosing_class, is_async, is_generator, } => { tag(h, 382); func_id.hash(h); params.hash(h); return_type.hash(h); body.hash(h); captures.hash(h); mutable_captures.hash(h); captures_this.hash(h); enclosing_class.hash(h); is_async.hash(h); is_generator.hash(h); }
             Expr::RegExp { pattern, flags } => { tag(h, 383); pattern.hash(h); flags.hash(h); }
             Expr::RegExpDynamic { pattern, flags } => { tag(h, 475); pattern.as_ref().hash(h); if let Some(f_box) = flags { tag(h, 476); f_box.as_ref().hash(h); } else { tag(h, 477); } }
             Expr::RegExpTest { regex, string } => { tag(h, 384); regex.as_ref().hash(h); string.as_ref().hash(h); }

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -429,6 +429,7 @@ pub fn transform_generator_function_with_extra_captures(
         captures_this,
         enclosing_class: enclosing_class.clone(),
         is_async: false,
+        is_generator: false,
     };
 
     // Build .throw(error) closure.
@@ -552,6 +553,7 @@ pub fn transform_generator_function_with_extra_captures(
         captures_this,
         enclosing_class: enclosing_class.clone(),
         is_async: false,
+        is_generator: false,
     };
 
     if func.was_plain_async {
@@ -627,6 +629,7 @@ pub fn transform_generator_function_with_extra_captures(
             captures_this,
             enclosing_class: enclosing_class.clone(),
             is_async: false,
+            is_generator: false,
         };
         let iter_obj = Expr::Object(vec![
             ("next".to_string(), next_closure),
@@ -888,6 +891,7 @@ pub fn build_async_step_driver_direct(
         captures_this,
         enclosing_class: enclosing_class.clone(),
         is_async: false,
+        is_generator: false,
     };
 
     // Outer wrapper:

--- a/crates/perry-transform/src/generator/mod.rs
+++ b/crates/perry-transform/src/generator/mod.rs
@@ -63,6 +63,204 @@ pub fn transform_generators(module: &mut Module) {
             transform_generator_function(func, &mut next_local_id, &mut next_func_id);
         }
     }
+
+    // #321: generator function EXPRESSIONS (`function*(){}`, e.g. effect's
+    // `Effect.gen(function*(){...})`) lower to `Expr::Closure { is_generator:
+    // true }`. Apply the SAME state-machine transform to each, using the
+    // captures-aware path so the closure's outer captures are threaded into the
+    // generated next/return/throw step closures. After the transform the
+    // closure's body returns a `{next,return,throw}` object when called — the
+    // same contract as a named `function* g(){}`.
+    for func in &mut module.functions {
+        let mut body = std::mem::take(&mut func.body);
+        transform_generator_closures_in_stmts(&mut body, &mut next_local_id, &mut next_func_id);
+        func.body = body;
+    }
+    // Top-level statements live in `module.init`, not `module.functions` — a
+    // `const g = function*(){...}` at module scope (and effect's `Effect.gen(
+    // function*(){...})`) is here.
+    {
+        let mut init = std::mem::take(&mut module.init);
+        transform_generator_closures_in_stmts(&mut init, &mut next_local_id, &mut next_func_id);
+        module.init = init;
+    }
+    // Class method / constructor / accessor bodies can also hold generator
+    // expressions (effect's classes do).
+    for class in &mut module.classes {
+        if let Some(ctor) = &mut class.constructor {
+            let mut b = std::mem::take(&mut ctor.body);
+            transform_generator_closures_in_stmts(&mut b, &mut next_local_id, &mut next_func_id);
+            ctor.body = b;
+        }
+        for m in class
+            .methods
+            .iter_mut()
+            .chain(class.static_methods.iter_mut())
+            .chain(class.getters.iter_mut().map(|(_, f)| f))
+            .chain(class.setters.iter_mut().map(|(_, f)| f))
+        {
+            let mut b = std::mem::take(&mut m.body);
+            transform_generator_closures_in_stmts(&mut b, &mut next_local_id, &mut next_func_id);
+            m.body = b;
+        }
+    }
+}
+
+fn transform_generator_closures_in_stmts(
+    stmts: &mut [Stmt],
+    next_local_id: &mut LocalId,
+    next_func_id: &mut FuncId,
+) {
+    for s in stmts.iter_mut() {
+        transform_generator_closures_in_stmt(s, next_local_id, next_func_id);
+    }
+}
+
+fn transform_generator_closures_in_stmt(
+    stmt: &mut Stmt,
+    next_local_id: &mut LocalId,
+    next_func_id: &mut FuncId,
+) {
+    match stmt {
+        Stmt::Let { init: Some(e), .. } => {
+            transform_generator_closures_in_expr(e, next_local_id, next_func_id)
+        }
+        Stmt::Expr(e) | Stmt::Throw(e) => {
+            transform_generator_closures_in_expr(e, next_local_id, next_func_id)
+        }
+        Stmt::Return(Some(e)) => {
+            transform_generator_closures_in_expr(e, next_local_id, next_func_id)
+        }
+        Stmt::If {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            transform_generator_closures_in_expr(condition, next_local_id, next_func_id);
+            transform_generator_closures_in_stmts(then_branch, next_local_id, next_func_id);
+            if let Some(eb) = else_branch {
+                transform_generator_closures_in_stmts(eb, next_local_id, next_func_id);
+            }
+        }
+        Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+            transform_generator_closures_in_expr(condition, next_local_id, next_func_id);
+            transform_generator_closures_in_stmts(body, next_local_id, next_func_id);
+        }
+        Stmt::For {
+            init,
+            condition,
+            update,
+            body,
+        } => {
+            if let Some(i) = init {
+                transform_generator_closures_in_stmt(i, next_local_id, next_func_id);
+            }
+            if let Some(c) = condition {
+                transform_generator_closures_in_expr(c, next_local_id, next_func_id);
+            }
+            if let Some(u) = update {
+                transform_generator_closures_in_expr(u, next_local_id, next_func_id);
+            }
+            transform_generator_closures_in_stmts(body, next_local_id, next_func_id);
+        }
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            transform_generator_closures_in_stmts(body, next_local_id, next_func_id);
+            if let Some(c) = catch {
+                transform_generator_closures_in_stmts(&mut c.body, next_local_id, next_func_id);
+            }
+            if let Some(f) = finally {
+                transform_generator_closures_in_stmts(f, next_local_id, next_func_id);
+            }
+        }
+        Stmt::Switch {
+            discriminant,
+            cases,
+        } => {
+            transform_generator_closures_in_expr(discriminant, next_local_id, next_func_id);
+            for case in cases.iter_mut() {
+                if let Some(t) = &mut case.test {
+                    transform_generator_closures_in_expr(t, next_local_id, next_func_id);
+                }
+                transform_generator_closures_in_stmts(&mut case.body, next_local_id, next_func_id);
+            }
+        }
+        Stmt::Labeled { body, .. } => {
+            transform_generator_closures_in_stmt(body, next_local_id, next_func_id)
+        }
+        _ => {}
+    }
+}
+
+fn transform_generator_closures_in_expr(
+    expr: &mut Expr,
+    next_local_id: &mut LocalId,
+    next_func_id: &mut FuncId,
+) {
+    // Bottom-up: descend into this closure's own body (the expr-children walker
+    // deliberately does NOT visit Closure bodies), then into all sub-exprs, so
+    // nested generator closures are transformed before their enclosing one.
+    if let Expr::Closure { body, .. } = expr {
+        transform_generator_closures_in_stmts(body, next_local_id, next_func_id);
+    }
+    perry_hir::walker::walk_expr_children_mut(expr, &mut |child| {
+        transform_generator_closures_in_expr(child, next_local_id, next_func_id);
+    });
+
+    // Now transform THIS closure if it's a generator expression.
+    if let Expr::Closure {
+        is_generator,
+        params,
+        body,
+        captures,
+        mutable_captures,
+        captures_this,
+        enclosing_class,
+        is_async,
+        ..
+    } = expr
+    {
+        if *is_generator {
+            let synth_id = {
+                let id = *next_func_id;
+                *next_func_id += 1;
+                id
+            };
+            let mut synth = Function {
+                id: synth_id,
+                name: "__gen_closure_body".to_string(),
+                type_params: Vec::new(),
+                params: params.clone(),
+                return_type: Type::Any,
+                body: std::mem::take(body),
+                is_async: *is_async,
+                is_generator: true,
+                is_exported: false,
+                captures: Vec::new(),
+                decorators: Vec::new(),
+                was_plain_async: false,
+                was_unrolled: false,
+            };
+            transform_generator_function_with_extra_captures(
+                &mut synth,
+                next_local_id,
+                next_func_id,
+                captures,
+                mutable_captures,
+                *captures_this,
+                enclosing_class.clone(),
+            );
+            *body = synth.body;
+            // The closure now returns a {next,return,throw} object when called;
+            // it is no longer a generator (and not async — the transform handles
+            // the async-generator Promise-wrapping internally for `async function*`).
+            *is_generator = false;
+            *is_async = false;
+        }
+    }
 }
 
 /// Issue #1021: apply the same generator + async-step-driver transform that

--- a/crates/perry-transform/src/state_desugar.rs
+++ b/crates/perry-transform/src/state_desugar.rs
@@ -898,6 +898,7 @@ fn try_rewrite_foreach(
         captures_this: false,
         enclosing_class: None,
         is_async: false,
+        is_generator: false,
     };
     Some(Expr::Call {
         callee: Box::new(closure),
@@ -1090,6 +1091,7 @@ fn try_rewrite_navstack(
         captures_this: false,
         enclosing_class: None,
         is_async: false,
+        is_generator: false,
     };
     Some(Expr::Call {
         callee: Box::new(closure),
@@ -1325,6 +1327,7 @@ mod tests {
                     captures_this: false,
                     enclosing_class: None,
                     is_async: false,
+                    is_generator: false,
                 },
             ],
         })

--- a/test-files/test_gap_generator_expressions.ts
+++ b/test-files/test_gap_generator_expressions.ts
@@ -1,0 +1,67 @@
+// Test: Generator function EXPRESSIONS (`const g = function*(){}`) — #321/#29.
+// Distinct from named `function* g(){}` declarations (test_gap_generators.ts):
+// a generator bound to a const/let lowers to `Expr::Closure { is_generator }`
+// and is driven through the captures-aware generator transform. Validated
+// byte-for-byte against `node --experimental-strip-types`.
+
+// --- .next() driving with sent values + return value ---
+const g = function* () {
+  const x = yield 1;
+  const y = yield 2;
+  return (x ?? 0) + (y ?? 0) + 100;
+};
+const it: any = g();
+console.log(JSON.stringify(it.next()));   // {"value":1,"done":false}
+console.log(JSON.stringify(it.next(10))); // {"value":2,"done":false}
+console.log(JSON.stringify(it.next(20))); // {"value":130,"done":true}
+
+// --- for-of over a generator expression ---
+const range = function* () {
+  yield 1;
+  yield 2;
+  yield 3;
+};
+let sum = 0;
+for (const n of range()) sum += n;
+console.log("for-of:", sum); // for-of: 6
+
+// --- spread over a generator expression ---
+console.log("spread:", [...range()].join(",")); // spread: 1,2,3
+
+// --- yield* delegation to another generator expression ---
+const inner = function* () {
+  yield "a";
+  yield "b";
+};
+const outer = function* () {
+  yield* inner();
+  yield "c";
+};
+console.log("yield*:", [...outer()].join(",")); // yield*: a,b,c
+
+// --- generator expression capturing an outer variable ---
+const base = 100;
+const adder = function* () {
+  yield base + 1;
+  yield base + 2;
+};
+console.log("capture:", [...adder()].join(",")); // capture: 101,102
+
+// --- let-bound (not just const) ---
+let counter = function* () {
+  yield 7;
+  yield 8;
+};
+console.log("let:", [...counter()].join(",")); // let: 7,8
+
+// --- generator expression inside a function body ---
+function makeGen() {
+  const local = function* () {
+    yield 41;
+    yield 42;
+  };
+  return [...local()];
+}
+console.log("nested:", makeGen().join(",")); // nested: 41,42
+
+console.log("ALL GENERATOR-EXPRESSION TESTS PASSED");


### PR DESCRIPTION
## Summary

Adds support for **generator function expressions** — `const g = function*(){}` (and `let`-bound, nested-in-function, and `Effect.gen(function*(){...})` forms). Previously only *named* `function* g(){}` declarations were lowered through the generator state-machine transform; a `function*` bound to a name lowered to an `Expr::Closure` that was never recognised as a generator, so driving it (`.next()`, `for-of`, spread, `yield*`) produced wrong results or segfaulted.

Refs #321 (Effect framework — `Effect.gen` is built on generator expressions), #29.

## What changed

1. **`Expr::Closure` gains an `is_generator: bool` field** (`perry-hir/src/ir/expr.rs`), set from `fn_expr.function.is_generator` in `lower_fn_expr`. Threaded through monomorph substitution and stable-hash; arrows are always `false`.

2. **The generator transform now visits closure bodies** (`perry-transform/src/generator/mod.rs`). After transforming top-level `module.functions`, it walks `module.functions` bodies, `module.init` (where top-level `const g = function*(){}` and `Effect.gen(function*(){...})` live), and every class constructor / method / accessor body. Each `Expr::Closure { is_generator: true }` is run through the existing **captures-aware** `transform_generator_function_with_extra_captures`, so the closure's outer captures are threaded into the generated `next`/`return`/`throw` step closures. After the transform the closure returns a `{next,return,throw}` object when called — the same contract as a named generator — and its `is_generator`/`is_async` flags are cleared.

3. **for-of / spread call-site detection** (name-based) now recognises generator *expressions*. `const g = function*(){}` registers `g` in `generator_func_names` (`destructuring/var_decl.rs`), so `for (x of g())` takes the iterator-protocol path. `is_generator_call_expr` (`lower/misc.rs`) additionally resolves a `LocalGet` callee's name (a `const`-bound gen expr lowers `g()` to `Call { callee: LocalGet }`, not `FuncRef`), so `[...g()]` wraps in `IteratorToArray`. `yield*` delegation to a gen-expr falls out of the same detection.

## Validation

`test-files/test_gap_generator_expressions.ts` (new) — byte-for-byte identical to `node --experimental-strip-types`:

- `.next()` driving with sent values + return value
- `for-of`, spread `[...g()]`
- `yield*` delegation to another generator expression
- capturing an outer variable; `let`-bound; nested inside a function body

Regression checks (all byte-identical to node):
- `test_gap_generators.ts` (named generators) — unchanged
- `test_closure_capture_types`, `test_closure_complex`, `test_edge_closures`, `test_edge_higher_order`, `test_edge_iteration`, `test_compat_arrays_iterators`, `test_gap_closures`, `test_gap_async_advanced`, `test_async_chain`

`cargo fmt --all --check` clean; full workspace test build compiles.

## Not in scope (pre-existing, follow-ups)

`Effect.gen` end-to-end still needs two further fixes, both of which **already affect named generators** (so they are orthogonal to this change, not regressions):

- #1831 — `yield*` over an **arbitrary iterable** (`yield* [1,2,3]`, `yield* someEffect`); mishandled for named generators too.
- #1832 — `yield*`-delegation **resume-value forwarding** (`it.next("X")` should reach the inner generator's `yield` expression).
