### PR TITLE
fix(generator): yield* forwards resume value to delegated iterator (#1832)

### DIFF
--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -48,12 +48,27 @@ pub fn linearize_body(
                 let del_iter_id = alloc_local(next_local_id);
                 let del_result_id = alloc_local(next_local_id);
 
+                // Initial pull: `__del_iter.next()` with no argument (the value
+                // passed to the *first* `next()` of a generator is discarded per
+                // spec).
                 let next_call = Expr::Call {
                     callee: Box::new(Expr::PropertyGet {
                         object: Box::new(Expr::LocalGet(del_iter_id)),
                         property: "next".to_string(),
                     }),
                     args: vec![],
+                    type_args: vec![],
+                };
+                // #1832: in-loop pull must forward the value the *outer* generator
+                // was resumed with (`outer.next(v)` → stored in `sent_id`) into the
+                // delegated iterator's `next(v)`, so `yield*`-delegated two-way
+                // communication matches spec. Argless here silently dropped it.
+                let next_call_resumed = Expr::Call {
+                    callee: Box::new(Expr::PropertyGet {
+                        object: Box::new(Expr::LocalGet(del_iter_id)),
+                        property: "next".to_string(),
+                    }),
+                    args: vec![Expr::LocalGet(sent_id)],
                     type_args: vec![],
                 };
 
@@ -64,7 +79,7 @@ pub fn linearize_body(
                 )));
                 current.push(Stmt::Expr(Expr::LocalSet(
                     del_result_id,
-                    Box::new(next_call.clone()),
+                    Box::new(next_call),
                 )));
 
                 // Build the while loop with yield
@@ -76,7 +91,7 @@ pub fn linearize_body(
                         })),
                         delegate: false,
                     }),
-                    Stmt::Expr(Expr::LocalSet(del_result_id, Box::new(next_call))),
+                    Stmt::Expr(Expr::LocalSet(del_result_id, Box::new(next_call_resumed))),
                 ];
 
                 let while_stmt = Stmt::While {
@@ -647,12 +662,22 @@ pub fn linearize_body(
                 let del_iter_id = alloc_local(next_local_id);
                 let del_result_id = alloc_local(next_local_id);
 
+                // Initial pull: argless (first `next()` value is discarded per spec).
                 let next_call = Expr::Call {
                     callee: Box::new(Expr::PropertyGet {
                         object: Box::new(Expr::LocalGet(del_iter_id)),
                         property: "next".to_string(),
                     }),
                     args: vec![],
+                    type_args: vec![],
+                };
+                // #1832: in-loop pull forwards the outer resume value (`sent_id`).
+                let next_call_resumed = Expr::Call {
+                    callee: Box::new(Expr::PropertyGet {
+                        object: Box::new(Expr::LocalGet(del_iter_id)),
+                        property: "next".to_string(),
+                    }),
+                    args: vec![Expr::LocalGet(sent_id)],
                     type_args: vec![],
                 };
 
@@ -662,7 +687,7 @@ pub fn linearize_body(
                 )));
                 current.push(Stmt::Expr(Expr::LocalSet(
                     del_result_id,
-                    Box::new(next_call.clone()),
+                    Box::new(next_call),
                 )));
 
                 let while_body = vec![
@@ -673,7 +698,7 @@ pub fn linearize_body(
                         })),
                         delegate: false,
                     }),
-                    Stmt::Expr(Expr::LocalSet(del_result_id, Box::new(next_call))),
+                    Stmt::Expr(Expr::LocalSet(del_result_id, Box::new(next_call_resumed))),
                 ];
 
                 let while_stmt = Stmt::While {

--- a/test-files/test_gap_yield_star_resume.ts
+++ b/test-files/test_gap_yield_star_resume.ts
@@ -1,0 +1,49 @@
+// Test: yield*-delegation forwards the resume value (#1832).
+// `outer.next(v)` across a `yield*` boundary must deliver `v` to the
+// delegated generator's pending `yield` expression. Previously the in-loop
+// `delegatedIterator.next()` was called with no argument, dropping `v`.
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+// --- bare yield* (statement position) forwards resume value ---
+function* inner1() {
+  const a = yield "i1";
+  const b = yield "i2";
+  return `inner:${a},${b}`;
+}
+function* outer1() {
+  const ret = yield* inner1() as any;
+  yield `ret=${ret}`;
+}
+const it1: any = outer1();
+console.log(JSON.stringify(it1.next()));        // {"value":"i1","done":false}
+console.log(JSON.stringify(it1.next("A")));     // {"value":"i2","done":false}
+console.log(JSON.stringify(it1.next("B")));     // {"value":"ret=inner:A,B","done":false}
+console.log(JSON.stringify(it1.next()));        // {"value":undefined→ ... ,"done":true}
+
+// --- const x = yield* inner() captures the inner return; resume flows in ---
+function* inner2() {
+  const r = yield "y";
+  return "innerRet:" + r;
+}
+function* g2() {
+  const a = yield* inner2() as any;
+  return "got:" + a;
+}
+const it2: any = g2();
+console.log(JSON.stringify(it2.next()));         // {"value":"y","done":false}
+console.log(JSON.stringify(it2.next("RESUME"))); // {"value":"got:innerRet:RESUME","done":true}
+
+// --- without an explicit cast (bare expression) ---
+function* inner3() {
+  const v = yield 1;
+  return v + 10;
+}
+function* g3() {
+  const out = yield* inner3();
+  return out;
+}
+const it3: any = g3();
+console.log(JSON.stringify(it3.next()));      // {"value":1,"done":false}
+console.log(JSON.stringify(it3.next(5)));     // {"value":15,"done":true}
+
+console.log("ALL YIELD-STAR-RESUME TESTS PASSED");


### PR DESCRIPTION
## Summary

Fixes `yield*`-delegation **resume-value forwarding** (#1832). When the outer generator is resumed with a value — `outerIt.next(v)` — that `v` must be delivered to the delegated generator's pending `yield` expression. The desugared `yield*` loop called the delegated iterator's `.next()` with **no argument**, silently dropping `v`.

Affects named generators (and, with #1829, generator expressions). Part of the `Effect.gen` path for #321 (`Effect.gen` drives a generator via `.next(value)` across a `yield*`).

## Fix

In both `yield*` desugaring arms in `crates/perry-transform/src/generator/linearize.rs` (statement-position `yield* inner()` and `const x = yield* inner()`), the **in-loop** pull now passes `sent_id` — the local holding the value the outer generator was resumed with — to the delegated `.next(sent)`. The **initial** pull stays argless (the value passed to a generator's first `next()` is discarded per spec).

## Before / after

```ts
function* inner() { const r = yield "y"; return "innerRet:" + r; }
function* g() { const a = yield* inner(); return "got:" + a; }
const it: any = g();
it.next();          // {value:"y", done:false}
it.next("RESUME");  // node: {value:"got:innerRet:RESUME", done:true}
                    // perry before: {value:"got:innerRet:undefined", done:true}
                    // perry after:  {value:"got:innerRet:RESUME", done:true}  ✓
```

## Validation

`test-files/test_gap_yield_star_resume.ts` (new) — byte-for-byte identical to `node --experimental-strip-types`: statement-position `yield*`, `const x = yield* inner()`, the `yield* inner() as any` cast form, and a bare-expression form, each exercising two-way resume across the delegation boundary.

Regression: `test_gap_generators.ts` unchanged (byte-identical to node); `perry-transform` unit tests green; `cargo fmt --all --check` clean.

## Follow-up

`yield*` over an arbitrary **iterable** that is not already an iterator (`yield* [1,2,3]`, `yield* anEffect`) is tracked separately in #1831 (needs `[Symbol.iterator]()` resolution before driving). That is the remaining `Effect.gen` blocker.
