### PR TITLE
fix(gc): restore shadow stack on exception unwind (#1830)

### DIFF
--- a/crates/perry-runtime/src/exception.rs
+++ b/crates/perry-runtime/src/exception.rs
@@ -31,6 +31,8 @@ impl JmpBuf {
     }
 }
 
+use crate::gc::{shadow_stack_restore, shadow_stack_savepoint, ShadowSavepoint};
+
 extern "C" {
     fn longjmp(env: *mut i32, val: i32) -> !;
 }
@@ -47,6 +49,11 @@ const MAX_TRY_DEPTH: usize = 128;
 /// corrupt under any concurrent throw.
 struct ExceptionState {
     jump_buffers: [JmpBuf; MAX_TRY_DEPTH],
+    /// Shadow-stack depth captured when each `try` block was pushed, so the
+    /// unwind path can drop the orphaned frames `longjmp` leaves behind (see
+    /// `js_throw` / issue #1830). Indexed by try-depth, in lockstep with
+    /// `jump_buffers`.
+    shadow_savepoints: [ShadowSavepoint; MAX_TRY_DEPTH],
     try_depth: usize,
     current_exception: f64,
     has_exception: bool,
@@ -57,6 +64,7 @@ impl ExceptionState {
     const fn new() -> Self {
         ExceptionState {
             jump_buffers: [JmpBuf::new(); MAX_TRY_DEPTH],
+            shadow_savepoints: [ShadowSavepoint::EMPTY; MAX_TRY_DEPTH],
             try_depth: 0,
             current_exception: 0.0,
             has_exception: false,
@@ -84,6 +92,10 @@ pub extern "C" fn js_try_push() -> *mut i32 {
             panic!("Try block nesting too deep");
         }
         let depth = (*s).try_depth;
+        // Capture the shadow-stack depth now, before the protected region
+        // can push any callee frames, so the unwind path can restore to
+        // exactly this point and drop the frames `longjmp` orphans (#1830).
+        (*s).shadow_savepoints[depth] = shadow_stack_savepoint();
         (*s).try_depth += 1;
         (*s).jump_buffers[depth].as_mut_ptr()
     })
@@ -121,6 +133,13 @@ pub extern "C" fn js_throw(value: f64) -> ! {
         }
 
         let depth = (*s).try_depth - 1;
+        // Drop the shadow-stack frames of the functions we are about to
+        // unwind past. `longjmp` skips their epilogues (and therefore their
+        // `js_shadow_frame_pop` calls), so without this the next GC would
+        // scan — and the copying collector would rewrite — slots living in
+        // already-unwound stack frames (#1830). Restore to the depth captured
+        // when this `try` was pushed.
+        shadow_stack_restore((*s).shadow_savepoints[depth]);
         (*s).jump_buffers[depth].as_mut_ptr()
     });
     unsafe { longjmp(jb_ptr, 1) }
@@ -297,4 +316,72 @@ pub(crate) fn test_set_exception(value: f64) {
         (*s).current_exception = value;
         (*s).has_exception = true;
     });
+}
+
+#[cfg(test)]
+pub(crate) fn test_try_depth() -> usize {
+    with_exception_state(|s| unsafe { (*s).try_depth })
+}
+
+/// Replay the shadow-stack restore that `js_throw` performs for the
+/// innermost open `try`, without the `longjmp` (which can't return in a
+/// unit test). Lets tests exercise the real #1830 savepoint/restore path
+/// recorded by `js_try_push`.
+#[cfg(test)]
+pub(crate) fn test_unwind_innermost_shadow_restore() {
+    with_exception_state(|s| unsafe {
+        assert!((*s).try_depth > 0, "no open try to unwind");
+        let depth = (*s).try_depth - 1;
+        shadow_stack_restore((*s).shadow_savepoints[depth]);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gc::{
+        js_shadow_frame_pop, js_shadow_frame_push, js_shadow_slot_set, shadow_stack_depth,
+    };
+
+    // Issue #1830: js_try_push must capture a shadow-stack savepoint, and the
+    // unwind path (js_throw, here replayed without the longjmp) must restore
+    // it so the orphaned frames of the functions being unwound past are
+    // dropped before any later GC scans roots. All assertions are relative to
+    // the entry state so this is robust under `--test-threads=1` (shared TLS).
+    #[test]
+    fn js_throw_path_restores_shadow_stack_across_unwound_frames() {
+        let base_depth = shadow_stack_depth();
+        let base_try = test_try_depth();
+
+        // Establish run()'s frame.
+        let run_frame = js_shadow_frame_push(1);
+        js_shadow_slot_set(0, 0x7FFD_0000_0000_0001);
+        let depth_at_try = shadow_stack_depth();
+
+        // try { ... } — js_try_push records the savepoint at this depth.
+        let _jb = js_try_push();
+        assert_eq!(test_try_depth(), base_try + 1);
+
+        // Callees push frames and the innermost throws (their pops skipped).
+        let _f1 = js_shadow_frame_push(1);
+        js_shadow_slot_set(0, 0x7FFD_0000_0000_00A1);
+        let _f2 = js_shadow_frame_push(2);
+        js_shadow_slot_set(0, 0x7FFD_0000_0000_00B1);
+        assert_eq!(shadow_stack_depth(), depth_at_try + 2);
+
+        // Replay js_throw's shadow restore (the longjmp itself can't return in
+        // a unit test), then the catch path's js_try_end().
+        test_unwind_innermost_shadow_restore();
+        js_try_end();
+
+        assert_eq!(test_try_depth(), base_try);
+        assert_eq!(
+            shadow_stack_depth(),
+            depth_at_try,
+            "unwind dropped the orphaned callee frames"
+        );
+
+        js_shadow_frame_pop(run_frame);
+        assert_eq!(shadow_stack_depth(), base_depth);
+    }
 }

--- a/crates/perry-runtime/src/gc/roots.rs
+++ b/crates/perry-runtime/src/gc/roots.rs
@@ -19,6 +19,7 @@ pub use shadow_stack::{
     js_shadow_frame_pop, js_shadow_frame_push, js_shadow_slot_bind, js_shadow_slot_get,
     js_shadow_slot_set, shadow_stack_depth, SHADOW_STACK_GROW_RESERVE, SHADOW_STACK_HEADER_SLOTS,
 };
+pub(crate) use shadow_stack::{shadow_stack_restore, shadow_stack_savepoint, ShadowSavepoint};
 
 pub type MutableRootScanner = for<'a> fn(&mut RuntimeRootVisitor<'a>);
 

--- a/crates/perry-runtime/src/gc/roots/shadow_stack.rs
+++ b/crates/perry-runtime/src/gc/roots/shadow_stack.rs
@@ -211,3 +211,69 @@ pub fn shadow_stack_depth() -> usize {
 pub(crate) fn shadow_stack_has_active_frame() -> bool {
     SHADOW.with(|cell| unsafe { (*cell.get()).frame_top != usize::MAX })
 }
+
+/// A snapshot of the shadow stack's depth at a point in time. Captured
+/// when a `try` block is established and replayed on the exception
+/// unwind path (issue #1830).
+///
+/// Why this exists: exception unwinding uses `longjmp` (see
+/// `crate::exception`), which restores the native SP/registers to the
+/// `setjmp` site WITHOUT running the epilogues of the functions being
+/// unwound past. Those functions emitted `js_shadow_frame_pop` before
+/// their `ret`, so on a normal return the shadow stack stays balanced —
+/// but a `longjmp` jumps straight over every skipped pop. The shadow
+/// stack's `frame_top` is then left pointing at the deepest (now-dead)
+/// callee frame. Until the unwinding function eventually returns, any GC
+/// that scans roots (`visit_shadow_stack_root_slots`) would walk those
+/// orphaned frames, reading — and, on the copying/evacuating path,
+/// *writing back into* — `slot_ptrs` that point into stack memory that
+/// has already been unwound and is being reused by the catch body.
+#[derive(Copy, Clone)]
+pub(crate) struct ShadowSavepoint {
+    frame_top: usize,
+    len: usize,
+}
+
+impl ShadowSavepoint {
+    /// Identity savepoint for an empty shadow stack — used to
+    /// zero-initialize the per-try-depth savepoint table.
+    pub(crate) const EMPTY: ShadowSavepoint = ShadowSavepoint {
+        frame_top: usize::MAX,
+        len: 0,
+    };
+}
+
+/// Capture the current shadow-stack depth so it can be restored after a
+/// non-local exit. Call at `js_try_push` time, before the protected
+/// region can push any callee frames.
+pub(crate) fn shadow_stack_savepoint() -> ShadowSavepoint {
+    SHADOW.with(|cell| unsafe {
+        let s = &*cell.get();
+        ShadowSavepoint {
+            frame_top: s.frame_top,
+            len: s.stack.len(),
+        }
+    })
+}
+
+/// Restore the shadow stack to a previously-captured savepoint, dropping
+/// any frames pushed after it. Called on the exception unwind path
+/// (before `longjmp`) so the orphaned shadow frames of the functions
+/// being unwound past are never scanned by a later GC (issue #1830).
+///
+/// A `longjmp` can only have *added* frames relative to the savepoint
+/// (the protected region runs strictly deeper than the `try`), so the
+/// saved length is `<=` the current length in the well-formed case. The
+/// `<=` guard is purely defensive against a corrupted savepoint; we
+/// always reset `frame_top` because it is the value the scanner reads.
+pub(crate) fn shadow_stack_restore(sp: ShadowSavepoint) {
+    SHADOW.with(|cell| unsafe {
+        let s = &mut *cell.get();
+        if sp.len <= s.stack.len() {
+            s.stack.truncate(sp.len);
+            s.slot_ptrs.truncate(sp.len);
+            s.active.truncate(sp.len);
+        }
+        s.frame_top = sp.frame_top;
+    });
+}

--- a/crates/perry-runtime/src/gc/tests/roots.rs
+++ b/crates/perry-runtime/src/gc/tests/roots.rs
@@ -689,3 +689,99 @@ fn test_shadow_stack_root_scanner_zero_slot_frames() {
     js_shadow_frame_pop(b);
     js_shadow_frame_pop(a);
 }
+
+// Issue #1830: a `throw` unwinds via `longjmp`, which skips the
+// `js_shadow_frame_pop` epilogues of the functions being unwound past, so
+// `frame_top` is left pointing at orphaned (now-dead) callee frames. A GC in
+// the catch body would then scan — and the copying collector would rewrite —
+// slots in stack frames that no longer exist. `js_try_push` captures a
+// `ShadowSavepoint` and `js_throw` restores it before the `longjmp` so the
+// orphaned frames are dropped first. This exercises the savepoint/restore pair.
+#[test]
+fn test_shadow_stack_savepoint_restore_drops_orphaned_frames() {
+    reset_shadow_stack();
+
+    // run()'s frame: two live pointer slots.
+    let run_frame = js_shadow_frame_push(2);
+    js_shadow_slot_set(0, 0x7FFD_0000_1111_1111);
+    js_shadow_slot_set(1, 0x7FFD_0000_2222_2222);
+
+    // js_try_push captures the savepoint here, before any callee frame.
+    let sp = shadow_stack_savepoint();
+
+    // Inlined/called deep1 -> deep2 -> deep3 each push a frame; deep3 throws,
+    // so none of their pops run.
+    let _d1 = js_shadow_frame_push(1);
+    js_shadow_slot_set(0, 0x7FFD_0000_AAAA_AAAA);
+    let _d2 = js_shadow_frame_push(1);
+    js_shadow_slot_set(0, 0x7FFD_0000_BBBB_BBBB);
+    let _d3 = js_shadow_frame_push(2);
+    js_shadow_slot_set(0, 0x7FFD_0000_CCCC_CCCC);
+    js_shadow_slot_set(1, 0x7FFD_0000_DDDD_DDDD);
+
+    // Pre-restore (the #1830 bug): a GC scans the orphaned deep frames too.
+    let mut before: Vec<u64> = Vec::new();
+    shadow_stack_root_scanner(&mut |v| before.push(v.to_bits()));
+    assert_eq!(shadow_stack_depth(), 4);
+    assert_eq!(before.len(), 6);
+    assert!(before.contains(&0x7FFD_0000_AAAA_AAAA));
+    assert!(before.contains(&0x7FFD_0000_CCCC_CCCC));
+
+    // js_throw restores to the savepoint before longjmp.
+    shadow_stack_restore(sp);
+
+    // Post-fix: only run()'s frame remains; orphaned frames are gone.
+    let mut after: Vec<u64> = Vec::new();
+    shadow_stack_root_scanner(&mut |v| after.push(v.to_bits()));
+    assert_eq!(shadow_stack_depth(), 1, "restored to run()'s frame");
+    assert_eq!(after.len(), 2);
+    assert!(after.contains(&0x7FFD_0000_1111_1111));
+    assert!(after.contains(&0x7FFD_0000_2222_2222));
+    assert!(
+        !after.contains(&0x7FFD_0000_CCCC_CCCC),
+        "orphaned callee slot must no longer be scanned"
+    );
+
+    // The restored frame still pops cleanly with its original handle.
+    js_shadow_frame_pop(run_frame);
+    assert_eq!(shadow_stack_depth(), 0);
+}
+
+// Issue #1830, bound-slot variant: a callee that binds a shadow slot to its
+// real local alloca (`js_shadow_slot_bind`) is the dangerous case — the
+// copying collector reads AND writes back through `slot_ptrs`, so an orphaned
+// bound slot points into already-unwound stack. After restore, the scanner
+// reads neither the value nor the pointer of the dropped callee slot.
+#[test]
+fn test_shadow_stack_restore_drops_orphaned_bound_slots() {
+    reset_shadow_stack();
+
+    let run_frame = js_shadow_frame_push(1);
+    let mut run_local: u64 = 0x7FFD_0000_5555_5555;
+    js_shadow_slot_bind(0, &mut run_local as *mut u64);
+
+    let sp = shadow_stack_savepoint();
+
+    // Callee binds a slot to a local that becomes dead stack after unwind.
+    let _callee = js_shadow_frame_push(1);
+    let mut callee_local: u64 = 0x7FFD_0000_6666_6666;
+    js_shadow_slot_bind(0, &mut callee_local as *mut u64);
+
+    // Pre-restore: the scanner reads through the (soon-dead) callee binding.
+    let mut before: Vec<u64> = Vec::new();
+    shadow_stack_root_scanner(&mut |v| before.push(v.to_bits()));
+    assert!(before.contains(&0x7FFD_0000_6666_6666));
+    assert!(before.contains(&0x7FFD_0000_5555_5555));
+
+    shadow_stack_restore(sp);
+
+    // Post-restore: only the surviving run() binding is read.
+    let mut after: Vec<u64> = Vec::new();
+    shadow_stack_root_scanner(&mut |v| after.push(v.to_bits()));
+    assert_eq!(after.len(), 1);
+    assert!(after.contains(&0x7FFD_0000_5555_5555));
+    assert!(!after.contains(&0x7FFD_0000_6666_6666));
+
+    js_shadow_frame_pop(run_frame);
+    assert_eq!(shadow_stack_depth(), 0);
+}

--- a/test-files/test_issue_1830_gc_in_catch_after_deep_throw.ts
+++ b/test-files/test_issue_1830_gc_in_catch_after_deep_throw.ts
@@ -1,0 +1,59 @@
+// Issue #1830: SIGSEGV from an explicit gc() inside a catch block when the
+// thrown exception propagated up from a DEEPER function that had pointer-typed
+// locals.
+//
+// Root cause: js_throw uses longjmp to unwind, which skips the intervening
+// functions' epilogues — and therefore their js_shadow_frame_pop calls. The
+// shadow stack's frame_top is left pointing at the orphaned (now-dead) callee
+// frames. A GC in the catch body then walks those frames, reads slot pointers
+// into dead stack memory, and tries to evacuate a garbage "pointer".
+//
+// gc() is guarded with `typeof gc === "function"` so this file also runs under
+// `node --experimental-strip-types` (Node does not expose gc() by default), and
+// the byte-for-byte output matches Perry.
+
+declare const gc: (() => void) | undefined;
+
+function deep3(): number {
+  const a = { x: 1, y: 2, tag: "deep3-obj" };
+  const b = [a, a, a, a];
+  const c = "deep3-" + String(b.length) + "-" + a.tag;
+  if (c.length > 0) {
+    throw new Error("boom from deep3 len=" + String(c.length));
+  }
+  return b.length;
+}
+
+function deep2(): number {
+  const arr = [1, 2, 3, 4, 5].map((n) => ({ n, label: "d2-" + String(n) }));
+  const s = { tag: "deep2", items: arr };
+  return deep3() + arr.length + s.items.length;
+}
+
+function deep1(): number {
+  const s = { tag: "d1", data: [10, 20, 30], note: "level-one" };
+  const more = s.data.map((v) => "v" + String(v));
+  return deep2() + s.data.length + more.length;
+}
+
+function run(): void {
+  try {
+    deep1();
+  } catch (e) {
+    // Orphaned shadow frames from deep1/deep2/deep3 are live here. Allocate
+    // heavily to create GC pressure and reuse the dead stack region, then force
+    // a collection while frame_top is (pre-fix) corrupted.
+    const acc: { i: number; s: string }[] = [];
+    for (let i = 0; i < 50000; i++) {
+      acc.push({ i, s: "x" + String(i) });
+    }
+    if (typeof gc === "function") {
+      gc();
+    }
+    const msg = (e as Error).message;
+    console.log("caught:", msg, "acc=", acc.length);
+  }
+}
+
+run();
+console.log("done");


### PR DESCRIPTION
## Summary

Fixes #1830 — a `gc()` inside a `try/catch` SIGSEGVs when the thrown exception propagated up from a **deeper** function that had pointer-typed locals.

## Root cause

`js_throw` unwinds with `longjmp`, which restores the native SP/registers to the `setjmp` site **without running the epilogues** of the functions being unwound past — so their codegen-emitted `js_shadow_frame_pop` calls are skipped. The precise-root shadow stack's `frame_top` is left pointing at the orphaned (now-dead) callee frames.

The shadow stack **is** consumed by the GC: `visit_mutable_root_slots` → `visit_shadow_stack_root_slots` is walked by both the mark phase (`roots.rs`) and the copying/evacuating fast path (`copying.rs`). On the copying path the collector both **reads** each slot and **writes the rewritten pointer back** through `slot_ptrs` — and for an orphaned frame those `slot_ptrs` point into stack memory that has already been unwound and is being reused by the catch body.

Whether this surfaces as a crash depends on the recycled stack contents passing the `valid_ptrs` classifier, which is exactly why every minimal repro in the issue passed (they all `throw` at the *same* frame as the catch, so there are no orphaned callee frames) while a real workload — a library throwing from deep in a call chain, caught at an outer `try`, then `gc()` — crashed. Matches the #1824 profile.

## Fix

Purely a runtime change (no codegen changes):

- `js_try_push` captures a `ShadowSavepoint` (`frame_top` + stack length) **before** the protected region can push any callee frames, indexed by try-depth alongside `jump_buffers`.
- `js_throw` restores that savepoint **right before** the `longjmp`, dropping the orphaned frames so no later GC can scan them.

The `try`-establishing function's `frame_top` is identical at `js_try_push` time and in the catch body (only callees move it, and they restore it on normal return), so restoring to the savepoint is exact — never over- or under-truncates. Correct for both inlined and non-inlined throwing callees (`alwaysinline` callees still emit their own push/pop at runtime).

## Tests

- `gc::tests::roots`: orphaned callee frames **are** scanned without the restore and **dropped** with it — value-slot and bound-slot (the dangerous copying-writeback case) variants.
- `exception::tests`: `js_try_push` records the savepoint and the unwind path restores it across orphaned frames (the `longjmp` is replayed without the jump since it can't return in a unit test).
- `test-files/test_issue_1830_gc_in_catch_after_deep_throw.ts`: deep `throw` caught at an outer `try`, then `gc()` under allocation pressure. Runs clean and byte-identical to `node --experimental-strip-types` (`gc()` guarded with `typeof gc === "function"` so it is Node-portable). Also clean under `PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1`.

All `perry-runtime` GC + exception test modules pass (`copying`, `evacuation`, `runtime_roots`, `barrier`, `oldgen`, `roots`, `exception` — 183 + 24 green locally).
