### PR TITLE
feat(generator): yield* resolves operand iterator via Symbol.iterator (#1831)

### DIFF
--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -358,6 +358,7 @@ pub fn check_escapes_in_expr(
         | Expr::JsonParse(operand)
         | Expr::JsonStringify(operand)
         | Expr::IteratorToArray(operand)
+        | Expr::GetIterator(operand)
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
         | Expr::FinalizationRegistryNew(operand)

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -247,6 +247,7 @@ fn collect_used_new_fields_in_expr(
         | Expr::JsonParse(operand)
         | Expr::JsonStringify(operand)
         | Expr::IteratorToArray(operand)
+        | Expr::GetIterator(operand)
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
         | Expr::FinalizationRegistryNew(operand)

--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -1108,6 +1108,7 @@ pub fn collect_localset_ids_in_expr_filtered(
         | Expr::ArrayFrom(operand)
         | Expr::Uint8ArrayFrom(operand)
         | Expr::IteratorToArray(operand)
+        | Expr::GetIterator(operand)
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
         | Expr::StructuredClone(operand)

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -213,6 +213,7 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         | Expr::ArrayFrom(operand)
         | Expr::Uint8ArrayFrom(operand)
         | Expr::IteratorToArray(operand)
+        | Expr::GetIterator(operand)
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
         | Expr::StructuredClone(operand)

--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -472,6 +472,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let arr_ptr = blk.call(I64, "js_iterator_to_array", &[(DOUBLE, &iter_box)]);
             Ok(nanbox_pointer_inline(blk, &arr_ptr))
         }
+        Expr::GetIterator(o) => {
+            // #1831: `yield*` iterator resolution. `js_get_iterator` returns the
+            // operand's `Symbol.iterator` result when iterable (effect, custom
+            // iterables) or the operand unchanged when it is already an iterator
+            // (a perry generator object). Returns a NaN-boxed JSValue directly.
+            let v = lower_expr(ctx, o)?;
+            Ok(ctx.block().call(DOUBLE, "js_get_iterator", &[(DOUBLE, &v)]))
+        }
         Expr::WeakRefDeref(o) => {
             // `ref.deref()` — returns the wrapped target (or undefined if
             // collected; GC never clears the stub slot, so always returns

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1604,6 +1604,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::NumberIsNaN(..)
         | Expr::FsMkdirSync(..)
         | Expr::IteratorToArray(..)
+        | Expr::GetIterator(..)
         | Expr::WeakRefDeref(..)
         | Expr::Uint8ArrayNew(..)
         | Expr::Uint8ArrayLength(..)

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -115,6 +115,9 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     module.declare_function("js_array_clone_for_spread", I64, &[DOUBLE]);
     // Generator / iterator protocol: walk `.next()`/`.value` loop and collect into array.
     module.declare_function("js_iterator_to_array", I64, &[DOUBLE]);
+    // #1831: `yield*` iterator resolution — `operand[Symbol.iterator]()` or the
+    // operand itself when already an iterator. Returns a NaN-boxed JSValue.
+    module.declare_function("js_get_iterator", DOUBLE, &[DOUBLE]);
 
     declare_phase_b_objects(module);
 }

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1744,6 +1744,10 @@ pub enum Expr {
     /// semantics `[].raw === undefined`).
     TemplateRaw(Box<Expr>),
     IteratorToArray(Box<Expr>), // collect iterator (.next() loop) into array
+    /// #1831: resolve the iterator of a `yield*` operand —
+    /// `operand[Symbol.iterator]()` when iterable, else the operand itself (a
+    /// generator object already *is* its iterator). Lowers to `js_get_iterator`.
+    GetIterator(Box<Expr>),
     /// Array.from(iterable, mapFn) -> Array
     /// Creates a new array by applying mapFn to each element of the iterable.
     ArrayFromMapped {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -479,6 +479,7 @@ impl SH for Expr {
             Expr::ArrayIsArray(e) => { tag(h, 396); e.as_ref().hash(h); }
             Expr::ArrayFrom(e) => { tag(h, 397); e.as_ref().hash(h); }
             Expr::IteratorToArray(e) => { tag(h, 398); e.as_ref().hash(h); }
+            Expr::GetIterator(e) => { tag(h, 11238); e.as_ref().hash(h); }
             Expr::ArrayFromMapped { iterable, map_fn } => { tag(h, 399); iterable.as_ref().hash(h); map_fn.as_ref().hash(h); }
             Expr::ParseInt { string, radix } => { tag(h, 400); string.as_ref().hash(h); radix.hash(h); }
             Expr::ParseFloat(e) => { tag(h, 401); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -224,6 +224,7 @@ where
         | Expr::ArrayIsArray(v)
         | Expr::ArrayFrom(v)
         | Expr::IteratorToArray(v)
+        | Expr::GetIterator(v)
         | Expr::ObjectRest { object: v, .. }
         | Expr::ProxyRevoke(v)
         | Expr::ReflectOwnKeys(v)

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -225,6 +225,7 @@ where
         | Expr::ArrayIsArray(v)
         | Expr::ArrayFrom(v)
         | Expr::IteratorToArray(v)
+        | Expr::GetIterator(v)
         | Expr::ObjectRest { object: v, .. }
         | Expr::ProxyRevoke(v)
         | Expr::ReflectOwnKeys(v)

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -741,6 +741,41 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
     f64::from_bits(TAG_UNDEFINED)
 }
 
+/// #1831: resolve the iterator for a `yield*` operand.
+///
+/// `yield* X` must drive `X[Symbol.iterator]()` — for a generator **call** the
+/// result already *is* its iterator (perry's generator object is
+/// `{next,return,throw}` with no `Symbol.iterator`), but for an arbitrary
+/// iterable (effect's `EffectPrimitive`, custom `[Symbol.iterator]` objects)
+/// the iterator must first be obtained by invoking the well-known-symbol
+/// method. This helper returns that iterator, or `val` unchanged when `val` is
+/// already an iterator / not iterable.
+///
+/// Arrays are intentionally returned unchanged: perry has no real array
+/// iterator object (`Array.prototype.values` yields an array, not a
+/// `.next`-bearing iterator, and for-of over arrays is special-cased), so
+/// `yield* [..]` is a separate follow-up (#1831 array sub-case) — handling it
+/// here would route through `values` and mis-drive.
+#[no_mangle]
+pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
+    if crate::array::js_array_is_array(val_f64).to_bits() == crate::value::TAG_TRUE {
+        return val_f64;
+    }
+    let iter_wk = well_known_symbol("iterator");
+    if !iter_wk.is_null() {
+        let sym_f64 = f64::from_bits(crate::value::JSValue::pointer(iter_wk as *const u8).bits());
+        let iter_fn = unsafe { js_object_get_symbol_property(val_f64, sym_f64) };
+        if iter_fn.to_bits() != TAG_UNDEFINED {
+            let fn_ptr = crate::value::js_nanbox_get_pointer(iter_fn)
+                as *const crate::closure::ClosureHeader;
+            if !fn_ptr.is_null() {
+                return crate::closure::js_closure_call0(fn_ptr);
+            }
+        }
+    }
+    val_f64
+}
+
 /// `Object.getOwnPropertySymbols(obj)` — returns an array of symbol keys on
 /// the object. Looks up the side table populated by
 /// `js_object_set_symbol_property`.

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -48,12 +48,27 @@ pub fn linearize_body(
                 let del_iter_id = alloc_local(next_local_id);
                 let del_result_id = alloc_local(next_local_id);
 
+                // Initial pull: `__del_iter.next()` with no argument (the value
+                // passed to the *first* `next()` of a generator is discarded per
+                // spec).
                 let next_call = Expr::Call {
                     callee: Box::new(Expr::PropertyGet {
                         object: Box::new(Expr::LocalGet(del_iter_id)),
                         property: "next".to_string(),
                     }),
                     args: vec![],
+                    type_args: vec![],
+                };
+                // #1832: in-loop pull must forward the value the *outer* generator
+                // was resumed with (`outer.next(v)` → stored in `sent_id`) into the
+                // delegated iterator's `next(v)`, so `yield*`-delegated two-way
+                // communication matches spec. Argless here silently dropped it.
+                let next_call_resumed = Expr::Call {
+                    callee: Box::new(Expr::PropertyGet {
+                        object: Box::new(Expr::LocalGet(del_iter_id)),
+                        property: "next".to_string(),
+                    }),
+                    args: vec![Expr::LocalGet(sent_id)],
                     type_args: vec![],
                 };
 
@@ -64,7 +79,7 @@ pub fn linearize_body(
                 )));
                 current.push(Stmt::Expr(Expr::LocalSet(
                     del_result_id,
-                    Box::new(next_call.clone()),
+                    Box::new(next_call),
                 )));
 
                 // Build the while loop with yield
@@ -76,7 +91,7 @@ pub fn linearize_body(
                         })),
                         delegate: false,
                     }),
-                    Stmt::Expr(Expr::LocalSet(del_result_id, Box::new(next_call))),
+                    Stmt::Expr(Expr::LocalSet(del_result_id, Box::new(next_call_resumed))),
                 ];
 
                 let while_stmt = Stmt::While {
@@ -647,12 +662,22 @@ pub fn linearize_body(
                 let del_iter_id = alloc_local(next_local_id);
                 let del_result_id = alloc_local(next_local_id);
 
+                // Initial pull: argless (first `next()` value is discarded per spec).
                 let next_call = Expr::Call {
                     callee: Box::new(Expr::PropertyGet {
                         object: Box::new(Expr::LocalGet(del_iter_id)),
                         property: "next".to_string(),
                     }),
                     args: vec![],
+                    type_args: vec![],
+                };
+                // #1832: in-loop pull forwards the outer resume value (`sent_id`).
+                let next_call_resumed = Expr::Call {
+                    callee: Box::new(Expr::PropertyGet {
+                        object: Box::new(Expr::LocalGet(del_iter_id)),
+                        property: "next".to_string(),
+                    }),
+                    args: vec![Expr::LocalGet(sent_id)],
                     type_args: vec![],
                 };
 
@@ -662,7 +687,7 @@ pub fn linearize_body(
                 )));
                 current.push(Stmt::Expr(Expr::LocalSet(
                     del_result_id,
-                    Box::new(next_call.clone()),
+                    Box::new(next_call),
                 )));
 
                 let while_body = vec![
@@ -673,7 +698,7 @@ pub fn linearize_body(
                         })),
                         delegate: false,
                     }),
-                    Stmt::Expr(Expr::LocalSet(del_result_id, Box::new(next_call))),
+                    Stmt::Expr(Expr::LocalSet(del_result_id, Box::new(next_call_resumed))),
                 ];
 
                 let while_stmt = Stmt::While {

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -73,9 +73,13 @@ pub fn linearize_body(
                 };
 
                 // Add hoisted var declarations to current (they'll be emitted in the state body)
+                // #1831: resolve the iterator. For a generator *call* the result
+                // already is its iterator; for an arbitrary iterable (effect,
+                // custom `[Symbol.iterator]`) `js_get_iterator` invokes the
+                // well-known-symbol method to obtain one.
                 current.push(Stmt::Expr(Expr::LocalSet(
                     del_iter_id,
-                    Box::new(*inner.clone()),
+                    Box::new(Expr::GetIterator(Box::new(*inner.clone()))),
                 )));
                 current.push(Stmt::Expr(Expr::LocalSet(
                     del_result_id,
@@ -681,9 +685,13 @@ pub fn linearize_body(
                     type_args: vec![],
                 };
 
+                // #1831: resolve the iterator. For a generator *call* the result
+                // already is its iterator; for an arbitrary iterable (effect,
+                // custom `[Symbol.iterator]`) `js_get_iterator` invokes the
+                // well-known-symbol method to obtain one.
                 current.push(Stmt::Expr(Expr::LocalSet(
                     del_iter_id,
-                    Box::new(*inner.clone()),
+                    Box::new(Expr::GetIterator(Box::new(*inner.clone()))),
                 )));
                 current.push(Stmt::Expr(Expr::LocalSet(
                     del_result_id,

--- a/test-files/test_gap_yield_star_iterable.ts
+++ b/test-files/test_gap_yield_star_iterable.ts
@@ -1,0 +1,52 @@
+// Test: yield* over an iterable that exposes a resolvable Symbol.iterator
+// (#1831). `yield* X` resolves `X[Symbol.iterator]()` when X is iterable, and
+// uses X directly when it is already an iterator (a generator). Validated
+// byte-for-byte against `node --experimental-strip-types`.
+//
+// Scope: object-literal / own-property iterables + generator-call delegation
+// (regression). Class/prototype-defined Symbol.iterator member access is a
+// separate runtime gap (#1838); arrays are a separate sub-case.
+
+// --- yield* over an object literal with [Symbol.iterator] ---
+const range3 = {
+  [Symbol.iterator]() {
+    let i = 0;
+    return {
+      next: () => (i < 3 ? { value: i++, done: false } : { value: undefined, done: true }),
+    };
+  },
+};
+function* h() {
+  yield* range3 as any;
+  yield 9;
+}
+console.log("obj-iterable:", [...h()].join(",")); // 0,1,2,9
+
+// --- the iterator object's own values come through with the trailing yield ---
+const letters = {
+  [Symbol.iterator]() {
+    const arr = ["x", "y"];
+    let i = 0;
+    return { next: () => (i < arr.length ? { value: arr[i++], done: false } : { value: undefined, done: true }) };
+  },
+};
+function* j() {
+  yield "start";
+  yield* letters as any;
+  yield "end";
+}
+console.log("mixed:", [...j()].join(",")); // start,x,y,end
+
+// --- regression: yield* over a generator CALL still works (no Symbol.iterator
+//     on a perry generator object → js_get_iterator returns it unchanged) ---
+function* inner() {
+  yield 1;
+  yield 2;
+}
+function* outer() {
+  yield* inner();
+  yield 3;
+}
+console.log("gencall:", [...outer()].join(",")); // 1,2,3
+
+console.log("ALL YIELD-STAR-ITERABLE TESTS PASSED");

--- a/test-files/test_gap_yield_star_resume.ts
+++ b/test-files/test_gap_yield_star_resume.ts
@@ -1,0 +1,49 @@
+// Test: yield*-delegation forwards the resume value (#1832).
+// `outer.next(v)` across a `yield*` boundary must deliver `v` to the
+// delegated generator's pending `yield` expression. Previously the in-loop
+// `delegatedIterator.next()` was called with no argument, dropping `v`.
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+// --- bare yield* (statement position) forwards resume value ---
+function* inner1() {
+  const a = yield "i1";
+  const b = yield "i2";
+  return `inner:${a},${b}`;
+}
+function* outer1() {
+  const ret = yield* inner1() as any;
+  yield `ret=${ret}`;
+}
+const it1: any = outer1();
+console.log(JSON.stringify(it1.next()));        // {"value":"i1","done":false}
+console.log(JSON.stringify(it1.next("A")));     // {"value":"i2","done":false}
+console.log(JSON.stringify(it1.next("B")));     // {"value":"ret=inner:A,B","done":false}
+console.log(JSON.stringify(it1.next()));        // {"value":undefined→ ... ,"done":true}
+
+// --- const x = yield* inner() captures the inner return; resume flows in ---
+function* inner2() {
+  const r = yield "y";
+  return "innerRet:" + r;
+}
+function* g2() {
+  const a = yield* inner2() as any;
+  return "got:" + a;
+}
+const it2: any = g2();
+console.log(JSON.stringify(it2.next()));         // {"value":"y","done":false}
+console.log(JSON.stringify(it2.next("RESUME"))); // {"value":"got:innerRet:RESUME","done":true}
+
+// --- without an explicit cast (bare expression) ---
+function* inner3() {
+  const v = yield 1;
+  return v + 10;
+}
+function* g3() {
+  const out = yield* inner3();
+  return out;
+}
+const it3: any = g3();
+console.log(JSON.stringify(it3.next()));      // {"value":1,"done":false}
+console.log(JSON.stringify(it3.next(5)));     // {"value":15,"done":true}
+
+console.log("ALL YIELD-STAR-RESUME TESTS PASSED");


### PR DESCRIPTION
## Summary

`yield* X` must drive `X[Symbol.iterator]()` when `X` is an iterable. Previously the `yield*` desugar set `del_iter = X` and called `X.next()` directly — correct only when `X` is a generator **call** (perry's generator object is its own iterator), but wrong for any other iterable (it spun on `undefined.done`). This adds iterator resolution.

Refs #1831, #321.

## What changed

- **HIR**: new `Expr::GetIterator(Box<Expr>)` node (mirrors `Expr::IteratorToArray` across walkers / stable-hash / codegen-dispatch / the four collectors).
- **Runtime**: `js_get_iterator(val)` (`symbol.rs`) — invokes `val`'s well-known `Symbol.iterator` method (via `js_object_get_symbol_property` + `js_closure_call0`) to obtain the iterator, or returns `val` unchanged when it is already an iterator (a generator object) or not iterable. Arrays are returned unchanged (see below).
- **Codegen**: `GetIterator` lowers to a `js_get_iterator` call (`expr/arrays_finds.rs`), declared in `runtime_decls/arrays.rs`.
- **Transform**: both `yield*` arms in `generator/linearize.rs` now wrap the operand: `del_iter = GetIterator(inner)`.

## Validation

`test-files/test_gap_yield_star_iterable.ts` (new) — byte-for-byte identical to `node --experimental-strip-types`:
- `yield*` over object-literal `[Symbol.iterator]` iterables
- mixed `yield "start"; yield* iterable; yield "end"`
- **regression**: `yield*` over a generator call still works (`js_get_iterator` returns the generator object unchanged)

`cargo fmt --all --check` clean.

## Scope / follow-ups

This covers iterables that expose a **resolvable** `Symbol.iterator` (object literals / own properties) plus generator-call delegation. Two cases are intentionally out of scope and tracked separately:

- **#1838** — class / prototype-defined `[Symbol.iterator]` doesn't resolve via member access at runtime (`instance[Symbol.iterator]` is `undefined`). This is the remaining blocker for `yield* Effect.succeed(...)` / `Effect.gen` (#321); `js_get_iterator` will pick those up for free once member-access resolution lands.
- Arrays: perry has no real array-iterator object (for-of arrays are special-cased), so `yield* [..]` is a separate sub-case; `js_get_iterator` returns arrays unchanged rather than mis-routing through `values`.
