### PR TITLE
feat(runtime): class [Symbol.iterator] resolvable via member access — Effect.gen works (#1838)

### DIFF
--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -735,10 +735,76 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
                 if let Some(v) = crate::object::resolve_proto_chain_symbol(cid, sym_f64) {
                     return v;
                 }
+                // #1838: a class can define a computed well-known-symbol METHOD
+                // (`[Symbol.iterator]() {}`) — class lowering names it
+                // `@@iterator` in the vtable (class_members.rs), NOT as a symbol
+                // property, so the proto-chain symbol walk above misses it. Map
+                // the well-known symbol back to its `@@name`, and if the class
+                // (or an ancestor) has that method, return it bound to the
+                // instance. This is how effect's `EffectPrimitive` exposes
+                // `Symbol.iterator` (→ `SingleShotGen`), so `yield* effectValue`
+                // / `Symbol.iterator in effectValue` resolve.
+                if let Some(at_name) = well_known_symbol_method_key(sym_f64) {
+                    if class_chain_has_method(cid, at_name) {
+                        return crate::object::js_class_method_bind(
+                            obj_f64,
+                            at_name.as_ptr(),
+                            at_name.len(),
+                        );
+                    }
+                }
             }
         }
     }
     f64::from_bits(TAG_UNDEFINED)
+}
+
+/// #1838: map a well-known symbol value to the synthetic `@@<name>` vtable key
+/// that class lowering assigns to a computed `[Symbol.X]() {}` method (see
+/// `lower_decl/class_members.rs`). Returns `None` for symbols that don't name a
+/// class method (or non-symbol values). `dispose`/`asyncDispose` use distinct
+/// `__perry_*__` names and are dispatched via the using-block desugarer, so
+/// they're deliberately excluded here.
+unsafe fn well_known_symbol_method_key(sym_f64: f64) -> Option<&'static str> {
+    let sk = sym_key_from_f64(sym_f64);
+    if sk == 0 {
+        return None;
+    }
+    for (short, at_name) in [
+        ("iterator", "@@iterator"),
+        ("asyncIterator", "@@asyncIterator"),
+        ("hasInstance", "@@hasInstance"),
+        ("toPrimitive", "@@toPrimitive"),
+        ("toStringTag", "@@toStringTag"),
+    ] {
+        let wk = well_known_symbol(short);
+        if !wk.is_null() {
+            let wk_f64 = f64::from_bits(crate::value::JSValue::pointer(wk as *const u8).bits());
+            if sym_key_from_f64(wk_f64) == sk {
+                return Some(at_name);
+            }
+        }
+    }
+    None
+}
+
+/// #1838: does `class_id` or any ancestor define a vtable method named `name`?
+fn class_chain_has_method(class_id: u32, name: &str) -> bool {
+    let mut cid = class_id;
+    let mut depth = 0usize;
+    while depth < 32 && cid != 0 {
+        if crate::object::class_has_own_method(cid, name) {
+            return true;
+        }
+        match crate::object::get_parent_class_id(cid) {
+            Some(p) if p != 0 && p != cid => {
+                cid = p;
+                depth += 1;
+            }
+            _ => break,
+        }
+    }
+    false
 }
 
 /// #1831: resolve the iterator for a `yield*` operand.

--- a/test-files/test_gap_class_symbol_iterator.ts
+++ b/test-files/test_gap_class_symbol_iterator.ts
@@ -1,0 +1,51 @@
+// Test: a class's computed well-known-symbol method `[Symbol.iterator]() {}`
+// is resolvable via member access (#1838). Class lowering names it `@@iterator`
+// in the vtable (not a symbol property), so `instance[Symbol.iterator]`,
+// `Symbol.iterator in instance`, and `yield*` delegation must all find it.
+// (This is how effect's `EffectPrimitive` exposes its iterator, which
+// `Effect.gen`'s `yield* effect` depends on.)
+//
+// Scope: member access / `in` / `yield*`. for-of and spread over a
+// non-generator class iterator go through a separate lowering path and are a
+// follow-up. Validated byte-for-byte against `node --experimental-strip-types`.
+
+class Range {
+  n: number;
+  constructor(n: number) {
+    this.n = n;
+  }
+  [Symbol.iterator]() {
+    let i = 0;
+    const n = this.n;
+    return {
+      next: () => (i < n ? { value: i++, done: false } : { value: undefined, done: true }),
+    };
+  }
+}
+
+// --- `Symbol.iterator in instance` + member access ---
+const r = new Range(3);
+console.log("has:", Symbol.iterator in r); // true
+console.log("typeof:", typeof (r as any)[Symbol.iterator]); // function
+
+// --- calling the resolved method yields a working iterator ---
+const it = (r as any)[Symbol.iterator]();
+console.log("manual:", JSON.stringify(it.next()), JSON.stringify(it.next()), JSON.stringify(it.next()), JSON.stringify(it.next()));
+// {"value":0,"done":false} {"value":1,"done":false} {"value":2,"done":false} {"value":...,"done":true}
+
+// --- yield* delegation to a class iterable ---
+function* g() {
+  yield 100;
+  yield* new Range(3) as any;
+  yield 200;
+}
+console.log("yield*:", [...g()].join(",")); // 100,0,1,2,200
+
+// --- inherited [Symbol.iterator] resolves through the class chain ---
+class Sub extends Range {}
+function* h() {
+  yield* new Sub(2) as any;
+}
+console.log("inherited:", [...h()].join(",")); // 0,1
+
+console.log("ALL CLASS-SYMBOL-ITERATOR TESTS PASSED");


### PR DESCRIPTION
## Summary

A class's computed well-known-symbol method — `[Symbol.iterator]() {}` — was not resolvable via member access at runtime: `instance[Symbol.iterator]` returned `undefined` and `Symbol.iterator in instance` was `false`. Class lowering names such a method `@@iterator` in the class **vtable** (`lower_decl/class_members.rs`), not as a symbol property, so the proto-chain symbol walk in `js_object_get_symbol_property` never found it.

This is how effect's `EffectPrimitive` exposes its iterator (`[Symbol.iterator]() { return new SingleShotGen(...) }`), so it's the final blocker for **`Effect.gen` end-to-end** (#321).

Refs #1838, #321.

## Fix

`js_object_get_symbol_property` (`perry-runtime/src/symbol.rs`), for a class-instance receiver, now maps a well-known symbol back to its synthetic `@@name` and — when the class **or an ancestor** defines that vtable method — returns it **bound** to the instance (`js_class_method_bind`). Covers `iterator`, `asyncIterator`, `hasInstance`, `toPrimitive`, `toStringTag` (the names class lowering assigns; `dispose`/`asyncDispose` use their own `__perry_*__` dispatch and are excluded).

## Result

`Effect.gen` runs end-to-end (with the generator-expression + `yield*` foundation from #1834/#1835/#1839 already on main):

```ts
import * as Effect from "effect/Effect";
const prog = Effect.gen(function* () {
  const a = yield* Effect.succeed(10);
  const b = yield* Effect.succeed(20);
  return a + b;
});
console.log(Effect.runSync(prog)); // 30 ✓ (was: "Cannot read properties of undefined (reading 'done')")
```

Effect survey: `02_map`, `05_gen` (Effect.gen), `06_fail_catch`, `09_either`, `30_option` all match Node byte-for-byte. (`07_all` still fails on the separate pre-existing #28 `Effect.all` blocker.)

## Validation

`test-files/test_gap_class_symbol_iterator.ts` (new) — byte-for-byte identical to `node --experimental-strip-types`: `Symbol.iterator in instance`, `typeof instance[Symbol.iterator]`, manually driving the resolved iterator, `yield*` over a class iterable, and an inherited `[Symbol.iterator]` resolved through the class chain.

Regression: confirmed the change is isolated — the generator/iterator/symbol/class gap-test sweep passes, and three pre-existing class failures (field layout, static-block boolean, mixin super-args) fail identically with and without this change (verified by stash + rebuild). `cargo fmt --all --check` clean.

## Follow-up

`for-of` / spread over a **non-generator** class iterator still go through the generator-only `iterator_func_for_class` lowering path and don't consult runtime `Symbol.iterator` resolution — so `[...new ClassIterable()]` / `for (x of new ClassIterable())` don't yet iterate (member access + `in` + `yield*` do). Filed separately.
