### PR TITLE
Add crypto Certificate SPKAC helpers

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1783,6 +1783,9 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // #1367: X509Certificate — `new X509Certificate(pem|der)` + read-only
     // subject/issuer/validFrom/validTo/serialNumber/fingerprint/ca props.
     class("crypto", "X509Certificate"),
+    // Legacy Netscape SPKAC helper namespace:
+    // crypto.Certificate.{verifySpkac,exportPublicKey,exportChallenge}.
+    property("crypto", "Certificate"),
     method("crypto", "createECDH", false, None),
     method("crypto", "createDiffieHellman", false, None),
     method("crypto", "createDiffieHellmanGroup", false, None),

--- a/crates/perry-codegen/src/expr/new_dynamic.rs
+++ b/crates/perry-codegen/src/expr/new_dynamic.rs
@@ -156,6 +156,30 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 }
             }
 
+            // `new crypto.Certificate()` is a legacy constructor in Node, but
+            // the implementation is a stateless namespace over the same SPKAC
+            // helper methods as `crypto.Certificate.*`. Represent instances as
+            // the `crypto.Certificate` native namespace so method calls dispatch
+            // through the existing native-module path.
+            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+                if property == "Certificate" && args.is_empty() {
+                    if let Expr::NativeModuleRef(mod_name) = object.as_ref() {
+                        if mod_name == "crypto" {
+                            let module_name = "crypto.Certificate";
+                            let mod_idx = ctx.strings.intern(module_name);
+                            let mod_bytes_global =
+                                format!("@{}", ctx.strings.entry(mod_idx).bytes_global);
+                            let mod_len_str = module_name.len().to_string();
+                            return Ok(ctx.block().call(
+                                DOUBLE,
+                                "js_create_native_module_namespace",
+                                &[(PTR, &mod_bytes_global), (I64, &mod_len_str)],
+                            ));
+                        }
+                    }
+                }
+            }
+
             // `new (PerformanceObserver as any)(cb?)` — the `as any` cast
             // (used because no-arg construction is a TS type error) strips the
             // bare identifier, so the constructor arrives as

--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -147,6 +147,28 @@ pub(crate) fn lower_native_method_call(
         ));
     }
 
+    if module == "crypto"
+        && class_name == Some("Certificate")
+        && matches!(
+            method,
+            "verifySpkac" | "exportPublicKey" | "exportChallenge"
+        )
+        && object.is_none()
+    {
+        let input = if let Some(arg) = args.first() {
+            lower_expr(ctx, arg)?
+        } else {
+            double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+        };
+        let runtime = match method {
+            "verifySpkac" => "js_crypto_certificate_verify_spkac",
+            "exportPublicKey" => "js_crypto_certificate_export_public_key",
+            "exportChallenge" => "js_crypto_certificate_export_challenge",
+            _ => unreachable!(),
+        };
+        return Ok(ctx.block().call(DOUBLE, runtime, &[(DOUBLE, &input)]));
+    }
+
     // `perry/ui.App({ title, width, height, body, icon? })` — minimum-viable
     // dispatch so a perry/ui app actually launches an NSApplication and
     // shows a window. Pre-v0.5.10 this fell into the receiver-less early-

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1347,6 +1347,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_crypto_create_hash_options", DOUBLE, &[I64, DOUBLE]);
     // #1367: `new X509Certificate(pem|der)` — parses to a NaN-boxed handle.
     module.declare_function("js_crypto_x509_new", DOUBLE, &[I64]);
+    module.declare_function("js_crypto_certificate_verify_spkac", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_crypto_certificate_export_public_key", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_crypto_certificate_export_challenge", DOUBLE, &[DOUBLE]);
     module.declare_function("js_crypto_create_sign", DOUBLE, &[I64]);
     module.declare_function("js_crypto_create_verify", DOUBLE, &[I64]);
     module.declare_function("js_crypto_create_ecdh", DOUBLE, &[I64]);

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -699,6 +699,9 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("crypto", "createCipheriv")
             | ("crypto", "createDecipheriv")
             | ("crypto", "createSecretKey")
+            | ("crypto.Certificate", "verifySpkac")
+            | ("crypto.Certificate", "exportPublicKey")
+            | ("crypto.Certificate", "exportChallenge")
     )
 }
 
@@ -1554,6 +1557,7 @@ pub(crate) unsafe fn get_native_module_constant(
         },
         "crypto" => match property {
             "constants" => Some(create_sub_namespace("crypto.constants")),
+            "Certificate" => Some(create_sub_namespace("crypto.Certificate")),
             // #1366: `crypto.subtle` is the WebCrypto SubtleCrypto
             // instance. Resolve to a sub-namespace so `typeof
             // crypto.subtle === "object"` matches Node and call

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -906,6 +906,23 @@ pub(crate) unsafe fn dispatch_native_module_method(
                 dispatch(method_name.as_ptr(), method_name.len(), args_ptr, args_len)
             }
         }
+        ("crypto.Certificate", _) => {
+            let qualified: &[u8] = match method_name {
+                "verifySpkac" => b"Certificate.verifySpkac",
+                "exportPublicKey" => b"Certificate.exportPublicKey",
+                "exportChallenge" => b"Certificate.exportChallenge",
+                _ => return f64::from_bits(JSValue::undefined().bits()),
+            };
+            let ptr =
+                crate::value::JS_NATIVE_CRYPTO_DISPATCH.load(std::sync::atomic::Ordering::SeqCst);
+            if ptr.is_null() {
+                f64::from_bits(JSValue::undefined().bits())
+            } else {
+                let dispatch: unsafe extern "C" fn(*const u8, usize, *const f64, usize) -> f64 =
+                    std::mem::transmute(ptr);
+                dispatch(qualified.as_ptr(), qualified.len(), args_ptr, args_len)
+            }
+        }
 
         _ => {
             // Method not found on native module — return undefined

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -8,6 +8,7 @@
 //!
 //! `util` declares shared imports, helpers, and private types that are
 //! re-exported only inside this module for sibling shards.
+mod certificate;
 mod cipher;
 mod ecdh;
 mod handles;
@@ -24,12 +25,12 @@ mod x509;
 #[allow(unused_imports)]
 // Private imports keep sibling modules able to share `pub(super)` helpers.
 use self::{
-    cipher::*, ecdh::*, handles::*, hash::*, hash_handles::*, kdf::*, keys::*, prime::*, random::*,
-    sign::*, util::*, x509::*,
+    certificate::*, cipher::*, ecdh::*, handles::*, hash::*, hash_handles::*, kdf::*, keys::*,
+    prime::*, random::*, sign::*, util::*, x509::*,
 };
 
 // Public re-exports preserve the parent module surface for FFI entry points.
 pub use self::{
-    cipher::*, ecdh::*, handles::*, hash::*, hash_handles::*, kdf::*, keys::*, prime::*, random::*,
-    sign::*, x509::*,
+    certificate::*, cipher::*, ecdh::*, handles::*, hash::*, hash_handles::*, kdf::*, keys::*,
+    prime::*, random::*, sign::*, x509::*,
 };

--- a/crates/perry-stdlib/src/crypto/certificate.rs
+++ b/crates/perry-stdlib/src/crypto/certificate.rs
@@ -1,0 +1,233 @@
+use super::*;
+
+#[derive(Clone, Copy)]
+struct DerNode {
+    tag: u8,
+    header_len: usize,
+    len: usize,
+    start: usize,
+}
+
+impl DerNode {
+    fn end(self) -> usize {
+        self.start + self.len
+    }
+
+    fn full_range(self) -> std::ops::Range<usize> {
+        (self.start - self.header_len)..self.end()
+    }
+}
+
+struct SpkacParts<'a> {
+    public_key_and_challenge_der: &'a [u8],
+    spki_der: &'a [u8],
+    challenge: &'a [u8],
+    signature: &'a [u8],
+}
+
+const MD5_WITH_RSA_ENCRYPTION_OID: &[u8] = &[0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x04];
+
+fn read_der_node(input: &[u8], offset: usize) -> Option<DerNode> {
+    let tag = *input.get(offset)?;
+    let len0 = *input.get(offset + 1)?;
+    if len0 & 0x80 == 0 {
+        let len = len0 as usize;
+        let start = offset + 2;
+        return (start + len <= input.len()).then_some(DerNode {
+            tag,
+            header_len: 2,
+            len,
+            start,
+        });
+    }
+
+    let n = (len0 & 0x7f) as usize;
+    if n == 0 || n > 4 || offset + 2 + n > input.len() {
+        return None;
+    }
+    let mut len = 0usize;
+    for b in &input[offset + 2..offset + 2 + n] {
+        len = (len << 8) | (*b as usize);
+    }
+    let start = offset + 2 + n;
+    (start + len <= input.len()).then_some(DerNode {
+        tag,
+        header_len: 2 + n,
+        len,
+        start,
+    })
+}
+
+fn decode_spkac_input(bytes: Vec<u8>) -> Option<Vec<u8>> {
+    let text = std::str::from_utf8(&bytes).ok()?.trim();
+    base64::engine::general_purpose::STANDARD
+        .decode(text.as_bytes())
+        .ok()
+}
+
+fn parse_spkac(bytes: &[u8]) -> Option<SpkacParts<'_>> {
+    let outer = read_der_node(bytes, 0)?;
+    if outer.tag != 0x30 || outer.end() != bytes.len() {
+        return None;
+    }
+
+    let pkac = read_der_node(bytes, outer.start)?;
+    if pkac.tag != 0x30 {
+        return None;
+    }
+    let sig_alg = read_der_node(bytes, pkac.end())?;
+    if sig_alg.tag != 0x30 {
+        return None;
+    }
+    if !is_md5_rsa_signature_algorithm(bytes, sig_alg) {
+        return None;
+    }
+    let sig = read_der_node(bytes, sig_alg.end())?;
+    if sig.tag != 0x03 || sig.end() != outer.end() || sig.len == 0 {
+        return None;
+    }
+
+    let spki = read_der_node(bytes, pkac.start)?;
+    if spki.tag != 0x30 {
+        return None;
+    }
+    let challenge = read_der_node(bytes, spki.end())?;
+    if challenge.tag != 0x16 || challenge.end() != pkac.end() {
+        return None;
+    }
+    if bytes[sig.start] != 0 {
+        return None;
+    }
+
+    Some(SpkacParts {
+        public_key_and_challenge_der: &bytes[pkac.full_range()],
+        spki_der: &bytes[spki.full_range()],
+        challenge: &bytes[challenge.start..challenge.end()],
+        signature: &bytes[sig.start + 1..sig.end()],
+    })
+}
+
+fn is_md5_rsa_signature_algorithm(bytes: &[u8], alg: DerNode) -> bool {
+    let Some(oid) = read_der_node(bytes, alg.start) else {
+        return false;
+    };
+    if oid.tag != 0x06 || &bytes[oid.start..oid.end()] != MD5_WITH_RSA_ENCRYPTION_OID {
+        return false;
+    }
+
+    if oid.end() == alg.end() {
+        return true;
+    }
+
+    let Some(params) = read_der_node(bytes, oid.end()) else {
+        return false;
+    };
+    params.tag == 0x05 && params.len == 0 && params.end() == alg.end()
+}
+
+unsafe fn bytes_from_value(value: f64) -> Vec<u8> {
+    if JSValue::from_bits(value.to_bits()).is_any_string() {
+        bytes_from_ptr(perry_runtime::js_get_string_pointer_unified(value) as i64)
+    } else {
+        bytes_from_ptr(perry_runtime::js_nanbox_get_pointer(value))
+    }
+}
+
+fn empty_buffer_value() -> f64 {
+    let buf = unsafe { alloc_buffer_from_slice(&[]) };
+    f64::from_bits(JSValue::pointer(buf as *const u8).bits())
+}
+
+fn pem_from_spki_der(spki_der: &[u8]) -> String {
+    let b64 = base64::engine::general_purpose::STANDARD.encode(spki_der);
+    let mut pem = String::from("-----BEGIN PUBLIC KEY-----\n");
+    for chunk in b64.as_bytes().chunks(64) {
+        pem.push_str(std::str::from_utf8(chunk).unwrap_or(""));
+        pem.push('\n');
+    }
+    pem.push_str("-----END PUBLIC KEY-----\n");
+    pem
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_crypto_certificate_verify_spkac(input: f64) -> f64 {
+    let Some(der) = decode_spkac_input(bytes_from_value(input)) else {
+        return js_bool(false);
+    };
+    let Some(parts) = parse_spkac(&der) else {
+        return js_bool(false);
+    };
+
+    use rsa::pkcs8::DecodePublicKey;
+    let public_key = match RsaPublicKey::from_public_key_der(parts.spki_der) {
+        Ok(key) => key,
+        Err(_) => return js_bool(false),
+    };
+    js_bool(verify_md5_rsa_pkcs1v15(
+        &public_key,
+        parts.public_key_and_challenge_der,
+        parts.signature,
+    ))
+}
+
+fn verify_md5_rsa_pkcs1v15(public_key: &RsaPublicKey, data: &[u8], signature: &[u8]) -> bool {
+    let k = public_key.n().bits().div_ceil(8);
+    if signature.len() != k {
+        return false;
+    }
+
+    let sig = RsaBigUint::from_bytes_be(signature);
+    let decoded = sig.modpow(public_key.e(), public_key.n()).to_bytes_be();
+    if decoded.len() > k {
+        return false;
+    }
+    let mut em = vec![0u8; k - decoded.len()];
+    em.extend_from_slice(&decoded);
+
+    if em.len() < 3 || em[0] != 0 || em[1] != 1 {
+        return false;
+    }
+    let Some(sep) = em[2..].iter().position(|b| *b == 0).map(|i| i + 2) else {
+        return false;
+    };
+    if sep < 10 || em[2..sep].iter().any(|b| *b != 0xff) {
+        return false;
+    }
+
+    let mut md5 = Md5::new();
+    Md5Digest::update(&mut md5, data);
+    let digest = md5.finalize();
+    const MD5_DIGEST_INFO_PREFIX: &[u8] = &[
+        0x30, 0x20, 0x30, 0x0c, 0x06, 0x08, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x02, 0x05, 0x05,
+        0x00, 0x04, 0x10,
+    ];
+    let digest_info = &em[sep + 1..];
+    digest_info.len() == MD5_DIGEST_INFO_PREFIX.len() + digest.len()
+        && digest_info.starts_with(MD5_DIGEST_INFO_PREFIX)
+        && digest_info[MD5_DIGEST_INFO_PREFIX.len()..] == digest[..]
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_crypto_certificate_export_public_key(input: f64) -> f64 {
+    let Some(der) = decode_spkac_input(bytes_from_value(input)) else {
+        return empty_buffer_value();
+    };
+    let Some(parts) = parse_spkac(&der) else {
+        return empty_buffer_value();
+    };
+    let pem = pem_from_spki_der(parts.spki_der);
+    let buf = alloc_buffer_from_slice(pem.as_bytes());
+    f64::from_bits(JSValue::pointer(buf as *const u8).bits())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_crypto_certificate_export_challenge(input: f64) -> f64 {
+    let Some(der) = decode_spkac_input(bytes_from_value(input)) else {
+        return empty_buffer_value();
+    };
+    let Some(parts) = parse_spkac(&der) else {
+        return empty_buffer_value();
+    };
+    let buf = alloc_buffer_from_slice(parts.challenge);
+    f64::from_bits(JSValue::pointer(buf as *const u8).bits())
+}

--- a/crates/perry-stdlib/src/crypto/random.rs
+++ b/crates/perry-stdlib/src/crypto/random.rs
@@ -133,6 +133,9 @@ pub unsafe extern "C" fn js_crypto_native_dispatch(
         // Node: randomInt(max) → [0,max); randomInt(min,max) → [min,max).
         "randomInt" if args_len >= 2 => js_crypto_random_int(arg(0), arg(1)),
         "randomInt" => js_crypto_random_int(0.0, arg(0)),
+        "Certificate.verifySpkac" => js_crypto_certificate_verify_spkac(arg(0)),
+        "Certificate.exportPublicKey" => js_crypto_certificate_export_public_key(arg(0)),
+        "Certificate.exportChallenge" => js_crypto_certificate_export_challenge(arg(0)),
         _ => undefined,
     }
 }

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1251 entries across 81 modules
+// Coverage: 1252 entries across 81 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -314,6 +314,8 @@ declare module "crypto" {
   export class ECDH { [key: string]: any; }
   /** stdlib */
   export class X509Certificate { [key: string]: any; }
+  /** stdlib */
+  export const Certificate: any;
   /** stdlib */
   export const constants: any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1251 entries across 81 modules.
+Total: 1252 entries across 81 modules.
 
 ## Modules
 
@@ -427,6 +427,7 @@ Total: 1251 entries across 81 modules.
 
 ### Properties
 
+- `Certificate`
 - `constants`
 - `subtle`
 

--- a/test-files/test_issue_1844_crypto_certificate_spkac.ts
+++ b/test-files/test_issue_1844_crypto_certificate_spkac.ts
@@ -1,0 +1,38 @@
+import * as crypto from "node:crypto";
+
+// Regression for #1844: legacy crypto.Certificate SPKAC helpers must
+// be present when node:crypto is compiled in strict API mode.
+const valid = "MIICUzCCATswggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC33FiIiiexwLe/P8DZx5HsqFlmUO7/lvJ7necJVNwqdZ3ax5jpQB0p6uxfqeOvzcN3k5V7UFb/Am+nkSNZMAZhsWzCU2Z4Pjh50QYz3f0Hour7/yIGStOLyYY3hgLK2K8TbhgjQPhdkw9+QtKlpvbL8fLgONAoGrVOFnRQGcr70iFffsm79mgZhKVMgYiHPJqJgGHvCtkGg9zMgS7p63+Q3ZWedtFS2RhMX3uCBy/mH6EOlRCNBbRmA4xxNzyf5GQaki3T+Iz9tOMjdPP+CwV2LqEdylmBuik8vrfTb3qIHLKKBAI8lXN26wWtA3kN4L7NP+cbKlCRlqctvhmylLH1AgMBAAEWE3RoaXMtaXMtYS1jaGFsbGVuZ2UwDQYJKoZIhvcNAQEEBQADggEBAIozmeW1kfDfAVwRQKileZGLRGCD7AjdHLYEe16xTBPve8Af1bDOyuWsAm4qQLYA4FAFROiKeGqxCtIErEvm87/09tCfF1My/1Uj+INjAk39DK9J9alLlTsrwSgd1lb3YlXY7TyitCmh7iXLo4pVhA2chNA3njiMq3CUpSvGbpzrESL2dv97lv590gUD988wkTDVyYsf0T8+X0Kww3AgPWGji+2f2i5/jTfD/s1lK1nqi7ZxFm0pGZoy1MJ51SCEy7Y82ajroI+5786nC02mo9ak7samca4YDZOoxN4d3tax4B/HDF5dqJSm1/31xYLDTfujCM5FkSjRc4m6hnriEkc=";
+const invalid = "UzCCATswggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC33FiIiiexwLe/P8DZx5HsqFlmUO7/lvJ7necJVNwqdZ3ax5jpQB0p6uxfqeOvzcN3k5V7UFb/Am+nkSNZMAZhsWzCU2Z4Pjh50QYz3f0Hour7/yIGStOLyYY3hgLK2K8TbhgjQPhdkw9+QtKlpvbL8fLgONAoGrVOFnRQGcr70iFffsm79mgZhKVMgYiHPJqJgGHvCtkGg9zMgS7p63+Q3ZWedtFS2RhMX3uCBy/mH6EOlRCNBbRmA4xxNzyf5GQaki3T+Iz9tOMjdPP+CwV2LqEdylmBuik8vrfTb3qIHLKKBAI8lXN26wWtA3kN4L7NP+cbKlCRlqctvhmylLH1AgMBAAEWE3RoaXMtaXMtYS1jaGFsbGVuZ2UwDQYJKoZIhvcNAQEEBQADggEBAIozmeW1kfDfAVwRQKileZGLRGCD7AjdHLYEe16xTBPve8Af1bDOyuWsAm4qQLYA4FAFROiKeGqxCtIErEvm87/09tCfF1My/1Uj+INjAk39DK9J9alLlTsrwSgd1lb3YlXY7TyitCmh7iXLo4pVhA2chNA3njiMq3CUpSvGbpzrESL2dv97lv590gUD988wkTDVyYsf0T8+X0Kww3AgPWGji+2f2i5/jTfD/s1lK1nqi7ZxFm0pGZoy1MJ51SCEy7Y82ajroI+5786nC02mo9ak7samca4YDZOoxN4d3tax4B/HDF5dqJSm1/31xYLDTfujCM5FkSjRc4m6hnriEkc=";
+const unsupportedSigAlg = "MIICUzCCATswggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC33FiIiiexwLe/P8DZx5HsqFlmUO7/lvJ7necJVNwqdZ3ax5jpQB0p6uxfqeOvzcN3k5V7UFb/Am+nkSNZMAZhsWzCU2Z4Pjh50QYz3f0Hour7/yIGStOLyYY3hgLK2K8TbhgjQPhdkw9+QtKlpvbL8fLgONAoGrVOFnRQGcr70iFffsm79mgZhKVMgYiHPJqJgGHvCtkGg9zMgS7p63+Q3ZWedtFS2RhMX3uCBy/mH6EOlRCNBbRmA4xxNzyf5GQaki3T+Iz9tOMjdPP+CwV2LqEdylmBuik8vrfTb3qIHLKKBAI8lXN26wWtA3kN4L7NP+cbKlCRlqctvhmylLH1AgMBAAEWE3RoaXMtaXMtYS1jaGFsbGVuZ2UwDQYJKoZIhvcNAQEFBQADggEBAIozmeW1kfDfAVwRQKileZGLRGCD7AjdHLYEe16xTBPve8Af1bDOyuWsAm4qQLYA4FAFROiKeGqxCtIErEvm87/09tCfF1My/1Uj+INjAk39DK9J9alLlTsrwSgd1lb3YlXY7TyitCmh7iXLo4pVhA2chNA3njiMq3CUpSvGbpzrESL2dv97lv590gUD988wkTDVyYsf0T8+X0Kww3AgPWGji+2f2i5/jTfD/s1lK1nqi7ZxFm0pGZoy1MJ51SCEy7Y82ajroI+5786nC02mo9ak7samca4YDZOoxN4d3tax4B/HDF5dqJSm1/31xYLDTfujCM5FkSjRc4m6hnriEkc=";
+const expectedPublicKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt9xYiIonscC3vz/A2ceR
+7KhZZlDu/5bye53nCVTcKnWd2seY6UAdKersX6njr83Dd5OVe1BW/wJvp5EjWTAG
+YbFswlNmeD44edEGM939B6Lq+/8iBkrTi8mGN4YCytivE24YI0D4XZMPfkLSpab2
+y/Hy4DjQKBq1ThZ0UBnK+9IhX37Ju/ZoGYSlTIGIhzyaiYBh7wrZBoPczIEu6et/
+kN2VnnbRUtkYTF97ggcv5h+hDpUQjQW0ZgOMcTc8n+RkGpIt0/iM/bTjI3Tz/gsF
+di6hHcpZgbopPL630296iByyigQCPJVzdusFrQN5DeC+zT/nGypQkZanLb4ZspSx
+9QIDAQAB
+-----END PUBLIC KEY-----
+`;
+
+const Certificate = (crypto as any).Certificate;
+const validBase64Buffer = Buffer.from(valid);
+const validDer = Buffer.from(valid, "base64");
+const certificateInstance = new (crypto as any).Certificate();
+console.log("Certificate.verifySpkac type:", typeof Certificate.verifySpkac);
+console.log("Certificate.exportPublicKey type:", typeof Certificate.exportPublicKey);
+console.log("Certificate.exportChallenge type:", typeof Certificate.exportChallenge);
+console.log("direct verify valid:", crypto.Certificate.verifySpkac(valid));
+console.log("instance verify valid:", certificateInstance.verifySpkac(valid));
+console.log("verify valid:", Certificate.verifySpkac(valid));
+console.log("verify valid base64 buffer:", Certificate.verifySpkac(validBase64Buffer));
+console.log("verify raw der:", Certificate.verifySpkac(validDer));
+console.log("verify invalid:", Certificate.verifySpkac(invalid));
+console.log("verify unsupported sig alg:", Certificate.verifySpkac(unsupportedSigAlg));
+console.log("challenge:", Certificate.exportChallenge(valid).toString("utf8"));
+console.log("instance challenge:", certificateInstance.exportChallenge(valid).toString("utf8"));
+console.log("invalid challenge:", Certificate.exportChallenge(invalid).toString("utf8"));
+console.log("public key matches:", Certificate.exportPublicKey(valid).toString("utf8") === expectedPublicKey);
+console.log("instance public key matches:", certificateInstance.exportPublicKey(valid).toString("utf8") === expectedPublicKey);
+console.log("invalid public key:", Certificate.exportPublicKey(invalid).toString("utf8"));

--- a/test-parity/node-suite/crypto/certificate/spkac.ts
+++ b/test-parity/node-suite/crypto/certificate/spkac.ts
@@ -1,0 +1,18 @@
+import * as crypto from "node:crypto";
+
+const valid = "MIICUzCCATswggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC33FiIiiexwLe/P8DZx5HsqFlmUO7/lvJ7necJVNwqdZ3ax5jpQB0p6uxfqeOvzcN3k5V7UFb/Am+nkSNZMAZhsWzCU2Z4Pjh50QYz3f0Hour7/yIGStOLyYY3hgLK2K8TbhgjQPhdkw9+QtKlpvbL8fLgONAoGrVOFnRQGcr70iFffsm79mgZhKVMgYiHPJqJgGHvCtkGg9zMgS7p63+Q3ZWedtFS2RhMX3uCBy/mH6EOlRCNBbRmA4xxNzyf5GQaki3T+Iz9tOMjdPP+CwV2LqEdylmBuik8vrfTb3qIHLKKBAI8lXN26wWtA3kN4L7NP+cbKlCRlqctvhmylLH1AgMBAAEWE3RoaXMtaXMtYS1jaGFsbGVuZ2UwDQYJKoZIhvcNAQEEBQADggEBAIozmeW1kfDfAVwRQKileZGLRGCD7AjdHLYEe16xTBPve8Af1bDOyuWsAm4qQLYA4FAFROiKeGqxCtIErEvm87/09tCfF1My/1Uj+INjAk39DK9J9alLlTsrwSgd1lb3YlXY7TyitCmh7iXLo4pVhA2chNA3njiMq3CUpSvGbpzrESL2dv97lv590gUD988wkTDVyYsf0T8+X0Kww3AgPWGji+2f2i5/jTfD/s1lK1nqi7ZxFm0pGZoy1MJ51SCEy7Y82ajroI+5786nC02mo9ak7samca4YDZOoxN4d3tax4B/HDF5dqJSm1/31xYLDTfujCM5FkSjRc4m6hnriEkc=";
+const invalid = "UzCCATswggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC33FiIiiexwLe/P8DZx5HsqFlmUO7/lvJ7necJVNwqdZ3ax5jpQB0p6uxfqeOvzcN3k5V7UFb/Am+nkSNZMAZhsWzCU2Z4Pjh50QYz3f0Hour7/yIGStOLyYY3hgLK2K8TbhgjQPhdkw9+QtKlpvbL8fLgONAoGrVOFnRQGcr70iFffsm79mgZhKVMgYiHPJqJgGHvCtkGg9zMgS7p63+Q3ZWedtFS2RhMX3uCBy/mH6EOlRCNBbRmA4xxNzyf5GQaki3T+Iz9tOMjdPP+CwV2LqEdylmBuik8vrfTb3qIHLKKBAI8lXN26wWtA3kN4L7NP+cbKlCRlqctvhmylLH1AgMBAAEWE3RoaXMtaXMtYS1jaGFsbGVuZ2UwDQYJKoZIhvcNAQEEBQADggEBAIozmeW1kfDfAVwRQKileZGLRGCD7AjdHLYEe16xTBPve8Af1bDOyuWsAm4qQLYA4FAFROiKeGqxCtIErEvm87/09tCfF1My/1Uj+INjAk39DK9J9alLlTsrwSgd1lb3YlXY7TyitCmh7iXLo4pVhA2chNA3njiMq3CUpSvGbpzrESL2dv97lv590gUD988wkTDVyYsf0T8+X0Kww3AgPWGji+2f2i5/jTfD/s1lK1nqi7ZxFm0pGZoy1MJ51SCEy7Y82ajroI+5786nC02mo9ak7samca4YDZOoxN4d3tax4B/HDF5dqJSm1/31xYLDTfujCM5FkSjRc4m6hnriEkc=";
+
+const Certificate = crypto.Certificate;
+const certificateInstance = new (crypto as any).Certificate();
+
+console.log("verify valid:", Certificate.verifySpkac(valid));
+console.log("verify base64 buffer:", Certificate.verifySpkac(Buffer.from(valid)));
+console.log("verify raw der:", Certificate.verifySpkac(Buffer.from(valid, "base64")));
+console.log("verify invalid:", Certificate.verifySpkac(invalid));
+console.log("challenge:", Certificate.exportChallenge(valid).toString("utf8"));
+console.log("invalid challenge length:", Certificate.exportChallenge(invalid).length);
+console.log("public key header:", Certificate.exportPublicKey(valid).toString("utf8").split("\n")[0]);
+console.log("invalid public key length:", Certificate.exportPublicKey(invalid).length);
+console.log("instance verify valid:", certificateInstance.verifySpkac(valid));
+console.log("instance challenge:", certificateInstance.exportChallenge(valid).toString("utf8"));


### PR DESCRIPTION
## Summary

Adds legacy `crypto.Certificate` SPKAC helpers so `node:crypto` code can call `Certificate.verifySpkac`, `exportPublicKey`, and `exportChallenge` instead of hitting the strict API/runtime missing-function path.

## Changes

- Registers `crypto.Certificate` in the API manifest and native module namespace surface.
- Adds codegen and runtime dispatch for `crypto.Certificate.*` calls and captured/destructured helper calls.
- Implements SPKAC DER/base64 parsing, public key/challenge export, and MD5-RSA PKCS#1 v1.5 signature verification.
- Adds a regression test covering valid/invalid SPKAC fixtures and public-key/challenge output.

## Related issue

Fixes #1844

## Test plan

- [x] `cargo check -q -p perry-codegen -p perry-runtime -p perry-stdlib`
- [x] `cargo run --quiet --bin perry -- compile test-files/test_issue_1844_crypto_certificate_spkac.ts -o /tmp/test_issue_1844_crypto_certificate_spkac && /tmp/test_issue_1844_crypto_certificate_spkac`
- [x] Added a test under `test-files/`

## Screenshots / output

```text
Certificate.verifySpkac type: function
Certificate.exportPublicKey type: function
Certificate.exportChallenge type: function
direct verify valid: true
verify valid: true
verify invalid: false
challenge: this-is-a-challenge
invalid challenge:
public key matches: true
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct
