### PR TITLE
fix(codegen): #1845 nested arrow captures dynamic `this` in computed-key methods (Effect.all/forEach)

### DIFF
--- a/crates/perry-codegen/src/expr/closure.rs
+++ b/crates/perry-codegen/src/expr/closure.rs
@@ -253,7 +253,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 Some(if let Some(slot) = this_slot {
                     ctx.block().load(DOUBLE, &slot)
                 } else {
-                    double_literal(0.0)
+                    // Issue #1845: empty `this_stack` => dynamically-bound
+                    // `this` (computed-key method / function-expression
+                    // receiver). Capture the runtime's `IMPLICIT_THIS`, not
+                    // a 0.0 sentinel. See the matching comment on the
+                    // post-create patch path below.
+                    ctx.block().call(DOUBLE, "js_implicit_this_get", &[])
                 })
             } else {
                 None
@@ -316,17 +321,34 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // topmost entry on `this_stack`; load and write that into
             // the reserved capture slot. Without this, the closure's
             // `Expr::This` reads back 0.0 and any `this.field` access in
-            // the body crashes. Module-level / function-level call sites
-            // have an empty `this_stack` — keep the 0.0 sentinel there
-            // (matches the previous behavior for top-level arrow expressions
-            // that legitimately have no `this` binding).
+            // the body crashes.
+            //
+            // Issue #1845: when `this_stack` is empty the enclosing
+            // function still has a dynamically-bound `this` — this is the
+            // case for a computed-key method (`[expr](){…}`) which lowers
+            // to a function-expression closure field (see
+            // `lower_computed_key_method_as_field`): its body reads `this`
+            // via the runtime's `IMPLICIT_THIS` (set by `recv[k]()`
+            // dispatch), NOT via `this_stack`. A direct `Expr::This` in
+            // such a body already falls back to `js_implicit_this_get`
+            // (see `this_super_call.rs`); a *nested* arrow that captures
+            // `this` must capture that same dynamic receiver, otherwise it
+            // snapshots a bogus 0.0 sentinel. effect's fiber-runtime
+            // op-dispatch hit this: `[OP_WITH_RUNTIME](op){ internalCall(()
+            // => op.i0(this, …)) }` passed `this = 0.0` (a raw number) into
+            // the WithRuntime handler, so `fiber.currentContext` read
+            // `undefined` and `Effect.all`/`Effect.forEach` died with a
+            // `{}` FiberFailure. Falling back to `js_implicit_this_get`
+            // here matches the direct-read path exactly: top-level arrows
+            // that legitimately have no `this` see `undefined` (the
+            // `IMPLICIT_THIS` default), not 0.0 — both are non-crashing.
             if *captures_this {
                 let this_idx = auto_captures.len().to_string();
                 let this_slot = ctx.this_stack.last().cloned();
                 let this_value = if let Some(slot) = this_slot {
                     ctx.block().load(DOUBLE, &slot)
                 } else {
-                    double_literal(0.0)
+                    ctx.block().call(DOUBLE, "js_implicit_this_get", &[])
                 };
                 let blk = ctx.block();
                 blk.call_void(

--- a/test-files/test_gap_computed_key_method_nested_this.ts
+++ b/test-files/test_gap_computed_key_method_nested_this.ts
@@ -1,0 +1,77 @@
+// #1845 / #321: a *nested arrow* that captures `this` inside a COMPUTED-KEY
+// method (`[KEY]() { ... () => this ... }`) snapshotted a bogus `0.0` sentinel
+// instead of the receiver, so the arrow's `this` arrived as the number `0`.
+//
+// Computed-key methods lower to a per-instance function-expression closure
+// field (see `lower_computed_key_method_as_field`): their `this` is bound
+// DYNAMICALLY at call time via the runtime's `IMPLICIT_THIS`, so the enclosing
+// codegen frame has an empty `this_stack`. A direct `this` read in such a body
+// already falls back to `js_implicit_this_get`, but the nested-closure
+// `captures_this` patch site used the `0.0` sentinel when `this_stack` was
+// empty. Fix: fall back to `js_implicit_this_get` there too, matching the
+// direct-read path.
+//
+// This was effect's `Effect.all` / `Effect.forEach` blocker: the fiber-runtime
+// handler `[OP_WITH_RUNTIME](op) { internalCall(() => op.i0(this, ...)) }`
+// passed `this = 0` into the WithRuntime body, so `fiber.currentContext` read
+// `undefined` and the fiber died with a `{}` FiberFailure.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+const wrap = <A>(body: () => A): A => body();
+const KEY = "run";
+
+function readCtx(fiber: any): any {
+  return fiber && fiber.ctx;
+}
+
+class Runtime {
+  public ctx: { v: number } = { v: 42 };
+
+  // Computed-key method: nested arrow captures `this` and passes it as a
+  // call argument to another function (effect's WithRuntime shape).
+  [KEY](): any {
+    return wrap(() => readCtx(this));
+  }
+
+  // Plain method with the identical body must keep working.
+  plain(): any {
+    return wrap(() => readCtx(this));
+  }
+}
+
+const r: any = new Runtime();
+console.log("computed-key:", JSON.stringify(r[KEY]())); // {"v":42}
+console.log("plain:", JSON.stringify(r.plain())); // {"v":42}
+
+// Nested arrow reads `this.field` directly (not just passing `this`).
+class Counter {
+  public n = 7;
+  ["bump"](by: number): number {
+    return wrap(() => this.n + by);
+  }
+}
+const c: any = new Counter();
+console.log("nested this.field:", c["bump"](3)); // 10
+
+// Two levels of nested arrow, both capturing `this`, in a computed-key method.
+class Deep {
+  public label = "deep";
+  ["go"](): string {
+    return wrap(() => wrap(() => this.label + "!"));
+  }
+}
+const d: any = new Deep();
+console.log("double-nested:", d["go"]()); // deep!
+
+// Symbol-keyed method whose nested arrow captures `this` (effect's
+// `[Hash.symbol]()` / `[Equal.symbol]()` shape).
+const TAG = Symbol("tag");
+class WithSym {
+  public val = 99;
+  [TAG](): number {
+    return wrap(() => this.val);
+  }
+}
+const ws: any = new WithSym();
+console.log("symbol-key nested this:", ws[TAG]()); // 99


### PR DESCRIPTION
## Summary

Fixes a codegen miscompile where a **nested arrow that captures `this` inside a computed-key method** snapshotted a bogus `0.0` sentinel instead of the receiver. The arrow's `this` then arrived as the number `0` rather than the object, corrupting any `this`/`this.field` access inside it.

This was the blocker for `Effect.all` / `Effect.forEach` from the `effect` npm framework (even `Effect.all([])` died with a `(FiberFailure) Error: {}`).

Refs #1845, #321.

## Root cause

Computed-key methods (`[expr]() { ... }`) lower to a per-instance **function-expression closure field** (see `lower_computed_key_method_as_field` in `crates/perry-hir/src/lower_decl/class_members.rs`). Their `this` is bound *dynamically* at call time via the runtime's `IMPLICIT_THIS` (set by `recv[k]()` dispatch), so the enclosing codegen frame has an **empty `this_stack`**.

A direct `Expr::This` read in such a body already falls back to `js_implicit_this_get` (`crates/perry-codegen/src/expr/this_super_call.rs`). But the **nested-closure `captures_this` patch site** in `crates/perry-codegen/src/expr/closure.rs` used a `0.0` sentinel when `this_stack` was empty:

```rust
let this_value = if let Some(slot) = this_slot {
    ctx.block().load(DOUBLE, &slot)
} else {
    double_literal(0.0)   // <-- bug: captured 0.0 instead of the dynamic receiver
};
```

So the nested arrow captured `this = 0.0` (NaN-boxed bits that read back as the number `0`).

### How it surfaced in effect

effect's fiber run-loop handler is a computed-key method:

```ts
[OpCodes.OP_WITH_RUNTIME](op) {
  return internalCall(() => op.effect_instruction_i0(this, FiberStatus.running(...)))
}
```

The nested `() => op.effect_instruction_i0(this, ...)` arrow captured `this = 0`, so `context()`'s body `(fiber) => exitSucceed(fiber.currentContext)` received `fiber = 0` (a number) and read `fiber.currentContext === undefined`. The `Effect.all`/`forEach` setup chain (`forEachSequential`'s `suspend` / `whileLoop`) then never ran, and the fiber died with the `{}` defect.

## Minimal standalone repro (no `effect` import)

```ts
const wrap = <A>(body: () => A): A => body();
const KEY = "m";
function read(fiber: any) { return fiber && fiber.ctx; }
class Runtime {
  public ctx: { v: number } = { v: 42 };
  [KEY]()  { return wrap(() => read(this)); }  // computed-key method
  plain()  { return wrap(() => read(this)); }  // plain method
}
const r = new Runtime();
console.log("computed-key:", JSON.stringify((r as any)[KEY]())); // perry: 0   node: {"v":42}
console.log("plain:",        JSON.stringify(r.plain()));         // perry+node: {"v":42}
```

Before fix: `computed-key: 0`. After fix: `computed-key: {"v":42}` — byte-identical to `node --experimental-strip-types`.

## Fix

In `crates/perry-codegen/src/expr/closure.rs`, both `captures_this` patch sites (the post-create patch and the captured-singleton cache buffer) now fall back to `js_implicit_this_get` when `this_stack` is empty, matching the direct-read path exactly. Top-level arrows that legitimately have no `this` see `undefined` (the `IMPLICIT_THIS` default), which is more correct than `0.0` and equally non-crashing.

## Validation

- Minimal repro: perry output byte-identical to node (confirmed it fails `computed-key: 0` without the fix, passes with it).
- `Effect.all([Effect.succeed(1),succeed(2),succeed(3)])` -> `[1,2,3]`; `Effect.all([])` -> `[]`; `Effect.forEach([1,2,3], x=>succeed(x*10))` -> `[10,20,30]` — all byte-identical to node.
- Effect survey (`/private/tmp/effect-dod/survey/*.ts`): `07_all`, `probe_all`, `probe_all2`, `probe_all_err`, `probe_foreach` now pass; `05_gen` still passes; the only remaining failures are the pre-existing Schema cases (`#684`/`#809`).
- Regression sweep over object/class/closure/symbol/spread `test-files/test_*.ts`: no regressions. (`test_gap_class_advanced`'s `static block initialized` diff is pre-existing — reproduced identically with the fix stashed out — and unrelated to this change.)
- New gap test: `test-files/test_gap_computed_key_method_nested_this.ts`, byte-identical to node.
- `cargo fmt --all -- --check` clean; workspace `cargo check` clean.
