### PR TITLE
feat(child_process): streaming spawn() ChildProcess + execFile/execFileSync (#1780)

### DIFF
--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -794,6 +794,36 @@ pub fn check_escapes_in_expr(
                 check_escapes_in_expr(c, candidates, classes, escaped);
             }
         }
+        Expr::ChildProcessExecFile {
+            file,
+            args,
+            options,
+            callback,
+        } => {
+            check_escapes_in_expr(file, candidates, classes, escaped);
+            if let Some(a) = args {
+                check_escapes_in_expr(a, candidates, classes, escaped);
+            }
+            if let Some(o) = options {
+                check_escapes_in_expr(o, candidates, classes, escaped);
+            }
+            if let Some(c) = callback {
+                check_escapes_in_expr(c, candidates, classes, escaped);
+            }
+        }
+        Expr::ChildProcessExecFileSync {
+            file,
+            args,
+            options,
+        } => {
+            check_escapes_in_expr(file, candidates, classes, escaped);
+            if let Some(a) = args {
+                check_escapes_in_expr(a, candidates, classes, escaped);
+            }
+            if let Some(o) = options {
+                check_escapes_in_expr(o, candidates, classes, escaped);
+            }
+        }
         Expr::ChildProcessSpawnBackground {
             command,
             args,

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -602,6 +602,36 @@ fn collect_used_new_fields_in_expr(
                 collect_used_new_fields_in_expr(callback, non_escaping_news, used);
             }
         }
+        Expr::ChildProcessExecFile {
+            file,
+            args,
+            options,
+            callback,
+        } => {
+            collect_used_new_fields_in_expr(file, non_escaping_news, used);
+            if let Some(args) = args {
+                collect_used_new_fields_in_expr(args, non_escaping_news, used);
+            }
+            if let Some(options) = options {
+                collect_used_new_fields_in_expr(options, non_escaping_news, used);
+            }
+            if let Some(callback) = callback {
+                collect_used_new_fields_in_expr(callback, non_escaping_news, used);
+            }
+        }
+        Expr::ChildProcessExecFileSync {
+            file,
+            args,
+            options,
+        } => {
+            collect_used_new_fields_in_expr(file, non_escaping_news, used);
+            if let Some(args) = args {
+                collect_used_new_fields_in_expr(args, non_escaping_news, used);
+            }
+            if let Some(options) = options {
+                collect_used_new_fields_in_expr(options, non_escaping_news, used);
+            }
+        }
         Expr::ChildProcessSpawnBackground {
             command,
             args,

--- a/crates/perry-codegen/src/expr/child_proc.rs
+++ b/crates/perry-codegen/src/expr/child_proc.rs
@@ -162,12 +162,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             } else {
                 "0".to_string()
             };
+            // #1780: spawn returns a streaming ChildProcess (EventEmitter with
+            // Readable stdout/stderr), not the spawnSync result object. The
+            // runtime returns an already-NaN-boxed pointer value.
             let result = ctx.block().call(
-                I64,
-                "js_child_process_spawn_sync",
+                DOUBLE,
+                "js_child_process_spawn_streams",
                 &[(I64, &cmd_str), (I64, &args_str), (I64, &opts_str)],
             );
-            Ok(nanbox_pointer_inline(ctx.block(), &result))
+            Ok(result)
         }
 
         Expr::ChildProcessExec {
@@ -200,6 +203,83 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 &[(I64, &cmd_str), (DOUBLE, &arg1), (DOUBLE, &arg2)],
             );
             Ok(result)
+        }
+
+        Expr::ChildProcessExecFile {
+            file,
+            args,
+            options,
+            callback,
+        } => {
+            // `execFile(file[, args][, options][, callback])` — runs the file
+            // directly (no shell) and fires the callback with `(err, stdout,
+            // stderr)`. file → i64 string handle; args/options/callback → NaN-
+            // boxed f64 (the runtime locates the array + closure). See
+            // `js_child_process_exec_file`.
+            let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+            let file_box = lower_expr(ctx, file)?;
+            let file_str = unbox_to_i64(ctx.block(), &file_box);
+            let args_v = if let Some(a) = args {
+                lower_expr(ctx, a)?
+            } else {
+                undef.clone()
+            };
+            let opts_v = if let Some(o) = options {
+                lower_expr(ctx, o)?
+            } else {
+                undef.clone()
+            };
+            let cb_v = if let Some(c) = callback {
+                lower_expr(ctx, c)?
+            } else {
+                undef.clone()
+            };
+            let result = ctx.block().call(
+                DOUBLE,
+                "js_child_process_exec_file",
+                &[
+                    (I64, &file_str),
+                    (DOUBLE, &args_v),
+                    (DOUBLE, &opts_v),
+                    (DOUBLE, &cb_v),
+                ],
+            );
+            Ok(result)
+        }
+
+        Expr::ChildProcessExecFileSync {
+            file,
+            args,
+            options,
+        } => {
+            // `execFileSync(file[, args][, options])` → stdout string. Runtime
+            // returns null on error; replace with an empty string so `.length`
+            // reads 0 instead of crashing (same guard as execSync).
+            let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+            let file_box = lower_expr(ctx, file)?;
+            let file_str = unbox_to_i64(ctx.block(), &file_box);
+            let args_v = if let Some(a) = args {
+                lower_expr(ctx, a)?
+            } else {
+                undef.clone()
+            };
+            let opts_v = if let Some(o) = options {
+                lower_expr(ctx, o)?
+            } else {
+                undef.clone()
+            };
+            let raw = ctx.block().call(
+                I64,
+                "js_child_process_exec_file_sync",
+                &[(I64, &file_str), (DOUBLE, &args_v), (DOUBLE, &opts_v)],
+            );
+            let is_null = ctx.block().icmp_eq(I64, &raw, "0");
+            let empty = ctx
+                .block()
+                .call(I64, "js_string_from_bytes", &[(PTR, "null"), (I32, "0")]);
+            let blk = ctx.block();
+            let result = blk.select(crate::types::I1, &is_null, I64, &empty, &raw);
+            Ok(nanbox_string_inline(ctx.block(), &result))
         }
 
         Expr::ChildProcessGetProcessStatus(handle) => {

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1903,6 +1903,8 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ChildProcessSpawnBackground { .. }
         | Expr::ChildProcessSpawn { .. }
         | Expr::ChildProcessExec { .. }
+        | Expr::ChildProcessExecFile { .. }
+        | Expr::ChildProcessExecFileSync { .. }
         | Expr::ChildProcessGetProcessStatus(..)
         | Expr::ChildProcessKillProcess(..) => child_proc::lower(ctx, expr),
         Expr::FileURLToPath(..)

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -390,6 +390,19 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
         &[DOUBLE, I64, DOUBLE, DOUBLE],
     );
     module.declare_function("js_child_process_spawn_sync", I64, &[I64, I64, I64]);
+    // #1780: streaming spawn → NaN-boxed ChildProcess pointer (returns DOUBLE).
+    module.declare_function("js_child_process_spawn_streams", DOUBLE, &[I64, I64, I64]);
+    // #1780: execFile (file, args, options, callback) + execFileSync (file, args, options).
+    module.declare_function(
+        "js_child_process_exec_file",
+        DOUBLE,
+        &[I64, DOUBLE, DOUBLE, DOUBLE],
+    );
+    module.declare_function(
+        "js_child_process_exec_file_sync",
+        I64,
+        &[I64, DOUBLE, DOUBLE],
+    );
 
     // ========== cheerio ==========
     module.declare_function("js_cheerio_load", I64, &[I64]);

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1073,6 +1073,19 @@ pub enum Expr {
         options: Option<Box<Expr>>,
         callback: Option<Box<Expr>>,
     },
+    ChildProcessExecFile {
+        // execFile(file, args?, opts?, callback?) -> ChildProcess
+        file: Box<Expr>,
+        args: Option<Box<Expr>>,
+        options: Option<Box<Expr>>,
+        callback: Option<Box<Expr>>,
+    },
+    ChildProcessExecFileSync {
+        // execFileSync(file, args?, opts?) -> Buffer | string
+        file: Box<Expr>,
+        args: Option<Box<Expr>>,
+        options: Option<Box<Expr>>,
+    },
     ChildProcessSpawnBackground {
         // child_process.spawnBackground(cmd, args, logFile, envJson?) -> {pid, handleId}
         command: Box<Expr>,

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -399,6 +399,34 @@ pub(super) fn try_global_builtins(
                             }));
                         }
                     }
+                    "execFile" => {
+                        if !args.is_empty() {
+                            let mut args_iter = args.into_iter();
+                            let file = args_iter.next().unwrap();
+                            let file_args = args_iter.next().map(Box::new);
+                            let options = args_iter.next().map(Box::new);
+                            let callback = args_iter.next().map(Box::new);
+                            return Ok(Ok(Expr::ChildProcessExecFile {
+                                file: Box::new(file),
+                                args: file_args,
+                                options,
+                                callback,
+                            }));
+                        }
+                    }
+                    "execFileSync" => {
+                        if !args.is_empty() {
+                            let mut args_iter = args.into_iter();
+                            let file = args_iter.next().unwrap();
+                            let file_args = args_iter.next().map(Box::new);
+                            let options = args_iter.next().map(Box::new);
+                            return Ok(Ok(Expr::ChildProcessExecFileSync {
+                                file: Box::new(file),
+                                args: file_args,
+                                options,
+                            }));
+                        }
+                    }
                     "spawnBackground" => {
                         if args.len() >= 3 {
                             let mut args_iter = args.into_iter();

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -1146,6 +1146,34 @@ pub(super) fn try_module_static_methods(
                                 }));
                             }
                         }
+                        "execFile" => {
+                            if !args.is_empty() {
+                                let mut args_iter = args.into_iter();
+                                let file = args_iter.next().unwrap();
+                                let file_args = args_iter.next().map(Box::new);
+                                let options = args_iter.next().map(Box::new);
+                                let callback = args_iter.next().map(Box::new);
+                                return Ok(Ok(Expr::ChildProcessExecFile {
+                                    file: Box::new(file),
+                                    args: file_args,
+                                    options,
+                                    callback,
+                                }));
+                            }
+                        }
+                        "execFileSync" => {
+                            if !args.is_empty() {
+                                let mut args_iter = args.into_iter();
+                                let file = args_iter.next().unwrap();
+                                let file_args = args_iter.next().map(Box::new);
+                                let options = args_iter.next().map(Box::new);
+                                return Ok(Ok(Expr::ChildProcessExecFileSync {
+                                    file: Box::new(file),
+                                    args: file_args,
+                                    options,
+                                }));
+                            }
+                        }
                         "spawnBackground" => {
                             if args.len() >= 3 {
                                 let mut args_iter = args.into_iter();

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -295,6 +295,8 @@ impl SH for Expr {
             Expr::ChildProcessSpawnSync { command, args, options, } => { tag(h, 237); command.as_ref().hash(h); args.hash(h); options.hash(h); }
             Expr::ChildProcessSpawn { command, args, options, } => { tag(h, 238); command.as_ref().hash(h); args.hash(h); options.hash(h); }
             Expr::ChildProcessExec { command, options, callback, } => { tag(h, 239); command.as_ref().hash(h); options.hash(h); callback.hash(h); }
+            Expr::ChildProcessExecFile { file, args, options, callback, } => { tag(h, 11239); file.as_ref().hash(h); args.hash(h); options.hash(h); callback.hash(h); }
+            Expr::ChildProcessExecFileSync { file, args, options, } => { tag(h, 11240); file.as_ref().hash(h); args.hash(h); options.hash(h); }
             Expr::ChildProcessSpawnBackground { command, args, log_file, env_json, } => { tag(h, 240); command.as_ref().hash(h); args.hash(h); log_file.as_ref().hash(h); env_json.hash(h); }
             Expr::ChildProcessGetProcessStatus(e) => { tag(h, 241); e.as_ref().hash(h); }
             Expr::ChildProcessKillProcess(e) => { tag(h, 242); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1150,6 +1150,36 @@ where
                 f(c);
             }
         }
+        Expr::ChildProcessExecFile {
+            file,
+            args,
+            options,
+            callback,
+        } => {
+            f(file);
+            if let Some(a) = args {
+                f(a);
+            }
+            if let Some(o) = options {
+                f(o);
+            }
+            if let Some(c) = callback {
+                f(c);
+            }
+        }
+        Expr::ChildProcessExecFileSync {
+            file,
+            args,
+            options,
+        } => {
+            f(file);
+            if let Some(a) = args {
+                f(a);
+            }
+            if let Some(o) = options {
+                f(o);
+            }
+        }
         Expr::ChildProcessSpawnBackground {
             command,
             args,

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1129,6 +1129,36 @@ where
                 f(c);
             }
         }
+        Expr::ChildProcessExecFile {
+            file,
+            args,
+            options,
+            callback,
+        } => {
+            f(file);
+            if let Some(a) = args {
+                f(a);
+            }
+            if let Some(o) = options {
+                f(o);
+            }
+            if let Some(c) = callback {
+                f(c);
+            }
+        }
+        Expr::ChildProcessExecFileSync {
+            file,
+            args,
+            options,
+        } => {
+            f(file);
+            if let Some(a) = args {
+                f(a);
+            }
+            if let Some(o) = options {
+                f(o);
+            }
+        }
         Expr::ChildProcessSpawnBackground {
             command,
             args,

--- a/crates/perry-runtime/src/child_process.rs
+++ b/crates/perry-runtime/src/child_process.rs
@@ -8,8 +8,17 @@ use std::sync::{
     Mutex,
 };
 
-use crate::object::ObjectHeader;
+use crate::closure::{
+    js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr, js_native_call_value,
+    js_register_closure_arity, ClosureHeader,
+};
+use crate::object::{
+    js_implicit_this_get, js_implicit_this_set, js_object_alloc_with_shape,
+    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
+    ObjectHeader,
+};
 use crate::string::{js_string_from_bytes, StringHeader};
+use crate::value::JSValue;
 
 // ============================================================================
 // Background Process Registry
@@ -523,6 +532,659 @@ pub extern "C" fn js_child_process_exec(cmd_ptr: *const StringHeader, arg1: f64,
     };
     crate::closure::js_closure_call3(cb, err_val, stdout_box, stderr_box);
     f64::from_bits(TAG_UNDEFINED_BITS)
+}
+
+// ============================================================================
+// Streaming spawn — a real ChildProcess (EventEmitter + Readable stdout/stderr)
+// ============================================================================
+//
+// `spawn(cmd, args)` runs the command, buffers its stdout/stderr, and returns a
+// heap ChildProcess object whose methods are real closures (the closure-fields
+// pattern from `node_stream.rs::build_object`). Event delivery (`spawn` /
+// `data` / `end` / `exit` / `close`) is deferred to a `setImmediate` macrotask,
+// so handlers registered synchronously after the `spawn()` call — e.g. inside a
+// Promise executor before the first `await`, as the parity test does — are
+// present when the events fire.
+//
+// Perry has no async subprocess reactor, so the child's output is captured
+// synchronously at spawn time. For the short-lived commands these APIs are used
+// with, that is observationally identical to Node's async pipe model once the
+// deferred emission runs on the next event-loop tick. #1780.
+
+// Shape-id band kept clear of node_stream (0x7FFF_FE60+), fs streams
+// (0x7FFF_FE40), and weakref (0x7FFF_FE10+).
+const CP_SHAPE_ID: u32 = 0x7FFF_FD00;
+const CP_READABLE_SHAPE_ID: u32 = 0x7FFF_FD40;
+const CP_WRITABLE_SHAPE_ID: u32 = 0x7FFF_FD80;
+
+#[inline]
+fn cp_undefined() -> f64 {
+    f64::from_bits(TAG_UNDEFINED_BITS)
+}
+
+#[inline]
+fn cp_box_ptr(ptr: *const u8) -> f64 {
+    f64::from_bits(JSValue::pointer(ptr).bits())
+}
+
+/// Recover the host object value captured in closure slot 0 by `cp_build_object`.
+#[inline]
+fn cp_this(closure: *const ClosureHeader) -> f64 {
+    if closure.is_null() {
+        return js_implicit_this_get();
+    }
+    f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64)
+}
+
+/// Resolve a NaN-boxed value to an `ObjectHeader*` iff it is a heap object.
+fn cp_object_ptr(value: f64) -> Option<*mut ObjectHeader> {
+    let bits = value.to_bits();
+    if !JSValue::from_bits(bits).is_pointer() {
+        return None;
+    }
+    let raw = (bits & crate::value::POINTER_MASK) as usize;
+    if raw < 0x10000 || crate::buffer::is_registered_buffer(raw) {
+        return None;
+    }
+    unsafe {
+        let header =
+            (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        if (*header).obj_type != crate::gc::GC_TYPE_OBJECT {
+            return None;
+        }
+    }
+    Some(raw as *mut ObjectHeader)
+}
+
+/// Resolve a NaN-boxed value to an `ArrayHeader*` iff it is a heap array.
+fn cp_array_ptr(value: f64) -> Option<*mut crate::array::ArrayHeader> {
+    let bits = value.to_bits();
+    if !JSValue::from_bits(bits).is_pointer() {
+        return None;
+    }
+    let raw = (bits & crate::value::POINTER_MASK) as usize;
+    if raw < 0x10000 {
+        return None;
+    }
+    unsafe {
+        let header =
+            (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        let t = (*header).obj_type;
+        if t == crate::gc::GC_TYPE_ARRAY || t == crate::gc::GC_TYPE_LAZY_ARRAY {
+            Some(raw as *mut crate::array::ArrayHeader)
+        } else {
+            None
+        }
+    }
+}
+
+#[inline]
+fn cp_str_key(bytes: &[u8]) -> *mut StringHeader {
+    js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
+}
+
+fn cp_get_field(value: f64, name: &[u8]) -> f64 {
+    match cp_object_ptr(value) {
+        Some(obj) => js_object_get_field_by_name_f64(obj, cp_str_key(name)),
+        None => cp_undefined(),
+    }
+}
+
+fn cp_set_field(value: f64, name: &[u8], field_value: f64) {
+    if let Some(obj) = cp_object_ptr(value) {
+        js_object_set_field_by_name(obj, cp_str_key(name), field_value);
+    }
+}
+
+#[inline]
+fn cp_box_string(s: &str) -> f64 {
+    let sh = js_string_from_bytes(s.as_ptr(), s.len() as u32);
+    crate::value::js_nanbox_string(sh as i64)
+}
+
+/// SSO-safe extraction of a JS string value to an owned Rust string. The fixed
+/// child_process event names (`data`/`end`/`exit`/`close`/`spawn`/`error`) and
+/// many argv entries are ≤5 bytes — i.e. SSO short strings — which the file's
+/// `extract_string_from_nanboxed` (STRING_TAG + StringHeader only) misses, so
+/// route through the unified accessor which materializes SSO bytes.
+fn cp_value_to_string(value: f64) -> Option<String> {
+    let ptr = crate::value::js_get_string_pointer_unified(value) as *const StringHeader;
+    if ptr.is_null() || (ptr as usize) < 0x1000 {
+        return None;
+    }
+    unsafe {
+        let len = (*ptr).byte_len as usize;
+        let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        std::str::from_utf8(std::slice::from_raw_parts(data, len))
+            .ok()
+            .map(|s| s.to_string())
+    }
+}
+
+/// Hidden field key holding the listener array for `event`.
+fn cp_listener_key(event: &str) -> Vec<u8> {
+    let mut k = b"__cpL_".to_vec();
+    k.extend_from_slice(event.as_bytes());
+    k
+}
+
+/// Append a listener closure to `target`'s `event` list (the `.on` body).
+fn cp_register(target: f64, event: f64, cb: f64) {
+    let name = match cp_value_to_string(event) {
+        Some(n) => n,
+        None => return,
+    };
+    let key = cp_listener_key(&name);
+    let arr = match cp_array_ptr(cp_get_field(target, &key)) {
+        Some(a) => a,
+        None => crate::array::js_array_alloc(2),
+    };
+    let arr = crate::array::js_array_push_f64(arr, cb);
+    cp_set_field(target, &key, cp_box_ptr(arr as *const u8));
+}
+
+/// Invoke every listener registered on `target` for `event`. Returns whether
+/// any fired. The listener array is re-read each iteration so a moving GC
+/// during a handler call can't strand us on a stale array pointer.
+fn cp_emit(target: f64, event: &str, args: &[f64]) -> bool {
+    let key = cp_listener_key(event);
+    let mut i: u32 = 0;
+    let mut fired = false;
+    loop {
+        let arr = match cp_array_ptr(cp_get_field(target, &key)) {
+            Some(a) => a,
+            None => break,
+        };
+        if i >= crate::array::js_array_length(arr) {
+            break;
+        }
+        let cb = crate::array::js_array_get_f64(arr, i);
+        let prev = js_implicit_this_set(target);
+        unsafe {
+            let _ = js_native_call_value(cb, args.as_ptr(), args.len());
+        }
+        js_implicit_this_set(prev);
+        fired = true;
+        i += 1;
+    }
+    fired
+}
+
+fn cp_signal_name(sig: i32) -> &'static str {
+    match sig {
+        1 => "SIGHUP",
+        2 => "SIGINT",
+        6 => "SIGABRT",
+        9 => "SIGKILL",
+        11 => "SIGSEGV",
+        15 => "SIGTERM",
+        _ => "SIGTERM",
+    }
+}
+
+// ----- method bodies (each receives the closure; slot 0 = host `this`) -----
+
+extern "C" fn cp_method_on(closure: *const ClosureHeader, event: f64, cb: f64) -> f64 {
+    let this = cp_this(closure);
+    cp_register(this, event, cb);
+    this
+}
+extern "C" fn cp_method_emit(closure: *const ClosureHeader, event: f64, arg: f64) -> f64 {
+    let this = cp_this(closure);
+    let name = match cp_value_to_string(event) {
+        Some(n) => n,
+        None => return TAG_FALSE_F64,
+    };
+    if cp_emit(this, &name, &[arg]) {
+        TAG_TRUE_F64
+    } else {
+        TAG_FALSE_F64
+    }
+}
+extern "C" fn cp_method_this0(closure: *const ClosureHeader) -> f64 {
+    cp_this(closure)
+}
+extern "C" fn cp_method_this1(closure: *const ClosureHeader, _a: f64) -> f64 {
+    cp_this(closure)
+}
+extern "C" fn cp_method_this2(closure: *const ClosureHeader, _a: f64, _b: f64) -> f64 {
+    cp_this(closure)
+}
+extern "C" fn cp_method_kill(closure: *const ClosureHeader, _signal: f64) -> f64 {
+    cp_set_field(cp_this(closure), b"killed", TAG_TRUE_F64);
+    TAG_TRUE_F64
+}
+extern "C" fn cp_method_read(_closure: *const ClosureHeader, _n: f64) -> f64 {
+    TAG_NULL_F64
+}
+extern "C" fn cp_method_pipe(_closure: *const ClosureHeader, dest: f64) -> f64 {
+    dest
+}
+extern "C" fn cp_method_write2(_closure: *const ClosureHeader, _chunk: f64, _enc: f64) -> f64 {
+    TAG_TRUE_F64
+}
+
+/// Deferred emission body, scheduled via `setImmediate` from `spawn`. Slot 0
+/// captures the ChildProcess value.
+extern "C" fn cp_emit_all(closure: *const ClosureHeader) -> f64 {
+    let cp = cp_this(closure);
+
+    // A spawn failure (e.g. ENOENT) surfaces as a single `error` event; Node
+    // never fires `spawn`/`exit` in that case.
+    let err = cp_get_field(cp, b"__cpError");
+    if !JSValue::from_bits(err.to_bits()).is_undefined() {
+        cp_emit(cp, "error", &[err]);
+        return cp_undefined();
+    }
+
+    cp_emit(cp, "spawn", &[]);
+
+    // Flush each output stream: a single `data` chunk (when non-empty) then `end`.
+    for field in [b"stdout".as_slice(), b"stderr".as_slice()] {
+        let stream = cp_get_field(cp, field);
+        if cp_object_ptr(stream).is_none() {
+            continue;
+        }
+        let chunk = cp_get_field(stream, b"__cpChunk");
+        if !JSValue::from_bits(chunk.to_bits()).is_undefined() {
+            cp_emit(stream, "data", &[chunk]);
+        }
+        cp_emit(stream, "end", &[]);
+    }
+
+    // Node populates `exitCode`/`signalCode` before emitting `exit`, then `close`.
+    let code = cp_get_field(cp, b"__cpExitCode");
+    let signal = cp_get_field(cp, b"__cpSignal");
+    cp_set_field(cp, b"exitCode", code);
+    cp_set_field(cp, b"signalCode", signal);
+    cp_emit(cp, "exit", &[code, signal]);
+    cp_emit(cp, "close", &[code, signal]);
+    cp_undefined()
+}
+
+// ----- object construction -----
+
+type CpFn = unsafe extern "C" fn();
+#[allow(clippy::missing_transmute_annotations)]
+fn cp_cast0(f: extern "C" fn(*const ClosureHeader) -> f64) -> CpFn {
+    unsafe { std::mem::transmute(f) }
+}
+#[allow(clippy::missing_transmute_annotations)]
+fn cp_cast1(f: extern "C" fn(*const ClosureHeader, f64) -> f64) -> CpFn {
+    unsafe { std::mem::transmute(f) }
+}
+#[allow(clippy::missing_transmute_annotations)]
+fn cp_cast2(f: extern "C" fn(*const ClosureHeader, f64, f64) -> f64) -> CpFn {
+    unsafe { std::mem::transmute(f) }
+}
+
+fn cp_register_arities() {
+    js_register_closure_arity(cp_method_on as *const u8, 2);
+    js_register_closure_arity(cp_method_emit as *const u8, 2);
+    js_register_closure_arity(cp_method_this0 as *const u8, 0);
+    js_register_closure_arity(cp_method_this1 as *const u8, 1);
+    js_register_closure_arity(cp_method_this2 as *const u8, 2);
+    js_register_closure_arity(cp_method_kill as *const u8, 1);
+    js_register_closure_arity(cp_method_read as *const u8, 1);
+    js_register_closure_arity(cp_method_pipe as *const u8, 1);
+    js_register_closure_arity(cp_method_write2 as *const u8, 2);
+    js_register_closure_arity(cp_emit_all as *const u8, 0);
+}
+
+/// Allocate a heap object whose method-name fields each hold a closure capturing
+/// the object itself in slot 0 (so method bodies recover `this`).
+fn cp_build_object(methods: &[(&str, CpFn)], shape_id: u32) -> *mut ObjectHeader {
+    let mut packed: Vec<u8> = Vec::new();
+    for (name, _) in methods {
+        packed.extend_from_slice(name.as_bytes());
+        packed.push(0);
+    }
+    let obj = js_object_alloc_with_shape(
+        shape_id,
+        methods.len() as u32,
+        packed.as_ptr(),
+        packed.len() as u32,
+    );
+    let this_bits = JSValue::pointer(obj as *const u8).bits();
+    for (i, (_name, func)) in methods.iter().enumerate() {
+        let closure = js_closure_alloc(*func as *const u8, 1);
+        js_closure_set_capture_ptr(closure, 0, this_bits as i64);
+        js_object_set_field(obj, i as u32, JSValue::pointer(closure as *const u8));
+    }
+    obj
+}
+
+/// Build a stdout/stderr Readable-shaped EventEmitter.
+fn cp_build_readable() -> f64 {
+    let methods: [(&str, CpFn); 13] = [
+        ("on", cp_cast2(cp_method_on)),
+        ("once", cp_cast2(cp_method_on)),
+        ("addListener", cp_cast2(cp_method_on)),
+        ("prependListener", cp_cast2(cp_method_on)),
+        ("off", cp_cast2(cp_method_this2)),
+        ("removeListener", cp_cast2(cp_method_this2)),
+        ("emit", cp_cast2(cp_method_emit)),
+        ("pause", cp_cast0(cp_method_this0)),
+        ("resume", cp_cast0(cp_method_this0)),
+        ("destroy", cp_cast0(cp_method_this0)),
+        ("setEncoding", cp_cast1(cp_method_this1)),
+        ("read", cp_cast1(cp_method_read)),
+        ("pipe", cp_cast1(cp_method_pipe)),
+    ];
+    let obj = cp_build_object(&methods, CP_READABLE_SHAPE_ID + methods.len() as u32);
+    let val = cp_box_ptr(obj as *const u8);
+    cp_set_field(val, b"readable", TAG_TRUE_F64);
+    cp_set_field(val, b"destroyed", TAG_FALSE_F64);
+    val
+}
+
+/// Build a stdin Writable-shaped EventEmitter.
+fn cp_build_writable() -> f64 {
+    let methods: [(&str, CpFn); 11] = [
+        ("on", cp_cast2(cp_method_on)),
+        ("once", cp_cast2(cp_method_on)),
+        ("addListener", cp_cast2(cp_method_on)),
+        ("removeListener", cp_cast2(cp_method_this2)),
+        ("off", cp_cast2(cp_method_this2)),
+        ("emit", cp_cast2(cp_method_emit)),
+        ("write", cp_cast2(cp_method_write2)),
+        ("end", cp_cast1(cp_method_this1)),
+        ("destroy", cp_cast0(cp_method_this0)),
+        ("cork", cp_cast0(cp_method_this0)),
+        ("uncork", cp_cast0(cp_method_this0)),
+    ];
+    let obj = cp_build_object(&methods, CP_WRITABLE_SHAPE_ID + methods.len() as u32);
+    let val = cp_box_ptr(obj as *const u8);
+    cp_set_field(val, b"writable", TAG_TRUE_F64);
+    cp_set_field(val, b"destroyed", TAG_FALSE_F64);
+    val
+}
+
+/// NaN-boxed `Buffer` value holding `bytes`.
+fn cp_make_buffer(bytes: &[u8]) -> f64 {
+    let buf = crate::buffer::js_buffer_alloc(bytes.len() as i32, 0);
+    if buf.is_null() {
+        return cp_undefined();
+    }
+    unsafe {
+        let data = (buf as *mut u8).add(std::mem::size_of::<crate::buffer::BufferHeader>());
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), data, bytes.len());
+        (*buf).length = bytes.len() as u32;
+    }
+    cp_box_ptr(buf as *const u8)
+}
+
+unsafe fn cp_read_string_header(ptr: i64) -> String {
+    if ptr == 0 {
+        return String::new();
+    }
+    let sh = ptr as *const StringHeader;
+    let len = (*sh).byte_len as usize;
+    let data = (sh as *const u8).add(std::mem::size_of::<StringHeader>());
+    String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned()
+}
+
+unsafe fn cp_read_arg_strings(args_ptr: i64) -> Vec<String> {
+    let mut out = Vec::new();
+    if args_ptr == 0 {
+        return out;
+    }
+    let arr = args_ptr as *const crate::array::ArrayHeader;
+    let n = (*arr).length as usize;
+    let data =
+        (arr as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const f64;
+    for i in 0..n {
+        if let Some(s) = cp_value_to_string(*data.add(i)) {
+            out.push(s);
+        }
+    }
+    out
+}
+
+/// `child_process.spawn(command[, args][, options])` — returns a streaming
+/// ChildProcess. `cmd_ptr`/`args_ptr` are raw (unboxed) `StringHeader` /
+/// `ArrayHeader` pointers; `opts_ptr` is currently unused (no shell, default
+/// stdio). #1780.
+#[no_mangle]
+pub extern "C" fn js_child_process_spawn_streams(
+    cmd_ptr: i64,
+    args_ptr: i64,
+    _opts_ptr: i64,
+) -> f64 {
+    cp_register_arities();
+
+    let (cmd_str, arg_strs) = unsafe {
+        (
+            cp_read_string_header(cmd_ptr),
+            cp_read_arg_strings(args_ptr),
+        )
+    };
+
+    // Run the command directly (no shell — matches Node's spawn) and collect its
+    // output synchronously.
+    let mut command = Command::new(&cmd_str);
+    command.args(&arg_strs);
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    let (pid, stdout_bytes, stderr_bytes, exit_code, signal_opt, spawn_err) = match command.spawn()
+    {
+        Ok(child) => {
+            let pid = child.id();
+            match child.wait_with_output() {
+                Ok(out) => {
+                    let code = out.status.code();
+                    #[cfg(unix)]
+                    let sig = {
+                        use std::os::unix::process::ExitStatusExt;
+                        out.status.signal()
+                    };
+                    #[cfg(not(unix))]
+                    let sig: Option<i32> = None;
+                    (Some(pid), out.stdout, out.stderr, code, sig, None)
+                }
+                Err(e) => (
+                    Some(pid),
+                    Vec::new(),
+                    Vec::new(),
+                    None,
+                    None,
+                    Some(e.to_string()),
+                ),
+            }
+        }
+        Err(e) => (
+            None,
+            Vec::new(),
+            Vec::new(),
+            None,
+            None,
+            Some(e.to_string()),
+        ),
+    };
+
+    // stdout/stderr Readable + stdin Writable sub-objects.
+    let stdout_obj = cp_build_readable();
+    let stderr_obj = cp_build_readable();
+    let stdin_obj = cp_build_writable();
+    if !stdout_bytes.is_empty() {
+        cp_set_field(stdout_obj, b"__cpChunk", cp_make_buffer(&stdout_bytes));
+    }
+    if !stderr_bytes.is_empty() {
+        cp_set_field(stderr_obj, b"__cpChunk", cp_make_buffer(&stderr_bytes));
+    }
+
+    // spawnargs = [command, ...args]
+    let mut spawnargs = crate::array::js_array_alloc((arg_strs.len() + 1) as u32);
+    spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(&cmd_str));
+    for a in &arg_strs {
+        spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(a));
+    }
+
+    let cp_methods: [(&str, CpFn); 11] = [
+        ("on", cp_cast2(cp_method_on)),
+        ("once", cp_cast2(cp_method_on)),
+        ("addListener", cp_cast2(cp_method_on)),
+        ("prependListener", cp_cast2(cp_method_on)),
+        ("removeListener", cp_cast2(cp_method_this2)),
+        ("off", cp_cast2(cp_method_this2)),
+        ("removeAllListeners", cp_cast1(cp_method_this1)),
+        ("emit", cp_cast2(cp_method_emit)),
+        ("kill", cp_cast1(cp_method_kill)),
+        ("ref", cp_cast0(cp_method_this0)),
+        ("unref", cp_cast0(cp_method_this0)),
+    ];
+    let cp_obj = cp_build_object(&cp_methods, CP_SHAPE_ID + cp_methods.len() as u32);
+    let cp = cp_box_ptr(cp_obj as *const u8);
+
+    cp_set_field(cp, b"stdout", stdout_obj);
+    cp_set_field(cp, b"stderr", stderr_obj);
+    cp_set_field(cp, b"stdin", stdin_obj);
+
+    let mut stdio = crate::array::js_array_alloc(3);
+    stdio = crate::array::js_array_push_f64(stdio, stdin_obj);
+    stdio = crate::array::js_array_push_f64(stdio, stdout_obj);
+    stdio = crate::array::js_array_push_f64(stdio, stderr_obj);
+    cp_set_field(cp, b"stdio", cp_box_ptr(stdio as *const u8));
+
+    cp_set_field(
+        cp,
+        b"pid",
+        match pid {
+            Some(p) => p as f64,
+            None => cp_undefined(),
+        },
+    );
+    cp_set_field(cp, b"exitCode", TAG_NULL_F64);
+    cp_set_field(cp, b"signalCode", TAG_NULL_F64);
+    cp_set_field(cp, b"killed", TAG_FALSE_F64);
+    cp_set_field(cp, b"connected", TAG_FALSE_F64);
+    cp_set_field(cp, b"spawnargs", cp_box_ptr(spawnargs as *const u8));
+    cp_set_field(cp, b"spawnfile", cp_box_string(&cmd_str));
+
+    // Hidden state consumed by the deferred emission.
+    cp_set_field(
+        cp,
+        b"__cpExitCode",
+        match exit_code {
+            Some(c) => c as f64,
+            None => TAG_NULL_F64,
+        },
+    );
+    cp_set_field(
+        cp,
+        b"__cpSignal",
+        match signal_opt {
+            Some(s) => cp_box_string(cp_signal_name(s)),
+            None => TAG_NULL_F64,
+        },
+    );
+    if let Some(msg) = spawn_err {
+        let mp = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+        let err = crate::error::js_error_new_with_message(mp);
+        cp_set_field(
+            cp,
+            b"__cpError",
+            crate::value::js_nanbox_pointer(err as i64),
+        );
+    }
+
+    // Defer spawn/data/end/exit/close until the next tick so handlers registered
+    // synchronously after this call are present when the events fire.
+    let emit_closure = js_closure_alloc(cp_emit_all as *const u8, 1);
+    js_closure_set_capture_ptr(emit_closure, 0, cp.to_bits() as i64);
+    crate::timer::js_set_immediate_callback(emit_closure as i64);
+
+    cp
+}
+
+/// Collect a NaN-boxed args value (array of strings) into owned Rust strings.
+fn cp_args_from_value(value: f64) -> Vec<String> {
+    match cp_array_ptr(value) {
+        Some(arr) => {
+            let n = unsafe { (*arr).length };
+            let mut out = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                if let Some(s) = cp_value_to_string(crate::array::js_array_get_f64(arr, i)) {
+                    out.push(s);
+                }
+            }
+            out
+        }
+        None => Vec::new(),
+    }
+}
+
+/// `child_process.execFile(file[, args][, options][, callback])` — like `exec`
+/// but runs `file` directly (no shell). The callback fires with
+/// `(err, stdout, stderr)`; with no callback the stdout string is returned.
+/// The callback may sit in the options slot (`execFile(file, args, cb)`), so it
+/// is located the same way `exec` disambiguates. #1780.
+#[no_mangle]
+pub extern "C" fn js_child_process_exec_file(
+    file_ptr: i64,
+    args_val: f64,
+    opts_val: f64,
+    cb_val: f64,
+) -> f64 {
+    use crate::fs::extract_closure_ptr;
+    let cb = {
+        let c = extract_closure_ptr(cb_val);
+        if !c.is_null() {
+            c
+        } else {
+            extract_closure_ptr(opts_val)
+        }
+    };
+    let box_string = |bytes: &[u8]| -> f64 {
+        let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+        crate::value::js_nanbox_string(ptr as i64)
+    };
+
+    let file_str = unsafe { cp_read_string_header(file_ptr) };
+    let arg_strs = cp_args_from_value(args_val);
+
+    let (stdout_bytes, stderr_bytes, success) =
+        match Command::new(&file_str).args(&arg_strs).output() {
+            Ok(o) => (o.stdout, o.stderr, o.status.success()),
+            Err(e) => (Vec::new(), e.to_string().into_bytes(), false),
+        };
+
+    let stdout_box = box_string(&stdout_bytes);
+    if cb.is_null() {
+        return stdout_box;
+    }
+    let stderr_box = box_string(&stderr_bytes);
+    let err_val = if success {
+        TAG_NULL_F64
+    } else {
+        let msg = "Command failed";
+        let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+        let err_ptr = crate::error::js_error_new_with_message(msg_ptr);
+        crate::value::js_nanbox_pointer(err_ptr as i64)
+    };
+    crate::closure::js_closure_call3(cb, err_val, stdout_box, stderr_box);
+    f64::from_bits(TAG_UNDEFINED_BITS)
+}
+
+/// `child_process.execFileSync(file[, args][, options])` — runs `file`
+/// directly (no shell) and returns its stdout. #1780.
+#[no_mangle]
+pub extern "C" fn js_child_process_exec_file_sync(
+    file_ptr: i64,
+    args_val: f64,
+    _opts_val: f64,
+) -> *mut StringHeader {
+    let file_str = unsafe { cp_read_string_header(file_ptr) };
+    if file_str.is_empty() {
+        return js_string_from_bytes(b"".as_ptr(), 0);
+    }
+    let arg_strs = cp_args_from_value(args_val);
+    match Command::new(&file_str).args(&arg_strs).output() {
+        Ok(o) => js_string_from_bytes(o.stdout.as_ptr(), o.stdout.len() as u32),
+        Err(_) => js_string_from_bytes(b"".as_ptr(), 0),
+    }
 }
 
 #[cfg(test)]

--- a/test-files/test_issue_1780_spawn_streams.ts
+++ b/test-files/test_issue_1780_spawn_streams.ts
@@ -1,0 +1,91 @@
+// Issue #1780: child_process.spawn() now returns a real streaming ChildProcess
+// — an EventEmitter (`spawn`/`exit`/`close`) whose `stdout`/`stderr` are
+// Readable streams (`data`/`end`) — instead of the spawnSync result object whose
+// `.stdout` was a string (so `child.stdout.on(...)` threw). Also adds
+// `execFile` (callback) and `execFileSync`.
+//
+// Probes shape + event delivery deterministically: no pid / raw exit codes /
+// stderr text that vary per host. Byte-for-byte vs `node --experimental-strip-types`.
+import { spawn, execFile, execFileSync } from "node:child_process";
+
+// ── spawn: stdout `data` accumulates, then `exit` fires ──
+await new Promise<void>((resolve) => {
+  const sp = spawn("/bin/echo", ["spawn-hello"]);
+  console.log("spawn typeof:", typeof sp);
+  console.log("spawn typeof stdout:", typeof sp.stdout);
+  console.log("spawn typeof kill:", typeof sp.kill);
+  let buf = "";
+  sp.stdout.on("data", (chunk: any) => {
+    buf += chunk.toString();
+  });
+  sp.on("exit", () => {
+    console.log("spawn stdout:", buf.trim());
+    resolve();
+  });
+});
+
+// ── ChildProcess shape (probe types only — values vary per run) ──
+{
+  const sp = spawn("/bin/echo", ["shape"]);
+  console.log("typeof channel:", typeof sp.channel);
+  console.log("typeof connected:", typeof sp.connected);
+  console.log("typeof exitCode:", typeof sp.exitCode);
+  console.log("typeof killed:", typeof sp.killed);
+  console.log("typeof pid:", typeof sp.pid);
+  console.log("typeof signalCode:", typeof sp.signalCode);
+  console.log("typeof spawnargs:", typeof sp.spawnargs);
+  console.log("spawnargs isArray:", Array.isArray(sp.spawnargs));
+  console.log("typeof spawnfile:", typeof sp.spawnfile);
+  console.log("typeof stdin:", typeof sp.stdin);
+  console.log("typeof stdout:", typeof sp.stdout);
+  console.log("typeof stderr:", typeof sp.stderr);
+  console.log("typeof stdio:", typeof sp.stdio);
+  console.log("typeof uid:", typeof sp.uid);
+  console.log("typeof gid:", typeof sp.gid);
+  console.log("typeof kill:", typeof sp.kill);
+  console.log("typeof send:", typeof sp.send);
+  console.log("typeof disconnect:", typeof sp.disconnect);
+  console.log("typeof ref:", typeof sp.ref);
+  console.log("typeof unref:", typeof sp.unref);
+  await new Promise<void>((resolve) => {
+    sp.on("exit", () => resolve());
+  });
+}
+
+// ── events: spawn / exit / close all fire ──
+{
+  const sp = spawn("/bin/echo", ["events"]);
+  let sawSpawn = false;
+  let sawExit = false;
+  let sawClose = false;
+  sp.on("spawn", () => {
+    sawSpawn = true;
+  });
+  sp.on("exit", () => {
+    sawExit = true;
+  });
+  sp.on("close", () => {
+    sawClose = true;
+  });
+  await new Promise<void>((resolve) => {
+    sp.on("close", () => resolve());
+  });
+  console.log("event spawn fired:", sawSpawn);
+  console.log("event exit fired:", sawExit);
+  console.log("event close fired:", sawClose);
+}
+
+// ── execFile(file, args, callback) ──
+const ef = await new Promise<string>((resolve, reject) => {
+  execFile("/bin/echo", ["execFile-hello"], (err: any, stdout: any) => {
+    if (err) reject(err);
+    else resolve(String(stdout).trim());
+  });
+});
+console.log("execFile stdout:", ef);
+
+// ── execFileSync(file, args) ──
+console.log(
+  "execFileSync stdout:",
+  execFileSync("/bin/echo", ["execFileSync-hello"]).toString().trim(),
+);


### PR DESCRIPTION
## Summary

Implements the largest remaining part of #1780: a **real streaming `child_process.spawn()`** plus `execFile`/`execFileSync`.

Before this, `spawn()` returned the `spawnSync` result object whose `.stdout` was a **string**, so the dominant node-core pattern

```ts
const child = spawn(cmd, args);
child.stdout.on("data", d => …);   // → "(string).on is not a function"
child.on("exit", …);
```

threw at runtime. Most of #1780's 52 radar fails bottom out there. (The `exec` callback path landed earlier in #1828.)

`spawn()` now returns a `ChildProcess`:

- an **EventEmitter** — `on`/`once`/`addListener`/`emit`/`kill`/`ref`/`unref` — that fires `spawn`, `exit`, `close` (and `error` on spawn failure);
- `stdout`/`stderr` are **Readable** sub-objects (`on('data'|'end')`, `pause`/`resume`/`pipe`/…), `stdin` is **Writable**;
- the shape probe matches Node: `pid` number, `exitCode`/`signalCode` null, `killed`/`connected` boolean, `spawnargs` array, `spawnfile` string, `stdio` array, and `channel`/`uid`/`gid`/`send`/`disconnect` correctly **`undefined`** (non-IPC child).

Plus **`execFile`** (fires `(err, stdout, stderr)`, runs the file directly with no shell) and **`execFileSync`**.

## How it works

- The child runs synchronously at `spawn()` time and its stdout/stderr are buffered. Perry has no async subprocess reactor; for the short-lived commands these APIs target, synchronous capture + deferred emission is observationally identical to Node once the events fire.
- Emission of `spawn`/`data`/`end`/`exit`/`close` is **deferred to a `setImmediate` macrotask**, so handlers registered synchronously after `spawn()` (e.g. inside a Promise executor before the first `await`) are present when the events fire.
- `ChildProcess` and its stdout/stderr/stdin sub-objects are heap objects whose methods are real closures (the `node_stream.rs::build_object` closure-fields pattern). So `child.stdout.on(...)`, `child.on(...)`, `child.kill()` dispatch as ordinary JS object methods — **no new codegen method dispatch**; only `spawn()`/`execFile()`/`execFileSync()` get codegen routing. Listener lists and buffered output live on the heap objects, so the GC manages their lifetimes (reachable from the user's `child`).
- SSO-safe event-name extraction (the event names `data`/`exit`/`end`/`close`/`spawn` are all ≤5 bytes → short strings, which the byte-pointer extractor misses).

## Test

`test-files/test_issue_1780_spawn_streams.ts` is **byte-identical** to `node --experimental-strip-types` — spawn stream `data`+`exit`, full ChildProcess shape probe, `spawn`/`exit`/`close` event firing, `execFile`, `execFileSync`. The existing `test_issue_1780_exec_callback.ts` still passes byte-for-byte (no regression); `cargo test -p perry-runtime -p perry-hir -p perry-codegen` green; `cargo fmt --all --check` clean.

## Remaining #1780 surface (split into follow-ups)

- **#1856** — `child_process.ChildProcess` / `Stream` named exports. A *value-form* read of `child_process.ChildProcess` currently trips the `#463` unimplemented-surface guard at compile time, which blocks the `test_parity_child_process` gap test from compiling at all.
- **#1857** — `util.promisify(exec)` / `promisify(execFile)`.

Once those two land the `test_parity_child_process` gap test can be flipped green.

## Files

Runtime `crates/perry-runtime/src/child_process.rs` (spawn_streams + execFile/sync), codegen routing + FFI decls, HIR `Expr::ChildProcessExecFile`/`ExecFileSync` variants + lowering + walkers/hash/escape-collectors.
