### PR TITLE
fix(node:net): connection lifecycle — 'end' event, ephemeral listen(0), address() object, end(data), option stubs (#1852)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -537,6 +537,24 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("net", "destroy", true, Some("Socket")),
     method("net", "on", true, Some("Socket")),
     method("net", "upgradeToTLS", true, Some("Socket")),
+    // Issue #1852 — chainable no-op `net.Socket` option setters. Perry's
+    // TCP transport doesn't model Nagle/keep-alive/idle-timeout or read
+    // back-pressure yet, but the methods must be callable (and return the
+    // socket for chaining) instead of throwing "not a function". These
+    // names also cover the `net.Server` `ref`/`unref`/`setTimeout` rows
+    // below (`module_has_symbol` is name-based), so they unblock the
+    // strict-API gate for both classes.
+    method("net", "setNoDelay", true, Some("Socket")),
+    method("net", "setKeepAlive", true, Some("Socket")),
+    method("net", "setTimeout", true, Some("Socket")),
+    method("net", "setEncoding", true, Some("Socket")),
+    method("net", "setDefaultEncoding", true, Some("Socket")),
+    method("net", "pause", true, Some("Socket")),
+    method("net", "resume", true, Some("Socket")),
+    method("net", "ref", true, Some("Socket")),
+    method("net", "unref", true, Some("Socket")),
+    method("net", "cork", true, Some("Socket")),
+    method("net", "uncork", true, Some("Socket")),
     // Issue #1123 followup — `net.Server` instance methods backing
     // `createServer(...).listen/.close/.address/.on`. Mirrors the
     // shape of the http-server rows at entries.rs:2298. The

--- a/crates/perry-codegen/src/ext_registry.rs
+++ b/crates/perry-codegen/src/ext_registry.rs
@@ -186,6 +186,9 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
     ("js_net_server_close",                         OwnerKind::WellKnown("net")),
     ("js_net_server_address",                       OwnerKind::WellKnown("net")),
     ("js_net_server_on",                            OwnerKind::WellKnown("net")),
+    // #1852 — chainable no-op option setters for Socket/Server.
+    ("js_net_socket_noop_self",                     OwnerKind::WellKnown("net")),
+    ("js_net_server_noop_self",                     OwnerKind::WellKnown("net")),
 
     // ── #1724: global Blob/File + URL object-URL helpers ──────────────
     // `new Blob([...])`, `new File([...], name)`, `URL.createObjectURL`,

--- a/crates/perry-codegen/src/lower_call/native_module_dispatch.rs
+++ b/crates/perry-codegen/src/lower_call/native_module_dispatch.rs
@@ -142,8 +142,19 @@ pub fn lower_native_module_dispatch(
                 ));
                 arg_types.push(DOUBLE);
             }
-            NativeArgKind::StrPtr | NativeArgKind::PtrI64 | NativeArgKind::JsvalI64 => {
+            NativeArgKind::StrPtr | NativeArgKind::PtrI64 => {
                 llvm_args.push((I64, "0".to_string()));
+                arg_types.push(I64);
+            }
+            NativeArgKind::JsvalI64 => {
+                // A missing NA_JSV arg is JS `undefined`, not numeric 0.
+                // NA_JSV slots carry the *raw NaN-box bits* as i64, so a
+                // padded `0` would be read back as the f64 `0.0` (a number)
+                // — issue #1852: `socket.end()` with no args then
+                // stringified `0` and wrote a spurious "0" byte before FIN.
+                // Pad with the TAG_UNDEFINED bit pattern so the callee's
+                // value-probe sees `undefined`.
+                llvm_args.push((I64, (crate::nanbox::TAG_UNDEFINED as i64).to_string()));
                 arg_types.push(I64);
             }
             NativeArgKind::VarArgsAsArray => {

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -271,7 +271,11 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         method: "end",
         class_filter: Some("Socket"),
         runtime: "js_net_socket_end",
-        args: &[],
+        // Issue #1852 — `socket.end([data])` writes the optional final
+        // chunk before half-closing. NA_JSV carries the full NaN-boxed
+        // value so the runtime can probe Buffer/string/number; the
+        // no-arg `socket.end()` form pads this slot with `undefined`.
+        args: &[NA_JSV],
         ret: NR_VOID,
     },
     NativeModSig {
@@ -291,6 +295,111 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         runtime: "js_net_socket_on",
         args: &[NA_STR, NA_PTR],
         ret: NR_VOID,
+    },
+    // Issue #1852 — chainable no-op `net.Socket` option setters. Perry's
+    // TCP transport doesn't model Nagle/keep-alive/idle-timeout or read
+    // back-pressure yet, but the methods must exist + be callable (pre-fix
+    // they threw "x is not a function" — the radar's "value() missing"
+    // cluster). Each returns the socket handle so chained forms keep
+    // dispatching. `args: &[]` ignores the option arguments.
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "setNoDelay",
+        class_filter: Some("Socket"),
+        runtime: "js_net_socket_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "setKeepAlive",
+        class_filter: Some("Socket"),
+        runtime: "js_net_socket_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "setTimeout",
+        class_filter: Some("Socket"),
+        runtime: "js_net_socket_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "setEncoding",
+        class_filter: Some("Socket"),
+        runtime: "js_net_socket_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "pause",
+        class_filter: Some("Socket"),
+        runtime: "js_net_socket_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "resume",
+        class_filter: Some("Socket"),
+        runtime: "js_net_socket_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "ref",
+        class_filter: Some("Socket"),
+        runtime: "js_net_socket_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "unref",
+        class_filter: Some("Socket"),
+        runtime: "js_net_socket_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "cork",
+        class_filter: Some("Socket"),
+        runtime: "js_net_socket_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "uncork",
+        class_filter: Some("Socket"),
+        runtime: "js_net_socket_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "setDefaultEncoding",
+        class_filter: Some("Socket"),
+        runtime: "js_net_socket_noop_self",
+        args: &[],
+        ret: NR_PTR,
     },
     // upgradeToTLS returns a Promise (handle pointer) — await it to wait
     // for the TLS handshake before sending anything over the upgraded stream.
@@ -352,7 +461,14 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         class_filter: Some("Server"),
         runtime: "js_net_server_address",
         args: &[],
-        ret: NR_PTR,
+        // Issue #1852 — `js_net_server_address` returns a JSON string
+        // (`{"port":…,"address":…,"family":…}` or `"null"`).
+        // NR_OBJ_FROM_JSON_STR pipes it through `js_json_parse_or_null`
+        // so `server.address().port` reads a real number. Pre-fix the
+        // NR_PTR kind NaN-boxed the StringHeader as a POINTER_TAG object,
+        // so `.port` came back `undefined` (the radar's "undefined.address"
+        // cluster).
+        ret: NR_OBJ_FROM_JSON_STR,
     },
     NativeModSig {
         module: "net",
@@ -371,6 +487,36 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         runtime: "js_net_server_on",
         args: &[NA_STR, NA_PTR],
         ret: NR_VOID,
+    },
+    // Issue #1852 — chainable no-op `net.Server` option setters
+    // (`ref`/`unref`/`setTimeout`). Same rationale as the Socket stubs
+    // above: callable + chainable, options ignored.
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "ref",
+        class_filter: Some("Server"),
+        runtime: "js_net_server_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "unref",
+        class_filter: Some("Server"),
+        runtime: "js_net_server_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "setTimeout",
+        class_filter: Some("Server"),
+        runtime: "js_net_server_noop_self",
+        args: &[],
+        ret: NR_PTR,
     },
     // ========== node:stream — Readable.from(iterable) (#631) ==========
     // The other stream constructors (`new Readable(opts)` etc.) are wired

--- a/crates/perry-ext-net/src/ip.rs
+++ b/crates/perry-ext-net/src/ip.rs
@@ -1,0 +1,97 @@
+//! `net.isIP` / `isIPv4` / `isIPv6` (issue #811) + the Happy-Eyeballs
+//! auto-select-family default accessors. Pure string/global-flag helpers
+//! with no socket state. Split out of `lib.rs` (#1852) to keep that file
+//! under the 2000-line gate; the logic is unchanged.
+
+use crate::string_from_header_i64;
+use perry_ffi::JsValue;
+
+/// Issue #811 — `net.isIP(s)` returns 0/4/6 (number).
+fn classify_ip(s: &str) -> i32 {
+    if is_ipv4_str(s) {
+        4
+    } else if is_ipv6_str(s) {
+        6
+    } else {
+        0
+    }
+}
+
+fn is_ipv4_str(s: &str) -> bool {
+    s.parse::<std::net::Ipv4Addr>().is_ok()
+}
+
+fn is_ipv6_str(s: &str) -> bool {
+    // Node's `net.isIPv6` rejects brackets and zone-id (`%`) suffixes —
+    // those forms aren't bare addresses.
+    if s.contains('[') || s.contains(']') || s.contains('%') {
+        return false;
+    }
+    s.parse::<std::net::Ipv6Addr>().is_ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_net_is_ip(s_ptr: i64) -> f64 {
+    let kind = match string_from_header_i64(s_ptr) {
+        Some(s) => classify_ip(&s),
+        None => 0,
+    };
+    f64::from_bits(JsValue::from_number(kind as f64).0)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_net_is_ipv4(s_ptr: i64) -> f64 {
+    let is = match string_from_header_i64(s_ptr) {
+        Some(s) => is_ipv4_str(&s),
+        None => false,
+    };
+    f64::from_bits(JsValue::from_bool(is).0)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_net_is_ipv6(s_ptr: i64) -> f64 {
+    let is = match string_from_header_i64(s_ptr) {
+        Some(s) => is_ipv6_str(&s),
+        None => false,
+    };
+    f64::from_bits(JsValue::from_bool(is).0)
+}
+
+// Happy-Eyeballs (auto-select-family) defaults. Process-wide globals
+// that `getDefault*` reads and `setDefault*` writes.
+static AUTO_SELECT_FAMILY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(true);
+// Node's current default is 500ms (raised from 250 in v20.x); pin to
+// 500 so byte-for-byte parity holds against `node --experimental-strip-types`.
+static AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS: std::sync::atomic::AtomicI32 =
+    std::sync::atomic::AtomicI32::new(500);
+
+#[no_mangle]
+pub unsafe extern "C" fn js_net_get_default_auto_select_family() -> f64 {
+    let v = AUTO_SELECT_FAMILY.load(std::sync::atomic::Ordering::Relaxed);
+    f64::from_bits(JsValue::from_bool(v).0)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_net_set_default_auto_select_family(val_f64: f64) -> f64 {
+    let val = JsValue(val_f64.to_bits()).to_bool();
+    AUTO_SELECT_FAMILY.store(val, std::sync::atomic::Ordering::Relaxed);
+    f64::from_bits(JsValue::UNDEFINED.0)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_net_get_default_auto_select_family_attempt_timeout() -> f64 {
+    let v = AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS.load(std::sync::atomic::Ordering::Relaxed);
+    f64::from_bits(JsValue::from_number(v as f64).0)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_net_set_default_auto_select_family_attempt_timeout(ms_f64: f64) -> f64 {
+    let n = JsValue(ms_f64.to_bits()).to_number();
+    let ms = if n.is_finite() && n >= 0.0 {
+        n as i32
+    } else {
+        0
+    };
+    AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS.store(ms, std::sync::atomic::Ordering::Relaxed);
+    f64::from_bits(JsValue::UNDEFINED.0)
+}

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -206,6 +206,12 @@ enum SocketCommand {
 enum PendingNetEvent {
     Connect(i64),
     Data(i64, Vec<u8>),
+    /// Issue #1852 — peer half-closed (FIN received, `read()` returned 0).
+    /// Node fires `'end'` on the readable side *before* `'close'`; lots of
+    /// net tests block on `socket.on('end', …)` to learn the peer is done,
+    /// so without this the connection lifecycle never completes and the
+    /// test hangs.
+    End(i64),
     Close(i64),
     Error(i64, String),
     /// Issue #1123 followup — accept-loop on a `net.Server` produced
@@ -985,6 +991,23 @@ pub unsafe extern "C" fn js_net_server_listen(handle: i64, port: f64, callback_i
                     return;
                 }
             };
+            // Issue #1852 — record the *actual* bound address. The
+            // dominant Node test pattern is `server.listen(0, () =>
+            // client.connect(server.address().port))`: port 0 asks the OS
+            // for an ephemeral port, so the requested `port_u16` (0) is
+            // never what we end up listening on. Read `local_addr()` and
+            // overwrite the stashed port/host BEFORE firing `'listening'`,
+            // so `server.address()` inside the listen callback reports the
+            // real port (pre-fix it returned 0 and every client connected
+            // to port 0 → connection refused → hang).
+            if let Ok(local) = listener.local_addr() {
+                if let Ok(mut servers) = statics::servers().lock() {
+                    if let Some(s) = servers.get_mut(&server_id) {
+                        s.bound_port = local.port();
+                        s.bound_host = local.ip().to_string();
+                    }
+                }
+            }
             // bind succeeded — fire `'listening'`.
             push_event(PendingNetEvent::ServerListening(server_id));
 
@@ -1340,6 +1363,11 @@ async fn run_socket_task(
             read_result = t.read(&mut buf) => {
                 match read_result {
                     Ok(0) => {
+                        // Issue #1852 — peer sent FIN. Fire `'end'` first
+                        // (readable side ended) then `'close'`, matching
+                        // Node's default `allowHalfOpen: false` socket
+                        // teardown order.
+                        push_event(PendingNetEvent::End(id));
                         push_event(PendingNetEvent::Close(id));
                         mark_closed(id);
                         break;
@@ -1438,13 +1466,33 @@ pub unsafe extern "C" fn js_net_socket_write(handle: i64, chunk_bits: i64) {
     }
 }
 
-// ─── FFI: socket.end() ───────────────────────────────────────────────────────
+// ─── FFI: socket.end([data]) ─────────────────────────────────────────────────
 
-/// `socket.end()` — graceful shutdown.
+/// `socket.end([data])` — optionally write a final chunk, then half-close
+/// the write side.
+///
+/// Issue #1852 — Node's `socket.end(data)` writes `data` and *then* sends
+/// FIN. The previous signature took no data, so `socket.end("bye")` (a
+/// single-call write+close, common in request/response protocols and echo
+/// tests) silently dropped the payload — the peer never saw the bytes, its
+/// `'data'` listener never fired, and the exchange hung. `chunk_bits` is the
+/// full NaN-boxed JS value (NA_JSV); `undefined`/`null` (the no-arg
+/// `socket.end()` form, where the dispatch table pads the slot with
+/// `TAG_UNDEFINED`) yields `None` and we just send FIN.
+///
+/// # Safety
+///
+/// `chunk_bits` must be a valid NaN-boxed JS value. String / Buffer pointers
+/// must reference live runtime allocations.
 #[no_mangle]
-pub unsafe extern "C" fn js_net_socket_end(handle: i64) {
+pub unsafe extern "C" fn js_net_socket_end(handle: i64, chunk_bits: i64) {
     let sockets = statics::sockets().lock().unwrap();
     if let Some(s) = sockets.get(&handle) {
+        if let Some(bytes) = jsvalue_to_socket_bytes(f64::from_bits(chunk_bits as u64)) {
+            if !bytes.is_empty() {
+                let _ = s.cmd_tx.send(SocketCommand::Write(bytes));
+            }
+        }
         let _ = s.cmd_tx.send(SocketCommand::End);
     }
 }
@@ -1458,6 +1506,39 @@ pub unsafe extern "C" fn js_net_socket_destroy(handle: i64) {
     if let Some(s) = sockets.get(&handle) {
         let _ = s.cmd_tx.send(SocketCommand::Destroy);
     }
+}
+
+// ─── FFI: chainable no-op socket/server options (issue #1852) ────────────────
+//
+// Node's `net.Socket` and `net.Server` expose a family of configuration
+// methods that return the instance (`this`) for chaining — `setNoDelay`,
+// `setKeepAlive`, `setTimeout`, `setEncoding`, `pause`, `resume`, `ref`,
+// `unref`, `cork`, `uncork`, etc. Perry's TCP transport doesn't model TCP
+// socket options (Nagle, keep-alive, idle-timeout) or read-pause yet, but
+// the methods still need to *exist and be callable*: pre-fix, calling any
+// of them threw "x is not a function" (the radar's "value() missing"
+// cluster) and aborted the program before the real I/O ever ran.
+//
+// These two shims accept the receiver handle (the dispatch table declares
+// `args: &[]`, so user-supplied option args are evaluated for the call but
+// not forwarded) and return it unchanged so `sock.setNoDelay(true)` and
+// chained forms like `sock.setKeepAlive().setNoDelay()` both type-check and
+// keep flowing. The codegen NaN-boxes the returned id with POINTER_TAG
+// (NR_PTR), reproducing the original Socket/Server value shape so a
+// subsequent method on the result still dispatches.
+
+/// Chainable no-op for `net.Socket` option setters — returns the socket
+/// handle unchanged.
+#[no_mangle]
+pub extern "C" fn js_net_socket_noop_self(handle: i64) -> i64 {
+    handle
+}
+
+/// Chainable no-op for `net.Server` option setters — returns the server
+/// handle unchanged.
+#[no_mangle]
+pub extern "C" fn js_net_server_noop_self(handle: i64) -> i64 {
+    handle
 }
 
 // ─── FFI: socket.on(event, callback) ─────────────────────────────────────────
@@ -1624,6 +1705,18 @@ pub unsafe extern "C" fn js_net_process_pending() -> i32 {
                 for cb in cbs {
                     if cb != 0 {
                         let _ = JsClosure::from_raw(cb as *const RawClosureHeader).call1(err_f64);
+                    }
+                }
+            }
+            PendingNetEvent::End(id) => {
+                // Issue #1852 — readable side ended (peer FIN). Fire the
+                // `'end'` listeners; the trailing `Close` event (pushed
+                // right after `End` in `run_socket_task`) does the actual
+                // listener-map / socket-map teardown, so don't remove
+                // anything here.
+                for cb in listeners_for(id, "end") {
+                    if cb != 0 {
+                        let _ = JsClosure::from_raw(cb as *const RawClosureHeader).call0();
                     }
                 }
             }

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -38,7 +38,6 @@ use perry_ffi::{
 use std::collections::HashMap;
 use std::io;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::sync::Mutex;
 use std::task::{Context, Poll};
 
@@ -46,7 +45,15 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, oneshot};
 
-use tokio_rustls::{client::TlsStream, rustls, TlsConnector};
+use tokio_rustls::client::TlsStream;
+
+// #1852 — topical sub-modules split out to keep this file under the
+// 2000-line size gate. `tls` holds the rustls config + handshake; `ip`
+// holds the `net.isIP*` + auto-select-family helpers.
+mod ip;
+mod tls;
+
+use crate::tls::do_tls_handshake;
 
 // ─── Transport enum (plain or TLS, swappable at runtime) ─────────────────────
 
@@ -235,97 +242,7 @@ enum PendingNetEvent {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-/// Issue #811 — `net.isIP(s)` returns 0/4/6 (number).
-fn classify_ip(s: &str) -> i32 {
-    if is_ipv4_str(s) {
-        4
-    } else if is_ipv6_str(s) {
-        6
-    } else {
-        0
-    }
-}
-
-fn is_ipv4_str(s: &str) -> bool {
-    s.parse::<std::net::Ipv4Addr>().is_ok()
-}
-
-fn is_ipv6_str(s: &str) -> bool {
-    // Node's `net.isIPv6` rejects brackets and zone-id (`%`) suffixes —
-    // those forms aren't bare addresses.
-    if s.contains('[') || s.contains(']') || s.contains('%') {
-        return false;
-    }
-    s.parse::<std::net::Ipv6Addr>().is_ok()
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn js_net_is_ip(s_ptr: i64) -> f64 {
-    let kind = match string_from_header_i64(s_ptr) {
-        Some(s) => classify_ip(&s),
-        None => 0,
-    };
-    f64::from_bits(JsValue::from_number(kind as f64).0)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn js_net_is_ipv4(s_ptr: i64) -> f64 {
-    let is = match string_from_header_i64(s_ptr) {
-        Some(s) => is_ipv4_str(&s),
-        None => false,
-    };
-    f64::from_bits(JsValue::from_bool(is).0)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn js_net_is_ipv6(s_ptr: i64) -> f64 {
-    let is = match string_from_header_i64(s_ptr) {
-        Some(s) => is_ipv6_str(&s),
-        None => false,
-    };
-    f64::from_bits(JsValue::from_bool(is).0)
-}
-
-// Happy-Eyeballs (auto-select-family) defaults. Process-wide globals
-// that `getDefault*` reads and `setDefault*` writes.
-static AUTO_SELECT_FAMILY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(true);
-// Node's current default is 500ms (raised from 250 in v20.x); pin to
-// 500 so byte-for-byte parity holds against `node --experimental-strip-types`.
-static AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS: std::sync::atomic::AtomicI32 =
-    std::sync::atomic::AtomicI32::new(500);
-
-#[no_mangle]
-pub unsafe extern "C" fn js_net_get_default_auto_select_family() -> f64 {
-    let v = AUTO_SELECT_FAMILY.load(std::sync::atomic::Ordering::Relaxed);
-    f64::from_bits(JsValue::from_bool(v).0)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn js_net_set_default_auto_select_family(val_f64: f64) -> f64 {
-    let val = JsValue(val_f64.to_bits()).to_bool();
-    AUTO_SELECT_FAMILY.store(val, std::sync::atomic::Ordering::Relaxed);
-    f64::from_bits(JsValue::UNDEFINED.0)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn js_net_get_default_auto_select_family_attempt_timeout() -> f64 {
-    let v = AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS.load(std::sync::atomic::Ordering::Relaxed);
-    f64::from_bits(JsValue::from_number(v as f64).0)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn js_net_set_default_auto_select_family_attempt_timeout(ms_f64: f64) -> f64 {
-    let n = JsValue(ms_f64.to_bits()).to_number();
-    let ms = if n.is_finite() && n >= 0.0 {
-        n as i32
-    } else {
-        0
-    };
-    AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS.store(ms, std::sync::atomic::Ordering::Relaxed);
-    f64::from_bits(JsValue::UNDEFINED.0)
-}
-
-unsafe fn string_from_header_i64(ptr: i64) -> Option<String> {
+pub(crate) unsafe fn string_from_header_i64(ptr: i64) -> Option<String> {
     let p = ptr as usize;
     if p < 0x1000 {
         return None;
@@ -547,94 +464,6 @@ fn mark_closed(id: i64) {
     if let Some(s) = statics::sockets().lock().unwrap().get_mut(&id) {
         s.is_open = false;
     }
-}
-
-// ─── rustls config ───────────────────────────────────────────────────────────
-
-fn build_tls_connector(verify: bool) -> Result<TlsConnector, String> {
-    if !verify {
-        return build_tls_connector_insecure();
-    }
-    let mut root_store = rustls::RootCertStore::empty();
-    let native = rustls_native_certs::load_native_certs();
-    for cert in native.certs {
-        let _ = root_store.add(cert);
-    }
-    let config = rustls::ClientConfig::builder()
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
-    Ok(TlsConnector::from(Arc::new(config)))
-}
-
-fn build_tls_connector_insecure() -> Result<TlsConnector, String> {
-    use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
-    use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
-    use rustls::{DigitallySignedStruct, SignatureScheme};
-
-    #[derive(Debug)]
-    struct NoVerify;
-
-    impl ServerCertVerifier for NoVerify {
-        fn verify_server_cert(
-            &self,
-            _end_entity: &CertificateDer<'_>,
-            _intermediates: &[CertificateDer<'_>],
-            _server_name: &ServerName<'_>,
-            _ocsp: &[u8],
-            _now: UnixTime,
-        ) -> Result<ServerCertVerified, rustls::Error> {
-            Ok(ServerCertVerified::assertion())
-        }
-        fn verify_tls12_signature(
-            &self,
-            _message: &[u8],
-            _cert: &CertificateDer<'_>,
-            _dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
-            Ok(HandshakeSignatureValid::assertion())
-        }
-        fn verify_tls13_signature(
-            &self,
-            _message: &[u8],
-            _cert: &CertificateDer<'_>,
-            _dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
-            Ok(HandshakeSignatureValid::assertion())
-        }
-        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-            vec![
-                SignatureScheme::RSA_PKCS1_SHA256,
-                SignatureScheme::RSA_PKCS1_SHA384,
-                SignatureScheme::RSA_PKCS1_SHA512,
-                SignatureScheme::ECDSA_NISTP256_SHA256,
-                SignatureScheme::ECDSA_NISTP384_SHA384,
-                SignatureScheme::RSA_PSS_SHA256,
-                SignatureScheme::RSA_PSS_SHA384,
-                SignatureScheme::RSA_PSS_SHA512,
-                SignatureScheme::ED25519,
-            ]
-        }
-    }
-
-    let config = rustls::ClientConfig::builder()
-        .dangerous()
-        .with_custom_certificate_verifier(Arc::new(NoVerify))
-        .with_no_client_auth();
-    Ok(TlsConnector::from(Arc::new(config)))
-}
-
-async fn do_tls_handshake(
-    tcp: TcpStream,
-    servername: &str,
-    verify: bool,
-) -> Result<TlsStream<TcpStream>, String> {
-    let connector = build_tls_connector(verify)?;
-    let server_name = rustls::pki_types::ServerName::try_from(servername.to_string())
-        .map_err(|e| format!("invalid servername '{}': {}", servername, e))?;
-    connector
-        .connect(server_name, tcp)
-        .await
-        .map_err(|e| format!("tls handshake: {}", e))
 }
 
 // ─── Spawning helper ─────────────────────────────────────────────────────────

--- a/crates/perry-ext-net/src/tls.rs
+++ b/crates/perry-ext-net/src/tls.rs
@@ -1,0 +1,94 @@
+//! rustls client config + handshake for `tls.connect` and the
+//! `socket.upgradeToTLS` mid-stream upgrade. Split out of `lib.rs` (#1852)
+//! to keep that file under the 2000-line gate; the logic is unchanged.
+
+use std::sync::Arc;
+
+use tokio::net::TcpStream;
+use tokio_rustls::{client::TlsStream, rustls, TlsConnector};
+
+fn build_tls_connector(verify: bool) -> Result<TlsConnector, String> {
+    if !verify {
+        return build_tls_connector_insecure();
+    }
+    let mut root_store = rustls::RootCertStore::empty();
+    let native = rustls_native_certs::load_native_certs();
+    for cert in native.certs {
+        let _ = root_store.add(cert);
+    }
+    let config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    Ok(TlsConnector::from(Arc::new(config)))
+}
+
+fn build_tls_connector_insecure() -> Result<TlsConnector, String> {
+    use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+    use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+    use rustls::{DigitallySignedStruct, SignatureScheme};
+
+    #[derive(Debug)]
+    struct NoVerify;
+
+    impl ServerCertVerifier for NoVerify {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            _server_name: &ServerName<'_>,
+            _ocsp: &[u8],
+            _now: UnixTime,
+        ) -> Result<ServerCertVerified, rustls::Error> {
+            Ok(ServerCertVerified::assertion())
+        }
+        fn verify_tls12_signature(
+            &self,
+            _message: &[u8],
+            _cert: &CertificateDer<'_>,
+            _dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+        fn verify_tls13_signature(
+            &self,
+            _message: &[u8],
+            _cert: &CertificateDer<'_>,
+            _dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+            vec![
+                SignatureScheme::RSA_PKCS1_SHA256,
+                SignatureScheme::RSA_PKCS1_SHA384,
+                SignatureScheme::RSA_PKCS1_SHA512,
+                SignatureScheme::ECDSA_NISTP256_SHA256,
+                SignatureScheme::ECDSA_NISTP384_SHA384,
+                SignatureScheme::RSA_PSS_SHA256,
+                SignatureScheme::RSA_PSS_SHA384,
+                SignatureScheme::RSA_PSS_SHA512,
+                SignatureScheme::ED25519,
+            ]
+        }
+    }
+
+    let config = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoVerify))
+        .with_no_client_auth();
+    Ok(TlsConnector::from(Arc::new(config)))
+}
+
+pub(crate) async fn do_tls_handshake(
+    tcp: TcpStream,
+    servername: &str,
+    verify: bool,
+) -> Result<TlsStream<TcpStream>, String> {
+    let connector = build_tls_connector(verify)?;
+    let server_name = rustls::pki_types::ServerName::try_from(servername.to_string())
+        .map_err(|e| format!("invalid servername '{}': {}", servername, e))?;
+    connector
+        .connect(server_name, tcp)
+        .await
+        .map_err(|e| format!("tls handshake: {}", e))
+}

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -643,7 +643,12 @@ unsafe fn dispatch_net_socket(handle: i64, method: &str, args: &[f64]) -> f64 {
             f64::from_bits(0x7FFC_0000_0000_0001) // undefined
         }
         "end" => {
-            crate::net::js_net_socket_end(handle);
+            // Issue #1852 — forward the optional `socket.end(data)` chunk.
+            let chunk = args
+                .first()
+                .copied()
+                .unwrap_or(f64::from_bits(0x7FFC_0000_0000_0001));
+            crate::net::js_net_socket_end(handle, chunk.to_bits() as i64);
             f64::from_bits(0x7FFC_0000_0000_0001)
         }
         "destroy" => {
@@ -699,7 +704,9 @@ unsafe fn dispatch_external_net_socket(handle: i64, method: &str, args: &[f64]) 
     }
     extern "C" {
         fn js_net_socket_write(handle: i64, buf_ptr: i64);
-        fn js_net_socket_end(handle: i64);
+        // Issue #1852 — `js_net_socket_end` now takes the optional final
+        // chunk (NA_JSV bits) so `socket.end(data)` writes before FIN.
+        fn js_net_socket_end(handle: i64, chunk_bits: i64);
         fn js_net_socket_destroy(handle: i64);
         fn js_net_socket_on(handle: i64, event_ptr: i64, cb_ptr: i64);
         fn js_net_socket_method_connect(handle: i64, port: f64, host_ptr: i64);
@@ -719,7 +726,13 @@ unsafe fn dispatch_external_net_socket(handle: i64, method: &str, args: &[f64]) 
             f64::from_bits(0x7FFC_0000_0000_0001)
         }
         "end" => {
-            js_net_socket_end(handle);
+            // Issue #1852 — forward the optional `socket.end(data)` chunk;
+            // pad with `undefined` for the no-arg `socket.end()` form.
+            let chunk = args
+                .first()
+                .copied()
+                .unwrap_or(f64::from_bits(0x7FFC_0000_0000_0001));
+            js_net_socket_end(handle, chunk.to_bits() as i64);
             f64::from_bits(0x7FFC_0000_0000_0001)
         }
         "destroy" => {

--- a/crates/perry-stdlib/src/net/mod.rs
+++ b/crates/perry-stdlib/src/net/mod.rs
@@ -833,14 +833,26 @@ pub unsafe extern "C" fn js_net_socket_write(handle: i64, chunk_bits: i64) {
     }
 }
 
-// ─── FFI: socket.end() ───────────────────────────────────────────────────────
+// ─── FFI: socket.end([data]) ─────────────────────────────────────────────────
 
-/// `socket.end()` — graceful shutdown: stops further writes, lets reads drain.
-/// Signature matches `{ has_receiver: true, method: "end", args: &[], ret: NR_VOID }`.
+/// `socket.end([data])` — optionally write a final chunk, then graceful
+/// shutdown: stops further writes, lets reads drain.
+///
+/// Issue #1852 — Node's `socket.end(data)` writes `data` then sends FIN.
+/// `chunk_bits` is the full NaN-boxed JS value (NA_JSV); `undefined`/`null`
+/// (the no-arg `socket.end()` form) yields no bytes. Kept in sync with the
+/// live perry-ext-net copy so the `js_net_socket_end` symbol has one
+/// signature regardless of which archive links.
+/// Signature matches `{ has_receiver: true, method: "end", args: &[NA_JSV], ret: NR_VOID }`.
 #[no_mangle]
-pub unsafe extern "C" fn js_net_socket_end(handle: i64) {
+pub unsafe extern "C" fn js_net_socket_end(handle: i64, chunk_bits: i64) {
     let sockets = NET_SOCKETS.lock().unwrap();
     if let Some(s) = sockets.get(&handle) {
+        if let Some(bytes) = jsvalue_to_socket_bytes(f64::from_bits(chunk_bits as u64)) {
+            if !bytes.is_empty() {
+                let _ = s.cmd_tx.send(SocketCommand::Write(bytes));
+            }
+        }
         let _ = s.cmd_tx.send(SocketCommand::End);
     }
 }

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1254 entries across 81 modules
+// Coverage: 1265 entries across 81 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1254 entries across 81 modules.
+Total: 1265 entries across 81 modules.
 
 ## Modules
 
@@ -1022,6 +1022,7 @@ Total: 1254 entries across 81 modules.
 - `close` — instance *(class: `Server`)*
 - `connect` — module
 - `connect` — instance *(class: `Socket`)*
+- `cork` — instance *(class: `Socket`)*
 - `createConnection` — module
 - `destroy` — instance *(class: `Socket`)*
 - `end` — instance *(class: `Socket`)*
@@ -1032,8 +1033,18 @@ Total: 1254 entries across 81 modules.
 - `isIPv6` — module
 - `listen` — instance *(class: `Server`)*
 - `on` — instance *(class: `Socket`)*
+- `pause` — instance *(class: `Socket`)*
+- `ref` — instance *(class: `Socket`)*
+- `resume` — instance *(class: `Socket`)*
 - `setDefaultAutoSelectFamily` — module
 - `setDefaultAutoSelectFamilyAttemptTimeout` — module
+- `setDefaultEncoding` — instance *(class: `Socket`)*
+- `setEncoding` — instance *(class: `Socket`)*
+- `setKeepAlive` — instance *(class: `Socket`)*
+- `setNoDelay` — instance *(class: `Socket`)*
+- `setTimeout` — instance *(class: `Socket`)*
+- `uncork` — instance *(class: `Socket`)*
+- `unref` — instance *(class: `Socket`)*
 - `upgradeToTLS` — instance *(class: `Socket`)*
 - `write` — instance *(class: `Socket`)*
 

--- a/test-files/test_issue_1852_net_lifecycle.ts
+++ b/test-files/test_issue_1852_net_lifecycle.ts
@@ -1,0 +1,68 @@
+// Issue #1852 — `node:net` connection lifecycle end-to-end. Pins the four
+// lifecycle fixes that flipped the net-layer parity clusters:
+//
+//   A. `server.address()` returns a real object (`{ port, address, family }`)
+//      so `server.address().port` reads a number — pre-fix the native-table
+//      `address` row used NR_PTR, which NaN-boxed the JSON StringHeader as a
+//      POINTER object so `.port` came back `undefined` ("undefined.address"
+//      cluster).
+//   B. `server.listen(0, cb)` records the *actual* ephemeral port the OS
+//      assigned (via `TcpListener::local_addr()`) before firing the listen
+//      callback — pre-fix `address().port` was the requested 0, so the
+//      client connected to port 0 and the whole exchange hung.
+//   C. The socket `'end'` event fires when the peer half-closes (FIN) —
+//      pre-fix only `'close'` fired, so `socket.on('end', …)` never ran and
+//      the lifecycle never completed (the 19-case "timeout/hang" cluster).
+//   D. `socket.end(data)` writes the final chunk before sending FIN — pre-fix
+//      the payload was silently dropped (the peer's `'data'` never fired).
+//   E. Chainable no-op option setters (`setNoDelay`, etc.) are callable
+//      instead of throwing "x is not a function" ("value() missing" cluster).
+//
+// Output is deterministic despite the ephemeral port: every line is gated on
+// a causal step of the protocol (server must receive "ping" before it can
+// reply "pong"; the client must receive "pong" before its FIN-driven 'end';
+// `server.close()` is invoked from inside the client's 'close' handler), and
+// the port is printed only as a `> 0` boolean, so Node and Perry agree
+// byte-for-byte.
+
+import { createServer, connect } from "node:net";
+
+const server = createServer((sock: any) => {
+  sock.on("data", (chunk: any) => {
+    console.log("S:got:" + chunk.toString());
+    // D — `end(data)` must put "pong" on the wire, then half-close.
+    sock.end("pong");
+  });
+});
+
+server.listen(0, () => {
+  const addr = server.address() as any;
+  // A + B — a real object whose port is the assigned ephemeral port.
+  console.log("L:addr-object=" + (typeof addr === "object" && addr !== null));
+  console.log("L:port>0=" + (addr.port > 0));
+
+  const client = connect(addr.port, "127.0.0.1");
+  // E — chainable no-op; if this threw, the program would abort here.
+  client.setNoDelay(true);
+
+  client.on("connect", () => {
+    client.write("ping");
+  });
+  client.on("data", (d: any) => {
+    console.log("C:got:" + d.toString());
+  });
+  client.on("end", () => {
+    // C — fires on the server's FIN (sent by `sock.end("pong")`).
+    console.log("C:end");
+  });
+  client.on("close", () => {
+    console.log("C:close");
+    server.close(() => {
+      console.log("S:closed");
+    });
+  });
+});
+
+// Safety net: if any step hangs the process still exits within the parity
+// budget. A warm local TCP round-trip + close handshake completes in <50ms.
+setTimeout(() => {}, 2000);

--- a/test-parity/expected/test_issue_1852_net_lifecycle.txt
+++ b/test-parity/expected/test_issue_1852_net_lifecycle.txt
@@ -1,0 +1,7 @@
+L:addr-object=true
+L:port>0=true
+S:got:ping
+C:got:pong
+C:end
+C:close
+S:closed


### PR DESCRIPTION
## Summary

`node:net` was the biggest measurable weak API in the #800 `--auto-optimize` radar sweep (24% parity, 75 runtime-fails). This PR closes the core connection-lifecycle gaps that drive the largest clusters — **timeout/hang (19)**, **undefined.address (7)**, and **value()-missing (11)**.

## What changed

- **Socket `'end'` event** — emitted on peer FIN (`read()==0`), before `'close'`, matching Node's default `allowHalfOpen: false` teardown. Pre-fix only `'close'` fired, so `socket.on('end', …)` never ran and the lifecycle never completed (the 19-case hang cluster).
- **`server.listen(0)` ephemeral port** — the accept loop now reads `TcpListener::local_addr()` after bind and records the OS-assigned port/host *before* firing the listen callback. Pre-fix `address().port` stayed the requested `0`, so clients connected to port 0 → connection refused → hang. This is the dominant Node test pattern (`server.listen(0, () => connect(server.address().port))`).
- **`server.address()` returns a real object** — the native-table row switched from `NR_PTR` to `NR_OBJ_FROM_JSON_STR`, so the `{port,address,family}` JSON is parsed into an object and `server.address().port` reads a number. Pre-fix `NR_PTR` NaN-boxed the JSON `StringHeader` as a POINTER object, so `.port` was `undefined` (the undefined.address cluster).
- **`socket.end(data)`** — `js_net_socket_end` gained a chunk arg; it writes the optional final chunk before sending FIN. Pre-fix the payload was silently dropped and the peer's `'data'` never fired.
- **Chainable no-op option setters** — `setNoDelay`/`setKeepAlive`/`setTimeout`/`setEncoding`/`pause`/`resume`/`ref`/`unref`/`cork`/`uncork`/`setDefaultEncoding` on Socket, and `ref`/`unref`/`setTimeout` on Server, are now callable (and return the instance for chaining) instead of throwing "x is not a function" (the value()-missing cluster). Perry's TCP transport doesn't model these socket options yet, so they're honest no-ops.
- **Codegen NA_JSV padding** — a missing `NA_JSV` arg now pads with `TAG_UNDEFINED` instead of numeric `0`. Without this, `socket.end()` (no args) read the padded `0` back as the number `0`, stringified it, and wrote a spurious `"0"` byte before FIN. This also nudges other optional-`NA_JSV` call sites (`dayjs()`, `reply.send()`) toward Node's "missing arg = undefined" semantics.

`js_net_socket_end`'s signature change is mirrored across perry-ext-net (the live `node:net` path), the bundled perry-stdlib `net` mod, and both `HANDLE_METHOD_DISPATCH` fallbacks, so the symbol keeps one signature regardless of which archive links.

## Test

`test-files/test_issue_1852_net_lifecycle.ts` is a full createServer → listen(0) → connect → echo → end → close round-trip. Output is deterministic despite the ephemeral port (every line is causally gated; the port is printed only as a `> 0` boolean) so it matches `node --experimental-strip-types` byte-for-byte:

```
L:addr-object=true
L:port>0=true
S:got:ping
C:got:pong
C:end
C:close
S:closed
```

Verified locally vs Node (3× for determinism). Existing `test_issue_1123_listen` / `test_issue_1123_net_createserver` still match their expected output. API docs regenerated for the manifest additions.

## Out of scope / follow-ups

- `net.BlockList` / `net.SocketAddress` remain unimplemented (separate gate).
- Connect-failure error objects still stringify to empty in `'X' + err` (a broader Error-object `toString` gap, not net-specific).
- `server.listen(port, host, cb)` / `listen(options)` overloads and `server.getConnections(cb)` are not yet wired.

Closes #1852 (lifecycle portion).
