### PR TITLE
fix(codegen): preserve JS semantics for POD initializer and capture fallbacks

### DIFF
--- a/crates/perry-codegen/src/native_value/pod.rs
+++ b/crates/perry-codegen/src/native_value/pod.rs
@@ -107,7 +107,7 @@ pub(crate) fn validate_exact_init(
         ));
     }
     let mut seen = std::collections::HashSet::new();
-    for ((actual_name, _), expected) in init_fields.fields.iter().zip(layout.fields.iter()) {
+    for ((actual_name, value), expected) in init_fields.fields.iter().zip(layout.fields.iter()) {
         if !seen.insert(actual_name.as_str()) {
             return Err(format!("duplicate_field:{}", actual_name));
         }
@@ -117,8 +117,88 @@ pub(crate) fn validate_exact_init(
                 expected.name, actual_name
             ));
         }
+        if !pod_init_value_roundtrips_exact(&expected.native_rep, value) {
+            return Err(format!(
+                "field:{}:inexact_or_dynamic_initializer:{}",
+                expected.name,
+                expected.native_rep.name()
+            ));
+        }
     }
     Ok(())
+}
+
+fn pod_init_value_roundtrips_exact(rep: &NativeRep, value: &Expr) -> bool {
+    match rep {
+        NativeRep::I32 => {
+            literal_i64(value).is_some_and(|n| i32::try_from(n).is_ok())
+                || literal_f64(value).is_some_and(|n| {
+                    int_roundtrips_exact(n, i32::MIN as f64, (i32::MAX as f64) + 1.0)
+                })
+        }
+        NativeRep::I64 => {
+            literal_i64(value).is_some_and(|n| {
+                let as_f64 = n as f64;
+                int_roundtrips_exact(as_f64, i64::MIN as f64, 9_223_372_036_854_775_808.0)
+                    && (as_f64 as i64) == n
+            }) || literal_f64(value).is_some_and(|n| {
+                int_roundtrips_exact(n, i64::MIN as f64, 9_223_372_036_854_775_808.0)
+            })
+        }
+        NativeRep::U32 | NativeRep::BufferLen => {
+            literal_i64(value).is_some_and(|n| u32::try_from(n).is_ok())
+                || literal_f64(value).is_some_and(|n| uint_roundtrips_exact(n, 4_294_967_296.0))
+        }
+        NativeRep::U64 | NativeRep::USize => {
+            literal_i64(value).is_some_and(|n| {
+                if n < 0 {
+                    return false;
+                }
+                let as_f64 = n as f64;
+                uint_roundtrips_exact(as_f64, 18_446_744_073_709_551_616.0)
+                    && (as_f64 as u64) == n as u64
+            }) || literal_f64(value)
+                .is_some_and(|n| uint_roundtrips_exact(n, 18_446_744_073_709_551_616.0))
+        }
+        NativeRep::F64 => matches!(value, Expr::Integer(_) | Expr::Number(_)),
+        NativeRep::F32 => literal_f64(value).is_some_and(f32_roundtrips_exact),
+        _ => false,
+    }
+}
+
+fn literal_i64(value: &Expr) -> Option<i64> {
+    match value {
+        Expr::Integer(n) => Some(*n),
+        _ => None,
+    }
+}
+
+fn literal_f64(value: &Expr) -> Option<f64> {
+    match value {
+        Expr::Integer(n) => Some(*n as f64),
+        Expr::Number(n) => Some(*n),
+        _ => None,
+    }
+}
+
+fn int_roundtrips_exact(number: f64, min_inclusive: f64, max_exclusive: f64) -> bool {
+    number.is_finite()
+        && number >= min_inclusive
+        && number < max_exclusive
+        && number.trunc() == number
+        && !(number == 0.0 && number.is_sign_negative())
+}
+
+fn uint_roundtrips_exact(number: f64, max_exclusive: f64) -> bool {
+    number.is_finite()
+        && number >= 0.0
+        && number < max_exclusive
+        && number.trunc() == number
+        && !(number == 0.0 && number.is_sign_negative())
+}
+
+fn f32_roundtrips_exact(number: f64) -> bool {
+    !number.is_nan() && ((number as f32) as f64).to_bits() == number.to_bits()
 }
 
 pub(crate) fn field_expected_rep(field: &PodLayoutField) -> ExpectedNativeRep {

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -185,6 +185,15 @@ pub(crate) fn lower_let(
 
     if let Some(init_expr) = init {
         match crate::native_value::layout_decision_for_type(ctx, &refined_ty) {
+            PodLayoutDecision::Layout(_)
+                if ctx.boxed_vars.contains(&id) && !ctx.module_globals.contains_key(&id) =>
+            {
+                record_pod_rejection(
+                    ctx,
+                    id,
+                    "boxed_capture_requires_js_object_storage".to_string(),
+                );
+            }
             PodLayoutDecision::Layout(layout) => {
                 match crate::native_value::collect_pod_init_fields(ctx, init_expr).and_then(
                     |fields| {

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -641,6 +641,62 @@ fn artifact_schema_v6_records_pod_dynamic_write_fallback() {
 }
 
 #[test]
+fn artifact_schema_v6_rejects_inexact_pod_initializer_values() {
+    let packet_ty = pod_type(&[
+        ("tag", Type::Named("PerryU32".to_string())),
+        ("gain", Type::Named("PerryF32".to_string())),
+        ("count", Type::Named("PerryBufferLen".to_string())),
+    ]);
+    let body = vec![
+        pod_let(
+            1,
+            "packet",
+            packet_ty,
+            vec![
+                ("tag", int(-1)),
+                ("gain", number(1.1)),
+                ("count", Expr::String("x".to_string())),
+            ],
+        ),
+        Stmt::Return(Some(Expr::PropertyGet {
+            object: Box::new(local(1)),
+            property: "tag".to_string(),
+        })),
+    ];
+
+    let artifact = compile_artifact_json("artifact_c_layout_pod_init_reject.ts", body);
+    assert_eq!(artifact["schema_version"], 6);
+    assert_eq!(artifact["summary"]["pod_layout_count"], 0);
+    assert_eq!(artifact["summary"]["pod_record_count"], 0);
+    assert!(artifact["pod_layouts"].as_array().unwrap().is_empty());
+    assert!(
+        !artifact["records"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|record| record["native_rep_name"] == "pod_record"),
+        "inexact POD initializer must not emit pod_record storage:\n{artifact:#}"
+    );
+    assert!(
+        artifact["records"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|record| {
+                record["expr_kind"] == "PodRecordRejected"
+                    && record["fallback_reason"] == "pod_unsupported"
+                    && record["notes"].as_array().is_some_and(|notes| {
+                        notes.iter().any(|note| {
+                            note.as_str()
+                                .is_some_and(|note| note.contains("inexact_or_dynamic_initializer"))
+                        })
+                    })
+            }),
+        "expected explicit POD initializer rejection record:\n{artifact:#}"
+    );
+}
+
+#[test]
 fn artifact_schema_v6_records_pod_pointerful_field_rejection() {
     let invalid_ty = pod_type(&[
         ("tag", Type::Named("PerryU32".to_string())),

--- a/tests/test_c_layout_pod_records.sh
+++ b/tests/test_c_layout_pod_records.sh
@@ -41,8 +41,10 @@ type Packet = PerryPod<{
 
 let packet: Packet = { tag: 7, gain: 1.5, total: 2.25, count: 4 };
 let lied: Packet = { tag: 7, gain: 1.5, total: 2.25, count: 4 };
+let inexact: Packet = { tag: (-1 as any), gain: (1.1 as any), total: 2.25, count: ("x" as any) };
 
 console.log("read=" + packet.tag + "," + packet.gain + "," + packet.total + "," + packet.count);
+console.log("init=" + inexact.tag + "," + inexact.count + "," + inexact.gain);
 (lied as any).tag = "x";
 console.log("lie=" + lied.tag);
 packet.tag = 9;
@@ -61,6 +63,15 @@ function ret(): Packet {
 }
 
 console.log("return=" + ret().count);
+
+function makeGetter(): any {
+  let captured: Packet = { tag: 7, gain: 1.5, total: 2.25, count: 4 };
+  const get = () => captured.tag;
+  captured = { tag: 8, gain: 1.5, total: 2.25, count: 4 };
+  return get;
+}
+
+console.log("capture=" + makeGetter()());
 EOF
 
 ARTIFACT_DIR="$TMPDIR/native-reps"
@@ -76,7 +87,7 @@ COMPILE_OUTPUT=$(PERRY_NATIVE_REPS=1 \
   exit 1
 }
 
-EXPECTED=$'read=7,1.5,2.25,4\nlie=x\nafter=9,2.5,11\nreturn=4'
+EXPECTED=$'read=7,1.5,2.25,4\ninit=-1,x,1.1\nlie=x\nafter=9,2.5,11\nreturn=4\ncapture=8'
 RUN_OUTPUT=$(./test_bin 2>&1)
 if [ "$RUN_OUTPUT" != "$EXPECTED" ]; then
   echo "FAIL: JS-visible POD behavior changed"


### PR DESCRIPTION
## Summary
- fall back to ordinary JS object storage for non-global boxed POD locals so closure captures/reassignments keep js_box semantics
- validate POD initializer fields for statically exact literal round-trips before allocating native POD stack storage
- add artifact and runtime regressions for inexact initializer fallback and captured/reassigned POD locals

## Tests
- cargo fmt --check
- git diff --check origin/main...HEAD
- cargo check -p perry-codegen -p perry-runtime
- cargo test -p perry-codegen --test native_proof_regressions -- --test-threads=1
- cargo test -p perry-codegen --test typed_shape_descriptors -- --test-threads=1
- cargo test -p perry-runtime typed_feedback -- --test-threads=1
- cargo build -p perry
- PERRY=target/debug/perry ./tests/test_c_layout_pod_records.sh
- PERRY=target/debug/perry ./tests/test_native_abi_contract.sh