### PR TITLE
feat(child_process,util): ChildProcess/Stream exports (#1856) + promisify(exec/execFile) (#1857)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2340,6 +2340,12 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("child_process", "spawn", false, None),
     method("child_process", "spawnSync", false, None),
     method("child_process", "fork", false, None),
+    // #1856: `ChildProcess` is the streaming-subprocess constructor; reading
+    // it as a value yields `[Function: ChildProcess]`. `Stream` is not a real
+    // `child_process` export (Node returns `undefined`) — registered so the
+    // value-read passes the #463 surface gate and resolves to `undefined`.
+    class("child_process", "ChildProcess"),
+    property("child_process", "Stream"),
     // --- tty (only `isatty` is implemented; ReadStream / WriteStream
     //     are wrapped via process.stdin / process.stdout) ---
     method("tty", "isatty", false, None),

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -214,26 +214,6 @@ fn format_function_for_console(closure_ptr: *const crate::closure::ClosureHeader
     if closure_ptr.is_null() {
         return "[Function (anonymous)]".to_string();
     }
-    let label = unsafe {
-        let func_ptr = (*closure_ptr).func_ptr;
-        if !func_ptr.is_null() {
-            if let Ok(map) = function_name_registry().lock() {
-                if let Some(name) = map.get(&(func_ptr as usize)) {
-                    if !name.is_empty() {
-                        format!("[Function: {}]", name)
-                    } else {
-                        "[Function (anonymous)]".to_string()
-                    }
-                } else {
-                    "[Function (anonymous)]".to_string()
-                }
-            } else {
-                "[Function (anonymous)]".to_string()
-            }
-        } else {
-            "[Function (anonymous)]".to_string()
-        }
-    };
 
     // Snapshot user-attached own properties and filter out the built-in
     // function slots that Node hides from `util.inspect`. Node prints
@@ -241,6 +221,39 @@ fn format_function_for_console(closure_ptr: *const crate::closure::ClosureHeader
     // `name` are runtime-allocated on every function, so always hiding
     // them yields parity for the common case (`f.x = 1`).
     let props = crate::closure::closure_dynamic_props_snapshot(closure_ptr as usize);
+
+    // The function name: prefer the codegen-registered name keyed by the
+    // function pointer (real named declarations), then fall back to the
+    // closure's own `name` property. Bound native-module exports
+    // (`child_process.ChildProcess`, `tty.ReadStream`, `events.EventEmitter`,
+    // …) all share one `BOUND_METHOD_FUNC_PTR`, so they carry no per-pointer
+    // registry name — their identity lives in the `name` prop set by
+    // `set_bound_native_closure_name`. Reading it here makes them print
+    // `[Function: ChildProcess]` instead of `[Function (anonymous)]`,
+    // matching Node. #1856.
+    let registry_name: Option<String> = unsafe {
+        let func_ptr = (*closure_ptr).func_ptr;
+        if func_ptr.is_null() {
+            None
+        } else {
+            function_name_registry()
+                .lock()
+                .ok()
+                .and_then(|map| map.get(&(func_ptr as usize)).map(|n| n.to_string()))
+                .filter(|n| !n.is_empty())
+        }
+    };
+    let label = match registry_name.or_else(|| {
+        props
+            .iter()
+            .find(|(k, _)| k == "name")
+            .and_then(|(_, v)| jsvalue_string_content(*v))
+            .filter(|n| !n.is_empty())
+    }) {
+        Some(name) => format!("[Function: {name}]"),
+        None => "[Function (anonymous)]".to_string(),
+    };
+
     let user_props: Vec<(String, f64)> = props
         .into_iter()
         .filter(|(k, _)| {

--- a/crates/perry-runtime/src/child_process.rs
+++ b/crates/perry-runtime/src/child_process.rs
@@ -1187,6 +1187,90 @@ pub extern "C" fn js_child_process_exec_file_sync(
     }
 }
 
+// ============================================================================
+// util.promisify(child_process.exec / execFile) — #1857
+// ============================================================================
+//
+// Node attaches a custom `util.promisify` hook to exec/execFile so the
+// promisified form resolves to `{ stdout, stderr }` (not just stdout). The
+// `("util","promisify")` dispatch arm detects the bound exec/execFile export
+// and routes here; we return a wrapper closure that runs the command (Perry's
+// synchronous model) and yields an already-resolved Promise of
+// `{ stdout, stderr }` (or a rejected Promise on failure).
+
+#[inline]
+fn cp_box_string_bytes(bytes: &[u8]) -> f64 {
+    let p = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+    crate::value::js_nanbox_string(p as i64)
+}
+
+#[inline]
+fn cp_error_value(msg: &str) -> f64 {
+    let mp = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_error_new_with_message(mp);
+    crate::value::js_nanbox_pointer(err as i64)
+}
+
+fn cp_exec_result_promise(output: std::io::Result<std::process::Output>) -> f64 {
+    match output {
+        Ok(o) => {
+            let stdout_b = cp_box_string_bytes(&o.stdout);
+            let stderr_b = cp_box_string_bytes(&o.stderr);
+            let obj = unsafe { make_two_field_object("stdout", stdout_b, "stderr", stderr_b) };
+            let obj_val = cp_box_ptr(obj as *const u8);
+            let promise = if o.status.success() {
+                crate::promise::js_promise_resolved(obj_val)
+            } else {
+                // Node rejects with an Error carrying .stdout/.stderr; the
+                // minimal shape (an Error) is enough for the supported cases.
+                crate::promise::js_promise_rejected(cp_error_value("Command failed"))
+            };
+            crate::value::js_nanbox_pointer(promise as i64)
+        }
+        Err(e) => {
+            let promise = crate::promise::js_promise_rejected(cp_error_value(&e.to_string()));
+            crate::value::js_nanbox_pointer(promise as i64)
+        }
+    }
+}
+
+extern "C" fn cp_promisified_exec(_closure: *const ClosureHeader, cmd_val: f64, _opts: f64) -> f64 {
+    let cmd = cp_value_to_string(cmd_val).unwrap_or_default();
+    #[cfg(unix)]
+    let output = Command::new("sh").arg("-c").arg(&cmd).output();
+    #[cfg(windows)]
+    let output = Command::new("cmd").arg("/C").arg(&cmd).output();
+    cp_exec_result_promise(output)
+}
+
+extern "C" fn cp_promisified_exec_file(
+    _closure: *const ClosureHeader,
+    file_val: f64,
+    args_val: f64,
+) -> f64 {
+    let file = cp_value_to_string(file_val).unwrap_or_default();
+    let arg_strs = cp_args_from_value(args_val);
+    cp_exec_result_promise(Command::new(&file).args(&arg_strs).output())
+}
+
+/// Build the wrapper function returned by `util.promisify(child_process.exec)`
+/// / `promisify(execFile)` — `method` is `"exec"` or `"execFile"`. Node's
+/// custom-promisify hook resolves these to `{ stdout, stderr }`, which the
+/// general `util.promisify` path (resolving the single first-result value)
+/// can't reproduce; `util_promisify::js_util_promisify` detects the bound
+/// export and delegates here. #1857.
+pub(crate) fn make_promisified_child_process(method: &str) -> f64 {
+    let func: *const u8 = if method == "execFile" {
+        js_register_closure_arity(cp_promisified_exec_file as *const u8, 2);
+        cp_promisified_exec_file as *const u8
+    } else {
+        js_register_closure_arity(cp_promisified_exec as *const u8, 2);
+        cp_promisified_exec as *const u8
+    };
+    let closure = js_closure_alloc(func, 0);
+    crate::value::js_nanbox_pointer(closure as i64)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -353,6 +353,13 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("tty", "isatty")
             | ("tty", "ReadStream")
             | ("tty", "WriteStream")
+            // #1856: `child_process.ChildProcess` reads as `[Function: ChildProcess]`.
+            | ("child_process", "ChildProcess")
+            // #1857: exec/execFile read as functions so `typeof child_process.exec
+            // === "function"` and `util.promisify(child_process.exec)` can detect
+            // and wrap them (see the `("util","promisify")` dispatch arm).
+            | ("child_process", "exec")
+            | ("child_process", "execFile")
             | ("events", "EventEmitter")
             | ("events", "on")
             | ("string_decoder", "StringDecoder")

--- a/crates/perry-runtime/src/util_promisify.rs
+++ b/crates/perry-runtime/src/util_promisify.rs
@@ -86,6 +86,19 @@ pub extern "C" fn js_util_promisify(fn_value: f64) -> f64 {
     if tag != POINTER_TAG {
         return fn_value;
     }
+
+    // #1857: `child_process.exec` / `execFile` carry a Node custom-promisify
+    // hook that resolves to `{ stdout, stderr }` — not the single first-result
+    // value the general wrapper below yields. Detect the bound export and hand
+    // off to the child_process-specific wrapper.
+    if let Some((module, method)) =
+        unsafe { crate::object::bound_native_callable_module_and_method(fn_value) }
+    {
+        if module == "child_process" && (method == "exec" || method == "execFile") {
+            return crate::child_process::make_promisified_child_process(&method);
+        }
+    }
+
     register_thunks_once();
 
     let scope = crate::gc::RuntimeHandleScope::new();

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1265 entries across 81 modules
+// Coverage: 1267 entries across 81 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -197,6 +197,10 @@ declare module "cheerio" {
 }
 
 declare module "child_process" {
+  /** stdlib */
+  export class ChildProcess { [key: string]: any; }
+  /** stdlib */
+  export const Stream: any;
   /** stdlib */
   export function exec(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1265 entries across 81 modules.
+Total: 1267 entries across 81 modules.
 
 ## Modules
 
@@ -280,6 +280,10 @@ Total: 1265 entries across 81 modules.
 
 ## `child_process`
 
+### Classes
+
+- `ChildProcess`
+
 ### Methods
 
 - `exec` — module
@@ -289,6 +293,10 @@ Total: 1265 entries across 81 modules.
 - `fork` — module
 - `spawn` — module
 - `spawnSync` — module
+
+### Properties
+
+- `Stream`
 
 ## `cluster`
 

--- a/test-files/test_issue_1856_1857_exports_promisify.ts
+++ b/test-files/test_issue_1856_1857_exports_promisify.ts
@@ -1,0 +1,30 @@
+// Issue #1856: `child_process.ChildProcess` reads as `[Function: ChildProcess]`
+// (previously the value-read tripped the #463 unimplemented-surface guard at
+// compile time); `child_process.Stream` reads as `undefined` (Node does not
+// export it).
+//
+// Issue #1857: `util.promisify(child_process.exec)` / `promisify(execFile)`
+// return a function whose Promise resolves to `{ stdout, stderr }` (Node's
+// custom-promisify shape), instead of `undefined`.
+//
+// Byte-for-byte vs `node --experimental-strip-types`.
+import * as child_process from "node:child_process";
+import { promisify } from "node:util";
+
+// ── #1856: named exports ──
+console.log("ChildProcess:", child_process.ChildProcess);
+console.log("typeof ChildProcess:", typeof child_process.ChildProcess);
+console.log("Stream:", child_process.Stream);
+console.log("typeof Stream:", typeof child_process.Stream);
+
+// ── #1857: promisify(exec) ──
+const execP = promisify(child_process.exec);
+console.log("typeof promisify(exec):", typeof execP);
+const r1 = await execP("/bin/echo promisify-exec");
+console.log("exec stdout:", String(r1.stdout).trim());
+
+// ── #1857: promisify(execFile) ──
+const execFileP = promisify(child_process.execFile);
+console.log("typeof promisify(execFile):", typeof execFileP);
+const r2 = await execFileP("/bin/echo", ["promisify-execFile"]);
+console.log("execFile stdout:", String(r2.stdout).trim());

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -134,12 +134,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory — `node:buffer` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
-  "test_parity_child_process": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:child_process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "test_parity_crypto": {
     "issue": "793",
     "added": "2026-05-15",


### PR DESCRIPTION
## Summary

Closes the two follow-ups left from the streaming-`spawn` work (#1780 / #1858), which together make the `test_parity_child_process` gap test byte-identical to `node --experimental-strip-types`.

### #1856 — `child_process.ChildProcess` / `Stream` named exports

A *value-form* read of `child_process.ChildProcess` (e.g. `console.log(child_process.ChildProcess)`) tripped the `#463` unimplemented-surface gate **at compile time**, which blocked the whole gap test from compiling. Now:

- `ChildProcess` is registered in the API manifest (as a class) and added to the runtime callable-export list, so it reads as `[Function: ChildProcess]`.
- `Stream` is registered as a manifest property and resolves to `undefined` (Node does not export it).
- The console function formatter now falls back to the closure's own `name` property when no name is registered for the (shared bound-method) function pointer — so bound native exports print their real name. This also nudges `events.EventEmitter` / `tty.ReadStream` toward Node's output; no parity fixture asserted the old `[Function (anonymous)]`.

### #1857 — `util.promisify(exec)` / `promisify(execFile)`

main's general `util.promisify` (shipped separately) resolves to the single first-result value — but Node attaches a *custom* promisify hook to `exec`/`execFile` that resolves to `{ stdout, stderr }`. Added a detection at the top of `util_promisify::js_util_promisify`: when the argument is the bound `child_process.exec`/`execFile` export, it returns a child_process-specific wrapper that runs the command (Perry's synchronous model) and yields an already-resolved Promise of `{ stdout, stderr }`. `exec`/`execFile` also join the callable-export list so `child_process.exec` reads as a function (`typeof === "function"`).

## Test

- `test_parity_child_process` (the canonical gap test) is now **byte-identical** to Node — removed from `test-parity/known_failures.json`.
- New focused regression test `test-files/test_issue_1856_1857_exports_promisify.ts` (exports + promisify(exec/execFile)) is byte-identical.
- Existing spawn-stream test still passes; `cargo fmt --all --check` clean; API docs regenerated.

Built on top of the merged #1858; integrates with main's general `util.promisify` rather than duplicating it.
