### PR TITLE
fix(runtime): #26/#321 symbol-keyed prototype walk follows Object.create chain (effect/Schema struct)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -221,18 +221,38 @@ pub(crate) unsafe fn resolve_proto_chain_field(
 }
 
 /// #1758: symbol-keyed analogue of [`resolve_proto_chain_field`]. Walks the
-/// `CLASS_PROTOTYPE_OBJECTS` / `get_parent_class_id` chain and, at each
-/// prototype object (a POINTER class-object), looks up its OWN symbol property
-/// via `js_object_get_symbol_property`. Lets a subclass whose parent is a
-/// class-expression value inherit the parent's static *symbol* statics — e.g.
-/// effect's `class BigIntFromSelf extends make(bigIntKeyword) {}` inheriting
+/// `CLASS_PROTOTYPE_OBJECTS` chain and, at each prototype object (a POINTER
+/// class-object), looks up its OWN symbol property via `own_symbol_property`.
+/// Lets a subclass whose parent is a class-expression value inherit the
+/// parent's static *symbol* statics — e.g. effect's
+/// `class BigIntFromSelf extends make(bigIntKeyword) {}` inheriting
 /// `static [TypeId]`, which `Predicate.hasProperty(.., TypeId)` (`isSchema`)
 /// and `u[TypeId]` both read. Returns the first defined value found.
+///
+/// #26 / #321: the walk must advance along TWO axes, because a synthetic
+/// `Object.create(proto)` class id links to its prototype via the *proto
+/// object's own class id*, not via `parent_class_id` (which only models the
+/// `class A extends B` axis). effect's `Either.right(x)` builds
+/// `Object.create(RightProto)` where `RightProto = Object.create(CommonProto)`
+/// and `CommonProto[TypeId]` carries the brand. With only the
+/// `parent_class_id` axis the walk stopped after the first prototype object
+/// (`RightProto`), so `TypeId in either` / `either[TypeId]` missed the brand
+/// two links up — making `ParseResult.isEither(...)` false for every struct
+/// property parse (`S.is`/`decodeUnknownSync`/`encodeSync` on a `Struct`).
+/// At each node we follow the proto object's own class id (the
+/// `Object.create` prototype link) first, then fall back to
+/// `parent_class_id` (the `extends` link); a `visited` set bounds cycles.
 pub(crate) unsafe fn resolve_proto_chain_symbol(class_id: u32, sym_f64: f64) -> Option<f64> {
     let mut cid = class_id;
     let mut depth = 0usize;
+    let mut visited: [u32; 32] = [0; 32];
     while depth < 32 {
+        if visited[..depth].contains(&cid) {
+            break;
+        }
+        visited[depth] = cid;
         let proto_obj = class_prototype_object(cid);
+        let mut next_cid: u32 = 0;
         if !proto_obj.is_null() {
             let proto_f64 = f64::from_bits(JSValue::pointer(proto_obj as *const u8).bits());
             // OWN lookup only — this fn IS the chain walk, so recursing into
@@ -240,6 +260,15 @@ pub(crate) unsafe fn resolve_proto_chain_symbol(class_id: u32, sym_f64: f64) -> 
             if let Some(v) = crate::symbol::own_symbol_property(proto_f64, sym_f64) {
                 return Some(v);
             }
+            // Prefer the `Object.create` prototype link: the next chain node
+            // is the proto object's own class id (which maps to ITS proto in
+            // CLASS_PROTOTYPE_OBJECTS). Falls back to `parent_class_id` below.
+            next_cid = crate::object::js_object_get_class_id(proto_obj as *const ObjectHeader);
+        }
+        if next_cid != 0 && next_cid != cid {
+            cid = next_cid;
+            depth += 1;
+            continue;
         }
         match get_parent_class_id(cid) {
             Some(p) if p != 0 && p != cid => {

--- a/test-files/test_gap_object_create_chain_symbol.ts
+++ b/test-files/test_gap_object_create_chain_symbol.ts
@@ -1,0 +1,71 @@
+// #26 / #321: symbol-keyed prototype-chain lookup across MULTIPLE levels of
+// `Object.create`. This is effect's `Either`/`ParseResult` brand pattern:
+//
+//   const TypeId = Symbol.for("effect/Either")
+//   const CommonProto = { [TypeId]: {...} }
+//   const RightProto  = Object.assign(Object.create(CommonProto), { _tag: "Right" })
+//   const right = (r) => { const a = Object.create(RightProto); a.right = r; return a }
+//
+// `isEither(x) = TypeId in x` must walk a→RightProto→CommonProto and find the
+// brand TWO links up. Pre-fix, `resolve_proto_chain_symbol` advanced the chain
+// only via `parent_class_id` (the `class A extends B` axis); a synthetic
+// `Object.create(proto)` class id has no parent, so the walk stopped after the
+// first prototype object. `TypeId in a` / `a[TypeId]` therefore missed the
+// brand, making `ParseResult.isEither(te)` false for every struct-property
+// parse — breaking `S.is`/`decodeUnknownSync`/`encodeSync` on a `Struct`.
+//
+// Fix: the symbol-chain walk now follows the prototype object's OWN class id
+// (the `Object.create` link) in addition to `parent_class_id`.
+//
+// Note: string-keyed reads (`_tag`) already worked because the string-chain
+// walk recurses through the full field getter at each prototype object.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+const TypeId: unique symbol = Symbol.for("perry-test-Either") as any;
+
+const CommonProto: any = { [TypeId]: { _R: 1 } };
+const RightProto: any = Object.assign(Object.create(CommonProto), { _tag: "Right" });
+const LeftProto: any = Object.assign(Object.create(CommonProto), { _tag: "Left" });
+
+const right = (r: unknown) => {
+  const a: any = Object.create(RightProto);
+  a.right = r;
+  return a;
+};
+const left = (l: unknown) => {
+  const a: any = Object.create(LeftProto);
+  a.left = l;
+  return a;
+};
+
+const isEither = (u: any) => u != null && (TypeId in u);
+const isRight = (u: any) => u._tag === "Right";
+
+const r = right(42);
+const l = left("err");
+
+// (1) two-level symbol-in: a -> RightProto -> CommonProto (brand on CommonProto).
+console.log("TypeId in r:", TypeId in r);          // expect true
+console.log("TypeId in l:", TypeId in l);          // expect true
+
+// (2) symbol READ across two levels.
+console.log("r[TypeId] obj:", typeof (r as any)[TypeId]); // expect object
+
+// (3) string key still works (one level: own on RightProto).
+console.log("r._tag:", r._tag, "l._tag:", l._tag); // expect Right Left
+
+// (4) negative: an unrelated plain object is NOT branded.
+console.log("TypeId in {}:", TypeId in ({} as any)); // expect false
+
+// (5) the actual isEither/isRight guard shape effect uses.
+console.log("isEither(r):", isEither(r), "isRight(r):", isRight(r)); // expect true true
+console.log("isEither({a:1}):", isEither({ a: 1 } as any));          // expect false
+
+// (6) three-level chain (a -> mid -> proto, brand on the top proto).
+const Sym2: unique symbol = Symbol.for("perry-test-Sym2") as any;
+const top: any = { [Sym2]: 7 };
+const mid: any = Object.create(top);
+const deep: any = Object.create(mid);
+console.log("Sym2 in deep:", Sym2 in deep);    // expect true
+console.log("deep[Sym2]:", (deep as any)[Sym2]); // expect 7


### PR DESCRIPTION
Refs #26 / #321. Final downstream blocker for `effect/Schema` struct decode/encode/is, separate from the schema-AST field-layout fix (#1853, already merged).

## Symptom

With #1853 merged the schema AST is correct, but struct/`TypeLiteral` operations still failed while primitives worked:

- `S.is(S.Number)(5)` -> `true`, `S.is(S.String)("a")` -> `true` (primitives OK)
- `S.is(S.Struct({ n: S.Number }))({ n: 5 })` -> `false` (should be `true`)
- `S.decodeUnknownSync(S.Struct({ name: S.String, age: S.Number }))({ name: "Ada", age: 36 })` threw `TypeError: Cannot read properties of undefined (reading '_tag')`
- `S.encodeSync(...)` threw the same.

## Root cause

`crates/perry-runtime/src/object/class_registry.rs` — `resolve_proto_chain_symbol` (the symbol-keyed prototype-chain walk used by `Sym in obj` / `obj[Sym]` on POINTER class-objects).

The walk advanced the chain **only** via `get_parent_class_id` — the `class A extends B` axis. But a synthetic `Object.create(proto)` class id links to its prototype via the *prototype object's own class id*, not via `parent_class_id` (synthetic ids have no parent). So the walk stopped after the **first** prototype object.

effect's `Either.right(x)` (and `ParseResult` results generally) builds:

```
const CommonProto = { [TypeId]: {...} }                              // brand here
const RightProto  = Object.assign(Object.create(CommonProto), { _tag: "Right" })
const right = (r) => { const a = Object.create(RightProto); a.right = r; return a }
```

`isEither(x) = hasProperty(x, TypeId) = TypeId in x` must walk `a -> RightProto -> CommonProto` (two links) to find the brand. With only the `parent_class_id` axis the walk reached `RightProto` (own miss) and stopped, so `TypeId in either` / `either[TypeId]` returned false/undefined.

In `ParseResult.go`'s `TypeLiteral` parser, every per-property result is checked with `isEither(te)`. Because `isEither` was false, the parser took the async/`Effect` queue branch instead of the synchronous Either branch, so `Either.isRight(parser(...))` (in `is`) got a non-Either -> `false`, and the decode/encode paths read `_tag` off `undefined`.

Note: string-keyed reads (`_tag`) already worked because the **string** chain walk (`resolve_proto_chain_field`) recurses through the full field getter at each prototype object, which naturally follows the `Object.create` link. Only the symbol walk had the missing axis.

## Minimal repro (standalone, no effect dependency)

```ts
const TypeId = Symbol.for("X");
const CommonProto = { [TypeId]: 1 };
const RightProto = Object.assign(Object.create(CommonProto), { _tag: "Right" });
const a = Object.create(RightProto);
console.log(TypeId in a);        // perry (pre-fix): false      node: true
console.log((a as any)[TypeId]); // perry (pre-fix): undefined  node: 1
```

## Fix

In `resolve_proto_chain_symbol`, at each prototype object follow the proto object's **own class id** (the `Object.create` prototype link) first, falling back to `parent_class_id` (the `extends` link). A `visited` set bounds cycles. This mirrors what the string-key walk already does.

## Validation

- 4 Schema cases byte-identical to Node:
  - `21_schema_decode` -> `Ada 36`
  - `22_schema_encode` -> `{"name":"x"}`
  - `23_schema_is` -> `true false`
  - `probe_is` struct-guard -> `true`
- Full effect survey `/private/tmp/effect-dod/survey/*.ts`: **34/34** byte-identical to Node (was 26/30); `05_gen` -> 30, `07_all` -> [1,2,3], no regressions.
- `test-files/` class/object/inheritance/spread/symbol/proto sweep: 56/64 byte-identical; the 8 mismatches are pre-existing (confirmed via `git stash` + rebuild: identical baseline) — timing benchmarks, missing-npm-dep tests (node MODULE_NOT_FOUND), and a separate static-block init gap.
- `test_gap_*` sweep: identical fails to baseline (`test_gap_class_advanced` static-block, `test_gap_console_methods` timer values) — both pre-existing and unrelated.
- `cargo test --release -p perry-runtime`: 635 passed, 0 failed.
- `cargo build --release --workspace` (minus cross-host UI crates): compiles clean.
- `./scripts/check_file_size.sh`: OK (file at 1864 lines).
- `cargo fmt --all -- --check`: clean.

## New test

`test-files/test_gap_object_create_chain_symbol.ts` — models effect's two- and three-level `Object.create` symbol-brand pattern; byte-identical to `node --experimental-strip-types`.
