### PR TITLE
feat(node:zlib): Transform-stream objects + Brotli fns (#1843)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5287,6 +5287,7 @@ dependencies = [
 name = "perry-ext-zlib"
 version = "0.5.1029"
 dependencies = [
+ "brotli",
  "flate2",
  "perry-ffi",
 ]

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -250,6 +250,17 @@ const fn p_any(name: &'static str) -> ParamSpec {
     }
 }
 
+/// #1843 — every `zlib.create*` Transform-stream factory shares the same
+/// shape: an optional `options` object in, a stream handle (`Any`) out.
+const ZLIB_STREAM_OPTS: &[ParamSpec] = &[ParamSpec::Named {
+    name: "options",
+    ty: TypeSpec::Any,
+    optional: true,
+}];
+const fn zlib_stream_factory(name: &'static str) -> ApiEntry {
+    method_sig("zlib", name, false, None, ZLIB_STREAM_OPTS, TypeSpec::Any)
+}
+
 /// Source-of-truth manifest. See module-level docs for what feeds it.
 pub static API_MANIFEST: &[ApiEntry] = &[
     // ===========================================================
@@ -1271,23 +1282,52 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // by axios for stream wiring. Values are resolved at runtime by
     // `get_native_module_constant` in `perry-runtime/src/object.rs`.
     property("zlib", "constants"),
-    // `zlib.createBrotliDecompress(options?)` — axios feature-checks this
-    // at module init (the typeof === 'function' shape). The native shim
-    // returns a registered Buffer-shaped handle; the real decode path is
-    // only reached when a server actually replies with
-    // `content-encoding: br`, which we leave for a follow-up.
+    // #1843 — Brotli one-shot compress/decompress (sync + async).
     method_sig(
         "zlib",
-        "createBrotliDecompress",
+        "brotliCompressSync",
         false,
         None,
-        &[ParamSpec::Named {
-            name: "options",
-            ty: TypeSpec::Any,
-            optional: true,
-        }],
+        &[p_str("p0")],
+        TypeSpec::String,
+    ),
+    method_sig(
+        "zlib",
+        "brotliDecompressSync",
+        false,
+        None,
+        &[p_str("p0")],
+        TypeSpec::String,
+    ),
+    method_sig(
+        "zlib",
+        "brotliCompress",
+        false,
+        None,
+        &[p_str("p0")],
         TypeSpec::Any,
     ),
+    method_sig(
+        "zlib",
+        "brotliDecompress",
+        false,
+        None,
+        &[p_str("p0")],
+        TypeSpec::Any,
+    ),
+    // #1843 — Transform-stream factories. Each returns a stream handle
+    // supporting `.write`/`.end`/`.on('data'|'end'|'error')`/`.pipe`.
+    zlib_stream_factory("createGzip"),
+    zlib_stream_factory("createGunzip"),
+    zlib_stream_factory("createDeflate"),
+    zlib_stream_factory("createInflate"),
+    zlib_stream_factory("createDeflateRaw"),
+    zlib_stream_factory("createInflateRaw"),
+    zlib_stream_factory("createUnzip"),
+    zlib_stream_factory("createBrotliCompress"),
+    // `zlib.createBrotliDecompress(options?)` — now a real Transform stream
+    // (still passes axios's `typeof === 'function'` module-init gate).
+    zlib_stream_factory("createBrotliDecompress"),
     method_sig(
         "cron",
         "validate",

--- a/crates/perry-codegen/src/lower_call/native_table/media.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/media.rs
@@ -322,11 +322,124 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
         args: &[NA_STR],
         ret: NR_PTR,
     },
-    // `zlib.createBrotliDecompress(options?)` — axios feature-checks
-    // this at module init. The runtime stub returns a registered
-    // Buffer-shaped handle (NaN-boxed as a pointer) so callers see
-    // a truthy non-null object; the real Brotli decode path is a
-    // follow-up. `options` is NaN-boxed as f64.
+    // `zlib.brotli{Compress,Decompress}Sync(data)` — one-shot Brotli via the
+    // `brotli` crate (already a `compression`-feature dep). #1843 cluster 2.
+    NativeModSig {
+        module: "zlib",
+        has_receiver: false,
+        method: "brotliCompressSync",
+        class_filter: None,
+        runtime: "js_zlib_brotli_compress_sync",
+        args: &[NA_STR],
+        ret: NR_STR,
+    },
+    NativeModSig {
+        module: "zlib",
+        has_receiver: false,
+        method: "brotliDecompressSync",
+        class_filter: None,
+        runtime: "js_zlib_brotli_decompress_sync",
+        args: &[NA_STR],
+        ret: NR_STR,
+    },
+    NativeModSig {
+        module: "zlib",
+        has_receiver: false,
+        method: "brotliCompress",
+        class_filter: None,
+        runtime: "js_zlib_brotli_compress",
+        args: &[NA_STR],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "zlib",
+        has_receiver: false,
+        method: "brotliDecompress",
+        class_filter: None,
+        runtime: "js_zlib_brotli_decompress",
+        args: &[NA_STR],
+        ret: NR_PTR,
+    },
+    // zlib Transform-stream factories (#1843 cluster 1). Each returns an i64
+    // stream handle (0x60000+ range) NaN-boxed with POINTER_TAG; subsequent
+    // `.write`/`.end`/`.on`/`.pipe`/`.flush`/`.close` lose their static type
+    // and route through HANDLE_METHOD_DISPATCH → `dispatch_zlib_stream`
+    // (crates/perry-stdlib/src/common/dispatch.rs). `options` is NaN-boxed f64.
+    NativeModSig {
+        module: "zlib",
+        has_receiver: false,
+        method: "createGzip",
+        class_filter: None,
+        runtime: "js_zlib_create_gzip",
+        args: &[NA_F64],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "zlib",
+        has_receiver: false,
+        method: "createGunzip",
+        class_filter: None,
+        runtime: "js_zlib_create_gunzip",
+        args: &[NA_F64],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "zlib",
+        has_receiver: false,
+        method: "createDeflate",
+        class_filter: None,
+        runtime: "js_zlib_create_deflate",
+        args: &[NA_F64],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "zlib",
+        has_receiver: false,
+        method: "createInflate",
+        class_filter: None,
+        runtime: "js_zlib_create_inflate",
+        args: &[NA_F64],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "zlib",
+        has_receiver: false,
+        method: "createDeflateRaw",
+        class_filter: None,
+        runtime: "js_zlib_create_deflate_raw",
+        args: &[NA_F64],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "zlib",
+        has_receiver: false,
+        method: "createInflateRaw",
+        class_filter: None,
+        runtime: "js_zlib_create_inflate_raw",
+        args: &[NA_F64],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "zlib",
+        has_receiver: false,
+        method: "createUnzip",
+        class_filter: None,
+        runtime: "js_zlib_create_unzip",
+        args: &[NA_F64],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "zlib",
+        has_receiver: false,
+        method: "createBrotliCompress",
+        class_filter: None,
+        runtime: "js_zlib_create_brotli_compress",
+        args: &[NA_F64],
+        ret: NR_PTR,
+    },
+    // `zlib.createBrotliDecompress(options?)` — now a real Transform-stream
+    // handle (previously a feature-check Buffer stub; axios's
+    // `typeof createBrotliDecompress === 'function'` gate still passes).
     NativeModSig {
         module: "zlib",
         has_receiver: false,

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -350,6 +350,22 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_zlib_gzip", I64, &[I64]);
     module.declare_function("js_zlib_gzip_sync", I64, &[I64]);
     module.declare_function("js_zlib_inflate_sync", I64, &[I64]);
+    // #1843 — Brotli one-shots (StringHeader ptr in/out; async returns a Promise ptr).
+    module.declare_function("js_zlib_brotli_compress_sync", I64, &[I64]);
+    module.declare_function("js_zlib_brotli_decompress_sync", I64, &[I64]);
+    module.declare_function("js_zlib_brotli_compress", I64, &[I64]);
+    module.declare_function("js_zlib_brotli_decompress", I64, &[I64]);
+    // #1843 — Transform-stream factories: `_opts` (DOUBLE) in, i64 handle out.
+    // (`js_zlib_create_brotli_decompress` is declared alongside the other
+    // crypto/zlib helpers in runtime_decls/strings.rs.)
+    module.declare_function("js_zlib_create_gzip", I64, &[DOUBLE]);
+    module.declare_function("js_zlib_create_gunzip", I64, &[DOUBLE]);
+    module.declare_function("js_zlib_create_deflate", I64, &[DOUBLE]);
+    module.declare_function("js_zlib_create_inflate", I64, &[DOUBLE]);
+    module.declare_function("js_zlib_create_deflate_raw", I64, &[DOUBLE]);
+    module.declare_function("js_zlib_create_inflate_raw", I64, &[DOUBLE]);
+    module.declare_function("js_zlib_create_unzip", I64, &[DOUBLE]);
+    module.declare_function("js_zlib_create_brotli_compress", I64, &[DOUBLE]);
 
     // ========== Buffer ==========
     module.declare_function("js_buffer_alloc_unsafe", I64, &[I32]);

--- a/crates/perry-ext-zlib/Cargo.toml
+++ b/crates/perry-ext-zlib/Cargo.toml
@@ -11,6 +11,9 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 flate2 = "1"
+# Brotli stream + one-shot support (#1843). Matches the version the
+# `compression` feature pulls into perry-stdlib.
+brotli = "8.0.2"
 
 [dev-dependencies]
 perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-zlib/src/lib.rs
+++ b/crates/perry-ext-zlib/src/lib.rs
@@ -9,15 +9,22 @@
 
 use flate2::read::{DeflateDecoder, DeflateEncoder, GzDecoder, GzEncoder};
 use flate2::Compression;
-use perry_ffi::{
-    alloc_buffer, alloc_bytes, read_bytes, spawn_blocking, BufferHeader, JsPromise, JsString,
-    JsValue, Promise, StringHeader,
-};
+use perry_ffi::{alloc_bytes, spawn_blocking, JsPromise, JsValue, Promise, StringHeader};
 use std::io::Read;
 
+// #1843 — Transform-stream objects (`createGzip`/`createDeflate`/… with
+// `.write`/`.end`/`.on`/`.pipe`) and Brotli one-shots. Split into its own
+// module to keep this file under the 2000-line size gate.
+mod stream;
+pub use stream::*;
+
 unsafe fn read_input(ptr: *const StringHeader) -> Option<Vec<u8>> {
-    let handle = JsString::from_raw(ptr as *mut StringHeader);
-    read_bytes(handle).map(|b| b.to_vec())
+    // #1843: route through the buffer-aware reader so `gzipSync` / `gunzipSync`
+    // / `deflateSync` / `inflateSync` accept real Buffers/Uint8Arrays (e.g.
+    // `gunzipSync(Buffer.concat(chunks))`, `gunzipSync(fs.readFileSync(...))`),
+    // not just StringHeader-shaped inputs. Falls back to the StringHeader path
+    // for JS strings / our own `alloc_bytes` outputs.
+    stream::read_input_bytes(ptr)
 }
 
 fn gzip_bytes(data: &[u8]) -> std::io::Result<Vec<u8>> {
@@ -102,15 +109,8 @@ pub unsafe extern "C" fn js_zlib_inflate_sync(data_ptr: *const StringHeader) -> 
     }
 }
 
-/// `zlib.createBrotliDecompress(options?)`.
-///
-/// Minimal feature-check shim: return a truthy Buffer-shaped object so package
-/// init paths that probe Brotli support can proceed. Real Brotli stream
-/// decoding remains outside this wrapper's current surface.
-#[no_mangle]
-pub unsafe extern "C" fn js_zlib_create_brotli_decompress(_opts: f64) -> *mut BufferHeader {
-    alloc_buffer(&[])
-}
+// `zlib.createBrotliDecompress` and the other `create*` Transform-stream
+// factories now live in `stream.rs` (returning real stream handles).
 
 // ── async variants ────────────────────────────────────────────
 
@@ -185,7 +185,7 @@ pub unsafe extern "C" fn js_zlib_inflate(data_ptr: *const StringHeader) -> *mut 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use perry_ffi::alloc_string;
+    use perry_ffi::{alloc_string, JsString};
 
     #[test]
     fn gzip_then_gunzip_round_trips_text() {

--- a/crates/perry-ext-zlib/src/stream.rs
+++ b/crates/perry-ext-zlib/src/stream.rs
@@ -1,0 +1,621 @@
+//! Node `zlib` Transform-stream objects + Brotli one-shots (#1843).
+//!
+//! `zlib.createGzip()` / `createGunzip()` / `createDeflate()` /
+//! `createInflate()` / `createDeflateRaw()` / `createInflateRaw()` /
+//! `createUnzip()` / `createBrotliCompress()` / `createBrotliDecompress()`
+//! return small-int handles (base 0x60000, under the 0x100000 small-handle
+//! dispatch threshold) that the codegen NaN-boxes with POINTER_TAG.
+//! Subsequent `s.write()` / `s.end()` / `s.on()` / `s.pipe()` calls lose
+//! their static type and route through perry-runtime's
+//! `js_native_call_method` → HANDLE_METHOD_DISPATCH → perry-stdlib's
+//! external-zlib-pump arm → `js_ext_zlib_dispatch_method` here.
+//!
+//! This mirrors the perry-ext-net handle+event pattern, but zlib compression
+//! is synchronous so there's no tokio task: input is buffered across
+//! `.write()`, the codec runs once on `.end()`, and the resulting
+//! 'data'/'end' events are *deferred* onto `ZLIB_PENDING` (drained by
+//! `js_ext_zlib_process_pending` on the next loop tick) so listeners
+//! registered after `.write()` still fire and `.pipe()` can forward chunks.
+
+use perry_ffi::{
+    alloc_buffer, alloc_bytes, alloc_string, gc_register_mutable_root_scanner_named,
+    notify_main_thread, BufferHeader, GcRootVisitor, JsClosure, JsValue, RawClosureHeader,
+    StringHeader,
+};
+use std::collections::HashMap;
+use std::io::Read;
+use std::sync::Mutex;
+
+use flate2::read::{
+    DeflateDecoder, DeflateEncoder, GzDecoder, GzEncoder, ZlibDecoder, ZlibEncoder,
+};
+use flate2::Compression;
+
+const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
+const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+const UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+const TRUE_BITS: u64 = 0x7FFC_0000_0000_0004;
+
+// perry-runtime `#[no_mangle]` symbols, resolved at final link (perry-runtime
+// is always linked). Mirrors perry-ext-net's extern usage.
+extern "C" {
+    fn js_buffer_is_buffer(ptr: i64) -> i32;
+    fn js_get_string_pointer_unified(value: f64) -> i64;
+    fn js_native_call_method_str_key(
+        object: f64,
+        name_handle: i64,
+        args_ptr: *const f64,
+        args_len: usize,
+    ) -> f64;
+}
+
+// ── Brotli one-shots (#1843 cluster 2) ───────────────────────────────────────
+
+fn brotli_compress_bytes(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut r = brotli::CompressorReader::new(data, 4096, 11, 22);
+    let _ = r.read_to_end(&mut out);
+    out
+}
+
+fn brotli_decompress_bytes(data: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut out = Vec::new();
+    brotli::Decompressor::new(data, 4096).read_to_end(&mut out)?;
+    Ok(out)
+}
+
+/// Read the bytes of a one-shot input argument. Node's `gzipSync` / `gunzipSync`
+/// / `brotli*Sync` accept BOTH strings and Buffers/Uint8Arrays; the codegen
+/// unboxes either to a raw pointer typed `*const StringHeader`. A real Buffer is
+/// a `BufferHeader` (length at offset 0), so reading it as a `StringHeader`
+/// (byte_len at offset 4) corrupts the length. Probe the buffer registry first
+/// (#1843 — `gunzipSync(Buffer.concat(chunks))` / `gunzipSync(fs.readFileSync)`).
+pub(crate) unsafe fn read_input_bytes(ptr: *const StringHeader) -> Option<Vec<u8>> {
+    if ptr.is_null() {
+        return None;
+    }
+    if js_buffer_is_buffer(ptr as i64) != 0 {
+        let buf = ptr as *const BufferHeader;
+        let len = (*buf).length as usize;
+        let data = (buf as *const u8).add(std::mem::size_of::<BufferHeader>());
+        return Some(std::slice::from_raw_parts(data, len).to_vec());
+    }
+    let len = (*ptr).byte_len as usize;
+    let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+    Some(std::slice::from_raw_parts(data, len).to_vec())
+}
+
+/// `zlib.brotliCompressSync(data)` -> Buffer.
+///
+/// # Safety
+/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_brotli_compress_sync(
+    data_ptr: *const StringHeader,
+) -> *mut StringHeader {
+    match read_input_bytes(data_ptr) {
+        Some(d) => alloc_bytes(&brotli_compress_bytes(&d)).as_raw(),
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// `zlib.brotliDecompressSync(data)` -> Buffer.
+///
+/// # Safety
+/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_brotli_decompress_sync(
+    data_ptr: *const StringHeader,
+) -> *mut StringHeader {
+    match read_input_bytes(data_ptr).map(|d| brotli_decompress_bytes(&d)) {
+        Some(Ok(out)) => alloc_bytes(&out).as_raw(),
+        _ => std::ptr::null_mut(),
+    }
+}
+
+/// `zlib.brotliCompress(data)` -> Promise<Buffer>.
+///
+/// # Safety
+/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_brotli_compress(
+    data_ptr: *const StringHeader,
+) -> *mut perry_ffi::Promise {
+    brotli_async(data_ptr, "BrotliCompress", |b| Ok(brotli_compress_bytes(b)))
+}
+
+/// `zlib.brotliDecompress(data)` -> Promise<Buffer>.
+///
+/// # Safety
+/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_brotli_decompress(
+    data_ptr: *const StringHeader,
+) -> *mut perry_ffi::Promise {
+    brotli_async(data_ptr, "BrotliDecompress", |b| brotli_decompress_bytes(b))
+}
+
+unsafe fn brotli_async<F>(
+    data_ptr: *const StringHeader,
+    label: &'static str,
+    op: F,
+) -> *mut perry_ffi::Promise
+where
+    F: FnOnce(&[u8]) -> std::io::Result<Vec<u8>> + Send + 'static,
+{
+    let promise = perry_ffi::JsPromise::new();
+    let raw = promise.as_raw();
+    let Some(data) = read_input_bytes(data_ptr) else {
+        promise.reject_string("Invalid input data");
+        return raw;
+    };
+    perry_ffi::spawn_blocking(move || match op(&data) {
+        Ok(out) => promise.resolve(JsValue::from_object_ptr(alloc_bytes(&out).as_raw())),
+        Err(e) => promise.reject_string(&format!("{} error: {}", label, e)),
+    });
+    raw
+}
+
+// ── stream codec ─────────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+enum Codec {
+    Gzip,
+    Gunzip,
+    Deflate,
+    Inflate,
+    DeflateRaw,
+    InflateRaw,
+    Unzip,
+    BrotliCompress,
+    BrotliDecompress,
+}
+
+fn run_codec(codec: Codec, input: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut out = Vec::new();
+    match codec {
+        Codec::Gzip => {
+            GzEncoder::new(input, Compression::default()).read_to_end(&mut out)?;
+        }
+        Codec::Gunzip => {
+            GzDecoder::new(input).read_to_end(&mut out)?;
+        }
+        Codec::Deflate => {
+            ZlibEncoder::new(input, Compression::default()).read_to_end(&mut out)?;
+        }
+        Codec::Inflate => {
+            ZlibDecoder::new(input).read_to_end(&mut out)?;
+        }
+        Codec::DeflateRaw => {
+            DeflateEncoder::new(input, Compression::default()).read_to_end(&mut out)?;
+        }
+        Codec::InflateRaw => {
+            DeflateDecoder::new(input).read_to_end(&mut out)?;
+        }
+        Codec::Unzip => {
+            // Node's `createUnzip` auto-detects gzip vs zlib by header.
+            if input.len() >= 2 && input[0] == 0x1f && input[1] == 0x8b {
+                GzDecoder::new(input).read_to_end(&mut out)?;
+            } else {
+                ZlibDecoder::new(input).read_to_end(&mut out)?;
+            }
+        }
+        Codec::BrotliCompress => out = brotli_compress_bytes(input),
+        Codec::BrotliDecompress => out = brotli_decompress_bytes(input)?,
+    }
+    Ok(out)
+}
+
+// ── registry ─────────────────────────────────────────────────────────────────
+
+struct ZlibStreamState {
+    codec: Codec,
+    input: Vec<u8>,
+    ended: bool,
+    /// `.pipe(dest)` destinations as NaN-boxed bits; 'data'/'end' forward here.
+    pipes: Vec<u64>,
+}
+
+enum ZlibEvent {
+    Data(i64, Vec<u8>),
+    End(i64),
+    Error(i64, String),
+}
+
+struct Statics {
+    streams: HashMap<i64, ZlibStreamState>,
+    listeners: HashMap<i64, HashMap<String, Vec<i64>>>,
+    pending: Vec<ZlibEvent>,
+    next_id: i64,
+}
+
+fn statics() -> &'static Mutex<Statics> {
+    static S: std::sync::OnceLock<Mutex<Statics>> = std::sync::OnceLock::new();
+    S.get_or_init(|| {
+        Mutex::new(Statics {
+            streams: HashMap::new(),
+            listeners: HashMap::new(),
+            pending: Vec::new(),
+            next_id: 0x60000,
+        })
+    })
+}
+
+static ZLIB_GC_REGISTERED: std::sync::Once = std::sync::Once::new();
+
+/// Register the GC root scanner once. Listener closures live only in the
+/// `listeners` map; without rooting them a GC between `.on()` and the deferred
+/// dispatch would free the closure (same hazard perry-ext-net guards).
+fn ensure_gc_scanner_registered() {
+    ZLIB_GC_REGISTERED.call_once(|| {
+        gc_register_mutable_root_scanner_named("perry-ext-zlib", scan_zlib_roots);
+    });
+}
+
+fn scan_zlib_roots(visitor: &mut GcRootVisitor<'_>) {
+    if let Ok(mut s) = statics().lock() {
+        for per_stream in s.listeners.values_mut() {
+            for cb_vec in per_stream.values_mut() {
+                for cb in cb_vec.iter_mut() {
+                    visitor.visit_i64_slot(cb);
+                }
+            }
+        }
+    }
+}
+
+fn create_stream(codec: Codec) -> i64 {
+    ensure_gc_scanner_registered();
+    let mut s = statics().lock().unwrap();
+    let id = s.next_id;
+    s.next_id += 1;
+    s.streams.insert(
+        id,
+        ZlibStreamState {
+            codec,
+            input: Vec::new(),
+            ended: false,
+            pipes: Vec::new(),
+        },
+    );
+    id
+}
+
+// ── factories ────────────────────────────────────────────────────────────────
+
+macro_rules! factory {
+    ($name:ident, $codec:expr) => {
+        /// # Safety
+        /// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+        #[no_mangle]
+        pub unsafe extern "C" fn $name(_opts: f64) -> i64 {
+            create_stream($codec)
+        }
+    };
+}
+factory!(js_zlib_create_gzip, Codec::Gzip);
+factory!(js_zlib_create_gunzip, Codec::Gunzip);
+factory!(js_zlib_create_deflate, Codec::Deflate);
+factory!(js_zlib_create_inflate, Codec::Inflate);
+factory!(js_zlib_create_deflate_raw, Codec::DeflateRaw);
+factory!(js_zlib_create_inflate_raw, Codec::InflateRaw);
+factory!(js_zlib_create_unzip, Codec::Unzip);
+factory!(js_zlib_create_brotli_compress, Codec::BrotliCompress);
+factory!(js_zlib_create_brotli_decompress, Codec::BrotliDecompress);
+
+// ── chunk / buffer helpers ─────────────────────────────────────────────────────
+
+/// Convert a `.write()`/`.end()` chunk (Buffer, string, number) to bytes.
+unsafe fn chunk_to_bytes(value: f64) -> Option<Vec<u8>> {
+    let v = JsValue::from_bits(value.to_bits());
+    if v.is_undefined() || v.is_null() {
+        return None;
+    }
+    if v.is_pointer() {
+        let raw = (value.to_bits() & POINTER_MASK) as i64;
+        if js_buffer_is_buffer(raw) != 0 {
+            let buf = raw as *const BufferHeader;
+            if !buf.is_null() {
+                let len = (*buf).length as usize;
+                let data = (buf as *const u8).add(std::mem::size_of::<BufferHeader>());
+                return Some(std::slice::from_raw_parts(data, len).to_vec());
+            }
+        }
+    }
+    // String (STRING_TAG / SSO / raw) or number/bool — SSO-safe.
+    let sptr = js_get_string_pointer_unified(value) as *const StringHeader;
+    if !sptr.is_null() {
+        let len = (*sptr).byte_len as usize;
+        if len <= (1 << 30) {
+            let data = (sptr as *const u8).add(std::mem::size_of::<StringHeader>());
+            return Some(std::slice::from_raw_parts(data, len).to_vec());
+        }
+    }
+    None
+}
+
+unsafe fn make_buffer_f64(bytes: &[u8]) -> Option<f64> {
+    let buf = alloc_buffer(bytes);
+    if buf.is_null() {
+        return None;
+    }
+    Some(f64::from_bits(POINTER_TAG | (buf as u64 & POINTER_MASK)))
+}
+
+unsafe fn event_name(value: f64) -> Option<String> {
+    let ptr = js_get_string_pointer_unified(value) as *const StringHeader;
+    if ptr.is_null() {
+        return None;
+    }
+    let len = (*ptr).byte_len as usize;
+    let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+    std::str::from_utf8(std::slice::from_raw_parts(data, len))
+        .ok()
+        .map(|s| s.to_string())
+}
+
+// ── instance ops ───────────────────────────────────────────────────────────────
+
+fn stream_write(handle: i64, bytes: &[u8]) {
+    if let Some(s) = statics().lock().unwrap().streams.get_mut(&handle) {
+        if !s.ended {
+            s.input.extend_from_slice(bytes);
+        }
+    }
+}
+
+/// Run the codec on the buffered input and queue 'data'/'end' (or 'error').
+fn finish_stream(handle: i64) {
+    let (codec, input) = {
+        let mut g = statics().lock().unwrap();
+        match g.streams.get_mut(&handle) {
+            Some(s) if !s.ended => {
+                s.ended = true;
+                (s.codec, std::mem::take(&mut s.input))
+            }
+            _ => return,
+        }
+    };
+    {
+        let mut g = statics().lock().unwrap();
+        match run_codec(codec, &input) {
+            Ok(out) => {
+                if !out.is_empty() {
+                    g.pending.push(ZlibEvent::Data(handle, out));
+                }
+                g.pending.push(ZlibEvent::End(handle));
+            }
+            Err(e) => g.pending.push(ZlibEvent::Error(handle, format!("{}", e))),
+        }
+    }
+    notify_main_thread();
+}
+
+fn stream_on(handle: i64, event: String, cb: i64) {
+    ensure_gc_scanner_registered();
+    statics()
+        .lock()
+        .unwrap()
+        .listeners
+        .entry(handle)
+        .or_default()
+        .entry(event)
+        .or_default()
+        .push(cb);
+}
+
+fn stream_pipe(handle: i64, dest_bits: u64) {
+    if let Some(s) = statics().lock().unwrap().streams.get_mut(&handle) {
+        s.pipes.push(dest_bits);
+    }
+}
+
+// ── dispatch (called from perry-stdlib's external-zlib-pump arm) ───────────────
+
+/// True iff `handle` indexes a live zlib stream.
+#[no_mangle]
+pub extern "C" fn js_ext_zlib_is_stream_handle(handle: i64) -> i32 {
+    if statics().lock().unwrap().streams.contains_key(&handle) {
+        1
+    } else {
+        0
+    }
+}
+
+/// Dispatch `.write`/`.end`/`.on`/`.once`/`.pipe`/`.flush`/`.close`/`.destroy`
+/// on a zlib stream handle. Method name arrives as a UTF-8 ptr+len; args are
+/// NaN-boxed f64s.
+///
+/// # Safety
+/// FFI entry; pointers must be valid for their stated lengths.
+#[no_mangle]
+pub unsafe extern "C" fn js_ext_zlib_dispatch_method(
+    handle: i64,
+    method_ptr: *const u8,
+    method_len: usize,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
+    let method = if method_ptr.is_null() || method_len == 0 {
+        return f64::from_bits(UNDEFINED);
+    } else {
+        String::from_utf8_lossy(std::slice::from_raw_parts(method_ptr, method_len)).into_owned()
+    };
+    let args: &[f64] = if args_len > 0 && !args_ptr.is_null() {
+        std::slice::from_raw_parts(args_ptr, args_len)
+    } else {
+        &[]
+    };
+    // The stream re-boxed as a POINTER_TAG handle (for `.on()` chaining).
+    let self_ref = f64::from_bits(POINTER_TAG | (handle as u64 & POINTER_MASK));
+    match method.as_str() {
+        "write" if !args.is_empty() => {
+            if let Some(bytes) = chunk_to_bytes(args[0]) {
+                stream_write(handle, &bytes);
+            }
+            f64::from_bits(TRUE_BITS) // Node's writable.write() returns a boolean
+        }
+        "end" => {
+            if let Some(chunk) = args.first().copied() {
+                if let Some(bytes) = chunk_to_bytes(chunk) {
+                    stream_write(handle, &bytes);
+                }
+            }
+            finish_stream(handle);
+            self_ref
+        }
+        "on" | "once" | "addListener" if args.len() >= 2 => {
+            if let Some(ev) = event_name(args[0]) {
+                let cb = (args[1].to_bits() & POINTER_MASK) as i64;
+                stream_on(handle, ev, cb);
+            }
+            self_ref
+        }
+        "pipe" if !args.is_empty() => {
+            stream_pipe(handle, args[0].to_bits());
+            args[0] // Node's `.pipe(dest)` returns `dest` for chaining
+        }
+        "close" | "destroy" => {
+            finish_stream(handle);
+            f64::from_bits(UNDEFINED)
+        }
+        // `.flush([cb])` — buffer-until-end model has nothing to flush mid-
+        // stream (output emits on `.end()`); accept as a no-op so callers
+        // don't hit "flush is not a function".
+        "flush" => f64::from_bits(UNDEFINED),
+        _ => f64::from_bits(UNDEFINED),
+    }
+}
+
+// ── pump (drained on the main thread from perry-stdlib) ─────────────────────────
+
+fn listeners_for(id: i64, event: &str) -> Vec<i64> {
+    statics()
+        .lock()
+        .unwrap()
+        .listeners
+        .get(&id)
+        .and_then(|m| m.get(event).cloned())
+        .unwrap_or_default()
+}
+
+fn pipes_for(id: i64) -> Vec<u64> {
+    statics()
+        .lock()
+        .unwrap()
+        .streams
+        .get(&id)
+        .map(|s| s.pipes.clone())
+        .unwrap_or_default()
+}
+
+/// Forward a piped chunk: `dest.write(Buffer.from(bytes))`. Builds the method-
+/// name string then the chunk Buffer back-to-back (the chunk comes from an
+/// owned `Vec<u8>`), so dispatch roots the arg before any further allocation.
+unsafe fn forward_write(dest_bits: u64, bytes: &[u8]) {
+    let name = alloc_string("write").as_raw();
+    if name.is_null() {
+        return;
+    }
+    let buf = match make_buffer_f64(bytes) {
+        Some(b) => b,
+        None => return,
+    };
+    let args = [buf];
+    js_native_call_method_str_key(f64::from_bits(dest_bits), name as i64, args.as_ptr(), 1);
+}
+
+unsafe fn forward_end(dest_bits: u64) {
+    let name = alloc_string("end").as_raw();
+    if name.is_null() {
+        return;
+    }
+    js_native_call_method_str_key(f64::from_bits(dest_bits), name as i64, std::ptr::null(), 0);
+}
+
+/// `{ message: msg }` error object so `s.on('error', e => e.message)` works.
+unsafe fn build_error_object(msg: &str) -> f64 {
+    let (packed, shape) = perry_ffi::build_object_shape(&["message"]);
+    let obj = perry_ffi::js_object_alloc_with_shape(shape, 1, packed.as_ptr(), packed.len() as u32);
+    let s = alloc_string(msg).as_raw();
+    if obj.is_null() {
+        return f64::from_bits(STRING_TAG | (s as u64 & POINTER_MASK));
+    }
+    perry_ffi::js_object_set_field(obj, 0, JsValue::from_string_ptr(s));
+    f64::from_bits(POINTER_TAG | (obj as u64 & POINTER_MASK))
+}
+
+/// Drain queued zlib stream events on the main thread. Wired into perry-stdlib's
+/// `js_stdlib_process_pending` via the external-zlib-pump feature.
+#[no_mangle]
+pub unsafe extern "C" fn js_ext_zlib_process_pending() -> i32 {
+    let events: Vec<ZlibEvent> = std::mem::take(&mut statics().lock().unwrap().pending);
+    let count = events.len() as i32;
+    for ev in events {
+        match ev {
+            ZlibEvent::Data(id, bytes) => {
+                let cbs = listeners_for(id, "data");
+                if !cbs.is_empty() {
+                    if let Some(buf_f64) = make_buffer_f64(&bytes) {
+                        for cb in cbs {
+                            if cb != 0 {
+                                let _ = JsClosure::from_raw(cb as *const RawClosureHeader)
+                                    .call1(buf_f64);
+                            }
+                        }
+                    }
+                }
+                for dest in pipes_for(id) {
+                    forward_write(dest, &bytes);
+                }
+            }
+            ZlibEvent::End(id) => {
+                for cb in listeners_for(id, "end") {
+                    if cb != 0 {
+                        let _ = JsClosure::from_raw(cb as *const RawClosureHeader).call0();
+                    }
+                }
+                for cb in listeners_for(id, "finish") {
+                    if cb != 0 {
+                        let _ = JsClosure::from_raw(cb as *const RawClosureHeader).call0();
+                    }
+                }
+                for dest in pipes_for(id) {
+                    forward_end(dest);
+                }
+                for cb in listeners_for(id, "close") {
+                    if cb != 0 {
+                        let _ = JsClosure::from_raw(cb as *const RawClosureHeader).call0();
+                    }
+                }
+                let mut g = statics().lock().unwrap();
+                g.listeners.remove(&id);
+                g.streams.remove(&id);
+            }
+            ZlibEvent::Error(id, msg) => {
+                let err_f64 = build_error_object(&msg);
+                for cb in listeners_for(id, "error") {
+                    if cb != 0 {
+                        let _ = JsClosure::from_raw(cb as *const RawClosureHeader).call1(err_f64);
+                    }
+                }
+                let mut g = statics().lock().unwrap();
+                g.listeners.remove(&id);
+                g.streams.remove(&id);
+            }
+        }
+    }
+    count
+}
+
+/// Keep the event loop alive while zlib stream events are queued. Wired into
+/// perry-stdlib's `js_stdlib_has_active_handles`.
+#[no_mangle]
+pub extern "C" fn js_ext_zlib_has_active_handles() -> i32 {
+    if statics().lock().unwrap().pending.is_empty() {
+        0
+    } else {
+        1
+    }
+}

--- a/crates/perry-runtime/src/builtins/arithmetic.rs
+++ b/crates/perry-runtime/src/builtins/arithmetic.rs
@@ -199,8 +199,14 @@ pub extern "C" fn js_value_typeof(value: f64) -> *mut StringHeader {
         }
     } else if jsval.is_pointer() {
         // Object/array/closure/symbol pointer - check via the side-table first.
+        // The `>= 0x100000` floor (raised from 0x10000, #1843) skips the deref
+        // for native-module registry handles (net.Socket, zlib stream, crypto,
+        // …) — small ids bit-OR'd with POINTER_TAG, not real heap pointers,
+        // which always live above 0x100000. `typeof aHandle` is "object".
+        // Reading a fake handle's `[ptr+12]` type tag otherwise segfaults
+        // (e.g. zlib's 0x60000 stream base).
         let ptr = jsval.as_pointer::<u8>();
-        if !ptr.is_null() && (ptr as usize) > 0x10000 {
+        if !ptr.is_null() && (ptr as usize) >= 0x100000 {
             // Symbols: registered in SYMBOL_POINTERS (handles both gc_malloc'd
             // and Box-leaked symbols, which have no GcHeader).
             if crate::symbol::is_registered_symbol(ptr as usize) {

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1610,7 +1610,15 @@ pub extern "C" fn js_object_mark_class(obj: i64) {
 /// so raw Map/Set/Buffer pointers (no GcHeader) are never misread. Used by
 /// `typeof`, `new`, and `instanceof` to recognize a class value.
 pub fn is_class_object_ptr(ptr: *const u8) -> bool {
-    if ptr.is_null() || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+    // Reject anything in the native-module handle range (< 0x100000). Those
+    // are registry ids (net.Socket, zlib stream, crypto, fastify, ioredis,
+    // timers, …) bit-OR'd with POINTER_TAG, not real heap pointers — real
+    // objects always live well above 0x100000. The previous 0x1008 floor only
+    // caught the tiny net/fastify id space; a mid-range handle (e.g. zlib's
+    // 0x60000 stream base, #1843) sailed past it and this function then
+    // segfaulted dereferencing `[handle - 8]` as a GcHeader. 0x100000 is the
+    // same handle/real-pointer threshold `js_native_call_method` already uses.
+    if ptr.is_null() || (ptr as usize) < 0x100000 {
         return false;
     }
     unsafe {

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -131,6 +131,18 @@ bundled-net = ["async-runtime"]
 # extern reference) when perry-ext-net is guaranteed to be linked.
 external-net-pump = ["async-runtime"]
 
+# Activated by `optimized_libs::build_optimized_libs` (#1843) when the
+# well-known flip routes `node:zlib` to perry-ext-zlib and strips
+# `compression`. Tells perry-stdlib's `js_stdlib_process_pending` /
+# `js_stdlib_has_active_handles` to drain perry-ext-zlib's deferred
+# stream-event queue (`js_ext_zlib_process_pending` /
+# `js_ext_zlib_has_active_handles`), and routes lost-static-type
+# `gz.write()` / `.on()` / `.pipe()` calls through
+# `js_ext_zlib_dispatch_method`. Mirrors `external-net-pump`. No async
+# runtime needed (zlib compression is synchronous), but the pump call
+# sites live in the async-bridge module which is `async-runtime`-gated.
+external-zlib-pump = ["async-runtime"]
+
 # Activated by `optimized_libs::build_optimized_libs` (v0.5.714) when
 # the well-known flip routes `node:http` / `node:https` / `node:http2`
 # to perry-ext-http (which bundles perry-ext-http-server). Tells

--- a/crates/perry-stdlib/src/common/async_bridge.rs
+++ b/crates/perry-stdlib/src/common/async_bridge.rs
@@ -496,6 +496,24 @@ pub extern "C" fn js_stdlib_process_pending() -> i32 {
     // reader's queue and dispatches to question/line/close callbacks.
     count += crate::readline::js_readline_process_pending();
 
+    // Process pending zlib stream events (#1843) — `createGzip()` etc.
+    // buffer input across `.write()` and queue 'data'/'end' on `.end()`;
+    // drained + dispatched to listeners (and forwarded to `.pipe()` dests)
+    // here on the main thread. Bundled path (perry-stdlib's own zlib mod):
+    #[cfg(feature = "compression")]
+    {
+        count += unsafe { crate::zlib::js_zlib_process_pending() };
+    }
+    // External path: the well-known flip routed `node:zlib` to perry-ext-zlib
+    // and stripped `compression`. Drain perry-ext-zlib's queue via its extern.
+    #[cfg(all(feature = "external-zlib-pump", not(feature = "compression")))]
+    {
+        extern "C" {
+            fn js_ext_zlib_process_pending() -> i32;
+        }
+        count += unsafe { js_ext_zlib_process_pending() };
+    }
+
     // Process pending fastify requests. With the bundled-fastify
     // adapter, `app.listen()` used to block the main TS thread inside
     // its own inner event loop forever, so an `await app.listen(...)`
@@ -678,6 +696,26 @@ pub extern "C" fn js_stdlib_has_active_handles() -> i32 {
             fn js_fastify_has_active() -> i32;
         }
         if unsafe { js_fastify_has_active() } != 0 {
+            return 1;
+        }
+    }
+    // zlib streams (#1843) — keep the loop alive while `.end()`-queued
+    // 'data'/'end' events are still waiting to be drained, so a purely-
+    // synchronous `createGzip().write(x).end()` program doesn't exit before
+    // its listeners fire. Bundled path:
+    #[cfg(feature = "compression")]
+    {
+        if crate::zlib::js_zlib_has_active_handles() != 0 {
+            return 1;
+        }
+    }
+    // External (perry-ext-zlib) path:
+    #[cfg(all(feature = "external-zlib-pump", not(feature = "compression")))]
+    {
+        extern "C" {
+            fn js_ext_zlib_has_active_handles() -> i32;
+        }
+        if unsafe { js_ext_zlib_has_active_handles() } != 0 {
             return 1;
         }
     }

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -293,6 +293,61 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
     if crate::net::is_net_socket_handle(handle) {
         return dispatch_net_socket(handle, method_name, &args);
     }
+
+    // zlib Transform streams (#1843): `zlib.createGzip()` etc. return handles
+    // in the 0x60000+ range; their `.write`/`.end`/`.on`/`.pipe`/`.flush`/
+    // `.close` calls lose their static type and route here. Gated on the
+    // registry AND the method vocabulary so a handle-id reused across another
+    // subsystem's registry can't misroute (handle id-spaces aren't unified —
+    // see the long comment above).
+    #[cfg(feature = "compression")]
+    if matches!(
+        method_name,
+        "write" | "end" | "on" | "once" | "pipe" | "flush" | "close" | "destroy"
+    ) && crate::zlib::is_zlib_stream_handle(handle)
+    {
+        // zlib streams are synchronous, so nothing else triggers the pump
+        // registration that async ops (spawn/queue) normally do. Register here
+        // so the event loop's `has_active` gate + pump drain the deferred
+        // 'data'/'end' events instead of exiting before they fire (#1843).
+        crate::common::async_bridge::ensure_pump_registered();
+        return dispatch_zlib_stream(handle, method_name, &args);
+    }
+
+    // External zlib path (#1843): when the well-known flip routes `node:zlib`
+    // to perry-ext-zlib and strips `compression`, the stream handle + dispatch
+    // live in perry-ext-zlib. Same registry-gated contract; the per-method
+    // match runs inside `js_ext_zlib_dispatch_method`.
+    #[cfg(all(feature = "external-zlib-pump", not(feature = "compression")))]
+    if matches!(
+        method_name,
+        "write" | "end" | "on" | "once" | "addListener" | "pipe" | "flush" | "close" | "destroy"
+    ) {
+        extern "C" {
+            fn js_ext_zlib_is_stream_handle(handle: i64) -> i32;
+            fn js_ext_zlib_dispatch_method(
+                handle: i64,
+                method_ptr: *const u8,
+                method_len: usize,
+                args_ptr: *const f64,
+                args_len: usize,
+            ) -> f64;
+        }
+        if unsafe { js_ext_zlib_is_stream_handle(handle) } != 0 {
+            // Register the stdlib pump (#1843) — see the bundled arm above.
+            crate::common::async_bridge::ensure_pump_registered();
+            return unsafe {
+                js_ext_zlib_dispatch_method(
+                    handle,
+                    method_name.as_ptr(),
+                    method_name.len(),
+                    args.as_ptr(),
+                    args.len(),
+                )
+            };
+        }
+    }
+
     // External net path (v0.5.581): perry-ext-net registers itself when
     // the well-known flip strips bundled-net. Same dispatch contract,
     // but routes through extern "C" symbols perry-ext-net provides.
@@ -680,6 +735,57 @@ unsafe fn dispatch_net_socket(handle: i64, method: &str, args: &[f64]) -> f64 {
             f64::from_bits(0x7FFD_0000_0000_0000u64 | (promise as u64 & 0x0000_FFFF_FFFF_FFFF))
         }
         _ => f64::from_bits(0x7FFC_0000_0000_0001),
+    }
+}
+
+/// Dispatch a method call on a zlib Transform-stream handle (#1843).
+///
+/// `createGzip()` / `createDeflate()` / `createBrotliCompress()` / … return
+/// handles whose `.write`/`.end`/`.on`/`.pipe`/`.flush`/`.close` lose their
+/// static type and arrive here. Compression is synchronous and buffered in the
+/// runtime: `.write()` accumulates input, `.end()` runs the codec and queues
+/// 'data'/'end' onto the deferred-event pump.
+#[cfg(feature = "compression")]
+unsafe fn dispatch_zlib_stream(handle: i64, method: &str, args: &[f64]) -> f64 {
+    fn unbox_to_i64(v: f64) -> i64 {
+        (v.to_bits() & 0x0000_FFFF_FFFF_FFFF) as i64
+    }
+    const UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+    const TRUE: u64 = 0x7FFC_0000_0000_0004;
+    // The stream itself, re-boxed as a POINTER_TAG handle (for `.on()` chaining
+    // `s.on('data', …).on('end', …)`).
+    let self_ref =
+        f64::from_bits(0x7FFD_0000_0000_0000u64 | (handle as u64 & 0x0000_FFFF_FFFF_FFFF));
+    match method {
+        "write" if !args.is_empty() => {
+            crate::zlib::zlib_stream_write(handle, args[0]);
+            f64::from_bits(TRUE) // Node's writable.write() returns a boolean
+        }
+        "end" => {
+            let chunk = args.first().copied().unwrap_or(f64::from_bits(UNDEFINED));
+            crate::zlib::zlib_stream_end(handle, chunk);
+            self_ref
+        }
+        "on" | "once" if args.len() >= 2 => {
+            // `args[0]` is the full NaN-boxed event name (SSO-safe extraction
+            // happens inside zlib_stream_on); `args[1]` is the closure pointer.
+            crate::zlib::zlib_stream_on(handle, args[0], unbox_to_i64(args[1]));
+            self_ref
+        }
+        "pipe" if !args.is_empty() => {
+            crate::zlib::zlib_stream_pipe(handle, args[0]);
+            args[0] // Node's `.pipe(dest)` returns `dest` for chaining
+        }
+        "close" | "destroy" => {
+            // Force the codec to run (so 'end' fires) if it hasn't already.
+            crate::zlib::zlib_stream_end(handle, f64::from_bits(UNDEFINED));
+            f64::from_bits(UNDEFINED)
+        }
+        // `.flush([cb])` — with the buffer-until-end model there's nothing to
+        // flush mid-stream (all output emits on `.end()`); accept it as a no-op
+        // so callers don't hit "flush is not a function".
+        "flush" => f64::from_bits(UNDEFINED),
+        _ => f64::from_bits(UNDEFINED),
     }
 }
 

--- a/crates/perry-stdlib/src/zlib.rs
+++ b/crates/perry-stdlib/src/zlib.rs
@@ -3,13 +3,18 @@
 //! Native implementation of Node.js zlib module.
 //! Provides gzip, gunzip, deflate, and inflate functions.
 
-use flate2::read::{DeflateDecoder, DeflateEncoder, GzDecoder, GzEncoder};
+use flate2::read::{
+    DeflateDecoder, DeflateEncoder, GzDecoder, GzEncoder, ZlibDecoder, ZlibEncoder,
+};
 use flate2::Compression;
 use perry_runtime::{
-    buffer::{buffer_alloc, mark_as_uint8array, BufferHeader},
-    js_string_from_bytes, JSValue, StringHeader,
+    buffer::{js_buffer_alloc, js_buffer_is_buffer, BufferHeader},
+    js_closure_call0, js_closure_call1, js_get_string_pointer_unified, js_string_from_bytes,
+    ClosureHeader, JSValue, StringHeader,
 };
+use std::collections::HashMap;
 use std::io::Read;
+use std::sync::Mutex;
 
 use crate::common::async_bridge::{queue_promise_resolution, spawn};
 
@@ -148,37 +153,610 @@ pub unsafe extern "C" fn js_zlib_gzip(
     promise
 }
 
-/// `zlib.createBrotliDecompress(options?)` — minimal feature-check
-/// shim.
+// ============================================================================
+// Brotli one-shot functions (#1843 cluster 2)
+//
+// The `brotli` crate is already a `compression`-feature dep. Use its
+// reader-based codecs for one-shot compress/decompress, mirroring the
+// flate2 `*Sync`/async wrappers above. Quality 11 / window 22 are Node's
+// defaults for `brotliCompressSync`.
+// ============================================================================
+
+fn brotli_compress_bytes(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut reader = brotli::CompressorReader::new(data, 4096, 11, 22);
+    let _ = reader.read_to_end(&mut out);
+    out
+}
+
+fn brotli_decompress_bytes(data: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut out = Vec::new();
+    let mut reader = brotli::Decompressor::new(data, 4096);
+    reader.read_to_end(&mut out)?;
+    Ok(out)
+}
+
+/// `zlib.brotliCompressSync(data)` -> Buffer
 ///
-/// Axios's compile-time module init calls
-/// `typeof zlib.createBrotliDecompress === 'function'` and only
-/// invokes this when a server actually replies with
-/// `content-encoding: br`. To get axios past the gate we return a
-/// registered Buffer-shaped handle (32 bytes, marked as Uint8Array
-/// so `instanceof Uint8Array` is true). The real Brotli pipe
-/// (`write` / `end` / `on('data')` / `on('end')`) is a TODO follow-
-/// up — when a Brotli response actually comes back the stream
-/// handlers will hit the unimplemented dispatch path and surface a
-/// clear error to the caller rather than silently corrupting the
-/// payload.
-///
-/// `_opts` is the (optional) BrotliDecompressOptions object; we
-/// ignore it for the stub since none of the configurable knobs
-/// affect feature-check semantics. Returns a `*mut BufferHeader`
-/// which the calling site NaN-boxes with POINTER_TAG via
-/// `nanbox_pointer_inline`.
+/// # Safety
+/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_create_brotli_decompress(_opts: f64) -> *mut BufferHeader {
-    // 32 bytes is arbitrary — large enough to look like a real
-    // stream handle, small enough to be cheap.
-    let buf = buffer_alloc(32);
-    if buf.is_null() {
-        return std::ptr::null_mut();
+pub unsafe extern "C" fn js_zlib_brotli_compress_sync(
+    data_ptr: *const StringHeader,
+) -> *mut StringHeader {
+    let data = match bytes_from_header(data_ptr) {
+        Some(d) => d,
+        None => return std::ptr::null_mut(),
+    };
+    let out = brotli_compress_bytes(&data);
+    js_string_from_bytes(out.as_ptr(), out.len() as u32)
+}
+
+/// `zlib.brotliDecompressSync(data)` -> Buffer
+///
+/// # Safety
+/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_brotli_decompress_sync(
+    data_ptr: *const StringHeader,
+) -> *mut StringHeader {
+    let data = match bytes_from_header(data_ptr) {
+        Some(d) => d,
+        None => return std::ptr::null_mut(),
+    };
+    match brotli_decompress_bytes(&data) {
+        Ok(out) => js_string_from_bytes(out.as_ptr(), out.len() as u32),
+        Err(_) => std::ptr::null_mut(),
     }
-    (*buf).length = 0;
-    mark_as_uint8array(buf as usize);
-    buf
+}
+
+/// `zlib.brotliCompress(data)` -> Promise<Buffer>
+///
+/// # Safety
+/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_brotli_compress(
+    data_ptr: *const StringHeader,
+) -> *mut perry_runtime::Promise {
+    let promise = perry_runtime::js_promise_new();
+    let promise_ptr = promise as usize;
+    let data = match bytes_from_header(data_ptr) {
+        Some(d) => d,
+        None => {
+            reject_promise(promise_ptr, "Invalid input data");
+            return promise;
+        }
+    };
+    spawn(async move {
+        let result = tokio::task::spawn_blocking(move || brotli_compress_bytes(&data)).await;
+        match result {
+            Ok(out) => resolve_promise_bytes(promise_ptr, &out),
+            Err(e) => reject_promise(promise_ptr, &format!("BrotliCompress task error: {}", e)),
+        }
+    });
+    promise
+}
+
+/// `zlib.brotliDecompress(data)` -> Promise<Buffer>
+///
+/// # Safety
+/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_brotli_decompress(
+    data_ptr: *const StringHeader,
+) -> *mut perry_runtime::Promise {
+    let promise = perry_runtime::js_promise_new();
+    let promise_ptr = promise as usize;
+    let data = match bytes_from_header(data_ptr) {
+        Some(d) => d,
+        None => {
+            reject_promise(promise_ptr, "Invalid input data");
+            return promise;
+        }
+    };
+    spawn(async move {
+        let result = tokio::task::spawn_blocking(move || brotli_decompress_bytes(&data)).await;
+        match result {
+            Ok(Ok(out)) => resolve_promise_bytes(promise_ptr, &out),
+            Ok(Err(e)) => reject_promise(promise_ptr, &format!("BrotliDecompress error: {}", e)),
+            Err(e) => reject_promise(promise_ptr, &format!("BrotliDecompress task error: {}", e)),
+        }
+    });
+    promise
+}
+
+unsafe fn resolve_promise_bytes(promise_ptr: usize, bytes: &[u8]) {
+    let s = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+    let bits = JSValue::pointer(s as *const u8).bits();
+    queue_promise_resolution(promise_ptr, true, bits);
+}
+
+unsafe fn reject_promise(promise_ptr: usize, msg: &str) {
+    let s = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let bits = JSValue::pointer(s as *const u8).bits();
+    queue_promise_resolution(promise_ptr, false, bits);
+}
+
+// ============================================================================
+// zlib Transform-stream objects (#1843 cluster 1)
+//
+// `zlib.createGzip()` / `createGunzip()` / `createDeflate()` /
+// `createInflate()` / `createDeflateRaw()` / `createInflateRaw()` /
+// `createUnzip()` / `createBrotliCompress()` / `createBrotliDecompress()`
+// return small-int handles (base 0x60000, under the 0x100000 small-handle
+// dispatch threshold) that the codegen NaN-boxes with POINTER_TAG. Subsequent
+// `s.write()` / `s.end()` / `s.on()` / `s.pipe()` calls lose their static type
+// and route through `js_native_call_method` → HANDLE_METHOD_DISPATCH →
+// `dispatch_zlib_stream` (crates/perry-stdlib/src/common/dispatch.rs).
+//
+// This mirrors the net.Socket handle pattern (crates/perry-stdlib/src/net/
+// mod.rs) but compression is synchronous, so there's no tokio task: input is
+// buffered across `.write()` calls, the codec runs once on `.end()`, and the
+// resulting 'data'/'end' events are merely *deferred* onto ZLIB_PENDING_EVENTS
+// (drained by js_zlib_process_pending on the next loop tick) so that listeners
+// registered after `.write()` still fire and `.pipe()` can forward chunks.
+// ============================================================================
+
+#[derive(Clone, Copy, PartialEq)]
+enum Codec {
+    Gzip,
+    Gunzip,
+    Deflate,
+    Inflate,
+    DeflateRaw,
+    InflateRaw,
+    Unzip,
+    BrotliCompress,
+    BrotliDecompress,
+}
+
+struct ZlibStreamState {
+    codec: Codec,
+    input: Vec<u8>,
+    ended: bool,
+    /// Destinations registered via `.pipe(dest)` — stored as NaN-boxed bits;
+    /// 'data'/'end' are forwarded to each via dynamic method dispatch.
+    pipes: Vec<u64>,
+}
+
+enum ZlibEvent {
+    Data(i64, Vec<u8>),
+    End(i64),
+    Error(i64, String),
+}
+
+lazy_static::lazy_static! {
+    static ref ZLIB_STREAMS: Mutex<HashMap<i64, ZlibStreamState>> = Mutex::new(HashMap::new());
+    static ref ZLIB_LISTENERS: Mutex<HashMap<i64, HashMap<String, Vec<i64>>>> =
+        Mutex::new(HashMap::new());
+    static ref ZLIB_PENDING_EVENTS: Mutex<Vec<ZlibEvent>> = Mutex::new(Vec::new());
+    static ref NEXT_ZLIB_ID: Mutex<i64> = Mutex::new(0x60000);
+}
+
+static ZLIB_GC_REGISTERED: std::sync::Once = std::sync::Once::new();
+
+/// Register the zlib-stream GC root scanner once. Listener closures
+/// (`s.on('data', cb)`) are only referenced from `ZLIB_LISTENERS`; without
+/// rooting them a GC between `.on()` and the deferred dispatch would free the
+/// closure body (the same hazard net.Socket guards against — issue #35).
+fn ensure_zlib_gc_scanner() {
+    ZLIB_GC_REGISTERED.call_once(|| {
+        perry_runtime::gc::gc_register_mutable_root_scanner_named("stdlib:zlib", scan_zlib_roots);
+    });
+}
+
+fn scan_zlib_roots(visitor: &mut perry_runtime::gc::RuntimeRootVisitor<'_>) {
+    if let Ok(mut listeners) = ZLIB_LISTENERS.lock() {
+        for per_stream in listeners.values_mut() {
+            for cb_vec in per_stream.values_mut() {
+                for cb in cb_vec.iter_mut() {
+                    visitor.visit_i64_slot(cb);
+                }
+            }
+        }
+    }
+}
+
+fn next_zlib_id() -> i64 {
+    let mut g = NEXT_ZLIB_ID.lock().unwrap();
+    let id = *g;
+    *g += 1;
+    id
+}
+
+fn create_zlib_stream(codec: Codec) -> i64 {
+    ensure_zlib_gc_scanner();
+    let id = next_zlib_id();
+    ZLIB_STREAMS.lock().unwrap().insert(
+        id,
+        ZlibStreamState {
+            codec,
+            input: Vec::new(),
+            ended: false,
+            pipes: Vec::new(),
+        },
+    );
+    id
+}
+
+/// True iff `handle` indexes a live zlib stream. Gates the dispatch arm in
+/// `common::dispatch` so a handle-id collision with another subsystem's
+/// registry can't misroute (handle id-spaces are not unified — see the long
+/// comment in `js_handle_method_dispatch`).
+pub fn is_zlib_stream_handle(handle: i64) -> bool {
+    ZLIB_STREAMS.lock().unwrap().contains_key(&handle)
+}
+
+// ── factories ──────────────────────────────────────────────────────────────
+
+/// # Safety
+/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_create_gzip(_opts: f64) -> i64 {
+    create_zlib_stream(Codec::Gzip)
+}
+/// # Safety
+/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_create_gunzip(_opts: f64) -> i64 {
+    create_zlib_stream(Codec::Gunzip)
+}
+/// # Safety
+/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_create_deflate(_opts: f64) -> i64 {
+    create_zlib_stream(Codec::Deflate)
+}
+/// # Safety
+/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_create_inflate(_opts: f64) -> i64 {
+    create_zlib_stream(Codec::Inflate)
+}
+/// # Safety
+/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_create_deflate_raw(_opts: f64) -> i64 {
+    create_zlib_stream(Codec::DeflateRaw)
+}
+/// # Safety
+/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_create_inflate_raw(_opts: f64) -> i64 {
+    create_zlib_stream(Codec::InflateRaw)
+}
+/// # Safety
+/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_create_unzip(_opts: f64) -> i64 {
+    create_zlib_stream(Codec::Unzip)
+}
+/// # Safety
+/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_create_brotli_compress(_opts: f64) -> i64 {
+    create_zlib_stream(Codec::BrotliCompress)
+}
+/// `zlib.createBrotliDecompress(options?)` — returns a real Transform-stream
+/// handle. (Previously a feature-check Buffer stub; axios's
+/// `typeof createBrotliDecompress === 'function'` gate still passes and a `br`
+/// response now actually decodes.)
+///
+/// # Safety
+/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_create_brotli_decompress(_opts: f64) -> i64 {
+    create_zlib_stream(Codec::BrotliDecompress)
+}
+
+// ── one-shot codec used by the streams on .end() ─────────────────────────────
+
+fn run_codec(codec: Codec, input: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut out = Vec::new();
+    match codec {
+        Codec::Gzip => {
+            GzEncoder::new(input, Compression::default()).read_to_end(&mut out)?;
+        }
+        Codec::Gunzip => {
+            GzDecoder::new(input).read_to_end(&mut out)?;
+        }
+        Codec::Deflate => {
+            ZlibEncoder::new(input, Compression::default()).read_to_end(&mut out)?;
+        }
+        Codec::Inflate => {
+            ZlibDecoder::new(input).read_to_end(&mut out)?;
+        }
+        Codec::DeflateRaw => {
+            DeflateEncoder::new(input, Compression::default()).read_to_end(&mut out)?;
+        }
+        Codec::InflateRaw => {
+            DeflateDecoder::new(input).read_to_end(&mut out)?;
+        }
+        Codec::Unzip => {
+            // Node's `createUnzip` auto-detects gzip vs zlib by header.
+            if input.len() >= 2 && input[0] == 0x1f && input[1] == 0x8b {
+                GzDecoder::new(input).read_to_end(&mut out)?;
+            } else {
+                ZlibDecoder::new(input).read_to_end(&mut out)?;
+            }
+        }
+        Codec::BrotliCompress => {
+            out = brotli_compress_bytes(input);
+        }
+        Codec::BrotliDecompress => {
+            out = brotli_decompress_bytes(input)?;
+        }
+    }
+    Ok(out)
+}
+
+// ── instance ops (called from dispatch_zlib_stream) ──────────────────────────
+
+/// Convert a `.write()`/`.end()` chunk (Buffer, string, number) to bytes.
+unsafe fn chunk_to_bytes(value: f64) -> Option<Vec<u8>> {
+    let v = JSValue::from_bits(value.to_bits());
+    if v.is_undefined() || v.is_null() {
+        return None;
+    }
+    if v.is_pointer() {
+        let raw = (value.to_bits() & 0x0000_FFFF_FFFF_FFFF) as i64;
+        if js_buffer_is_buffer(raw) != 0 {
+            let buf = raw as *const BufferHeader;
+            if !buf.is_null() {
+                let len = (*buf).length as usize;
+                let data = (buf as *const u8).add(std::mem::size_of::<BufferHeader>());
+                return Some(std::slice::from_raw_parts(data, len).to_vec());
+            }
+        }
+    }
+    // String (STRING_TAG / SSO short string / raw pointer) or number/bool.
+    let sptr = js_get_string_pointer_unified(value) as *const StringHeader;
+    if !sptr.is_null() {
+        let len = (*sptr).byte_len as usize;
+        if len <= (1 << 30) {
+            let data = (sptr as *const u8).add(std::mem::size_of::<StringHeader>());
+            return Some(std::slice::from_raw_parts(data, len).to_vec());
+        }
+    }
+    None
+}
+
+/// `stream.write(chunk)` — buffer the chunk for the deferred codec run.
+pub unsafe fn zlib_stream_write(handle: i64, chunk: f64) {
+    if let Some(bytes) = chunk_to_bytes(chunk) {
+        if let Some(s) = ZLIB_STREAMS.lock().unwrap().get_mut(&handle) {
+            if !s.ended {
+                s.input.extend_from_slice(&bytes);
+            }
+        }
+    }
+}
+
+/// `stream.end([chunk])` — optional final chunk, then run the codec and queue
+/// the 'data'/'end' (or 'error') events.
+pub unsafe fn zlib_stream_end(handle: i64, chunk: f64) {
+    zlib_stream_write(handle, chunk);
+    finish_zlib_stream(handle);
+}
+
+fn finish_zlib_stream(handle: i64) {
+    let (codec, input) = {
+        let mut g = ZLIB_STREAMS.lock().unwrap();
+        match g.get_mut(&handle) {
+            Some(s) if !s.ended => {
+                s.ended = true;
+                (s.codec, std::mem::take(&mut s.input))
+            }
+            _ => return,
+        }
+    };
+    {
+        let mut pending = ZLIB_PENDING_EVENTS.lock().unwrap();
+        match run_codec(codec, &input) {
+            Ok(out) => {
+                if !out.is_empty() {
+                    pending.push(ZlibEvent::Data(handle, out));
+                }
+                pending.push(ZlibEvent::End(handle));
+            }
+            Err(e) => pending.push(ZlibEvent::Error(handle, format!("{}", e))),
+        }
+    }
+    perry_runtime::event_pump::js_notify_main_thread();
+}
+
+/// `stream.on(event, cb)` / `stream.once(event, cb)` — register a listener.
+/// `event` is extracted SSO-safely via `js_get_string_pointer_unified` (short
+/// names like "data"/"end" are SSO-inlined, so a raw unbox would miss them).
+pub unsafe fn zlib_stream_on(handle: i64, event_value: f64, cb: i64) {
+    ensure_zlib_gc_scanner();
+    let event_ptr = js_get_string_pointer_unified(event_value) as *const StringHeader;
+    if event_ptr.is_null() {
+        return;
+    }
+    let len = (*event_ptr).byte_len as usize;
+    let data = (event_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+    let event = match std::str::from_utf8(std::slice::from_raw_parts(data, len)) {
+        Ok(s) => s.to_string(),
+        Err(_) => return,
+    };
+    ZLIB_LISTENERS
+        .lock()
+        .unwrap()
+        .entry(handle)
+        .or_default()
+        .entry(event)
+        .or_default()
+        .push(cb);
+}
+
+/// `stream.pipe(dest)` — forward 'data' (→ dest.write) and 'end' (→ dest.end)
+/// to `dest`. Stored as NaN-boxed bits; forwarding happens during the deferred
+/// drain. Returns nothing here — the dispatch arm returns `dest` for chaining.
+pub unsafe fn zlib_stream_pipe(handle: i64, dest: f64) {
+    if let Some(s) = ZLIB_STREAMS.lock().unwrap().get_mut(&handle) {
+        s.pipes.push(dest.to_bits());
+    }
+}
+
+// ── pump (drained on the main thread from js_stdlib_process_pending) ─────────
+
+extern "C" {
+    fn js_native_call_method_str_key(
+        object: f64,
+        name_handle: i64,
+        args_ptr: *const f64,
+        args_len: usize,
+    ) -> f64;
+}
+
+fn listeners_for(id: i64, event: &str) -> Vec<i64> {
+    ZLIB_LISTENERS
+        .lock()
+        .unwrap()
+        .get(&id)
+        .and_then(|m| m.get(event).cloned())
+        .unwrap_or_default()
+}
+
+fn pipes_for(id: i64) -> Vec<u64> {
+    ZLIB_STREAMS
+        .lock()
+        .unwrap()
+        .get(&id)
+        .map(|s| s.pipes.clone())
+        .unwrap_or_default()
+}
+
+unsafe fn make_buffer(bytes: &[u8]) -> Option<f64> {
+    let buf = js_buffer_alloc(bytes.len() as i32, 0);
+    if buf.is_null() {
+        return None;
+    }
+    let data = (buf as *mut u8).add(std::mem::size_of::<BufferHeader>());
+    std::ptr::copy_nonoverlapping(bytes.as_ptr(), data, bytes.len());
+    (*buf).length = bytes.len() as u32;
+    Some(f64::from_bits(JSValue::pointer(buf as *const u8).bits()))
+}
+
+/// Forward a `.pipe(dest)` chunk: `dest.write(Buffer.from(bytes))`. Builds the
+/// method-name string and the chunk Buffer back-to-back (name first) so there's
+/// no allocation between the Buffer's creation and the dispatch that roots it —
+/// the chunk comes from an owned `Vec<u8>`, not a GC-movable source.
+unsafe fn forward_write(dest_bits: u64, bytes: &[u8]) {
+    let name = js_string_from_bytes(b"write".as_ptr(), 5);
+    if name.is_null() {
+        return;
+    }
+    let buf = match make_buffer(bytes) {
+        Some(b) => b,
+        None => return,
+    };
+    let args = [buf];
+    js_native_call_method_str_key(f64::from_bits(dest_bits), name as i64, args.as_ptr(), 1);
+}
+
+/// Forward `.pipe(dest)` end: `dest.end()`.
+unsafe fn forward_end(dest_bits: u64) {
+    let name = js_string_from_bytes(b"end".as_ptr(), 3);
+    if name.is_null() {
+        return;
+    }
+    js_native_call_method_str_key(f64::from_bits(dest_bits), name as i64, std::ptr::null(), 0);
+}
+
+unsafe fn build_zlib_error(msg: &str) -> f64 {
+    // `{ message: msg }` so `s.on('error', e => e.message)` works.
+    use perry_runtime::JSValue as V;
+    let name = b"message";
+    let mut shape_id: u32 = 0x5A4C_0000; // "ZL"
+    for &b in name {
+        shape_id = shape_id.wrapping_mul(31).wrapping_add(b as u32);
+    }
+    shape_id = shape_id.wrapping_add(1);
+    let s_msg = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let obj =
+        perry_runtime::js_object_alloc_with_shape(shape_id, 1, name.as_ptr(), name.len() as u32);
+    if obj.is_null() {
+        return f64::from_bits(V::string_ptr(s_msg).bits());
+    }
+    perry_runtime::js_object_set_field(obj, 0, V::string_ptr(s_msg));
+    f64::from_bits((obj as u64 & 0x0000_FFFF_FFFF_FFFF) | 0x7FFD_0000_0000_0000)
+}
+
+/// Drain queued zlib stream events on the main thread. Wired into
+/// `js_stdlib_process_pending`.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_process_pending() -> i32 {
+    let events: Vec<ZlibEvent> = {
+        let mut g = ZLIB_PENDING_EVENTS.lock().unwrap();
+        std::mem::take(&mut *g)
+    };
+    let count = events.len() as i32;
+    for ev in events {
+        match ev {
+            ZlibEvent::Data(id, bytes) => {
+                let cbs = listeners_for(id, "data");
+                if !cbs.is_empty() {
+                    if let Some(buf_f64) = make_buffer(&bytes) {
+                        for cb in cbs {
+                            if cb != 0 {
+                                js_closure_call1(cb as *const ClosureHeader, buf_f64);
+                            }
+                        }
+                    }
+                }
+                // Fresh Buffer per pipe dest (the chunk lives in the owned
+                // `bytes`, so this is safe even after listener callbacks GC'd).
+                for dest in pipes_for(id) {
+                    forward_write(dest, &bytes);
+                }
+            }
+            ZlibEvent::End(id) => {
+                for cb in listeners_for(id, "end") {
+                    if cb != 0 {
+                        js_closure_call0(cb as *const ClosureHeader);
+                    }
+                }
+                for cb in listeners_for(id, "finish") {
+                    if cb != 0 {
+                        js_closure_call0(cb as *const ClosureHeader);
+                    }
+                }
+                for dest in pipes_for(id) {
+                    forward_end(dest);
+                }
+                for cb in listeners_for(id, "close") {
+                    if cb != 0 {
+                        js_closure_call0(cb as *const ClosureHeader);
+                    }
+                }
+                ZLIB_LISTENERS.lock().unwrap().remove(&id);
+                ZLIB_STREAMS.lock().unwrap().remove(&id);
+            }
+            ZlibEvent::Error(id, msg) => {
+                let err_f64 = build_zlib_error(&msg);
+                for cb in listeners_for(id, "error") {
+                    if cb != 0 {
+                        js_closure_call1(cb as *const ClosureHeader, err_f64);
+                    }
+                }
+                ZLIB_LISTENERS.lock().unwrap().remove(&id);
+                ZLIB_STREAMS.lock().unwrap().remove(&id);
+            }
+        }
+    }
+    count
+}
+
+/// Keep the event loop alive while zlib stream events are queued. Wired into
+/// `js_stdlib_has_active_handles`.
+pub fn js_zlib_has_active_handles() -> i32 {
+    if !ZLIB_PENDING_EVENTS.lock().unwrap().is_empty() {
+        1
+    } else {
+        0
+    }
 }
 
 /// Gunzip decompress data asynchronously

--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -335,6 +335,16 @@ pub(super) fn build_optimized_libs(
             if original_features.contains(&"bundled-net") {
                 features.insert("external-net-pump");
             }
+            // #1843 — when the flip strips `compression` and routes
+            // `node:zlib` to perry-ext-zlib, activate `external-zlib-pump`
+            // so perry-stdlib's main-thread pump + active-handles gate drain
+            // perry-ext-zlib's deferred stream-event queue and route
+            // `gz.write()`/`.on()`/`.pipe()` (lost-static-type) calls into its
+            // `js_ext_zlib_dispatch_method`. Without this the events stay
+            // queued forever (`createGzip().on('data')` never fires).
+            if original_features.contains(&"compression") {
+                features.insert("external-zlib-pump");
+            }
             // Closes #606 — same shape for ws. When the well-known flip
             // strips `bundled-ws` and routes to perry-ext-ws, activate
             // `external-ws-pump` so perry-stdlib's main-thread pump and

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1267 entries across 81 modules
+// Coverage: 1279 entries across 81 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -2013,7 +2013,31 @@ declare module "zlib" {
   /** stdlib */
   export const constants: any;
   /** stdlib */
+  export function brotliCompress(p0: string): any;
+  /** stdlib */
+  export function brotliCompressSync(p0: string): string;
+  /** stdlib */
+  export function brotliDecompress(p0: string): any;
+  /** stdlib */
+  export function brotliDecompressSync(p0: string): string;
+  /** stdlib */
+  export function createBrotliCompress(options?: any): any;
+  /** stdlib */
   export function createBrotliDecompress(options?: any): any;
+  /** stdlib */
+  export function createDeflate(options?: any): any;
+  /** stdlib */
+  export function createDeflateRaw(options?: any): any;
+  /** stdlib */
+  export function createGunzip(options?: any): any;
+  /** stdlib */
+  export function createGzip(options?: any): any;
+  /** stdlib */
+  export function createInflate(options?: any): any;
+  /** stdlib */
+  export function createInflateRaw(options?: any): any;
+  /** stdlib */
+  export function createUnzip(options?: any): any;
   /** stdlib */
   export function deflateSync(p0: string): string;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1267 entries across 81 modules.
+Total: 1279 entries across 81 modules.
 
 ## Modules
 
@@ -1885,7 +1885,19 @@ Total: 1267 entries across 81 modules.
 
 ### Methods
 
+- `brotliCompress` — module
+- `brotliCompressSync` — module
+- `brotliDecompress` — module
+- `brotliDecompressSync` — module
+- `createBrotliCompress` — module
 - `createBrotliDecompress` — module
+- `createDeflate` — module
+- `createDeflateRaw` — module
+- `createGunzip` — module
+- `createGzip` — module
+- `createInflate` — module
+- `createInflateRaw` — module
+- `createUnzip` — module
 - `deflateSync` — module
 - `gunzip` — module
 - `gunzipSync` — module


### PR DESCRIPTION
## Summary

Implements the `node:zlib` Transform-stream interface (cluster 1 of #1843, the highest-leverage gap) plus Brotli functions (cluster 2) and fixes two latent handle-dereference segfaults surfaced along the way.

`node:zlib` is routed to the `perry-ext-zlib` crate via `well_known_bindings.toml` (#466), so the work lands there, wired into perry-stdlib's event loop through a new `external-zlib-pump` feature (mirroring `external-net-pump`). A bundled equivalent lives in perry-stdlib's `compression` feature for the no-flip path.

## What now works

`zlib.createGzip()` / `createGunzip()` / `createDeflate()` / `createInflate()` / `createDeflateRaw()` / `createInflateRaw()` / `createUnzip()` / `createBrotliCompress()` / `createBrotliDecompress()` return real stream objects supporting:

- `.write(chunk)` / `.end([chunk])` (Buffer or string chunks)
- `.on('data' | 'end' | 'error' | 'finish' | 'close', cb)` / `.once` / `.addListener`
- `.pipe(dest)` (forwards `data`→`dest.write`, `end`→`dest.end`, returns `dest` for chaining)
- `.flush()` / `.close()` / `.destroy()`

Plus one-shot `zlib.brotliCompressSync` / `brotliDecompressSync` / `brotliCompress` / `brotliDecompress` (the `brotli` crate was already a `compression` dep).

Compression is synchronous, so input is buffered across `.write()` and the codec runs once on `.end()`; the resulting `data`/`end` events are deferred onto a queue drained by the main-thread pump, so listeners registered after `.write()` still fire and `.pipe()` can forward chunks.

End-to-end output is byte-for-byte identical to `node --experimental-strip-types` for gzip/deflate/brotli stream round-trips, `.pipe()` chains, and `zlib.constants.Z_*`.

## Runtime segfault fixes (general)

Two `is_class_object_ptr` / `js_value_typeof` low-address guards only rejected the tiny net/fastify id space (`< 0x1008` / `> 0x10000`). A native-module registry handle in the mid range (zlib uses a `0x60000` stream base to stay clear of those id spaces) sailed past them and segfaulted dereferencing `[handle - 8]` / `[handle + 12]`. Both now reject anything `< 0x100000` — the same handle/real-pointer boundary `js_native_call_method` already uses (real heap objects always live well above it). This also raises every handle subsystem's latent id ceiling from `0x1008` to `0x100000`, and makes `typeof aStreamHandle === "object"`.

## Buffer-aware one-shot input

`gzipSync`/`gunzipSync`/`deflateSync`/`inflateSync`/`brotli*Sync` read their argument through a buffer-aware reader, so a real `Buffer`/`Uint8Array` (e.g. `gunzipSync(Buffer.concat(chunks))`, `gunzipSync(fs.readFileSync(...))`) is read via its `BufferHeader` rather than misread as a `StringHeader`.

## Out of scope / follow-ups

- `.flush([cb])` is a no-op (the buffer-until-end model has nothing to flush mid-stream); incremental-flush tests like `test-zlib-flush-drain-longblock.js` are not addressed here.
- Per-write incremental `data` emission (output currently emits on `.end()`).

Closes #1843 (cluster 1 + cluster 2 + cluster 3 Z_* constants).
