### PR TITLE
fix(transform): #34 — `return yield*` delegation drives the iterator protocol (effect/Ref in Effect.gen)

### DIFF
--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -144,6 +144,110 @@ pub fn linearize_body(
                 });
             }
 
+            // #34: `return yield* inner` — delegation in return position.
+            // The earlier catch-all arm (`Return(Some(Yield { .. }))`) ignored
+            // the `delegate` flag and yielded `inner` itself as a single
+            // (non-delegated) value, so the outer generator handed the raw
+            // delegated object straight to its consumer. For `yield* effect`
+            // that consumer is effect's `yieldWrapGet`, which expects a
+            // `YieldWrap` (produced by the effect's `[Symbol.iterator]`) and
+            // threw "BUG: yieldWrapGet" on the bare effect. Desugar identically
+            // to the `Let`-initializer delegation arm (drive the inner
+            // iterator, re-yielding each value through the iterator protocol),
+            // then `return { value: <final>, done: true }` so the iterator's
+            // completion value becomes the generator's return value.
+            Stmt::Return(Some(Expr::Yield {
+                value: Some(inner),
+                delegate: true,
+            })) => {
+                let del_iter_id = alloc_local(next_local_id);
+                let del_result_id = alloc_local(next_local_id);
+
+                // Initial pull: argless (the first `next()` value is discarded
+                // per spec).
+                let next_call = Expr::Call {
+                    callee: Box::new(Expr::PropertyGet {
+                        object: Box::new(Expr::LocalGet(del_iter_id)),
+                        property: "next".to_string(),
+                    }),
+                    args: vec![],
+                    type_args: vec![],
+                };
+                // #1832: in-loop pull forwards the outer resume value (`sent_id`).
+                let next_call_resumed = Expr::Call {
+                    callee: Box::new(Expr::PropertyGet {
+                        object: Box::new(Expr::LocalGet(del_iter_id)),
+                        property: "next".to_string(),
+                    }),
+                    args: vec![Expr::LocalGet(sent_id)],
+                    type_args: vec![],
+                };
+
+                // #1831: resolve the iterator (effect / custom `[Symbol.iterator]`
+                // operands need `js_get_iterator` to invoke the well-known-symbol
+                // method; a generator call already is its iterator).
+                current.push(Stmt::Expr(Expr::LocalSet(
+                    del_iter_id,
+                    Box::new(Expr::GetIterator(Box::new(*inner.clone()))),
+                )));
+                current.push(Stmt::Expr(Expr::LocalSet(
+                    del_result_id,
+                    Box::new(next_call),
+                )));
+
+                let while_body = vec![
+                    Stmt::Expr(Expr::Yield {
+                        value: Some(Box::new(Expr::PropertyGet {
+                            object: Box::new(Expr::LocalGet(del_result_id)),
+                            property: "value".to_string(),
+                        })),
+                        delegate: false,
+                    }),
+                    Stmt::Expr(Expr::LocalSet(del_result_id, Box::new(next_call_resumed))),
+                ];
+
+                let while_stmt = Stmt::While {
+                    condition: Expr::Unary {
+                        op: UnaryOp::Not,
+                        operand: Box::new(Expr::PropertyGet {
+                            object: Box::new(Expr::LocalGet(del_result_id)),
+                            property: "done".to_string(),
+                        }),
+                    },
+                    body: while_body,
+                };
+
+                linearize_body(
+                    &[while_stmt],
+                    states,
+                    current,
+                    state_num,
+                    state_id,
+                    next_local_id,
+                    sent_id,
+                    catches,
+                );
+
+                // After the loop, the iterator's final `value` (from
+                // {value, done:true}) is the value of `yield* inner`, which is
+                // exactly what `return yield* inner` returns. Wrap it as the
+                // generator's terminal {value, done:true} and flush a Done state.
+                current.push(Stmt::Return(Some(make_iter_result(
+                    Expr::PropertyGet {
+                        object: Box::new(Expr::LocalGet(del_result_id)),
+                        property: "value".to_string(),
+                    },
+                    true,
+                ))));
+                let cont_state = *state_num;
+                *state_num += 1;
+                states.push(State {
+                    num: cont_state,
+                    body: std::mem::take(current),
+                    exit: StateExit::Done,
+                });
+            }
+
             // return (yield expr)  — i.e. `return await x` after async→generator rewrite
             // The yield must be emitted as a real yield state so the async-step driver can
             // await the expression; the continuation state then returns {value: __sent, done: true}

--- a/test-files/test_gap_yield_star_return.ts
+++ b/test-files/test_gap_yield_star_return.ts
@@ -1,0 +1,47 @@
+// Test: `return yield* inner` delegation in RETURN position (#34).
+// The generator linearizer treated `return yield* X` like `return yield X`,
+// ignoring the delegate flag: it yielded `X` itself once and returned the
+// caller-sent value instead of driving `X`'s iterator protocol and returning
+// the delegated iterator's completion value. This surfaced as effect's
+// "BUG: yieldWrapGet" for `return yield* Effect.succeed(...)` /
+// `return yield* Ref.get(ref)` inside `Effect.gen`, because the bare effect
+// (not its `[Symbol.iterator]`-produced YieldWrap) reached the consumer.
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+// --- return yield* drives the inner iterator and returns its completion ---
+function* inner1() {
+  yield "a";
+  yield "b";
+  return "innerDone";
+}
+function* outer1() {
+  return yield* inner1() as any;
+}
+const it1: any = outer1();
+console.log(JSON.stringify(it1.next())); // {"value":"a","done":false}
+console.log(JSON.stringify(it1.next())); // {"value":"b","done":false}
+console.log(JSON.stringify(it1.next())); // {"value":"innerDone","done":true}
+
+// --- the resume value still flows into the delegated generator ---
+function* echo() {
+  const x = yield "ask";
+  return "got:" + x;
+}
+function* wrap() {
+  return yield* echo() as any;
+}
+const it2: any = wrap();
+console.log(JSON.stringify(it2.next()));        // {"value":"ask","done":false}
+console.log(JSON.stringify(it2.next("REPLY"))); // {"value":"got:REPLY","done":true}
+
+// --- delegating to an empty-yield generator returns its value immediately ---
+function* onlyReturn() {
+  return 42;
+}
+function* wrap3() {
+  return yield* onlyReturn() as any;
+}
+const it3: any = wrap3();
+console.log(JSON.stringify(it3.next())); // {"value":42,"done":true}
+
+console.log("ALL YIELD-STAR-RETURN TESTS PASSED");


### PR DESCRIPTION
## Summary

Fixes the `BUG: yieldWrapGet` thrown by `effect/Ref` mutable state inside `Effect.gen` (part of the Effect framework epic #321). Root cause is a generic generator-lowering bug, not Ref-specific.

## Root cause

`crates/perry-transform/src/generator/linearize.rs` — the `Return(Some(Yield { .. }))` arm (the `return await x` / `return yield x` path) **ignored the `delegate` flag**. So `return yield* X` was lowered exactly like `return yield X`:

- it emitted a single (non-delegated) `yield X`, handing `X` itself to the outer generator's consumer, and
- returned the caller-sent value (`__sent`) instead of `X`'s iterator completion value.

By contrast, the statement-level `yield* X` arm and the `const x = yield* X` (Let-initializer) arm both correctly desugar delegation via `GetIterator` + a drive-and-re-yield while-loop. The return-position case was simply never handled.

For `Effect.gen`, `yield* effect` must iterate `effect[Symbol.iterator]()` → `SingleShotGen(new YieldWrap(effect))`, so the value handed back through the iterator protocol is a `YieldWrap`. With the bug, the **bare effect** (e.g. a `Sync` `EffectPrimitive`) reached effect's `yieldWrapGet`, which checks `YieldWrapTypeId in self` and throws `BUG: yieldWrapGet` because the raw effect has no `YieldWrap` symbol.

Instrumented diagnostic at the failure point:
```
PERRY_YWG typeof= object isobj= true symIn= false _op= Sync isYW= false
```
i.e. `yieldWrapGet` received a raw `Sync` effect, not a YieldWrap.

## Repro

```ts
import * as Effect from "effect/Effect";
import * as Ref from "effect/Ref";
const prog = Effect.gen(function* () {
  const ref = yield* Ref.make(0);
  yield* Ref.update(ref, (n) => n + 5);
  return yield* Ref.get(ref);     // <- BUG: yieldWrapGet
});
console.log(Effect.runSync(prog)); // node: 5 ; perry (before): BUG
```

The trigger is `return yield* <effect>`. It looked Ref-specific only because `Ref.get` is typically the final `return yield* Ref.get(ref)`. `return yield* Effect.succeed(42)` failed identically; `const x = yield* Ref.get(ref)` (non-return) already worked.

## Fix

Add a dedicated `Return(Some(Yield { value: Some(inner), delegate: true }))` arm that desugars identically to the existing `Let`-initializer delegation arm (resolve the iterator via `GetIterator`, drive `.next()` in a while-loop re-yielding each `.value` through the iterator protocol, forwarding the outer resume value per #1832), then `return { value: <iterator final value>, done: true }`.

Purely additive — non-delegate `return yield` (incl. async `return await x`) and every other statement path are untouched.

## Validation

- **Repro** byte-identical to Node (`5`).
- **Ref ops in a gen** (`Ref.set`/`Ref.modify`/`Ref.getAndUpdate`/`Ref.get`) byte-identical to Node.
- **Standalone perry generator delegation** in return position (single-value + two-way resume + empty-yield) byte-identical to Node.
- **Effect survey** (`/private/tmp/effect-dod-ref/survey`): the numbered set 01–31 + real* all pass; `real4_ref`/`nref` (the Ref cases) now flip to PASS; `05_gen`, `07_all`, and the four `*_schema_*` cases stay green. The only remaining survey DIFFs (`nlay`, `real3_context_layer`) are a pre-existing `Effect.provide`/`Layer.succeed` async-resolution blocker unrelated to this change — `nlay` uses no generator at all yet fails identically.
- **Regression sweep** over `test-files` generator / yield / class / object / symbol / iterator gap tests: all byte-identical to Node. The one DIFF (`test_gap_class_advanced`, static-init blocks) is a pre-existing known failure (`known_failures.json`, #1635) with zero generators.
- New gap test `test-files/test_gap_yield_star_return.ts` passes.
- `cargo fmt --all -- --check` clean; `./scripts/check_file_size.sh` OK (linearize.rs 892 lines); workspace `cargo build --release` compiles; `cargo test --release -p perry-transform` 23 passed / 0 failed.

Refs #34 #321.
