### PR TITLE
Add guarded raw numeric storage

### DIFF
--- a/benchmarks/compiler_output/fixtures/raw_numeric_layout_smoke.ts
+++ b/benchmarks/compiler_output/fixtures/raw_numeric_layout_smoke.ts
@@ -1,0 +1,47 @@
+declare function gc(): void;
+
+let held: any = null;
+
+class Gauge {
+  value: number = 1;
+  total: number = 2;
+  label: string = "stable";
+}
+
+function numericArrays(): number {
+  const xs: number[] = [1, 2, 3, 4];
+  xs[0] = 4;
+  xs.push(5);
+  let sum = xs[0] + xs[4];
+  gc();
+
+  (xs as any)[1] = "drop";
+  sum += typeof (xs as any)[1] === "string" ? 17 : 0;
+  xs[2] = 6;
+  sum += xs[2];
+  return sum;
+}
+
+function classFields(): number {
+  const gauge = new Gauge();
+  gauge.value = 2.5;
+  gauge.total = 7.5;
+  let sum = gauge.value + gauge.total;
+  held = gauge;
+  gc();
+
+  (gauge as any).value = "boxed";
+  sum += typeof (gauge as any).value === "string" ? 19 : 0;
+
+  const fast = new Gauge();
+  fast.value = 4.5;
+  fast.total = 5.5;
+  sum += fast.value + fast.total;
+  held = fast;
+  gc();
+  return sum;
+}
+
+const arrayResult = numericArrays();
+const fieldResult = classFields();
+console.log("raw_numeric_layouts:" + (arrayResult + fieldResult));

--- a/benchmarks/compiler_output/workloads.toml
+++ b/benchmarks/compiler_output/workloads.toml
@@ -647,6 +647,8 @@ consumer = "js_array_numeric_push_f64_unboxed"
 native_rep_name = "f64"
 access_mode = "checked_native"
 bounds_state = "proven_or_guarded"
+consumed_fact_kind = "raw_f64_layout"
+consumed_fact_state = "consumed"
 
 [[workloads.numeric_arrays.native_rep_checks.require_records]]
 name = "numeric_array_push_dynamic_fallback"
@@ -654,6 +656,17 @@ expr_kind = "NumericArrayPush"
 consumer = "js_array_push_f64"
 access_mode = "dynamic_fallback"
 materialization_reason = "runtime_api"
+rejected_fact_kind = "raw_f64_layout"
+rejected_fact_state = "rejected"
+
+[[workloads.numeric_arrays.native_rep_checks.require_records]]
+name = "numeric_array_push_dynamic_fallback_invalidates_layout"
+expr_kind = "NumericArrayPush"
+consumer = "js_array_push_f64"
+access_mode = "dynamic_fallback"
+materialization_reason = "runtime_api"
+rejected_fact_kind = "raw_f64_layout"
+rejected_fact_state = "invalidated"
 
 [[workloads.numeric_arrays.native_rep_checks.require_records]]
 name = "numeric_array_get_fast_f64"
@@ -662,6 +675,8 @@ consumer = "js_array_numeric_get_f64_unboxed"
 native_rep_name = "f64"
 access_mode = "checked_native"
 bounds_state = "proven_or_guarded"
+consumed_fact_kind = "raw_f64_layout"
+consumed_fact_state = "consumed"
 
 [[workloads.numeric_arrays.native_rep_checks.require_records]]
 name = "numeric_array_get_dynamic_fallback"
@@ -669,6 +684,17 @@ expr_kind = "NumericArrayIndexGet"
 consumer = "js_typed_feedback_array_index_get_fallback_boxed"
 access_mode = "dynamic_fallback"
 materialization_reason = "runtime_api"
+rejected_fact_kind = "raw_f64_layout"
+rejected_fact_state = "rejected"
+
+[[workloads.numeric_arrays.native_rep_checks.require_records]]
+name = "numeric_array_get_dynamic_fallback_invalidates_layout"
+expr_kind = "NumericArrayIndexGet"
+consumer = "js_typed_feedback_array_index_get_fallback_boxed"
+access_mode = "dynamic_fallback"
+materialization_reason = "runtime_api"
+rejected_fact_kind = "raw_f64_layout"
+rejected_fact_state = "invalidated"
 
 [[workloads.numeric_arrays.native_rep_checks.require_records]]
 name = "numeric_array_set_fast_f64"
@@ -677,6 +703,8 @@ consumer = "js_array_numeric_set_f64_unboxed"
 native_rep_name = "f64"
 access_mode = "checked_native"
 bounds_state = "proven_or_guarded"
+consumed_fact_kind = "raw_f64_layout"
+consumed_fact_state = "consumed"
 
 [[workloads.numeric_arrays.native_rep_checks.require_records]]
 name = "numeric_array_set_dynamic_fallback"
@@ -684,6 +712,17 @@ expr_kind = "NumericArrayIndexSet"
 consumer_contains = "fallback"
 access_mode = "dynamic_fallback"
 materialization_reason = "runtime_api"
+rejected_fact_kind = "raw_f64_layout"
+rejected_fact_state = "rejected"
+
+[[workloads.numeric_arrays.native_rep_checks.require_records]]
+name = "numeric_array_set_dynamic_fallback_invalidates_layout"
+expr_kind = "NumericArrayIndexSet"
+consumer_contains = "fallback"
+access_mode = "dynamic_fallback"
+materialization_reason = "runtime_api"
+rejected_fact_kind = "raw_f64_layout"
+rejected_fact_state = "invalidated"
 
 [workloads.raw_numeric_object_fields]
 source = "tests/raw_numeric_object_fields.ts"
@@ -737,12 +776,26 @@ consumer = "class_field_get.raw_f64_load"
 native_rep_name = "f64"
 access_mode = "checked_native"
 bounds_state = "proven_or_guarded"
+consumed_fact_kind = "raw_f64_layout"
+consumed_fact_state = "consumed"
 
 [[workloads.raw_numeric_object_fields.native_rep_checks.require_records]]
 name = "raw_class_field_get_dynamic_fallback"
 expr_kind = "ClassFieldGet"
 consumer = "js_object_get_field_by_name_f64"
 access_mode = "dynamic_fallback"
+materialization_reason = "runtime_api"
+rejected_fact_kind = "raw_f64_layout"
+rejected_fact_state = "rejected"
+
+[[workloads.raw_numeric_object_fields.native_rep_checks.require_records]]
+name = "raw_class_field_get_dynamic_fallback_invalidates_layout"
+expr_kind = "ClassFieldGet"
+consumer = "js_object_get_field_by_name_f64"
+access_mode = "dynamic_fallback"
+materialization_reason = "runtime_api"
+rejected_fact_kind = "raw_f64_layout"
+rejected_fact_state = "invalidated"
 
 [[workloads.raw_numeric_object_fields.native_rep_checks.require_records]]
 name = "raw_class_field_set_fast_f64"
@@ -751,12 +804,26 @@ consumer = "class_field_set.raw_f64_store"
 native_rep_name = "f64"
 access_mode = "checked_native"
 bounds_state = "proven_or_guarded"
+consumed_fact_kind = "raw_f64_layout"
+consumed_fact_state = "consumed"
 
 [[workloads.raw_numeric_object_fields.native_rep_checks.require_records]]
 name = "raw_class_field_set_dynamic_fallback"
 expr_kind = "ClassFieldSet"
 consumer = "js_object_set_field_by_name"
 access_mode = "dynamic_fallback"
+materialization_reason = "runtime_api"
+rejected_fact_kind = "raw_f64_layout"
+rejected_fact_state = "rejected"
+
+[[workloads.raw_numeric_object_fields.native_rep_checks.require_records]]
+name = "raw_class_field_set_dynamic_fallback_invalidates_layout"
+expr_kind = "ClassFieldSet"
+consumer = "js_object_set_field_by_name"
+access_mode = "dynamic_fallback"
+materialization_reason = "runtime_api"
+rejected_fact_kind = "raw_f64_layout"
+rejected_fact_state = "invalidated"
 
 [workloads.scalar_replacement_literals]
 source = "benchmarks/compiler_output/fixtures/scalar_replacement_literals.ts"

--- a/crates/perry-codegen/src/expr/array_push.rs
+++ b/crates/perry-codegen/src/expr/array_push.rs
@@ -46,10 +46,10 @@ use super::{
     lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
     lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
     lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx, TypedFeedbackContract, TypedFeedbackKind,
+    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, raw_f64_layout_fact,
+    try_flat_const_2d_int, try_lower_flat_const_index_get, try_match_channel_reduction,
+    try_static_class_name, unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction,
+    FlatConstInfo, FnCtx, I18nLowerCtx, TypedFeedbackContract, TypedFeedbackKind,
 };
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
@@ -63,15 +63,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let layout_note_needed = array_store_needs_layout_note(ctx, &array_expr, value);
             let write_barrier_needed = array_store_needs_write_barrier(ctx, value);
             let value_is_numeric = is_numeric_expr(ctx, value);
-            let value_is_plain_number = is_plain_number_value_expr(ctx, value);
             let require_numeric_layout =
                 value_is_numeric && expr_has_numeric_pointer_free_array_layout(ctx, &array_expr);
             let v = lower_expr(ctx, value)?;
             let arr_box = lower_expr(ctx, &array_expr)?;
-            let skip_guarded_numeric_push = !ctx.loop_targets.is_empty() && value_is_plain_number;
 
             if require_numeric_layout
-                && !skip_guarded_numeric_push
                 && !ctx.boxed_vars.contains(array_id)
                 && !ctx.closure_captures.contains_key(array_id)
                 && ctx.locals.contains_key(array_id)
@@ -120,7 +117,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     llvm_ty: DOUBLE,
                     value: v.clone(),
                 };
-                ctx.record_lowered_value_with_access_mode(
+                ctx.record_lowered_value_with_access_mode_and_facts(
                     "NumericArrayPush",
                     Some(*array_id),
                     "js_array_numeric_push_f64_unboxed",
@@ -131,6 +128,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     None,
                     Some(BufferAccessMode::CheckedNative),
                     None,
+                    None,
+                    None,
+                    vec![raw_f64_layout_fact(
+                        Some(*array_id),
+                        "consumed",
+                        "numeric_array_push_guard",
+                        None,
+                    )],
+                    Vec::new(),
                     false,
                     false,
                     Vec::new(),
@@ -159,7 +165,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     llvm_ty: DOUBLE,
                     value: v.clone(),
                 };
-                ctx.record_lowered_value_with_access_mode(
+                ctx.record_lowered_value_with_access_mode_and_facts(
                     "NumericArrayPush",
                     Some(*array_id),
                     "js_array_push_f64",
@@ -168,6 +174,23 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     None,
                     Some(BufferAccessMode::DynamicFallback),
                     Some(MaterializationReason::RuntimeApi),
+                    None,
+                    None,
+                    Vec::new(),
+                    vec![
+                        raw_f64_layout_fact(
+                            Some(*array_id),
+                            "rejected",
+                            "numeric_array_push_guard",
+                            Some(MaterializationReason::RuntimeApi),
+                        ),
+                        raw_f64_layout_fact(
+                            Some(*array_id),
+                            "invalidated",
+                            "runtime_api",
+                            Some(MaterializationReason::RuntimeApi),
+                        ),
+                    ],
                     false,
                     false,
                     Vec::new(),
@@ -454,57 +477,5 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // (`perry_closure_<modprefix>__<func_id>`) earlier in
         // `compile_module` via the `compile_closure` pass.
         _ => unreachable!("expr/mod.rs dispatched a variant not handled by this submodule"),
-    }
-}
-
-fn is_plain_number_value_expr(ctx: &FnCtx<'_>, expr: &Expr) -> bool {
-    match expr {
-        Expr::Integer(_) | Expr::Number(_) | Expr::DateNow => true,
-        Expr::Uint8ArrayGet { .. }
-        | Expr::BufferIndexGet { .. }
-        | Expr::Uint8ArrayLength(_)
-        | Expr::BufferLength(_) => true,
-        Expr::LocalGet(id) | Expr::Update { id, .. } => {
-            ctx.integer_locals.contains(id) || ctx.unsigned_i32_locals.contains(id)
-        }
-        Expr::MathImul(_, _) => true,
-        Expr::Binary { op, left, right } => match op {
-            BinaryOp::Add
-            | BinaryOp::Sub
-            | BinaryOp::Mul
-            | BinaryOp::BitAnd
-            | BinaryOp::BitOr
-            | BinaryOp::BitXor
-            | BinaryOp::Shl
-            | BinaryOp::Shr
-            | BinaryOp::UShr => {
-                is_plain_number_value_expr(ctx, left) && is_plain_number_value_expr(ctx, right)
-            }
-            BinaryOp::Div => {
-                is_plain_number_value_expr(ctx, left)
-                    && match right.as_ref() {
-                        Expr::Integer(n) => *n != 0,
-                        Expr::Number(n) => n.is_finite() && n.abs() >= 1.0,
-                        other => is_plain_number_value_expr(ctx, other),
-                    }
-            }
-            BinaryOp::Mod => {
-                is_plain_number_value_expr(ctx, left)
-                    && match right.as_ref() {
-                        Expr::Integer(n) => *n != 0,
-                        Expr::Number(n) => n.is_finite() && *n != 0.0,
-                        other => is_plain_number_value_expr(ctx, other),
-                    }
-            }
-            _ => false,
-        },
-        Expr::Conditional {
-            then_expr,
-            else_expr,
-            ..
-        } => {
-            is_plain_number_value_expr(ctx, then_expr) && is_plain_number_value_expr(ctx, else_expr)
-        }
-        _ => false,
     }
 }

--- a/crates/perry-codegen/src/expr/index.rs
+++ b/crates/perry-codegen/src/expr/index.rs
@@ -5,14 +5,14 @@ use anyhow::{anyhow, Result};
 
 use super::{
     emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
-    emit_write_barrier_slot_on_block, nanbox_pointer_inline, FnCtx,
+    emit_write_barrier_slot_on_block, nanbox_pointer_inline, raw_f64_layout_fact, FnCtx,
 };
 use crate::block::LlBlock;
 use crate::nanbox::POINTER_MASK_I64;
 use crate::native_value::{
     BoundsState, BufferAccessMode, LoweredValue, MaterializationReason, NativeRep, SemanticKind,
 };
-use crate::types::{DOUBLE, I32, I64};
+use crate::types::{DOUBLE, I1, I32, I64};
 
 /// Inline fast-path lowering for `local_arr[i] = v`.
 ///
@@ -38,7 +38,9 @@ use crate::types::{DOUBLE, I32, I64};
 ///   check_capacity:
 ///     %capacity = load i32, ptr @ arr_handle+4
 ///     %within_cap = icmp ult %idx_i32, %capacity
-///     br i1 %within_cap, label %extend_inline, label %realloc
+///     %dense_append = icmp eq %idx_i32, %length
+///     %can_extend_inline = and %within_cap, %dense_append
+///     br i1 %can_extend_inline, label %extend_inline, label %runtime_extend
 ///
 ///   extend_inline:
 ///     store double %v, ptr %element_ptr
@@ -46,7 +48,7 @@ use crate::types::{DOUBLE, I32, I64};
 ///     store i32 %new_len, ptr @ arr_handle+0
 ///     br merge
 ///
-///   realloc:
+///   runtime_extend:
 ///     %new_handle = call i64 @js_array_set_f64_extend(...)
 ///     %new_box = nanbox_pointer_inline(new_handle)
 ///     store double %new_box, ptr %local_slot
@@ -63,8 +65,8 @@ use crate::types::{DOUBLE, I32, I64};
 ///
 /// The inline store paths are entered only after the runtime guard proves the
 /// receiver is a live, non-forwarded plain array with a sane header. The realloc
-/// path only fires when the array actually has to grow (~17 times for a
-/// 100K-element build with doubling growth).
+/// path also handles sparse extensions so holes are filled and numeric raw
+/// layout is downgraded before JavaScript can observe the gap.
 pub(crate) fn lower_index_set_fast(
     ctx: &mut FnCtx<'_>,
     arr_box: &str,
@@ -154,7 +156,7 @@ pub(crate) fn lower_index_set_fast(
                 llvm_ty: DOUBLE,
                 value: fallback_box,
             };
-            ctx.record_lowered_value_with_access_mode(
+            ctx.record_lowered_value_with_access_mode_and_facts(
                 "NumericArrayIndexSet",
                 Some(local_id),
                 "js_typed_feedback_array_index_set_fallback_boxed",
@@ -163,6 +165,23 @@ pub(crate) fn lower_index_set_fast(
                 None,
                 Some(BufferAccessMode::DynamicFallback),
                 Some(MaterializationReason::RuntimeApi),
+                None,
+                None,
+                Vec::new(),
+                vec![
+                    raw_f64_layout_fact(
+                        Some(local_id),
+                        "rejected",
+                        "numeric_array_index_set_guard",
+                        Some(MaterializationReason::RuntimeApi),
+                    ),
+                    raw_f64_layout_fact(
+                        Some(local_id),
+                        "invalidated",
+                        "runtime_api",
+                        Some(MaterializationReason::RuntimeApi),
+                    ),
+                ],
                 false,
                 false,
                 Vec::new(),
@@ -224,7 +243,7 @@ pub(crate) fn lower_index_set_fast(
             llvm_ty: DOUBLE,
             value: val_double.to_string(),
         };
-        ctx.record_lowered_value_with_access_mode(
+        ctx.record_lowered_value_with_access_mode_and_facts(
             "NumericArrayIndexSet",
             Some(local_id),
             "js_array_numeric_set_f64_unboxed",
@@ -235,13 +254,24 @@ pub(crate) fn lower_index_set_fast(
             None,
             Some(BufferAccessMode::CheckedNative),
             None,
+            None,
+            None,
+            vec![raw_f64_layout_fact(
+                Some(local_id),
+                "consumed",
+                "numeric_array_index_set_guard",
+                None,
+            )],
+            Vec::new(),
             false,
             false,
             Vec::new(),
         );
     }
 
-    // MEDIUM: idx >= length but < capacity. Store + bump length.
+    // MEDIUM: idx == length and idx < capacity. Store + bump length.
+    // Sparse writes must go through `js_array_set_f64_extend` so gaps become
+    // TAG_HOLE and raw numeric layout is downgraded before user-visible reads.
     ctx.current_block = check_cap_idx;
     let capacity = {
         let blk = ctx.block();
@@ -251,9 +281,14 @@ pub(crate) fn lower_index_set_fast(
         let cap_ptr = blk.inttoptr(I64, &cap_addr);
         blk.load(I32, &cap_ptr)
     };
-    let within_cap = ctx.block().icmp_ult(I32, &idx_i32, &capacity);
+    let can_extend_inline = {
+        let blk = ctx.block();
+        let within_cap = blk.icmp_ult(I32, &idx_i32, &capacity);
+        let dense_append = blk.icmp_eq(I32, &idx_i32, &length);
+        blk.and(I1, &within_cap, &dense_append)
+    };
     ctx.block()
-        .cond_br(&within_cap, &extend_inline_label, &realloc_label);
+        .cond_br(&can_extend_inline, &extend_inline_label, &realloc_label);
 
     ctx.current_block = extend_inline_idx;
     {

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -45,9 +45,10 @@ use super::{
     lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
     lower_typed_array_load, lower_url_string_getter, materialize_js_value, nanbox_bigint_inline,
     nanbox_pointer_inline, nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array,
-    try_flat_const_2d_int, try_lower_flat_const_index_get, try_match_channel_reduction,
-    try_static_class_name, unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction,
-    FlatConstInfo, FnCtx, I18nLowerCtx, TypedFeedbackContract, TypedFeedbackKind,
+    raw_f64_layout_fact, try_flat_const_2d_int, try_lower_flat_const_index_get,
+    try_match_channel_reduction, try_static_class_name, unbox_str_handle, unbox_to_i64,
+    variant_name, ChannelReduction, FlatConstInfo, FnCtx, I18nLowerCtx, TypedFeedbackContract,
+    TypedFeedbackKind,
 };
 
 fn is_width_tracked_typed_array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
@@ -133,7 +134,7 @@ fn lower_guarded_array_index_get(
             llvm_ty: DOUBLE,
             value: fallback_val.clone(),
         };
-        ctx.record_lowered_value_with_access_mode(
+        ctx.record_lowered_value_with_access_mode_and_facts(
             "NumericArrayIndexGet",
             None,
             "js_typed_feedback_array_index_get_fallback_boxed",
@@ -142,6 +143,23 @@ fn lower_guarded_array_index_get(
             None,
             Some(BufferAccessMode::DynamicFallback),
             Some(MaterializationReason::RuntimeApi),
+            None,
+            None,
+            Vec::new(),
+            vec![
+                raw_f64_layout_fact(
+                    None,
+                    "rejected",
+                    "numeric_array_index_get_guard",
+                    Some(MaterializationReason::RuntimeApi),
+                ),
+                raw_f64_layout_fact(
+                    None,
+                    "invalidated",
+                    "runtime_api",
+                    Some(MaterializationReason::RuntimeApi),
+                ),
+            ],
             false,
             false,
             Vec::new(),
@@ -181,7 +199,7 @@ fn lower_guarded_array_index_get(
             llvm_ty: DOUBLE,
             value: fast_val.clone(),
         };
-        ctx.record_lowered_value_with_access_mode(
+        ctx.record_lowered_value_with_access_mode_and_facts(
             "NumericArrayIndexGet",
             None,
             "js_array_numeric_get_f64_unboxed",
@@ -192,6 +210,15 @@ fn lower_guarded_array_index_get(
             None,
             Some(BufferAccessMode::CheckedNative),
             None,
+            None,
+            None,
+            vec![raw_f64_layout_fact(
+                None,
+                "consumed",
+                "numeric_array_index_get_guard",
+                None,
+            )],
+            Vec::new(),
             false,
             false,
             Vec::new(),
@@ -564,6 +591,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             let idx_double = lower_expr(ctx, index)?;
                             ctx.block().fptosi(DOUBLE, &idx_double, I32)
                         };
+                        if require_numeric_layout {
+                            let idx_double = ctx.block().sitofp(I32, &idx_i32, DOUBLE);
+                            return lower_guarded_array_index_get(
+                                ctx,
+                                &arr_box,
+                                &idx_double,
+                                &idx_i32,
+                                "bidx.num",
+                                true,
+                            );
+                        }
                         return lower_bounded_array_index_get(ctx, &arr_box, &idx_i32);
                     }
                 }
@@ -571,7 +609,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 let arr_box = lower_expr(ctx, object)?;
                 let idx_double = lower_expr(ctx, index)?;
                 let idx_i32 = ctx.block().fptosi(DOUBLE, &idx_double, I32);
-                if !matches!(index.as_ref(), Expr::Integer(_) | Expr::Number(_)) {
+                if !require_numeric_layout
+                    && !matches!(index.as_ref(), Expr::Integer(_) | Expr::Number(_))
+                {
                     return lower_legacy_array_index_get(ctx, &arr_box, &idx_i32);
                 }
                 return lower_guarded_array_index_get(

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -21,7 +21,9 @@ use crate::lower_string_method::{
 };
 #[allow(unused_imports)]
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
-use crate::native_value::{BoundsState, BufferAccessMode, LoweredValue, MaterializationReason};
+use crate::native_value::{
+    BoundsState, BufferAccessMode, LoweredValue, MaterializationReason, NativeRep, SemanticKind,
+};
 #[allow(unused_imports)]
 use crate::type_analysis::{
     compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
@@ -45,9 +47,10 @@ use super::{
     lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
     lower_typed_array_store, lower_url_string_getter, materialize_js_value, nanbox_bigint_inline,
     nanbox_pointer_inline, nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array,
-    try_flat_const_2d_int, try_lower_flat_const_index_get, try_match_channel_reduction,
-    try_static_class_name, unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction,
-    FlatConstInfo, FnCtx, I18nLowerCtx, TypedFeedbackContract, TypedFeedbackKind,
+    raw_f64_layout_fact, try_flat_const_2d_int, try_lower_flat_const_index_get,
+    try_match_channel_reduction, try_static_class_name, unbox_str_handle, unbox_to_i64,
+    variant_name, ChannelReduction, FlatConstInfo, FnCtx, I18nLowerCtx, TypedFeedbackContract,
+    TypedFeedbackKind,
 };
 
 fn is_width_tracked_typed_array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
@@ -266,42 +269,161 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             let idx_double = lower_expr(ctx, index)?;
                             ctx.block().fptosi(DOUBLE, &idx_double, I32)
                         };
+                        if require_numeric_layout {
+                            let feedback_site_id = emit_typed_feedback_register_site(
+                                ctx,
+                                TypedFeedbackKind::ArrayElement,
+                                "array[index]=",
+                                TypedFeedbackContract::numeric_array_set_index(),
+                            );
+                            let fast_idx = ctx.new_block("idxset.bounded_numeric_fast");
+                            let fallback_idx = ctx.new_block("idxset.bounded_numeric_fallback");
+                            let merge_idx = ctx.new_block("idxset.bounded_numeric_merge");
+                            let fast_label = ctx.block_label(fast_idx);
+                            let fallback_label = ctx.block_label(fallback_idx);
+                            let merge_label = ctx.block_label(merge_idx);
+
+                            let guard_ok = {
+                                let blk = ctx.block();
+                                let guard_i32 = blk.call(
+                                    I32,
+                                    "js_typed_feedback_numeric_array_index_set_guard",
+                                    &[
+                                        (I64, &feedback_site_id),
+                                        (DOUBLE, &arr_box),
+                                        (I32, &idx_i32),
+                                        (DOUBLE, &val_double),
+                                        (I32, "1"),
+                                    ],
+                                );
+                                blk.icmp_ne(I32, &guard_i32, "0")
+                            };
+                            ctx.block().cond_br(&guard_ok, &fast_label, &fallback_label);
+
+                            ctx.current_block = fallback_idx;
+                            {
+                                let fallback_box = ctx.block().call(
+                                    DOUBLE,
+                                    "js_typed_feedback_array_index_set_fallback_boxed",
+                                    &[
+                                        (I64, &feedback_site_id),
+                                        (DOUBLE, &arr_box),
+                                        (I32, &idx_i32),
+                                        (DOUBLE, &val_double),
+                                    ],
+                                );
+                                if let Some(slot) = ctx.locals.get(arr_id).cloned() {
+                                    ctx.block().store(DOUBLE, &fallback_box, &slot);
+                                }
+                                ctx.block().br(&merge_label);
+                                let fallback = LoweredValue {
+                                    semantic: SemanticKind::JsValue,
+                                    rep: NativeRep::JsValue,
+                                    llvm_ty: DOUBLE,
+                                    value: fallback_box,
+                                };
+                                ctx.record_lowered_value_with_access_mode_and_facts(
+                                    "NumericArrayIndexSet",
+                                    Some(*arr_id),
+                                    "js_typed_feedback_array_index_set_fallback_boxed",
+                                    &fallback,
+                                    Some(BoundsState::Unknown),
+                                    None,
+                                    Some(BufferAccessMode::DynamicFallback),
+                                    Some(MaterializationReason::RuntimeApi),
+                                    None,
+                                    None,
+                                    Vec::new(),
+                                    vec![
+                                        raw_f64_layout_fact(
+                                            Some(*arr_id),
+                                            "rejected",
+                                            "numeric_array_index_set_guard",
+                                            Some(MaterializationReason::RuntimeApi),
+                                        ),
+                                        raw_f64_layout_fact(
+                                            Some(*arr_id),
+                                            "invalidated",
+                                            "runtime_api",
+                                            Some(MaterializationReason::RuntimeApi),
+                                        ),
+                                    ],
+                                    false,
+                                    false,
+                                    Vec::new(),
+                                );
+                            }
+
+                            ctx.current_block = fast_idx;
+                            {
+                                let blk = ctx.block();
+                                let arr_bits = blk.bitcast_double_to_i64(&arr_box);
+                                let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+                                blk.call(
+                                    I32,
+                                    "js_array_numeric_set_f64_unboxed",
+                                    &[(I64, &arr_handle), (I32, &idx_i32), (DOUBLE, &val_double)],
+                                );
+                                blk.br(&merge_label);
+                            }
+                            let stored = LoweredValue {
+                                semantic: SemanticKind::JsNumber,
+                                rep: NativeRep::F64,
+                                llvm_ty: DOUBLE,
+                                value: val_double.clone(),
+                            };
+                            ctx.record_lowered_value_with_access_mode_and_facts(
+                                "NumericArrayIndexSet",
+                                Some(*arr_id),
+                                "js_array_numeric_set_f64_unboxed",
+                                &stored,
+                                Some(BoundsState::Guarded {
+                                    guard_id: "numeric_array_index_set_guard".to_string(),
+                                }),
+                                None,
+                                Some(BufferAccessMode::CheckedNative),
+                                None,
+                                None,
+                                None,
+                                vec![raw_f64_layout_fact(
+                                    Some(*arr_id),
+                                    "consumed",
+                                    "numeric_array_index_set_guard",
+                                    None,
+                                )],
+                                Vec::new(),
+                                false,
+                                false,
+                                Vec::new(),
+                            );
+
+                            ctx.current_block = merge_idx;
+                            return Ok(val_double);
+                        }
                         let blk = ctx.block();
                         let arr_bits = blk.bitcast_double_to_i64(&arr_box);
                         let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
-                        if require_numeric_layout {
-                            blk.call(
-                                I32,
-                                "js_array_numeric_set_f64_unboxed",
-                                &[(I64, &arr_handle), (I32, &idx_i32), (DOUBLE, &val_double)],
-                            );
-                        } else {
-                            // ptr = arr_handle + 8 + idx*8
-                            let idx_i64 = blk.zext(I32, &idx_i32, I64);
-                            let byte_offset = blk.shl(I64, &idx_i64, "3");
-                            let with_header = blk.add(I64, &byte_offset, "8");
-                            let element_addr = blk.add(I64, &arr_handle, &with_header);
-                            let element_ptr = blk.inttoptr(I64, &element_addr);
-                            let value_bits = emit_jsvalue_slot_store_on_block(
-                                blk,
-                                &element_ptr,
-                                &val_double,
-                                &arr_handle,
-                                &idx_i32,
-                                layout_note_needed,
-                                &arr_handle,
-                                &element_addr,
-                                write_barrier_needed,
-                            );
-                            if !value_is_numeric {
-                                let value_bits = value_bits
-                                    .unwrap_or_else(|| blk.bitcast_double_to_i64(&val_double));
-                                emit_array_numeric_write_note_on_block(
-                                    blk,
-                                    &arr_handle,
-                                    &value_bits,
-                                );
-                            }
+                        // ptr = arr_handle + 8 + idx*8
+                        let idx_i64 = blk.zext(I32, &idx_i32, I64);
+                        let byte_offset = blk.shl(I64, &idx_i64, "3");
+                        let with_header = blk.add(I64, &byte_offset, "8");
+                        let element_addr = blk.add(I64, &arr_handle, &with_header);
+                        let element_ptr = blk.inttoptr(I64, &element_addr);
+                        let value_bits = emit_jsvalue_slot_store_on_block(
+                            blk,
+                            &element_ptr,
+                            &val_double,
+                            &arr_handle,
+                            &idx_i32,
+                            layout_note_needed,
+                            &arr_handle,
+                            &element_addr,
+                            write_barrier_needed,
+                        );
+                        if !value_is_numeric {
+                            let value_bits = value_bits
+                                .unwrap_or_else(|| blk.bitcast_double_to_i64(&val_double));
+                            emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
                         }
                         return Ok(val_double);
                     }

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -996,6 +996,15 @@ fn native_fact_use(
     }
 }
 
+pub(crate) fn raw_f64_layout_fact(
+    local_id: Option<u32>,
+    state: &'static str,
+    detail: &str,
+    reason: Option<MaterializationReason>,
+) -> NativeFactUse {
+    native_fact_use("raw_f64_layout", local_id, state, detail, reason)
+}
+
 fn native_fact_uses_for_record(
     local_id: Option<u32>,
     lowered: &LoweredValue,
@@ -1295,8 +1304,45 @@ impl<'a> FnCtx<'a> {
         emitted_noalias: bool,
         notes: Vec<String>,
     ) {
+        self.record_lowered_value_with_access_mode_and_facts(
+            expr_kind,
+            local_id,
+            consumer,
+            lowered,
+            bounds_state,
+            alias_state,
+            access_mode,
+            materialization_reason,
+            scalar_conversion,
+            buffer_access,
+            Vec::new(),
+            Vec::new(),
+            emitted_inbounds,
+            emitted_noalias,
+            notes,
+        );
+    }
+
+    pub fn record_lowered_value_with_access_mode_and_facts(
+        &mut self,
+        expr_kind: impl Into<String>,
+        local_id: Option<u32>,
+        consumer: impl Into<String>,
+        lowered: &LoweredValue,
+        bounds_state: Option<BoundsState>,
+        alias_state: Option<AliasState>,
+        access_mode: Option<BufferAccessMode>,
+        materialization_reason: Option<MaterializationReason>,
+        scalar_conversion: Option<ScalarConversionRecord>,
+        buffer_access: Option<BufferAccessFacts>,
+        extra_consumed_facts: Vec<NativeFactUse>,
+        extra_rejected_facts: Vec<NativeFactUse>,
+        emitted_inbounds: bool,
+        emitted_noalias: bool,
+        notes: Vec<String>,
+    ) {
         let block_label = self.current_block_label();
-        let (consumed_facts, rejected_facts) = native_fact_uses_for_record(
+        let (mut consumed_facts, mut rejected_facts) = native_fact_uses_for_record(
             local_id,
             lowered,
             bounds_state.as_ref(),
@@ -1304,6 +1350,8 @@ impl<'a> FnCtx<'a> {
             access_mode.as_ref(),
             materialization_reason.as_ref(),
         );
+        consumed_facts.extend(extra_consumed_facts);
+        rejected_facts.extend(extra_rejected_facts);
         let fallback_reason = if matches!(
             access_mode.as_ref(),
             Some(BufferAccessMode::DynamicFallback)

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -43,10 +43,11 @@ use super::{
     lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
     lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
     lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_lower_pod_field_get, try_match_channel_reduction,
-    try_static_class_name, unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction,
-    FlatConstInfo, FnCtx, I18nLowerCtx, TypedFeedbackContract, TypedFeedbackKind,
+    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, raw_f64_layout_fact,
+    try_flat_const_2d_int, try_lower_flat_const_index_get, try_lower_pod_field_get,
+    try_match_channel_reduction, try_static_class_name, unbox_str_handle, unbox_to_i64,
+    variant_name, ChannelReduction, FlatConstInfo, FnCtx, I18nLowerCtx, TypedFeedbackContract,
+    TypedFeedbackKind,
 };
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
@@ -1055,7 +1056,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                 llvm_ty: DOUBLE,
                                 value: val_fast.clone(),
                             };
-                            ctx.record_lowered_value_with_access_mode(
+                            ctx.record_lowered_value_with_access_mode_and_facts(
                                 "ClassFieldGet",
                                 None,
                                 "class_field_get.raw_f64_load",
@@ -1066,6 +1067,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                 None,
                                 Some(BufferAccessMode::CheckedNative),
                                 None,
+                                None,
+                                None,
+                                vec![raw_f64_layout_fact(
+                                    None,
+                                    "consumed",
+                                    "class_field_get_guard",
+                                    None,
+                                )],
+                                Vec::new(),
                                 false,
                                 false,
                                 vec![
@@ -1093,7 +1103,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                 llvm_ty: DOUBLE,
                                 value: val_fallback.clone(),
                             };
-                            ctx.record_lowered_value_with_access_mode(
+                            ctx.record_lowered_value_with_access_mode_and_facts(
                                 "ClassFieldGet",
                                 None,
                                 "js_object_get_field_by_name_f64",
@@ -1102,6 +1112,23 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                 None,
                                 Some(BufferAccessMode::DynamicFallback),
                                 Some(MaterializationReason::RuntimeApi),
+                                None,
+                                None,
+                                Vec::new(),
+                                vec![
+                                    raw_f64_layout_fact(
+                                        None,
+                                        "rejected",
+                                        "class_field_get_guard",
+                                        Some(MaterializationReason::RuntimeApi),
+                                    ),
+                                    raw_f64_layout_fact(
+                                        None,
+                                        "invalidated",
+                                        "runtime_api",
+                                        Some(MaterializationReason::RuntimeApi),
+                                    ),
+                                ],
                                 false,
                                 false,
                                 vec![

--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -43,10 +43,11 @@ use super::{
     is_known_finite, lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
     lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
     lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_lower_pod_field_set, try_match_channel_reduction,
-    try_static_class_name, unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction,
-    FlatConstInfo, FnCtx, I18nLowerCtx, TypedFeedbackContract, TypedFeedbackKind,
+    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, raw_f64_layout_fact,
+    try_flat_const_2d_int, try_lower_flat_const_index_get, try_lower_pod_field_set,
+    try_match_channel_reduction, try_static_class_name, unbox_str_handle, unbox_to_i64,
+    variant_name, ChannelReduction, FlatConstInfo, FnCtx, I18nLowerCtx, TypedFeedbackContract,
+    TypedFeedbackKind,
 };
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
@@ -298,7 +299,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                 llvm_ty: DOUBLE,
                                 value: val_double.clone(),
                             };
-                            ctx.record_lowered_value_with_access_mode(
+                            ctx.record_lowered_value_with_access_mode_and_facts(
                                 "ClassFieldSet",
                                 None,
                                 "class_field_set.raw_f64_store",
@@ -309,6 +310,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                 None,
                                 Some(BufferAccessMode::CheckedNative),
                                 None,
+                                None,
+                                None,
+                                vec![raw_f64_layout_fact(
+                                    None,
+                                    "consumed",
+                                    "class_field_set_guard",
+                                    None,
+                                )],
+                                Vec::new(),
                                 false,
                                 false,
                                 vec![
@@ -335,7 +345,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                 llvm_ty: DOUBLE,
                                 value: val_double.clone(),
                             };
-                            ctx.record_lowered_value_with_access_mode(
+                            ctx.record_lowered_value_with_access_mode_and_facts(
                                 "ClassFieldSet",
                                 None,
                                 "js_object_set_field_by_name",
@@ -344,6 +354,23 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                 None,
                                 Some(BufferAccessMode::DynamicFallback),
                                 Some(MaterializationReason::RuntimeApi),
+                                None,
+                                None,
+                                Vec::new(),
+                                vec![
+                                    raw_f64_layout_fact(
+                                        None,
+                                        "rejected",
+                                        "class_field_set_guard",
+                                        Some(MaterializationReason::RuntimeApi),
+                                    ),
+                                    raw_f64_layout_fact(
+                                        None,
+                                        "invalidated",
+                                        "runtime_api",
+                                        Some(MaterializationReason::RuntimeApi),
+                                    ),
+                                ],
                                 false,
                                 false,
                                 vec![

--- a/crates/perry-codegen/src/native_value/artifact.rs
+++ b/crates/perry-codegen/src/native_value/artifact.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -143,6 +143,7 @@ struct NativeRepSummary {
     unsafe_unchecked_unknown_bounds_accesses: usize,
     consumed_fact_count: usize,
     rejected_fact_count: usize,
+    raw_f64_layout_fact_counts: BTreeMap<String, usize>,
     native_owned_view_count: usize,
     pod_layout_count: usize,
     pod_record_count: usize,
@@ -161,6 +162,11 @@ impl NativeRepSummary {
         let mut unsafe_unchecked_unknown_bounds_accesses = 0;
         let mut consumed_fact_count = 0;
         let mut rejected_fact_count = 0;
+        let mut raw_f64_layout_fact_counts = BTreeMap::from([
+            ("consumed".to_string(), 0),
+            ("rejected".to_string(), 0),
+            ("invalidated".to_string(), 0),
+        ]);
         let mut native_owned_view_count = 0;
         let mut pod_layout_count = 0;
         let mut pod_record_count = 0;
@@ -236,6 +242,17 @@ impl NativeRepSummary {
             }
             consumed_fact_count += record.consumed_facts.len();
             rejected_fact_count += record.rejected_facts.len();
+            for fact in record
+                .consumed_facts
+                .iter()
+                .chain(record.rejected_facts.iter())
+            {
+                if fact.kind == "raw_f64_layout" {
+                    *raw_f64_layout_fact_counts
+                        .entry(fact.state.clone())
+                        .or_insert(0) += 1;
+                }
+            }
         }
         Self {
             record_count: records.len(),
@@ -249,6 +266,7 @@ impl NativeRepSummary {
             unsafe_unchecked_unknown_bounds_accesses,
             consumed_fact_count,
             rejected_fact_count,
+            raw_f64_layout_fact_counts,
             native_owned_view_count,
             pod_layout_count,
             pod_record_count,
@@ -301,7 +319,7 @@ pub(crate) fn write_native_rep_artifact_if_enabled(
         pid, wall_nonce, counter
     ));
     let artifact = NativeRepArtifact {
-        schema_version: 8,
+        schema_version: 9,
         module,
         records,
         pod_layouts: collect_pod_layouts(records),

--- a/crates/perry-codegen/src/native_value/verify.rs
+++ b/crates/perry-codegen/src/native_value/verify.rs
@@ -3,9 +3,10 @@ use anyhow::{bail, Result};
 #[cfg(test)]
 use super::artifact::NativeAbiTransitionRecord;
 use super::artifact::{
-    NativeAbiTransitionOp, NativeRepRecord, NativeValueState, PodLayoutManifest,
+    NativeAbiTransitionOp, NativeFactUse, NativeRepRecord, NativeValueState, PodLayoutManifest,
 };
 use super::buffer::{AliasState, BoundsState, BufferAccessMode};
+use super::materialize::MaterializationReason;
 use super::pod::recompute_layout_from_fields;
 use super::rep::NativeRep;
 use crate::types::{DOUBLE, F32, I32, I64, I8, PTR};
@@ -199,6 +200,7 @@ pub(crate) fn verify_native_rep_records(records: &[NativeRepRecord]) -> Result<(
                 record.function, record.block_label, record.consumer
             ));
         }
+        validate_raw_f64_layout_facts(record, &mut errors);
     }
     if !errors.is_empty() {
         bail!(
@@ -207,6 +209,90 @@ pub(crate) fn verify_native_rep_records(records: &[NativeRepRecord]) -> Result<(
         );
     }
     Ok(())
+}
+
+fn raw_f64_checked_native_consumer(record: &NativeRepRecord) -> bool {
+    matches!(
+        record.consumer.as_str(),
+        "js_array_numeric_get_f64_unboxed"
+            | "js_array_numeric_set_f64_unboxed"
+            | "js_array_numeric_push_f64_unboxed"
+            | "class_field_get.raw_f64_load"
+            | "class_field_set.raw_f64_store"
+    )
+}
+
+fn raw_f64_dynamic_fallback_record(record: &NativeRepRecord) -> bool {
+    matches!(
+        (record.expr_kind.as_str(), record.consumer.as_str()),
+        ("NumericArrayPush", "js_array_push_f64")
+            | (
+                "NumericArrayIndexGet",
+                "js_typed_feedback_array_index_get_fallback_boxed"
+            )
+            | (
+                "NumericArrayIndexSet",
+                "js_typed_feedback_array_index_set_fallback_boxed"
+            )
+            | ("ClassFieldGet", "js_object_get_field_by_name_f64")
+            | ("ClassFieldSet", "js_object_set_field_by_name")
+    )
+}
+
+fn has_raw_f64_layout_fact(
+    facts: &[NativeFactUse],
+    state: &str,
+    reason: Option<MaterializationReason>,
+) -> bool {
+    facts.iter().any(|fact| {
+        fact.kind == "raw_f64_layout"
+            && fact.state == state
+            && match reason.as_ref() {
+                Some(expected) => fact.reason.as_ref() == Some(expected),
+                None => true,
+            }
+    })
+}
+
+fn validate_raw_f64_layout_facts(record: &NativeRepRecord, errors: &mut Vec<String>) {
+    if raw_f64_checked_native_consumer(record)
+        && !has_raw_f64_layout_fact(&record.consumed_facts, "consumed", None)
+    {
+        errors.push(format!(
+            "{}:{} {} raw-f64 fast path missing consumed raw_f64_layout fact",
+            record.function, record.block_label, record.consumer
+        ));
+    }
+    if raw_f64_dynamic_fallback_record(record) {
+        if record.materialization_reason.as_ref() != Some(&MaterializationReason::RuntimeApi)
+            || record.fallback_reason.as_ref() != Some(&MaterializationReason::RuntimeApi)
+        {
+            errors.push(format!(
+                "{}:{} {} raw-f64 fallback missing runtime_api materialization/fallback reason",
+                record.function, record.block_label, record.consumer
+            ));
+        }
+        if !has_raw_f64_layout_fact(
+            &record.rejected_facts,
+            "rejected",
+            Some(MaterializationReason::RuntimeApi),
+        ) {
+            errors.push(format!(
+                "{}:{} {} raw-f64 fallback missing rejected raw_f64_layout fact",
+                record.function, record.block_label, record.consumer
+            ));
+        }
+        if !has_raw_f64_layout_fact(
+            &record.rejected_facts,
+            "invalidated",
+            Some(MaterializationReason::RuntimeApi),
+        ) {
+            errors.push(format!(
+                "{}:{} {} raw-f64 fallback missing invalidated raw_f64_layout fact",
+                record.function, record.block_label, record.consumer
+            ));
+        }
+    }
 }
 
 fn validate_native_owned_unchecked_access(record: &NativeRepRecord, errors: &mut Vec<String>) {
@@ -415,7 +501,8 @@ mod tests {
     use super::{NativeAbiTransitionOp, NativeAbiTransitionRecord};
     use crate::native_value::{
         verify_native_rep_records, AliasState, BoundsProof, BoundsState, BufferAccessMode,
-        BufferViewRep, LoweredValue, NativeRep, NativeRepRecord, NativeValueState, SemanticKind,
+        BufferViewRep, LoweredValue, MaterializationReason, NativeFactUse, NativeRep,
+        NativeRepRecord, NativeValueState, SemanticKind,
     };
     use crate::types::{DOUBLE, F32, I32, I64, PTR};
 
@@ -457,6 +544,16 @@ mod tests {
             emitted_inbounds: false,
             emitted_noalias: false,
             notes: Vec::new(),
+        }
+    }
+
+    fn raw_f64_layout_fact(state: &str, reason: Option<MaterializationReason>) -> NativeFactUse {
+        NativeFactUse {
+            fact_id: format!("test.raw_f64_layout.{state}"),
+            kind: "raw_f64_layout".to_string(),
+            local_id: None,
+            state: state.to_string(),
+            reason,
         }
     }
 
@@ -565,6 +662,92 @@ mod tests {
         r.access_mode = Some(BufferAccessMode::CheckedNative);
         r.bounds_state = Some(BoundsState::Unknown);
         assert!(verify_native_rep_records(&[r]).is_err());
+    }
+
+    #[test]
+    fn rejects_raw_f64_checked_native_without_consumed_layout_fact() {
+        for (expr_kind, consumer) in [
+            ("NumericArrayIndexGet", "js_array_numeric_get_f64_unboxed"),
+            ("NumericArrayIndexSet", "js_array_numeric_set_f64_unboxed"),
+            ("NumericArrayPush", "js_array_numeric_push_f64_unboxed"),
+            ("ClassFieldGet", "class_field_get.raw_f64_load"),
+            ("ClassFieldSet", "class_field_set.raw_f64_store"),
+        ] {
+            let mut r = record();
+            r.expr_kind = expr_kind.to_string();
+            r.consumer = consumer.to_string();
+            r.semantic = SemanticKind::JsNumber;
+            r.native_rep = NativeRep::F64;
+            r.native_rep_name = "f64".to_string();
+            r.llvm_ty = DOUBLE;
+            r.access_mode = Some(BufferAccessMode::CheckedNative);
+            r.bounds_state = Some(BoundsState::Guarded {
+                guard_id: "raw_f64_guard".to_string(),
+            });
+
+            assert!(
+                verify_native_rep_records(&[r.clone()]).is_err(),
+                "{consumer} should require a consumed raw_f64_layout fact"
+            );
+
+            r.consumed_facts.push(raw_f64_layout_fact("consumed", None));
+            assert!(
+                verify_native_rep_records(&[r]).is_ok(),
+                "{consumer} should verify once the consumed layout fact is present"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_raw_f64_dynamic_fallback_without_rejected_and_invalidated_layout_facts() {
+        for (expr_kind, consumer) in [
+            ("NumericArrayPush", "js_array_push_f64"),
+            (
+                "NumericArrayIndexGet",
+                "js_typed_feedback_array_index_get_fallback_boxed",
+            ),
+            (
+                "NumericArrayIndexSet",
+                "js_typed_feedback_array_index_set_fallback_boxed",
+            ),
+            ("ClassFieldGet", "js_object_get_field_by_name_f64"),
+            ("ClassFieldSet", "js_object_set_field_by_name"),
+        ] {
+            let mut r = record();
+            r.expr_kind = expr_kind.to_string();
+            r.consumer = consumer.to_string();
+            r.semantic = SemanticKind::JsValue;
+            r.native_rep = NativeRep::JsValue;
+            r.native_rep_name = "js_value".to_string();
+            r.llvm_ty = DOUBLE;
+            r.access_mode = Some(BufferAccessMode::DynamicFallback);
+            r.materialization_reason = Some(MaterializationReason::RuntimeApi);
+            r.fallback_reason = Some(MaterializationReason::RuntimeApi);
+            r.native_value_state = NativeValueState::DynamicFallback;
+
+            assert!(
+                verify_native_rep_records(&[r.clone()]).is_err(),
+                "{consumer} should require rejected and invalidated raw_f64_layout facts"
+            );
+
+            r.rejected_facts.push(raw_f64_layout_fact(
+                "rejected",
+                Some(MaterializationReason::RuntimeApi),
+            ));
+            assert!(
+                verify_native_rep_records(&[r.clone()]).is_err(),
+                "{consumer} should still require invalidated raw_f64_layout fact"
+            );
+
+            r.rejected_facts.push(raw_f64_layout_fact(
+                "invalidated",
+                Some(MaterializationReason::RuntimeApi),
+            ));
+            assert!(
+                verify_native_rep_records(&[r]).is_ok(),
+                "{consumer} should verify once rejection and invalidation are recorded"
+            );
+        }
     }
 
     #[test]

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -530,7 +530,7 @@ fn artifact_schema_v6_records_consumed_native_facts_for_buffer_region() {
     ];
 
     let artifact = compile_artifact_json("artifact_positive_buffer_region.ts", body);
-    assert_eq!(artifact["schema_version"], 8);
+    assert_eq!(artifact["schema_version"], 9);
     let records = artifact["records"].as_array().unwrap();
     assert!(
         records.iter().any(|record| {
@@ -563,7 +563,7 @@ fn artifact_schema_v6_records_rejected_facts_for_buffer_fallback() {
     ];
 
     let artifact = compile_artifact_json("artifact_rejected_buffer_region.ts", body);
-    assert_eq!(artifact["schema_version"], 8);
+    assert_eq!(artifact["schema_version"], 9);
     let records = artifact["records"].as_array().unwrap();
     assert!(
         records.iter().any(|record| {
@@ -609,7 +609,7 @@ fn artifact_schema_v6_records_c_layout_pod_manifest() {
     ];
 
     let artifact = compile_artifact_json("artifact_c_layout_pod_record.ts", body);
-    assert_eq!(artifact["schema_version"], 8);
+    assert_eq!(artifact["schema_version"], 9);
     assert_eq!(artifact["summary"]["pod_layout_count"], 1);
     assert_eq!(artifact["summary"]["pod_record_count"], 1);
     let layouts = artifact["pod_layouts"].as_array().unwrap();
@@ -681,7 +681,7 @@ fn artifact_schema_v6_records_pod_dynamic_write_fallback() {
     ];
 
     let artifact = compile_artifact_json("artifact_c_layout_pod_dynamic_write.ts", body);
-    assert_eq!(artifact["schema_version"], 8);
+    assert_eq!(artifact["schema_version"], 9);
     assert!(
         artifact["records"]
             .as_array()
@@ -728,7 +728,7 @@ fn artifact_schema_v8_rejects_inexact_pod_initializer_values() {
     ];
 
     let artifact = compile_artifact_json("artifact_c_layout_pod_init_reject.ts", body);
-    assert_eq!(artifact["schema_version"], 8);
+    assert_eq!(artifact["schema_version"], 9);
     assert_eq!(artifact["summary"]["pod_layout_count"], 0);
     assert_eq!(artifact["summary"]["pod_record_count"], 0);
     assert!(artifact["pod_layouts"].as_array().unwrap().is_empty());
@@ -779,7 +779,7 @@ fn artifact_schema_v6_records_pod_pointerful_field_rejection() {
     ];
 
     let artifact = compile_artifact_json("artifact_c_layout_pod_reject.ts", body);
-    assert_eq!(artifact["schema_version"], 8);
+    assert_eq!(artifact["schema_version"], 9);
     assert_eq!(artifact["summary"]["pod_layout_count"], 0);
     assert!(artifact["pod_layouts"].as_array().unwrap().is_empty());
     assert!(
@@ -827,6 +827,14 @@ fn artifact_records_buffer_length_as_buffer_len_and_unsigned_materialization() {
         }),
         "expected unsigned BufferLen JS materialization record:\n{artifact:#}"
     );
+}
+
+fn record_has_raw_f64_layout_fact(record: &serde_json::Value, list: &str, state: &str) -> bool {
+    record[list].as_array().is_some_and(|facts| {
+        facts
+            .iter()
+            .any(|fact| fact["kind"] == "raw_f64_layout" && fact["state"] == state)
+    })
 }
 
 #[test]
@@ -1024,7 +1032,7 @@ fn native_library_manifest_lowercase_abi_params_emit_c_abi_signature() {
 }
 
 #[test]
-fn artifact_records_numeric_array_f64_fast_paths_and_fallback_reasons() {
+fn artifact_records_raw_numeric_array_f64_fast_paths_and_fallback_reasons() {
     let array_ty = Type::Array(Box::new(Type::Number));
     let module = module_with_classes_and_params(
         "artifact_numeric_array_f64.ts",
@@ -1052,6 +1060,7 @@ fn artifact_records_numeric_array_f64_fast_paths_and_fallback_reasons() {
                 && record["consumer"] == "js_array_numeric_set_f64_unboxed"
                 && record["native_rep_name"] == "f64"
                 && record["access_mode"] == "checked_native"
+                && record_has_raw_f64_layout_fact(record, "consumed_facts", "consumed")
         }),
         "expected numeric array f64 set fast-path record:\n{artifact:#}"
     );
@@ -1061,6 +1070,7 @@ fn artifact_records_numeric_array_f64_fast_paths_and_fallback_reasons() {
                 && record["consumer"] == "js_array_numeric_get_f64_unboxed"
                 && record["native_rep_name"] == "f64"
                 && record["access_mode"] == "checked_native"
+                && record_has_raw_f64_layout_fact(record, "consumed_facts", "consumed")
         }),
         "expected numeric array f64 get fast-path record:\n{artifact:#}"
     );
@@ -1069,8 +1079,31 @@ fn artifact_records_numeric_array_f64_fast_paths_and_fallback_reasons() {
             record["access_mode"] == "dynamic_fallback"
                 && record["materialization_reason"] == "runtime_api"
                 && record["fallback_reason"] == "runtime_api"
+                && record_has_raw_f64_layout_fact(record, "rejected_facts", "rejected")
+                && record_has_raw_f64_layout_fact(record, "rejected_facts", "invalidated")
         }),
         "expected boxed runtime fallback reason records:\n{artifact:#}"
+    );
+    assert!(
+        artifact["summary"]["raw_f64_layout_fact_counts"]["consumed"]
+            .as_u64()
+            .unwrap_or(0)
+            >= 2,
+        "expected raw-f64 layout consumed summary:\n{artifact:#}"
+    );
+    assert!(
+        artifact["summary"]["raw_f64_layout_fact_counts"]["rejected"]
+            .as_u64()
+            .unwrap_or(0)
+            >= 1,
+        "expected raw-f64 layout rejection summary:\n{artifact:#}"
+    );
+    assert!(
+        artifact["summary"]["raw_f64_layout_fact_counts"]["invalidated"]
+            .as_u64()
+            .unwrap_or(0)
+            >= 1,
+        "expected raw-f64 layout invalidation summary:\n{artifact:#}"
     );
 }
 
@@ -1103,6 +1136,7 @@ fn artifact_records_raw_numeric_class_field_f64_fast_paths_and_fallback_reasons(
                 && record["consumer"] == "class_field_set.raw_f64_store"
                 && record["native_rep_name"] == "f64"
                 && record["access_mode"] == "checked_native"
+                && record_has_raw_f64_layout_fact(record, "consumed_facts", "consumed")
         }),
         "expected raw numeric class field f64 store record:\n{artifact:#}"
     );
@@ -1112,6 +1146,7 @@ fn artifact_records_raw_numeric_class_field_f64_fast_paths_and_fallback_reasons(
                 && record["consumer"] == "class_field_get.raw_f64_load"
                 && record["native_rep_name"] == "f64"
                 && record["access_mode"] == "checked_native"
+                && record_has_raw_f64_layout_fact(record, "consumed_facts", "consumed")
         }),
         "expected raw numeric class field f64 load record:\n{artifact:#}"
     );
@@ -1120,8 +1155,17 @@ fn artifact_records_raw_numeric_class_field_f64_fast_paths_and_fallback_reasons(
             record["access_mode"] == "dynamic_fallback"
                 && record["materialization_reason"] == "runtime_api"
                 && record["fallback_reason"] == "runtime_api"
+                && record_has_raw_f64_layout_fact(record, "rejected_facts", "rejected")
+                && record_has_raw_f64_layout_fact(record, "rejected_facts", "invalidated")
         }),
         "expected boxed raw-field fallback reason records:\n{artifact:#}"
+    );
+    assert!(
+        artifact["summary"]["raw_f64_layout_fact_counts"]["consumed"]
+            .as_u64()
+            .unwrap_or(0)
+            >= 2,
+        "expected raw-f64 layout consumed summary:\n{artifact:#}"
     );
 }
 

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -467,7 +467,7 @@ fn typed_feedback_inline_array_writes_note_numeric_downgrade() {
 }
 
 #[test]
-fn typed_feedback_skips_array_index_guard_for_computed_numeric_hot_path() {
+fn typed_feedback_guards_computed_numeric_array_index_hot_path() {
     let array_ty = Type::Array(Box::new(Type::Number));
     let ir = ir_for(module(
         "typed_feedback_computed_array.ts",
@@ -483,8 +483,7 @@ fn typed_feedback_skips_array_index_guard_for_computed_numeric_hot_path() {
         }))],
     ));
 
-    assert!(!ir.contains("call i32 @js_typed_feedback_plain_array_index_get_guard"));
-    assert!(!ir.contains("call double @js_typed_feedback_array_index_get_fallback_boxed"));
-    assert!(ir.contains("call double @js_array_get_f64"));
-    assert!(ir.contains("load double"));
+    assert!(ir.contains("call i32 @js_typed_feedback_numeric_array_index_get_guard"));
+    assert!(ir.contains("call double @js_typed_feedback_array_index_get_fallback_boxed"));
+    assert!(ir.contains("call double @js_array_numeric_get_f64_unboxed"));
 }

--- a/crates/perry-codegen/tests/typed_shape_descriptors.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptors.rs
@@ -336,12 +336,12 @@ fn bounded_integer_array_store_omits_layout_note_and_barrier() {
         "bounded numeric array store should route through the raw-f64 payload helper"
     );
     assert!(
-        !ir.contains("call i32 @js_typed_feedback_numeric_array_index_set_guard"),
-        "bounded numeric array stores should not reintroduce typed-feedback guards into hot loops"
+        ir.contains("call i32 @js_typed_feedback_numeric_array_index_set_guard"),
+        "bounded numeric array stores must guard that the runtime layout is still raw-f64"
     );
     assert!(
-        !ir.contains("call i32 @js_typed_feedback_plain_array_index_set_guard"),
-        "bounded numeric array stores should not fall back to plain typed-feedback guards"
+        ir.contains("call double @js_typed_feedback_array_index_set_fallback_boxed"),
+        "guarded bounded stores need a boxed fallback when the array downgraded"
     );
     assert!(
         !ir.contains("call void @js_gc_note_slot_layout"),
@@ -398,22 +398,22 @@ fn integer_arithmetic_array_push_omits_inbounds_layout_note_and_barrier() {
     );
 
     let ir = ir_for(module);
-    let inbounds_ir = block_between(&ir, "\napush.inbounds.", "\napush.realloc.");
+    let fast_ir = block_between(&ir, "\napush.numeric_fast.", "\napush.numeric_fallback.");
 
     assert!(
-        !ir.contains("call i32 @js_typed_feedback_numeric_array_push_guard"),
-        "plain-number loop pushes should not reintroduce typed-feedback guards into hot loops"
+        ir.contains("call i32 @js_typed_feedback_numeric_array_push_guard"),
+        "plain-number loop pushes must guard that the runtime layout is still raw-f64"
     );
     assert!(
-        inbounds_ir.contains("store double"),
-        "plain-number loop pushes should keep the hot inbounds store inline"
+        ir.contains("call i64 @js_array_numeric_push_f64_unboxed"),
+        "plain-number loop pushes should use the raw-f64 push helper on the guarded fast path"
     );
     assert!(
-        !inbounds_ir.contains("call void @js_gc_note_slot_layout"),
+        !fast_ir.contains("call void @js_gc_note_slot_layout"),
         "integer arithmetic push value should not update slot layout"
     );
     assert!(
-        !inbounds_ir.contains("call void @js_write_barrier_slot"),
+        !fast_ir.contains("call void @js_write_barrier_slot"),
         "integer arithmetic push value should not emit a slot barrier"
     );
 }

--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -15,20 +15,12 @@ thread_local! {
     /// Both pointers are GC-rooted via `scan_template_raw_roots`.
     static TEMPLATE_RAW_MAP: RefCell<HashMap<usize, *mut ArrayHeader>> =
         RefCell::new(HashMap::new());
-    static NUMERIC_ARRAY_LAYOUTS: RefCell<HashMap<usize, NumericArrayState>> =
-        RefCell::new(HashMap::new());
 }
 
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum NumericArrayLayout {
     RawF64 = 1,
-}
-
-#[derive(Clone, Debug)]
-struct NumericArrayState {
-    layout: NumericArrayLayout,
-    raw_f64: Option<Vec<f64>>,
 }
 
 /// Register the (cooked, raw) pair for a tagged-template call. Returns
@@ -296,7 +288,16 @@ pub(crate) fn value_bits_to_number(value_bits: u64) -> Option<f64> {
     if (0x7FF9..=0x7FFF).contains(&upper) {
         return None;
     }
-    Some(f64::from_bits(value_bits))
+    Some(canonical_raw_f64(f64::from_bits(value_bits)))
+}
+
+#[inline]
+fn canonical_raw_f64(value: f64) -> f64 {
+    if value.is_nan() {
+        f64::NAN
+    } else {
+        value
+    }
 }
 
 #[inline]
@@ -344,6 +345,42 @@ unsafe fn array_slots_are_numeric(arr: *const ArrayHeader) -> bool {
     true
 }
 
+#[inline]
+unsafe fn array_gc_header(arr: *const ArrayHeader) -> Option<*mut crate::gc::GcHeader> {
+    if arr.is_null() || (arr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return None;
+    }
+    let header = (arr as *mut u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader;
+    if (*header).obj_type != crate::gc::GC_TYPE_ARRAY {
+        return None;
+    }
+    Some(header)
+}
+
+#[inline]
+unsafe fn array_has_raw_f64_layout_flag(arr: *const ArrayHeader) -> bool {
+    array_gc_header(arr)
+        .is_some_and(|header| (*header)._reserved & crate::gc::GC_ARRAY_RAW_F64_LAYOUT != 0)
+}
+
+#[inline]
+unsafe fn set_array_raw_f64_layout_flag(arr: *const ArrayHeader) {
+    if let Some(header) = array_gc_header(arr) {
+        (*header)._reserved |= crate::gc::GC_ARRAY_RAW_F64_LAYOUT;
+    }
+}
+
+#[inline]
+unsafe fn clear_array_raw_f64_layout_flag(arr: *const ArrayHeader) {
+    if let Some(header) = array_gc_header(arr) {
+        let had_raw_layout = (*header)._reserved & crate::gc::GC_ARRAY_RAW_F64_LAYOUT != 0;
+        (*header)._reserved &= !crate::gc::GC_ARRAY_RAW_F64_LAYOUT;
+        if had_raw_layout {
+            crate::typed_feedback::invalidate_representation_change(arr as usize);
+        }
+    }
+}
+
 unsafe fn rebuild_array_numeric_raw_f64(arr: *mut ArrayHeader) -> bool {
     if arr.is_null() {
         return false;
@@ -355,30 +392,17 @@ unsafe fn rebuild_array_numeric_raw_f64(arr: *mut ArrayHeader) -> bool {
         return false;
     }
 
-    let mut raw = Vec::with_capacity(length);
-    let elements_ptr = array_elements_ptr(arr);
+    let elements = array_elements_ptr(arr);
     for i in 0..length {
         let slot_bits = array_slot_bits(arr, i);
         let Some(number) = value_bits_to_number(slot_bits) else {
             clear_array_numeric_layout(arr);
             return false;
         };
-        let canonical_bits = number.to_bits();
-        if slot_bits != canonical_bits {
-            std::ptr::write(elements_ptr.add(i), canonical_bits);
-        }
-        raw.push(number);
+        std::ptr::write(elements.add(i) as *mut f64, number);
     }
 
-    NUMERIC_ARRAY_LAYOUTS.with(|m| {
-        m.borrow_mut().insert(
-            arr as usize,
-            NumericArrayState {
-                layout: NumericArrayLayout::RawF64,
-                raw_f64: Some(raw),
-            },
-        );
-    });
+    set_array_raw_f64_layout_flag(arr);
     crate::gc::layout_init_pointer_free(arr as *mut u8);
     true
 }
@@ -388,15 +412,9 @@ pub(crate) unsafe fn set_array_numeric_layout(arr: *mut ArrayHeader, layout: Num
     if arr.is_null() {
         return;
     }
-    NUMERIC_ARRAY_LAYOUTS.with(|m| {
-        m.borrow_mut().insert(
-            arr as usize,
-            NumericArrayState {
-                layout,
-                raw_f64: None,
-            },
-        );
-    });
+    match layout {
+        NumericArrayLayout::RawF64 => set_array_raw_f64_layout_flag(arr),
+    }
     crate::gc::layout_init_pointer_free(arr as *mut u8);
 }
 
@@ -405,9 +423,7 @@ pub(crate) unsafe fn clear_array_numeric_layout(arr: *const ArrayHeader) {
     if arr.is_null() {
         return;
     }
-    NUMERIC_ARRAY_LAYOUTS.with(|m| {
-        m.borrow_mut().remove(&(arr as usize));
-    });
+    clear_array_raw_f64_layout_flag(arr);
 }
 
 #[inline]
@@ -415,9 +431,9 @@ pub(crate) fn clear_array_numeric_layout_ptr(user_ptr: usize) {
     if user_ptr == 0 {
         return;
     }
-    NUMERIC_ARRAY_LAYOUTS.with(|m| {
-        m.borrow_mut().remove(&user_ptr);
-    });
+    unsafe {
+        clear_array_raw_f64_layout_flag(user_ptr as *const ArrayHeader);
+    }
 }
 
 #[inline]
@@ -425,13 +441,13 @@ pub(crate) fn transfer_array_numeric_layout(old_user: usize, new_user: usize) {
     if old_user == 0 || new_user == 0 || old_user == new_user {
         return;
     }
-    NUMERIC_ARRAY_LAYOUTS.with(|m| {
-        let mut layouts = m.borrow_mut();
-        layouts.remove(&new_user);
-        if let Some(state) = layouts.remove(&old_user) {
-            layouts.insert(new_user, state);
+    unsafe {
+        if array_has_raw_f64_layout_flag(old_user as *const ArrayHeader) {
+            set_array_raw_f64_layout_flag(new_user as *const ArrayHeader);
+        } else {
+            clear_array_raw_f64_layout_flag(new_user as *const ArrayHeader);
         }
-    });
+    }
 }
 
 #[inline]
@@ -440,20 +456,14 @@ pub(crate) unsafe fn array_numeric_layout(arr: *const ArrayHeader) -> Option<Num
     if arr.is_null() {
         return None;
     }
-    NUMERIC_ARRAY_LAYOUTS.with(|m| m.borrow().get(&(arr as usize)).map(|state| state.layout))
+    array_has_raw_f64_layout_flag(arr).then_some(NumericArrayLayout::RawF64)
 }
 
 #[inline]
 pub(crate) unsafe fn note_array_numeric_write(arr: *mut ArrayHeader, value_bits: u64) {
     if !value_bits_are_numeric(value_bits) {
         clear_array_numeric_layout(arr);
-        return;
     }
-    NUMERIC_ARRAY_LAYOUTS.with(|m| {
-        if let Some(state) = m.borrow_mut().get_mut(&(arr as usize)) {
-            state.raw_f64 = None;
-        }
-    });
 }
 
 #[inline]
@@ -461,24 +471,17 @@ pub(crate) unsafe fn note_array_numeric_index_write(
     arr: *mut ArrayHeader,
     index: usize,
     value_bits: u64,
-) {
+) -> u64 {
     let Some(number) = value_bits_to_number(value_bits) else {
         clear_array_numeric_layout(arr);
-        return;
+        return value_bits;
     };
-    NUMERIC_ARRAY_LAYOUTS.with(|m| {
-        if let Some(state) = m.borrow_mut().get_mut(&(arr as usize)) {
-            if let Some(raw) = state.raw_f64.as_mut() {
-                if index < raw.len() {
-                    raw[index] = number;
-                } else if index == raw.len() {
-                    raw.push(number);
-                } else {
-                    state.raw_f64 = None;
-                }
-            }
-        }
-    });
+    if array_has_raw_f64_layout_flag(arr) && index < (*arr).length as usize {
+        let elements = array_elements_ptr(arr) as *mut f64;
+        std::ptr::write(elements.add(index), number);
+        return number.to_bits();
+    }
+    value_bits
 }
 
 #[inline]
@@ -493,13 +496,7 @@ pub(crate) unsafe fn ensure_array_numeric_raw_f64(arr: *mut ArrayHeader) -> bool
         clear_array_numeric_layout(arr);
         return false;
     }
-    let ready = NUMERIC_ARRAY_LAYOUTS.with(|m| {
-        m.borrow()
-            .get(&(arr as usize))
-            .and_then(|state| state.raw_f64.as_ref())
-            .is_some_and(|raw| raw.len() == length)
-    });
-    if ready {
+    if array_has_raw_f64_layout_flag(arr) {
         return true;
     }
     rebuild_array_numeric_raw_f64(arr)
@@ -517,12 +514,8 @@ pub(crate) unsafe fn array_numeric_raw_f64_get(arr: *mut ArrayHeader, index: u32
     if !ensure_array_numeric_raw_f64(arr) {
         return None;
     }
-    NUMERIC_ARRAY_LAYOUTS.with(|m| {
-        m.borrow()
-            .get(&(arr as usize))
-            .and_then(|state| state.raw_f64.as_ref())
-            .and_then(|raw| raw.get(index as usize).copied())
-    })
+    let elements = array_elements_ptr(arr) as *const f64;
+    Some(*elements.add(index as usize))
 }
 
 #[inline]
@@ -538,6 +531,9 @@ pub(crate) unsafe fn array_numeric_raw_f64_set_inbounds(
     let original_bits = value.to_bits();
     let value_bits = canonicalize_array_numeric_store_bits(arr, original_bits);
     let value = f64::from_bits(value_bits);
+    if !ensure_array_numeric_raw_f64(arr) {
+        return false;
+    }
     let elements_ptr = array_elements_ptr(arr) as *mut f64;
     std::ptr::write(elements_ptr.add(index as usize), value);
     note_array_numeric_index_write(arr, index as usize, value_bits);
@@ -560,24 +556,13 @@ pub(crate) unsafe fn array_numeric_raw_f64_push_inbounds(
         return false;
     }
 
-    let value_bits = value.to_bits();
-    let Some(number) = value_bits_to_number(value_bits) else {
+    let Some(number) = value_bits_to_number(value.to_bits()) else {
+        clear_array_numeric_layout(arr);
         return false;
     };
-    let value_bits = number.to_bits();
-    let value = f64::from_bits(value_bits);
     let elements_ptr = array_elements_ptr(arr) as *mut f64;
-    std::ptr::write(elements_ptr.add(length as usize), value);
-    NUMERIC_ARRAY_LAYOUTS.with(|m| {
-        if let Some(state) = m.borrow_mut().get_mut(&(arr as usize)) {
-            match state.raw_f64.as_mut() {
-                Some(raw) if raw.len() == length as usize => raw.push(number),
-                Some(_) => state.raw_f64 = None,
-                None => {}
-            }
-        }
-    });
-    crate::gc::layout_note_slot(arr as usize, length as usize, value_bits);
+    std::ptr::write(elements_ptr.add(length as usize), number);
+    crate::gc::layout_note_slot(arr as usize, length as usize, number.to_bits());
     (*arr).length = length + 1;
     true
 }
@@ -701,7 +686,18 @@ pub(crate) unsafe fn store_array_slot(arr: *mut ArrayHeader, index: usize, value
     let value_bits = canonicalize_array_numeric_store_bits(arr, value_bits);
     note_array_numeric_index_write(arr, index, value_bits);
     let slot = array_elements_ptr(arr).add(index) as usize;
-    crate::gc::runtime_store_jsvalue_slot(arr as usize, slot, index, value_bits);
+    let stored_bits = if array_has_raw_f64_layout_flag(arr) {
+        match value_bits_to_number(value_bits) {
+            Some(number) => number.to_bits(),
+            None => {
+                clear_array_numeric_layout(arr);
+                value_bits
+            }
+        }
+    } else {
+        value_bits
+    };
+    crate::gc::runtime_store_jsvalue_slot(arr as usize, slot, index, stored_bits);
 }
 
 #[inline]

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -37,6 +37,11 @@ fn assert_canonical_raw_slot(arr: *mut ArrayHeader, index: u32, expected: f64) {
     assert_eq!(js_array_numeric_get_f64_unboxed(arr, index), expected);
 }
 
+unsafe fn raw_slot_bits(arr: *mut ArrayHeader, index: usize) -> u64 {
+    let elements = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const u64;
+    *elements.add(index)
+}
+
 #[test]
 fn test_array_alloc_and_access() {
     let arr = js_array_alloc(5);
@@ -302,6 +307,30 @@ fn test_numeric_array_layout_mark_rejects_holes_and_accepts_dense_numbers() {
 }
 
 #[test]
+fn test_numeric_array_mark_canonicalizes_int32_and_nan_inline() {
+    let arr = js_array_alloc_with_length(3);
+    let int32_value = f64::from_bits(crate::value::INT32_TAG | ((-17i32 as u32) as u64));
+    let payload_nan = f64::from_bits(0x7FF8_0000_0000_1234);
+
+    js_array_set_f64(arr, 0, int32_value);
+    js_array_set_f64(arr, 1, payload_nan);
+    js_array_set_f64(arr, 2, -0.0);
+
+    assert_eq!(js_array_mark_numeric_f64_layout(arr), 1);
+    assert_eq!(js_array_numeric_get_f64_unboxed(arr, 0), -17.0);
+    assert!(js_array_numeric_get_f64_unboxed(arr, 1).is_nan());
+    assert_eq!(
+        js_array_numeric_get_f64_unboxed(arr, 2).to_bits(),
+        (-0.0f64).to_bits()
+    );
+    unsafe {
+        assert_eq!(raw_slot_bits(arr, 0), (-17.0f64).to_bits());
+        assert_eq!(raw_slot_bits(arr, 1), f64::NAN.to_bits());
+        assert_eq!(raw_slot_bits(arr, 2), (-0.0f64).to_bits());
+    }
+}
+
+#[test]
 fn test_numeric_array_raw_f64_payload_tracks_sets_and_downgrades() {
     let mut arr = js_array_alloc(2);
     arr = js_array_push_f64(arr, 1.5);
@@ -325,6 +354,32 @@ fn test_numeric_array_raw_f64_payload_tracks_sets_and_downgrades() {
         str_value.to_bits(),
         "unboxed helper falls back to boxed slots after downgrade"
     );
+}
+
+#[test]
+fn test_numeric_array_sparse_extend_fills_holes_and_downgrades_raw_layout() {
+    let mut arr = js_array_alloc(8);
+    arr = js_array_push_f64(arr, 1.0);
+    arr = js_array_push_f64(arr, 2.0);
+
+    assert_eq!(js_array_mark_numeric_f64_layout(arr), 1);
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 1);
+
+    let extended = js_array_set_f64_extend(arr, 5, 6.0);
+
+    assert_eq!(extended, arr);
+    assert_eq!(js_array_length(extended), 6);
+    assert_eq!(js_array_is_numeric_f64_layout(extended), 0);
+    assert_eq!(js_array_get_f64(extended, 0), 1.0);
+    assert_eq!(js_array_get_f64(extended, 1), 2.0);
+    assert_eq!(
+        js_array_get_f64(extended, 3).to_bits(),
+        crate::value::TAG_UNDEFINED
+    );
+    unsafe {
+        assert_eq!(raw_slot_bits(extended, 3), crate::value::TAG_HOLE);
+    }
+    assert_eq!(js_array_get_f64(extended, 5), 6.0);
 }
 
 #[test]

--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -126,6 +126,24 @@ impl LayoutSlotMask {
         }
     }
 
+    pub(super) fn count_slots(&self, slot_count: usize) -> usize {
+        let mut count = 0usize;
+        self.visit_slots(slot_count, |_| {
+            count += 1;
+        });
+        count
+    }
+
+    pub(super) fn intersects(&self, other: &Self, slot_count: usize) -> bool {
+        let mut found = false;
+        self.visit_slots(slot_count, |slot| {
+            if other.contains_slot(slot) {
+                found = true;
+            }
+        });
+        found
+    }
+
     #[inline]
     pub(super) fn contains_slot(&self, slot_index: usize) -> bool {
         match self {
@@ -372,22 +390,25 @@ pub(crate) fn layout_note_slot(parent_user: usize, slot_index: usize, value_bits
         if (*header)._reserved & GC_LAYOUT_STATE_MASK == GC_LAYOUT_UNKNOWN {
             return;
         }
-        let pointer = layout_pointer_bearing_bits(value_bits);
         if let Some(typed) = TYPED_LAYOUTS.with(|m| m.borrow().get(&parent_user).cloned()) {
             if slot_index >= typed.slot_count {
                 layout_set_typed_unknown(header, parent_user);
                 return;
             }
-            if typed.raw_f64_mask.contains_slot(slot_index) && !layout_raw_f64_bits(value_bits) {
-                layout_set_typed_unknown(header, parent_user);
+            if typed.raw_f64_mask.contains_slot(slot_index) {
+                if !layout_raw_f64_bits(value_bits) {
+                    layout_set_typed_unknown(header, parent_user);
+                }
                 return;
             }
+            let pointer = layout_pointer_bearing_bits(value_bits);
             if pointer && !typed.pointer_mask.contains_slot(slot_index) {
                 layout_set_typed_unknown(header, parent_user);
                 return;
             }
             return;
         }
+        let pointer = layout_pointer_bearing_bits(value_bits);
         if !pointer && (*header)._reserved & GC_LAYOUT_STATE_MASK == GC_LAYOUT_POINTER_FREE {
             return;
         }
@@ -442,6 +463,10 @@ unsafe fn init_typed_shape_layout(
 
     let raw_f64_mask = LayoutSlotMask::from_words(raw_f64_words);
     let pointer_mask = LayoutSlotMask::from_words(pointer_words);
+    if raw_f64_mask.intersects(&pointer_mask, slot_count) {
+        layout_set_typed_unknown(header, user_ptr);
+        return;
+    }
 
     if slot_count != 0 {
         let fields = (obj_header as *const u8)
@@ -449,9 +474,12 @@ unsafe fn init_typed_shape_layout(
             as *const u64;
         for i in 0..slot_count {
             let bits = *fields.add(i);
-            if raw_f64_mask.contains_slot(i) && !layout_raw_f64_bits(bits) {
-                layout_set_typed_unknown(header, user_ptr);
-                return;
+            if raw_f64_mask.contains_slot(i) {
+                if !layout_raw_f64_bits(bits) {
+                    layout_set_typed_unknown(header, user_ptr);
+                    return;
+                }
+                continue;
             }
             if layout_pointer_bearing_bits(bits) && !pointer_mask.contains_slot(i) {
                 layout_set_typed_unknown(header, user_ptr);
@@ -539,6 +567,10 @@ pub extern "C" fn js_gc_init_unboxed_object_layout(
 
         let raw_f64_mask = LayoutSlotMask::Inline(raw_f64_mask);
         let pointer_mask = LayoutSlotMask::Inline(pointer_mask);
+        if raw_f64_mask.intersects(&pointer_mask, slot_count) {
+            layout_set_typed_unknown(header, user_ptr);
+            return;
+        }
 
         if slot_count != 0 {
             let fields = (obj_header as *const u8)
@@ -546,9 +578,12 @@ pub extern "C" fn js_gc_init_unboxed_object_layout(
                 as *const u64;
             for i in 0..slot_count {
                 let bits = *fields.add(i);
-                if raw_f64_mask.contains_slot(i) && !layout_raw_f64_bits(bits) {
-                    layout_set_typed_unknown(header, user_ptr);
-                    return;
+                if raw_f64_mask.contains_slot(i) {
+                    if !layout_raw_f64_bits(bits) {
+                        layout_set_typed_unknown(header, user_ptr);
+                        return;
+                    }
+                    continue;
                 }
                 if layout_pointer_bearing_bits(bits) && !pointer_mask.contains_slot(i) {
                     layout_set_typed_unknown(header, user_ptr);
@@ -716,6 +751,18 @@ pub(crate) fn layout_typed_raw_f64_slot_for_user(user_ptr: usize, slot_index: us
     })
 }
 
+fn layout_typed_raw_f64_slot_count_for_user(user_ptr: usize, slot_count: usize) -> usize {
+    TYPED_LAYOUTS.with(|m| {
+        m.borrow()
+            .get(&user_ptr)
+            .map(|layout| {
+                let bounded_count = slot_count.min(layout.slot_count);
+                layout.raw_f64_mask.count_slots(bounded_count)
+            })
+            .unwrap_or(0)
+    })
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct HeapSlotRange {
     pub(super) slots: *mut u64,
@@ -758,7 +805,10 @@ pub(crate) enum HeapChildSlot {
 
 pub(super) enum HeapPayloadSlotScan {
     Empty,
-    PointerFree,
+    PointerFree {
+        raw_numeric_array: bool,
+        raw_numeric_object_slots: usize,
+    },
     Masked,
     All(HeapSlotRange),
 }
@@ -766,9 +816,20 @@ pub(super) enum HeapPayloadSlotScan {
 #[derive(Clone)]
 pub(super) enum HeapPayloadSlotSelection {
     Empty,
-    PointerFree { emitted: bool },
-    Masked { mask: LayoutSlotMask, cursor: usize },
-    All { cursor: usize },
+    PointerFree {
+        emitted: bool,
+        raw_numeric_array: bool,
+        raw_numeric_object_slots: usize,
+    },
+    Masked {
+        mask: LayoutSlotMask,
+        cursor: usize,
+        raw_numeric_object_slots: usize,
+        raw_numeric_recorded: bool,
+    },
+    All {
+        cursor: usize,
+    },
 }
 
 pub(crate) struct HeapChildSlotIterator {
@@ -806,7 +867,14 @@ impl HeapChildSlotIterator {
     pub(super) fn payload_scan(&self) -> HeapPayloadSlotScan {
         match self.selection {
             HeapPayloadSlotSelection::Empty => HeapPayloadSlotScan::Empty,
-            HeapPayloadSlotSelection::PointerFree { .. } => HeapPayloadSlotScan::PointerFree,
+            HeapPayloadSlotSelection::PointerFree {
+                raw_numeric_array,
+                raw_numeric_object_slots,
+                ..
+            } => HeapPayloadSlotScan::PointerFree {
+                raw_numeric_array,
+                raw_numeric_object_slots,
+            },
             HeapPayloadSlotSelection::Masked { .. } => HeapPayloadSlotScan::Masked,
             HeapPayloadSlotSelection::All { .. } => HeapPayloadSlotScan::All(self.payload),
         }
@@ -822,16 +890,41 @@ impl Iterator for HeapChildSlotIterator {
         }
         match &mut self.selection {
             HeapPayloadSlotSelection::Empty => None,
-            HeapPayloadSlotSelection::PointerFree { emitted } => {
+            HeapPayloadSlotSelection::PointerFree {
+                emitted,
+                raw_numeric_array,
+                raw_numeric_object_slots,
+            } => {
                 if *emitted || self.payload.is_empty() {
                     None
                 } else {
                     *emitted = true;
                     record_layout_pointer_free_range_skipped(self.payload.slot_count());
+                    if *raw_numeric_array {
+                        record_layout_raw_numeric_array_range_skipped(self.payload.slot_count());
+                    }
+                    if *raw_numeric_object_slots != 0 {
+                        record_layout_raw_numeric_object_field_range_skipped(
+                            *raw_numeric_object_slots,
+                        );
+                    }
                     Some(HeapChildSlot::PointerFreeRange(self.payload))
                 }
             }
-            HeapPayloadSlotSelection::Masked { mask, cursor } => {
+            HeapPayloadSlotSelection::Masked {
+                mask,
+                cursor,
+                raw_numeric_object_slots,
+                raw_numeric_recorded,
+            } => {
+                if !*raw_numeric_recorded {
+                    *raw_numeric_recorded = true;
+                    if *raw_numeric_object_slots != 0 {
+                        record_layout_raw_numeric_object_field_range_skipped(
+                            *raw_numeric_object_slots,
+                        );
+                    }
+                }
                 let index = mask.next_slot_at_or_after(*cursor, self.payload.slot_count())?;
                 *cursor = index + 1;
                 Some(HeapChildSlot::Child(
@@ -862,12 +955,27 @@ pub(super) unsafe fn heap_payload_slot_selection(
         return HeapPayloadSlotSelection::Empty;
     }
     let user_ptr = (header as *mut u8).add(GC_HEADER_SIZE) as usize;
+    let raw_numeric_object_slots = if (*header).obj_type == GC_TYPE_OBJECT {
+        layout_typed_raw_f64_slot_count_for_user(user_ptr, payload.slot_count())
+    } else {
+        0
+    };
     match (*header)._reserved & GC_LAYOUT_STATE_MASK {
-        GC_LAYOUT_POINTER_FREE => HeapPayloadSlotSelection::PointerFree { emitted: false },
+        GC_LAYOUT_POINTER_FREE => HeapPayloadSlotSelection::PointerFree {
+            emitted: false,
+            raw_numeric_array: (*header).obj_type == GC_TYPE_ARRAY
+                && (*header)._reserved & GC_ARRAY_RAW_F64_LAYOUT != 0,
+            raw_numeric_object_slots,
+        },
         GC_LAYOUT_SIDE_MASK => {
             let mask = LAYOUT_SLOT_MASKS.with(|m| m.borrow().get(&user_ptr).cloned());
             match mask {
-                Some(mask) => HeapPayloadSlotSelection::Masked { mask, cursor: 0 },
+                Some(mask) => HeapPayloadSlotSelection::Masked {
+                    mask,
+                    cursor: 0,
+                    raw_numeric_object_slots,
+                    raw_numeric_recorded: false,
+                },
                 None => {
                     set_layout_state(header, GC_LAYOUT_UNKNOWN);
                     HeapPayloadSlotSelection::All { cursor: 0 }
@@ -977,9 +1085,18 @@ pub(super) unsafe fn visit_gc_layout_slot_descriptors(
 
     match child_slots.payload_scan() {
         HeapPayloadSlotScan::Empty => {}
-        HeapPayloadSlotScan::PointerFree => {
+        HeapPayloadSlotScan::PointerFree {
+            raw_numeric_array,
+            raw_numeric_object_slots,
+        } => {
             let range = child_slots.payload;
             record_layout_pointer_free_range_skipped(range.slot_count());
+            if raw_numeric_array {
+                record_layout_raw_numeric_array_range_skipped(range.slot_count());
+            }
+            if raw_numeric_object_slots != 0 {
+                record_layout_raw_numeric_object_field_range_skipped(raw_numeric_object_slots);
+            }
             visit(GcMutableSlotDescriptor::PointerFreeRange);
         }
         HeapPayloadSlotScan::Masked => {

--- a/crates/perry-runtime/src/gc/telemetry.rs
+++ b/crates/perry-runtime/src/gc/telemetry.rs
@@ -247,6 +247,12 @@ pub(super) struct LayoutScanTraceStats {
     pub(super) pointer_free_ranges_skipped: usize,
     pub(super) pointer_free_slots_skipped: usize,
     pub(super) pointer_free_payload_bytes_skipped: usize,
+    pub(super) raw_numeric_array_ranges_skipped: usize,
+    pub(super) raw_numeric_array_slots_skipped: usize,
+    pub(super) raw_numeric_array_payload_bytes_skipped: usize,
+    pub(super) raw_numeric_object_field_ranges_skipped: usize,
+    pub(super) raw_numeric_object_field_slots_skipped: usize,
+    pub(super) raw_numeric_object_field_payload_bytes_skipped: usize,
 }
 
 impl LayoutScanTraceStats {
@@ -259,6 +265,12 @@ impl LayoutScanTraceStats {
             pointer_free_ranges_skipped: 0,
             pointer_free_slots_skipped: 0,
             pointer_free_payload_bytes_skipped: 0,
+            raw_numeric_array_ranges_skipped: 0,
+            raw_numeric_array_slots_skipped: 0,
+            raw_numeric_array_payload_bytes_skipped: 0,
+            raw_numeric_object_field_ranges_skipped: 0,
+            raw_numeric_object_field_slots_skipped: 0,
+            raw_numeric_object_field_payload_bytes_skipped: 0,
         }
     }
 }
@@ -341,6 +353,45 @@ pub(super) fn record_layout_pointer_free_range_skipped(slot_count: usize) {
             .saturating_add(slot_count);
         current.pointer_free_payload_bytes_skipped = current
             .pointer_free_payload_bytes_skipped
+            .saturating_add(slot_count.saturating_mul(std::mem::size_of::<u64>()));
+        stats.set(current);
+    });
+}
+
+#[inline]
+pub(super) fn record_layout_raw_numeric_array_range_skipped(slot_count: usize) {
+    if slot_count == 0 || !layout_scan_trace_active() {
+        return;
+    }
+    LAYOUT_SCAN_TRACE_STATS.with(|stats| {
+        let mut current = stats.get();
+        current.raw_numeric_array_ranges_skipped =
+            current.raw_numeric_array_ranges_skipped.saturating_add(1);
+        current.raw_numeric_array_slots_skipped = current
+            .raw_numeric_array_slots_skipped
+            .saturating_add(slot_count);
+        current.raw_numeric_array_payload_bytes_skipped = current
+            .raw_numeric_array_payload_bytes_skipped
+            .saturating_add(slot_count.saturating_mul(std::mem::size_of::<u64>()));
+        stats.set(current);
+    });
+}
+
+#[inline]
+pub(super) fn record_layout_raw_numeric_object_field_range_skipped(slot_count: usize) {
+    if slot_count == 0 || !layout_scan_trace_active() {
+        return;
+    }
+    LAYOUT_SCAN_TRACE_STATS.with(|stats| {
+        let mut current = stats.get();
+        current.raw_numeric_object_field_ranges_skipped = current
+            .raw_numeric_object_field_ranges_skipped
+            .saturating_add(1);
+        current.raw_numeric_object_field_slots_skipped = current
+            .raw_numeric_object_field_slots_skipped
+            .saturating_add(slot_count);
+        current.raw_numeric_object_field_payload_bytes_skipped = current
+            .raw_numeric_object_field_payload_bytes_skipped
             .saturating_add(slot_count.saturating_mul(std::mem::size_of::<u64>()));
         stats.set(current);
     });
@@ -575,6 +626,12 @@ impl GcCycleTrace {
             "pointer_free_ranges_skipped": self.layout_scans.pointer_free_ranges_skipped,
             "pointer_free_slots_skipped": self.layout_scans.pointer_free_slots_skipped,
             "pointer_free_payload_bytes_skipped": self.layout_scans.pointer_free_payload_bytes_skipped,
+            "raw_numeric_array_ranges_skipped": self.layout_scans.raw_numeric_array_ranges_skipped,
+            "raw_numeric_array_slots_skipped": self.layout_scans.raw_numeric_array_slots_skipped,
+            "raw_numeric_array_payload_bytes_skipped": self.layout_scans.raw_numeric_array_payload_bytes_skipped,
+            "raw_numeric_object_field_ranges_skipped": self.layout_scans.raw_numeric_object_field_ranges_skipped,
+            "raw_numeric_object_field_slots_skipped": self.layout_scans.raw_numeric_object_field_slots_skipped,
+            "raw_numeric_object_field_payload_bytes_skipped": self.layout_scans.raw_numeric_object_field_payload_bytes_skipped,
         });
         let evacuation_json = serde_json::json!({
             "objects": self.evacuation.objects,

--- a/crates/perry-runtime/src/gc/tests/layout_trace.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace.rs
@@ -52,6 +52,7 @@ fn test_layout_mask_pointer_free_array_scans_zero_slots() {
     for i in 0..4 {
         crate::array::js_array_set_f64(arr, i, (i + 1) as f64);
     }
+    assert_eq!(crate::array::js_array_mark_numeric_f64_layout(arr), 1);
 
     let valid_ptrs = build_valid_pointer_set();
     let mut worklist = Vec::new();
@@ -96,6 +97,7 @@ fn test_layout_scan_trace_json_counts_pointer_free_slots() {
     for i in 0..4 {
         crate::array::js_array_set_f64(arr, i, (i + 1) as f64);
     }
+    assert_eq!(crate::array::js_array_mark_numeric_f64_layout(arr), 1);
 
     let valid_ptrs = build_valid_pointer_set();
     assert!(try_mark_value(
@@ -115,6 +117,18 @@ fn test_layout_scan_trace_json_counts_pointer_free_slots() {
     assert_eq!(layout_scans["pointer_free_slots_skipped"].as_u64(), Some(4));
     assert_eq!(
         layout_scans["pointer_free_payload_bytes_skipped"].as_u64(),
+        Some(32)
+    );
+    assert_eq!(
+        layout_scans["raw_numeric_array_ranges_skipped"].as_u64(),
+        Some(1)
+    );
+    assert_eq!(
+        layout_scans["raw_numeric_array_slots_skipped"].as_u64(),
+        Some(4)
+    );
+    assert_eq!(
+        layout_scans["raw_numeric_array_payload_bytes_skipped"].as_u64(),
         Some(32)
     );
 
@@ -178,6 +192,37 @@ fn test_pointer_free_target_gate_emits_trace() {
 
     assert_ne!(after, arr as usize);
     assert!(crate::arena::pointer_in_nursery(after));
+}
+
+#[test]
+fn test_raw_numeric_array_layout_transfers_on_copying_minor_and_skips_payload() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+    let arr = crate::array::js_array_alloc_with_length(4);
+    for i in 0..4 {
+        crate::array::js_array_set_f64(arr, i, (i + 1) as f64 + 0.25);
+    }
+    assert_eq!(crate::array::js_array_mark_numeric_f64_layout(arr), 1);
+    js_shadow_slot_set(0, ptr_bits(arr as usize));
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    let after = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+    let header = unsafe { header_from_user_ptr(after as *const u8) };
+
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+    assert_ne!(after, arr as usize);
+    assert!(crate::arena::pointer_in_nursery(after));
+    unsafe {
+        assert_ne!((*header)._reserved & GC_ARRAY_RAW_F64_LAYOUT, 0);
+    }
+    assert_eq!(test_layout_pointer_slot_count(after, 4), Some(0));
+    assert_eq!(test_heap_child_slot_count(after as *mut u8), 0);
+    assert!(
+        trace.layout_scans.raw_numeric_array_slots_skipped >= 4,
+        "copied raw numeric array payload should be skipped by layout scan: {:?}",
+        trace.layout_scans
+    );
 }
 
 #[test]
@@ -420,6 +465,43 @@ fn test_typed_shape_descriptor_tracks_raw_numeric_slots() {
 }
 
 #[test]
+fn test_typed_shape_raw_numeric_slots_accept_pointer_like_f64_bits() {
+    clear_marks();
+    clear_mark_seeds();
+
+    let obj = crate::object::js_object_alloc(0, 2);
+    let pointer_like_number = f64::from_bits(0x1000);
+    crate::object::js_object_set_unboxed_f64_field(obj, 0, pointer_like_number);
+    let child = crate::string::js_string_from_bytes(b"mixed-child".as_ptr(), 11);
+    crate::object::js_object_set_field(obj, 1, crate::value::JSValue::string_ptr(child));
+
+    let raw_mask = [0b01u64];
+    let pointer_mask = [0b10u64];
+    js_gc_init_typed_shape_layout(
+        obj as u64,
+        2,
+        raw_mask.as_ptr(),
+        raw_mask.len() as u32,
+        pointer_mask.as_ptr(),
+        pointer_mask.len() as u32,
+    );
+
+    assert!(layout_typed_raw_f64_slot_for_user(obj as usize, 0));
+    assert_eq!(test_layout_pointer_slot_count(obj as usize, 2), Some(1));
+
+    let next_pointer_like_number = f64::from_bits(0x2000);
+    crate::object::js_object_set_unboxed_f64_field(obj, 0, next_pointer_like_number);
+    assert!(
+        layout_typed_raw_f64_slot_for_user(obj as usize, 0),
+        "raw f64 slots must not be downgraded by numeric payload bits that resemble raw pointers"
+    );
+    assert_eq!(test_layout_pointer_slot_count(obj as usize, 2), Some(1));
+
+    clear_marks();
+    clear_mark_seeds();
+}
+
+#[test]
 fn test_typed_shape_descriptor_rejects_nanbox_non_number_tags() {
     clear_marks();
     clear_mark_seeds();
@@ -556,6 +638,115 @@ fn test_unboxed_object_layout_scans_zero_raw_numeric_fields() {
 }
 
 #[test]
+fn test_layout_scan_trace_counts_raw_numeric_object_fields() {
+    clear_marks();
+    clear_mark_seeds();
+
+    let trace = GcCycleTrace::new(
+        GcCollectionKind::Minor,
+        GcTriggerSnapshot {
+            kind: GcTriggerKind::Direct,
+            steps_before: Some(GcStepSnapshot::current()),
+        },
+    )
+    .expect("test requested GC trace capture");
+
+    let obj = crate::object::js_object_alloc(0, 2);
+    crate::object::js_object_set_unboxed_f64_field(obj, 0, 1.25);
+    crate::object::js_object_set_unboxed_f64_field(obj, 1, -2.5);
+    let raw_mask = [0b11u64];
+    js_gc_init_typed_shape_layout(
+        obj as u64,
+        2,
+        raw_mask.as_ptr(),
+        raw_mask.len() as u32,
+        std::ptr::null(),
+        0,
+    );
+
+    let valid_ptrs = build_valid_pointer_set();
+    assert!(try_mark_value(
+        POINTER_TAG | (obj as u64 & POINTER_MASK),
+        &valid_ptrs
+    ));
+    trace_marked_objects(&valid_ptrs);
+
+    let event = trace.into_json(GcStepSnapshot::current());
+    let layout_scans = &event["layout_scans"];
+    assert_eq!(
+        layout_scans["raw_numeric_object_field_ranges_skipped"].as_u64(),
+        Some(1)
+    );
+    assert_eq!(
+        layout_scans["raw_numeric_object_field_slots_skipped"].as_u64(),
+        Some(2)
+    );
+    assert_eq!(
+        layout_scans["raw_numeric_object_field_payload_bytes_skipped"].as_u64(),
+        Some(16)
+    );
+
+    clear_marks();
+    clear_mark_seeds();
+}
+
+#[test]
+fn test_layout_scan_trace_counts_mixed_raw_numeric_object_fields() {
+    clear_marks();
+    clear_mark_seeds();
+
+    let trace = GcCycleTrace::new(
+        GcCollectionKind::Minor,
+        GcTriggerSnapshot {
+            kind: GcTriggerKind::Direct,
+            steps_before: Some(GcStepSnapshot::current()),
+        },
+    )
+    .expect("test requested GC trace capture");
+
+    let obj = crate::object::js_object_alloc(0, 2);
+    crate::object::js_object_set_unboxed_f64_field(obj, 0, f64::from_bits(0x1000));
+    let child = crate::string::js_string_from_bytes(b"mixed-child".as_ptr(), 11);
+    crate::object::js_object_set_field(obj, 1, crate::value::JSValue::string_ptr(child));
+    let raw_mask = [0b01u64];
+    let pointer_mask = [0b10u64];
+    js_gc_init_typed_shape_layout(
+        obj as u64,
+        2,
+        raw_mask.as_ptr(),
+        raw_mask.len() as u32,
+        pointer_mask.as_ptr(),
+        pointer_mask.len() as u32,
+    );
+
+    let valid_ptrs = build_valid_pointer_set();
+    assert!(try_mark_value(
+        POINTER_TAG | (obj as u64 & POINTER_MASK),
+        &valid_ptrs
+    ));
+    trace_marked_objects(&valid_ptrs);
+
+    let event = trace.into_json(GcStepSnapshot::current());
+    let layout_scans = &event["layout_scans"];
+    assert_eq!(layout_scans["masked_pointer_slots_read"].as_u64(), Some(1));
+    assert_eq!(
+        layout_scans["raw_numeric_object_field_ranges_skipped"].as_u64(),
+        Some(1)
+    );
+    assert_eq!(
+        layout_scans["raw_numeric_object_field_slots_skipped"].as_u64(),
+        Some(1)
+    );
+    assert_eq!(
+        layout_scans["raw_numeric_object_field_payload_bytes_skipped"].as_u64(),
+        Some(8)
+    );
+
+    clear_marks();
+    clear_mark_seeds();
+}
+
+#[test]
 fn test_unboxed_object_pointer_write_to_raw_slot_falls_back_and_traces() {
     clear_marks();
     clear_mark_seeds();
@@ -617,6 +808,63 @@ fn test_unboxed_object_descriptor_transfers_on_object_move() {
 
     clear_marks();
     clear_mark_seeds();
+}
+
+#[test]
+fn test_raw_numeric_object_descriptor_transfers_on_copying_minor_and_skips_raw_slots() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+    let child = young_leaf();
+    let obj = crate::object::js_object_alloc(0, 3);
+    crate::object::js_object_set_unboxed_f64_field(obj, 0, 10.5);
+    crate::object::js_object_set_field(obj, 1, crate::value::JSValue::from_bits(ptr_bits(child)));
+    crate::object::js_object_set_unboxed_f64_field(obj, 2, -3.25);
+    let raw_mask = [0b101u64];
+    let pointer_mask = [0b010u64];
+    js_gc_init_typed_shape_layout(
+        obj as u64,
+        3,
+        raw_mask.as_ptr(),
+        raw_mask.len() as u32,
+        pointer_mask.as_ptr(),
+        pointer_mask.len() as u32,
+    );
+    assert!(layout_typed_raw_f64_slot_for_user(obj as usize, 0));
+    assert!(layout_typed_raw_f64_slot_for_user(obj as usize, 2));
+    assert_eq!(test_layout_pointer_slot_count(obj as usize, 3), Some(1));
+    js_shadow_slot_set(0, ptr_bits(obj as usize));
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    let after = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+    let fields = unsafe {
+        (after as *const u8).add(std::mem::size_of::<crate::object::ObjectHeader>()) as *const u64
+    };
+    let first = f64::from_bits(unsafe { *fields.add(0) });
+    let child_after = unsafe { (*fields.add(1) & POINTER_MASK) as usize };
+    let third = f64::from_bits(unsafe { *fields.add(2) });
+
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+    assert_ne!(after, obj as usize);
+    assert_ne!(child_after, child);
+    assert!(crate::arena::pointer_in_nursery(after));
+    assert!(crate::arena::pointer_in_nursery(child_after));
+    assert_eq!(first, 10.5);
+    assert_eq!(third, -3.25);
+    assert!(layout_typed_raw_f64_slot_for_user(after, 0));
+    assert!(layout_typed_raw_f64_slot_for_user(after, 2));
+    assert_eq!(test_layout_pointer_slot_count(after, 3), Some(1));
+    assert_eq!(test_heap_child_slot_count(after as *mut u8), 1);
+    assert!(
+        trace.layout_scans.masked_pointer_slots_read >= 1,
+        "pointer slot should still be scanned: {:?}",
+        trace.layout_scans
+    );
+    assert!(
+        trace.layout_scans.raw_numeric_object_field_slots_skipped >= 2,
+        "raw numeric object slots should be skipped: {:?}",
+        trace.layout_scans
+    );
 }
 
 fn unboxed_point_for_shape_change_test(shape_id: u32) -> *mut crate::object::ObjectHeader {

--- a/crates/perry-runtime/src/gc/types.rs
+++ b/crates/perry-runtime/src/gc/types.rs
@@ -678,6 +678,10 @@ pub const OBJ_FLAG_NO_EXTEND: u16 = 0x04;
 // (`GC_COPY_SURVIVAL_AGE_MASK = 0x0038`) and bits 14..15 the layout state,
 // so 0x08 would be clobbered on every minor GC. Bits 6..13 are free.
 pub const OBJ_FLAG_NULL_PROTO: u16 = 0x40;
+/// Array payload is stored as canonical raw `f64` values, not NaN-boxed
+/// `JSValue` slots. This is only meaningful for `GC_TYPE_ARRAY`; object
+/// flags share the same `_reserved` word but never inspect this bit.
+pub(crate) const GC_ARRAY_RAW_F64_LAYOUT: u16 = 0x80;
 
 pub(super) const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
 pub(super) const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;

--- a/scripts/compiler_output_harness/verification.py
+++ b/scripts/compiler_output_harness/verification.py
@@ -321,6 +321,29 @@ def _matches_state(actual: Any, expected: Any, *, state_kind: str) -> bool:
     return actual_name == expected_name
 
 
+def _fact_matches(fact: Any, *, kind: Any = None, state: Any = None) -> bool:
+    if not isinstance(fact, dict):
+        return False
+    if kind is not None and str(fact.get("kind") or "") != str(kind):
+        return False
+    if state is not None and str(fact.get("state") or "") != str(state):
+        return False
+    return True
+
+
+def _record_has_fact(
+    record: dict[str, Any],
+    field: str,
+    *,
+    kind: Any = None,
+    state: Any = None,
+) -> bool:
+    facts = record.get(field) or []
+    if not isinstance(facts, list):
+        return False
+    return any(_fact_matches(fact, kind=kind, state=state) for fact in facts)
+
+
 def _record_matches_required(record: dict[str, Any], spec: dict[str, Any]) -> bool:
     exact_fields = (
         "expr_kind",
@@ -363,6 +386,32 @@ def _record_matches_required(record: dict[str, Any], spec: dict[str, Any]) -> bo
         return False
     if "alias_state" in spec and not _matches_state(
         record.get("alias_state"), spec["alias_state"], state_kind="alias"
+    ):
+        return False
+    if "consumed_fact_kind" in spec and not _record_has_fact(
+        record,
+        "consumed_facts",
+        kind=spec.get("consumed_fact_kind"),
+        state=spec.get("consumed_fact_state"),
+    ):
+        return False
+    if "consumed_fact_state" in spec and "consumed_fact_kind" not in spec and not _record_has_fact(
+        record,
+        "consumed_facts",
+        state=spec.get("consumed_fact_state"),
+    ):
+        return False
+    if "rejected_fact_kind" in spec and not _record_has_fact(
+        record,
+        "rejected_facts",
+        kind=spec.get("rejected_fact_kind"),
+        state=spec.get("rejected_fact_state"),
+    ):
+        return False
+    if "rejected_fact_state" in spec and "rejected_fact_kind" not in spec and not _record_has_fact(
+        record,
+        "rejected_facts",
+        state=spec.get("rejected_fact_state"),
     ):
         return False
     return True

--- a/scripts/copied_minor_fallback_report.py
+++ b/scripts/copied_minor_fallback_report.py
@@ -46,6 +46,10 @@ LAYOUT_SCAN_TOTALS = (
     "unknown_layout_slots_read",
     "pointer_free_ranges_skipped",
     "pointer_free_slots_skipped",
+    "raw_numeric_array_ranges_skipped",
+    "raw_numeric_array_slots_skipped",
+    "raw_numeric_object_field_ranges_skipped",
+    "raw_numeric_object_field_slots_skipped",
 )
 
 ROOT_SOURCE_SLOT_NAMES = (
@@ -922,6 +926,13 @@ def run_target_collector_gates(
                     f"{name}: pointer_slots_read={read} exceeds pointer-free "
                     f"payload allowance {max_expected_reads} for skipped={skipped}"
                 )
+
+        if "raw_numeric" in name:
+            layout = workload["layout_scans"]
+            if layout["raw_numeric_array_slots_skipped"] == 0:
+                errors.append(f"{name}: no raw numeric array slots were skipped")
+            if layout["raw_numeric_object_field_slots_skipped"] == 0:
+                errors.append(f"{name}: no raw numeric object field slots were skipped")
 
         if "large" in name and target_gates_require_copied_minor(name):
             copying = workload["copying_nursery"]

--- a/scripts/run_memory_stability_tests.sh
+++ b/scripts/run_memory_stability_tests.sh
@@ -633,6 +633,10 @@ for idx, cycle in enumerate(cycles):
             "unknown_layout_slots_read",
             "pointer_free_ranges_skipped",
             "pointer_free_slots_skipped",
+            "raw_numeric_array_ranges_skipped",
+            "raw_numeric_array_slots_skipped",
+            "raw_numeric_object_field_ranges_skipped",
+            "raw_numeric_object_field_slots_skipped",
         ):
             value = layout_scans.get(field)
             if not isinstance(value, int) or value < 0:
@@ -1536,6 +1540,8 @@ run_raw_numeric_object_fields_codegen_semantics() {
         '9.5' \
         'sealed-extra-error' \
         '{"value":12.5}' \
+        'prevent-extra-error' \
+        '{"value":13.5}' \
         '44' \
         '15.5' >"$expected_output"
 
@@ -1562,6 +1568,7 @@ run_target_collector_architecture_gates() {
         "closure_heavy|243150|$workloads_dir/closure_heavy.ts"
         "async_promise_closures|18540|$workloads_dir/async_promise_closures.ts|PERRY_GEN_GC_EVACUATE=0 PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1"
         "large_object_barriers|36052|$workloads_dir/large_object_barriers.ts"
+        "raw_numeric_layouts|71|benchmarks/compiler_output/fixtures/raw_numeric_layout_smoke.ts"
     )
 
     local report_args=()

--- a/test-files/test_guarded_raw_numeric_arrays.ts
+++ b/test-files/test_guarded_raw_numeric_arrays.ts
@@ -1,0 +1,62 @@
+// JS-visible parity coverage for guarded raw-f64 array storage.
+// The runtime may keep dense numeric arrays unboxed internally, but every
+// observable boundary must behave like ordinary JavaScript arrays.
+
+function line(label: string, value: unknown) {
+  console.log(label + ":", value);
+}
+
+const dense: number[] = [];
+for (let i = 0; i < 24; i++) {
+  dense.push(i + 0.5);
+}
+dense[3] = 7;
+dense.push(-0);
+dense.push(NaN);
+line("dense-length", dense.length);
+line("dense-sum", dense[0] + dense[3] + dense[23]);
+line("dense-negative-zero", Object.is(dense[24], -0));
+line("dense-nan", Number.isNaN(dense[25]));
+
+const methodSource = [1, 2, 3, 4, 5];
+line("slice", methodSource.slice(1, 4).join(","));
+line("concat", methodSource.concat([6, 7]).join(","));
+line("reverse", methodSource.slice().reverse().join(","));
+line("map", methodSource.map((n) => n * 2).join(","));
+line("filter", methodSource.filter((n) => n % 2 === 1).join(","));
+const spliced = methodSource.slice();
+const removed = spliced.splice(1, 2, 9, 10);
+line("splice-removed", removed.join(","));
+line("splice-result", spliced.join(","));
+
+const mixed: any[] = [1, 2, 3];
+mixed[1] = "two";
+mixed.push({ value: 4 });
+mixed.push(undefined);
+line("mixed-length", mixed.length);
+line(
+  "mixed-types",
+  typeof mixed[0] + "," + typeof mixed[1] + "," + typeof mixed[3] + "," + typeof mixed[4],
+);
+
+const sparse: any[] = [1, 2];
+sparse[5] = 6;
+line("sparse-length", sparse.length);
+line("sparse-hole", 3 in sparse);
+line("sparse-value", sparse[5]);
+
+const rawSparse: number[] = [];
+rawSparse.push(1);
+rawSparse.push(2);
+rawSparse[5] = 6;
+line("raw-sparse-length", rawSparse.length);
+line("raw-sparse-hole3", 3 in rawSparse);
+line("raw-sparse-v3", rawSparse[3]);
+line("raw-sparse-join", rawSparse.join("|"));
+
+const deleted: any[] = [10, 20, 30];
+const deleteResult = delete deleted[1];
+line("delete-result", deleteResult);
+line("delete-length", deleted.length);
+
+console.log("guarded-raw-numeric-arrays: ok");

--- a/tests/raw_numeric_object_fields.ts
+++ b/tests/raw_numeric_object_fields.ts
@@ -95,6 +95,17 @@ try {
 }
 console.log(JSON.stringify(sealed));
 
+const nonExtensible = new GuardedCounter();
+Object.preventExtensions(nonExtensible);
+nonExtensible.value = 13.5;
+try {
+  (nonExtensible as any).extra = 101;
+  console.log("prevent-extra-ok");
+} catch (e) {
+  console.log("prevent-extra-error");
+}
+console.log(JSON.stringify(nonExtensible));
+
 let accessorSeen = 0;
 function readAccessor(): number {
   return 44;

--- a/tests/test_compiler_output_regression.py
+++ b/tests/test_compiler_output_regression.py
@@ -119,6 +119,30 @@ def native_record(function="main", block="for.body.2", rep="i32", **overrides):
     return row
 
 
+def raw_f64_layout_fact(state):
+    return {
+        "fact_id": f"native_region.raw_f64_layout.test.{state}",
+        "kind": "raw_f64_layout",
+        "local_id": None,
+        "state": state,
+        "reason": "runtime_api" if state != "consumed" else None,
+    }
+
+
+def attach_raw_f64_layout_facts(records):
+    for record in records:
+        if record.get("access_mode") == "checked_native":
+            record.setdefault("consumed_facts", []).append(raw_f64_layout_fact("consumed"))
+        elif record.get("access_mode") == "dynamic_fallback":
+            record.setdefault("rejected_facts", []).extend(
+                [
+                    raw_f64_layout_fact("rejected"),
+                    raw_f64_layout_fact("invalidated"),
+                ]
+            )
+    return records
+
+
 def image_native_records():
     proven = {"proven": {"proof": "loop_guard"}}
     input_records = [
@@ -232,7 +256,7 @@ def image_native_records():
 
 
 def loop_data_dependent_native_records():
-    return [
+    return attach_raw_f64_layout_facts([
         native_record(
             block="apush.numeric_fast.5",
             rep="f64",
@@ -284,7 +308,57 @@ def loop_data_dependent_native_records():
             bounds_state="unknown",
             materialization_reason="runtime_api",
         ),
-    ]
+    ])
+
+
+def numeric_array_native_records():
+    return attach_raw_f64_layout_facts([
+        native_record(
+            rep="f64",
+            expr_kind="NumericArrayPush",
+            consumer="js_array_numeric_push_f64_unboxed",
+            access_mode="checked_native",
+            bounds_state={"guarded": {"guard_id": "numeric_array_push_guard"}},
+        ),
+        native_record(
+            rep="js_value",
+            expr_kind="NumericArrayPush",
+            consumer="js_array_push_f64",
+            access_mode="dynamic_fallback",
+            bounds_state="unknown",
+            materialization_reason="runtime_api",
+        ),
+        native_record(
+            rep="f64",
+            expr_kind="NumericArrayIndexGet",
+            consumer="js_array_numeric_get_f64_unboxed",
+            access_mode="checked_native",
+            bounds_state={"guarded": {"guard_id": "numeric_array_index_get_guard"}},
+        ),
+        native_record(
+            rep="js_value",
+            expr_kind="NumericArrayIndexGet",
+            consumer="js_typed_feedback_array_index_get_fallback_boxed",
+            access_mode="dynamic_fallback",
+            bounds_state="unknown",
+            materialization_reason="runtime_api",
+        ),
+        native_record(
+            rep="f64",
+            expr_kind="NumericArrayIndexSet",
+            consumer="js_array_numeric_set_f64_unboxed",
+            access_mode="checked_native",
+            bounds_state={"guarded": {"guard_id": "numeric_array_index_set_guard"}},
+        ),
+        native_record(
+            rep="js_value",
+            expr_kind="NumericArrayIndexSet",
+            consumer="js_typed_feedback_array_index_set_fallback_boxed",
+            access_mode="dynamic_fallback",
+            bounds_state="unknown",
+            materialization_reason="runtime_api",
+        ),
+    ])
 
 
 class CompilerOutputRegressionTests(unittest.TestCase):
@@ -453,7 +527,7 @@ entry:
   ret i32 0
 }
 """
-        records = [
+        records = attach_raw_f64_layout_facts([
             native_record(
                 rep="f64",
                 expr_kind="NumericArrayPush",
@@ -499,7 +573,7 @@ entry:
                 bounds_state="unknown",
                 materialization_reason="runtime_api",
             ),
-        ]
+        ])
         for record in records:
             if record.get("access_mode") == "dynamic_fallback":
                 record["materialization_reason"] = None
@@ -819,7 +893,7 @@ entry:
   ret i32 0
 }
 """
-        records = [
+        records = attach_raw_f64_layout_facts([
             native_record(
                 rep="f64",
                 expr_kind="NumericArrayPush",
@@ -865,7 +939,7 @@ entry:
                 bounds_state="unknown",
                 materialization_reason="runtime_api",
             ),
-        ]
+        ])
         report = HARNESS.verify_artifacts(
             workload="numeric_arrays",
             ir_before=ir,
@@ -876,6 +950,57 @@ entry:
             native_reps=[{"records": records}],
         )
         self.assertEqual(report["status"], "pass", report["errors"])
+
+    def test_numeric_array_native_rep_checks_require_raw_layout_facts(self):
+        ir = """
+define i32 @main() {
+entry:
+  call i64 @js_array_numeric_push_f64_unboxed(i64 1, double 2.0)
+  call double @js_array_numeric_get_f64_unboxed(i64 1, i32 0)
+  call i32 @js_array_numeric_set_f64_unboxed(i64 1, i32 0, double 3.0)
+  ret i32 0
+}
+"""
+        checked_records = numeric_array_native_records()
+        for record in checked_records:
+            if record.get("access_mode") == "checked_native":
+                record["consumed_facts"] = []
+        checked_report = HARNESS.verify_artifacts(
+            workload="numeric_arrays",
+            ir_before=ir,
+            ir_after=ir,
+            assembly=GOOD_ASM,
+            benchmark={"runs": [{"exit_code": 0, "stdout_first": "25\n"}]},
+            vectorization={"vectorized_count": 0, "missed_count": 0, "analysis_count": 0},
+            native_reps=[{"records": checked_records}],
+        )
+        self.assertEqual(checked_report["status"], "fail")
+        self.assertTrue(
+            any("native_reps_required_numeric_array_push_fast_f64" in error for error in checked_report["errors"]),
+            checked_report["errors"],
+        )
+
+        fallback_records = numeric_array_native_records()
+        for record in fallback_records:
+            if record.get("access_mode") == "dynamic_fallback":
+                record["rejected_facts"] = []
+        fallback_report = HARNESS.verify_artifacts(
+            workload="numeric_arrays",
+            ir_before=ir,
+            ir_after=ir,
+            assembly=GOOD_ASM,
+            benchmark={"runs": [{"exit_code": 0, "stdout_first": "25\n"}]},
+            vectorization={"vectorized_count": 0, "missed_count": 0, "analysis_count": 0},
+            native_reps=[{"records": fallback_records}],
+        )
+        self.assertEqual(fallback_report["status"], "fail")
+        self.assertTrue(
+            any(
+                "native_reps_required_numeric_array_get_dynamic_fallback" in error
+                for error in fallback_report["errors"]
+            ),
+            fallback_report["errors"],
+        )
 
     def test_generic_native_rep_checks_reject_unexpected_materialization(self):
         ir = "define i32 @main() { entry: ret i32 0 }\n"

--- a/tests/test_typed_feedback_runtime_evidence.py
+++ b/tests/test_typed_feedback_runtime_evidence.py
@@ -68,6 +68,7 @@ class TypedFeedbackRuntimeEvidenceTest(unittest.TestCase):
             self.assertTrue(trace_path.exists(), "compiled program did not write typed-feedback trace")
 
             data = json.loads(trace_path.read_text(encoding="utf-8"))
+            self.assertGreaterEqual(data.get("invalidations", {}).get("representation", 0), 1)
             sites = data.get("sites", [])
             self.assertGreater(len(sites), 0)
             required = {
@@ -94,11 +95,25 @@ class TypedFeedbackRuntimeEvidenceTest(unittest.TestCase):
             ]
             self.assertTrue(array_set, sites)
             self.assertTrue(any(site["guard_passes"] >= 1 for site in array_set), array_set)
+            self.assertTrue(any(site["guard_failures"] >= 1 for site in array_set), array_set)
             self.assertTrue(any(site["fallback_calls"] >= 1 for site in array_set), array_set)
+            self.assertTrue(
+                any(site["invalidations"]["representation"] >= 1 for site in array_set),
+                array_set,
+            )
             array_kinds = [kind for site in array_set for kind in site["observed_kinds"]]
             self.assertTrue(any(kind.get("source") == "array" for kind in array_kinds), array_kinds)
             self.assertTrue(any(kind.get("value_kind") == "number" for kind in array_kinds), array_kinds)
             self.assertTrue(any(kind.get("value_kind") == "string" for kind in array_kinds), array_kinds)
+
+            array_get = [
+                site
+                for site in sites
+                if site.get("guard_name") == "numeric_array_index_get_guard"
+            ]
+            self.assertTrue(array_get, sites)
+            self.assertTrue(any(site["guard_failures"] >= 1 for site in array_get), array_get)
+            self.assertTrue(any(site["fallback_calls"] >= 1 for site in array_get), array_get)
 
             raw_set = [
                 site
@@ -107,7 +122,12 @@ class TypedFeedbackRuntimeEvidenceTest(unittest.TestCase):
             ]
             self.assertTrue(raw_set, sites)
             self.assertTrue(any(site["guard_passes"] >= 1 for site in raw_set), raw_set)
+            self.assertTrue(any(site["guard_failures"] >= 1 for site in raw_set), raw_set)
             self.assertTrue(any(site["fallback_calls"] >= 1 for site in raw_set), raw_set)
+            self.assertTrue(
+                any(site["invalidations"]["representation"] >= 1 for site in raw_set),
+                raw_set,
+            )
             raw_kinds = [kind for site in raw_set for kind in site["observed_kinds"]]
             self.assertTrue(
                 any(
@@ -134,6 +154,8 @@ class TypedFeedbackRuntimeEvidenceTest(unittest.TestCase):
                 if site.get("guard_name") == "class_field_get_guard"
             ]
             self.assertTrue(any(site["guard_passes"] >= 1 for site in raw_get), raw_get)
+            self.assertTrue(any(site["guard_failures"] >= 1 for site in raw_get), raw_get)
+            self.assertTrue(any(site["fallback_calls"] >= 1 for site in raw_get), raw_get)
 
 
 if __name__ == "__main__":

--- a/tests/typed_feedback_runtime_evidence.ts
+++ b/tests/typed_feedback_runtime_evidence.ts
@@ -8,7 +8,7 @@ console.log(numbers[0]);
 
 function writeArrayFallback(target: number[], value: number): void {
   target[1] = value;
-  console.log((target as any)[1]);
+  console.log(target[1]);
 }
 
 writeArrayFallback(numbers, runtimeValue());
@@ -24,7 +24,7 @@ function writeCounterSuccess(target: Counter): void {
 
 function writeCounterFallback(target: Counter, value: number): void {
   target.value = value;
-  console.log((target as any).value);
+  console.log(target.value);
 }
 
 const counter = new Counter();


### PR DESCRIPTION
## Summary

Closes #1096.

This PR adds the raw numeric storage slice on top of the typed-native foundation:

- adds guarded raw-f64 storage for numeric arrays
- adds shape-guarded raw-f64 object field slots
- records/verifies raw numeric layout facts in native proof artifacts
- teaches GC layout telemetry/proofs that numeric backing storage is pointer-free
- preserves boxed/NaN-boxed JSValue behavior at public/dynamic boundaries and downgrades on unsafe writes

## Why

Perry already carries TypeScript/HIR type facts far enough to make codegen decisions, but the runtime still needs heap layout wins. This change makes the #1096 numeric-layout path concrete: stable numeric arrays/fields can use raw-f64 storage internally while dynamic JS boundaries still see normal JS values.

## Verification

Ran after rebasing onto current `origin/main` after #1862 merged:

```bash
git diff --check origin/main...HEAD
cargo fmt --check
cargo check -p perry-runtime -p perry-codegen
cargo test -p perry-runtime array::tests::test_numeric_array -- --nocapture
cargo test -p perry-codegen --test typed_feedback -- --nocapture
```


Note: cargo emits the repo's existing warning noise; commands above completed successfully.

