### PR TITLE
fix(runtime): new Map(existingMap) copies entries (#33/#321) — needed by, but not sufficient for, Context/Layer

### DIFF
--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -1129,10 +1129,60 @@ pub extern "C" fn js_map_values(map: *const MapHeader) -> *mut crate::array::Arr
     }
 }
 
-/// Create a new Map from an array of [key, value] pair arrays.
-/// Used for `new Map([["a", 1], ["b", 2]])` construction.
+/// Copy all entries of a source Map into a freshly-allocated Map.
+/// Used by `js_map_from_array` for the `new Map(otherMap)` case: a Map is
+/// itself iterable in JS and yields `[key, value]` pairs, so cloning must
+/// preserve every entry rather than treat the MapHeader bytes as an
+/// ArrayHeader (which read `size`/`capacity` as `length`/`capacity` and
+/// produced an empty Map — the root cause of effect's `FiberRefs.updateAs`
+/// dropping every fiber-ref except the one being set; see #33/#321).
+fn copy_map_into_new(src: *const MapHeader) -> *mut MapHeader {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let src = clean_map_ptr(src);
+    if src.is_null() {
+        return js_map_alloc(4);
+    }
+    let src_handle = scope.root_raw_const_ptr(src);
+    let size = unsafe {
+        let s = src_handle.get_raw_const_ptr::<MapHeader>();
+        (*s).size as usize
+    };
+    let map = js_map_alloc(size.max(4) as u32);
+    let map_handle = scope.root_raw_mut_ptr(map);
+    for i in 0..size {
+        let (key, value) = unsafe {
+            let s = src_handle.get_raw_const_ptr::<MapHeader>();
+            if i >= (*s).size as usize {
+                break;
+            }
+            let entries = entries_ptr(s);
+            (
+                ptr::read(entries.add(i * 2)),
+                ptr::read(entries.add(i * 2 + 1)),
+            )
+        };
+        let map = map_handle.get_raw_mut_ptr::<MapHeader>();
+        js_map_set(map, key, value);
+    }
+    map_handle.get_raw_mut_ptr::<MapHeader>()
+}
+
+/// Create a new Map from an iterable source. Two shapes are supported:
+/// - an array of `[key, value]` pair arrays (`new Map([["a", 1]])`), and
+/// - another Map (`new Map(otherMap)`), whose entries are copied directly.
+///
+/// The Map case is detected first because a MapHeader and an ArrayHeader
+/// share the same `(u32, u32)` prefix but mean different things, so casting
+/// a Map to ArrayHeader silently mis-reads it. Codegen passes the raw
+/// (unboxed) pointer here for both `Expr::MapNewFromArray` shapes.
 #[no_mangle]
 pub extern "C" fn js_map_from_array(arr: *const crate::array::ArrayHeader) -> *mut MapHeader {
+    // `new Map(otherMap)`: a Map is iterable and yields [k, v] pairs. The
+    // registry check (GcHeader.obj_type fast-path + MAP_REGISTRY) is robust
+    // against false positives from the shared header prefix.
+    if !arr.is_null() && crate::map::is_registered_map(arr as usize) {
+        return copy_map_into_new(arr as *const MapHeader);
+    }
     let scope = crate::gc::RuntimeHandleScope::new();
     let arr_handle = if arr.is_null() {
         None

--- a/test-files/test_gap_map_from_map.ts
+++ b/test-files/test_gap_map_from_map.ts
@@ -1,0 +1,55 @@
+// #33/#321: `new Map(existingMap)` must copy entries. A Map is itself an
+// iterable of [key, value] pairs, so cloning one with `new Map(other)` should
+// reproduce every entry. Perry previously treated the source Map's pointer as
+// an ArrayHeader (the two share a `(u32, u32)` prefix that means different
+// things) and produced an EMPTY map — which broke effect's
+// `FiberRefs.updateAs` (`new Map(self.locals)` dropped every fiber-ref except
+// the one being set), corrupting the `currentScheduler` override and making
+// `Effect.runSync` of a `Layer`/`Context`-provided effect throw
+// "Fiber #0 cannot be resolved synchronously".
+// Run: node --experimental-strip-types test_gap_map_from_map.ts
+
+// --- new Map(existingMap) copies all entries ---
+const src = new Map<string, number>();
+src.set("x", 1);
+src.set("y", 2);
+src.set("z", 3);
+
+const copy = new Map(src);
+console.log("copy.size:", copy.size); // 3
+console.log("copy.x:", copy.get("x")); // 1
+console.log("copy.y:", copy.get("y")); // 2
+console.log("copy.z:", copy.get("z")); // 3
+console.log("copy.has(x):", copy.has("x")); // true
+
+// The copy is independent: mutating it does not touch the source.
+copy.set("x", 99);
+console.log("after copy.set x=99 -> src.x:", src.get("x")); // 1
+console.log("after copy.set x=99 -> copy.x:", copy.get("x")); // 99
+
+// --- empty source ---
+const empty = new Map<string, number>();
+const emptyCopy = new Map(empty);
+console.log("emptyCopy.size:", emptyCopy.size); // 0
+
+// --- numeric keys survive the copy ---
+const numKeys = new Map<number, string>();
+numKeys.set(1, "one");
+numKeys.set(2, "two");
+const numCopy = new Map(numKeys);
+console.log("numCopy.size:", numCopy.size); // 2
+console.log("numCopy.get(1):", numCopy.get(1)); // one
+console.log("numCopy.get(2):", numCopy.get(2)); // two
+
+// --- the array-of-entries form still works (regression guard) ---
+const fromEntries = new Map([
+  ["a", 10],
+  ["b", 20],
+]);
+console.log("fromEntries.size:", fromEntries.size); // 2
+console.log("fromEntries.a:", fromEntries.get("a")); // 10
+
+// --- new Map([...map]) (spread) still works ---
+const fromSpread = new Map([...src]);
+console.log("fromSpread.size:", fromSpread.size); // 3
+console.log("fromSpread.y:", fromSpread.get("y")); // 2


### PR DESCRIPTION
## Summary

Fixes a Perry runtime bug where `new Map(existingMap)` produced an **empty** Map, which broke effect's `Context`/`Layer` dependency injection: `Effect.runSync(Effect.provide(prog, Layer.succeed(...)))` threw `Fiber #0 cannot be resolved synchronously`.

Refs #33 / #321 (Effect framework end-to-end).

## Root cause (`crates/perry-runtime/src/map.rs`, `js_map_from_array`)

`new Map(arg)` lowers to `Expr::MapNewFromArray` → the runtime `js_map_from_array(arg)`, which iterates `arg` as an **array of `[k, v]` entries**. A JS `Map` is itself iterable and yields `[key, value]` pairs, so `new Map(otherMap)` is a valid clone — but Perry passed the `MapHeader` pointer straight into the array iterator. `MapHeader { size: u32, capacity: u32, entries: *mut f64 }` and `ArrayHeader { length: u32, capacity: u32}` share a `(u32, u32)` prefix that means different things, so the Map was mis-read and the result came back **empty**.

### Why this broke `Effect.provide` / `Layer.succeed`

effect's `FiberRefs.updateAs` (`src/internal/fiberRefs.ts`) does:

```ts
const locals = new Map(self.locals)   // clone all fiber-refs
unsafeUpdateAs(locals, fiberId, fiberRef, value)
return new FiberRefsImpl(locals)
```

With the empty-clone bug, `new Map(self.locals)` dropped **every** fiber-ref except the one being set. The lost ref that matters is `currentScheduler`: `Effect.runSync` forks the fiber with a `SyncScheduler` stored in that ref. After the first `setFiberRef` (e.g. the `provide` setting `currentContext`), the scheduler override was gone and the fiber fell back to the default (macrotask) scheduler. The Layer-build semaphore's resume task was then scheduled on a scheduler that `runSync`'s `scheduler.flush()` never drains, so the fiber stayed suspended and `unsafeRunSyncExit` raised the spurious `AsyncFiberException`.

Localized by instrumenting effect's `src/internal/fiberRefs.ts` `updateAs`: with a 2-entry source map, `new Map(self.locals)` returned size 0. Confirmed with a standalone repro (`new Map(m)` → empty in Perry, correct in Node).

## Fix

`js_map_from_array` now detects when the incoming pointer is a registered Map (`crate::map::is_registered_map`, a GcHeader `obj_type` fast-path + `MAP_REGISTRY` membership check — robust against the shared-header-prefix false positive) and copies its entries directly via a new `copy_map_into_new` helper. The existing array-of-entries fast path and `new Map([...map])` (spread) path are unchanged.

## Repro

```ts
import * as Effect from "effect/Effect";
import * as Context from "effect/Context";
import * as Layer from "effect/Layer";
class Svc extends Context.Tag("Svc")<Svc, { v: number }>() {}
const prog = Effect.map(Svc, (s) => s.v + 1);
console.log(Effect.runSync(Effect.provide(prog, Layer.succeed(Svc, { v: 41 }))));
// node: 42 ; perry before: throws "cannot be resolved synchronously"
```

## Validation

- New gap test `test-files/test_gap_map_from_map.ts` — byte-identical to `node --experimental-strip-types` (covers `new Map(map)` copy + independence, empty source, numeric keys, and the array-of-entries / spread regression guards).
- `cargo test -p perry-runtime` map suite: green.
- Regression sweep (class/object/async/closure/map/destructuring/spread gap tests): no new failures. Pre-existing, unrelated failures confirmed identical on clean `main`: `test_gap_class_advanced` (static class blocks) and `test_gap_console_methods` (known `console.dir`/`console.group*` gap).
- effect survey: the 15 numbered cases (incl. `05_gen`, `07_all`, all four `*_schema_*`) and 21 probe/real cases stay green.
- `./scripts/check_file_size.sh` passes (map.rs 1276 lines); `cargo fmt --all -- --check` clean; workspace builds (excluding cross-host UI crates).

## Known remaining blocker (separate, deferred)

With this fix the minimal repro gets past the scheduler/async error but now hits a **second, distinct, pre-existing codegen bug** that the Layer/provide path also exercises: cross-module calls to effect's `Equal.equals` (a zero-formal-parameter function that reads the JS `arguments` object — Perry models this as a synthesized `...arguments` rest param) deliver `arguments[0]`/`[1]` as `undefined` at ~34 of 36 invocations while `arguments.length` is correct. That makes `Equal.equals(oldCtx, newCtx)` wrongly return `true`, so `FiberRefs.unsafeUpdateAs` skips storing the provided context. Localized to the synthetic-`arguments` calling convention in the full-effect compilation (does not reproduce in small standalone cases; the bare-function-name keying of the cross-module signature maps — `imported_func_has_rest`/`imported_func_param_counts`/`imported_func_synthetic_arguments` — collides across effect's several `equals` exports, e.g. `Equal.equals` vs `SchemaAST.equals`). Tracked for a follow-up; this PR ships the validated Map-copy root-cause fix.
