### PR TITLE
Fix namespace process.version string methods

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -389,6 +389,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // ObjectHeader, and the outer PropertyGet routes through
             // `js_object_get_field_by_name`'s NATIVE_MODULE_CLASS_ID arm.
             if let Expr::NativeModuleRef(module_name) = object.as_ref() {
+                if module_name == "process" && property == "version" {
+                    let blk = ctx.block();
+                    let handle = blk.call(I64, "js_process_version", &[]);
+                    return Ok(nanbox_string_inline(blk, &handle));
+                }
                 let mod_idx = ctx.strings.intern(module_name);
                 let mod_bytes_global = format!("@{}", ctx.strings.entry(mod_idx).bytes_global);
                 let mod_len_str = module_name.len().to_string();

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -18,6 +18,10 @@ pub(crate) fn is_global_constructor_expr(e: &Expr, name: &str) -> bool {
         )
 }
 
+fn is_process_namespace_version_property(object: &Expr, property: &str) -> bool {
+    property == "version" && matches!(object, Expr::NativeModuleRef(module) if module == "process")
+}
+
 /// Refine an `Any`-typed local's static type based on its initializer
 /// expression. Returns Some(Type) when we can statically prove the
 /// initializer produces a more specific type, so the `Stmt::Let`
@@ -278,6 +282,9 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
             None
         }
         Expr::PropertyGet { object, property } => {
+            if is_process_namespace_version_property(object, property) {
+                return Some(HirType::String);
+            }
             // Error instance `e.message` / `e.stack` / `e.name` — all
             // return string handles via the runtime's GC_TYPE_ERROR
             // dispatch in js_object_get_field_by_name_f64. Refining to
@@ -989,6 +996,11 @@ pub(crate) fn is_definitely_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
             else_expr,
             ..
         } => is_definitely_string_expr(ctx, then_expr) && is_definitely_string_expr(ctx, else_expr),
+        Expr::PropertyGet { object, property }
+            if is_process_namespace_version_property(object, property) =>
+        {
+            true
+        }
         _ => false,
     }
 }
@@ -1138,6 +1150,15 @@ pub(crate) fn is_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         // `e.stack!.includes("...")` hit the string method fast path.
         Expr::PropertyGet { property, .. }
             if matches!(property.as_str(), "message" | "stack" | "name") =>
+        {
+            true
+        }
+        // Namespace `node:process` exports share the same runtime process
+        // surface as bare `process`. Keep the string method dispatch
+        // available for namespace imports:
+        // `import * as process from "node:process"; process.version.startsWith("v")`.
+        Expr::PropertyGet { object, property }
+            if is_process_namespace_version_property(object, property) =>
         {
             true
         }
@@ -1625,6 +1646,9 @@ pub(crate) fn static_type_of(ctx: &FnCtx<'_>, e: &Expr) -> Option<HirType> {
         Expr::Bool(_) => Some(HirType::Boolean),
         Expr::LocalGet(id) => ctx.local_types.get(id).cloned(),
         Expr::PropertyGet { object, property } => {
+            if is_process_namespace_version_property(object, property) {
+                return Some(HirType::String);
+            }
             if matches!(property.as_str(), "publicKey" | "privateKey")
                 && matches!(
                     static_type_of(ctx, object),

--- a/crates/perry-hir/src/lower/expr_call/module_class_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_class_static.rs
@@ -56,6 +56,11 @@ pub(super) fn try_module_class_static(
                                 // value-method dispatch instead of building a
                                 // bogus NativeMethodCall(class="supportedEntryTypes").
                                 | ("perf_hooks", "supportedEntryTypes")
+                                // `process.version` is a string value. Let
+                                // String.prototype methods dispatch through
+                                // the normal value-method path instead of
+                                // building NativeMethodCall(class="version").
+                                | ("process", "version")
                         );
                         // Unimplemented-API gate (#463) for the chained
                         // `mod.X.Y()` case. The lower_member gate fires

--- a/reference/deepwiki/deno-process-version-namespace-startswith-2026-05-26.md
+++ b/reference/deepwiki/deno-process-version-namespace-startswith-2026-05-26.md
@@ -1,0 +1,157 @@
+# DeepWiki Response
+
+Repository: `denoland/deno`
+Question: For Node compatibility in Deno, what source files/tests establish that the node:process namespace export version is a normal string value supporting String.prototype methods such as startsWith("v"), and that import * as process from "node:process"; process.version matches global process.version string semantics? Focus only on public source/tests useful as reference for a PerryTS/perry namespace process.version string-method dispatch fix.
+Search: https://deepwiki.com/search/for-node-compatibility-in-deno_539e6ff8-75ff-4c1a-a44f-d7e2910d2975
+
+**Question**: For Node compatibility in Deno, what source files/tests establish that the node:process namespace export version is a normal string value supporting String.prototype methods such as startsWith("v"), and that import * as process from "node:process"; process.version matches global process.version string semantics? Focus only on public source/tests useful as reference for a PerryTS/perry namespace process.version string-method dispatch fix.
+
+# Answer
+
+You're asking about which source files and tests in Deno's Node.js compatibility layer establish that `process.version` is a normal string value supporting `String.prototype` methods like `startsWith("v")`, and that both the namespace export and global `process.version` have matching string semantics.
+
+## Key Source Files
+
+The primary source file defining `process.version` is [1](#ref-q1-1) , which declares `version` as a string constant `"v24.2.0"`. This is then exported and assigned to the process object in [2](#ref-q1-2) .
+
+The `process.version` value is a plain string literal, which inherently supports all `String.prototype` methods including `startsWith()`. [3](#ref-q1-3)  includes a comment explaining that this value is hardcoded to match Node.js's latest stable release for compatibility.
+
+## Test Establishing String Semantics
+
+The test file [4](#ref-q1-4)  contains the `"process.version"` test that validates `process.version` is a string type. More specifically, [5](#ref-q1-5)  asserts `typeof process.version === "string"`.
+
+Additionally, [6](#ref-q1-6)  demonstrates that `process.report.getReport()` returns a `nodejsVersion` field that `startsWith("v")`, confirming the version string format supports this method.
+
+## Namespace Export Matching
+
+The test imports at [7](#ref-q1-7)  show `import process` from `"node:process"` alongside named exports, establishing that both the default export and namespace access work identically. The test then uses `process.version` directly (e.g., line 99), confirming that `import * as process from "node:process"; process.version` has the same string semantics as the global `process.version`.
+
+## Notes
+
+The `process.version` string is defined as a simple string constant in the polyfill layer, not a getter or special object, so it naturally supports all `String.prototype` methods. The test suite validates the type but doesn't explicitly test `startsWith("v")` on `process.version` itself—that validation appears in the `process.report` test which checks the version format. For a PerryTS/perry namespace fix, the relevant reference points are the string constant definition and the type assertions confirming it's a `string` type.
+
+Wiki pages you might want to explore:
+- [Node.js Compatibility Layer (denoland/deno)](/wiki/denoland/deno#7)
+
+View this search on DeepWiki: https://deepwiki.com/search/for-node-compatibility-in-deno_539e6ff8-75ff-4c1a-a44f-d7e2910d2975
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `ext/node/polyfills/_process/process.ts:200-208`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_process/process.ts#L200-L208)
+
+```typescript
+/**
+ * https://nodejs.org/api/process.html#process_process_version
+ *
+ * This value is hard coded to latest stable release of Node, as
+ * some packages are checking it for compatibility. Previously
+ * it pointed to Deno version, but that led to incompability
+ * with some packages.
+ */
+const version = "v24.2.0";
+```
+
+<a id="ref-q1-2"></a>
+### [2] `ext/node/polyfills/process.ts:1140-1141`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/process.ts#L1140-L1141)
+
+```typescript
+/** https://nodejs.org/api/process.html#process_process_version */
+process.version = version;
+```
+
+<a id="ref-q1-3"></a>
+### [3] `ext/node/polyfills/_process/process.ts:200-207`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_process/process.ts#L200-L207)
+
+```typescript
+/**
+ * https://nodejs.org/api/process.html#process_process_version
+ *
+ * This value is hard coded to latest stable release of Node, as
+ * some packages are checking it for compatibility. Previously
+ * it pointed to Deno version, but that led to incompability
+ * with some packages.
+ */
+```
+
+<a id="ref-q1-4"></a>
+### [4] `tests/unit_node/process_test.ts:95-122`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/tests/unit_node/process_test.ts#L95-L122)
+
+```typescript
+Deno.test({
+  name: "process.version",
+  fn() {
+    assertEquals(typeof process, "object");
+    assertEquals(typeof process.version, "string");
+    assertEquals(typeof process.versions, "object");
+    assertEquals(typeof process.versions.node, "string");
+    assertEquals(typeof process.versions.v8, "string");
+    assertEquals(typeof process.versions.uv, "string");
+    assertEquals(typeof process.versions.zlib, "string");
+    assertEquals(typeof process.versions.brotli, "string");
+    assertEquals(typeof process.versions.ares, "string");
+    assertEquals(typeof process.versions.modules, "string");
+    assertEquals(typeof process.versions.nghttp2, "string");
+    assertEquals(typeof process.versions.napi, "string");
+    // Must match the NAPI_VERSION in ext/napi/js_native_api.rs
+    assertEquals(process.versions.napi, "9");
+    assertEquals(typeof process.versions.llhttp, "string");
+    assertEquals(typeof process.versions.openssl, "string");
+    assertEquals(typeof process.versions.cldr, "string");
+    assertEquals(typeof process.versions.icu, "string");
+    assertEquals(typeof process.versions.tz, "string");
+    assertEquals(typeof process.versions.unicode, "string");
+    // These two are not present in `process.versions` in Node, but we
+    // add them anyway
+    assertEquals(typeof process.versions.deno, "string");
+    assertEquals(typeof process.versions.typescript, "string");
+  },
+```
+
+<a id="ref-q1-5"></a>
+### [5] `tests/unit_node/process_test.ts:98-99`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/tests/unit_node/process_test.ts#L98-L99)
+
+```typescript
+    assertEquals(typeof process, "object");
+    assertEquals(typeof process.version, "string");
+```
+
+<a id="ref-q1-6"></a>
+### [6] `tests/unit_node/process_test.ts:1188-1189`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/tests/unit_node/process_test.ts#L1188-L1189)
+
+```typescript
+    assert(typeof result.header.nodejsVersion === "string");
+    assert(result.header.nodejsVersion.startsWith("v"));
+```
+
+<a id="ref-q1-7"></a>
+### [7] `tests/unit_node/process_test.ts:5-23`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/tests/unit_node/process_test.ts#L5-L23)
+
+```typescript
+import process, {
+  arch as importedArch,
+  argv,
+  argv0 as importedArgv0,
+  cpuUsage as importedCpuUsage,
+  env,
+  execArgv as importedExecArgv,
+  execPath as importedExecPath,
+  getegid,
+  geteuid,
+  getgid,
+  getuid,
+  pid as importedPid,
+  platform as importedPlatform,
+  setegid,
+  seteuid,
+  setgid,
+  setuid,
+} from "node:process";
+```

--- a/test-parity/node-suite/process/version/namespace-version-startswith.ts
+++ b/test-parity/node-suite/process/version/namespace-version-startswith.ts
@@ -1,0 +1,6 @@
+import * as process from "node:process";
+import * as proc from "node:process";
+
+console.log("namespace version typeof:", typeof process.version);
+console.log("namespace version starts v:", process.version.startsWith("v"));
+console.log("namespace alias starts v:", proc.version.startsWith("v"));


### PR DESCRIPTION
## Summary

- Keep `process.version.startsWith(...)` on the value-method path instead of lowering it as `NativeMethodCall(class="version")`.
- Materialize `NativeModuleRef("process").version` through `js_process_version` and refine it as a string for string-method dispatch/local typing.
- Add a focused parity fixture covering both `import * as process from "node:process"` and an aliased namespace import.


## Verification

- `cargo fmt --package perry-hir --package perry-codegen`
- `./run_parity_tests.sh --suite node-suite --module process --filter node-suite/process/version/namespace-version-startswith` PASS
- `./run_parity_tests.sh --suite node-suite --module process --filter node-suite/process/version/version-format` PASS
- `./run_parity_tests.sh --suite node-suite --module process` PASS 75/75
- `git diff --check`
- `./run_parity_tests.sh --filter test_parity_process` expected FAIL: remaining unrelated diffs are `stdout/stderr.writable` on this branch (covered separately by #1881) and `globalThis.process` still being a number without EventEmitter methods.

## Non-goals

- `globalThis.process` EventEmitter object shape.
- `process.stdout/stderr.writable` from #1881.
- Removing the broad `test_parity_process` known-failure entry.

