### PR TITLE
fix(node:os): return buffers for userInfo buffer encoding

### DIFF
--- a/crates/perry-codegen/src/collectors/escape_objects.rs
+++ b/crates/perry-codegen/src/collectors/escape_objects.rs
@@ -446,7 +446,7 @@ pub fn check_object_literal_escapes_in_expr(
         | Expr::OsPlatform | Expr::OsArch | Expr::OsHostname | Expr::OsHomedir
         | Expr::OsTmpdir | Expr::OsTotalmem | Expr::OsFreemem | Expr::OsUptime
         | Expr::OsType | Expr::OsRelease | Expr::OsCpus | Expr::OsNetworkInterfaces
-        | Expr::OsUserInfo | Expr::OsEOL | Expr::OsDevNull | Expr::OsAvailableParallelism | Expr::OsEndianness | Expr::OsLoadavg | Expr::OsMachine | Expr::OsVersion
+        | Expr::OsUserInfo | Expr::OsUserInfoBuffer | Expr::OsEOL | Expr::OsDevNull | Expr::OsAvailableParallelism | Expr::OsEndianness | Expr::OsLoadavg | Expr::OsMachine | Expr::OsVersion
         // Collection constructors (no sub-exprs)
         | Expr::MapNew | Expr::SetNew
         // RegExp leaf accessors

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1710,6 +1710,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::OsCpus
         | Expr::OsNetworkInterfaces
         | Expr::OsUserInfo
+        | Expr::OsUserInfoBuffer
         | Expr::OsDevNull
         | Expr::OsAvailableParallelism
         | Expr::OsEndianness

--- a/crates/perry-codegen/src/expr/string_regex_proc.rs
+++ b/crates/perry-codegen/src/expr/string_regex_proc.rs
@@ -578,6 +578,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let h = blk.call(I64, "js_os_user_info", &[]);
             Ok(nanbox_pointer_inline(blk, &h))
         }
+        Expr::OsUserInfoBuffer => {
+            let blk = ctx.block();
+            let h = blk.call(I64, "js_os_user_info_buffer", &[]);
+            Ok(nanbox_pointer_inline(blk, &h))
+        }
         Expr::OsDevNull => {
             let blk = ctx.block();
             let h = blk.call(I64, "js_os_dev_null", &[]);

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -576,6 +576,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_os_totalmem", DOUBLE, &[]);
     module.declare_function("js_os_uptime", DOUBLE, &[]);
     module.declare_function("js_os_user_info", I64, &[]);
+    module.declare_function("js_os_user_info_buffer", I64, &[]);
 
     // ========== Crypto ==========
     module.declare_function("js_crypto_aes256_decrypt", I64, &[I64, I64, I64]);

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -700,6 +700,7 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
         | Expr::OsCpus
         | Expr::OsNetworkInterfaces
         | Expr::OsUserInfo
+        | Expr::OsUserInfoBuffer
         | Expr::OsEOL
         | Expr::OsDevNull
         | Expr::OsAvailableParallelism

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -942,6 +942,7 @@ pub enum Expr {
     OsCpus,                 // os.cpus() -> array of CPU info objects
     OsNetworkInterfaces,    // os.networkInterfaces() -> object
     OsUserInfo,             // os.userInfo() -> object
+    OsUserInfoBuffer,       // os.userInfo({ encoding: "buffer" }) -> object
     OsEOL,                  // os.EOL -> string ("\n" or "\r\n")
     OsDevNull,              // os.devNull -> string
     OsAvailableParallelism, // os.availableParallelism() -> number

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -13,6 +13,7 @@ use super::super::{
     extract_typed_parse_source_order, is_generator_call_expr, is_widget_modifier_name, lower_expr,
     resolve_typed_parse_ty, LoweringContext,
 };
+use super::os::user_info_expr_for_call;
 
 pub(super) fn try_global_builtins(
     ctx: &mut LoweringContext,
@@ -786,7 +787,7 @@ pub(super) fn try_global_builtins(
                     "version" => return Ok(Ok(Expr::OsVersion)),
                     "cpus" => return Ok(Ok(Expr::OsCpus)),
                     "networkInterfaces" => return Ok(Ok(Expr::OsNetworkInterfaces)),
-                    "userInfo" => return Ok(Ok(Expr::OsUserInfo)),
+                    "userInfo" => return Ok(Ok(user_info_expr_for_call(call))),
                     _ => {}
                 }
             }

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -39,6 +39,7 @@ mod module_static;
 mod native_module;
 mod nested_namespace;
 mod object_static;
+mod os;
 mod post_args_dispatch;
 mod prescans;
 mod reflect_args;

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -16,6 +16,7 @@ use super::super::{
     extract_typed_parse_source_order, is_generator_call_expr, is_widget_modifier_name, lower_expr,
     resolve_typed_parse_ty, LoweringContext,
 };
+use super::os::user_info_expr_for_call;
 
 pub(super) fn try_module_static_methods(
     ctx: &mut LoweringContext,
@@ -966,7 +967,7 @@ pub(super) fn try_module_static_methods(
                             return Ok(Ok(Expr::OsNetworkInterfaces));
                         }
                         "userInfo" => {
-                            return Ok(Ok(Expr::OsUserInfo));
+                            return Ok(Ok(user_info_expr_for_call(call)));
                         }
                         _ => {} // Fall through to generic handling
                     }

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -16,6 +16,7 @@ use super::super::{
     extract_typed_parse_source_order, is_generator_call_expr, is_widget_modifier_name, lower_expr,
     resolve_typed_parse_ty, LoweringContext,
 };
+use super::os::user_info_expr_for_call;
 
 /// Peel runtime-transparent TypeScript wrappers (`as`, `as const`, `!`,
 /// `satisfies`, angle-bracket assertions, parens) off an expression so a
@@ -335,7 +336,7 @@ pub(super) fn try_native_module_methods(
                         "version" => return Ok(Ok(Expr::OsVersion)),
                         "cpus" => return Ok(Ok(Expr::OsCpus)),
                         "networkInterfaces" => return Ok(Ok(Expr::OsNetworkInterfaces)),
-                        "userInfo" => return Ok(Ok(Expr::OsUserInfo)),
+                        "userInfo" => return Ok(Ok(user_info_expr_for_call(call))),
                         _ => {} // Fall through to generic handling
                     }
                 }

--- a/crates/perry-hir/src/lower/expr_call/os.rs
+++ b/crates/perry-hir/src/lower/expr_call/os.rs
@@ -1,0 +1,63 @@
+use swc_ecma_ast as ast;
+
+use crate::ir::Expr;
+
+pub(super) fn user_info_expr_for_call(call: &ast::CallExpr) -> Expr {
+    if first_arg_has_buffer_encoding(call) {
+        Expr::OsUserInfoBuffer
+    } else {
+        Expr::OsUserInfo
+    }
+}
+
+fn first_arg_has_buffer_encoding(call: &ast::CallExpr) -> bool {
+    let Some(first) = call.args.first() else {
+        return false;
+    };
+    if first.spread.is_some() {
+        return false;
+    }
+    let ast::Expr::Object(obj) = unwrap_ts_wrappers(first.expr.as_ref()) else {
+        return false;
+    };
+
+    obj.props.iter().any(|prop| {
+        let ast::PropOrSpread::Prop(prop) = prop else {
+            return false;
+        };
+        let ast::Prop::KeyValue(kv) = prop.as_ref() else {
+            return false;
+        };
+        prop_name_is(&kv.key, "encoding") && string_literal_is(kv.value.as_ref(), "buffer")
+    })
+}
+
+fn prop_name_is(name: &ast::PropName, expected: &str) -> bool {
+    match name {
+        ast::PropName::Ident(ident) => ident.sym == expected,
+        ast::PropName::Str(s) => s.value.as_str() == Some(expected),
+        _ => false,
+    }
+}
+
+fn string_literal_is(expr: &ast::Expr, expected: &str) -> bool {
+    match unwrap_ts_wrappers(expr) {
+        ast::Expr::Lit(ast::Lit::Str(s)) => s.value.as_str() == Some(expected),
+        _ => false,
+    }
+}
+
+fn unwrap_ts_wrappers(e: &ast::Expr) -> &ast::Expr {
+    let mut cur = e;
+    loop {
+        match cur {
+            ast::Expr::TsAs(x) => cur = &x.expr,
+            ast::Expr::TsNonNull(x) => cur = &x.expr,
+            ast::Expr::TsSatisfies(x) => cur = &x.expr,
+            ast::Expr::TsTypeAssertion(x) => cur = &x.expr,
+            ast::Expr::TsConstAssertion(x) => cur = &x.expr,
+            ast::Expr::Paren(x) => cur = x.expr.as_ref(),
+            _ => return cur,
+        }
+    }
+}

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -828,6 +828,7 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
         Expr::OsCpus => Expr::OsCpus,
         Expr::OsNetworkInterfaces => Expr::OsNetworkInterfaces,
         Expr::OsUserInfo => Expr::OsUserInfo,
+        Expr::OsUserInfoBuffer => Expr::OsUserInfoBuffer,
         Expr::OsUptime => Expr::OsUptime,
         Expr::OsEOL => Expr::OsEOL,
         Expr::OsDevNull => Expr::OsDevNull,

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -261,6 +261,7 @@ impl SH for Expr {
             Expr::OsCpus => tag(h, 211),
             Expr::OsNetworkInterfaces => tag(h, 212),
             Expr::OsUserInfo => tag(h, 213),
+            Expr::OsUserInfoBuffer => tag(h, 11221),
             Expr::OsEOL => tag(h, 214),
             Expr::OsDevNull => tag(h, 215),
             Expr::OsAvailableParallelism => tag(h, 216),

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -77,6 +77,7 @@ where
         | Expr::OsCpus
         | Expr::OsNetworkInterfaces
         | Expr::OsUserInfo
+        | Expr::OsUserInfoBuffer
         | Expr::OsEOL
         | Expr::OsDevNull
         | Expr::OsAvailableParallelism

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -78,6 +78,7 @@ where
         | Expr::OsCpus
         | Expr::OsNetworkInterfaces
         | Expr::OsUserInfo
+        | Expr::OsUserInfoBuffer
         | Expr::OsEOL
         | Expr::OsDevNull
         | Expr::OsAvailableParallelism

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -1354,6 +1354,15 @@ pub extern "C" fn js_os_network_interfaces() -> *mut ObjectHeader {
 /// TODO: Implement properly when dynamic object properties are supported
 #[no_mangle]
 pub extern "C" fn js_os_user_info() -> *mut ObjectHeader {
+    js_os_user_info_impl(false)
+}
+
+#[no_mangle]
+pub extern "C" fn js_os_user_info_buffer() -> *mut ObjectHeader {
+    js_os_user_info_impl(true)
+}
+
+fn js_os_user_info_impl(buffer_encoding: bool) -> *mut ObjectHeader {
     use crate::object::{js_object_alloc_with_shape, js_object_set_field};
     use crate::value::JSValue;
 
@@ -1391,13 +1400,25 @@ pub extern "C" fn js_os_user_info() -> *mut ObjectHeader {
         let ptr = js_string_from_bytes(s.as_ptr(), s.len() as u32);
         JSValue::string_ptr(ptr)
     };
+    let buffer_value = |s: &str| -> JSValue {
+        let ptr = js_string_from_bytes(s.as_ptr(), s.len() as u32);
+        let buf = crate::buffer::js_buffer_from_string(ptr as *const StringHeader, 0);
+        JSValue::pointer(buf as *const u8)
+    };
+    let text_value = |s: &str| -> JSValue {
+        if buffer_encoding {
+            buffer_value(s)
+        } else {
+            string_value(s)
+        }
+    };
 
     js_object_set_field(obj, 0, JSValue::number(uid));
     js_object_set_field(obj, 1, JSValue::number(gid));
-    js_object_set_field(obj, 2, string_value(&username));
-    js_object_set_field(obj, 3, string_value(&homedir));
+    js_object_set_field(obj, 2, text_value(&username));
+    js_object_set_field(obj, 3, text_value(&homedir));
     #[cfg(unix)]
-    js_object_set_field(obj, 4, string_value(&shell));
+    js_object_set_field(obj, 4, text_value(&shell));
     #[cfg(not(unix))]
     js_object_set_field(obj, 4, JSValue::null());
 

--- a/reference/deepwiki/deno-os-userinfo-buffer.md
+++ b/reference/deepwiki/deno-os-userinfo-buffer.md
@@ -1,0 +1,281 @@
+# DeepWiki Response
+
+Repository: `denoland/deno`
+Question: How does Deno's Node compatibility implementation of node:os userInfo handle the options.encoding='buffer' case? Please identify the source files and tests showing which userInfo fields are returned as Buffers versus numbers/null, and how invalid encodings are validated.
+Search: https://deepwiki.com/search/how-does-denos-node-compatibil_e57c1e37-73ad-4b87-a745-f20b561c30fc
+
+**Question**: How does Deno's Node compatibility implementation of node:os userInfo handle the options.encoding='buffer' case? Please identify the source files and tests showing which userInfo fields are returned as Buffers versus numbers/null, and how invalid encodings are validated.
+
+Deno's Node compatibility implementation of `node:os`'s `userInfo` function handles the `options.encoding='buffer'` case by returning `homedir`, `shell`, and `username` fields as `Buffer` objects, while `uid` and `gid` are returned as numbers. Invalid encodings are not explicitly validated within the `userInfo` function itself, as the `encoding` option is specifically checked for the string `'buffer'`.
+
+### `userInfo` Implementation and Buffer Handling
+The `userInfo` function is located in [1](#ref-q1-1) . When `options.encoding` is set to `'buffer'`, the `homedir`, `shell`, and `username` fields are converted to `Buffer` objects using `Buffer.from()` [2](#ref-q1-2) .
+
+The `userInfo` function retrieves user information by calling the Rust operation `op_node_os_user_info` [3](#ref-q1-3) . This operation returns the `username`, `homedir`, and `shell` as strings. The `uid` and `gid` are obtained directly from `Deno.uid()` and `Deno.gid()` respectively [4](#ref-q1-4) . On Windows, `uid` and `gid` are explicitly set to `-1` [5](#ref-q1-5) .
+
+The `op_node_os_user_info` Rust operation is defined in [6](#ref-q1-6) . This Rust function retrieves the `username` and `homedir` from the operating system. The `shell` field is currently returned as `None` (null) on Windows [7](#ref-q1-7) .
+
+### Returned Fields
+When `options.encoding='buffer'`, the `userInfo` function returns an object with the following types for its fields:
+*   `uid`: `number` [8](#ref-q1-8) 
+*   `gid`: `number` [9](#ref-q1-9) 
+*   `homedir`: `Buffer` or `null` (if the original `homedir` was null) [10](#ref-q1-10) 
+*   `shell`: `Buffer` or `null` (if the original `shell` was null) [11](#ref-q1-11) 
+*   `username`: `Buffer` [12](#ref-q1-12) 
+
+### Invalid Encoding Validation
+The `userInfo` function explicitly checks if `options?.encoding` is equal to the string `"buffer"` [10](#ref-q1-10) . If it's not `"buffer"`, it defaults to `"utf-8"` [13](#ref-q1-13) . There is no explicit validation for other invalid encoding strings within the `userInfo` function itself. However, the `Buffer.from()` method, which is used for conversion, handles various encodings and would likely throw an error for an unsupported encoding if it were passed directly. The `Buffer` object is imported from [14](#ref-q1-14) .
+
+### Tests
+The Node.js compatibility test suite includes `parallel/test-os-userinfo-handles-getter-errors.js` [15](#ref-q1-15) , which is relevant to the `os.userInfo` functionality. While this specific test focuses on error handling for getter errors, it indicates that the `userInfo` function's behavior is covered by the Node.js compatibility tests.
+
+## Notes
+The `validateEncoding` function found in [16](#ref-q1-16)  is not directly used by `os.userInfo`. It is used for `fs.readdir` and demonstrates how encoding validation might be handled in other parts of the Node compatibility layer, but it is not part of the `userInfo` implementation.
+
+Wiki pages you might want to explore:
+- [Node.js Compatibility Layer (denoland/deno)](/wiki/denoland/deno#7)
+- [Process, TTY, and OS APIs (denoland/deno)](/wiki/denoland/deno#7.7)
+
+View this search on DeepWiki: https://deepwiki.com/search/how-does-denos-node-compatibil_e57c1e37-73ad-4b87-a745-f20b561c30fc
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `ext/node/polyfills/os.ts:233-258`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/os.ts#L233-L258)
+
+```typescript
+function userInfo(
+  options = { encoding: "utf-8" },
+) {
+  let uid = Deno.uid();
+  let gid = Deno.gid();
+
+  if (isWindows) {
+    uid = -1;
+    gid = -1;
+  }
+  let { username, homedir: hd, shell } = op_node_os_user_info(uid);
+
+  if (options?.encoding === "buffer") {
+    hd = hd ? Buffer.from(hd) : hd;
+    shell = shell ? Buffer.from(shell) : shell;
+    username = Buffer.from(username);
+  }
+
+  return {
+    uid,
+    gid,
+    homedir: hd,
+    shell,
+    username,
+  };
+}
+```
+
+<a id="ref-q1-2"></a>
+### [2] `ext/node/polyfills/os.ts:245-248`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/os.ts#L245-L248)
+
+```typescript
+  if (options?.encoding === "buffer") {
+    hd = hd ? Buffer.from(hd) : hd;
+    shell = shell ? Buffer.from(shell) : shell;
+    username = Buffer.from(username);
+```
+
+<a id="ref-q1-3"></a>
+### [3] `ext/node/polyfills/os.ts:243`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/os.ts#L243)
+
+```typescript
+  let { username, homedir: hd, shell } = op_node_os_user_info(uid);
+```
+
+<a id="ref-q1-4"></a>
+### [4] `ext/node/polyfills/os.ts:236-237`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/os.ts#L236-L237)
+
+```typescript
+  let uid = Deno.uid();
+  let gid = Deno.gid();
+```
+
+<a id="ref-q1-5"></a>
+### [5] `ext/node/polyfills/os.ts:239-242`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/os.ts#L239-L242)
+
+```typescript
+  if (isWindows) {
+    uid = -1;
+    gid = -1;
+  }
+```
+
+<a id="ref-q1-6"></a>
+### [6] `ext/node/ops/os/mod.rs:134-207`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/ops/os/mod.rs#L134-L207)
+
+```rust
+#[cfg(windows)]
+fn get_user_info(_uid: u32) -> Result<UserInfo, OsError> {
+  use std::ffi::OsString;
+  use std::os::windows::ffi::OsStringExt;
+
+  use windows_sys::Win32::Foundation::CloseHandle;
+  use windows_sys::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
+  use windows_sys::Win32::Foundation::GetLastError;
+  use windows_sys::Win32::Foundation::HANDLE;
+  use windows_sys::Win32::System::Threading::GetCurrentProcess;
+  use windows_sys::Win32::System::Threading::OpenProcessToken;
+  use windows_sys::Win32::UI::Shell::GetUserProfileDirectoryW;
+  struct Handle(HANDLE);
+  impl Drop for Handle {
+    fn drop(&mut self) {
+      // SAFETY: win32 call
+      unsafe {
+        CloseHandle(self.0);
+      }
+    }
+  }
+  let mut token: MaybeUninit<HANDLE> = MaybeUninit::uninit();
+
+  // Get a handle to the current process
+  // SAFETY: win32 call
+  unsafe {
+    if OpenProcessToken(
+      GetCurrentProcess(),
+      windows_sys::Win32::Security::TOKEN_READ,
+      token.as_mut_ptr(),
+    ) == 0
+    {
+      return Err(
+        OsError::FailedToGetUserInfo(std::io::Error::last_os_error()),
+      );
+    }
+  }
+
+  // SAFETY: initialized by call above
+  let token = Handle(unsafe { token.assume_init() });
+
+  let mut bufsize = 0;
+  // get the size for the homedir buf (it'll end up in `bufsize`)
+  // SAFETY: win32 call
+  unsafe {
+    GetUserProfileDirectoryW(token.0, std::ptr::null_mut(), &mut bufsize);
+    let err = GetLastError();
+    if err != ERROR_INSUFFICIENT_BUFFER {
+      return Err(OsError::FailedToGetUserInfo(
+        std::io::Error::from_raw_os_error(err as i32),
+      ));
+    }
+  }
+  let mut path = vec![0; bufsize as usize];
+  // Actually get the homedir
+  // SAFETY: path is `bufsize` elements
+  unsafe {
+    if GetUserProfileDirectoryW(token.0, path.as_mut_ptr(), &mut bufsize) == 0 {
+      return Err(
+        OsError::FailedToGetUserInfo(std::io::Error::last_os_error()),
+      );
+    }
+  }
+  // remove trailing nul
+  path.pop();
+  let homedir_wide = OsString::from_wide(&path);
+  let homedir = homedir_wide.to_string_lossy().into_owned();
+
+  Ok(UserInfo {
+    username: deno_whoami::username(),
+    homedir,
+    shell: None,
+  })
+}
+```
+
+<a id="ref-q1-7"></a>
+### [7] `ext/node/ops/os/mod.rs:205`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/ops/os/mod.rs#L205)
+
+```rust
+    shell: None,
+```
+
+<a id="ref-q1-8"></a>
+### [8] `ext/node/polyfills/os.ts:252`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/os.ts#L252)
+
+```typescript
+    uid,
+```
+
+<a id="ref-q1-9"></a>
+### [9] `ext/node/polyfills/os.ts:253`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/os.ts#L253)
+
+```typescript
+    gid,
+```
+
+<a id="ref-q1-10"></a>
+### [10] `ext/node/polyfills/os.ts:245`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/os.ts#L245)
+
+```typescript
+  if (options?.encoding === "buffer") {
+```
+
+<a id="ref-q1-11"></a>
+### [11] `ext/node/polyfills/os.ts:246`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/os.ts#L246)
+
+```typescript
+    hd = hd ? Buffer.from(hd) : hd;
+```
+
+<a id="ref-q1-12"></a>
+### [12] `ext/node/polyfills/os.ts:247`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/os.ts#L247)
+
+```typescript
+    shell = shell ? Buffer.from(shell) : shell;
+```
+
+<a id="ref-q1-13"></a>
+### [13] `ext/node/polyfills/os.ts:234`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/os.ts#L234)
+
+```typescript
+  options = { encoding: "utf-8" },
+```
+
+<a id="ref-q1-14"></a>
+### [14] `ext/node/polyfills/os.ts:39`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/os.ts#L39)
+
+```typescript
+const { Buffer } = core.loadExtScript("ext:deno_node/internal/buffer.mjs");
+```
+
+<a id="ref-q1-15"></a>
+### [15] `tests/node_compat/config.jsonc:2558`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/tests/node_compat/config.jsonc#L2558)
+
+```
+    "parallel/test-os-userinfo-handles-getter-errors.js": {},
+```
+
+<a id="ref-q1-16"></a>
+### [16] `ext/node/polyfills/_fs/_fs_readdir.ts:45-52`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_fs/_fs_readdir.ts#L45-L52)
+
+```typescript
+function validateEncoding(encoding: string | undefined) {
+  if (!encoding || encoding === "buffer") return;
+  if (!Buffer.isEncoding(encoding)) {
+    throw new Error(
+      `TypeError [ERR_INVALID_OPT_VALUE_ENCODING]: The value "${encoding}" is invalid for option "encoding"`,
+    );
+  }
+}
+```


### PR DESCRIPTION
## Summary
- add a literal `{ encoding: "buffer" }` lowering path for `os.userInfo()` calls
- return Buffer values for `username`, `homedir`, and Unix `shell` while preserving numeric `uid`/`gid` and non-Unix `shell: null`

## Verification
- `cargo fmt --all --check`
- `cargo check -p perry-hir -p perry-codegen -p perry-runtime`
- `./scripts/check_file_size.sh`
- `./scripts/regen_api_docs.sh` (no docs drift on this branch)
- `./run_parity_tests.sh --suite node-suite --module os --filter encoding-buffer`
- `./run_parity_tests.sh --suite node-suite --module os --filter userinfo`
- `./run_parity_tests.sh --suite node-suite --module os` (34 pass / 5 existing non-goal failures)

## Non-goals
- `os.networkInterfaces()` shape parity
- `os.getPriority()` / `os.setPriority()`
- `os.tmpdir()` env edge case
- CPU object shape details
- `os.constants` identity stability

