### PR TITLE
fix(hir,compile): #35/#321 disambiguate same-named cross-module functions

### DIFF
--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -131,8 +131,37 @@ pub(crate) fn lower_module_decl(
                                 );
                             }
                         } else {
-                            // Register as imported function (we assume all imports are functions for now)
-                            ctx.register_imported_func(local.clone(), imported.clone());
+                            // Register as imported function. Issue #35 (#321):
+                            // use the LOCAL name as the original-name marker
+                            // (identity registration) — mirroring the Default
+                            // specifier's #901 fix below — so the resulting
+                            // `ExternFuncRef` carries a per-import-site UNIQUE
+                            // name. Before this, an aliased named import
+                            // registered `(local, imported)`, so the
+                            // `ExternFuncRef` carried the EXPORTED name. Two
+                            // modules exporting the SAME name (`export function
+                            // equals` in both `eqA.ts` and `eqB.ts`, imported
+                            // as `{ equals as eqA }` / `{ equals as eqB }`)
+                            // both lowered to `ExternFuncRef { name: "equals" }`
+                            // and the codegen's flat `import_function_prefixes`
+                            // lookup keyed on "equals" collided — whichever
+                            // module's prefix landed last in the HashMap won, so
+                            // BOTH `eqA(...)` and `eqB(...)` dispatched into the
+                            // same source module's `equals` body. effect's
+                            // Context/Layer DI hit this (same-named cross-module
+                            // helpers). The local name is unique per import
+                            // site, so `ExternFuncRef { name: <local> }` resolves
+                            // correctly against `import_function_prefixes` (which
+                            // already inserts both `exported_name` AND
+                            // `local_name`). The CLI's companion insert at
+                            // `crates/perry/src/commands/compile.rs` places
+                            // `local_name → exported_name` into
+                            // `import_function_origin_names` so the symbol the
+                            // codegen forms is still `perry_fn_<src>__<exported>`
+                            // — matching what the origin module emits. When
+                            // `local == imported` (the common no-alias case)
+                            // this is identical to the previous behavior.
+                            ctx.register_imported_func(local.clone(), local.clone());
                         }
                         specifiers.push(ImportSpecifier::Named { imported, local });
                     }

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -2475,6 +2475,27 @@ pub fn run_with_parse_cache(
                         }
                     }
 
+                    // Issue #35 (#321): companion to the HIR-side change in
+                    // `module_decl.rs` (Named specifier now registers
+                    // `(local, local)`, so an ALIASED named import's
+                    // `ExternFuncRef` carries the unique LOCAL name). The
+                    // origin module still emits its symbol under the EXPORTED
+                    // name, so map `local → exported_name` (or the deeper
+                    // re-export origin name when one applies) here so codegen
+                    // forms `perry_fn_<src>__<exported>` rather than
+                    // `perry_fn_<src>__<local>`. Mirrors the #901 Default-import
+                    // override below. Only needed when `local != exported`
+                    // (the alias case); the no-alias case carries the export
+                    // name verbatim. Skip if the re-export-rename block above
+                    // already inserted a (deeper) override for this local.
+                    if matches!(spec, perry_hir::ImportSpecifier::Named { .. })
+                        && local_name != exported_name
+                        && !import_function_origin_names.contains_key(&local_name)
+                    {
+                        import_function_origin_names
+                            .insert(local_name.clone(), exported_name.clone());
+                    }
+
                     // Issue #901: companion to the HIR-side change at
                     // `crates/perry-hir/src/lower.rs`'s Default specifier
                     // (which now registers `(local, local)` instead of

--- a/test-files/_helpers/same_name_xmodule_fn_a.ts
+++ b/test-files/_helpers/same_name_xmodule_fn_a.ts
@@ -1,0 +1,16 @@
+// Issue #35 / #321: models effect's same-named cross-module DI helpers.
+// Module A exports a function named `equals` that takes ZERO declared
+// parameters and reads `arguments` (so its body and signature differ from
+// module B's same-named `equals`). When imported as `{ equals as eqA }`,
+// the call must dispatch into THIS body, not module B's.
+export function equals(): any {
+  return (
+    "A:" +
+    arguments[0] +
+    "," +
+    arguments[1] +
+    " (len=" +
+    arguments.length +
+    ")"
+  );
+}

--- a/test-files/_helpers/same_name_xmodule_fn_b.ts
+++ b/test-files/_helpers/same_name_xmodule_fn_b.ts
@@ -1,0 +1,7 @@
+// Issue #35 / #321: a SECOND module exporting a function named `equals`
+// (distinct from `same_name_xmodule_fn_a.ts`'s `equals`). This one has two
+// normal parameters and a different body. Imported as `{ equals as eqB }`,
+// the call must dispatch into THIS body, not module A's.
+export function equals(x: number, y: number): any {
+  return "B:" + (x + y);
+}

--- a/test-files/test_gap_same_name_xmodule_fn.ts
+++ b/test-files/test_gap_same_name_xmodule_fn.ts
@@ -1,0 +1,30 @@
+// Issue #35 / #321: same-named functions exported from DIFFERENT modules,
+// imported under distinct aliases, must each dispatch into their OWN module's
+// body / signature.
+//
+// effect's Context/Layer DI hit this: helper functions with identical names
+// live in separate modules. Perry resolved imported functions (and their
+// signatures) by BARE NAME — two modules both exporting `equals` collided.
+// The HIR lowered an aliased named import `{ equals as eqA }` to
+// `ExternFuncRef { name: "equals" }` (the EXPORTED name), so both `eqA(...)`
+// and `eqB(...)` carried the same name and the codegen's flat
+// `import_function_prefixes` lookup keyed on "equals" picked whichever module's
+// prefix landed last in the HashMap — BOTH calls dispatched into one module's
+// body with the wrong signature.
+//
+// Fix (mirrors the #901 Default-import fix): a non-native named import now
+// registers `(local, local)` so its `ExternFuncRef` carries the UNIQUE local
+// name, and the CLI maps `local -> exported_name` in
+// `import_function_origin_names` so the emitted symbol stays
+// `perry_fn_<src>__<exported>`. Compared byte-for-byte against
+// `node --experimental-strip-types`.
+import { equals as eqA } from "./_helpers/same_name_xmodule_fn_a.ts";
+import { equals as eqB } from "./_helpers/same_name_xmodule_fn_b.ts";
+
+// eqA reads `arguments` (zero declared params); eqB uses two normal params.
+console.log("eqA:", eqA("P", "Q")); // A:P,Q (len=2)
+console.log("eqB:", eqB(3, 4)); // B:7
+
+// Call again in the reverse order to make sure neither dispatch got rebound.
+console.log("eqB2:", eqB(10, 20)); // B:30
+console.log("eqA2:", eqA("X", "Y", "Z")); // A:X,Y (len=3)


### PR DESCRIPTION
## Summary

Same-named functions exported from **different** modules, imported under distinct aliases, were conflated by Perry: both calls resolved to the wrong function body/signature. This is the function analog of the recently-merged same-named-**class** disambiguation (PR #1853) and the final blocker investigated for `effect/Context` + `effect/Layer` DI under epic #321 (internal task #35).

Refs #35 #321.

## Repro (minimal, no effect dependency)

`eqA.ts`: `export function equals(): any { return "A:" + arguments[0] + "," + arguments[1] + " (len=" + arguments.length + ")"; }`
`eqB.ts`: `export function equals(x: number, y: number): any { return "B:" + (x + y); }`
`main2.ts`:

    import { equals as eqA } from "./eqA.ts";
    import { equals as eqB } from "./eqB.ts";
    console.log("eqA:", eqA("P", "Q"));
    console.log("eqB:", eqB(3, 4));

| | eqA("P","Q") | eqB(3,4) |
|---|---|---|
| Node | `A:P,Q (len=2)` | `B:7` |
| Perry (before) | `B:P` | `B:3,4` |
| Perry (after) | `A:P,Q (len=2)` | `B:7` |

Before the fix BOTH imports dispatched into module B's body with B's signature.

## Root cause

An aliased named import lowered to an `ExternFuncRef` carrying the **exported** name, not the per-import-site-unique local alias:

- `crates/perry-hir/src/lower/module_decl.rs:135` registered `(local, imported)` for a named import, so `lookup_imported_func("eqA")` returned `"equals"` and the call lowered to `ExternFuncRef { name: "equals" }` — discarding which module it came from.
- Codegen resolves the cross-module symbol via the **flat** `import_function_prefixes: HashMap<String, String>` keyed by bare name (`crates/perry-codegen/src/codegen/opts.rs:98`, consumed at `crates/perry-codegen/src/lower_call/extern_func.rs:790`). Two modules both exporting `equals` overwrote each other's entry — the **last** one in the HashMap won, so both `eqA(...)` and `eqB(...)` formed `perry_fn_<last_module>__equals` and dispatched into the same body. The signature maps (`imported_func_param_counts` / `imported_func_has_rest` / `imported_func_synthetic_arguments`) collide the same way.

This is exactly the collision the `#680` namespace-member fix (`namespace_member_prefixes`) and the `#901` default-import fix already solved for their respective import shapes; aliased **named** imports were the remaining gap.

## Fix

Mirrors the #901 Default-import fix end-to-end (carry a unique local name through HIR, translate back to the export name for the symbol suffix):

- **`crates/perry-hir/src/lower/module_decl.rs`** — a non-native named import now registers `(local, local)` (identity), so its `ExternFuncRef` carries the unique local alias `eqA` / `eqB`. When `local == imported` (the common no-alias case) this is byte-identical to the previous behavior.
- **`crates/perry/src/commands/compile.rs`** — for an aliased named import (`local != exported`), insert `local -> exported_name` into `import_function_origin_names` so the emitted symbol stays `perry_fn_<src>__<exported>` (matching what the origin module emits). The CLI already inserted `import_function_prefixes[local]` and the signature maps under both names, so resolution lands on the correct source module.

No new fields, no risky core-codegen surgery — the existing per-site plumbing (built for #901/#680) just receives the unique local key it was designed for.

## Validation

- **`main2.ts`** (+ a 3-module variant + reverse-order calls): byte-identical to `node --experimental-strip-types`.
- **New gap test** `test-files/test_gap_same_name_xmodule_fn.ts` (+ `_helpers/same_name_xmodule_fn_{a,b}.ts`): byte-identical to Node; the pre-fix binary produces the wrong `B:...` output, the fixed binary matches.
- **effect survey** (`/private/tmp/effect-dod-ref/survey`): all 41 cases (numbered 01–31 incl. `05_gen`, `07_all`, the four `*_schema_*`, plus all `real*`/`probe*` and the two Layer cases) produce **byte-identical** output before vs after — **no regression**.
- **Regression sweep**: 93 cross-module / import / re-export / closure / class / function / namespace test-files (incl. `test_issue_431_cross_module_class_collision`, `test_issue_392_cross_module_method_dispatch`, `test_issue_310_namespace_reexport`, `test_lodash_default_import_methods`, `test_ramda_user_import`, `test_issue_678_reexport_default`) — **93/93 byte-identical baseline-vs-fixed, 0 diffs**.
- `cargo fmt --all -- --check` clean; `scripts/check_file_size.sh` OK; workspace release build green; `perry-hir` (111) + `perry-codegen` (63) lib tests pass.

## effect Layer status — STILL BLOCKED (necessary, not sufficient)

`nlay.ts` (expect `42`) and `real3_context_layer.ts` (expect `ctx/layer: Hello, Ada`) **still throw** `Uncaught exception: {}` / `Error: {}`, and the output is **identical before and after this fix** — so the Layer blocker is downstream of the same-named-function collision, not caused by it (matching the prior investigation's note that "undefined-args is downstream of call-site bundling"). This PR removes one confirmed correctness bug on the path to Layer/DI; the remaining `Error: {}` is a separate issue to localize next.
