### PR TITLE
fix(node:os): treat string constants as value method receivers

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/module_class_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_class_static.rs
@@ -61,6 +61,11 @@ pub(super) fn try_module_class_static(
                                 // the normal value-method path instead of
                                 // building NativeMethodCall(class="version").
                                 | ("process", "version")
+                                // `os.EOL` / `os.devNull` are string-valued
+                                // module properties, so `os.devNull.includes(x)`
+                                // is a String method on the property value.
+                                | ("os", "EOL")
+                                | ("os", "devNull")
                         );
                         // Unimplemented-API gate (#463) for the chained
                         // `mod.X.Y()` case. The lower_member gate fires


### PR DESCRIPTION
## Summary
- keep os.EOL and os.devNull out of the module.Class.staticMethod lowering path
- let calls such as os.devNull.includes(...) lower as normal String method calls on the property value
- save the Deno node:os string-property reference used for this slice

## Verification
- cargo fmt --all --check
- cargo check -p perry-hir
- ./scripts/check_file_size.sh
- ./scripts/regen_api_docs.sh
- ./run_parity_tests.sh --suite node-suite --module os --filter tmpdir-env-extra
- ./run_parity_tests.sh --suite node-suite --module os --filter paths
- ./run_parity_tests.sh --suite node-suite --module os --filter dev-null
- ./run_parity_tests.sh --suite node-suite --module os --filter named-newer
- ./run_parity_tests.sh --suite node-suite --module os (34 pass / 5 fail; remaining failures are unrelated, with constants identity covered by #1887 and userInfo buffer encoding covered by #1884)
