### PR TITLE
fix(runtime): #36/#321 — class extends function-value inherits static props + setPrototypeOf chain

### DIFF
--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -11,6 +11,41 @@ fn get_closure_props() -> &'static Mutex<HashMap<usize, HashMap<String, f64>>> {
     CLOSURE_PROPS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// #36 / #321: `Object.setPrototypeOf(closure, protoObj)` side-table.
+///
+/// Maps a closure pointer to the NaN-box bits of the object that was set as
+/// its static prototype. effect's `Context.Tag(id)` returns a plain function
+/// `TagClass` whose `_op: "Tag"`, `[TagTypeId]`, and `[EffectTypeId]` live on
+/// `TagProto` (a regular object), wired by `Object.setPrototypeOf(TagClass,
+/// TagProto)`. Perry bakes class IDs at allocation time so it can't mutate a
+/// real prototype chain, but recording the (closure → proto) link here lets
+/// string- and symbol-keyed property reads on the closure walk to the proto's
+/// own properties — so `TagClass._op === "Tag"` and `isTag(TagClass)` hold.
+static CLOSURE_STATIC_PROTOTYPES: OnceLock<Mutex<HashMap<usize, u64>>> = OnceLock::new();
+
+fn get_closure_prototypes() -> &'static Mutex<HashMap<usize, u64>> {
+    CLOSURE_STATIC_PROTOTYPES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record `Object.setPrototypeOf(closure_ptr, proto)`. `proto_bits` is the
+/// NaN-box bits of the prototype object (POINTER-tagged). Idempotent overwrite.
+pub fn closure_set_static_prototype(closure_ptr: usize, proto_bits: u64) {
+    if closure_ptr == 0 {
+        return;
+    }
+    if let Ok(mut map) = get_closure_prototypes().lock() {
+        map.insert(closure_ptr, proto_bits);
+    }
+}
+
+/// Look up the static prototype object bits recorded for a closure, if any.
+pub fn closure_static_prototype(closure_ptr: usize) -> Option<u64> {
+    get_closure_prototypes()
+        .lock()
+        .ok()
+        .and_then(|map| map.get(&closure_ptr).copied())
+}
+
 fn barrier_closure_dynamic_props(owner: usize, props: &mut HashMap<String, f64>) {
     for value in props.values_mut() {
         crate::gc::runtime_write_barrier_external_slot(
@@ -128,6 +163,46 @@ pub fn closure_get_dynamic_prop(ptr: usize, prop: &str) -> f64 {
                 return val;
             }
         }
+    }
+    // #36 / #321: own prop miss — walk the closure's static prototype chain
+    // (`Object.setPrototypeOf(closure, protoObj)`). Reads a string-keyed field
+    // off the proto object. Lets effect's `TagClass._op` resolve to "Tag" on
+    // the proto. Bounded depth guards against an accidental cycle.
+    let mut cur = ptr;
+    let mut depth = 0usize;
+    while depth < 8 {
+        let Some(proto_bits) = closure_static_prototype(cur) else {
+            break;
+        };
+        let proto_f64 = f64::from_bits(proto_bits);
+        let proto_ptr = crate::value::js_nanbox_get_pointer(proto_f64) as usize;
+        if proto_ptr == 0 || proto_ptr == cur {
+            break;
+        }
+        // The proto may itself be a closure (rare) or a regular object. For a
+        // regular object, read the named field via the field getter; for a
+        // closure, recurse via its own props. Distinguish by CLOSURE_MAGIC.
+        if is_closure_ptr(proto_ptr) {
+            if let Ok(props) = get_closure_props().lock() {
+                if let Some(p) = props.get(&proto_ptr).and_then(|m| m.get(prop)) {
+                    return *p;
+                }
+            }
+            cur = proto_ptr;
+            depth += 1;
+            continue;
+        }
+        unsafe {
+            let key_hdr = crate::string::js_string_from_bytes(prop.as_ptr(), prop.len() as u32);
+            let v = crate::object::js_object_get_field_by_name(
+                proto_ptr as *const crate::object::ObjectHeader,
+                key_hdr as *const crate::StringHeader,
+            );
+            if !v.is_undefined() && !v.is_null() {
+                return f64::from_bits(v.bits());
+            }
+        }
+        break;
     }
     f64::from_bits(crate::value::TAG_UNDEFINED)
 }

--- a/crates/perry-runtime/src/closure/mod.rs
+++ b/crates/perry-runtime/src/closure/mod.rs
@@ -47,7 +47,8 @@ pub(crate) use dynamic_props::{
 };
 pub use dynamic_props::{
     closure_dynamic_props_snapshot, closure_get_dynamic_prop, closure_set_dynamic_prop,
-    is_closure_ptr, js_closure_unbind_this, scan_closure_dynamic_props_roots_mut,
+    closure_set_static_prototype, closure_static_prototype, is_closure_ptr, js_closure_unbind_this,
+    scan_closure_dynamic_props_roots_mut,
 };
 
 // v8_stubs re-exports the AOT stubs + non-macOS Rust V8-interop stubs.

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -77,6 +77,26 @@ pub static FUNCTION_CLASS_IDS: RwLock<Option<HashMap<u64, u32>>> = RwLock::new(N
 // usage is guaranteed.
 pub static CLASS_PROTOTYPE_OBJECTS: RwLock<Option<HashMap<u32, usize>>> = RwLock::new(None);
 
+/// #36 / #321: maps a child class_id to the raw address of a parent CLOSURE
+/// (function value) when `class Child extends <function value> {}`. effect's
+/// `class Svc extends Context.Tag("Svc")<...>() {}` extends the function
+/// `TagClass` returned by `Tag(id)()`. In JS this sets `Svc.__proto__ =
+/// TagClass` so static-property reads on `Svc` (`Svc.key`, `Svc._op`,
+/// `Svc[TagTypeId]`) walk to the parent function's own props + ITS static
+/// prototype. Perry's existing dynamic-parent path only models OBJECT parents
+/// (class-expression values), so this records the closure-parent axis so the
+/// class-ref static getters can reach the closure's props and proto chain.
+/// Stored as `usize` (raw address) for Send + Sync; converted back at use.
+pub static CLASS_PARENT_CLOSURES: RwLock<Option<HashMap<u32, usize>>> = RwLock::new(None);
+
+/// Look up the parent-closure address recorded for a child class_id, if any.
+pub(crate) fn class_parent_closure(class_id: u32) -> Option<usize> {
+    CLASS_PARENT_CLOSURES
+        .read()
+        .ok()
+        .and_then(|g| g.as_ref().and_then(|m| m.get(&class_id).copied()))
+}
+
 /// Synthetic class id allocator for prototype-object classes. High bit
 /// set (0x8000_0000+) to keep them separate from codegen-assigned ids
 /// (which start from 1 and grow by module). u32 wraparound is not a
@@ -1583,6 +1603,19 @@ pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, parent_value: 
         let ptr = crate::value::js_nanbox_get_pointer(parent_value) as *mut ObjectHeader;
         if !ptr.is_null() && js_object_get_class_id(ptr as *const ObjectHeader) != 0 {
             let mut write = CLASS_PROTOTYPE_OBJECTS.write().unwrap();
+            if write.is_none() {
+                *write = Some(HashMap::new());
+            }
+            write.as_mut().unwrap().insert(class_id, ptr as usize);
+        } else if !ptr.is_null() && crate::closure::is_closure_ptr(ptr as usize) {
+            // #36 / #321: the parent is a plain FUNCTION value (closure), e.g.
+            // effect's `class Svc extends Context.Tag("Svc")<...>() {}`. Record
+            // the closure-parent edge so static-field reads on the subclass
+            // (`Svc.key`, `Svc._op`, `Svc[TagTypeId]`) walk to the parent
+            // function's own props + ITS static prototype. The parent class_id
+            // edge isn't wired (a closure carries no class_id), so this is the
+            // only inheritance link for a function-valued superclass.
+            let mut write = CLASS_PARENT_CLOSURES.write().unwrap();
             if write.is_none() {
                 *write = Some(HashMap::new());
             }

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -934,6 +934,19 @@ pub extern "C" fn js_object_get_field_by_name(
                             return v;
                         }
                     }
+                    // #36 / #321: the subclass extends a FUNCTION value
+                    // (`class Svc extends Context.Tag(id)<...>() {}`). Read the
+                    // named static off the parent closure — its OWN props
+                    // (`Svc.key` → "Svc") plus, via the closure getter, its
+                    // static prototype (`Svc._op` → "Tag" on TagProto).
+                    if let Some(closure_ptr) = super::class_registry::class_parent_closure(class_id)
+                    {
+                        let v = crate::closure::closure_get_dynamic_prop(closure_ptr, name);
+                        let vb = JSValue::from_bits(v.to_bits());
+                        if !vb.is_undefined() && !vb.is_null() {
+                            return vb;
+                        }
+                    }
                 }
             }
             return JSValue::undefined();

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1244,9 +1244,28 @@ fn str_from_value(v: f64) -> *const crate::string::StringHeader {
 /// thread-local side-table so a downstream `Object.getPrototypeOf(obj)`
 /// + inherited property dispatch can consult it.
 #[no_mangle]
-pub extern "C" fn js_object_set_prototype_of(obj_value: f64, _proto: f64) -> f64 {
-    // Spec: `Object.setPrototypeOf(O, proto)` returns O. We deliberately
-    // do nothing else — see the function doc above for the trade-off.
+pub extern "C" fn js_object_set_prototype_of(obj_value: f64, proto: f64) -> f64 {
+    // #36 / #321: when the target is a closure (a plain function value) and the
+    // proto is an object, record the (closure → proto) link in the closure
+    // static-prototype side-table. effect's `Context.Tag(id)` returns a
+    // function `TagClass` whose `_op`/`[TagTypeId]`/`[EffectTypeId]` live on a
+    // `TagProto` object wired in via `Object.setPrototypeOf(TagClass,
+    // TagProto)`. Recording the link lets later string/symbol property reads on
+    // the closure (and on a subclass that `extends TagClass`) walk to the
+    // proto's own properties, so the Tag is recognized as a valid Effect.
+    let obj_bits = obj_value.to_bits();
+    let proto_bits = proto.to_bits();
+    const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+    if (obj_bits & 0xFFFF_0000_0000_0000) == POINTER_TAG
+        && (proto_bits & 0xFFFF_0000_0000_0000) == POINTER_TAG
+    {
+        let obj_ptr = crate::value::js_nanbox_get_pointer(obj_value) as usize;
+        let proto_ptr = crate::value::js_nanbox_get_pointer(proto) as usize;
+        if obj_ptr != 0 && proto_ptr != 0 && crate::closure::is_closure_ptr(obj_ptr) {
+            crate::closure::closure_set_static_prototype(obj_ptr, proto_bits);
+        }
+    }
+    // Spec: `Object.setPrototypeOf(O, proto)` returns O.
     obj_value
 }
 

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -676,6 +676,20 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
         if let Some(v) = crate::object::resolve_proto_chain_symbol(class_id, sym_f64) {
             return v;
         }
+        // #36 / #321: the subclass extends a FUNCTION value
+        // (`class Svc extends Context.Tag(id)<...>() {}`). Read the symbol off
+        // the parent closure — own symbol props plus, via the closure symbol
+        // getter, its static prototype (`Svc[TagTypeId]`/`Svc[EffectTypeId]`
+        // live on TagProto). Recurse into the closure-aware getter so its proto
+        // walk fires.
+        if let Some(closure_ptr) = crate::object::class_parent_closure(class_id) {
+            let closure_f64 =
+                f64::from_bits(crate::value::js_nanbox_pointer(closure_ptr as i64).to_bits());
+            let v = js_object_get_symbol_property(closure_f64, sym_f64);
+            if v.to_bits() != TAG_UNDEFINED {
+                return v;
+            }
+        }
         return f64::from_bits(TAG_UNDEFINED);
     }
     // #1213: Timeout/Immediate handles expose `Symbol.dispose` so
@@ -702,6 +716,49 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
     }
     if let Some(v) = own_symbol_property(obj_f64, sym_f64) {
         return v;
+    }
+    // #36 / #321: the receiver is a closure whose OWN symbol props miss — walk
+    // its static prototype chain (`Object.setPrototypeOf(closure, protoObj)`).
+    // effect's `TagClass[TagTypeId]` / `isTag(TagClass)` read symbols off
+    // `TagProto`. Bounded depth guards against an accidental cycle.
+    if (bits >> 48) == 0x7FFD {
+        let ptr = crate::value::js_nanbox_get_pointer(obj_f64) as usize;
+        if ptr != 0 && crate::closure::is_closure_ptr(ptr) {
+            let mut cur = ptr;
+            let mut depth = 0usize;
+            while depth < 8 {
+                let Some(proto_bits) = crate::closure::closure_static_prototype(cur) else {
+                    break;
+                };
+                let proto_f64 = f64::from_bits(proto_bits);
+                let proto_ptr = crate::value::js_nanbox_get_pointer(proto_f64) as usize;
+                if proto_ptr == 0 || proto_ptr == cur {
+                    break;
+                }
+                if let Some(v) = own_symbol_property(proto_f64, sym_f64) {
+                    return v;
+                }
+                // A class-object proto may carry the symbol through ITS own
+                // class_id prototype chain (effect's TagProto spreads
+                // EffectPrototype). Walk that before following the closure link.
+                let proto_obj = crate::value::JSValue::from_bits(proto_bits)
+                    .as_pointer::<crate::object::ObjectHeader>();
+                if !proto_obj.is_null() {
+                    let cid = crate::object::js_object_get_class_id(proto_obj);
+                    if cid != 0 {
+                        if let Some(v) = crate::object::resolve_proto_chain_symbol(cid, sym_f64) {
+                            return v;
+                        }
+                    }
+                }
+                if crate::closure::is_closure_ptr(proto_ptr) {
+                    cur = proto_ptr;
+                    depth += 1;
+                    continue;
+                }
+                break;
+            }
+        }
     }
     // #321: arrays expose `Symbol.iterator`. perry has no standalone array
     // iterator object (for-of is special-cased), but `arr[Symbol.iterator]`

--- a/test-files/test_gap_class_extends_function_static.ts
+++ b/test-files/test_gap_class_extends_function_static.ts
@@ -1,0 +1,39 @@
+// Issue #36 / #321 (effect Context/Layer): a class DECLARATION that `extends`
+// a plain FUNCTION value (not a class) must inherit the parent function's OWN
+// static properties AND any properties on the function's static prototype
+// (`Object.setPrototypeOf(fn, protoObj)`).
+//
+// effect's `Context.Tag(id)` returns a function `TagClass` with `TagClass.key
+// = id` (an OWN static) whose `_op: "Tag"` / `[TagTypeId]` live on a `TagProto`
+// object wired in via `Object.setPrototypeOf(TagClass, TagProto)`. User code
+// then writes `class Svc extends Context.Tag("Svc")<...>() {}`, so reading
+// `Svc.key` / `Svc._op` must walk the static prototype chain to the parent
+// function and ITS proto. Pre-fix Perry returned `undefined` for all of them,
+// which made effect treat the Tag as a non-Effect and the fiber died with a
+// `Cause.die(<TypeError reading '_V'>)` that pretty-printed as `{}`.
+//
+// Expected output:
+// Parent.key direct: K
+// Parent._op direct: Tag
+// Child.key: K
+// Child._op: Tag
+// Child.marker: 123
+// typeof Child: function
+
+const Proto: any = { _op: "Tag", marker: 123 };
+function makeParent(id: string) {
+  function P() {}
+  Object.setPrototypeOf(P, Proto);
+  (P as any).key = id;
+  return P as any;
+}
+
+const Parent = makeParent("K");
+console.log("Parent.key direct:", (Parent as any).key);
+console.log("Parent._op direct:", (Parent as any)._op);
+
+class Child extends Parent {}
+console.log("Child.key:", (Child as any).key);
+console.log("Child._op:", (Child as any)._op);
+console.log("Child.marker:", (Child as any).marker);
+console.log("typeof Child:", typeof Child);


### PR DESCRIPTION
## Summary

Third fix in the `effect/Context` + `effect/Layer` DI series (epic #321, task #36). On main (with the two prior fixes — `new Map(existingMap)` #1871 and same-named cross-module fns #1888), running a `Context`/`Layer`-provided effect threw `(FiberFailure) Error: {}`.

This PR fixes the documented `{}` defect's root cause: **a `class` that `extends` a plain FUNCTION value did not inherit the parent function's static properties.** It is a clean, contained, regression-free runtime fix (no codegen change) and a prerequisite for effect DI. It is **necessary but not sufficient** for the full Layer repro — there are two further, separate downstream bugs (localized below) that still block end-to-end Layer execution.

## What the `{}` defect was

Instrumenting effect's run-loop catch (`internal/fiberRuntime.ts`) showed the thrown value `e` had `msg = "Cannot read properties of undefined (reading '_V')"` and `cur._op = undefined` — i.e. the version check `cur[EffectTypeId]._V` failed because `cur[EffectTypeId]` was `undefined`. `cur` was the `Svc` Tag.

`effect/Context`'s `Tag(id)` returns a function `TagClass` with an OWN static `TagClass.key = id`, and `_op: "Tag"` / `[TagTypeId]` / `[EffectTypeId]` on a `TagProto` object wired via `Object.setPrototypeOf(TagClass, TagProto)`. User code writes `class Svc extends Context.Tag("Svc")<...>() {}`.

In Perry, `Svc.key`, `Svc._op`, and `isTag(Svc)` (= `TagTypeId in Svc`) all returned `undefined`/`false`, so effect treated the Tag as a non-Effect → `Cause.die(<TypeError>)` → the `{}` FiberFailure.

## Root cause (file:line)

`class Svc extends <call expr>` is lowered to the #711 dynamic-parent path (`RegisterClassParentDynamic`). Two gaps:

1. `crates/perry-runtime/src/object/object_ops.rs` — `js_object_set_prototype_of` was a **no-op**, so `Object.setPrototypeOf(TagClass, TagProto)` contributed nothing: `TagClass._op` / `TagClass[TagTypeId]` were unreachable.
2. `crates/perry-runtime/src/object/class_registry.rs` — `js_register_class_parent_dynamic` only recorded OBJECT (class-expression) parents in `CLASS_PROTOTYPE_OBJECTS` (gated on `class_id != 0`). A plain function-value superclass (a closure, `class_id == 0`) was dropped entirely, so the subclass `Svc.key` (an OWN static on the parent closure) and `Svc._op` (on the parent's setPrototypeOf proto) had nothing to walk to.

## Fix (runtime side-tables only — no codegen change)

- `object_ops.rs`: `js_object_set_prototype_of(closure, protoObj)` now records the closure→proto link in a new `CLOSURE_STATIC_PROTOTYPES` side-table.
- `closure/dynamic_props.rs`: `closure_get_dynamic_prop` walks that proto chain on own-prop miss (string keys). Adds `closure_set_static_prototype` / `closure_static_prototype`.
- `symbol.rs`: `js_object_get_symbol_property` walks the closure's static prototype (and the proto's own class_id symbol chain) for symbol keys on a closure receiver.
- `class_registry.rs`: `js_register_class_parent_dynamic` records a closure parent in a new `CLASS_PARENT_CLOSURES` map when the superclass is a function value.
- `field_get_set.rs` / `symbol.rs`: class-ref static getters (string + symbol) consult `CLASS_PARENT_CLOSURES` after the existing `CLASS_PROTOTYPE_OBJECTS` walk misses, reading the parent closure's own props + its proto chain.

The new paths only fire when the existing class-expression-parent paths miss, so there is no behavior change for the #1788/#809 cases.

## Minimal repro (standalone, no effect)

`test-files/test_gap_class_extends_function_static.ts`:

```ts
const Proto: any = { _op: "Tag", marker: 123 };
function makeParent(id: string) {
  function P() {}
  Object.setPrototypeOf(P, Proto);
  (P as any).key = id;
  return P as any;
}
const Parent = makeParent("K");
class Child extends Parent {}
console.log((Child as any).key, (Child as any)._op, (Child as any).marker);
// pre-fix: undefined undefined undefined ; post-fix + node: K Tag 123
```

## Validation

- New gap test: byte-identical to Node.
- Effect Tag identity now works: `Svc.key`, `Svc._op`, `isTag(Svc)`, `TagClass._op`, `isTag(TagClass)` all match Node.
- Regression sweep (24 tests, byte-vs-Node): all PASS — incl. `test_gap_class_expr_extends_static*`, `test_gap_in_operator_closure`, `test_gap_object_create_chain_symbol`, `test_constructor_prototype_method`, `test_get_prototype_of_instance`, `test_class_static_symbol`, `test_compat_objects_symbols`, closures/this/generic-class.
- Effect survey (Node-comparable cases): 11/11 non-schema PASS (incl. `05_gen`, `07_all`, `09_either`). The 4 `*_schema_*` cases fail **identically on the branch base (pre-fix) and with the fix** — confirmed pre-existing (#684 Schema blocker), not a regression (verified via `git stash` + baseline rebuild).
- `cargo fmt --all -- --check` clean; `scripts/check_file_size.sh` clean; full workspace `cargo build --release` (excl. cross-host UI crates) succeeds.

## Does the Layer repro now FULLY work?

**No — necessary but not sufficient.** With this fix the Tag-identity `{}` defect is resolved, but the `nlay.ts` / `real3_context_layer.ts` Layer repros still throw `{}`, now from **two further separate downstream bugs** (localized for follow-up):

1. **`internalCall` try/finally drops the return value.** effect's `Utils.ts` selects `internalCall = isNotOptimizedAway ? standard : forced`, where `isNotOptimizedAway = Error().stack.includes("effect_internal_function")`. Perry's `Error().stack` has no function names → `isNotOptimizedAway === false` → effect uses `forced = (body) => { try { return body() } finally {} }`. `OP_WITH_RUNTIME` calls `internalCall(() => op.effect_instruction_i0(this, status))`; instrumenting `forced` showed `body()` returns a valid object and `return __v` executes, yet **the caller receives `undefined`** — the try/finally function's return value is lost in this specific compiled context. Forcing `internalCall = standard` makes the run loop advance past this. I could not reduce it to a standalone Perry repro (every reduction — cross-module imported, ternary-selected, this-capturing, nested-closure — returns correctly), so it needs deeper codegen investigation.
2. **`unsafeMap.size` undefined.** With `internalCall` forced to `standard`, the next error is `Cannot read properties of undefined (reading 'size')` (`curOp = WithRuntime`) — a Context/FiberRef default-value issue in `effect/Context`, only visible once bug #1 is bypassed.

Both are independent of the Tag-inheritance fix in this PR and should be tracked as separate issues under #321.

Refs #36 #321.
