### PR TITLE
fix(node:events): emit error monitor listeners

### DIFF
--- a/crates/perry-stdlib/src/events.rs
+++ b/crates/perry-stdlib/src/events.rs
@@ -28,6 +28,7 @@ use std::collections::HashMap;
 
 const TAG_FALSE_F64: f64 = f64::from_bits(0x7FFC_0000_0000_0003);
 const TAG_TRUE_F64: f64 = f64::from_bits(0x7FFC_0000_0000_0004);
+const ERROR_MONITOR_EVENT_NAME: &str = "Symbol(events.errorMonitor)";
 
 fn bool_to_js(value: bool) -> f64 {
     if value {
@@ -185,10 +186,42 @@ unsafe fn string_from_header(ptr: *const StringHeader) -> Option<String> {
     if ptr.is_null() {
         return None;
     }
+
+    let sym_ptr = ptr as *const perry_runtime::symbol::SymbolHeader;
+    if (*sym_ptr).magic == perry_runtime::symbol::SYMBOL_MAGIC {
+        let sym_value = js_nanbox_pointer(ptr as i64);
+        let rendered = perry_runtime::symbol::js_symbol_to_string(sym_value);
+        return string_from_header(rendered as *const StringHeader);
+    }
+
     let len = (*ptr).byte_len as usize;
     let data_ptr = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
     let bytes = std::slice::from_raw_parts(data_ptr, len);
     Some(String::from_utf8_lossy(bytes).to_string())
+}
+
+unsafe fn dispatch_error_monitor(emitter: &mut EventEmitterHandle, arg: Option<f64>) {
+    let snapshot: Vec<Listener> = match emitter.events.get(ERROR_MONITOR_EVENT_NAME) {
+        Some(v) if !v.is_empty() => v.clone(),
+        _ => return,
+    };
+    if snapshot.iter().any(|l| l.once) {
+        if let Some(v) = emitter.events.get_mut(ERROR_MONITOR_EVENT_NAME) {
+            v.retain(|l| !l.once);
+        }
+        emitter.prune_event_if_empty(ERROR_MONITOR_EVENT_NAME);
+    }
+
+    for l in snapshot {
+        if l.callback != 0 {
+            let closure_ptr = l.callback as *const ClosureHeader;
+            if let Some(arg) = arg {
+                js_closure_call1(closure_ptr, arg);
+            } else {
+                js_closure_call0(closure_ptr);
+            }
+        }
+    }
 }
 
 /// Create a new EventEmitter
@@ -353,14 +386,17 @@ pub unsafe extern "C" fn js_event_emitter_emit(
             }
         }
 
-        if event_name == "error" && snapshot.is_empty() {
-            perry_runtime::exception::js_throw(first_arg_or_undefined(args_ptr));
+        let first_arg = first_arg_or_undefined(args_ptr);
+        if event_name == "error" {
+            dispatch_error_monitor(emitter, Some(first_arg));
+            if snapshot.is_empty() {
+                perry_runtime::exception::js_throw(first_arg);
+            }
         }
 
         // Resolve any pending `events.once` Promises before dispatch.
         drain_pending_once_promises(emitter, &event_name, args_ptr);
 
-        let first_arg = first_arg_or_undefined(args_ptr);
         for l in snapshot {
             if l.callback != 0 {
                 let closure_ptr = l.callback as *const ClosureHeader;
@@ -400,8 +436,11 @@ pub unsafe extern "C" fn js_event_emitter_emit0(
         }
 
         let empty_args = js_array_alloc(0);
-        if event_name == "error" && snapshot.is_empty() {
-            perry_runtime::exception::js_throw(f64::from_bits(TAG_UNDEFINED_F64_BITS));
+        if event_name == "error" {
+            dispatch_error_monitor(emitter, None);
+            if snapshot.is_empty() {
+                perry_runtime::exception::js_throw(f64::from_bits(TAG_UNDEFINED_F64_BITS));
+            }
         }
         drain_pending_once_promises(emitter, &event_name, empty_args);
 

--- a/reference/deepwiki/deno-node-events-error-monitor-2026-05-26.md
+++ b/reference/deepwiki/deno-node-events-error-monitor-2026-05-26.md
@@ -1,0 +1,429 @@
+# DeepWiki Response
+
+Repository: `denoland/deno`
+Question: For Deno's Node compatibility layer, how does EventEmitter emit the node:events errorMonitor symbol when emit('error', err) is called? Focus on listener registration keying, order relative to regular error listeners, and whether the original error is still thrown when there are no regular error listeners.
+Search: https://deepwiki.com/search/for-denos-node-compatibility-l_f2740b34-94e3-4449-a706-6bbf9777fcbf
+
+**Question**: For Deno's Node compatibility layer, how does EventEmitter emit the node:events errorMonitor symbol when emit('error', err) is called? Focus on listener registration keying, order relative to regular error listeners, and whether the original error is still thrown when there are no regular error listeners.
+
+In Deno's Node compatibility layer, when `emit('error', err)` is called on an `EventEmitter` instance, the `errorMonitor` symbol is emitted before any regular `'error'` listeners. The original error is still thrown if no regular `'error'` listeners are registered. [1](#ref-q1-1)
+
+### Listener Registration and Keying [2](#ref-q1-2)
+The `errorMonitor` symbol is a `unique symbol` defined as `kErrorMonitor` [3](#ref-q1-3) . It is exposed as a static property `EventEmitter.errorMonitor` [4](#ref-q1-4) . Listeners for `errorMonitor` are registered using this symbol as the event type, similar to how regular event listeners are registered for string-based event names [2](#ref-q1-2) .
+
+### Order Relative to Regular Error Listeners [1](#ref-q1-1)
+When `emit('error', ...args)` is called, the `EventEmitter.prototype.emit` method first checks if there are any listeners registered for `kErrorMonitor` [5](#ref-q1-5) . If `kErrorMonitor` listeners exist, `this.emit(kErrorMonitor, ...args)` is called *before* checking for or emitting to regular `'error'` listeners [6](#ref-q1-6) . This ensures that `errorMonitor` listeners are always invoked first. [6](#ref-q1-6)
+
+### Error Throwing Behavior [7](#ref-q1-7)
+If, after the `errorMonitor` listeners have been called, there are *no* regular `'error'` listeners registered for the `'error'` event (i.e., `events.error === undefined`), the `EventEmitter` will throw the original error [8](#ref-q1-8) . If the emitted argument is not an instance of `Error`, it will be wrapped in an `ERR_UNHANDLED_ERROR` and then thrown [9](#ref-q1-9) . This behavior is consistent with Node.js's `EventEmitter` where an `'error'` event without a listener will crash the process. [10](#ref-q1-10)
+
+## Notes
+The `EventEmitter` implementation in Deno's Node compatibility layer is located in `ext/node/polyfills/_events.mjs` [11](#ref-q1-11) . The TypeScript declaration for `errorMonitor` is found in `cli/tsc/dts/node/events.d.cts` [12](#ref-q1-12)  and `ext/node/polyfills/_events.d.ts` [13](#ref-q1-13) . The `tests/node_compat/config.jsonc` file indicates that there are compatibility tests specifically for `test-event-emitter-error-monitor.js`, confirming that this behavior is tested [14](#ref-q1-14) .
+
+Wiki pages you might want to explore:
+- [File System Operations (denoland/deno)](/wiki/denoland/deno#3.4)
+- [Node.js Compatibility Layer (denoland/deno)](/wiki/denoland/deno#7)
+
+View this search on DeepWiki: https://deepwiki.com/search/for-denos-node-compatibility-l_f2740b34-94e3-4449-a706-6bbf9777fcbf
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `ext/node/polyfills/_events.mjs:384-392`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_events.mjs#L384-L392)
+
+```
+EventEmitter.prototype.emit = function emit(type, ...args) {
+  let doError = type === "error";
+
+  const events = this._events;
+  if (events !== undefined) {
+    if (doError && events[kErrorMonitor] !== undefined) {
+      this.emit(kErrorMonitor, ...args);
+    }
+    doError = doError && events.error === undefined;
+```
+
+<a id="ref-q1-2"></a>
+### [2] `ext/node/polyfills/_events.mjs:468-540`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_events.mjs#L468-L540)
+
+```
+function _addListener(target, type, listener, prepend) {
+  let m;
+  let events;
+  let existing;
+
+  checkListener(listener);
+
+  events = target._events;
+  if (events === undefined) {
+    events = target._events = ObjectCreate(null);
+    target._eventsCount = 0;
+  } else {
+    // To avoid recursion in the case that type === "newListener"! Before
+    // adding it to the listeners, first emit "newListener".
+    if (events.newListener !== undefined) {
+      target.emit("newListener", type, listener.listener ?? listener);
+
+      // Re-assign `events` because a newListener handler could have caused the
+      // this._events to be assigned to a new object
+      events = target._events;
+    }
+    existing = events[type];
+  }
+
+  if (existing === undefined) {
+    // Optimize the case of one listener. Don't need the extra array object.
+    events[type] = listener;
+    ++target._eventsCount;
+  } else {
+    if (typeof existing === "function") {
+      // Adding the second element, need to change to array.
+      existing = events[type] = prepend
+        ? [listener, existing]
+        : [existing, listener];
+      // If we've already got an array, just append.
+    } else if (prepend) {
+      ArrayPrototypeUnshift(existing, listener);
+    } else {
+      ArrayPrototypePush(existing, listener);
+    }
+
+    // Check for listener leak
+    m = _getMaxListeners(target);
+    if (m > 0 && existing.length > m && !existing.warned) {
+      existing.warned = true;
+      // No error code for this since it is a Warning
+      // eslint-disable-next-line no-restricted-syntax
+      const w = new Error(
+        "Possible EventEmitter memory leak detected. " +
+          `${existing.length} ${String(type)} listeners ` +
+          `added to ${inspect(target, { depth: -1 })}. ` +
+          `MaxListeners is ${m}.`,
+      );
+      w.name = "MaxListenersExceededWarning";
+      w.emitter = target;
+      w.type = type;
+      w.count = existing.length;
+      process.emitWarning(w);
+    }
+  }
+
+  return target;
+}
+
+/**
+ * Adds a listener to the event emitter.
+ * @param {string | symbol} type
+ * @param {Function} listener
+ * @returns {EventEmitter}
+ */
+EventEmitter.prototype.addListener = function addListener(type, listener) {
+  return _addListener(this, type, listener, false);
+};
+```
+
+<a id="ref-q1-3"></a>
+### [3] `ext/node/polyfills/_events.mjs:88`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_events.mjs#L88)
+
+```
+const kErrorMonitor = Symbol("events.errorMonitor");
+```
+
+<a id="ref-q1-4"></a>
+### [4] `ext/node/polyfills/_events.mjs:128`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_events.mjs#L128)
+
+```
+EventEmitter.errorMonitor = kErrorMonitor;
+```
+
+<a id="ref-q1-5"></a>
+### [5] `ext/node/polyfills/_events.mjs:388-389`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_events.mjs#L388-L389)
+
+```
+  if (events !== undefined) {
+    if (doError && events[kErrorMonitor] !== undefined) {
+```
+
+<a id="ref-q1-6"></a>
+### [6] `ext/node/polyfills/_events.mjs:389-390`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_events.mjs#L389-L390)
+
+```
+    if (doError && events[kErrorMonitor] !== undefined) {
+      this.emit(kErrorMonitor, ...args);
+```
+
+<a id="ref-q1-7"></a>
+### [7] `ext/node/polyfills/_events.mjs:397-431`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_events.mjs#L397-L431)
+
+```
+  // If there is no 'error' event listener then throw.
+  if (doError) {
+    let er;
+    if (args.length > 0) {
+      er = args[0];
+    }
+    if (er instanceof Error) {
+      try {
+        const capture = {};
+        ErrorCaptureStackTrace(capture, EventEmitter.prototype.emit);
+        // ObjectDefineProperty(er, kEnhanceStackBeforeInspector, {
+        //   value: enhanceStackTrace.bind(this, er, capture),
+        //   configurable: true
+        // });
+      } catch {
+        // pass
+      }
+
+      // Note: The comments on the `throw` lines are intentional, they show
+      // up in Node's output if this results in an unhandled exception.
+      throw er; // Unhandled 'error' event
+    }
+
+    let stringifiedEr;
+    try {
+      stringifiedEr = inspect(er);
+    } catch {
+      stringifiedEr = er;
+    }
+
+    // At least give some kind of context to the user
+    const err = new ERR_UNHANDLED_ERROR(stringifiedEr);
+    err.context = er;
+    throw err; // Unhandled 'error' event
+  }
+```
+
+<a id="ref-q1-8"></a>
+### [8] `ext/node/polyfills/_events.mjs:397-417`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_events.mjs#L397-L417)
+
+```
+  // If there is no 'error' event listener then throw.
+  if (doError) {
+    let er;
+    if (args.length > 0) {
+      er = args[0];
+    }
+    if (er instanceof Error) {
+      try {
+        const capture = {};
+        ErrorCaptureStackTrace(capture, EventEmitter.prototype.emit);
+        // ObjectDefineProperty(er, kEnhanceStackBeforeInspector, {
+        //   value: enhanceStackTrace.bind(this, er, capture),
+        //   configurable: true
+        // });
+      } catch {
+        // pass
+      }
+
+      // Note: The comments on the `throw` lines are intentional, they show
+      // up in Node's output if this results in an unhandled exception.
+      throw er; // Unhandled 'error' event
+```
+
+<a id="ref-q1-9"></a>
+### [9] `ext/node/polyfills/_events.mjs:427-430`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_events.mjs#L427-L430)
+
+```
+    // At least give some kind of context to the user
+    const err = new ERR_UNHANDLED_ERROR(stringifiedEr);
+    err.context = er;
+    throw err; // Unhandled 'error' event
+```
+
+<a id="ref-q1-10"></a>
+### [10] `ext/node/polyfills/_events.mjs:417`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_events.mjs#L417)
+
+```
+      throw er; // Unhandled 'error' event
+```
+
+<a id="ref-q1-11"></a>
+### [11] `ext/node/polyfills/_events.mjs:31-180`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_events.mjs#L31-L180)
+
+```
+  ArrayPrototypePush,
+  ArrayPrototypeShift,
+  ArrayPrototypeUnshift,
+  Error,
+  ErrorCaptureStackTrace,
+  FunctionPrototypeCall,
+  FunctionPrototypeApply,
+  ObjectCreate,
+  ObjectDefineProperty,
+  ObjectEntries,
+  ObjectGetPrototypeOf,
+  ObjectSetPrototypeOf,
+  ReflectOwnKeys,
+  SafeMap,
+  SafeSet,
+  Symbol,
+  SymbolFor,
+  SymbolAsyncIterator,
+} = primordials;
+
+const kRejection = SymbolFor("nodejs.rejection");
+const kWatermarkData = SymbolFor("nodejs.watermarkData");
+const kEvents = Symbol("kEvents");
+
+const { inspect } = core.loadExtScript(
+  "ext:deno_node/internal/util/inspect.mjs",
+);
+const { kEmptyObject } = core.loadExtScript("ext:deno_node/internal/util.mjs");
+const {
+  AbortError,
+  ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_THIS,
+  ERR_UNHANDLED_ERROR,
+} = core.loadExtScript("ext:deno_node/internal/errors.ts");
+
+const lazyAsyncHooks = core.createLazyLoader("node:async_hooks");
+const {
+  validateAbortSignal,
+  validateBoolean,
+  validateFunction,
+  validateInteger,
+  validateNumber,
+  validateObject,
+  validateString,
+} = core.loadExtScript("ext:deno_node/internal/validators.mjs");
+const { spliceOne } = core.loadExtScript("ext:deno_node/_utils.ts");
+const { nextTick } = core.loadExtScript("ext:deno_node/_process/process.ts");
+const {
+  eventTargetData,
+  kResistStopImmediatePropagation,
+} = core.loadExtScript("ext:deno_web/02_event.js");
+
+const { addAbortListener } = core.loadExtScript(
+  "ext:deno_node/internal/events/abort_listener.mjs",
+);
+const kFirstEventParam = Symbol("kFirstEventParam");
+const kCapture = Symbol("kCapture");
+const kErrorMonitor = Symbol("events.errorMonitor");
+const kMaxEventTargetListeners = Symbol("events.maxEventTargetListeners");
+const kMaxEventTargetListenersWarned = Symbol(
+  "events.maxEventTargetListenersWarned",
+);
+
+/**
+ * Creates a new `EventEmitter` instance.
+ * @param {{ captureRejections?: boolean; }} [opts]
+ * @returns {EventEmitter}
+ */
+function EventEmitter(opts) {
+  FunctionPrototypeCall(EventEmitter.init, this, opts);
+}
+EventEmitter.on = on;
+EventEmitter.once = once;
+EventEmitter.getEventListeners = getEventListeners;
+EventEmitter.setMaxListeners = setMaxListeners;
+EventEmitter.getMaxListeners = getMaxListeners;
+EventEmitter.listenerCount = listenerCount;
+// Backwards-compat with node 0.10.x
+EventEmitter.EventEmitter = EventEmitter;
+EventEmitter.usingDomains = false;
+
+EventEmitter.captureRejectionSymbol = kRejection;
+const captureRejectionSymbol = EventEmitter.captureRejectionSymbol;
+const errorMonitor = EventEmitter.errorMonitor;
+
+ObjectDefineProperty(EventEmitter, "captureRejections", {
+  get() {
+    return EventEmitter.prototype[kCapture];
+  },
+  set(value) {
+    validateBoolean(value, "EventEmitter.captureRejections");
+
+    EventEmitter.prototype[kCapture] = value;
+  },
+  enumerable: true,
+});
+
+EventEmitter.errorMonitor = kErrorMonitor;
+
+// The default for captureRejections is false
+ObjectDefineProperty(EventEmitter.prototype, kCapture, {
+  value: false,
+  writable: true,
+  enumerable: false,
+});
+
+EventEmitter.prototype._events = undefined;
+EventEmitter.prototype._eventsCount = 0;
+EventEmitter.prototype._maxListeners = undefined;
+
+// By default EventEmitters will print a warning if more than 10 listeners are
+// added to it. This is a useful default which helps finding memory leaks.
+let defaultMaxListeners = 10;
+
+function checkListener(listener) {
+  validateFunction(listener, "listener");
+}
+
+ObjectDefineProperty(EventEmitter, "defaultMaxListeners", {
+  enumerable: true,
+  get: function () {
+    return defaultMaxListeners;
+  },
+  set: function (arg) {
+    validateNumber(arg, "defaultMaxListeners", 0);
+    defaultMaxListeners = arg;
+  },
+});
+
+Object.defineProperties(EventEmitter, {
+  kMaxEventTargetListeners: {
+    value: kMaxEventTargetListeners,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  },
+  kMaxEventTargetListenersWarned: {
+    value: kMaxEventTargetListenersWarned,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  },
+});
+
+/**
+ * Sets the max listeners.
+ * @param {number} n
+ * @param {EventTarget[] | EventEmitter[]} [eventTargets]
+ * @returns {void}
+ */
+```
+
+<a id="ref-q1-12"></a>
+### [12] `cli/tsc/dts/node/events.d.cts:444`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/cli/tsc/dts/node/events.d.cts#L444)
+
+```
+        static readonly errorMonitor: unique symbol;
+```
+
+<a id="ref-q1-13"></a>
+### [13] `ext/node/polyfills/_events.d.ts:8`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/_events.d.ts#L8)
+
+```typescript
+export const errorMonitor: unique symbol;
+```
+
+<a id="ref-q1-14"></a>
+### [14] `tests/node_compat/config.jsonc:1118`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/tests/node_compat/config.jsonc#L1118)
+
+```
+    "parallel/test-event-emitter-error-monitor.js": {},
+```

--- a/test-parity/node-suite/events/errors/error-monitor.ts
+++ b/test-parity/node-suite/events/errors/error-monitor.ts
@@ -5,3 +5,10 @@ const seen: string[] = [];
 ee.on(errorMonitor, (err: any) => seen.push("monitor:" + err.message));
 try { ee.emit("error", new Error("boom")); } catch (err: any) { seen.push("caught:" + err.message); }
 console.log("seen:", seen.join(","));
+
+const handled = new EventEmitter();
+const handledSeen: string[] = [];
+handled.on(errorMonitor, (err: any) => handledSeen.push("monitor:" + err.message));
+handled.on("error", (err: any) => handledSeen.push("handler:" + err.message));
+const returned = handled.emit("error", new Error("handled"));
+console.log("handled:", handledSeen.join(","), returned);


### PR DESCRIPTION
## Summary
- dispatch `events.errorMonitor` listeners before normal `emit("error", err)` handling
- preserve Node behavior where the original error is still thrown when there is no regular `"error"` listener
- normalize symbol event-name arguments at the native boundary enough for the exported `errorMonitor` symbol
- extend the parity fixture to cover both no-handler throw behavior and monitor-before-handler ordering

Part of https://github.com/PerryTS/perry/issues/793.


## Before
- `./run_parity_tests.sh --suite node-suite --module events --filter error-monitor` failed: Perry skipped the monitor listener and only caught the thrown error.

## After
- `./run_parity_tests.sh --suite node-suite --module events --filter error-monitor`
  - PASS 1/1
- `./run_parity_tests.sh --suite node-suite --module events --filter errors`
  - PASS 4/4
- `./run_parity_tests.sh --suite node-suite --module events --filter module-properties`
  - PASS 1/1
- `cargo test -p perry-stdlib --no-default-features --features "bundled-events crypto" events --lib`
  - PASS 1/1, 34 filtered
- `./run_parity_tests.sh --suite node-suite --module events`
  - completed above threshold: 42 pass / 9 residual mismatches; `error-monitor` PASS
  - residual mismatches are unrelated/open lanes: capture rejections, symbol eventNames rendering, addAbortListener disposal detail, removeListener meta flag (#1882), EventTarget static helpers, max-listener invalid-count validation (#1893), async iterator abort, once abort/error, and once multiple args
- `jq empty test-parity/known_failures.json`
- `git diff --check`
- `cargo fmt --check`

## Non-goals
- no general symbol-keyed EventEmitter parity claim
- no capture-rejection behavior changes
- no addAbortListener/EventTarget/async-iterator/once behavior changes
- no max-listener validation changes; that is covered by #1893

