### PR TITLE
fix(codegen): #37/#321 catch-less try/finally must re-propagate exceptions (not swallow)

### DIFF
--- a/crates/perry-codegen/src/stmt/try_stmt.rs
+++ b/crates/perry-codegen/src/stmt/try_stmt.rs
@@ -9,8 +9,13 @@ use super::*;
 ///   2. Call setjmp(jmpbuf) — returns 0 on first call, non-0 after longjmp
 ///   3. Branch: 0 → try_body, non-0 → catch_entry
 ///   4. try_body runs, calls js_try_end(), branches to finally
-///   5. catch_entry calls js_try_end(), reads exception, runs catch, branches to finally
-///   6. finally runs (if present), then falls through to merge
+///   5. catch_entry calls js_try_end(). With a user `catch`: reads the
+///      exception, runs catch, branches to finally. WITHOUT a `catch`
+///      (a `try/finally` with no handler): captures the exception, runs
+///      a dedicated copy of the finally body, then re-raises via
+///      js_throw so the throw propagates instead of being swallowed.
+///   6. finally runs (if present), then falls through to merge (only the
+///      normal-completion path reaches this merge finally)
 pub(crate) fn lower_try(
     ctx: &mut FnCtx<'_>,
     body: &[perry_hir::Stmt],
@@ -101,12 +106,39 @@ pub(crate) fn lower_try(
             ctx.block().store(DOUBLE, &exc, &slot);
         }
         lower_stmts(ctx, &clause.body)?;
-    }
-    if !ctx.block().is_terminated() {
-        ctx.block().br(&finally_label);
+        if !ctx.block().is_terminated() {
+            ctx.block().br(&finally_label);
+        }
+    } else {
+        // No catch clause: this is a `try { ... } finally { ... }`
+        // (or a bare `try { ... } finally {}`). The longjmp landed
+        // here because the try body threw. ECMAScript requires the
+        // finally to run and then the ORIGINAL exception to RE-PROPAGATE
+        // — it must NOT be swallowed. Previously this block only did
+        // `js_try_end()` + fell through to the shared merge finally and
+        // the function returned `undefined`, silently eating the throw.
+        //
+        // Issue #37 / effect's `internalCall` "forced" path:
+        // `try { return body() } finally {}` swallowed body()'s throw,
+        // surfacing as `(FiberFailure) Error: {}`.
+        //
+        // Capture the pending exception BEFORE running finally (the
+        // finally body may touch exception state), run a dedicated copy
+        // of the finally body on this exception path, then re-raise via
+        // js_throw — unless the finally itself completed abruptly (a
+        // `return`/`throw` inside finally overrides the pending
+        // exception, per spec), in which case its own terminator stands.
+        let exc = ctx.block().call(DOUBLE, "js_get_exception", &[]);
+        if let Some(f) = finally {
+            lower_stmts(ctx, f)?;
+        }
+        if !ctx.block().is_terminated() {
+            ctx.block().call_void("js_throw", &[(DOUBLE, &exc)]);
+            ctx.block().unreachable();
+        }
     }
 
-    // --- finally / merge ---
+    // --- finally / merge (normal-completion path) ---
     ctx.current_block = finally_idx;
     if let Some(f) = finally {
         lower_stmts(ctx, f)?;

--- a/test-files/test_gap_try_finally_no_catch_rethrow.ts
+++ b/test-files/test_gap_try_finally_no_catch_rethrow.ts
@@ -1,0 +1,104 @@
+// Issue #37 / #321: `try { ... } finally { ... }` with NO catch clause must
+// run the finally and then RE-PROPAGATE the original exception — it must not
+// be swallowed. Previously Perry's setjmp landing pad for a catch-less
+// try/finally ran `js_try_end()`, fell through to the finally/merge, and
+// returned `undefined`, silently eating the throw. This surfaced in the
+// effect framework's `internalCall` "forced" path
+// (`try { return body() } finally {}`) as a dropped return value.
+
+// 1. Empty finally, body throws — exception must propagate.
+function inner1(): number {
+  throw new Error("boom");
+}
+function wrap1(): number {
+  try {
+    return inner1();
+  } finally {
+    // empty
+  }
+}
+try {
+  const r = wrap1();
+  console.log("wrap1 returned (WRONG):", r);
+} catch (e) {
+  console.log("wrap1 caught:", (e as Error).message);
+}
+
+// 2. Non-empty finally, body throws — finally runs, then exception propagates.
+let cleanups = 0;
+function inner2(): string {
+  throw new Error("kaboom");
+}
+function wrap2(): string {
+  try {
+    return inner2();
+  } finally {
+    cleanups++;
+  }
+}
+try {
+  wrap2();
+  console.log("wrap2 returned (WRONG)");
+} catch (e) {
+  console.log("wrap2 caught:", (e as Error).message, "cleanups:", cleanups);
+}
+
+// 3. Normal completion (no throw) still returns the value and runs finally.
+let ran = 0;
+function wrap3(): number {
+  try {
+    return 99;
+  } finally {
+    ran++;
+  }
+}
+console.log("wrap3:", wrap3(), "ran:", ran);
+
+// 4. Indirect call through a function-valued variable (the effect shape):
+//    a generic arrow holding `try { return body() } finally {}` that the
+//    caller invokes; when body throws the exception must propagate.
+const forced = <A>(body: () => A): A => {
+  try {
+    return body();
+  } finally {
+  }
+};
+try {
+  forced(() => {
+    throw new Error("indirect");
+  });
+  console.log("forced returned (WRONG)");
+} catch (e) {
+  console.log("forced caught:", (e as Error).message);
+}
+
+// 5. finally with its own `return` overrides the pending exception (spec).
+function wrap5(): string {
+  try {
+    throw new Error("overridden");
+  } finally {
+    return "from-finally"; // eslint-disable-line no-unsafe-finally
+  }
+}
+console.log("wrap5:", wrap5());
+
+// 6. Nested catch-less try/finally inside an outer try/catch — propagates
+//    out through both finallies to the outer catch.
+let order: string[] = [];
+function wrap6(): number {
+  try {
+    try {
+      throw new Error("nested");
+    } finally {
+      order.push("inner-finally");
+    }
+  } finally {
+    order.push("outer-finally");
+  }
+}
+try {
+  wrap6();
+  console.log("wrap6 returned (WRONG)");
+} catch (e) {
+  console.log("wrap6 caught:", (e as Error).message, "order:", order.join(","));
+}


### PR DESCRIPTION
## Summary

Fixes a real Perry codegen correctness bug: a `try { ... } finally { ... }` with **no `catch` clause** silently **swallows exceptions** thrown in the try body, returning `undefined` instead of re-propagating. Per ECMAScript, the finally must run and then the original exception must propagate.

This is angle (A) (the root correctness fix) from internal task #37 under epic #321 (effect Context/Layer DI). It is a genuine, isolated correctness improvement with a standalone repro and zero regression in Perry's own exception/async/closure/generator test suite.

**Important — read the "Effect Layer status" section below before merging.** This fix alone does NOT unblock the effect Layer path and in fact regresses the effect survey by unmasking a separate, deeper pre-existing bug (effect's `dual`/`arguments.length`). The true #37/#321 blocker is that deeper gap, not try/finally.

## Root cause (file:line)

`crates/perry-codegen/src/stmt/try_stmt.rs` — `lower_try()`.

The try/finally CFG uses setjmp/longjmp. When the try body throws, control longjmps into the `catch_idx` block. For a try with a user `catch`, that block reads the exception and runs the handler. But when there is **no** catch clause (a `try/finally`), the block only did `js_try_end()` and fell through to the shared finally/merge, after which the function emitted the implicit `ret undefined` — eating the throw.

LLVM evidence (effect's `forced` arrow `(body) => { try { return body() } finally {} }`):

```
try.catch.2:
  call void @js_try_end()
  br label %try.finally.3
try.finally.3:
  ret double 0x7FFC000000000001   ; <- returns undefined, exception lost
```

## Fix

In `lower_try`, the catch block's no-catch arm now:
1. captures the pending exception (`js_get_exception`) before running finally,
2. runs a dedicated copy of the finally body on the exception path,
3. re-raises via `js_throw` (+ `unreachable`) — unless the finally itself completes abruptly (a `return`/`throw` in finally overrides the pending exception, per spec).

The normal-completion path still runs the merge finally and falls through unchanged. +38/-6 lines.

## Repro

Standalone (was wrong, now correct):

```ts
function inner(): number { throw new Error("boom"); }
function wrap(): number { try { return inner(); } finally {} }
try { console.log("got:", wrap()); } catch (e) { console.log("caught:", (e as Error).message); }
// Node: caught: boom        Perry (before): got: 0        Perry (after): caught: boom
```

Gap test `test-files/test_gap_try_finally_no_catch_rethrow.ts` covers: empty finally + throw, non-empty finally + throw, normal completion, indirect call through a function-valued arrow (the effect shape), finally-return override, and nested catch-less try/finally. Byte-identical to `node --experimental-strip-types`.

## How this surfaced (effect)

effect's `Utils.ts` `internalCall` picks one of two impls at module load based on whether `new Error().stack` contains the wrapper's function name (`isNotOptimizedAway`). On Perry the stack lacks function names, so effect picks the `forced` impl: `(body) => { try { return body() } finally {} }`. With the swallow bug, when `body()` threw, `forced` returned `undefined` to the caller (e.g. `OP_WITH_RUNTIME` in `fiberRuntime.ts`), presenting as `(FiberFailure) Error: {}`. Confirmed via instrumentation: `body()` produced a valid object, yet the caller received `undefined`, with the corresponding `forced` "returning" log missing because `body()` had thrown.

## Effect Layer status (NEW state) — why this does not fully unblock #37 yet

With this fix, `survey/nlay.ts` and `survey/real3_context_layer.ts` advance **past** the `internalCall` swallow (no more `Error: {}`). They now hit a **separate, deeper, pre-existing** error: `TypeError: value is not a function`.

A symbolized backtrace localizes it precisely:

```
js_throw_type_error_not_a_function
  perry_fn_..._Function_ts__pipe          (effect pipe)
  ..._internal_metric_hook_ts__28
  MetricRegistryImpl__getHistogram        (registry.ts:44 pipe(this.map, MutableHashMap.get(...), Option.getOrUndefined))
  FiberRuntime__reportExitValue           (fiberRuntime.ts:825 fiberLifetimes.unsafeUpdate)
  FiberRuntime__setExitValue / evaluateEffect / start
```

`reportExitValue` is gated by `runtimeFlags_.runtimeMetrics(flags)` which is `isEnabled(self, RuntimeMetrics)` = `(self & 4) !== 0`. `isEnabled`/`MutableHashMap.get` are built with effect's `dual(arity, body)`, whose returned wrapper branches on `arguments.length` (`if (arguments.length >= 2) ...`). Perry currently does **not** support `arguments` (compile-time warning: "unknown identifier 'arguments' — bare reads lower to 0"), so the `dual` wrappers mis-dispatch — `runtimeMetrics` returns a function instead of `false`, the metric path runs, and `MutableHashMap.get`/`Option.getOrUndefined` resolve to non-functions and throw.

The old swallow behavior was masking this throw (it happens at fiber exit, after the result is computed), so the effect survey "passed". This fix removes the mask, so the survey regresses (11/14 effect-runtime cases) — but the underlying bug was always there. **The real #37/#321 Layer blocker is the `arguments`/`dual` gap, which is a large, separate feature.** Recommend filing it as the next granular blocker; once it lands, this try/finally fix becomes regression-free against the survey.

## Validation

- Gap test `test_gap_try_finally_no_catch_rethrow.ts`: byte-identical to Node (6 scenarios).
- Perry exception/try/finally/async sweep (15 files: `test_try_catch`, `test_issue_536_*`, `test_issue_921/928`, `test_microtask_inv_06_finally_after_await`, etc.): 14/15 byte-identical to Node; the 1 "diff" (`test_issue_510_primitive_method_typeerror`) is a pre-existing uncaught-error stack-format gap and is **identical to baseline** (not a regression).
- Broader sweep (async/closure/generator gap tests): all byte-identical.
- `cargo test -p perry-codegen`: pass.
- `cargo fmt --all -- --check`: clean. `scripts/check_file_size.sh`: clean. Workspace build (`--no-run`, UI crates excluded): green.
- Effect survey: `01_succeed`/`30_option`/`31_data` unchanged; the 11 fiber-driven cases regress to the `arguments`/`dual` throw described above (root cause separate from this change; documented for the maintainer to gate the merge).

Refs #37, #321. Do not merge until the effect-survey gate is reconciled (see "Effect Layer status").
