### PR TITLE
fix(node:stream): expose readable async iterator symbol

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -31,6 +31,8 @@ use crate::object::{
 };
 use crate::value::JSValue;
 
+mod async_iterator;
+
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
 const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
@@ -1496,7 +1498,7 @@ pub(crate) fn js_node_stream_readable_chunks_result(stream: f64) -> Result<Optio
 // WRITABLE_SHAPE_ID.
 // ─────────────────────────────────────────────────────────────────
 
-fn readable_methods() -> [(&'static str, StubFn); 30] {
+fn readable_methods() -> [(&'static str, StubFn); 31] {
     [
         ("on", cast2(ns_on2)),
         ("once", cast2(ns_on2)),
@@ -1531,6 +1533,7 @@ fn readable_methods() -> [(&'static str, StubFn); 30] {
         ("flatMap", cast2(ns_iter_flat_map)),
         ("take", cast1(ns_iter_take)),
         ("drop", cast1(ns_iter_drop)),
+        ("iterator", cast0(async_iterator::ns_async_iterator)),
         // #1539 — push() backpressure return + readable.compose() instance form.
         ("push", cast1(ns_push1)),
         ("compose", cast1(ns_compose1)),
@@ -1691,19 +1694,20 @@ fn resolve_hwm(opts: f64, specific: &[u8], specific_object_mode: &[u8]) -> f64 {
 
 /// Initialize the readable side of a stream: direction flag, buffered byte
 /// counter, effective readable highWaterMark, and the visible
-/// `readableHighWaterMark` property (#1534/#1539).
+/// `readableHighWaterMark` / `destroyed` properties (#1534/#1539).
 fn init_readable_state(stream: f64, opts: f64) {
     set_hidden_value(stream, hidden_readable_flag_key(), f64::from_bits(TAG_TRUE));
+    set_hidden_value(stream, hidden_key(b"destroyed"), f64::from_bits(TAG_FALSE));
     set_hidden_value(stream, hidden_buffered_key(), 0.0);
     let r_hwm = resolve_hwm(opts, b"readableHighWaterMark", b"readableObjectMode");
     set_hidden_value(stream, hidden_hwm_key(), r_hwm);
     set_hidden_value(stream, hidden_key(b"readableHighWaterMark"), r_hwm);
 }
 
-/// Initialize the writable side: direction flag and the visible
-/// `writableHighWaterMark` property (#1534/#1539).
+/// Initialize the writable side: direction flag and visible stream flags.
 fn init_writable_state(stream: f64, opts: f64) {
     set_hidden_value(stream, hidden_writable_flag_key(), f64::from_bits(TAG_TRUE));
+    set_hidden_value(stream, hidden_key(b"destroyed"), f64::from_bits(TAG_FALSE));
     let w_hwm = resolve_hwm(opts, b"writableHighWaterMark", b"writableObjectMode");
     set_hidden_value(stream, hidden_key(b"writableHighWaterMark"), w_hwm);
 }
@@ -1718,6 +1722,7 @@ pub extern "C" fn js_node_stream_readable_new(opts: f64) -> f64 {
         js_object_set_field_by_name(obj, hidden_read_key(), rebind_callback_this(read, readable));
     }
     init_readable_state(readable, opts);
+    async_iterator::install_readable_async_iterator_symbol(readable);
     readable
 }
 
@@ -1747,6 +1752,7 @@ pub extern "C" fn js_node_stream_duplex_new(opts: f64) -> f64 {
     }
     init_readable_state(duplex, opts);
     init_writable_state(duplex, opts);
+    async_iterator::install_readable_async_iterator_symbol(duplex);
     duplex
 }
 

--- a/crates/perry-runtime/src/node_stream/async_iterator.rs
+++ b/crates/perry-runtime/src/node_stream/async_iterator.rs
@@ -1,0 +1,116 @@
+use super::*;
+
+const READABLE_ITERATOR_SHAPE_ID: u32 = 0x7FFF_FF60;
+const READABLE_ITERATOR_STREAM_KEY: &[u8] = b"__perryReadableIteratorStream";
+const READABLE_ITERATOR_INDEX_KEY: &[u8] = b"__perryReadableIteratorIndex";
+const READABLE_ITERATOR_DONE_KEY: &[u8] = b"__perryReadableIteratorDone";
+
+fn iterator_result(value: f64, done: bool) -> f64 {
+    let obj = crate::object::js_object_alloc(0, 2);
+    js_object_set_field_by_name(obj, hidden_key(b"value"), value);
+    js_object_set_field_by_name(
+        obj,
+        hidden_key(b"done"),
+        f64::from_bits(if done { TAG_TRUE } else { TAG_FALSE }),
+    );
+    box_pointer(obj as *const u8)
+}
+
+fn readable_iterator_done() -> f64 {
+    resolved_promise(iterator_result(f64::from_bits(TAG_UNDEFINED), true))
+}
+
+extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
+    let iterator = this_value(closure);
+    if get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_DONE_KEY))
+        .is_some_and(|v| crate::value::js_is_truthy(v) != 0)
+    {
+        return readable_iterator_done();
+    }
+    let Some(stream) = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_STREAM_KEY)) else {
+        return readable_iterator_done();
+    };
+    if let Some(err) = readable_hidden_error(stream) {
+        set_hidden_value(
+            iterator,
+            hidden_key(READABLE_ITERATOR_DONE_KEY),
+            f64::from_bits(TAG_TRUE),
+        );
+        return rejected_promise(err);
+    }
+    let arr = readable_chunks_array(stream);
+    let index = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_INDEX_KEY))
+        .and_then(jsvalue_as_f64)
+        .unwrap_or(0.0)
+        .max(0.0) as u32;
+    if arr.is_null() || index >= crate::array::js_array_length(arr) {
+        set_hidden_value(
+            iterator,
+            hidden_key(READABLE_ITERATOR_DONE_KEY),
+            f64::from_bits(TAG_TRUE),
+        );
+        set_hidden_value(stream, hidden_ended_key(), f64::from_bits(TAG_TRUE));
+        return readable_iterator_done();
+    }
+    let value = crate::array::js_array_get_f64(arr, index);
+    set_hidden_value(
+        iterator,
+        hidden_key(READABLE_ITERATOR_INDEX_KEY),
+        (index + 1) as f64,
+    );
+    mark_disturbed(stream);
+    resolved_promise(iterator_result(value, false))
+}
+
+extern "C" fn ns_readable_iterator_return(closure: *const ClosureHeader) -> f64 {
+    set_hidden_value(
+        this_value(closure),
+        hidden_key(READABLE_ITERATOR_DONE_KEY),
+        f64::from_bits(TAG_TRUE),
+    );
+    readable_iterator_done()
+}
+
+extern "C" fn ns_readable_iterator_self(closure: *const ClosureHeader) -> f64 {
+    this_value(closure)
+}
+
+pub(super) extern "C" fn ns_async_iterator(closure: *const ClosureHeader) -> f64 {
+    build_readable_async_iterator(this_value(closure))
+}
+
+fn install_async_iterator_symbol(target: f64, func: extern "C" fn(*const ClosureHeader) -> f64) {
+    let async_iterator = crate::symbol::well_known_symbol("asyncIterator");
+    if async_iterator.is_null() {
+        return;
+    }
+    let closure = js_closure_alloc(func as *const u8, 1);
+    js_closure_set_capture_ptr(closure, 0, target.to_bits() as i64);
+    let closure_value = box_pointer(closure as *const u8);
+    let symbol_value = box_pointer(async_iterator as *const u8);
+    unsafe {
+        crate::symbol::js_object_set_symbol_property(target, symbol_value, closure_value);
+    }
+}
+
+fn build_readable_async_iterator(stream: f64) -> f64 {
+    let methods = [
+        ("next", cast0(ns_readable_iterator_next)),
+        ("return", cast0(ns_readable_iterator_return)),
+    ];
+    let obj = build_object(&methods, READABLE_ITERATOR_SHAPE_ID + methods.len() as u32);
+    let iterator = box_pointer(obj as *const u8);
+    set_hidden_value(iterator, hidden_key(READABLE_ITERATOR_STREAM_KEY), stream);
+    set_hidden_value(iterator, hidden_key(READABLE_ITERATOR_INDEX_KEY), 0.0);
+    set_hidden_value(
+        iterator,
+        hidden_key(READABLE_ITERATOR_DONE_KEY),
+        f64::from_bits(TAG_FALSE),
+    );
+    install_async_iterator_symbol(iterator, ns_readable_iterator_self);
+    iterator
+}
+
+pub(super) fn install_readable_async_iterator_symbol(stream: f64) {
+    install_async_iterator_symbol(stream, ns_async_iterator);
+}


### PR DESCRIPTION
## Summary
- expose a Symbol.asyncIterator function on readable-side stream stubs
- install the symbol on Readable and Duplex-derived stubs while leaving Symbol.iterator absent
- keep this as a shape-level compatibility slice; full async iterator protocol remains separate

## Verification
- `./run_parity_tests.sh --suite node-suite --module stream --filter symbol/no-sync-iterator`
- `./run_parity_tests.sh --suite node-suite --module stream --filter static/is-readable-fresh-true`
- `./run_parity_tests.sh --suite node-suite --module stream --filter static/readable-from-array`
- `cargo test -p perry-runtime node_stream --lib -- --nocapture`
- `cargo fmt --all --check`
- `./scripts/check_file_size.sh`
- `git diff --check origin/main...HEAD`
- `jq empty test-parity/known_failures.json`

## Non-goals
- Does not implement full Readable async iteration or stream consumption semantics.
- Does not expose Symbol.iterator; Readable remains async-only like Node.
