### PR TITLE
fix(runtime): return utf16 length for heap strings

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1472,7 +1472,7 @@ pub extern "C" fn js_object_get_field_by_name(
         }
         // Strings: handle `.length` so `(x as string).length` on an
         // unknown-typed local (TypeScript `as` casts are erased in
-        // HIR) produces the real codepoint length.
+        // HIR) produces the real UTF-16 code-unit length.
         if gc_type == crate::gc::GC_TYPE_STRING {
             if !key.is_null() {
                 let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
@@ -1480,7 +1480,7 @@ pub extern "C" fn js_object_get_field_by_name(
                 let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
                 if key_bytes == b"length" {
                     let s = obj as *const crate::StringHeader;
-                    return JSValue::number((*s).byte_len as f64);
+                    return JSValue::number((*s).utf16_len as f64);
                 }
                 if let Some((kind, asym_type)) = crate::buffer::asymmetric_key_meta(obj as usize) {
                     if key_bytes == b"type" {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3512,12 +3512,6 @@
     "category": "bug-open",
     "reason": "node:stream: promises.finished({signal}) — abort doesn't reject with AbortError. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/consumers/text-from-buffer-chunks": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream/consumers: text() on Buffer chunks with multibyte UTF-8 — decode boundary wrong. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/promises/pipeline-with-transform-collect": {
     "issue": "1532",
     "added": "2026-05-25",


### PR DESCRIPTION
## Summary
- return heap-backed string `.length` from `StringHeader.utf16_len` in the generic object-field path instead of `byte_len`
- remove the now-passing `node-suite/stream/consumers/text-from-buffer-chunks` known-failure entry

## Before / After
- Before: `stream/consumers.text(Readable.from([Buffer.from("hé"), Buffer.from("llo")]))` printed `result: héllo` but `length: 6` in Perry; Node prints `length: 5`.
- After: Perry matches Node: decoded text keeps JS `String.length` as UTF-16 code units, not UTF-8 bytes.

## Verification
- Pre-fix repro: `./run_parity_tests.sh --suite node-suite --module stream --filter consumers/text-from-buffer-chunks` failed with Node `length: 5`, Perry `length: 6`.
- `./run_parity_tests.sh --suite node-suite --module stream --filter consumers/text-from-buffer-chunks`
- `./run_parity_tests.sh --suite node-suite --module stream --filter consumers/text-multi-chunk-concat`
- `./run_parity_tests.sh --suite node-suite --module stream --filter consumers/text-single-chunk`
- `cargo test -p perry-runtime string --lib`
- `cargo fmt --check`
- `git diff --check`
- `jq empty test-parity/known_failures.json`

## Non-goals
- No changes to full stream iteration, Web ReadableStream consumers, or Buffer byte collection.
- No broad string subsystem refactor; this only fixes the generic heap-string property fallback.
