### PR TITLE
fix(node:stream): mark destroy error state asynchronously

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2364,6 +2364,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // Readable/Writable/Duplex/Transform/PassThrough constructor surface.
     method("stream", "read", true, None),
     method("stream", "resume", true, None),
+    method("stream", "destroy", true, None),
     method("stream", "write", true, None),
     method("stream", "end", true, None),
     // #1539: push() backpressure return + readable/writableHighWaterMark

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -746,6 +746,15 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "stream",
         has_receiver: true,
+        method: "destroy",
+        class_filter: None,
+        runtime: "js_node_stream_method_destroy",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
         method: "write",
         class_filter: None,
         runtime: "js_node_stream_method_write",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -858,6 +858,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // #1540: Readable/Writable .toWeb / .fromWeb — return fresh Duplex stubs.
     module.declare_function("js_node_stream_to_web", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_from_web", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_node_stream_method_destroy", DOUBLE, &[I64, DOUBLE]);
 
     // ========== Event emitter ==========
     module.declare_function("js_event_emitter_emit", DOUBLE, &[I64, I64, I64]);

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -47,6 +47,7 @@ pub mod map;
 pub mod math;
 pub mod native_arena;
 pub mod node_stream;
+mod node_stream_keepalive;
 pub mod node_submodules;
 pub mod object;
 pub mod os;

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -96,6 +96,30 @@ extern "C" fn ns_chain0(closure: *const ClosureHeader) -> f64 {
 extern "C" fn ns_chain1(closure: *const ClosureHeader, _a: f64) -> f64 {
     this_value(closure)
 }
+extern "C" fn ns_destroy_error_microtask(closure: *const ClosureHeader) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let stream = f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64);
+    let err = crate::closure::js_closure_get_capture_f64(closure, 1);
+    set_hidden_value(stream, hidden_error_key(), err);
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+fn schedule_destroy_error(stream: f64, err: f64) {
+    let bits = err.to_bits();
+    if bits != TAG_UNDEFINED && bits != TAG_NULL {
+        let closure = js_closure_alloc(ns_destroy_error_microtask as *const u8, 2);
+        js_closure_set_capture_ptr(closure, 0, stream.to_bits() as i64);
+        crate::closure::js_closure_set_capture_f64(closure, 1, err);
+        crate::builtins::js_queue_microtask(closure as i64);
+    }
+}
+extern "C" fn ns_destroy1(closure: *const ClosureHeader, err: f64) -> f64 {
+    let stream = this_value(closure);
+    schedule_destroy_error(stream, err);
+    stream
+}
 extern "C" fn ns_chain2(closure: *const ClosureHeader, _a: f64, _b: f64) -> f64 {
     this_value(closure)
 }
@@ -291,6 +315,13 @@ pub extern "C" fn js_node_stream_method_resume(stream_handle: i64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
     set_hidden_value(stream, hidden_ended_key(), f64::from_bits(TAG_TRUE));
     mark_disturbed(stream);
+    stream
+}
+
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_destroy(stream_handle: i64, err: f64) -> f64 {
+    let stream = stream_value_from_handle(stream_handle);
+    schedule_destroy_error(stream, err);
     stream
 }
 
@@ -857,6 +888,8 @@ fn register_stub_arities() {
     };
     register(ns_chain0 as *const u8, 0);
     register(ns_chain1 as *const u8, 1);
+    register(ns_destroy_error_microtask as *const u8, 0);
+    register(ns_destroy1 as *const u8, 1);
     register(ns_chain2 as *const u8, 2);
     register(ns_chain3 as *const u8, 3);
     register(ns_on2 as *const u8, 2);
@@ -1462,7 +1495,7 @@ fn readable_methods() -> [(&'static str, StubFn); 30] {
         ("unpipe", cast1(ns_chain1)),
         ("pause", cast0(ns_chain0)),
         ("resume", cast0(ns_resume0)),
-        ("destroy", cast1(ns_chain1)),
+        ("destroy", cast1(ns_destroy1)),
         ("setEncoding", cast1(ns_chain1)),
         ("isPaused", cast0(ns_undefined0)),
         // #1558 — async iterator helpers. The consuming helpers accept a
@@ -1502,7 +1535,7 @@ fn writable_methods() -> [(&'static str, StubFn); 16] {
         ("end", cast1(ns_end1)),
         ("cork", cast0(ns_chain0)),
         ("uncork", cast0(ns_chain0)),
-        ("destroy", cast1(ns_chain1)),
+        ("destroy", cast1(ns_destroy1)),
         ("setDefaultEncoding", cast1(ns_chain1)),
         ("_write", cast3(ns_chain3)),
     ]
@@ -1533,7 +1566,7 @@ fn duplex_methods() -> [(&'static str, StubFn); 22] {
         ("end", cast1(ns_end1)),
         ("cork", cast0(ns_chain0)),
         ("uncork", cast0(ns_chain0)),
-        ("destroy", cast1(ns_chain1)),
+        ("destroy", cast1(ns_destroy1)),
         ("setDefaultEncoding", cast1(ns_chain1)),
     ]
 }
@@ -1914,71 +1947,6 @@ pub extern "C" fn js_node_stream_to_web(_node_stream: f64) -> f64 {
 pub extern "C" fn js_node_stream_from_web(_web_stream: f64) -> f64 {
     js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
 }
-
-// ─────────────────────────────────────────────────────────────────
-// #1534/#1539/#1540/#1541: symbol retention.
-//
-// These `#[no_mangle]` entry points are emitted by codegen's stream
-// dispatch (native_table/net_events.rs) but several are never referenced
-// by any Rust code in the crate graph. The default `.a` staticlib keeps
-// them via staticlib-export semantics, but the auto-optimize build round-
-// trips the runtime through whole-program LLVM bitcode and is free to
-// internalize + dead-strip an unreferenced symbol — which is exactly why
-// `Readable.isDisturbed(s)` / `r.read()` failed with
-// `Undefined symbols: _js_node_stream_is_disturbed` at final link even
-// though the feature was wired. The `#[used]` statics below pin a retained
-// reference edge so every entry point survives all link modes. See the
-// same pattern in `value/dyn_index.rs` and `process.rs` (#1344).
-#[used]
-static KEEP_NS_METHOD_EMIT: extern "C" fn(i64, f64, f64) -> f64 = js_node_stream_method_emit;
-#[used]
-static KEEP_NS_METHOD_READ: extern "C" fn(i64, f64) -> f64 = js_node_stream_method_read;
-#[used]
-static KEEP_NS_METHOD_PUSH: extern "C" fn(i64, f64) -> f64 = js_node_stream_method_push;
-#[used]
-static KEEP_NS_READABLE_HWM: extern "C" fn(i64) -> f64 = js_node_stream_method_readable_hwm;
-#[used]
-static KEEP_NS_WRITABLE_HWM: extern "C" fn(i64) -> f64 = js_node_stream_method_writable_hwm;
-#[used]
-static KEEP_NS_METHOD_RESUME: extern "C" fn(i64) -> f64 = js_node_stream_method_resume;
-#[used]
-static KEEP_NS_METHOD_WRITE: extern "C" fn(i64, f64, f64) -> f64 = js_node_stream_method_write;
-#[used]
-static KEEP_NS_METHOD_END: extern "C" fn(i64, f64) -> f64 = js_node_stream_method_end;
-#[used]
-static KEEP_NS_READABLE_NEW: extern "C" fn(f64) -> f64 = js_node_stream_readable_new;
-#[used]
-static KEEP_NS_WRITABLE_NEW: extern "C" fn(f64) -> f64 = js_node_stream_writable_new;
-#[used]
-static KEEP_NS_DUPLEX_NEW: extern "C" fn(f64) -> f64 = js_node_stream_duplex_new;
-#[used]
-static KEEP_NS_TRANSFORM_NEW: extern "C" fn(f64) -> f64 = js_node_stream_transform_new;
-#[used]
-static KEEP_NS_PASSTHROUGH_NEW: extern "C" fn(f64) -> f64 = js_node_stream_passthrough_new;
-#[used]
-static KEEP_NS_READABLE_FROM: extern "C" fn(f64) -> f64 = js_node_stream_readable_from;
-#[used]
-static KEEP_NS_IS_DISTURBED: extern "C" fn(f64) -> f64 = js_node_stream_is_disturbed;
-#[used]
-static KEEP_NS_IS_ERRORED: extern "C" fn(f64) -> f64 = js_node_stream_is_errored;
-#[used]
-static KEEP_NS_IS_READABLE: extern "C" fn(f64) -> f64 = js_node_stream_is_readable;
-#[used]
-static KEEP_NS_IS_WRITABLE: extern "C" fn(f64) -> f64 = js_node_stream_is_writable;
-#[used]
-static KEEP_NS_GET_DEFAULT_HWM: extern "C" fn(f64) -> f64 = js_node_stream_get_default_hwm;
-#[used]
-static KEEP_NS_SET_DEFAULT_HWM: extern "C" fn(f64, f64) -> f64 = js_node_stream_set_default_hwm;
-#[used]
-static KEEP_NS_ADD_ABORT_SIGNAL: extern "C" fn(f64, f64) -> f64 = js_node_stream_add_abort_signal;
-#[used]
-static KEEP_NS_COMPOSE: extern "C" fn(f64) -> f64 = js_node_stream_compose;
-#[used]
-static KEEP_NS_DUPLEX_PAIR: extern "C" fn(f64) -> f64 = js_node_stream_duplex_pair;
-#[used]
-static KEEP_NS_TO_WEB: extern "C" fn(f64) -> f64 = js_node_stream_to_web;
-#[used]
-static KEEP_NS_FROM_WEB: extern "C" fn(f64) -> f64 = js_node_stream_from_web;
 
 #[cfg(test)]
 #[path = "node_stream_tests.rs"]

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -1,0 +1,71 @@
+//! Retain `node:stream` runtime entry points across whole-program optimization.
+//!
+//! Codegen references these `#[no_mangle]` exports by symbol name from stream
+//! dispatch paths, so Rust's crate graph does not always contain a direct call
+//! edge. The auto-optimize build can otherwise internalize and strip an export.
+
+use crate::node_stream::{
+    js_node_stream_add_abort_signal, js_node_stream_compose, js_node_stream_duplex_new,
+    js_node_stream_duplex_pair, js_node_stream_from_web, js_node_stream_get_default_hwm,
+    js_node_stream_is_disturbed, js_node_stream_is_errored, js_node_stream_is_readable,
+    js_node_stream_is_writable, js_node_stream_method_destroy, js_node_stream_method_emit,
+    js_node_stream_method_end, js_node_stream_method_push, js_node_stream_method_read,
+    js_node_stream_method_readable_hwm, js_node_stream_method_resume,
+    js_node_stream_method_writable_hwm, js_node_stream_method_write,
+    js_node_stream_passthrough_new, js_node_stream_readable_from, js_node_stream_readable_new,
+    js_node_stream_set_default_hwm, js_node_stream_to_web, js_node_stream_transform_new,
+    js_node_stream_writable_new,
+};
+
+#[used]
+static KEEP_NS_METHOD_EMIT: extern "C" fn(i64, f64, f64) -> f64 = js_node_stream_method_emit;
+#[used]
+static KEEP_NS_METHOD_READ: extern "C" fn(i64, f64) -> f64 = js_node_stream_method_read;
+#[used]
+static KEEP_NS_METHOD_PUSH: extern "C" fn(i64, f64) -> f64 = js_node_stream_method_push;
+#[used]
+static KEEP_NS_READABLE_HWM: extern "C" fn(i64) -> f64 = js_node_stream_method_readable_hwm;
+#[used]
+static KEEP_NS_WRITABLE_HWM: extern "C" fn(i64) -> f64 = js_node_stream_method_writable_hwm;
+#[used]
+static KEEP_NS_METHOD_RESUME: extern "C" fn(i64) -> f64 = js_node_stream_method_resume;
+#[used]
+static KEEP_NS_METHOD_DESTROY: extern "C" fn(i64, f64) -> f64 = js_node_stream_method_destroy;
+#[used]
+static KEEP_NS_METHOD_WRITE: extern "C" fn(i64, f64, f64) -> f64 = js_node_stream_method_write;
+#[used]
+static KEEP_NS_METHOD_END: extern "C" fn(i64, f64) -> f64 = js_node_stream_method_end;
+#[used]
+static KEEP_NS_READABLE_NEW: extern "C" fn(f64) -> f64 = js_node_stream_readable_new;
+#[used]
+static KEEP_NS_WRITABLE_NEW: extern "C" fn(f64) -> f64 = js_node_stream_writable_new;
+#[used]
+static KEEP_NS_DUPLEX_NEW: extern "C" fn(f64) -> f64 = js_node_stream_duplex_new;
+#[used]
+static KEEP_NS_TRANSFORM_NEW: extern "C" fn(f64) -> f64 = js_node_stream_transform_new;
+#[used]
+static KEEP_NS_PASSTHROUGH_NEW: extern "C" fn(f64) -> f64 = js_node_stream_passthrough_new;
+#[used]
+static KEEP_NS_READABLE_FROM: extern "C" fn(f64) -> f64 = js_node_stream_readable_from;
+#[used]
+static KEEP_NS_IS_DISTURBED: extern "C" fn(f64) -> f64 = js_node_stream_is_disturbed;
+#[used]
+static KEEP_NS_IS_ERRORED: extern "C" fn(f64) -> f64 = js_node_stream_is_errored;
+#[used]
+static KEEP_NS_IS_READABLE: extern "C" fn(f64) -> f64 = js_node_stream_is_readable;
+#[used]
+static KEEP_NS_IS_WRITABLE: extern "C" fn(f64) -> f64 = js_node_stream_is_writable;
+#[used]
+static KEEP_NS_GET_DEFAULT_HWM: extern "C" fn(f64) -> f64 = js_node_stream_get_default_hwm;
+#[used]
+static KEEP_NS_SET_DEFAULT_HWM: extern "C" fn(f64, f64) -> f64 = js_node_stream_set_default_hwm;
+#[used]
+static KEEP_NS_ADD_ABORT_SIGNAL: extern "C" fn(f64, f64) -> f64 = js_node_stream_add_abort_signal;
+#[used]
+static KEEP_NS_COMPOSE: extern "C" fn(f64) -> f64 = js_node_stream_compose;
+#[used]
+static KEEP_NS_DUPLEX_PAIR: extern "C" fn(f64) -> f64 = js_node_stream_duplex_pair;
+#[used]
+static KEEP_NS_TO_WEB: extern "C" fn(f64) -> f64 = js_node_stream_to_web;
+#[used]
+static KEEP_NS_FROM_WEB: extern "C" fn(f64) -> f64 = js_node_stream_from_web;

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -159,6 +159,23 @@ fn stream_methods_dispatch_through_dynamic_method_call() {
 }
 
 #[test]
+fn stream_destroy_with_error_marks_errored_state() {
+    let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let destroy = js_object_get_field_by_name_f64(
+        raw_ptr_from_value(stream) as *const ObjectHeader,
+        hidden_key(b"destroy"),
+    );
+    let err = string_value("boom");
+
+    let ret = unsafe { crate::closure::js_native_call_value(destroy, &err, 1) };
+
+    assert_eq!(ret.to_bits(), stream.to_bits());
+    assert_eq!(js_node_stream_is_errored(stream).to_bits(), TAG_FALSE);
+    let _ = crate::promise::js_promise_run_microtasks();
+    assert_eq!(js_node_stream_is_errored(stream).to_bits(), TAG_TRUE);
+}
+
+#[test]
 fn stream_native_receiver_methods_update_hidden_state() {
     let stream = js_node_stream_passthrough_new(f64::from_bits(TAG_UNDEFINED));
     let handle = raw_ptr_from_value(stream) as i64;
@@ -174,6 +191,13 @@ fn stream_native_receiver_methods_update_hidden_state() {
     let handle = raw_ptr_from_value(stream) as i64;
     let _ = js_node_stream_method_end(handle, f64::from_bits(TAG_UNDEFINED));
     assert!(js_node_stream_is_stub_ended_after_read(stream));
+
+    let stream = js_node_stream_passthrough_new(f64::from_bits(TAG_UNDEFINED));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let _ = js_node_stream_method_destroy(handle, err);
+    assert!(readable_hidden_error(stream).is_none());
+    let _ = crate::promise::js_promise_run_microtasks();
+    assert!(js_node_stream_hidden_error_after_read(stream).is_some());
 }
 
 #[test]
@@ -183,12 +207,28 @@ fn stream_stub_arities_are_registered_per_thread() {
         crate::closure::lookup_closure_arity(ns_end1 as *const u8),
         Some(1)
     );
+    assert_eq!(
+        crate::closure::lookup_closure_arity(ns_destroy1 as *const u8),
+        Some(1)
+    );
+    assert_eq!(
+        crate::closure::lookup_closure_arity(ns_destroy_error_microtask as *const u8),
+        Some(0)
+    );
 
     std::thread::spawn(|| {
         let _ = js_node_stream_passthrough_new(f64::from_bits(TAG_UNDEFINED));
         assert_eq!(
             crate::closure::lookup_closure_arity(ns_end1 as *const u8),
             Some(1)
+        );
+        assert_eq!(
+            crate::closure::lookup_closure_arity(ns_destroy1 as *const u8),
+            Some(1)
+        );
+        assert_eq!(
+            crate::closure::lookup_closure_arity(ns_destroy_error_microtask as *const u8),
+            Some(0)
         );
         assert_eq!(
             crate::closure::lookup_closure_arity(ns_write2 as *const u8),

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1279 entries across 81 modules
+// Coverage: 1280 entries across 81 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1279 entries across 81 modules.
+Total: 1280 entries across 81 modules.
 
 ## Modules
 
@@ -1655,6 +1655,7 @@ Total: 1279 entries across 81 modules.
 - `addAbortSignal` — module
 - `addListener` — instance
 - `compose` — module
+- `destroy` — instance
 - `duplexPair` — module
 - `emit` — instance
 - `end` — instance

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -3530,12 +3530,6 @@
     "category": "bug-open",
     "reason": "node:stream/consumers: buffer() from raw-byte Buffer chunks — byte sequence or Array.from output differs from Node. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/static/is-errored-after-destroy": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: isErrored(stream) stays false after destroy(err) (should be true). Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/static/is-writable-after-end-false": {
     "issue": "1532",
     "added": "2026-05-25",


### PR DESCRIPTION
## Summary
- queue stream `destroy(err)` error-state recording through Perry microtasks so immediate static `Readable.isErrored(r)` remains false while later `stream.isErrored(r)` observes the error
- wire typed stream receiver `destroy` calls into the runtime helper

## Verification
- `./run_parity_tests.sh --suite node-suite --module stream --filter static/is-errored-after-destroy`
- `./run_parity_tests.sh --suite node-suite --module stream --filter static/readable-is-errored`
- `./run_parity_tests.sh --suite node-suite --module stream --filter static/is-errored-false-initially`
- `cargo test -p perry-runtime node_stream --lib`
- `cargo test -p perry-codegen manifest_consistency --lib`
- `cargo fmt --check`
- `git diff --check`
- `jq empty test-parity/known_failures.json`

## Non-goals
- full stream destroy lifecycle, `destroyed` property semantics, `_destroy` callbacks, or `close`/`error` event ordering
- broad stream event delivery semantics
