### PR TITLE
fix(node:stream): expose fresh destroyed state

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2371,6 +2371,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("stream", "push", true, None),
     method("stream", "readableHighWaterMark", true, None),
     method("stream", "writableHighWaterMark", true, None),
+    method("stream", "destroyed", true, None),
     // --- child_process (synchronous + async exec surface;
     //     spawn/fork are documented but not yet codegen'd) ---
     method("child_process", "exec", false, None),

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -737,6 +737,15 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "stream",
         has_receiver: true,
+        method: "destroyed",
+        class_filter: None,
+        runtime: "js_node_stream_method_destroyed",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
         method: "resume",
         class_filter: None,
         runtime: "js_node_stream_method_resume",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -858,6 +858,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // #1540: Readable/Writable .toWeb / .fromWeb — return fresh Duplex stubs.
     module.declare_function("js_node_stream_to_web", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_from_web", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_node_stream_method_destroyed", DOUBLE, &[I64]);
 
     // ========== Event emitter ==========
     module.declare_function("js_event_emitter_emit", DOUBLE, &[I64, I64, I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -278,6 +278,13 @@ pub extern "C" fn js_node_stream_method_writable_hwm(stream_handle: i64) -> f64 
     get_hidden_value(stream, hidden_key(b"writableHighWaterMark")).unwrap_or(16384.0)
 }
 
+/// `stream.destroyed` property getter on typed stream instances.
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_destroyed(stream_handle: i64) -> f64 {
+    let stream = stream_value_from_handle(stream_handle);
+    get_hidden_value(stream, hidden_key(b"destroyed")).unwrap_or(f64::from_bits(TAG_FALSE))
+}
+
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_read(stream_handle: i64, _n: f64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
@@ -1639,6 +1646,11 @@ fn resolve_hwm(opts: f64, specific: &[u8], specific_object_mode: &[u8]) -> f64 {
     default_hwm(object_mode)
 }
 
+/// Initialize visible lifecycle flags shared by all stream sides.
+fn init_lifecycle_state(stream: f64) {
+    set_hidden_value(stream, hidden_key(b"destroyed"), f64::from_bits(TAG_FALSE));
+}
+
 /// Initialize the readable side of a stream: direction flag, buffered byte
 /// counter, effective readable highWaterMark, and the visible
 /// `readableHighWaterMark` property (#1534/#1539).
@@ -1667,6 +1679,7 @@ pub extern "C" fn js_node_stream_readable_new(opts: f64) -> f64 {
     if let Some(read) = read_callback_from_options(opts) {
         js_object_set_field_by_name(obj, hidden_read_key(), rebind_callback_this(read, readable));
     }
+    init_lifecycle_state(readable);
     init_readable_state(readable, opts);
     readable
 }
@@ -1683,6 +1696,7 @@ pub extern "C" fn js_node_stream_writable_new(opts: f64) -> f64 {
             rebind_callback_this(write, writable),
         );
     }
+    init_lifecycle_state(writable);
     init_writable_state(writable, opts);
     writable
 }
@@ -1695,6 +1709,7 @@ pub extern "C" fn js_node_stream_duplex_new(opts: f64) -> f64 {
     if let Some(write) = write_callback_from_options(opts) {
         js_object_set_field_by_name(obj, hidden_write_key(), rebind_callback_this(write, duplex));
     }
+    init_lifecycle_state(duplex);
     init_readable_state(duplex, opts);
     init_writable_state(duplex, opts);
     duplex

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -159,6 +159,28 @@ fn stream_methods_dispatch_through_dynamic_method_call() {
 }
 
 #[test]
+fn fresh_streams_expose_destroyed_false() {
+    let streams = [
+        js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED)),
+        js_node_stream_writable_new(f64::from_bits(TAG_UNDEFINED)),
+        js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED)),
+        js_node_stream_transform_new(f64::from_bits(TAG_UNDEFINED)),
+    ];
+
+    for stream in streams {
+        let destroyed = js_object_get_field_by_name_f64(
+            raw_ptr_from_value(stream) as *const ObjectHeader,
+            hidden_key(b"destroyed"),
+        );
+        assert_eq!(destroyed.to_bits(), TAG_FALSE);
+        assert_eq!(
+            js_node_stream_method_destroyed(raw_ptr_from_value(stream) as i64).to_bits(),
+            TAG_FALSE
+        );
+    }
+}
+
+#[test]
 fn stream_native_receiver_methods_update_hidden_state() {
     let stream = js_node_stream_passthrough_new(f64::from_bits(TAG_UNDEFINED));
     let handle = raw_ptr_from_value(stream) as i64;

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1279 entries across 81 modules
+// Coverage: 1280 entries across 81 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1279 entries across 81 modules.
+Total: 1280 entries across 81 modules.
 
 ## Modules
 
@@ -1655,6 +1655,7 @@ Total: 1279 entries across 81 modules.
 - `addAbortSignal` — module
 - `addListener` — instance
 - `compose` — module
+- `destroyed` — instance
 - `duplexPair` — module
 - `emit` — instance
 - `end` — instance

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2798,12 +2798,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: pipeTo with pre-aborted signal — does not reject immediately. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/flags/destroyed-initial-false": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: destroyed flag — wrong initial value on R/W/D/T. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipe/pipe-adds-listener-on-dst": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- initialize fresh Node stream stubs with visible `destroyed: false` state
- add the typed stream instance getter so compiled `r.destroyed` property reads return the boolean instead of the native dispatch zero sentinel

## Verification
- `./run_parity_tests.sh --suite node-suite --module stream --filter flags/destroyed-initial-false`
- `cargo test -p perry-runtime node_stream --lib`
- `cargo test -p perry-codegen manifest_consistency --lib`
- `cargo fmt --check`
- `git diff --check`
- `jq empty test-parity/known_failures.json`

## Non-goals
- full destroy lifecycle semantics or flipping `destroyed` after `destroy()`
- close/error event ordering, `_destroy` callbacks, or broader stream state-machine behavior
