### PR TITLE
fix(hir): #39/#321 data-last namespace export sort/reverse must dispatch member, not fold to ArraySort (carries #1901 try/finally)

### DIFF
--- a/crates/perry-codegen/src/stmt/try_stmt.rs
+++ b/crates/perry-codegen/src/stmt/try_stmt.rs
@@ -9,8 +9,13 @@ use super::*;
 ///   2. Call setjmp(jmpbuf) — returns 0 on first call, non-0 after longjmp
 ///   3. Branch: 0 → try_body, non-0 → catch_entry
 ///   4. try_body runs, calls js_try_end(), branches to finally
-///   5. catch_entry calls js_try_end(), reads exception, runs catch, branches to finally
-///   6. finally runs (if present), then falls through to merge
+///   5. catch_entry calls js_try_end(). With a user `catch`: reads the
+///      exception, runs catch, branches to finally. WITHOUT a `catch`
+///      (a `try/finally` with no handler): captures the exception, runs
+///      a dedicated copy of the finally body, then re-raises via
+///      js_throw so the throw propagates instead of being swallowed.
+///   6. finally runs (if present), then falls through to merge (only the
+///      normal-completion path reaches this merge finally)
 pub(crate) fn lower_try(
     ctx: &mut FnCtx<'_>,
     body: &[perry_hir::Stmt],
@@ -101,12 +106,39 @@ pub(crate) fn lower_try(
             ctx.block().store(DOUBLE, &exc, &slot);
         }
         lower_stmts(ctx, &clause.body)?;
-    }
-    if !ctx.block().is_terminated() {
-        ctx.block().br(&finally_label);
+        if !ctx.block().is_terminated() {
+            ctx.block().br(&finally_label);
+        }
+    } else {
+        // No catch clause: this is a `try { ... } finally { ... }`
+        // (or a bare `try { ... } finally {}`). The longjmp landed
+        // here because the try body threw. ECMAScript requires the
+        // finally to run and then the ORIGINAL exception to RE-PROPAGATE
+        // — it must NOT be swallowed. Previously this block only did
+        // `js_try_end()` + fell through to the shared merge finally and
+        // the function returned `undefined`, silently eating the throw.
+        //
+        // Issue #37 / effect's `internalCall` "forced" path:
+        // `try { return body() } finally {}` swallowed body()'s throw,
+        // surfacing as `(FiberFailure) Error: {}`.
+        //
+        // Capture the pending exception BEFORE running finally (the
+        // finally body may touch exception state), run a dedicated copy
+        // of the finally body on this exception path, then re-raise via
+        // js_throw — unless the finally itself completed abruptly (a
+        // `return`/`throw` inside finally overrides the pending
+        // exception, per spec), in which case its own terminator stands.
+        let exc = ctx.block().call(DOUBLE, "js_get_exception", &[]);
+        if let Some(f) = finally {
+            lower_stmts(ctx, f)?;
+        }
+        if !ctx.block().is_terminated() {
+            ctx.block().call_void("js_throw", &[(DOUBLE, &exc)]);
+            ctx.block().unreachable();
+        }
     }
 
-    // --- finally / merge ---
+    // --- finally / merge (normal-completion path) ---
     ctx.current_block = finally_idx;
     if let Some(f) = finally {
         lower_stmts(ctx, f)?;

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -88,6 +88,31 @@ pub(super) fn try_array_only_methods(
                 let recv_is_class = match member.obj.as_ref() {
                     ast::Expr::Ident(ident) => {
                         let n = ident.sym.to_string();
+                        // #39 (#321): a module namespace import
+                        // (`import * as NS from "..."`) is NOT an array. Its
+                        // exports are member functions, so `NS.sort(cmp)` /
+                        // `NS.reverse()` / `NS.entries()` etc. must dispatch the
+                        // namespace export, never `js_array_<method>` on the
+                        // namespace object. effect's `Array.sort = dual(2, ...)`
+                        // is data-last: `Arr.sort(numberOrder)` should return the
+                        // curried `(self) => ...` closure. The non-overlapping
+                        // mutators (`sort`/`reverse`/`entries`/`keys`/`values`/
+                        // `splice`/`fill`/…) bypass the `is_overlapping` gate
+                        // below and the `"sort" if !args.is_empty()` arm folds
+                        // `NS.sort(cmp)` to `Expr::ArraySort { array: NS, ... }`,
+                        // making the compiled binary call `js_array_sort(NS, cmp)`
+                        // — which returned the namespace object itself (typeof
+                        // "object"). The downstream `pipe(bounds, sortFn, ...)`
+                        // then threw "value is not a function" inside effect's
+                        // metric histogram path at fiber exit. `try_imported_
+                        // array_methods` already guards namespaces, but it runs
+                        // *before* this pass and returns `Err(args)`, so the call
+                        // re-enters here; guard at the top of the Ident arm and
+                        // bail (treat as not-an-array) for ALL method names when
+                        // the receiver is a namespace import.
+                        if ctx.namespace_import_locals.contains(&n) {
+                            return Ok(Err(args));
+                        }
                         let ty = ctx.lookup_local_type(&n);
                         let class_typed = ty
                             .as_ref()

--- a/test-files/_helpers/ns_member_fns_mod.ts
+++ b/test-files/_helpers/ns_member_fns_mod.ts
@@ -9,3 +9,34 @@ export const find = (x: number): number => x + 1;
 
 // A real exported array, to confirm `NS.items.map(cb)` still array-maps.
 export const items = [10, 20, 30];
+
+// #39 (#321): effect's `Array.sort = dual(2, body)` — a data-last (pipeable)
+// export named `sort`. Called with ONE arg (`NS.sort(cmp)`) it must return the
+// curried `(self) => sorted` closure, NOT fold to the `js_array_sort`
+// intrinsic on the namespace object (which returned the namespace itself,
+// typeof "object", and threw "value is not a function" downstream in
+// `pipe(bounds, sortFn, ...)`). `sort` is NOT in the array-method
+// `is_overlapping` set, so it bypassed the imported-array guard and reached
+// `try_array_only_methods`, which folded it to `Expr::ArraySort`.
+const dual = function (arity: number, body: any): any {
+  if (arity === 2) {
+    return function (a: any, b: any) {
+      // eslint-disable-next-line prefer-rest-params
+      if (arguments.length >= 2) {
+        return body(a, b);
+      }
+      return function (self: any) {
+        return body(self, a);
+      };
+    };
+  }
+};
+
+export const sort: {
+  <B>(O: (a: B, b: B) => number): <A extends B>(self: Array<A>) => Array<A>;
+  <A extends B, B>(self: Array<A>, O: (a: B, b: B) => number): Array<A>;
+} = dual(2, <A extends B, B>(self: Array<A>, O: (a: B, b: B) => number): Array<A> => {
+  const out = Array.from(self);
+  out.sort(O);
+  return out;
+});

--- a/test-files/test_gap_namespace_member_sort_dual.ts
+++ b/test-files/test_gap_namespace_member_sort_dual.ts
@@ -1,0 +1,48 @@
+// #39 (#321): a data-last (pipeable) namespace export named `sort` —
+// `export const sort = dual(2, body)`, exactly effect's `Array.sort` — was
+// mis-lowered to the `js_array_sort` intrinsic when called as `NS.sort(cmp)`.
+// `sort` (and `reverse`/`entries`/`keys`/`values`/`splice`/`fill`/...) are NOT
+// in the array-method "overlapping" set, so the existing imported-array
+// namespace guard didn't cover them; the call fell through to
+// `try_array_only_methods`, whose `"sort" if !args.is_empty()` arm folded
+// `NS.sort(cmp)` into `Expr::ArraySort { array: NS, comparator: cmp }`. The
+// compiled binary then ran `js_array_sort(NS, cmp)`, which returned the
+// namespace object itself (`typeof` "object") instead of the curried
+// `(self) => sorted` closure — so `pipe(bounds, NS.sort(cmp), ...)` threw
+// "value is not a function". This surfaced in effect's metric histogram path
+// (`MetricRegistryImpl.getHistogram` → `Arr.sort(number.Order)`) at fiber exit,
+// breaking every `Effect.runSync(...)` fiber case.
+//
+// Fix: in `try_array_only_methods`, bail (treat the receiver as not-an-array)
+// for ALL method names when the receiver identifier is a module namespace
+// import (`namespace_import_locals`), so the call dispatches the namespace
+// export and the data-last curried form is returned.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+import * as NS from "./_helpers/ns_member_fns_mod.ts";
+
+// Data-last form: one arg returns a unary closure.
+const sortFn = NS.sort((a: number, b: number) => (a === b ? 0 : a < b ? -1 : 1));
+console.log("typeof NS.sort:", typeof NS.sort); // function
+console.log("typeof sortFn:", typeof sortFn); // function
+console.log("sortFn([3,1,2]):", JSON.stringify(sortFn([3, 1, 2]))); // [1,2,3]
+
+// Data-first form: two args sort directly.
+console.log(
+  "NS.sort([5,4,6], asc):",
+  JSON.stringify(NS.sort([5, 4, 6], (a: number, b: number) => (a === b ? 0 : a < b ? -1 : 1)))
+); // [4,5,6]
+
+// Used inside a pipe, exactly like effect's metric histogram path.
+const pipe = (a: any, ab?: any, bc?: any): any => {
+  if (bc) return bc(ab(a));
+  if (ab) return ab(a);
+  return a;
+};
+const result = pipe(
+  [30, 10, 20],
+  NS.sort((a: number, b: number) => (a === b ? 0 : a < b ? -1 : 1)),
+  (arr: number[]) => arr.map((n) => n / 10)
+);
+console.log("pipe(sort,map):", JSON.stringify(result)); // [1,2,3]

--- a/test-files/test_gap_try_finally_no_catch_rethrow.ts
+++ b/test-files/test_gap_try_finally_no_catch_rethrow.ts
@@ -1,0 +1,104 @@
+// Issue #37 / #321: `try { ... } finally { ... }` with NO catch clause must
+// run the finally and then RE-PROPAGATE the original exception — it must not
+// be swallowed. Previously Perry's setjmp landing pad for a catch-less
+// try/finally ran `js_try_end()`, fell through to the finally/merge, and
+// returned `undefined`, silently eating the throw. This surfaced in the
+// effect framework's `internalCall` "forced" path
+// (`try { return body() } finally {}`) as a dropped return value.
+
+// 1. Empty finally, body throws — exception must propagate.
+function inner1(): number {
+  throw new Error("boom");
+}
+function wrap1(): number {
+  try {
+    return inner1();
+  } finally {
+    // empty
+  }
+}
+try {
+  const r = wrap1();
+  console.log("wrap1 returned (WRONG):", r);
+} catch (e) {
+  console.log("wrap1 caught:", (e as Error).message);
+}
+
+// 2. Non-empty finally, body throws — finally runs, then exception propagates.
+let cleanups = 0;
+function inner2(): string {
+  throw new Error("kaboom");
+}
+function wrap2(): string {
+  try {
+    return inner2();
+  } finally {
+    cleanups++;
+  }
+}
+try {
+  wrap2();
+  console.log("wrap2 returned (WRONG)");
+} catch (e) {
+  console.log("wrap2 caught:", (e as Error).message, "cleanups:", cleanups);
+}
+
+// 3. Normal completion (no throw) still returns the value and runs finally.
+let ran = 0;
+function wrap3(): number {
+  try {
+    return 99;
+  } finally {
+    ran++;
+  }
+}
+console.log("wrap3:", wrap3(), "ran:", ran);
+
+// 4. Indirect call through a function-valued variable (the effect shape):
+//    a generic arrow holding `try { return body() } finally {}` that the
+//    caller invokes; when body throws the exception must propagate.
+const forced = <A>(body: () => A): A => {
+  try {
+    return body();
+  } finally {
+  }
+};
+try {
+  forced(() => {
+    throw new Error("indirect");
+  });
+  console.log("forced returned (WRONG)");
+} catch (e) {
+  console.log("forced caught:", (e as Error).message);
+}
+
+// 5. finally with its own `return` overrides the pending exception (spec).
+function wrap5(): string {
+  try {
+    throw new Error("overridden");
+  } finally {
+    return "from-finally"; // eslint-disable-line no-unsafe-finally
+  }
+}
+console.log("wrap5:", wrap5());
+
+// 6. Nested catch-less try/finally inside an outer try/catch — propagates
+//    out through both finallies to the outer catch.
+let order: string[] = [];
+function wrap6(): number {
+  try {
+    try {
+      throw new Error("nested");
+    } finally {
+      order.push("inner-finally");
+    }
+  } finally {
+    order.push("outer-finally");
+  }
+}
+try {
+  wrap6();
+  console.log("wrap6 returned (WRONG)");
+} catch (e) {
+  console.log("wrap6 caught:", (e as Error).message, "order:", order.join(","));
+}


### PR DESCRIPTION
## Summary

Fixes the effect-survey regression under #321 (internal task #39): every `Effect.runSync(...)` fiber case (`05_gen`, `07_all`, `02_map`, ...) threw `TypeError: value is not a function` once the held #1901 try/finally fix was applied (that fix stopped swallowing the throw, exposing this real miscompile).

This PR carries **both** commits as a landable pair:
- `5079aacf` — #37/#321 catch-less try/finally must re-propagate exceptions (the held #1901 fix; **#1901 can be closed in favor of this PR**).
- `3b6b0724` — the new #39 fix below.

## Root cause: `value is not a function`

Symbolized to effect's metric histogram path at fiber exit. The default runtime flags include `RuntimeMetrics`, so `FiberRuntime.reportExitValue` runs the metric path on every `runSync`:

`fiberLifetimes.unsafeUpdate(...)` -> `hook(extraTags).update(...)` -> `globalMetricRegistry.get(...)` -> `getHistogram(key)` -> `metricHook.histogram(key)` which does:

`pipe(bounds, Arr.sort(number.Order), Arr.map((n, i) => { boundaries[i] = n }))`

Instrumenting that path, the failing value was `Arr.sort(number.Order)`: it returned `typeof "object"` instead of a function, so `pipe`'s `ab(a)` call threw "value is not a function".

`Arr` is `import * as Arr from ".../Array.js"` and `Array.sort` is effect's `dual(2, body)` (data-last/pipeable) — `Arr.sort(cmp)` should return the curried `(self) => sorted` closure.

## perry root cause (file:line)

`crates/perry-hir/src/lower/expr_call/array_only_methods.rs` (the `"sort" if !args.is_empty()` arm). `sort` (and the other non-overlapping mutators `reverse`/`entries`/`keys`/`values`/`splice`/`fill`/...) are NOT in the array-method `is_overlapping` set, so the existing imported-array namespace guard (`try_imported_array_methods`, which runs first and correctly returns `Err(args)` for namespaces) did not cover them. The call re-entered `try_array_only_methods`, which lowered `member.obj` (`Arr`) to `ExternFuncRef("Arr")` and folded `Arr.sort(cmp)` to `Expr::ArraySort { array: ExternFuncRef("Arr"), comparator: cmp }`. The compiled binary then ran `js_array_sort(NS, cmp)`, which returned the namespace object itself (typeof "object").

Confirmed via `--print-hir`: `sortFn = Arr.sort(cmp)` lowered to `ArraySort { array: ExternFuncRef("Arr"), ... }` before the fix, and to `Call { callee: PropertyGet { object: Arr, property: "sort" }, args: [cmp] }` after.

## Fix

In `try_array_only_methods`, bail (treat the receiver as not-an-array) for ALL method names when the receiver identifier is a module namespace import (`ctx.namespace_import_locals`). The call then dispatches the namespace export and the data-last curried form is returned correctly. Additive, scoped strictly to namespace-import receivers — no other receiver shape is affected.

## Minimal repro

`import * as Arr from "./arr.ts"` where `arr.ts` exports `sort = dual(2, body)`, then `const sortFn = Arr.sort(cmp)`:
- Before: `typeof sortFn = object`, `pipe(...)` throws "value is not a function".
- After / Node: `typeof sortFn = function`, sorts correctly.

Captured as gap test `test-files/test_gap_namespace_member_sort_dual.ts` (plus a `sort` export added to the shared `_helpers/ns_member_fns_mod.ts`). Both data-last and data-first forms plus a `pipe`-wrapped use are byte-identical to `node --experimental-strip-types`.

## Validation

Effect survey (`/private/tmp/effect-dod-ref/survey/*.ts`, `PERRY_NO_AUTO_OPTIMIZE=1`):

| | before (base = main + #1901) | after |
|---|---|---|
| fiber/effect cases (01-09) | 1/9 (01 only; 02-09 throw "value is not a function") | **9/9** |
| 05_gen | throws | **30** |
| 07_all | throws | **[1,2,3]** |
| 02_map | throws | **20** |
| 30_option / 31_data | pass | pass |
| schema cases (20-23) | SIGSEGV (pre-existing #684) | SIGSEGV (pre-existing #684, unchanged) |
| **total** | 3/15 | **11/15** |

All previously-passing fiber cases recovered; the 4 `*_schema_*` cases SIGSEGV identically with and without this fix (pre-existing #684 Schema.ts blocker, not a regression — verified via `git stash` + rebuild on the base).

Layer repros now ADVANCE past the `value is not a function` blocker to the next downstream blocker `Cannot read properties of undefined (reading 'size')` (the #38 `unsafeMap.size` blocker), as expected — `nlay.ts` and `real3_context_layer.ts` both reach it now instead of throwing at fiber exit.

Regression sweep (closure/object/class/map/hashmap/pipe/option/array/namespace/static `test_gap_*`, byte-vs-Node): 17/19 match. The 2 mismatches (`test_gap_class_advanced` static-block-init bool, `test_gap_typed_arrays` Int32Array length) are pre-existing and unrelated — confirmed identical on the base via `git stash` + rebuild; neither uses a namespace-import receiver.

`./scripts/check_file_size.sh` OK (array_only_methods.rs = 758 lines). `cargo fmt --all -- --check` clean. Workspace build green (cross-host UI crates excluded).

Refs #39, #321. Supersedes / closes #1901 (this PR carries its commit).
