### PR TITLE
Fix Buffer subclass static construction

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1766,6 +1766,32 @@ unsafe fn call_static_method(
     }
 }
 
+unsafe fn try_native_static_method_in_proto_chain(
+    class_id: u32,
+    name: &str,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> Option<f64> {
+    let mut cid = class_id;
+    let mut depth = 0u32;
+    while cid != 0 && depth < 64 {
+        let proto_obj = class_prototype_object(cid);
+        if !proto_obj.is_null() && (*proto_obj).class_id == NATIVE_MODULE_CLASS_ID {
+            if read_native_module_name(proto_obj as *const ObjectHeader).as_deref()
+                == Some("buffer.Buffer")
+            {
+                let result = dispatch_native_module_method(proto_obj, name, args_ptr, args_len);
+                if !JSValue::from_bits(result.to_bits()).is_undefined() {
+                    return Some(result);
+                }
+            }
+        }
+        cid = get_parent_class_id(cid).unwrap_or(0);
+        depth += 1;
+    }
+    None
+}
+
 /// #1788: dispatch a static method on a class value (`Sub.greet()` where
 /// `Sub extends make(...)`, or a class-object value) by walking the class_id
 /// parent chain in `CLASS_STATIC_METHODS`. Binds `this` to the receiver (so
@@ -1862,6 +1888,11 @@ pub unsafe extern "C" fn js_class_static_method_call(
             cid = get_parent_class_id(cid).unwrap_or(0);
             depth += 1;
         }
+    }
+    if let Some(result) =
+        try_native_static_method_in_proto_chain(class_id, name, args_ptr, args_len)
+    {
+        return result;
     }
     // True miss: no static method and no callable static field resolved on the
     // class chain. We hand back the receiver (load-bearing for effect's

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1182,6 +1182,12 @@ pub extern "C" fn js_object_get_field_by_name(
                     let b = obj as *const crate::buffer::BufferHeader;
                     return JSValue::number(crate::buffer::js_buffer_length(b) as f64);
                 }
+                if key_bytes == b"constructor" {
+                    let module = b"buffer.Buffer";
+                    return JSValue::from_bits(
+                        js_create_native_module_namespace(module.as_ptr(), module.len()).to_bits(),
+                    );
+                }
                 if crate::buffer::is_secret_key(obj as usize) {
                     if key_bytes == b"type" {
                         let s = crate::string::js_string_from_bytes(b"secret".as_ptr(), 6);

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1512,6 +1512,7 @@ pub(crate) unsafe fn get_native_module_constant(
         },
         "buffer.Buffer" => match property {
             "poolSize" => Some(buffer_pool_size()),
+            "name" => Some(str_val("Buffer")),
             _ => None,
         },
         "os" => match property {

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -34,6 +34,18 @@ pub(crate) unsafe fn dispatch_native_module_method(
             f64::from_bits(JSValue::undefined().bits())
         }
     };
+    let i32_arg = |n: usize| -> i32 {
+        let v = arg(n);
+        let bits = v.to_bits();
+        if (bits >> 48) == 0x7FFE {
+            return (bits & 0xFFFF_FFFF) as u32 as i32;
+        }
+        if v.is_nan() || v.is_infinite() {
+            0
+        } else {
+            v as i32
+        }
+    };
 
     // Helper: extract raw string pointer from a NaN-boxed f64 value
     let arg_str_ptr = |n: usize| -> *const crate::StringHeader {
@@ -133,6 +145,83 @@ pub(crate) unsafe fn dispatch_native_module_method(
     };
 
     match (module_name, method_name) {
+        // ── Buffer constructor static API ──
+        // `class MyBuffer extends Buffer {}; MyBuffer.from(...)` reaches this
+        // path through js_class_static_method_call's native-superclass
+        // fallback. Return plain Buffer instances, matching Node's internal
+        // FastBuffer behavior rather than species/subclass construction.
+        ("buffer.Buffer", "from") => {
+            let data = arg(0);
+            let second = JSValue::from_bits(arg(1).to_bits());
+            let second_is_offset = args_len >= 2
+                && !second.is_undefined()
+                && !second.is_null()
+                && !second.is_string()
+                && !second.is_short_string();
+            let buf = if args_len >= 3 || second_is_offset {
+                let len = if args_len >= 3 { i32_arg(2) } else { -1 };
+                crate::buffer::js_buffer_from_arraybuffer_slice(
+                    data.to_bits() as i64,
+                    i32_arg(1),
+                    len,
+                )
+            } else {
+                let enc = if args_len >= 2 {
+                    crate::buffer::js_encoding_tag_from_value(arg(1))
+                } else {
+                    0
+                };
+                crate::buffer::js_buffer_from_value(data.to_bits() as i64, enc)
+            };
+            ptr_to_f64(buf as *const u8)
+        }
+        ("buffer.Buffer", "alloc") => {
+            let buf = if args_len >= 2 {
+                let enc = if args_len >= 3 {
+                    crate::buffer::js_encoding_tag_from_value(arg(2))
+                } else {
+                    0
+                };
+                crate::buffer::js_buffer_alloc_fill_value(i32_arg(0), arg(1), enc)
+            } else {
+                crate::buffer::js_buffer_alloc(i32_arg(0), 0)
+            };
+            ptr_to_f64(buf as *const u8)
+        }
+        ("buffer.Buffer", "allocUnsafe") | ("buffer.Buffer", "allocUnsafeSlow") => {
+            let buf = crate::buffer::js_buffer_alloc_unsafe(i32_arg(0));
+            ptr_to_f64(buf as *const u8)
+        }
+        ("buffer.Buffer", "concat") => {
+            let arr = ptr_addr(arg(0)) as *const crate::array::ArrayHeader;
+            ptr_to_f64(crate::buffer::js_buffer_concat(arr) as *const u8)
+        }
+        ("buffer.Buffer", "of") => {
+            let arr = pack_args();
+            ptr_to_f64(crate::buffer::js_buffer_from_array(arr) as *const u8)
+        }
+        ("buffer.Buffer", "isBuffer") => {
+            bool_to_f64(crate::buffer::js_buffer_is_buffer(arg(0).to_bits() as i64))
+        }
+        ("buffer.Buffer", "isEncoding") => {
+            bool_to_f64(crate::buffer::js_buffer_is_encoding(arg(0)))
+        }
+        ("buffer.Buffer", "byteLength") => {
+            crate::buffer::js_buffer_byte_length_value(arg(0), arg(1)) as f64
+        }
+        ("buffer.Buffer", "compare") => {
+            let a = ptr_addr(arg(0));
+            let b = ptr_addr(arg(1));
+            if crate::buffer::is_registered_buffer(a) && crate::buffer::is_registered_buffer(b) {
+                crate::buffer::js_buffer_compare(
+                    a as *const crate::buffer::BufferHeader,
+                    b as *const crate::buffer::BufferHeader,
+                ) as f64
+            } else {
+                0.0
+            }
+        }
+
         // ── process EventEmitter API ──
         ("process", "on") => crate::os::js_process_on(arg_event_ptr(0), arg_closure_ptr(1)),
         ("process", "addListener") => {

--- a/reference/deepwiki/deno-node-buffer-instanceof-constructor-2026-05-26.md
+++ b/reference/deepwiki/deno-node-buffer-instanceof-constructor-2026-05-26.md
@@ -1,0 +1,214 @@
+# DeepWiki Response
+
+Repository: `denoland/deno`
+Question: For Node compatibility, how should Buffer instances created by Buffer.from or Buffer.prototype.slice behave for instanceof Buffer and the constructor.name property? Does subclassing Buffer make MyBuffer.from return subclass instances or plain Buffer instances?
+Search: https://deepwiki.com/search/for-node-compatibility-how-sho_ba39f09a-383c-400b-9f61-a31c213cdef0
+
+**Question**: For Node compatibility, how should Buffer instances created by Buffer.from or Buffer.prototype.slice behave for instanceof Buffer and the constructor.name property? Does subclassing Buffer make MyBuffer.from return subclass instances or plain Buffer instances?
+
+For Node compatibility, `Buffer` instances created by `Buffer.from()` or `Buffer.prototype.slice()` will behave as `Buffer` instances for `instanceof Buffer` checks and will have a `constructor.name` of "Buffer" [1](#ref-q1-1) . Subclassing `Buffer` will not make `MyBuffer.from()` return subclass instances; instead, it will return plain `Buffer` instances [2](#ref-q1-2) .
+
+## `instanceof Buffer` and `constructor.name` Behavior
+
+The `Buffer` class in Deno's Node compatibility layer is implemented as a constructor function that delegates to `FastBuffer`, which extends `Uint8Array` [3](#ref-q1-3) . To ensure `instanceof Buffer` checks work correctly, `Buffer.prototype` is set to `FastBuffer.prototype` [4](#ref-q1-4) . The `Buffer.isBuffer()` static method also checks if an object's prototype is `Buffer.prototype` [5](#ref-q1-5) .
+
+For the `constructor.name` property, the `inspect` method on `Buffer.prototype` explicitly attempts to retrieve the `constructor.name` of the instance [1](#ref-q1-1) . If successful, it uses that name; otherwise, it defaults to "Buffer" [6](#ref-q1-6) .
+
+## `Buffer.from()` and Subclassing
+
+The `Buffer.from()` method is defined as `BufferFrom` and internally calls the `_from` function [2](#ref-q1-2) . The `_from` function, when creating a new buffer from various inputs (string, ArrayBuffer, etc.), ultimately calls `createBuffer()` or directly instantiates `FastBuffer` [7](#ref-q1-7) . For example, `createBuffer()` returns `new FastBuffer(length)` [8](#ref-q1-8) .
+
+Similarly, `Buffer.prototype.slice()` is implemented by calling `this.subarray()` [9](#ref-q1-9) . The `subarray()` method then creates a new `FastBuffer` instance using the underlying `ArrayBuffer` of the original buffer [10](#ref-q1-10) .
+
+Because `Buffer.from()` and `Buffer.prototype.slice()` explicitly create instances of `FastBuffer` (which is the internal representation of `Buffer`), subclassing `Buffer` will not result in instances of the subclass being returned by these methods. They will always return plain `Buffer` instances (i.e., `FastBuffer` instances).
+
+## Notes
+
+The `Buffer` implementation in Deno's Node compatibility layer uses a `FastBuffer` class that extends `Uint8Array` for performance and to align with Web standards [3](#ref-q1-3) . The `Buffer` constructor itself is a wrapper that delegates to `FastBuffer` and emits a deprecation warning [11](#ref-q1-11) . This architecture ensures Node.js compatibility while leveraging `Uint8Array`'s native performance.
+
+Wiki pages you might want to explore:
+- [Node.js Compatibility Layer (denoland/deno)](/wiki/denoland/deno#7)
+- [Buffer and Core APIs (denoland/deno)](/wiki/denoland/deno#7.2)
+
+View this search on DeepWiki: https://deepwiki.com/search/for-node-compatibility-how-sho_ba39f09a-383c-400b-9f61-a31c213cdef0
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `ext/node/polyfills/internal/buffer.mjs:851-858`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/buffer.mjs#L851-L858)
+
+```
+      let constructorName = "Buffer";
+      try {
+        const { constructor } = this;
+        if (
+          typeof constructor === "function" &&
+          ObjectPrototypeHasOwnProperty(constructor, "name")
+        ) {
+          constructorName = constructor.name;
+```
+
+<a id="ref-q1-2"></a>
+### [2] `ext/node/polyfills/internal/buffer.mjs:334-340`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/buffer.mjs#L334-L340)
+
+```
+const BufferFrom = Buffer.from = function from(
+  value,
+  encodingOrOffset,
+  length,
+) {
+  return _from(value, encodingOrOffset, length);
+};
+```
+
+<a id="ref-q1-3"></a>
+### [3] `ext/node/polyfills/internal/buffer.mjs:197-201`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/buffer.mjs#L197-L201)
+
+```
+class FastBuffer extends Uint8Array {
+  constructor(bufferOrLength, byteOffset, length) {
+    super(bufferOrLength, byteOffset, length);
+  }
+}
+```
+
+<a id="ref-q1-4"></a>
+### [4] `ext/node/polyfills/internal/buffer.mjs:204`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/buffer.mjs#L204)
+
+```
+Buffer.prototype = FastBuffer.prototype;
+```
+
+<a id="ref-q1-5"></a>
+### [5] `ext/node/polyfills/internal/buffer.mjs:547-549`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/buffer.mjs#L547-L549)
+
+```
+const BufferIsBuffer = Buffer.isBuffer = function isBuffer(b) {
+  return ObjectPrototypeIsPrototypeOf(Buffer.prototype, b);
+};
+```
+
+<a id="ref-q1-6"></a>
+### [6] `ext/node/polyfills/internal/buffer.mjs:860`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/buffer.mjs#L860)
+
+```
+      } catch {
+```
+
+<a id="ref-q1-7"></a>
+### [7] `ext/node/polyfills/internal/buffer.mjs:294-331`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/buffer.mjs#L294-L331)
+
+```
+function _from(value, encodingOrOffset, length) {
+  if (typeof value === "string") {
+    return fromString(value, encodingOrOffset);
+  }
+
+  if (typeof value === "object" && value !== null) {
+    if (isAnyArrayBuffer(value)) {
+      return fromArrayBuffer(value, encodingOrOffset, length);
+    }
+
+    // deno-lint-ignore prefer-primordials
+    const valueOf = value.valueOf && value.valueOf();
+    if (
+      valueOf != null &&
+      valueOf !== value &&
+      (typeof valueOf === "string" || typeof valueOf === "object")
+    ) {
+      return _from(valueOf, encodingOrOffset, length);
+    }
+
+    const b = fromObject(value);
+    if (b) {
+      return b;
+    }
+
+    if (typeof value[SymbolToPrimitive] === "function") {
+      const primitive = value[SymbolToPrimitive]("string");
+      if (typeof primitive === "string") {
+        return fromString(primitive, encodingOrOffset);
+      }
+    }
+  }
+
+  throw new codes.ERR_INVALID_ARG_TYPE(
+    "first argument",
+    ["string", "Buffer", "ArrayBuffer", "Array", "Array-like Object"],
+    value,
+  );
+```
+
+<a id="ref-q1-8"></a>
+### [8] `ext/node/polyfills/internal/buffer.mjs:237-244`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/buffer.mjs#L237-L244)
+
+```
+function createBuffer(length) {
+  if (length > kMaxLength) {
+    throw new RangeError(
+      'The value "' + length + '" is invalid for option "size"',
+    );
+  }
+
+  return new FastBuffer(length);
+```
+
+<a id="ref-q1-9"></a>
+### [9] `ext/node/polyfills/internal/buffer.mjs:1326-1331`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/buffer.mjs#L1326-L1331)
+
+```
+Buffer.prototype.slice = function slice(start, end) {
+  // Intentionally `this.subarray` so generic calls on a Uint8Array stay a
+  // Uint8Array (Uint8Array.prototype.subarray) while Buffer instances pick up
+  // Buffer.prototype.subarray and produce a FastBuffer.
+  return this.subarray(start, end);
+};
+```
+
+<a id="ref-q1-10"></a>
+### [10] `ext/node/polyfills/internal/buffer.mjs:1314-1324`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/buffer.mjs#L1314-L1324)
+
+```
+Buffer.prototype.subarray = function subarray(start, end) {
+  const srcLength = this.length;
+  start = adjustOffset(start, srcLength);
+  end = end !== undefined ? adjustOffset(end, srcLength) : srcLength;
+  const newLength = end > start ? end - start : 0;
+  return new FastBuffer(
+    TypedArrayPrototypeGetBuffer(this),
+    TypedArrayPrototypeGetByteOffset(this) + start,
+    newLength,
+  );
+};
+```
+
+<a id="ref-q1-11"></a>
+### [11] `ext/node/polyfills/internal/buffer.mjs:258-271`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/buffer.mjs#L258-L271)
+
+```
+function Buffer(arg, encodingOrOffset, length) {
+  showFlaggedDeprecation();
+  if (typeof arg === "number") {
+    if (typeof encodingOrOffset === "string") {
+      throw new codes.ERR_INVALID_ARG_TYPE(
+        "string",
+        "string",
+        arg,
+      );
+    }
+    return _allocUnsafe(arg);
+  }
+  return _from(arg, encodingOrOffset, length);
+}
+```


### PR DESCRIPTION
## Summary
- route inherited static Buffer calls through the native buffer.Buffer superclass so MyBuffer.from(...) returns a plain Buffer
- expose Buffer instance constructor.name as Buffer for Buffer.from(...).slice(...).constructor.name

## Verification
- ./run_parity_tests.sh --suite node-suite --module buffer --filter properties/subclass-species
- ./run_parity_tests.sh --suite node-suite --module buffer --filter properties
- cargo test -p perry-runtime buffer --lib
- cargo fmt --all -- --check
- git diff --check
- jq empty test-parity/known_failures.json
