### PR TITLE
fix(runtime): validate node:path string args

### DIFF
--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -45,6 +45,31 @@ pub(crate) unsafe fn dispatch_native_module_method(
             std::ptr::null()
         }
     };
+    let require_path_str_ptr = |n: usize| -> *const crate::StringHeader {
+        if n < args_len {
+            let v = arg(n);
+            let ptr = crate::string::js_string_materialize_to_heap(v);
+            if !ptr.is_null() {
+                return ptr;
+            }
+        }
+        crate::path::throw_invalid_path_arg_type()
+    };
+    let optional_path_str_ptr = |n: usize| -> *const crate::StringHeader {
+        if n >= args_len {
+            return std::ptr::null();
+        }
+        let v = arg(n);
+        let jsv = JSValue::from_bits(v.to_bits());
+        if jsv.is_undefined() {
+            return std::ptr::null();
+        }
+        let ptr = crate::string::js_string_materialize_to_heap(v);
+        if !ptr.is_null() {
+            return ptr;
+        }
+        crate::path::throw_invalid_path_arg_type()
+    };
 
     // Helper: convert i32 boolean to NaN-boxed TAG_TRUE / TAG_FALSE
     let bool_to_f64 = |v: i32| -> f64 {
@@ -58,6 +83,70 @@ pub(crate) unsafe fn dispatch_native_module_method(
     // Helper: convert *mut StringHeader to NaN-boxed string f64
     let str_to_f64 =
         |ptr: *mut crate::StringHeader| -> f64 { f64::from_bits(JSValue::string_ptr(ptr).bits()) };
+    let path_join_value = |win32: bool| -> f64 {
+        if args_len == 0 {
+            let result = if win32 {
+                crate::path::js_path_win32_join_unchecked(std::ptr::null(), std::ptr::null())
+            } else {
+                crate::path::js_path_join_unchecked(std::ptr::null(), std::ptr::null())
+            };
+            return str_to_f64(result);
+        }
+        let first = require_path_str_ptr(0);
+        let mut result = if win32 {
+            crate::path::js_path_win32_join_unchecked(first, std::ptr::null())
+        } else {
+            crate::path::js_path_join_unchecked(first, std::ptr::null())
+        };
+        for i in 1..args_len {
+            let segment = require_path_str_ptr(i);
+            result = if win32 {
+                crate::path::js_path_win32_join_unchecked(result, segment)
+            } else {
+                crate::path::js_path_join_unchecked(result, segment)
+            };
+        }
+        str_to_f64(result)
+    };
+    let path_resolve_value = |win32: bool| -> f64 {
+        let mut result = if args_len == 0 {
+            if win32 {
+                crate::path::js_path_win32_join_unchecked(std::ptr::null(), std::ptr::null())
+            } else {
+                crate::path::js_path_join_unchecked(std::ptr::null(), std::ptr::null())
+            }
+        } else {
+            require_path_str_ptr(0) as *mut crate::StringHeader
+        };
+        for i in 1..args_len {
+            let segment = require_path_str_ptr(i);
+            result = if win32 {
+                crate::path::js_path_win32_resolve_join(result, segment)
+            } else {
+                crate::path::js_path_resolve_join(result, segment)
+            };
+        }
+        if win32 {
+            str_to_f64(crate::path::js_path_win32_resolve(result))
+        } else {
+            str_to_f64(crate::path::js_path_resolve(result))
+        }
+    };
+    let path_basename_value = |win32: bool| -> f64 {
+        let path = require_path_str_ptr(0);
+        let ext = optional_path_str_ptr(1);
+        if win32 {
+            if ext.is_null() {
+                str_to_f64(crate::path::js_path_win32_basename(path))
+            } else {
+                str_to_f64(crate::path::js_path_win32_basename_ext(path, ext))
+            }
+        } else if ext.is_null() {
+            str_to_f64(crate::path::js_path_basename(path))
+        } else {
+            str_to_f64(crate::path::js_path_basename_ext(path, ext))
+        }
+    };
     let pack_args = || -> *mut crate::array::ArrayHeader {
         let mut arr = crate::array::js_array_alloc(args_len as u32);
         for i in 0..args_len {
@@ -587,12 +676,14 @@ pub(crate) unsafe fn dispatch_native_module_method(
         }
 
         // ── path module (args are NaN-boxed strings → extract raw StringHeader ptr) ──
-        ("path", "dirname") => str_to_f64(crate::path::js_path_dirname(arg_str_ptr(0))),
-        ("path", "basename") => str_to_f64(crate::path::js_path_basename(arg_str_ptr(0))),
-        ("path", "extname") => str_to_f64(crate::path::js_path_extname(arg_str_ptr(0))),
-        ("path", "resolve") => str_to_f64(crate::path::js_path_resolve(arg_str_ptr(0))),
-        ("path", "join") => str_to_f64(crate::path::js_path_join(arg_str_ptr(0), arg_str_ptr(1))),
-        ("path", "isAbsolute") => bool_to_f64(crate::path::js_path_is_absolute(arg_str_ptr(0))),
+        ("path", "dirname") => str_to_f64(crate::path::js_path_dirname(require_path_str_ptr(0))),
+        ("path", "basename") => path_basename_value(false),
+        ("path", "extname") => str_to_f64(crate::path::js_path_extname(require_path_str_ptr(0))),
+        ("path", "resolve") => path_resolve_value(false),
+        ("path", "join") => path_join_value(false),
+        ("path", "isAbsolute") => {
+            bool_to_f64(crate::path::js_path_is_absolute(require_path_str_ptr(0)))
+        }
 
         // #1740: dynamic sub-namespace method dispatch — `path[k].method(...)`
         // where `k` resolves to "win32"/"posix" at runtime. `path[k].sep`
@@ -602,68 +693,65 @@ pub(crate) unsafe fn dispatch_native_module_method(
         // posix routes to the base `js_path_*` family (POSIX `/` semantics),
         // mirroring how the static `path.win32.X()` / `path.posix.X()` forms
         // lower in codegen.
-        ("path.win32", "dirname") => str_to_f64(crate::path::js_path_win32_dirname(arg_str_ptr(0))),
-        ("path.win32", "basename") if args_len >= 2 => str_to_f64(
-            crate::path::js_path_win32_basename_ext(arg_str_ptr(0), arg_str_ptr(1)),
-        ),
-        ("path.win32", "basename") => {
-            str_to_f64(crate::path::js_path_win32_basename(arg_str_ptr(0)))
+        ("path.win32", "dirname") => {
+            str_to_f64(crate::path::js_path_win32_dirname(require_path_str_ptr(0)))
         }
-        ("path.win32", "extname") => str_to_f64(crate::path::js_path_win32_extname(arg_str_ptr(0))),
-        ("path.win32", "normalize") => {
-            str_to_f64(crate::path::js_path_win32_normalize(arg_str_ptr(0)))
+        ("path.win32", "basename") => path_basename_value(true),
+        ("path.win32", "extname") => {
+            str_to_f64(crate::path::js_path_win32_extname(require_path_str_ptr(0)))
         }
-        ("path.win32", "resolve") => str_to_f64(crate::path::js_path_win32_resolve(arg_str_ptr(0))),
-        ("path.win32", "join") => str_to_f64(crate::path::js_path_win32_join(
-            arg_str_ptr(0),
-            arg_str_ptr(1),
+        ("path.win32", "normalize") => str_to_f64(crate::path::js_path_win32_normalize(
+            require_path_str_ptr(0),
         )),
+        ("path.win32", "resolve") => path_resolve_value(true),
+        ("path.win32", "join") => path_join_value(true),
         ("path.win32", "relative") => str_to_f64(crate::path::js_path_win32_relative(
-            arg_str_ptr(0),
-            arg_str_ptr(1),
+            require_path_str_ptr(0),
+            require_path_str_ptr(1),
         )),
         ("path.win32", "toNamespacedPath") => str_to_f64(
             crate::path::js_path_win32_to_namespaced_path(arg_str_ptr(0)),
         ),
-        ("path.win32", "isAbsolute") => {
-            bool_to_f64(crate::path::js_path_win32_is_absolute(arg_str_ptr(0)))
-        }
+        ("path.win32", "isAbsolute") => bool_to_f64(crate::path::js_path_win32_is_absolute(
+            require_path_str_ptr(0),
+        )),
         ("path.win32", "matchesGlob") => bool_to_f64(crate::path::js_path_win32_matches_glob(
-            arg_str_ptr(0),
-            arg_str_ptr(1),
+            require_path_str_ptr(0),
+            require_path_str_ptr(1),
         )),
         ("path.win32", "parse") => {
-            ptr_to_f64(crate::path::js_path_win32_parse(arg_str_ptr(0)) as *const u8)
+            ptr_to_f64(crate::path::js_path_win32_parse(require_path_str_ptr(0)) as *const u8)
         }
         ("path.win32", "format") => str_to_f64(crate::path::js_path_win32_format(arg(0))),
 
-        ("path.posix", "dirname") => str_to_f64(crate::path::js_path_dirname(arg_str_ptr(0))),
-        ("path.posix", "basename") if args_len >= 2 => str_to_f64(
-            crate::path::js_path_basename_ext(arg_str_ptr(0), arg_str_ptr(1)),
-        ),
-        ("path.posix", "basename") => str_to_f64(crate::path::js_path_basename(arg_str_ptr(0))),
-        ("path.posix", "extname") => str_to_f64(crate::path::js_path_extname(arg_str_ptr(0))),
-        ("path.posix", "normalize") => str_to_f64(crate::path::js_path_normalize(arg_str_ptr(0))),
-        ("path.posix", "resolve") => str_to_f64(crate::path::js_path_resolve(arg_str_ptr(0))),
-        ("path.posix", "join") => {
-            str_to_f64(crate::path::js_path_join(arg_str_ptr(0), arg_str_ptr(1)))
+        ("path.posix", "dirname") => {
+            str_to_f64(crate::path::js_path_dirname(require_path_str_ptr(0)))
         }
+        ("path.posix", "basename") => path_basename_value(false),
+        ("path.posix", "extname") => {
+            str_to_f64(crate::path::js_path_extname(require_path_str_ptr(0)))
+        }
+        ("path.posix", "normalize") => {
+            str_to_f64(crate::path::js_path_normalize(require_path_str_ptr(0)))
+        }
+        ("path.posix", "resolve") => path_resolve_value(false),
+        ("path.posix", "join") => path_join_value(false),
         ("path.posix", "relative") => str_to_f64(crate::path::js_path_relative(
-            arg_str_ptr(0),
-            arg_str_ptr(1),
+            require_path_str_ptr(0),
+            require_path_str_ptr(1),
         )),
         ("path.posix", "toNamespacedPath") => {
             str_to_f64(crate::path::js_path_to_namespaced_path(arg_str_ptr(0)))
         }
         ("path.posix", "isAbsolute") => {
-            bool_to_f64(crate::path::js_path_is_absolute(arg_str_ptr(0)))
+            bool_to_f64(crate::path::js_path_is_absolute(require_path_str_ptr(0)))
         }
         ("path.posix", "matchesGlob") => bool_to_f64(crate::path::js_path_matches_glob(
-            arg_str_ptr(0),
-            arg_str_ptr(1),
+            require_path_str_ptr(0),
+            require_path_str_ptr(1),
         )),
         ("path.posix", "parse") => {
-            ptr_to_f64(crate::path::js_path_parse(arg_str_ptr(0)) as *const u8)
+            ptr_to_f64(crate::path::js_path_parse(require_path_str_ptr(0)) as *const u8)
         }
         ("path.posix", "format") => str_to_f64(crate::path::js_path_format(arg(0))),
 

--- a/crates/perry-runtime/src/path.rs
+++ b/crates/perry-runtime/src/path.rs
@@ -6,7 +6,7 @@ use crate::string::{js_string_from_bytes, StringHeader};
 
 /// Helper to extract string from StringHeader pointer
 unsafe fn string_from_header(ptr: *const StringHeader) -> Option<String> {
-    if ptr.is_null() || (ptr as usize) < 0x1000 {
+    if !is_string_header_ptr(ptr) {
         return None;
     }
     let len = (*ptr).byte_len as usize;
@@ -15,10 +15,49 @@ unsafe fn string_from_header(ptr: *const StringHeader) -> Option<String> {
     std::str::from_utf8(bytes).ok().map(|s| s.to_string())
 }
 
+fn is_string_header_ptr(ptr: *const StringHeader) -> bool {
+    if ptr.is_null() || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return false;
+    }
+    if ptr == crate::string::js_get_empty_string() {
+        return true;
+    }
+    if matches!(
+        crate::arena::classify_heap_generation(ptr as usize),
+        crate::arena::HeapGeneration::Unknown
+    ) {
+        return false;
+    }
+    unsafe {
+        let gc_header =
+            (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        if (*gc_header).obj_type != crate::gc::GC_TYPE_STRING {
+            return false;
+        }
+        let byte_len = (*ptr).byte_len;
+        let capacity = (*ptr).capacity;
+        byte_len <= capacity && capacity < 1_073_741_824
+    }
+}
+
 /// Helper to create a JS string from a Rust string
 fn string_to_js(s: &str) -> *mut StringHeader {
     let bytes = s.as_bytes();
     js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
+}
+
+pub(crate) fn throw_invalid_path_arg_type() -> ! {
+    let msg = b"The \"path\" argument must be of type string.";
+    let s = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    crate::node_submodules::register_error_code_pub(s, "ERR_INVALID_ARG_TYPE");
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(f64::from_bits(
+        crate::value::JSValue::pointer(err as *const u8).bits(),
+    ))
+}
+
+fn string_from_header_or_throw(ptr: *const StringHeader) -> String {
+    unsafe { string_from_header(ptr) }.unwrap_or_else(|| throw_invalid_path_arg_type())
 }
 
 fn resolve_posix_str(path_str: &str) -> String {
@@ -41,8 +80,7 @@ fn resolve_posix_str(path_str: &str) -> String {
 /// normalizes — it does NOT reset on an absolute segment (that's
 /// `path.resolve`'s job). We can't use Rust's `Path::join` because it
 /// resets on absolute segments.
-#[no_mangle]
-pub extern "C" fn js_path_join(
+pub(crate) fn js_path_join_unchecked(
     a_ptr: *const StringHeader,
     b_ptr: *const StringHeader,
 ) -> *mut StringHeader {
@@ -62,12 +100,21 @@ pub extern "C" fn js_path_join(
     }
 }
 
+#[no_mangle]
+pub extern "C" fn js_path_join(
+    a_ptr: *const StringHeader,
+    b_ptr: *const StringHeader,
+) -> *mut StringHeader {
+    let _ = string_from_header_or_throw(a_ptr);
+    let _ = string_from_header_or_throw(b_ptr);
+    js_path_join_unchecked(a_ptr, b_ptr)
+}
+
 /// `path.win32.join(a, b)` — Windows-style join. Always emits backslash
 /// separators regardless of host platform. Treats both `/` and `\` as
 /// segment separators in normalization (Node's win32 implementation does
 /// the same) and collapses repeated separators.
-#[no_mangle]
-pub extern "C" fn js_path_win32_join(
+pub(crate) fn js_path_win32_join_unchecked(
     a_ptr: *const StringHeader,
     b_ptr: *const StringHeader,
 ) -> *mut StringHeader {
@@ -86,6 +133,16 @@ pub extern "C" fn js_path_win32_join(
         };
         string_to_js(&normalize_win32_str(&joined))
     }
+}
+
+#[no_mangle]
+pub extern "C" fn js_path_win32_join(
+    a_ptr: *const StringHeader,
+    b_ptr: *const StringHeader,
+) -> *mut StringHeader {
+    let _ = string_from_header_or_throw(a_ptr);
+    let _ = string_from_header_or_throw(b_ptr);
+    js_path_win32_join_unchecked(a_ptr, b_ptr)
 }
 
 /// Result of splitting a win32 path into its root and remainder.
@@ -291,128 +348,100 @@ fn normalize_win32_str(input: &str) -> String {
 /// returns `None` there, which we treat as "stay at root".
 #[no_mangle]
 pub extern "C" fn js_path_dirname(path_ptr: *const StringHeader) -> *mut StringHeader {
-    unsafe {
-        let path_str = match string_from_header(path_ptr) {
-            Some(s) => s,
-            None => return string_to_js("."),
-        };
+    let path_str = string_from_header_or_throw(path_ptr);
 
-        if path_str.is_empty() {
-            return string_to_js(".");
-        }
+    if path_str.is_empty() {
+        return string_to_js(".");
+    }
 
-        // POSIX root: dirname("/") = "/", dirname("///") = "/"
-        if path_str.chars().all(|c| c == '/') {
-            return string_to_js("/");
-        }
-        // Node preserves exactly two leading slashes for the dirname of
-        // `//foo` on POSIX.
-        if path_str.starts_with("//")
-            && !path_str.starts_with("///")
-            && !path_str[2..].contains('/')
-        {
-            return string_to_js("//");
-        }
+    // POSIX root: dirname("/") = "/", dirname("///") = "/"
+    if path_str.chars().all(|c| c == '/') {
+        return string_to_js("/");
+    }
+    // Node preserves exactly two leading slashes for the dirname of
+    // `//foo` on POSIX.
+    if path_str.starts_with("//") && !path_str.starts_with("///") && !path_str[2..].contains('/') {
+        return string_to_js("//");
+    }
 
-        let path = Path::new(&path_str);
-        match path.parent() {
-            Some(parent) => {
-                let s = parent.to_string_lossy();
-                if s.is_empty() {
-                    string_to_js(".")
-                } else {
-                    string_to_js(&s)
-                }
+    let path = Path::new(&path_str);
+    match path.parent() {
+        Some(parent) => {
+            let s = parent.to_string_lossy();
+            if s.is_empty() {
+                string_to_js(".")
+            } else {
+                string_to_js(&s)
             }
-            None => string_to_js("."),
         }
+        None => string_to_js("."),
     }
 }
 
 /// Get base name (file name) from path
 #[no_mangle]
 pub extern "C" fn js_path_basename(path_ptr: *const StringHeader) -> *mut StringHeader {
-    unsafe {
-        let path_str = match string_from_header(path_ptr) {
-            Some(s) => s,
-            None => return string_to_js(""),
-        };
+    let path_str = string_from_header_or_throw(path_ptr);
 
-        let path = Path::new(&path_str);
-        match path.file_name() {
-            Some(name) => string_to_js(&name.to_string_lossy()),
-            None => string_to_js(""),
-        }
+    let path = Path::new(&path_str);
+    match path.file_name() {
+        Some(name) => string_to_js(&name.to_string_lossy()),
+        None => string_to_js(""),
     }
 }
 
 /// Get file extension from path (including the dot)
 #[no_mangle]
 pub extern "C" fn js_path_extname(path_ptr: *const StringHeader) -> *mut StringHeader {
-    unsafe {
-        let path_str = match string_from_header(path_ptr) {
-            Some(s) => s,
-            None => return string_to_js(""),
-        };
+    let path_str = string_from_header_or_throw(path_ptr);
 
-        let path = Path::new(&path_str);
-        match path.extension() {
-            Some(ext) => {
-                let mut result = String::from(".");
-                result.push_str(&ext.to_string_lossy());
-                string_to_js(&result)
-            }
-            None => string_to_js(""),
+    let path = Path::new(&path_str);
+    match path.extension() {
+        Some(ext) => {
+            let mut result = String::from(".");
+            result.push_str(&ext.to_string_lossy());
+            string_to_js(&result)
         }
+        None => string_to_js(""),
     }
 }
 
 /// Check if path is absolute
 #[no_mangle]
 pub extern "C" fn js_path_is_absolute(path_ptr: *const StringHeader) -> i32 {
-    unsafe {
-        let path_str = match string_from_header(path_ptr) {
-            Some(s) => s,
-            None => return 0,
-        };
-        if Path::new(&path_str).is_absolute() {
-            1
-        } else {
-            0
-        }
+    let path_str = string_from_header_or_throw(path_ptr);
+    if Path::new(&path_str).is_absolute() {
+        1
+    } else {
+        0
     }
 }
 
 /// Resolve path to absolute path
 #[no_mangle]
 pub extern "C" fn js_path_resolve(path_ptr: *const StringHeader) -> *mut StringHeader {
-    unsafe {
-        let path_str = match string_from_header(path_ptr) {
-            Some(s) => s,
-            None => return string_to_js(""),
+    let path_str = string_from_header_or_throw(path_ptr);
+
+    if path_str.is_empty() {
+        return match std::env::current_dir() {
+            Ok(cwd) => string_to_js(&cwd.to_string_lossy()),
+            Err(_) => string_to_js(""),
         };
+    }
 
-        if path_str.is_empty() {
-            return match std::env::current_dir() {
-                Ok(cwd) => string_to_js(&cwd.to_string_lossy()),
-                Err(_) => string_to_js(""),
-            };
-        }
-
-        match std::fs::canonicalize(&path_str) {
-            Ok(abs_path) => string_to_js(&abs_path.to_string_lossy()),
-            Err(_) => {
-                // If canonicalize fails (file doesn't exist), try to construct absolute path
-                if Path::new(&path_str).is_absolute() {
-                    string_to_js(&path_str)
-                } else {
-                    match std::env::current_dir() {
-                        Ok(cwd) => {
-                            let joined = cwd.join(&path_str);
-                            string_to_js(&joined.to_string_lossy())
-                        }
-                        Err(_) => string_to_js(&path_str),
+    match std::fs::canonicalize(&path_str) {
+        Ok(abs_path) => string_to_js(&abs_path.to_string_lossy()),
+        Err(_) => {
+            // If canonicalize fails (file doesn't exist), try to construct absolute path
+            if Path::new(&path_str).is_absolute() {
+                string_to_js(&path_str)
+            } else {
+                match std::env::current_dir() {
+                    Ok(cwd) => {
+                        let joined = cwd.join(&path_str);
+                        string_to_js(&joined.to_string_lossy())
                     }
+                    Err(_) => string_to_js(&path_str),
                 }
             }
         }
@@ -463,13 +492,8 @@ fn normalize_str(input: &str) -> String {
 
 #[no_mangle]
 pub extern "C" fn js_path_normalize(path_ptr: *const StringHeader) -> *mut StringHeader {
-    unsafe {
-        let path_str = match string_from_header(path_ptr) {
-            Some(s) => s,
-            None => return string_to_js("."),
-        };
-        string_to_js(&normalize_str(&path_str))
-    }
+    let path_str = string_from_header_or_throw(path_ptr);
+    string_to_js(&normalize_str(&path_str))
 }
 
 #[no_mangle]
@@ -656,21 +680,19 @@ pub extern "C" fn js_path_resolve_join(
     a_ptr: *const StringHeader,
     b_ptr: *const StringHeader,
 ) -> *mut StringHeader {
-    unsafe {
-        let a = string_from_header(a_ptr).unwrap_or_default();
-        let b = string_from_header(b_ptr).unwrap_or_default();
+    let a = string_from_header_or_throw(a_ptr);
+    let b = string_from_header_or_throw(b_ptr);
 
-        let joined = if b.starts_with('/') {
-            b
-        } else if a.is_empty() {
-            b
-        } else if b.is_empty() {
-            a
-        } else {
-            format!("{}/{}", a, b)
-        };
-        string_to_js(&normalize_str(&joined))
-    }
+    let joined = if b.starts_with('/') {
+        b
+    } else if a.is_empty() {
+        b
+    } else if b.is_empty() {
+        a
+    } else {
+        format!("{}/{}", a, b)
+    };
+    string_to_js(&normalize_str(&joined))
 }
 
 /// `path.toNamespacedPath(path)` — Windows-only effect on Node. On POSIX

--- a/reference/deepwiki/deno-node-path-type-errors-2026-05-26.md
+++ b/reference/deepwiki/deno-node-path-type-errors-2026-05-26.md
@@ -1,0 +1,250 @@
+# DeepWiki Response
+
+Repository: `denoland/deno`
+Question: For Node compatibility, how should node:path methods such as join, resolve, and basename validate non-string path arguments? What error name and code should be observable when null, undefined, numbers, objects, or arrays are passed?
+Search: https://deepwiki.com/search/for-node-compatibility-how-sho_b0173353-cfbb-480c-ba79-4295deda6f25
+
+**Question**: For Node compatibility, how should node:path methods such as join, resolve, and basename validate non-string path arguments? What error name and code should be observable when null, undefined, numbers, objects, or arrays are passed?
+
+For Node compatibility, `node:path` methods like `join`, `resolve`, and `basename` should validate non-string path arguments by throwing a `TypeError` with the error code `ERR_INVALID_ARG_TYPE` [1](#ref-q1-1) . This applies when `null`, `undefined`, numbers, objects, or arrays are passed as arguments [2](#ref-q1-2) .
+
+## Argument Validation in `node:path` Methods
+
+The `deno_node` extension, which provides Node.js API compatibility in Deno, implements argument validation for `node:path` methods.
+
+### `assertPath` Function
+The core of this validation is handled by the `assertPath` function, defined in `ext/node/polyfills/path/_util.ts` [2](#ref-q1-2) . This function checks if a given `path` argument is a string. If it is not, it throws an `ERR_INVALID_ARG_TYPE` error [3](#ref-q1-3) .
+
+### Usage in `path.join`
+For example, in the Windows-specific implementation of `path.join` (`ext/node/polyfills/path/_win32.ts`), each path segment passed to the function is validated using `assertPath` [4](#ref-q1-4) . If any segment is not a string, `assertPath` will throw the `ERR_INVALID_ARG_TYPE` error. The `cli/tsc/dts/node/path.d.cts` file also indicates that `path.join` should throw a `TypeError` if any path segment is not a string [5](#ref-q1-5) .
+
+### Usage in `path.resolve` and `path.basename`
+Similarly, `path.resolve` is also expected to throw a `TypeError` if any of its arguments are not strings [6](#ref-q1-6) . While `basename` is not explicitly shown calling `assertPath` in the provided snippets, the general Node.js compatibility guidelines suggest similar validation for path-related functions. The `ext/node/ops/require.rs` file shows Rust operations for `op_require_path_basename` and `op_require_path_resolve` which handle string inputs [7](#ref-q1-7)  [8](#ref-q1-8) , implying that non-string arguments would be caught at the JavaScript polyfill layer.
+
+## Error Name and Code
+
+When a non-string argument is provided to these `node:path` methods, the observable error will be a `TypeError` with the code `ERR_INVALID_ARG_TYPE` [1](#ref-q1-1) . This error is constructed by the `ERR_INVALID_ARG_TYPE` class, which extends `NodeTypeError` [1](#ref-q1-1) . The error message will indicate the argument name, the expected types (e.g., "string"), and the actual received value [9](#ref-q1-9) .
+
+For example, tests for `fs.stat` and `fs.statSync` explicitly check for this error when `undefined` is passed as a path argument [10](#ref-q1-10)  [11](#ref-q1-11) . Similarly, `require` also throws `ERR_INVALID_ARG_TYPE` for non-string IDs [12](#ref-q1-12) .
+
+## Notes
+
+The `ext/node/polyfills/internal/fs/utils.mjs` file contains a `join` function that handles `string` or `Uint8Array` types for paths [13](#ref-q1-13) . If the arguments do not match these types, it also throws an `ERR_INVALID_ARG_TYPE` error, expecting "string" or "Buffer" [14](#ref-q1-14) . This `join` function is used internally for `getDirents` [15](#ref-q1-15)  and is distinct from the `node:path.join` method, which primarily expects string arguments. The user's query specifically refers to `node:path` methods, so the primary answer focuses on string validation.
+
+Wiki pages you might want to explore:
+- [deno_node Extension Architecture (denoland/deno)](/wiki/denoland/deno#7.1)
+- [File System Polyfills (denoland/deno)](/wiki/denoland/deno#7.4)
+
+View this search on DeepWiki: https://deepwiki.com/search/for-node-compatibility-how-sho_b0173353-cfbb-480c-ba79-4295deda6f25
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `ext/node/polyfills/internal/errors.ts:770-774`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/errors.ts#L770-L774)
+
+```typescript
+class ERR_INVALID_ARG_TYPE extends NodeTypeError {
+  constructor(name: string, expected: string | string[], actual: unknown) {
+    const msg = createInvalidArgType(name, expected);
+    super("ERR_INVALID_ARG_TYPE", `${msg}.${invalidArgTypeHelper(actual)}`);
+  }
+```
+
+<a id="ref-q1-2"></a>
+### [2] `ext/node/polyfills/path/_util.ts:24-28`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/path/_util.ts#L24-L28)
+
+```typescript
+function assertPath(path: string) {
+  if (typeof path !== "string") {
+    throw new ERR_INVALID_ARG_TYPE("path", ["string"], path);
+  }
+}
+```
+
+<a id="ref-q1-3"></a>
+### [3] `ext/node/polyfills/path/_util.ts:25-27`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/path/_util.ts#L25-L27)
+
+```typescript
+  if (typeof path !== "string") {
+    throw new ERR_INVALID_ARG_TYPE("path", ["string"], path);
+  }
+```
+
+<a id="ref-q1-4"></a>
+### [4] `ext/node/polyfills/path/_win32.ts:467-468`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/path/_win32.ts#L467-L468)
+
+```typescript
+    const path = paths[i];
+    assertPath(path);
+```
+
+<a id="ref-q1-5"></a>
+### [5] `cli/tsc/dts/node/path.d.cts:78-81`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/cli/tsc/dts/node/path.d.cts#L78-L81)
+
+```
+             *
+             * @param paths paths to join.
+             * @throws {TypeError} if any of the path segments is not a string.
+             */
+```
+
+<a id="ref-q1-6"></a>
+### [6] `cli/tsc/dts/node/path.d.cts:93-95`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/cli/tsc/dts/node/path.d.cts#L93-L95)
+
+```
+             * @param paths A sequence of paths or path segments.
+             * @throws {TypeError} if any of the arguments is not a string.
+             */
+```
+
+<a id="ref-q1-7"></a>
+### [7] `ext/node/ops/require.rs:409-413`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/ops/require.rs#L409-L413)
+
+```rust
+#[string]
+pub fn op_require_path_resolve(#[scoped] parts: Vec<String>) -> String {
+  path_resolve(parts.iter().map(|s| s.as_str()))
+    .to_string_lossy()
+    .into_owned()
+```
+
+<a id="ref-q1-8"></a>
+### [8] `ext/node/ops/require.rs:431-433`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/ops/require.rs#L431-L433)
+
+```rust
+pub fn op_require_path_basename(
+  #[string] request: &str,
+) -> Result<String, JsErrorBox> {
+```
+
+<a id="ref-q1-9"></a>
+### [9] `ext/node/polyfills/internal/errors.ts:771-773`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/errors.ts#L771-L773)
+
+```typescript
+  constructor(name: string, expected: string | string[], actual: unknown) {
+    const msg = createInvalidArgType(name, expected);
+    super("ERR_INVALID_ARG_TYPE", `${msg}.${invalidArgTypeHelper(actual)}`);
+```
+
+<a id="ref-q1-10"></a>
+### [10] `tests/unit_node/_fs/_fs_stat_test.ts:90-103`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/tests/unit_node/_fs/_fs_stat_test.ts#L90-L103)
+
+```typescript
+    try {
+      await new Promise<Stats>((resolve, reject) => {
+        stat(
+          // deno-lint-ignore no-explicit-any
+          undefined as any,
+          (err, stats) => err ? reject(err) : resolve(stats),
+        );
+      });
+      fail();
+    } catch (err) {
+      assert(err instanceof TypeError);
+      // deno-lint-ignore no-explicit-any
+      assertEquals((err as any).code, "ERR_INVALID_ARG_TYPE");
+    }
+```
+
+<a id="ref-q1-11"></a>
+### [11] `tests/unit_node/_fs/_fs_stat_test.ts:107-118`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/tests/unit_node/_fs/_fs_stat_test.ts#L107-L118)
+
+```typescript
+Deno.test({
+  name: "[node/fs] statSync invalid path error",
+  fn() {
+    try {
+      // deno-lint-ignore no-explicit-any
+      statSync(undefined as any);
+      fail();
+    } catch (err) {
+      assert(err instanceof TypeError);
+      // deno-lint-ignore no-explicit-any
+      assertEquals((err as any).code, "ERR_INVALID_ARG_TYPE");
+    }
+```
+
+<a id="ref-q1-12"></a>
+### [12] `tests/unit_node/module_test.ts:179-190`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/tests/unit_node/module_test.ts#L179-L190)
+
+```typescript
+Deno.test("[node/module require] throws ERR_INVALID_ARG_TYPE for non-string id", () => {
+  const require = createRequire(import.meta.url);
+  const err = assertThrows(
+    // @ts-expect-error testing invalid input
+    () => require(123),
+    TypeError,
+  );
+  assertEquals(
+    (err as TypeError & { code?: string }).code,
+    "ERR_INVALID_ARG_TYPE",
+  );
+});
+```
+
+<a id="ref-q1-13"></a>
+### [13] `ext/node/polyfills/internal/fs/utils.mjs:246-273`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/fs/utils.mjs#L246-L273)
+
+```
+function join(path, name) {
+  if (
+    (typeof path === "string" || isUint8Array(path)) &&
+    name === undefined
+  ) {
+    return path;
+  }
+
+  if (typeof path === "string" && isUint8Array(name)) {
+    const pathBuffer = Buffer.from(
+      // deno-lint-ignore prefer-primordials `join` is a `node:path` function
+      lazyPath().default.join(path, lazyPath().default.sep),
+    );
+    // Ignore lint. `concat` is a 'node:buffer' static method on `Buffer`
+    // deno-lint-ignore prefer-primordials
+    return Buffer.concat([pathBuffer, name]);
+  }
+
+  if (typeof path === "string" && typeof name === "string") {
+    // deno-lint-ignore prefer-primordials `join` is a `node:path` function
+    return lazyPath().default.join(path, name);
+  }
+
+  if (isUint8Array(path) && isUint8Array(name)) {
+    // Ignore lint. `concat` is a 'node:buffer' static method on `Buffer`
+    // deno-lint-ignore prefer-primordials
+    return Buffer.concat([path, bufferSep, name]);
+  }
+```
+
+<a id="ref-q1-14"></a>
+### [14] `ext/node/polyfills/internal/fs/utils.mjs:275-279`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/fs/utils.mjs#L275-L279)
+
+```
+  throw new ERR_INVALID_ARG_TYPE(
+    "path",
+    ["string", "Buffer"],
+    path,
+  );
+```
+
+<a id="ref-q1-15"></a>
+### [15] `ext/node/polyfills/internal/fs/utils.mjs:296`
+Source: [denoland/deno @ d6212d40](https://github.com/denoland/deno/blob/d6212d40/ext/node/polyfills/internal/fs/utils.mjs#L296)
+
+```
+          filepath = join(path, name);
+```


### PR DESCRIPTION
## Summary
- validate required node:path string arguments with Node-style TypeError/ERR_INVALID_ARG_TYPE
- prevent non-string heap pointers from being interpreted as empty StringHeader values
- preserve legal zero-argument path.join()/path.resolve() behavior while validating each provided segment in native dispatch

## Verification
- ./run_parity_tests.sh --suite node-suite --module path --filter join/type-errors-extra
- ./run_parity_tests.sh --suite node-suite --module path --filter resolve/type-errors-extra
- ./run_parity_tests.sh --suite node-suite --module path --filter zero-length/type-errors-extra
- ./run_parity_tests.sh --suite node-suite --module path (77 pass / 5 existing residual mismatches)
- cargo test -p perry-runtime path --lib
- cargo fmt --all -- --check
- git diff --check
- jq empty test-parity/known_failures.json