### PR TITLE
Add target-gated native backend packaging

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -80,6 +80,7 @@ use post_link::{
     summarize_codegen_cache_stats,
 };
 pub use resolve::find_perry_workspace_root;
+pub(crate) use resolve::validate_native_library_manifest_value;
 use resolve::{
     cached_resolve_import, compute_module_prefix, extract_compile_package_dir,
     has_perry_native_library, is_declaration_file, is_in_compile_package,
@@ -4816,6 +4817,8 @@ pub fn run_with_parse_cache(
             // ctx.harmonyos_index_ets has the harvested ArkUI (if any). We just
             // pass it through to the EntryAbility/Index.ets writer.
             let index_ets = ctx.harmonyos_index_ets.as_deref();
+            resources::stage_native_library_artifacts(&ctx, output_dir, format)?;
+            let native_resources_dir = output_dir.join("NativeLibraries");
             match emit_harmonyos_arkts_stubs(output_dir, so_filename, index_ets) {
                 Err(e) => eprintln!("Warning: failed to emit ArkTS shim: {}", e),
                 Ok(()) => {
@@ -4859,6 +4862,7 @@ pub fn run_with_parse_cache(
                         profile: args.harmonyos_profile.as_deref(),
                         key_alias: args.harmonyos_key_alias.as_deref(),
                         assets_dir: assets_dir.as_deref(),
+                        native_resources_dir: Some(native_resources_dir.as_path()),
                     };
                     match crate::commands::harmonyos_hap::build_hap(&hap_args) {
                         Ok(res) => {
@@ -5038,6 +5042,9 @@ pub fn run_with_parse_cache(
                         }
                     }
                 }
+            }
+            if !is_harmonyos {
+                resources::stage_native_library_artifacts(&ctx, output_dir, format)?;
             }
         }
 

--- a/crates/perry/src/commands/compile/bundle_apple.rs
+++ b/crates/perry/src/commands/compile/bundle_apple.rs
@@ -14,7 +14,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::i18n_emit::write_lproj_localized_strings;
-use super::resources::{copy_bundle_resource_dirs, find_project_root_for_resources};
+use super::resources::{
+    copy_bundle_resource_dirs, find_project_root_for_resources, stage_native_library_artifacts,
+};
 use super::targets::{compile_metallib_for_bundle, lookup_bundle_id_from_toml};
 use super::CompilationContext;
 
@@ -90,6 +92,7 @@ pub(super) fn bundle_for_watchos(
     }
 
     compile_metallib_for_bundle(ctx, target, &app_dir, format)?;
+    stage_native_library_artifacts(ctx, &app_dir, format)?;
 
     match format {
         OutputFormat::Text => {
@@ -175,6 +178,7 @@ pub(super) fn bundle_for_tvos(
     fs::write(app_dir.join("Info.plist"), info_plist)?;
 
     compile_metallib_for_bundle(ctx, target, &app_dir, format)?;
+    stage_native_library_artifacts(ctx, &app_dir, format)?;
 
     match format {
         OutputFormat::Text => {
@@ -423,6 +427,8 @@ pub(super) fn bundle_for_visionos(
         let project_root = find_project_root_for_resources(&src_dir, true);
         copy_bundle_resource_dirs(&project_root, &app_dir);
     }
+    compile_metallib_for_bundle(ctx, target, &app_dir, format)?;
+    stage_native_library_artifacts(ctx, &app_dir, format)?;
 
     write_lproj_localized_strings(&app_dir, i18n_table, i18n_config);
 

--- a/crates/perry/src/commands/compile/bundle_ios.rs
+++ b/crates/perry/src/commands/compile/bundle_ios.rs
@@ -19,6 +19,7 @@ use crate::OutputFormat;
 use super::apple_info_plist::{
     inject_google_auth_info_plist, inject_ios_app_group_entitlement, inject_ios_deeplinks,
 };
+use super::resources::stage_native_library_artifacts;
 use super::targets::compile_metallib_for_bundle;
 use super::widget_build;
 use super::CompilationContext;
@@ -710,6 +711,7 @@ pub(super) fn build_ios_app_bundle(
     }
 
     compile_metallib_for_bundle(&ctx, target, &app_dir, format)?;
+    stage_native_library_artifacts(ctx, &app_dir, format)?;
 
     // Issue #676: build any [[widget]] entries declared in perry.toml,
     // embedding each produced .appex into <app>.app/Frameworks/<Name>.appex/.

--- a/crates/perry/src/commands/compile/fixtures/native-target-packaging/target-gated-backends.package.json
+++ b/crates/perry/src/commands/compile/fixtures/native-target-packaging/target-gated-backends.package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@scope/demo-native",
+  "version": "1.0.0",
+  "perry": {
+    "nativeLibrary": {
+      "abiVersion": "0.5.0",
+      "functions": [
+        {
+          "name": "renderFrame",
+          "params": ["string"],
+          "returns": "void"
+        }
+      ],
+      "targets": {
+        "linux": {
+          "crate": "native/linux",
+          "lib": "demo_linux",
+          "resources": ["assets/linux-config.json"],
+          "backends": {
+            "vulkan": {
+              "libs": ["vulkan"],
+              "libDirs": ["vendor/vulkan/lib"],
+              "shaderSources": ["shaders/default.comp"],
+              "shaderOutputs": ["prebuilt/default.spv"],
+              "resources": ["resources/vulkan"],
+              "package": {
+                "name": "demo-vulkan",
+                "version": "1.0.0",
+                "kind": "spirv"
+              }
+            }
+          }
+        },
+        "android": {
+          "available": false,
+          "unavailableReason": "Android native package ships separately"
+        },
+        "windows": {
+          "prebuilt": "./prebuilt/windows/demo.lib",
+          "backends": {
+            "d3d12": {
+              "libs": ["d3d12", "dxgi", "dxguid"],
+              "shaderSources": ["shaders/default.hlsl"],
+              "shaderOutputs": ["prebuilt/default.dxil"],
+              "package": {
+                "name": "demo-d3d12",
+                "version": "1.0.0",
+                "kind": "dxil"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -41,6 +41,124 @@ mod platform_cmd;
 
 pub use platform_cmd::select_linker_command;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NativeBackendLinkMetadata {
+    backend: super::NativeBackend,
+    prebuilt: Option<PathBuf>,
+    frameworks: Vec<String>,
+    libs: Vec<String>,
+    lib_dirs: Vec<PathBuf>,
+    pkg_config: Vec<String>,
+}
+
+fn select_available_backend_link_metadata(
+    target_config: &super::TargetNativeConfig,
+) -> Vec<NativeBackendLinkMetadata> {
+    if !target_config.available {
+        return Vec::new();
+    }
+
+    target_config
+        .backends
+        .iter()
+        .filter(|backend| backend.available)
+        .map(|backend| NativeBackendLinkMetadata {
+            backend: backend.backend,
+            prebuilt: backend.prebuilt.clone(),
+            frameworks: backend.frameworks.clone(),
+            libs: backend.libs.clone(),
+            lib_dirs: backend.lib_dirs.clone(),
+            pkg_config: backend.pkg_config.clone(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod native_package_selection_tests {
+    use super::*;
+    use crate::commands::compile::{
+        NativeBackend, NativeBackendConfig, NativeBackendPackageMetadata, TargetNativeConfig,
+    };
+
+    fn target_config() -> TargetNativeConfig {
+        TargetNativeConfig {
+            available: true,
+            unavailable_reason: None,
+            crate_path: PathBuf::from("crate"),
+            lib_name: "demo".to_string(),
+            prebuilt: Some(PathBuf::from("target/libdemo.a")),
+            frameworks: vec!["Metal".to_string()],
+            optional_frameworks: Vec::new(),
+            frameworks_env: None,
+            libs: vec!["z".to_string()],
+            lib_dirs: vec![PathBuf::from("vendor/lib")],
+            pkg_config: vec!["openssl".to_string()],
+            resources: vec![PathBuf::from("resources/common.dat")],
+            shader_outputs: vec![PathBuf::from("shaders/common.spv")],
+            backends: Vec::new(),
+            swift_sources: Vec::new(),
+            metal_sources: vec![PathBuf::from("shaders/default.metal")],
+        }
+    }
+
+    fn backend_config(backend: NativeBackend, available: bool) -> NativeBackendConfig {
+        NativeBackendConfig {
+            backend,
+            available,
+            unavailable_reason: if available {
+                None
+            } else {
+                Some("not shipped".to_string())
+            },
+            prebuilt: Some(PathBuf::from(format!("backend/{}.a", backend.as_str()))),
+            frameworks: vec![format!("{}Framework", backend.as_str())],
+            libs: vec![format!("{}_sys", backend.as_str())],
+            lib_dirs: vec![PathBuf::from(format!("vendor/{}/lib", backend.as_str()))],
+            pkg_config: vec![format!("{}-pkg", backend.as_str())],
+            shader_sources: vec![PathBuf::from(format!("shaders/{}.src", backend.as_str()))],
+            shader_outputs: vec![PathBuf::from(format!("shaders/{}.bin", backend.as_str()))],
+            resources: vec![PathBuf::from(format!("resources/{}", backend.as_str()))],
+            package: NativeBackendPackageMetadata {
+                name: Some(format!("demo-{}", backend.as_str())),
+                version: Some("1.0.0".to_string()),
+                kind: Some("shader-package".to_string()),
+            },
+        }
+    }
+
+    #[test]
+    fn selection_includes_available_backend_link_metadata() {
+        let mut tc = target_config();
+        tc.backends
+            .push(backend_config(NativeBackend::Vulkan, true));
+        tc.backends
+            .push(backend_config(NativeBackend::D3d12, false));
+
+        let selection = select_available_backend_link_metadata(&tc);
+
+        assert_eq!(selection.len(), 1);
+        let backend = &selection[0];
+        assert_eq!(backend.backend, NativeBackend::Vulkan);
+        assert_eq!(backend.prebuilt, Some(PathBuf::from("backend/vulkan.a")));
+        assert_eq!(backend.frameworks, vec!["vulkanFramework".to_string()]);
+        assert_eq!(backend.libs, vec!["vulkan_sys".to_string()]);
+        assert_eq!(backend.lib_dirs, vec![PathBuf::from("vendor/vulkan/lib")]);
+        assert_eq!(backend.pkg_config, vec!["vulkan-pkg".to_string()]);
+    }
+
+    #[test]
+    fn unavailable_target_selects_no_backend_link_metadata() {
+        let mut tc = target_config();
+        tc.available = false;
+        tc.backends
+            .push(backend_config(NativeBackend::Vulkan, true));
+
+        let selection = select_available_backend_link_metadata(&tc);
+
+        assert!(selection.is_empty());
+    }
+}
+
 /// Construct the platform-specific linker command, append every required
 /// argument (object files, libraries, frameworks, system libs, native libs,
 /// geisterhand libs), invoke it, and bail on non-zero status.
@@ -1147,6 +1265,18 @@ pub(super) fn build_and_run_link(
         std::collections::HashSet::new();
     for native_lib in &ctx.native_libraries {
         if let Some(ref target_config) = native_lib.target_config {
+            if !target_config.available {
+                if let (OutputFormat::Text, Some(reason)) =
+                    (format, target_config.unavailable_reason.as_deref())
+                {
+                    println!(
+                        "Skipping native library {} for this target: {}",
+                        native_lib.module, reason
+                    );
+                }
+                continue;
+            }
+
             match format {
                 OutputFormat::Text => {
                     println!("Building native library: {} ...", native_lib.module)
@@ -1414,6 +1544,74 @@ pub(super) fn build_and_run_link(
                 }
             }
 
+            for backend in &target_config.backends {
+                if !backend.available {
+                    if let (OutputFormat::Text, Some(reason)) =
+                        (format, backend.unavailable_reason.as_deref())
+                    {
+                        println!(
+                            "Skipping {} backend for {}: {}",
+                            backend.backend.as_str(),
+                            native_lib.module,
+                            reason
+                        );
+                    }
+                }
+            }
+
+            for backend in select_available_backend_link_metadata(target_config) {
+                if let Some(prebuilt) = backend.prebuilt.as_ref() {
+                    if !prebuilt.exists() {
+                        return Err(anyhow!(
+                            "Prebuilt {} backend library declared by {} not found at {}. \
+                             Install the matching optional dependency or update \
+                             perry.nativeLibrary.targets.<target>.backends.{}.prebuilt.",
+                            backend.backend.as_str(),
+                            native_lib.module,
+                            prebuilt.display(),
+                            backend.backend.as_str()
+                        ));
+                    }
+                    cmd.arg(prebuilt);
+                    match format {
+                        OutputFormat::Text => println!(
+                            "Linking prebuilt {} backend library: {}",
+                            backend.backend.as_str(),
+                            prebuilt.display()
+                        ),
+                        OutputFormat::Json => {}
+                    }
+                }
+
+                for framework in &backend.frameworks {
+                    cmd.arg("-framework").arg(framework);
+                }
+                for lib_dir in &backend.lib_dirs {
+                    if is_windows {
+                        cmd.arg(format!("/LIBPATH:{}", lib_dir.display()));
+                    } else {
+                        cmd.arg(format!("-L{}", lib_dir.display()));
+                    }
+                }
+                for lib in &backend.libs {
+                    if is_windows {
+                        cmd.arg(format!("{}.lib", lib));
+                    } else {
+                        cmd.arg(format!("-l{}", lib));
+                    }
+                }
+                for pkg in &backend.pkg_config {
+                    if let Ok(output) = Command::new("pkg-config").args(["--libs", pkg]).output() {
+                        if output.status.success() {
+                            let libs = String::from_utf8_lossy(&output.stdout);
+                            for flag in libs.trim().split_whitespace() {
+                                cmd.arg(flag);
+                            }
+                        }
+                    }
+                }
+            }
+
             // Compile manifest-declared Swift sources to object files and
             // append them to the link line. Used by `--features watchos-swift-app`
             // so a native lib can ship its own `@main struct App: App`.
@@ -1514,10 +1712,12 @@ pub(super) fn build_and_run_link(
                         | Some("tvos-simulator")
                         | Some("watchos")
                         | Some("watchos-simulator")
+                        | Some("visionos")
+                        | Some("visionos-simulator")
                 )
             {
                 return Err(anyhow!(
-                    "perry.nativeLibrary.targets.<target>.metal_sources is only supported on ios / ios-simulator / tvos / tvos-simulator / watchos / watchos-simulator"
+                    "perry.nativeLibrary.targets.<target>.metal_sources is only supported on ios / ios-simulator / tvos / tvos-simulator / watchos / watchos-simulator / visionos / visionos-simulator"
                 ));
             }
         }

--- a/crates/perry/src/commands/compile/lock_scan.rs
+++ b/crates/perry/src/commands/compile/lock_scan.rs
@@ -46,17 +46,12 @@ pub fn collect_native_archives_for_lock(
         return Ok(Vec::new());
     }
 
-    let mut parse_error = None;
     for_each_native_library_package(&node_modules, &mut |pkg_dir, pkg_name| {
-        let manifest = match parse_native_library_manifest(pkg_dir, pkg_name, target) {
-            Ok(manifest) => manifest,
-            Err(err) => {
-                parse_error = Some(err);
-                return;
-            }
-        };
-        if let Some(manifest) = manifest {
+        if let Some(manifest) = parse_native_library_manifest(pkg_dir, pkg_name, target)? {
             if let Some(tc) = manifest.target_config.as_ref() {
+                if !tc.available {
+                    return Ok(());
+                }
                 if let Some(prebuilt) = tc.prebuilt.as_ref() {
                     if prebuilt.exists() {
                         archives.push(ArchiveEntry {
@@ -66,12 +61,28 @@ pub fn collect_native_archives_for_lock(
                         });
                     }
                 }
+                for backend in &tc.backends {
+                    if !backend.available {
+                        continue;
+                    }
+                    if let Some(prebuilt) = backend.prebuilt.as_ref() {
+                        if prebuilt.exists() {
+                            archives.push(ArchiveEntry {
+                                package: format!(
+                                    "{}:{}",
+                                    manifest.module,
+                                    backend.backend.as_str()
+                                ),
+                                target_key: derive_target_key(target),
+                                path: prebuilt.clone(),
+                            });
+                        }
+                    }
+                }
             }
         }
-    });
-    if let Some(err) = parse_error {
-        return Err(err);
-    }
+        Ok(())
+    })?;
 
     Ok(archives)
 }
@@ -80,9 +91,12 @@ pub fn collect_native_archives_for_lock(
 /// `@scope/*` sub-children), invoking `cb(pkg_dir, pkg_name)` for
 /// each directory that has a `package.json` declaring a
 /// `perry.nativeLibrary` block.
-fn for_each_native_library_package(node_modules: &Path, cb: &mut dyn FnMut(&Path, &str)) {
+fn for_each_native_library_package(
+    node_modules: &Path,
+    cb: &mut dyn FnMut(&Path, &str) -> Result<()>,
+) -> Result<()> {
     let Ok(entries) = fs::read_dir(node_modules) else {
-        return;
+        return Ok(());
     };
     for entry in entries.flatten() {
         let Ok(ft) = entry.file_type() else { continue };
@@ -104,14 +118,15 @@ fn for_each_native_library_package(node_modules: &Path, cb: &mut dyn FnMut(&Path
                     let pkg_dir = scope_entry.path();
                     let full_name = format!("{}/{}", name, sub_name);
                     if has_perry_native_library(&pkg_dir) {
-                        cb(&pkg_dir, &full_name);
+                        cb(&pkg_dir, &full_name)?;
                     }
                 }
             }
         } else if has_perry_native_library(&path) {
-            cb(&path, &name);
+            cb(&path, &name)?;
         }
     }
+    Ok(())
 }
 
 /// Map a Perry target string into the per-arch lockfile key used in
@@ -170,6 +185,9 @@ pub(crate) fn run_lock_verify_for_compile(
     let mut archives: Vec<ArchiveEntry> = Vec::new();
     for manifest in &ctx.native_libraries {
         if let Some(tc) = manifest.target_config.as_ref() {
+            if !tc.available {
+                continue;
+            }
             if let Some(prebuilt) = tc.prebuilt.as_ref() {
                 if prebuilt.exists() {
                     archives.push(ArchiveEntry {
@@ -177,6 +195,20 @@ pub(crate) fn run_lock_verify_for_compile(
                         target_key: derive_target_key(target),
                         path: prebuilt.clone(),
                     });
+                }
+            }
+            for backend in &tc.backends {
+                if !backend.available {
+                    continue;
+                }
+                if let Some(prebuilt) = backend.prebuilt.as_ref() {
+                    if prebuilt.exists() {
+                        archives.push(ArchiveEntry {
+                            package: format!("{}:{}", manifest.module, backend.backend.as_str()),
+                            target_key: derive_target_key(target),
+                            path: prebuilt.clone(),
+                        });
+                    }
                 }
             }
         }
@@ -281,5 +313,54 @@ mod lock_integration_tests {
         // boxes and x86_64 Linux CI runners.
         assert_eq!(archives[0].target_key, derive_target_key(Some("macos")));
         assert_eq!(archives[0].path, archive_path);
+    }
+
+    #[test]
+    fn collect_archives_includes_backend_prebuilt_packages() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path();
+        let pkg_dir = project.join("node_modules/@bloom/engine");
+        fs::create_dir_all(&pkg_dir).unwrap();
+        let target_archive_path = pkg_dir.join("libengine.a");
+        let backend_archive_path = pkg_dir.join("libengine_vulkan.a");
+        fs::write(&target_archive_path, b"target-static-archive-bytes").unwrap();
+        fs::write(&backend_archive_path, b"vulkan-static-archive-bytes").unwrap();
+        let manifest = serde_json::json!({
+            "name": "@bloom/engine",
+            "perry": {
+                "nativeLibrary": {
+                    "functions": [],
+                    "targets": {
+                        "linux": {
+                            "lib": "engine",
+                            "prebuilt": "./libengine.a",
+                            "backends": {
+                                "vulkan": {
+                                    "prebuilt": "./libengine_vulkan.a"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        fs::write(
+            pkg_dir.join("package.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let mut archives =
+            collect_native_archives_for_lock(project, None, Some("linux"), OutputFormat::Json)
+                .expect("scan");
+        archives.sort_by(|a, b| a.package.cmp(&b.package));
+
+        assert_eq!(archives.len(), 2);
+        assert_eq!(archives[0].package, "@bloom/engine");
+        assert_eq!(archives[0].target_key, derive_target_key(Some("linux")));
+        assert_eq!(archives[0].path, target_archive_path);
+        assert_eq!(archives[1].package, "@bloom/engine:vulkan");
+        assert_eq!(archives[1].target_key, derive_target_key(Some("linux")));
+        assert_eq!(archives[1].path, backend_archive_path);
     }
 }

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -36,7 +36,14 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use super::{CompilationContext, NativeFunctionDecl, NativeLibraryManifest, TargetNativeConfig};
+use super::{
+    CompilationContext, NativeBackend, NativeBackendConfig, NativeBackendPackageMetadata,
+    NativeFunctionDecl, NativeLibraryManifest, TargetNativeConfig,
+};
+
+mod native_library;
+use native_library::native_manifest_target_key;
+pub(crate) use native_library::validate_native_library_manifest_value;
 
 /// Find the Perry workspace root by searching upward from the executable location.
 pub fn find_perry_workspace_root() -> Option<PathBuf> {
@@ -143,20 +150,7 @@ pub(super) fn parse_native_library_manifest(
     let functions = parse_native_library_functions(&package_json, native_lib)?;
 
     // Parse target config
-    let target_key = match target {
-        Some("ios-simulator") | Some("ios") => "ios",
-        Some("visionos-simulator") | Some("visionos") => "visionos",
-        Some("android") => "android",
-        Some("tvos-simulator") | Some("tvos") => "tvos",
-        Some("watchos-simulator") | Some("watchos") => "watchos",
-        Some("harmonyos-simulator") | Some("harmonyos") => "harmonyos",
-        Some("linux") => "linux",
-        Some("windows") => "windows",
-        Some("web") => "web",
-        None if cfg!(target_os = "linux") => "linux",
-        None if cfg!(target_os = "windows") => "windows",
-        _ => "macos",
-    };
+    let target_key = native_manifest_target_key(target);
 
     // Issue #860 — prebuilt distribution (esbuild / sharp / swc /
     // lightningcss pattern) needs per-arch target keys so a single
@@ -174,93 +168,17 @@ pub(super) fn parse_native_library_manifest(
         .and_then(|k| targets_block.and_then(|t| t.get(k)))
         .or_else(|| targets_block.and_then(|t| t.get(target_key)));
 
-    let target_config = target_value.map(|tc| TargetNativeConfig {
-        crate_path: package_dir.join(tc.get("crate").and_then(|c| c.as_str()).unwrap_or("")),
-        lib_name: tc
-            .get("lib")
-            .and_then(|l| l.as_str())
-            .unwrap_or("")
-            .to_string(),
-        prebuilt: tc
-            .get("prebuilt")
-            .and_then(|p| p.as_str())
-            .and_then(|spec| resolve_prebuilt_path(package_dir, spec)),
-        frameworks: tc
-            .get("frameworks")
-            .and_then(|f| f.as_array())
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default(),
-        // Issue #1304 — vendored-SDK frameworks gated on an env var.
-        // Accept both camelCase (`optionalFrameworks`/`frameworksEnv`,
-        // matching `libDirs`/`pkgConfig`) and snake_case
-        // (`optional_frameworks`/`frameworks_env`, matching
-        // `swift_sources`/`metal_sources`) so package authors don't get
-        // tripped up by the manifest's mixed casing convention.
-        optional_frameworks: tc
-            .get("optionalFrameworks")
-            .or_else(|| tc.get("optional_frameworks"))
-            .and_then(|f| f.as_array())
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default(),
-        frameworks_env: tc
-            .get("frameworksEnv")
-            .or_else(|| tc.get("frameworks_env"))
-            .and_then(|v| v.as_str())
-            .map(String::from),
-        libs: tc
-            .get("libs")
-            .and_then(|l| l.as_array())
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default(),
-        lib_dirs: tc
-            .get("libDirs")
-            .and_then(|l| l.as_array())
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(|p| package_dir.join(p)))
-                    .collect()
-            })
-            .unwrap_or_default(),
-        pkg_config: tc
-            .get("pkgConfig")
-            .and_then(|p| p.as_array())
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default(),
-        swift_sources: tc
-            .get("swift_sources")
-            .and_then(|s| s.as_array())
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(|p| package_dir.join(p)))
-                    .collect()
-            })
-            .unwrap_or_default(),
-        metal_sources: tc
-            .get("metal_sources")
-            .and_then(|s| s.as_array())
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(|p| package_dir.join(p)))
-                    .collect()
-            })
-            .unwrap_or_default(),
-    });
+    let target_config = target_value
+        .map(|tc| {
+            parse_target_native_config(
+                package_dir,
+                module_name,
+                target_key,
+                &format!("perry.nativeLibrary.targets.{target_key}"),
+                tc,
+            )
+        })
+        .transpose()?;
 
     Ok(Some(NativeLibraryManifest {
         module: module_name.to_string(),
@@ -614,6 +532,492 @@ fn invalid_native_abi_error(
         spelling,
         reason
     )
+}
+
+fn parse_target_native_config(
+    package_dir: &Path,
+    module_name: &str,
+    target_key: &str,
+    manifest_path: &str,
+    tc: &serde_json::Value,
+) -> Result<TargetNativeConfig> {
+    let Some(obj) = tc.as_object() else {
+        return Err(anyhow!(
+            "native library `{}` has invalid `{}`: expected object",
+            module_name,
+            manifest_path
+        ));
+    };
+
+    let available =
+        optional_bool_field(obj, "available", module_name, manifest_path)?.unwrap_or(true);
+    let unavailable_reason = optional_alias_string_field(
+        obj,
+        "unavailableReason",
+        "unavailable_reason",
+        module_name,
+        manifest_path,
+    )?;
+
+    if !available {
+        return Ok(TargetNativeConfig {
+            available,
+            unavailable_reason,
+            crate_path: PathBuf::new(),
+            lib_name: String::new(),
+            prebuilt: None,
+            frameworks: Vec::new(),
+            optional_frameworks: Vec::new(),
+            frameworks_env: None,
+            libs: Vec::new(),
+            lib_dirs: Vec::new(),
+            pkg_config: Vec::new(),
+            resources: Vec::new(),
+            shader_outputs: Vec::new(),
+            backends: Vec::new(),
+            swift_sources: Vec::new(),
+            metal_sources: Vec::new(),
+        });
+    }
+
+    let prebuilt =
+        parse_optional_path_spec(package_dir, obj.get("prebuilt"), module_name, manifest_path)?;
+    let backends = parse_backend_configs(package_dir, module_name, target_key, manifest_path, obj)?;
+
+    let has_crate = obj.get("crate").is_some();
+    let has_lib = obj.get("lib").is_some();
+    if prebuilt.is_none() && (has_crate ^ has_lib) {
+        return Err(anyhow!(
+            "native library `{}` has incomplete `{}`: `crate` and `lib` must be declared together when `prebuilt` is absent",
+            module_name,
+            manifest_path
+        ));
+    }
+
+    Ok(TargetNativeConfig {
+        available,
+        unavailable_reason,
+        crate_path: package_dir.join(
+            optional_string_field(obj, "crate", module_name, manifest_path)?.unwrap_or_default(),
+        ),
+        lib_name: optional_string_field(obj, "lib", module_name, manifest_path)?
+            .unwrap_or_default(),
+        prebuilt,
+        frameworks: parse_optional_string_array(obj, "frameworks", module_name, manifest_path)?,
+        // Issue #1304 — vendored-SDK frameworks gated on an env var.
+        // Accept both camelCase (`optionalFrameworks`/`frameworksEnv`,
+        // matching `libDirs`/`pkgConfig`) and snake_case
+        // (`optional_frameworks`/`frameworks_env`, matching
+        // `swift_sources`/`metal_sources`) so package authors don't get
+        // tripped up by the manifest's mixed casing convention.
+        optional_frameworks: parse_optional_alias_string_array(
+            obj,
+            "optionalFrameworks",
+            "optional_frameworks",
+            module_name,
+            manifest_path,
+        )?,
+        frameworks_env: optional_alias_string_field(
+            obj,
+            "frameworksEnv",
+            "frameworks_env",
+            module_name,
+            manifest_path,
+        )?,
+        libs: parse_optional_string_array(obj, "libs", module_name, manifest_path)?,
+        lib_dirs: parse_optional_path_array(
+            obj,
+            "libDirs",
+            package_dir,
+            module_name,
+            manifest_path,
+        )?,
+        pkg_config: parse_optional_string_array(obj, "pkgConfig", module_name, manifest_path)?,
+        resources: parse_optional_path_array(
+            obj,
+            "resources",
+            package_dir,
+            module_name,
+            manifest_path,
+        )?,
+        shader_outputs: parse_optional_alias_path_array(
+            obj,
+            "shaderOutputs",
+            "shader_outputs",
+            package_dir,
+            module_name,
+            manifest_path,
+        )?,
+        backends,
+        swift_sources: parse_optional_path_array(
+            obj,
+            "swift_sources",
+            package_dir,
+            module_name,
+            manifest_path,
+        )?,
+        metal_sources: parse_optional_path_array(
+            obj,
+            "metal_sources",
+            package_dir,
+            module_name,
+            manifest_path,
+        )?,
+    })
+}
+
+fn parse_backend_configs(
+    package_dir: &Path,
+    module_name: &str,
+    target_key: &str,
+    manifest_path: &str,
+    target_obj: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Vec<NativeBackendConfig>> {
+    let Some(backends_value) = target_obj.get("backends") else {
+        return Ok(Vec::new());
+    };
+    let Some(backends_obj) = backends_value.as_object() else {
+        return Err(anyhow!(
+            "native library `{}` has invalid `{}.backends`: expected object",
+            module_name,
+            manifest_path
+        ));
+    };
+
+    let mut backends = Vec::with_capacity(backends_obj.len());
+    for (name, value) in backends_obj {
+        let backend = parse_backend_name(name).ok_or_else(|| {
+            anyhow!(
+                "native library `{}` has unsupported backend `{}.backends.{}`. \
+                 Supported backends are `metal`, `vulkan`, and `d3d12`.",
+                module_name,
+                manifest_path,
+                name
+            )
+        })?;
+        if !backend_supported_on_target(backend, target_key) {
+            return Err(anyhow!(
+                "native library `{}` declares backend `{}` under `{}` but `{}` is not supported on target `{}`. \
+                 Metal is Apple-only, Vulkan is supported on macos/linux/windows/android/harmonyos, and D3D12 is Windows-only.",
+                module_name,
+                backend.as_str(),
+                manifest_path,
+                backend.as_str(),
+                target_key
+            ));
+        }
+        let backend_path = format!("{manifest_path}.backends.{name}");
+        let backend_obj = value.as_object().ok_or_else(|| {
+            anyhow!(
+                "native library `{}` has invalid `{}`: expected object",
+                module_name,
+                backend_path
+            )
+        })?;
+        let available = optional_bool_field(backend_obj, "available", module_name, &backend_path)?
+            .unwrap_or(true);
+        let unavailable_reason = optional_alias_string_field(
+            backend_obj,
+            "unavailableReason",
+            "unavailable_reason",
+            module_name,
+            &backend_path,
+        )?;
+        if !available {
+            backends.push(NativeBackendConfig {
+                backend,
+                available,
+                unavailable_reason,
+                prebuilt: None,
+                frameworks: Vec::new(),
+                libs: Vec::new(),
+                lib_dirs: Vec::new(),
+                pkg_config: Vec::new(),
+                shader_sources: Vec::new(),
+                shader_outputs: Vec::new(),
+                resources: Vec::new(),
+                package: NativeBackendPackageMetadata::default(),
+            });
+            continue;
+        }
+
+        backends.push(NativeBackendConfig {
+            backend,
+            available,
+            unavailable_reason,
+            prebuilt: parse_optional_path_spec(
+                package_dir,
+                backend_obj.get("prebuilt"),
+                module_name,
+                &backend_path,
+            )?,
+            frameworks: parse_optional_string_array(
+                backend_obj,
+                "frameworks",
+                module_name,
+                &backend_path,
+            )?,
+            libs: parse_optional_string_array(backend_obj, "libs", module_name, &backend_path)?,
+            lib_dirs: parse_optional_path_array(
+                backend_obj,
+                "libDirs",
+                package_dir,
+                module_name,
+                &backend_path,
+            )?,
+            pkg_config: parse_optional_string_array(
+                backend_obj,
+                "pkgConfig",
+                module_name,
+                &backend_path,
+            )?,
+            shader_sources: parse_optional_alias_path_array(
+                backend_obj,
+                "shaderSources",
+                "shader_sources",
+                package_dir,
+                module_name,
+                &backend_path,
+            )?,
+            shader_outputs: parse_optional_alias_path_array(
+                backend_obj,
+                "shaderOutputs",
+                "shader_outputs",
+                package_dir,
+                module_name,
+                &backend_path,
+            )?,
+            resources: parse_optional_path_array(
+                backend_obj,
+                "resources",
+                package_dir,
+                module_name,
+                &backend_path,
+            )?,
+            package: parse_backend_package_metadata(backend_obj, module_name, &backend_path)?,
+        });
+    }
+    Ok(backends)
+}
+
+fn parse_backend_package_metadata(
+    backend_obj: &serde_json::Map<String, serde_json::Value>,
+    module_name: &str,
+    backend_path: &str,
+) -> Result<NativeBackendPackageMetadata> {
+    let Some(package) = backend_obj.get("package") else {
+        return Ok(NativeBackendPackageMetadata::default());
+    };
+    let Some(package_obj) = package.as_object() else {
+        return Err(anyhow!(
+            "native library `{}` has invalid `{}.package`: expected object",
+            module_name,
+            backend_path
+        ));
+    };
+    Ok(NativeBackendPackageMetadata {
+        name: optional_string_field(
+            package_obj,
+            "name",
+            module_name,
+            &format!("{backend_path}.package"),
+        )?,
+        version: optional_string_field(
+            package_obj,
+            "version",
+            module_name,
+            &format!("{backend_path}.package"),
+        )?,
+        kind: optional_string_field(
+            package_obj,
+            "kind",
+            module_name,
+            &format!("{backend_path}.package"),
+        )?,
+    })
+}
+
+fn parse_backend_name(name: &str) -> Option<NativeBackend> {
+    match name {
+        "metal" => Some(NativeBackend::Metal),
+        "vulkan" => Some(NativeBackend::Vulkan),
+        "d3d12" => Some(NativeBackend::D3d12),
+        _ => None,
+    }
+}
+
+fn backend_supported_on_target(backend: NativeBackend, target_key: &str) -> bool {
+    match backend {
+        NativeBackend::Metal => matches!(
+            target_key,
+            "macos" | "ios" | "tvos" | "watchos" | "visionos"
+        ),
+        NativeBackend::Vulkan => matches!(
+            target_key,
+            "macos" | "linux" | "windows" | "android" | "harmonyos"
+        ),
+        NativeBackend::D3d12 => target_key == "windows",
+    }
+}
+
+fn optional_string_field(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+    module_name: &str,
+    manifest_path: &str,
+) -> Result<Option<String>> {
+    let Some(value) = obj.get(field) else {
+        return Ok(None);
+    };
+    value.as_str().map(|s| Some(s.to_string())).ok_or_else(|| {
+        anyhow!(
+            "native library `{}` has invalid `{}.{}`: expected string",
+            module_name,
+            manifest_path,
+            field
+        )
+    })
+}
+
+fn optional_alias_string_field(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    camel: &str,
+    snake: &str,
+    module_name: &str,
+    manifest_path: &str,
+) -> Result<Option<String>> {
+    if obj.contains_key(camel) {
+        optional_string_field(obj, camel, module_name, manifest_path)
+    } else {
+        optional_string_field(obj, snake, module_name, manifest_path)
+    }
+}
+
+fn optional_bool_field(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+    module_name: &str,
+    manifest_path: &str,
+) -> Result<Option<bool>> {
+    let Some(value) = obj.get(field) else {
+        return Ok(None);
+    };
+    value.as_bool().map(Some).ok_or_else(|| {
+        anyhow!(
+            "native library `{}` has invalid `{}.{}`: expected boolean",
+            module_name,
+            manifest_path,
+            field
+        )
+    })
+}
+
+fn parse_optional_string_array(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+    module_name: &str,
+    manifest_path: &str,
+) -> Result<Vec<String>> {
+    let Some(value) = obj.get(field) else {
+        return Ok(Vec::new());
+    };
+    parse_string_array_value(value, module_name, &format!("{manifest_path}.{field}"))
+}
+
+fn parse_optional_alias_string_array(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    camel: &str,
+    snake: &str,
+    module_name: &str,
+    manifest_path: &str,
+) -> Result<Vec<String>> {
+    if obj.contains_key(camel) {
+        parse_optional_string_array(obj, camel, module_name, manifest_path)
+    } else {
+        parse_optional_string_array(obj, snake, module_name, manifest_path)
+    }
+}
+
+fn parse_string_array_value(
+    value: &serde_json::Value,
+    module_name: &str,
+    path: &str,
+) -> Result<Vec<String>> {
+    let Some(arr) = value.as_array() else {
+        return Err(anyhow!(
+            "native library `{}` has invalid `{}`: expected array of strings",
+            module_name,
+            path
+        ));
+    };
+    let mut out = Vec::with_capacity(arr.len());
+    for (idx, item) in arr.iter().enumerate() {
+        let Some(s) = item.as_str() else {
+            return Err(anyhow!(
+                "native library `{}` has invalid `{}[{}]`: expected string",
+                module_name,
+                path,
+                idx
+            ));
+        };
+        out.push(s.to_string());
+    }
+    Ok(out)
+}
+
+fn parse_optional_path_array(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+    package_dir: &Path,
+    module_name: &str,
+    manifest_path: &str,
+) -> Result<Vec<PathBuf>> {
+    let values = parse_optional_string_array(obj, field, module_name, manifest_path)?;
+    Ok(values.into_iter().map(|p| package_dir.join(p)).collect())
+}
+
+fn parse_optional_alias_path_array(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    camel: &str,
+    snake: &str,
+    package_dir: &Path,
+    module_name: &str,
+    manifest_path: &str,
+) -> Result<Vec<PathBuf>> {
+    if obj.contains_key(camel) {
+        parse_optional_path_array(obj, camel, package_dir, module_name, manifest_path)
+    } else {
+        parse_optional_path_array(obj, snake, package_dir, module_name, manifest_path)
+    }
+}
+
+fn parse_optional_path_spec(
+    package_dir: &Path,
+    value: Option<&serde_json::Value>,
+    module_name: &str,
+    manifest_path: &str,
+) -> Result<Option<PathBuf>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let spec = value.as_str().ok_or_else(|| {
+        anyhow!(
+            "native library `{}` has invalid `{}.prebuilt`: expected string",
+            module_name,
+            manifest_path
+        )
+    })?;
+    resolve_prebuilt_path(package_dir, spec)
+        .map(Some)
+        .ok_or_else(|| {
+            anyhow!(
+                "native library `{}` could not resolve `{}.prebuilt` value `{}`. \
+                 Use a relative path, an absolute path, or an installed node_modules subpath.",
+                module_name,
+                manifest_path,
+                spec
+            )
+        })
 }
 
 /// Map a Perry target string to the architecture token used in

--- a/crates/perry/src/commands/compile/resolve/native_library.rs
+++ b/crates/perry/src/commands/compile/resolve/native_library.rs
@@ -1,0 +1,89 @@
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+
+use super::{parse_native_library_functions, parse_target_native_config};
+
+pub(crate) fn validate_native_library_manifest_value(
+    package_dir: &Path,
+    module_name: &str,
+    native_lib: &serde_json::Value,
+) -> Result<()> {
+    let package_json = package_dir.join("package.json");
+    parse_native_library_functions(&package_json, native_lib)?;
+    let Some(targets) = native_lib.get("targets") else {
+        return Ok(());
+    };
+    let Some(targets_obj) = targets.as_object() else {
+        return Err(anyhow!(
+            "native library `{}` has invalid `perry.nativeLibrary.targets`: expected object",
+            module_name
+        ));
+    };
+    for (target_key, value) in targets_obj {
+        let base_target = base_target_key(target_key).ok_or_else(|| {
+            anyhow!(
+                "native library `{}` has unsupported target key `perry.nativeLibrary.targets.{}`. \
+                 Expected macos, ios, linux, windows, android, web, harmonyos, tvos, watchos, \
+                 visionos, or a supported per-arch key such as macos-arm64.",
+                module_name,
+                target_key
+            )
+        })?;
+        parse_target_native_config(
+            package_dir,
+            module_name,
+            base_target,
+            &format!("perry.nativeLibrary.targets.{target_key}"),
+            value,
+        )?;
+    }
+    Ok(())
+}
+
+pub(super) fn native_manifest_target_key(target: Option<&str>) -> &'static str {
+    match target {
+        Some("ios-simulator") | Some("ios") => "ios",
+        Some("visionos-simulator") | Some("visionos") => "visionos",
+        Some("android") => "android",
+        Some("tvos-simulator") | Some("tvos") => "tvos",
+        Some("watchos-simulator") | Some("watchos") => "watchos",
+        Some("harmonyos-simulator") | Some("harmonyos") => "harmonyos",
+        Some("linux") => "linux",
+        Some("windows") => "windows",
+        Some("web") => "web",
+        Some("macos") => "macos",
+        None if cfg!(target_os = "linux") => "linux",
+        None if cfg!(target_os = "windows") => "windows",
+        _ => "macos",
+    }
+}
+
+fn base_target_key(target_key: &str) -> Option<&str> {
+    const BASES: &[&str] = &[
+        "macos",
+        "ios",
+        "linux",
+        "windows",
+        "android",
+        "web",
+        "harmonyos",
+        "tvos",
+        "watchos",
+        "visionos",
+    ];
+    if BASES.contains(&target_key) {
+        return Some(target_key);
+    }
+    for base in BASES {
+        if let Some(suffix) = target_key.strip_prefix(&format!("{base}-")) {
+            if matches!(
+                suffix,
+                "arm64" | "aarch64" | "x64" | "x86_64" | "ia32" | "i686"
+            ) {
+                return Some(base);
+            }
+        }
+    }
+    None
+}

--- a/crates/perry/src/commands/compile/resolve/tests.rs
+++ b/crates/perry/src/commands/compile/resolve/tests.rs
@@ -683,6 +683,387 @@ mod manifest_parse_tests {
         assert!(tc.optional_frameworks.is_empty());
         assert!(tc.frameworks_env.is_none());
     }
+
+    #[test]
+    fn parses_metal_backend_target_metadata() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+        let manifest = serde_json::json!({
+            "perry": {
+                "nativeLibrary": {
+                    "functions": [],
+                    "targets": {
+                        "ios": {
+                            "crate": "crate-ios",
+                            "lib": "demo",
+                            "backends": {
+                                "metal": {
+                                    "frameworks": ["Metal", "QuartzCore"],
+                                    "shaderSources": ["shaders/default.metal"],
+                                    "shaderOutputs": ["prebuilt/default.metallib"],
+                                    "resources": ["resources/metal"],
+                                    "package": {
+                                        "name": "demo-metal",
+                                        "version": "1.0.0",
+                                        "kind": "metallib"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .expect("write package.json");
+
+        let parsed = parse_native_library_manifest(pkg_dir, "demo", Some("ios"))
+            .expect("parse manifest")
+            .expect("parsed manifest");
+        let tc = parsed.target_config.expect("target_config");
+        let backend = tc.backends.first().expect("metal backend");
+        assert_eq!(backend.backend, NativeBackend::Metal);
+        assert_eq!(backend.frameworks, vec!["Metal", "QuartzCore"]);
+        assert_eq!(
+            backend.shader_sources,
+            vec![pkg_dir.join("shaders/default.metal")]
+        );
+        assert_eq!(
+            backend.shader_outputs,
+            vec![pkg_dir.join("prebuilt/default.metallib")]
+        );
+        assert_eq!(backend.resources, vec![pkg_dir.join("resources/metal")]);
+        assert_eq!(backend.package.name.as_deref(), Some("demo-metal"));
+        assert_eq!(backend.package.kind.as_deref(), Some("metallib"));
+    }
+
+    #[test]
+    fn parses_vulkan_backend_target_metadata() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+        let manifest = serde_json::json!({
+            "perry": {
+                "nativeLibrary": {
+                    "functions": [],
+                    "targets": {
+                        "linux": {
+                            "crate": "crate-linux",
+                            "lib": "demo",
+                            "backends": {
+                                "vulkan": {
+                                    "libs": ["vulkan"],
+                                    "libDirs": ["vendor/vulkan/lib"],
+                                    "shaderOutputs": ["shaders/default.spv"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .expect("write package.json");
+
+        let parsed = parse_native_library_manifest(pkg_dir, "demo", Some("linux"))
+            .expect("parse manifest")
+            .expect("parsed manifest");
+        let tc = parsed.target_config.expect("target_config");
+        let backend = tc.backends.first().expect("vulkan backend");
+        assert_eq!(backend.backend, NativeBackend::Vulkan);
+        assert_eq!(backend.libs, vec!["vulkan"]);
+        assert_eq!(backend.lib_dirs, vec![pkg_dir.join("vendor/vulkan/lib")]);
+        assert_eq!(
+            backend.shader_outputs,
+            vec![pkg_dir.join("shaders/default.spv")]
+        );
+    }
+
+    #[test]
+    fn parses_d3d12_backend_target_metadata() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+        let manifest = serde_json::json!({
+            "perry": {
+                "nativeLibrary": {
+                    "functions": [],
+                    "targets": {
+                        "windows": {
+                            "prebuilt": "./prebuilt/demo.lib",
+                            "backends": {
+                                "d3d12": {
+                                    "libs": ["d3d12", "dxgi", "dxguid"],
+                                    "shaderSources": ["shaders/default.hlsl"],
+                                    "shaderOutputs": ["shaders/default.dxil"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .expect("write package.json");
+
+        let parsed = parse_native_library_manifest(pkg_dir, "demo", Some("windows"))
+            .expect("parse manifest")
+            .expect("parsed manifest");
+        let tc = parsed.target_config.expect("target_config");
+        assert_eq!(
+            tc.prebuilt.as_ref().expect("prebuilt"),
+            &pkg_dir.join("./prebuilt/demo.lib")
+        );
+        let backend = tc.backends.first().expect("d3d12 backend");
+        assert_eq!(backend.backend, NativeBackend::D3d12);
+        assert_eq!(backend.libs, vec!["d3d12", "dxgi", "dxguid"]);
+        assert_eq!(
+            backend.shader_sources,
+            vec![pkg_dir.join("shaders/default.hlsl")]
+        );
+    }
+
+    #[test]
+    fn rejects_d3d12_backend_on_linux_target() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+        let manifest = serde_json::json!({
+            "perry": {
+                "nativeLibrary": {
+                    "functions": [],
+                    "targets": {
+                        "linux": {
+                            "crate": "crate-linux",
+                            "lib": "demo",
+                            "backends": { "d3d12": { "libs": ["d3d12"] } }
+                        }
+                    }
+                }
+            }
+        });
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .expect("write package.json");
+
+        let err = parse_native_library_manifest(pkg_dir, "demo", Some("linux"))
+            .expect_err("d3d12 on linux must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("d3d12"), "got: {msg}");
+        assert!(msg.contains("Windows-only"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_unknown_backend_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+        let manifest = serde_json::json!({
+            "perry": {
+                "nativeLibrary": {
+                    "functions": [],
+                    "targets": {
+                        "linux": {
+                            "crate": "crate-linux",
+                            "lib": "demo",
+                            "backends": { "cuda": {} }
+                        }
+                    }
+                }
+            }
+        });
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .expect("write package.json");
+
+        let err = parse_native_library_manifest(pkg_dir, "demo", Some("linux"))
+            .expect_err("unknown backend must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("cuda"), "got: {msg}");
+        assert!(msg.contains("metal"), "got: {msg}");
+        assert!(msg.contains("vulkan"), "got: {msg}");
+        assert!(msg.contains("d3d12"), "got: {msg}");
+    }
+
+    #[test]
+    fn parses_target_gated_backend_fixture() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            include_str!("../fixtures/native-target-packaging/target-gated-backends.package.json"),
+        )
+        .expect("write fixture package.json");
+        std::fs::create_dir_all(pkg_dir.join("prebuilt/windows"))
+            .expect("create prebuilt fixture dir");
+        std::fs::write(pkg_dir.join("prebuilt/windows/demo.lib"), b"fixture")
+            .expect("write prebuilt fixture lib");
+
+        let linux = parse_native_library_manifest(pkg_dir, "@scope/demo-native", Some("linux"))
+            .expect("parse linux manifest")
+            .expect("linux manifest");
+        let linux_tc = linux.target_config.expect("linux target_config");
+        assert!(linux_tc.available);
+        assert_eq!(linux_tc.lib_name, "demo_linux");
+        assert_eq!(
+            linux_tc.resources,
+            vec![pkg_dir.join("assets/linux-config.json")]
+        );
+        let vulkan = linux_tc.backends.first().expect("vulkan backend");
+        assert_eq!(vulkan.backend, NativeBackend::Vulkan);
+        assert_eq!(vulkan.libs, vec!["vulkan"]);
+        assert_eq!(vulkan.lib_dirs, vec![pkg_dir.join("vendor/vulkan/lib")]);
+        assert_eq!(
+            vulkan.shader_sources,
+            vec![pkg_dir.join("shaders/default.comp")]
+        );
+        assert_eq!(
+            vulkan.shader_outputs,
+            vec![pkg_dir.join("prebuilt/default.spv")]
+        );
+        assert_eq!(vulkan.resources, vec![pkg_dir.join("resources/vulkan")]);
+        assert_eq!(vulkan.package.name.as_deref(), Some("demo-vulkan"));
+        assert_eq!(vulkan.package.kind.as_deref(), Some("spirv"));
+
+        let android = parse_native_library_manifest(pkg_dir, "@scope/demo-native", Some("android"))
+            .expect("parse android manifest")
+            .expect("android manifest");
+        let android_tc = android.target_config.expect("android target_config");
+        assert!(!android_tc.available);
+        assert_eq!(
+            android_tc.unavailable_reason.as_deref(),
+            Some("Android native package ships separately")
+        );
+        assert!(android_tc.backends.is_empty());
+
+        let windows = parse_native_library_manifest(pkg_dir, "@scope/demo-native", Some("windows"))
+            .expect("parse windows manifest")
+            .expect("windows manifest");
+        let windows_tc = windows.target_config.expect("windows target_config");
+        assert_eq!(
+            windows_tc.prebuilt.as_ref().expect("windows prebuilt"),
+            &pkg_dir.join("./prebuilt/windows/demo.lib")
+        );
+        let d3d12 = windows_tc.backends.first().expect("d3d12 backend");
+        assert_eq!(d3d12.backend, NativeBackend::D3d12);
+        assert_eq!(d3d12.libs, vec!["d3d12", "dxgi", "dxguid"]);
+        assert_eq!(
+            d3d12.shader_sources,
+            vec![pkg_dir.join("shaders/default.hlsl")]
+        );
+        assert_eq!(d3d12.package.kind.as_deref(), Some("dxil"));
+    }
+
+    #[test]
+    fn unavailable_target_skips_without_build_metadata() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+        let manifest = serde_json::json!({
+            "perry": {
+                "nativeLibrary": {
+                    "functions": [],
+                    "targets": {
+                        "linux": {
+                            "available": false,
+                            "unavailableReason": "GPU SDK not distributed for this target"
+                        }
+                    }
+                }
+            }
+        });
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .expect("write package.json");
+
+        let parsed = parse_native_library_manifest(pkg_dir, "demo", Some("linux"))
+            .expect("parse manifest")
+            .expect("parsed manifest");
+        let tc = parsed.target_config.expect("target_config");
+        assert!(!tc.available);
+        assert_eq!(
+            tc.unavailable_reason.as_deref(),
+            Some("GPU SDK not distributed for this target")
+        );
+        assert!(tc.backends.is_empty());
+    }
+
+    #[test]
+    fn rejects_invalid_target_available_type() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+        let manifest = serde_json::json!({
+            "perry": {
+                "nativeLibrary": {
+                    "functions": [],
+                    "targets": {
+                        "linux": {
+                            "available": "false",
+                            "crate": "crate-linux",
+                            "lib": "demo"
+                        }
+                    }
+                }
+            }
+        });
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .expect("write package.json");
+
+        let err = parse_native_library_manifest(pkg_dir, "demo", Some("linux"))
+            .expect_err("string available must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("targets.linux.available"), "got: {msg}");
+        assert!(msg.contains("expected boolean"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_invalid_backend_available_type() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+        let manifest = serde_json::json!({
+            "perry": {
+                "nativeLibrary": {
+                    "functions": [],
+                    "targets": {
+                        "linux": {
+                            "crate": "crate-linux",
+                            "lib": "demo",
+                            "backends": {
+                                "vulkan": {
+                                    "available": "yes",
+                                    "libs": ["vulkan"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .expect("write package.json");
+
+        let err = parse_native_library_manifest(pkg_dir, "demo", Some("linux"))
+            .expect_err("string backend available must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("backends.vulkan.available"), "got: {msg}");
+        assert!(msg.contains("expected boolean"), "got: {msg}");
+    }
 }
 
 #[cfg(test)]

--- a/crates/perry/src/commands/compile/resources.rs
+++ b/crates/perry/src/commands/compile/resources.rs
@@ -8,6 +8,15 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{anyhow, Context, Result};
+
+use crate::OutputFormat;
+
+use super::{CompilationContext, NativeBackend, NativeBackendConfig};
+
+const BACKEND_PACKAGE_METADATA_FILE: &str = "perry-backend-package.json";
 
 /// Walk up from `start` looking for a project anchor (`package.json`,
 /// or `perry.toml` if `watch_for_perry_toml` is `true`). Bounded to 5
@@ -61,5 +70,538 @@ pub(super) fn copy_bundle_resource_dirs(project_root: &Path, dest_dir: &Path) {
             let dest = dest_dir.join(dir_name);
             let _ = copy_dir_recursive(&resource_dir, &dest);
         }
+    }
+}
+
+/// Copy target/backend-owned native-library resources into a stable
+/// bundle subdirectory. Perry does not interpret these files; it only
+/// preserves the package boundary so native code can resolve its own
+/// backend artifacts without app-specific APIs.
+pub(super) fn copy_native_library_resources(
+    ctx: &CompilationContext,
+    dest_dir: &Path,
+) -> Result<()> {
+    for native_lib in &ctx.native_libraries {
+        let Some(target_config) = native_lib.target_config.as_ref() else {
+            continue;
+        };
+        if !target_config.available {
+            continue;
+        }
+
+        let module_dir = dest_dir
+            .join("NativeLibraries")
+            .join(sanitize_resource_component(&native_lib.module));
+        for path in target_config
+            .resources
+            .iter()
+            .chain(target_config.shader_outputs.iter())
+        {
+            copy_resource_entry(path, &module_dir).with_context(|| {
+                format!(
+                    "copying native resource declared by {}: {}",
+                    native_lib.module,
+                    path.display()
+                )
+            })?;
+        }
+
+        for backend in &target_config.backends {
+            if !backend.available {
+                continue;
+            }
+            let backend_dir = module_dir.join(backend_component(backend.backend));
+            for path in backend
+                .resources
+                .iter()
+                .chain(backend.shader_outputs.iter())
+            {
+                copy_resource_entry(path, &backend_dir).with_context(|| {
+                    format!(
+                        "copying {} backend resource declared by {}: {}",
+                        backend.backend.as_str(),
+                        native_lib.module,
+                        path.display()
+                    )
+                })?;
+            }
+            write_backend_package_metadata(&backend_dir, backend)?;
+        }
+    }
+    Ok(())
+}
+
+/// Compile backend shader sources that need platform SDK tools and
+/// then copy any declared native-library resource artifacts. Metal
+/// shaders stay in `compile_metallib_for_bundle` because Apple bundles
+/// combine them into one `default.metallib`; Vulkan/D3D12 sources keep
+/// their package/backend boundaries under `NativeLibraries/`.
+pub(super) fn stage_native_library_artifacts(
+    ctx: &CompilationContext,
+    dest_dir: &Path,
+    format: OutputFormat,
+) -> Result<()> {
+    compile_backend_shader_sources(ctx, dest_dir, format)?;
+    copy_native_library_resources(ctx, dest_dir)
+}
+
+pub(super) fn compile_backend_shader_sources(
+    ctx: &CompilationContext,
+    dest_dir: &Path,
+    format: OutputFormat,
+) -> Result<()> {
+    for native_lib in &ctx.native_libraries {
+        let Some(target_config) = native_lib.target_config.as_ref() else {
+            continue;
+        };
+        if !target_config.available {
+            continue;
+        }
+
+        let module_dir = dest_dir
+            .join("NativeLibraries")
+            .join(sanitize_resource_component(&native_lib.module));
+        for backend in &target_config.backends {
+            if !backend.available || backend.shader_sources.is_empty() {
+                continue;
+            }
+            if backend.backend == NativeBackend::Metal {
+                continue;
+            }
+
+            let backend_dir = module_dir.join(backend_component(backend.backend));
+            fs::create_dir_all(&backend_dir)?;
+            write_backend_package_metadata(&backend_dir, backend)?;
+            for src in &backend.shader_sources {
+                let output = compiled_shader_output_path(&backend_dir, backend.backend, src)?;
+                compile_backend_shader_source(backend.backend, src, &output).with_context(
+                    || {
+                        format!(
+                            "compiling {} shader declared by {}: {}",
+                            backend.backend.as_str(),
+                            native_lib.module,
+                            src.display()
+                        )
+                    },
+                )?;
+                if matches!(format, OutputFormat::Text) {
+                    println!(
+                        "Compiled {} shader: {} -> {}",
+                        backend.backend.as_str(),
+                        src.display(),
+                        output.display()
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn copy_resource_entry(src: &Path, dst_dir: &Path) -> std::io::Result<()> {
+    let name = src.file_name().unwrap_or_default();
+    let dst = dst_dir.join(name);
+    if src.is_dir() {
+        copy_dir_recursive(src, &dst)
+    } else {
+        fs::create_dir_all(dst_dir)?;
+        fs::copy(src, dst)?;
+        Ok(())
+    }
+}
+
+fn write_backend_package_metadata(dst_dir: &Path, backend: &NativeBackendConfig) -> Result<()> {
+    if backend.package.name.is_none()
+        && backend.package.version.is_none()
+        && backend.package.kind.is_none()
+    {
+        return Ok(());
+    }
+
+    fs::create_dir_all(dst_dir)?;
+    let mut metadata = serde_json::Map::new();
+    metadata.insert(
+        "backend".to_string(),
+        serde_json::Value::String(backend.backend.as_str().to_string()),
+    );
+    if let Some(name) = backend.package.name.as_ref() {
+        metadata.insert(
+            "name".to_string(),
+            serde_json::Value::String(name.to_string()),
+        );
+    }
+    if let Some(version) = backend.package.version.as_ref() {
+        metadata.insert(
+            "version".to_string(),
+            serde_json::Value::String(version.to_string()),
+        );
+    }
+    if let Some(kind) = backend.package.kind.as_ref() {
+        metadata.insert(
+            "kind".to_string(),
+            serde_json::Value::String(kind.to_string()),
+        );
+    }
+    let bytes = serde_json::to_vec_pretty(&serde_json::Value::Object(metadata))?;
+    fs::write(dst_dir.join(BACKEND_PACKAGE_METADATA_FILE), bytes)?;
+    Ok(())
+}
+
+fn compiled_shader_output_path(
+    dst_dir: &Path,
+    backend: NativeBackend,
+    src: &Path,
+) -> Result<PathBuf> {
+    let file_name = src
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            anyhow!(
+                "native {} shader source has no file name: {}",
+                backend.as_str(),
+                src.display()
+            )
+        })?;
+    Ok(dst_dir.join(format!(
+        "{file_name}.{}",
+        compiled_shader_extension(backend)
+    )))
+}
+
+fn compiled_shader_extension(backend: NativeBackend) -> &'static str {
+    match backend {
+        NativeBackend::Metal => "metallib",
+        NativeBackend::Vulkan => "spv",
+        NativeBackend::D3d12 => "dxil",
+    }
+}
+
+fn compile_backend_shader_source(backend: NativeBackend, src: &Path, output: &Path) -> Result<()> {
+    let tool = shader_tool_path(backend);
+    let mut cmd = Command::new(&tool);
+    match backend {
+        NativeBackend::Metal => unreachable!("Metal shaders are compiled by xcrun metal"),
+        NativeBackend::Vulkan => {
+            cmd.arg(src).arg("-o").arg(output);
+        }
+        NativeBackend::D3d12 => {
+            cmd.arg(src).arg("-Fo").arg(output);
+        }
+    }
+
+    let status = cmd.status().map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            anyhow!(
+                "could not find {} for {} shader source {}. Install the SDK toolchain or set {}",
+                shader_tool_name(backend),
+                backend.as_str(),
+                src.display(),
+                shader_tool_env_var(backend)
+            )
+        } else {
+            anyhow!(
+                "failed to run {} for {} shader source {}: {}",
+                tool.display(),
+                backend.as_str(),
+                src.display(),
+                err
+            )
+        }
+    })?;
+    if !status.success() {
+        return Err(anyhow!(
+            "{} failed for {} shader source {}",
+            tool.display(),
+            backend.as_str(),
+            src.display()
+        ));
+    }
+    Ok(())
+}
+
+fn shader_tool_path(backend: NativeBackend) -> PathBuf {
+    std::env::var_os(shader_tool_env_var(backend))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(shader_tool_name(backend)))
+}
+
+fn shader_tool_name(backend: NativeBackend) -> &'static str {
+    match backend {
+        NativeBackend::Metal => "xcrun",
+        NativeBackend::Vulkan => "glslc",
+        NativeBackend::D3d12 => "dxc",
+    }
+}
+
+fn shader_tool_env_var(backend: NativeBackend) -> &'static str {
+    match backend {
+        NativeBackend::Metal => "PERRY_XCRUN",
+        NativeBackend::Vulkan => "PERRY_GLSLC",
+        NativeBackend::D3d12 => "PERRY_DXC",
+    }
+}
+
+fn backend_component(backend: NativeBackend) -> &'static str {
+    match backend {
+        NativeBackend::Metal => "metal",
+        NativeBackend::Vulkan => "vulkan",
+        NativeBackend::D3d12 => "d3d12",
+    }
+}
+
+fn sanitize_resource_component(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.' {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        "native-library".to_string()
+    } else {
+        out
+    }
+}
+
+#[cfg(test)]
+mod native_resource_tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+
+    use crate::OutputFormat;
+
+    use super::super::{
+        CompilationContext, NativeBackend, NativeBackendConfig, NativeBackendPackageMetadata,
+        NativeLibraryManifest, TargetNativeConfig,
+    };
+    use super::{
+        copy_native_library_resources, stage_native_library_artifacts,
+        BACKEND_PACKAGE_METADATA_FILE,
+    };
+
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    #[test]
+    fn copies_target_and_backend_resources_into_package_boundaries() {
+        let dir = tempfile::tempdir().unwrap();
+        let package_dir = dir.path().join("node_modules/@scope/demo");
+        let bundle_dir = dir.path().join("Demo.app");
+        fs::create_dir_all(&package_dir).unwrap();
+        fs::create_dir_all(&bundle_dir).unwrap();
+
+        let target_resource = package_dir.join("target-config.json");
+        let target_shader_dir = package_dir.join("target-shaders");
+        let target_shader = target_shader_dir.join("default.metallib");
+        let backend_resource = package_dir.join("vk-config.json");
+        let backend_shader = package_dir.join("default.spv");
+        fs::create_dir_all(&target_shader_dir).unwrap();
+        fs::write(&target_resource, b"{\"target\":true}").unwrap();
+        fs::write(&target_shader, b"metallib").unwrap();
+        fs::write(&backend_resource, b"{\"backend\":\"vulkan\"}").unwrap();
+        fs::write(&backend_shader, b"spv").unwrap();
+
+        let mut ctx = CompilationContext::new(dir.path().to_path_buf());
+        ctx.native_libraries.push(NativeLibraryManifest {
+            module: "@scope/demo".to_string(),
+            package_dir: package_dir.clone(),
+            abi_version: None,
+            functions: Vec::new(),
+            target_config: Some(TargetNativeConfig {
+                available: true,
+                unavailable_reason: None,
+                crate_path: PathBuf::new(),
+                lib_name: "demo".to_string(),
+                prebuilt: None,
+                frameworks: Vec::new(),
+                optional_frameworks: Vec::new(),
+                frameworks_env: None,
+                libs: Vec::new(),
+                lib_dirs: Vec::new(),
+                pkg_config: Vec::new(),
+                resources: vec![target_resource],
+                shader_outputs: vec![target_shader_dir],
+                backends: vec![
+                    NativeBackendConfig {
+                        backend: NativeBackend::Vulkan,
+                        available: true,
+                        unavailable_reason: None,
+                        prebuilt: None,
+                        frameworks: Vec::new(),
+                        libs: Vec::new(),
+                        lib_dirs: Vec::new(),
+                        pkg_config: Vec::new(),
+                        shader_sources: Vec::new(),
+                        shader_outputs: vec![backend_shader],
+                        resources: vec![backend_resource],
+                        package: NativeBackendPackageMetadata {
+                            name: Some("demo-vulkan".to_string()),
+                            version: Some("1.2.3".to_string()),
+                            kind: Some("spirv".to_string()),
+                        },
+                    },
+                    NativeBackendConfig {
+                        backend: NativeBackend::D3d12,
+                        available: false,
+                        unavailable_reason: Some("windows only".to_string()),
+                        prebuilt: None,
+                        frameworks: Vec::new(),
+                        libs: Vec::new(),
+                        lib_dirs: Vec::new(),
+                        pkg_config: Vec::new(),
+                        shader_sources: Vec::new(),
+                        shader_outputs: Vec::new(),
+                        resources: vec![package_dir.join("should-not-copy.bin")],
+                        package: NativeBackendPackageMetadata::default(),
+                    },
+                ],
+                swift_sources: Vec::new(),
+                metal_sources: Vec::new(),
+            }),
+        });
+
+        copy_native_library_resources(&ctx, &bundle_dir).expect("copy native resources");
+
+        let package_resource_dir = bundle_dir.join("NativeLibraries/_scope_demo");
+        assert!(package_resource_dir.join("target-config.json").is_file());
+        assert!(package_resource_dir
+            .join("target-shaders/default.metallib")
+            .is_file());
+        assert!(package_resource_dir.join("vulkan/vk-config.json").is_file());
+        assert!(package_resource_dir.join("vulkan/default.spv").is_file());
+        let metadata = fs::read_to_string(
+            package_resource_dir
+                .join("vulkan")
+                .join(BACKEND_PACKAGE_METADATA_FILE),
+        )
+        .expect("read backend package metadata");
+        let metadata: serde_json::Value =
+            serde_json::from_str(&metadata).expect("parse backend package metadata");
+        assert_eq!(metadata["backend"], "vulkan");
+        assert_eq!(metadata["name"], "demo-vulkan");
+        assert_eq!(metadata["version"], "1.2.3");
+        assert_eq!(metadata["kind"], "spirv");
+        assert!(!package_resource_dir.join("d3d12").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stages_vulkan_and_d3d12_shader_sources_with_fake_tools() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock");
+        let dir = tempfile::tempdir().unwrap();
+        let package_dir = dir.path().join("node_modules/@scope/demo");
+        let bundle_dir = dir.path().join("out");
+        fs::create_dir_all(&package_dir).unwrap();
+        fs::create_dir_all(&bundle_dir).unwrap();
+
+        let fake_glslc = dir.path().join("fake-glslc");
+        fs::write(
+            &fake_glslc,
+            "#!/bin/sh\nout=\"\"\nprev=\"\"\nfor arg in \"$@\"; do\n  if [ \"$prev\" = \"-o\" ]; then out=\"$arg\"; fi\n  prev=\"$arg\"\ndone\nif [ -z \"$out\" ]; then exit 2; fi\nmkdir -p \"$(dirname \"$out\")\"\nprintf spv > \"$out\"\nexit 0\n",
+        )
+        .unwrap();
+        let fake_dxc = dir.path().join("fake-dxc");
+        fs::write(
+            &fake_dxc,
+            "#!/bin/sh\nout=\"\"\nprev=\"\"\nfor arg in \"$@\"; do\n  if [ \"$prev\" = \"-Fo\" ]; then out=\"$arg\"; fi\n  prev=\"$arg\"\ndone\nif [ -z \"$out\" ]; then exit 2; fi\nmkdir -p \"$(dirname \"$out\")\"\nprintf dxil > \"$out\"\nexit 0\n",
+        )
+        .unwrap();
+        for tool in [&fake_glslc, &fake_dxc] {
+            let mut perms = fs::metadata(tool).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(tool, perms).unwrap();
+        }
+
+        let vulkan_shader = package_dir.join("compute.glsl");
+        let d3d12_shader = package_dir.join("compute.hlsl");
+        fs::write(&vulkan_shader, "#version 450\nvoid main() {}\n").unwrap();
+        fs::write(&d3d12_shader, "[numthreads(1,1,1)] void main() {}\n").unwrap();
+
+        let mut ctx = CompilationContext::new(dir.path().to_path_buf());
+        ctx.native_libraries.push(NativeLibraryManifest {
+            module: "@scope/demo".to_string(),
+            package_dir: package_dir.clone(),
+            abi_version: None,
+            functions: Vec::new(),
+            target_config: Some(TargetNativeConfig {
+                available: true,
+                unavailable_reason: None,
+                crate_path: PathBuf::new(),
+                lib_name: "demo".to_string(),
+                prebuilt: None,
+                frameworks: Vec::new(),
+                optional_frameworks: Vec::new(),
+                frameworks_env: None,
+                libs: Vec::new(),
+                lib_dirs: Vec::new(),
+                pkg_config: Vec::new(),
+                resources: Vec::new(),
+                shader_outputs: Vec::new(),
+                backends: vec![
+                    NativeBackendConfig {
+                        backend: NativeBackend::Vulkan,
+                        available: true,
+                        unavailable_reason: None,
+                        prebuilt: None,
+                        frameworks: Vec::new(),
+                        libs: Vec::new(),
+                        lib_dirs: Vec::new(),
+                        pkg_config: Vec::new(),
+                        shader_sources: vec![vulkan_shader],
+                        shader_outputs: Vec::new(),
+                        resources: Vec::new(),
+                        package: NativeBackendPackageMetadata::default(),
+                    },
+                    NativeBackendConfig {
+                        backend: NativeBackend::D3d12,
+                        available: true,
+                        unavailable_reason: None,
+                        prebuilt: None,
+                        frameworks: Vec::new(),
+                        libs: Vec::new(),
+                        lib_dirs: Vec::new(),
+                        pkg_config: Vec::new(),
+                        shader_sources: vec![d3d12_shader],
+                        shader_outputs: Vec::new(),
+                        resources: Vec::new(),
+                        package: NativeBackendPackageMetadata::default(),
+                    },
+                ],
+                swift_sources: Vec::new(),
+                metal_sources: Vec::new(),
+            }),
+        });
+
+        let old_glslc = std::env::var_os("PERRY_GLSLC");
+        let old_dxc = std::env::var_os("PERRY_DXC");
+        std::env::set_var("PERRY_GLSLC", &fake_glslc);
+        std::env::set_var("PERRY_DXC", &fake_dxc);
+        let result = stage_native_library_artifacts(&ctx, &bundle_dir, OutputFormat::Json);
+        match old_glslc {
+            Some(value) => std::env::set_var("PERRY_GLSLC", value),
+            None => std::env::remove_var("PERRY_GLSLC"),
+        }
+        match old_dxc {
+            Some(value) => std::env::set_var("PERRY_DXC", value),
+            None => std::env::remove_var("PERRY_DXC"),
+        }
+
+        result.expect("stage native shader artifacts");
+        let package_resource_dir = bundle_dir.join("NativeLibraries/_scope_demo");
+        assert_eq!(
+            fs::read(package_resource_dir.join("vulkan/compute.glsl.spv")).unwrap(),
+            b"spv"
+        );
+        assert_eq!(
+            fs::read(package_resource_dir.join("d3d12/compute.hlsl.dxil")).unwrap(),
+            b"dxil"
+        );
     }
 }

--- a/crates/perry/src/commands/compile/targets.rs
+++ b/crates/perry/src/commands/compile/targets.rs
@@ -21,7 +21,7 @@ use std::process::Command;
 
 use crate::OutputFormat;
 
-use super::{CompilationContext, CompileArgs, CompileResult};
+use super::{CompilationContext, CompileArgs, CompileResult, NativeBackend};
 
 pub(super) fn generate_js_bundle(ctx: &CompilationContext, output_dir: &Path) -> Result<PathBuf> {
     let bundle_path = output_dir.join("__perry_js_bundle.js");
@@ -771,6 +771,17 @@ pub(super) fn compile_metallib_for_bundle(
                     sources.push((src.clone(), native_lib.module.clone()));
                 }
             }
+            for backend in &tc.backends {
+                if backend.backend != NativeBackend::Metal || !backend.available {
+                    continue;
+                }
+                for src in &backend.shader_sources {
+                    let canonical = src.canonicalize().unwrap_or_else(|_| src.clone());
+                    if seen.insert(canonical) {
+                        sources.push((src.clone(), native_lib.module.clone()));
+                    }
+                }
+            }
         }
     }
     if sources.is_empty() {
@@ -784,13 +795,19 @@ pub(super) fn compile_metallib_for_bundle(
         Some("ios") => "iphoneos",
         Some("tvos-simulator") => "appletvsimulator",
         Some("tvos") => "appletvos",
+        Some("visionos-simulator") => "xrsimulator",
+        Some("visionos") => "xros",
         other => {
             return Err(anyhow!(
-                "metal_sources is only supported on ios/tvos/watchos (got {:?})",
+                "metal_sources is only supported on ios/tvos/watchos/visionos (got {:?})",
                 other
             ))
         }
     };
+
+    let xcrun = std::env::var_os("PERRY_XCRUN")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("xcrun"));
 
     let air_dir = std::env::temp_dir().join(format!("perry_metal_{}", std::process::id()));
     std::fs::create_dir_all(&air_dir).ok();
@@ -806,7 +823,7 @@ pub(super) fn compile_metallib_for_bundle(
         }
         let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("shader");
         let air_out = air_dir.join(format!("{}.air", stem));
-        let status = Command::new("xcrun")
+        let status = Command::new(&xcrun)
             .args(["-sdk", metal_sdk, "metal", "-c"])
             .arg(src)
             .arg("-o")
@@ -823,7 +840,7 @@ pub(super) fn compile_metallib_for_bundle(
     }
 
     let metallib_out = app_dir.join("default.metallib");
-    let mut link_cmd = Command::new("xcrun");
+    let mut link_cmd = Command::new(&xcrun);
     link_cmd
         .args(["-sdk", metal_sdk, "metallib", "-o"])
         .arg(&metallib_out);
@@ -950,6 +967,163 @@ pub(super) fn compile_for_android_widget(
         is_dylib: false,
         codegen_cache_stats: None,
     })
+}
+
+#[cfg(test)]
+mod native_shader_tool_tests {
+    use super::*;
+    use crate::commands::compile::{
+        NativeBackendConfig, NativeBackendPackageMetadata, NativeFunctionDecl,
+        NativeLibraryManifest, TargetNativeConfig,
+    };
+    use std::sync::{Mutex, OnceLock};
+
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn empty_target_config(shader: PathBuf) -> TargetNativeConfig {
+        TargetNativeConfig {
+            available: true,
+            unavailable_reason: None,
+            crate_path: PathBuf::new(),
+            lib_name: String::new(),
+            prebuilt: None,
+            frameworks: Vec::new(),
+            optional_frameworks: Vec::new(),
+            frameworks_env: None,
+            libs: Vec::new(),
+            lib_dirs: Vec::new(),
+            pkg_config: Vec::new(),
+            resources: Vec::new(),
+            shader_outputs: Vec::new(),
+            backends: vec![NativeBackendConfig {
+                backend: NativeBackend::Metal,
+                available: true,
+                unavailable_reason: None,
+                prebuilt: None,
+                frameworks: Vec::new(),
+                libs: Vec::new(),
+                lib_dirs: Vec::new(),
+                pkg_config: Vec::new(),
+                shader_sources: vec![shader],
+                shader_outputs: Vec::new(),
+                resources: Vec::new(),
+                package: NativeBackendPackageMetadata::default(),
+            }],
+            swift_sources: Vec::new(),
+            metal_sources: Vec::new(),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn metallib_compile_uses_fake_xcrun_from_env() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fake_xcrun = dir.path().join("fake-xcrun");
+        std::fs::write(
+            &fake_xcrun,
+            "#!/bin/sh\nout=\"\"\nprev=\"\"\nfor arg in \"$@\"; do\n  if [ \"$prev\" = \"-o\" ]; then out=\"$arg\"; fi\n  prev=\"$arg\"\ndone\nif [ -n \"$out\" ]; then mkdir -p \"$(dirname \"$out\")\"; printf fake > \"$out\"; fi\nexit 0\n",
+        )
+        .expect("write fake xcrun");
+        let mut perms = std::fs::metadata(&fake_xcrun)
+            .expect("fake metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_xcrun, perms).expect("chmod fake xcrun");
+
+        let shader = dir.path().join("default.metal");
+        std::fs::write(&shader, "kernel void k() {}\n").expect("write shader");
+        let app_dir = dir.path().join("Demo.app");
+        std::fs::create_dir_all(&app_dir).expect("mkdir app");
+
+        let mut ctx = CompilationContext::new(dir.path().to_path_buf());
+        ctx.native_libraries.push(NativeLibraryManifest {
+            module: "demo".to_string(),
+            package_dir: dir.path().to_path_buf(),
+            abi_version: None,
+            functions: Vec::<NativeFunctionDecl>::new(),
+            target_config: Some(empty_target_config(shader)),
+        });
+
+        let old = std::env::var_os("PERRY_XCRUN");
+        std::env::set_var("PERRY_XCRUN", &fake_xcrun);
+        let result =
+            compile_metallib_for_bundle(&ctx, Some("ios-simulator"), &app_dir, OutputFormat::Json);
+        match old {
+            Some(value) => std::env::set_var("PERRY_XCRUN", value),
+            None => std::env::remove_var("PERRY_XCRUN"),
+        }
+
+        result.expect("compile metallib");
+        assert!(app_dir.join("default.metallib").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn metallib_compile_supports_visionos_simulator_sdk() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fake_xcrun = dir.path().join("fake-xcrun");
+        let log_path = dir.path().join("xcrun.log");
+        std::fs::write(
+            &fake_xcrun,
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" >> \"$PERRY_FAKE_XCRUN_LOG\"\nout=\"\"\nprev=\"\"\nfor arg in \"$@\"; do\n  if [ \"$prev\" = \"-o\" ]; then out=\"$arg\"; fi\n  prev=\"$arg\"\ndone\nif [ -n \"$out\" ]; then mkdir -p \"$(dirname \"$out\")\"; printf fake > \"$out\"; fi\nexit 0\n",
+        )
+        .expect("write fake xcrun");
+        let mut perms = std::fs::metadata(&fake_xcrun)
+            .expect("fake metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_xcrun, perms).expect("chmod fake xcrun");
+
+        let shader = dir.path().join("default.metal");
+        std::fs::write(&shader, "kernel void k() {}\n").expect("write shader");
+        let app_dir = dir.path().join("Demo.app");
+        std::fs::create_dir_all(&app_dir).expect("mkdir app");
+
+        let mut ctx = CompilationContext::new(dir.path().to_path_buf());
+        ctx.native_libraries.push(NativeLibraryManifest {
+            module: "demo".to_string(),
+            package_dir: dir.path().to_path_buf(),
+            abi_version: None,
+            functions: Vec::<NativeFunctionDecl>::new(),
+            target_config: Some(empty_target_config(shader)),
+        });
+
+        let old_xcrun = std::env::var_os("PERRY_XCRUN");
+        let old_log = std::env::var_os("PERRY_FAKE_XCRUN_LOG");
+        std::env::set_var("PERRY_XCRUN", &fake_xcrun);
+        std::env::set_var("PERRY_FAKE_XCRUN_LOG", &log_path);
+        let result = compile_metallib_for_bundle(
+            &ctx,
+            Some("visionos-simulator"),
+            &app_dir,
+            OutputFormat::Json,
+        );
+        match old_xcrun {
+            Some(value) => std::env::set_var("PERRY_XCRUN", value),
+            None => std::env::remove_var("PERRY_XCRUN"),
+        }
+        match old_log {
+            Some(value) => std::env::set_var("PERRY_FAKE_XCRUN_LOG", value),
+            None => std::env::remove_var("PERRY_FAKE_XCRUN_LOG"),
+        }
+
+        result.expect("compile visionOS metallib");
+        assert!(app_dir.join("default.metallib").exists());
+        let log = std::fs::read_to_string(log_path).expect("read fake xcrun log");
+        assert!(log.contains("xrsimulator"), "got: {log}");
+    }
 }
 
 /// Compile for Wear OS tile target: emit Kotlin Tiles source + JNI bridge

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -690,9 +690,70 @@ pub struct NativeFunctionDecl {
     pub returns: perry_api_manifest::NativeAbiType,
 }
 
+/// Backend package metadata a native library can attach to a target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NativeBackend {
+    Metal,
+    Vulkan,
+    D3d12,
+}
+
+impl NativeBackend {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            NativeBackend::Metal => "metal",
+            NativeBackend::Vulkan => "vulkan",
+            NativeBackend::D3d12 => "d3d12",
+        }
+    }
+}
+
+/// Optional package metadata for backend-owned artifacts. This is
+/// intentionally descriptive: Perry packages and copies artifacts but
+/// does not create an app-level graphics API surface from this block.
+#[derive(Debug, Clone, Default)]
+pub struct NativeBackendPackageMetadata {
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub kind: Option<String>,
+}
+
+/// Backend-specific packaging metadata nested under
+/// `perry.nativeLibrary.targets.<target>.backends.<backend>`.
+#[derive(Debug, Clone)]
+pub struct NativeBackendConfig {
+    pub backend: NativeBackend,
+    /// False means the backend is intentionally unavailable for this
+    /// target and should not add link/resource metadata.
+    pub available: bool,
+    pub unavailable_reason: Option<String>,
+    /// Optional backend-specific archive to link in addition to the
+    /// target-level `prebuilt` / `crate` output.
+    pub prebuilt: Option<PathBuf>,
+    pub frameworks: Vec<String>,
+    pub libs: Vec<String>,
+    pub lib_dirs: Vec<PathBuf>,
+    pub pkg_config: Vec<String>,
+    /// Source shaders that may require backend tools (`xcrun metal`,
+    /// `glslc`, `dxc`) to build during packaging.
+    pub shader_sources: Vec<PathBuf>,
+    /// Precompiled shader/resource outputs (`.metallib`, `.spv`,
+    /// `.cso`/`.dxil`, etc.) that Perry should package directly.
+    pub shader_outputs: Vec<PathBuf>,
+    /// Backend-owned resource files or directories copied into bundle
+    /// resource output when the target has one.
+    pub resources: Vec<PathBuf>,
+    pub package: NativeBackendPackageMetadata,
+}
+
 /// Target-specific native library build configuration
 #[derive(Debug, Clone)]
 pub struct TargetNativeConfig {
+    /// False means the package explicitly does not ship this target.
+    /// Compile/link should skip it without treating missing crate/lib
+    /// metadata as an error.
+    pub available: bool,
+    pub unavailable_reason: Option<String>,
     pub crate_path: PathBuf,
     pub lib_name: String,
     /// If set, the absolute path to a prebuilt static library that the
@@ -739,6 +800,14 @@ pub struct TargetNativeConfig {
     /// against the package, not the user's cwd.
     pub lib_dirs: Vec<PathBuf>,
     pub pkg_config: Vec<String>,
+    /// Target-level resource files or directories copied into bundle
+    /// resource output when the target has one.
+    pub resources: Vec<PathBuf>,
+    /// Target-level precompiled shader/resource outputs copied into
+    /// bundle resource output when the target has one.
+    pub shader_outputs: Vec<PathBuf>,
+    /// Backend-specific packaging metadata for Metal, Vulkan, and D3D12.
+    pub backends: Vec<NativeBackendConfig>,
     /// Swift sources (absolute paths) to compile via swiftc and link into the
     /// final binary. Used by `--features watchos-swift-app` so a native lib
     /// can ship its own `@main struct App: App` SwiftUI root.

--- a/crates/perry/src/commands/harmonyos_hap.rs
+++ b/crates/perry/src/commands/harmonyos_hap.rs
@@ -94,6 +94,12 @@ pub struct HapBuildArgs<'a> {
     /// `Image()` / `ImageFile()` calls into the `$rawfile()` form.
     /// `None` skips the copy.
     pub assets_dir: Option<&'a Path>,
+
+    /// Staged `NativeLibraries/` directory produced by compile's native
+    /// artifact packaging. When present it is copied into
+    /// `resources/rawfile/NativeLibraries/` so backend resources and
+    /// shaders are included in the HAP.
+    pub native_resources_dir: Option<&'a Path>,
 }
 
 pub struct HapBuildResult {
@@ -127,6 +133,9 @@ pub fn build_hap(args: &HapBuildArgs) -> Result<HapBuildResult> {
     write_resources(&staging, args.stem)?;
     if let Some(assets) = args.assets_dir {
         copy_assets_to_rawfile(&staging, assets)?;
+    }
+    if let Some(native_resources) = args.native_resources_dir {
+        copy_native_resources_to_rawfile(&staging, native_resources)?;
     }
     copy_so(&staging, args.so_path)?;
     copy_ets(&staging, args.ets_dir)?;
@@ -459,6 +468,17 @@ fn copy_assets_to_rawfile(staging: &Path, assets: &Path) -> Result<()> {
     walk(assets, &dest_root, assets)
 }
 
+fn copy_native_resources_to_rawfile(staging: &Path, native_resources: &Path) -> Result<()> {
+    if !native_resources.is_dir() {
+        return Ok(());
+    }
+    let dest_root = staging
+        .join("resources")
+        .join("rawfile")
+        .join("NativeLibraries");
+    copy_dir_recursive(native_resources, &dest_root)
+}
+
 fn copy_so(staging: &Path, so_path: &Path) -> Result<()> {
     // HarmonyOS expects .so libs under libs/<abi>/; the only ABI we target
     // today is arm64-v8a (physical device) and x86_64 (emulator). Perry's
@@ -783,8 +803,14 @@ mod build_hap_tests {
         let tmp = std::env::temp_dir().join(format!("perry-hap-test-{}", std::process::id()));
         let _ = fs::remove_dir_all(&tmp);
         fs::create_dir_all(tmp.join("ets/entryability")).unwrap();
+        fs::create_dir_all(tmp.join("NativeLibraries/_scope_demo/vulkan")).unwrap();
         fs::write(tmp.join("libhi.so"), b"fake so").unwrap();
         fs::write(tmp.join("ets/entryability/EntryAbility.ets"), "// ability").unwrap();
+        fs::write(
+            tmp.join("NativeLibraries/_scope_demo/vulkan/default.spv"),
+            b"spv",
+        )
+        .unwrap();
 
         // Scrub signing env so we stay on the unsigned path regardless of
         // whatever the host developer may have exported.
@@ -803,6 +829,7 @@ mod build_hap_tests {
 
         let so = tmp.join("libhi.so");
         let ets = tmp.join("ets");
+        let native_resources = tmp.join("NativeLibraries");
         let args = HapBuildArgs {
             so_path: &so,
             ets_dir: &ets,
@@ -815,6 +842,7 @@ mod build_hap_tests {
             profile: None,
             key_alias: None,
             assets_dir: None,
+            native_resources_dir: Some(native_resources.as_path()),
         };
         let res = build_hap(&args).expect("build_hap failed");
         assert!(!res.signed, "no P12 env → unsigned");
@@ -837,6 +865,7 @@ mod build_hap_tests {
             "resources/base/media/icon.png",
             "resources/base/string/string.json",
             "resources/base/color/color.json",
+            "resources/rawfile/NativeLibraries/_scope_demo/vulkan/default.spv",
         ];
         for r in required {
             assert!(
@@ -971,6 +1000,7 @@ mod build_hap_tests {
             profile: Some(&fake_profile),
             key_alias: Some("ciKey"),
             assets_dir: None,
+            native_resources_dir: None,
         };
         // Signing will fail (no real keystore / no java reachable in CI
         // environment baseline), so the result is `signed: false`. The

--- a/crates/perry/src/commands/native/validate.rs
+++ b/crates/perry/src/commands/native/validate.rs
@@ -50,6 +50,16 @@ pub fn run(args: ValidateArgs, format: OutputFormat, _use_color: bool) -> Result
         .pointer("/perry/nativeLibrary")
         .ok_or_else(|| anyhow!("no `perry.nativeLibrary` block in {}", pkg_path.display()))?;
 
+    let package_name = pkg
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("<unknown>");
+    crate::commands::compile::validate_native_library_manifest_value(
+        &args.path,
+        package_name,
+        manifest,
+    )?;
+
     let declared_funcs: Vec<String> = manifest
         .pointer("/functions")
         .and_then(|v| v.as_array())
@@ -275,5 +285,45 @@ mod tests {
         std::fs::write(dir.path().join("Cargo.toml"), cargo).unwrap();
         let n = read_crate_name(dir.path()).expect("read");
         assert_eq!(n, "perry-ext-foo");
+    }
+
+    #[test]
+    fn invalid_backend_metadata_fails_before_cargo_lookup() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manifest = serde_json::json!({
+            "name": "bad-backend",
+            "perry": {
+                "nativeLibrary": {
+                    "functions": [],
+                    "targets": {
+                        "linux": {
+                            "crate": "native",
+                            "lib": "bad_backend",
+                            "backends": {
+                                "d3d12": { "libs": ["d3d12"] }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        std::fs::write(
+            dir.path().join("package.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .expect("write package.json");
+
+        let err = run(
+            ValidateArgs {
+                path: dir.path().to_path_buf(),
+                no_build: true,
+            },
+            OutputFormat::Json,
+            false,
+        )
+        .expect_err("invalid backend should fail");
+        let msg = err.to_string();
+        assert!(msg.contains("d3d12"), "got: {msg}");
+        assert!(msg.contains("Windows-only"), "got: {msg}");
     }
 }

--- a/docs/api/manifest.schema.json
+++ b/docs/api/manifest.schema.json
@@ -343,6 +343,18 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "available": {
+          "type": "boolean",
+          "description": "Set false when this package intentionally does not ship the selected target. Perry skips the target config without requiring crate/lib/prebuilt metadata."
+        },
+        "unavailableReason": {
+          "type": "string",
+          "description": "Human-readable reason shown when available is false."
+        },
+        "unavailable_reason": {
+          "type": "string",
+          "description": "Snake_case alias for unavailableReason."
+        },
         "crate": {
           "type": "string",
           "description": "Path (relative to package.json) to the Cargo crate that produces the staticlib."
@@ -365,6 +377,36 @@
           "type": "array",
           "items": { "type": "string" }
         },
+        "libDirs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional library search paths, relative to package.json unless absolute."
+        },
+        "resources": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Native resource files/directories copied into NativeLibraries/<package>/ in the target bundle or output staging directory."
+        },
+        "shaderOutputs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Precompiled shader/resource outputs copied into NativeLibraries/<package>/ in the target bundle or output staging directory."
+        },
+        "shader_outputs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Snake_case alias for shaderOutputs."
+        },
+        "backends": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "metal": { "$ref": "#/$defs/backendConfig" },
+            "vulkan": { "$ref": "#/$defs/backendConfig" },
+            "d3d12": { "$ref": "#/$defs/backendConfig" }
+          },
+          "description": "Backend-specific packaging metadata. Metal is Apple-only; Vulkan is supported on macOS/Linux/Windows/Android/HarmonyOS; D3D12 is Windows-only."
+        },
         "swift_sources": {
           "type": "array",
           "items": { "type": "string" }
@@ -376,6 +418,74 @@
         "prebuilt": {
           "type": "string",
           "description": "Path to a pre-built .a archive. When set, Perry skips `cargo build`."
+        }
+      }
+    },
+    "backendConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available": {
+          "type": "boolean",
+          "description": "Set false when this backend is intentionally unavailable for this target."
+        },
+        "unavailableReason": {
+          "type": "string"
+        },
+        "unavailable_reason": {
+          "type": "string"
+        },
+        "prebuilt": {
+          "type": "string",
+          "description": "Backend-specific archive to link in addition to the target-level archive."
+        },
+        "frameworks": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "libs": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "libDirs": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "pkgConfig": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "shaderSources": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Source shaders compiled during packaging with xcrun metal, glslc, or dxc. Override discovery with PERRY_XCRUN, PERRY_GLSLC, or PERRY_DXC."
+        },
+        "shader_sources": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Snake_case alias for shaderSources."
+        },
+        "shaderOutputs": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "shader_outputs": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "resources": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "package": {
+          "type": "object",
+          "description": "Optional descriptive backend artifact metadata emitted as perry-backend-package.json inside NativeLibraries/<package>/<backend>/.",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "version": { "type": "string" },
+            "kind": { "type": "string" }
+          }
         }
       }
     }

--- a/docs/src/native-libraries/authoring-guide.md
+++ b/docs/src/native-libraries/authoring-guide.md
@@ -124,9 +124,9 @@ The `perry.nativeLibrary` block tells Perry's compiler about every
         }
       ],
       "targets": {
-        "macos":   { "cargo_features": [] },
-        "linux":   { "cargo_features": [] },
-        "windows": { "cargo_features": [] }
+        "macos":   { "crate": "native", "lib": "perry_ext_my_bindings" },
+        "linux":   { "crate": "native", "lib": "perry_ext_my_bindings" },
+        "windows": { "crate": "native", "lib": "perry_ext_my_bindings" }
       }
     }
   }
@@ -271,8 +271,61 @@ find a prebuilt for the user's compile target:
 }
 ```
 
-If the prebuilt path doesn't exist on disk at compile time, Perry
-falls back to `cargo build --release`.
+If a `prebuilt` field is present, Perry treats the archive as required
+for that target and fails with a diagnostic when it cannot be resolved
+or linked. Omit `prebuilt` and provide `crate` / `lib` when the target
+should build from source instead.
+
+### Backend-aware packaging
+
+Graphics or compute wrappers can describe backend-owned artifacts
+without adding app-specific APIs to Perry. Put backend metadata under
+the target that can actually use it:
+
+```json
+{
+  "perry": {
+    "nativeLibrary": {
+      "targets": {
+        "ios": {
+          "prebuilt": "./prebuilt/ios/libdemo.a",
+          "backends": {
+            "metal": {
+              "frameworks": ["Metal", "QuartzCore"],
+              "shaderSources": ["shaders/default.metal"],
+              "shaderOutputs": ["prebuilt/default.metallib"],
+              "resources": ["resources/metal"]
+            }
+          }
+        },
+        "linux": {
+          "prebuilt": "./prebuilt/linux/libdemo.a",
+          "backends": {
+            "vulkan": {
+              "libs": ["vulkan"],
+              "shaderOutputs": ["prebuilt/default.spv"]
+            }
+          }
+        },
+        "windows": {
+          "prebuilt": "./prebuilt/windows/demo.lib",
+          "backends": {
+            "d3d12": {
+              "libs": ["d3d12", "dxgi", "dxguid"],
+              "shaderOutputs": ["prebuilt/default.dxil"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Perry validates the backend/target pairing early: Metal is Apple-only,
+Vulkan is available on macOS/Linux/Windows/Android/HarmonyOS, and D3D12
+is Windows-only. Precompiled shader outputs and resources are copied
+under `NativeLibraries/<package>/<backend>/` in app bundles.
 
 ## 6. Update over time
 

--- a/docs/src/native-libraries/manifest-v1.md
+++ b/docs/src/native-libraries/manifest-v1.md
@@ -242,6 +242,11 @@ as their device counterpart (`ios` covers both `ios-simulator` and
 | `libs`          | array of string  | no       | System libraries to pass to the linker (`-lcurl`, etc.). |
 | `libDirs`       | array of paths   | no       | Extra linker search paths. Emitted before `libs` as `-L<dir>` (or `/LIBPATH:<dir>` on Windows MSVC). Relative entries resolve against `package.json`. |
 | `pkgConfig`     | array of string  | no       | pkg-config package names. The compiler runs `pkg-config --libs` and forwards the output. |
+| `available`     | boolean          | no       | Set `false` when the package intentionally does not ship this target. Perry skips it without requiring `crate` / `lib` / `prebuilt`. |
+| `unavailableReason` | string       | no       | Optional diagnostic text shown when `available: false`. Snake_case `unavailable_reason` also accepted. |
+| `resources`     | array of paths   | no       | Native resource files/directories copied into `NativeLibraries/<package>/` in the target bundle or output staging directory. |
+| `shaderOutputs` | array of paths   | no       | Precompiled shader/resource files copied into `NativeLibraries/<package>/`. Snake_case `shader_outputs` also accepted. |
+| `backends`      | object           | no       | Backend-specific packaging blocks for `metal`, `vulkan`, and `d3d12`; see below. |
 | `swift_sources` | array of paths   | no       | Swift sources to compile via `swiftc` and link in. Used by SwiftUI wrappers. |
 | `metal_sources` | array of paths   | no       | Metal shader sources to compile via `xcrun metal` into `<app>.app/default.metallib`. |
 | `prebuilt`      | path string      | no       | Path (relative to package.json) to a pre-built `.a` archive. When present, Perry uses this instead of running `cargo build`. |
@@ -249,6 +254,87 @@ as their device counterpart (`ios` covers both `ios-simulator` and
 When both `prebuilt` and `crate`/`lib` are absent for the user's
 compile target, the wrapper is silently skipped on that target —
 useful for platform-specific bindings that only exist on macOS, etc.
+
+### Backend packaging (`backends`)
+
+`targets.<target>.backends` describes backend-owned packaging without
+adding app-specific graphics APIs to Perry. The keys are:
+
+| Backend | Valid target keys |
+|---------|-------------------|
+| `metal` | `macos`, `ios`, `tvos`, `watchos`, `visionos` |
+| `vulkan` | `macos`, `linux`, `windows`, `android`, `harmonyos` |
+| `d3d12` | `windows` |
+
+Unsupported combinations fail during manifest parsing or
+`perry native validate`, before any SDK-specific tool is invoked.
+
+Each backend block accepts:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `available` | boolean | Set `false` to document an intentionally unavailable backend for that target. |
+| `unavailableReason` | string | Optional skip reason. Snake_case alias accepted. |
+| `prebuilt` | path string | Backend-specific archive linked in addition to the target-level archive. |
+| `frameworks` | array of string | Apple framework names for Metal packaging. |
+| `libs` | array of string | System libraries such as `vulkan`, `d3d12`, `dxgi`, `dxguid`. |
+| `libDirs` | array of paths | Extra backend library search paths. |
+| `pkgConfig` | array of string | Backend pkg-config packages. |
+| `shaderSources` | array of paths | Source shaders that require backend tools (`xcrun metal`, `glslc`, `dxc`) when Perry packages them. Snake_case alias accepted. |
+| `shaderOutputs` | array of paths | Precompiled shader outputs (`.metallib`, `.spv`, `.dxil`, `.cso`) copied into the target bundle or output staging directory. Snake_case alias accepted. |
+| `resources` | array of paths | Backend-owned resource files/directories copied into `NativeLibraries/<package>/<backend>/`. |
+| `package` | object | Optional descriptive metadata: `name`, `version`, `kind`. Perry writes it to `NativeLibraries/<package>/<backend>/perry-backend-package.json`; native code owns interpretation. |
+
+Example:
+
+```json
+"targets": {
+  "macos": {
+    "prebuilt": "./prebuilt/macos/libdemo.a",
+    "backends": {
+      "metal": {
+        "frameworks": ["Metal", "QuartzCore"],
+        "shaderSources": ["shaders/default.metal"],
+        "shaderOutputs": ["prebuilt/default.metallib"],
+        "resources": ["resources/metal"],
+        "package": {
+          "name": "demo-metal",
+          "version": "1.0.0",
+          "kind": "metallib"
+        }
+      },
+      "vulkan": {
+        "libs": ["vulkan"],
+        "shaderOutputs": ["prebuilt/default.spv"]
+      }
+    }
+  },
+  "windows": {
+    "prebuilt": "./prebuilt/windows/demo.lib",
+    "backends": {
+      "d3d12": {
+        "libs": ["d3d12", "dxgi", "dxguid"],
+        "shaderOutputs": ["prebuilt/default.dxil"]
+      },
+      "vulkan": {
+        "libs": ["vulkan-1"],
+        "shaderOutputs": ["prebuilt/default.spv"]
+      }
+    }
+  }
+}
+```
+
+For Apple app-bundle targets, Metal shader sources are compiled into
+`default.metallib`. Set `PERRY_XCRUN=/path/to/fake-or-real-xcrun` to
+override tool discovery in tests. Vulkan shader sources are compiled
+with `glslc` into `NativeLibraries/<package>/vulkan/<source>.spv`;
+set `PERRY_GLSLC=/path/to/glslc` to override discovery. D3D12 shader
+sources are compiled with `dxc` into
+`NativeLibraries/<package>/d3d12/<source>.dxil`; set
+`PERRY_DXC=/path/to/dxc` to override discovery. If your shader build
+needs custom profiles, entry points, or flags, ship prebuilt
+`shaderOutputs` from your package build instead.
 
 ### Vendored frameworks (`optionalFrameworks` + `frameworksEnv`)
 


### PR DESCRIPTION
## Summary\n- add target/backend native-library packaging metadata for Metal, Vulkan, and D3D12\n- stage target/backend resources and shader outputs into stable package boundaries\n- include backend prebuilt archives in lock scanning and link metadata\n- document manifest fields and schema coverage\n\n## Verification\n- git diff --check origin/main...HEAD\n- cargo fmt --check\n- cargo check -p perry\n- cargo test -p perry native_resource_tests\n- cargo test -p perry native_shader_tool_tests\n- cargo test -p perry lock_scan\n- cargo test -p perry target_gated\n- cargo test -p perry backend\n- cargo test -p perry invalid_backend_metadata_fails_before_cargo_lookup