### PR TITLE
fix(node:events): handle rejection paths

### DIFF
--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -153,11 +153,16 @@ pub(super) fn lower_builtin_new(
         // every .on/.emit call dispatched against a junk pointer and
         // silently registered nothing / fired nothing.
         "EventEmitter" => {
-            for a in args {
+            let opts = if let Some(a) = args.first() {
+                lower_expr(ctx, a)?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            for a in args.iter().skip(1) {
                 let _ = lower_expr(ctx, a)?;
             }
             let blk = ctx.block();
-            let handle = blk.call(I64, "js_event_emitter_new", &[]);
+            let handle = blk.call(I64, "js_event_emitter_new_with_options", &[(DOUBLE, &opts)]);
             Ok(Some(nanbox_pointer_inline(blk, &handle)))
         }
         // node:perf_hooks — `new PerformanceObserver(cb)` registers the

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -865,6 +865,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_event_emitter_emit0", DOUBLE, &[I64, I64]);
     module.declare_function("js_event_emitter_listener_count", DOUBLE, &[I64, I64, I64]);
     module.declare_function("js_event_emitter_new", I64, &[]);
+    module.declare_function("js_event_emitter_new_with_options", I64, &[DOUBLE]);
     module.declare_function("js_event_emitter_on", I64, &[I64, I64, I64]);
     module.declare_function("js_event_emitter_once", I64, &[I64, I64, I64]);
     module.declare_function("js_event_emitter_prepend_listener", I64, &[I64, I64, I64]);

--- a/crates/perry-stdlib/src/events.rs
+++ b/crates/perry-stdlib/src/events.rs
@@ -21,8 +21,9 @@
 
 use perry_runtime::{
     js_array_alloc, js_array_length, js_array_push_f64, js_closure_call0, js_closure_call1,
-    js_closure_call2, js_nanbox_pointer, js_nanbox_string, js_object_alloc, js_promise_new,
-    js_promise_resolve, js_string_from_bytes, ArrayHeader, ClosureHeader, Promise, StringHeader,
+    js_closure_call2, js_nanbox_get_pointer, js_nanbox_pointer, js_nanbox_string, js_object_alloc,
+    js_object_get_field_by_name, js_promise_new, js_promise_reject, js_promise_resolve,
+    js_string_from_bytes, ArrayHeader, ClosureHeader, JSValue, ObjectHeader, Promise, StringHeader,
 };
 use std::collections::HashMap;
 
@@ -98,6 +99,9 @@ pub struct EventEmitterHandle {
     /// when the count exceeds it — `getMaxListeners()` just reads back
     /// whatever was written.
     max_listeners: f64,
+    /// Constructor-level `{ captureRejections: true }` flag. When enabled,
+    /// rejected promises returned from listeners are routed to `"error"`.
+    capture_rejections: bool,
 }
 
 // SAFETY: `*mut Promise` is not Send/Sync by default, but the runtime
@@ -160,6 +164,7 @@ impl EventEmitterHandle {
             // Node's default is 10. We mirror it so `getMaxListeners()`
             // on a fresh emitter returns 10 (matching Node).
             max_listeners: 10.0,
+            capture_rejections: false,
         }
     }
 
@@ -255,12 +260,39 @@ unsafe fn dispatch_error_monitor(emitter: &mut EventEmitterHandle, arg: Option<f
     }
 }
 
+unsafe fn event_emitter_options_capture_rejections(options: f64) -> bool {
+    if !JSValue::from_bits(options.to_bits()).is_pointer() {
+        return false;
+    }
+    let options_obj = js_nanbox_get_pointer(options) as *const ObjectHeader;
+    if options_obj.is_null() || (options_obj as usize) < 0x100000 {
+        return false;
+    }
+    let gc_header = (options_obj as *const u8).sub(perry_runtime::gc::GC_HEADER_SIZE)
+        as *const perry_runtime::gc::GcHeader;
+    if (*gc_header).obj_type != perry_runtime::gc::GC_TYPE_OBJECT {
+        return false;
+    }
+    let key = b"captureRejections";
+    let key_ptr = js_string_from_bytes(key.as_ptr(), key.len() as u32);
+    let value = js_object_get_field_by_name(options_obj, key_ptr);
+    perry_runtime::value::js_is_truthy(f64::from_bits(value.bits())) != 0
+}
+
 /// Create a new EventEmitter
 /// Returns a handle (i64) to the emitter
 #[no_mangle]
 pub extern "C" fn js_event_emitter_new() -> Handle {
     ensure_gc_scanner_registered();
     register_handle(EventEmitterHandle::new())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_event_emitter_new_with_options(options: f64) -> Handle {
+    ensure_gc_scanner_registered();
+    let mut emitter = EventEmitterHandle::new();
+    emitter.capture_rejections = event_emitter_options_capture_rejections(options);
+    register_handle(emitter)
 }
 
 /// EventEmitter.on(eventName, listener) — also serves as `addListener`.
@@ -373,6 +405,31 @@ unsafe fn drain_pending_once_promises(
     }
 }
 
+unsafe fn reject_pending_once_promises_for_error(
+    emitter: &mut EventEmitterHandle,
+    error_value: f64,
+) -> bool {
+    let event_names: Vec<String> = emitter
+        .pending_once_promises
+        .keys()
+        .filter(|name| name.as_str() != "error")
+        .cloned()
+        .collect();
+    let mut rejected_any = false;
+    for event_name in event_names {
+        let Some(pending) = emitter.pending_once_promises.remove(&event_name) else {
+            continue;
+        };
+        for promise_ptr in pending {
+            if !promise_ptr.is_null() {
+                js_promise_reject(promise_ptr, error_value);
+                rejected_any = true;
+            }
+        }
+    }
+    rejected_any
+}
+
 unsafe fn first_arg_or_undefined(args_ptr: *const ArrayHeader) -> f64 {
     if args_ptr.is_null() || js_array_length(args_ptr) == 0 {
         f64::from_bits(TAG_UNDEFINED_F64_BITS)
@@ -382,6 +439,37 @@ unsafe fn first_arg_or_undefined(args_ptr: *const ArrayHeader) -> f64 {
 }
 
 const TAG_UNDEFINED_F64_BITS: u64 = 0x7FFC_0000_0000_0001;
+
+extern "C" fn events_capture_rejection_handler(closure: *const ClosureHeader, reason: f64) -> f64 {
+    use perry_runtime::closure::js_closure_get_capture_ptr;
+
+    let handle = js_closure_get_capture_ptr(closure, 0) as Handle;
+    if handle != 0 {
+        let event_name = b"error";
+        let event_str = js_string_from_bytes(event_name.as_ptr(), event_name.len() as u32);
+        let mut args = js_array_alloc(0);
+        args = js_array_push_f64(args, reason);
+        unsafe {
+            js_event_emitter_emit(handle, event_str, args);
+        }
+    }
+    f64::from_bits(TAG_UNDEFINED_F64_BITS)
+}
+
+unsafe fn capture_listener_rejection(handle: Handle, result: f64) {
+    use perry_runtime::closure::{js_closure_alloc, js_closure_set_capture_ptr};
+
+    if perry_runtime::promise::js_value_is_promise(result) == 0 {
+        return;
+    }
+    let promise = js_nanbox_get_pointer(result) as *mut Promise;
+    if promise.is_null() {
+        return;
+    }
+    let on_rejected = js_closure_alloc(events_capture_rejection_handler as *const u8, 1);
+    js_closure_set_capture_ptr(on_rejected, 0, handle);
+    perry_runtime::promise::js_promise_then(promise, std::ptr::null(), on_rejected);
+}
 
 /// EventEmitter.emit(eventName, ...args)
 /// Emit an event with variadic arguments packed into an ArrayHeader.
@@ -420,7 +508,13 @@ pub unsafe extern "C" fn js_event_emitter_emit(
         let first_arg = first_arg_or_undefined(args_ptr);
         if event_name == "error" {
             dispatch_error_monitor(emitter, Some(first_arg));
-            if snapshot.is_empty() {
+            let has_error_once = emitter
+                .pending_once_promises
+                .get("error")
+                .is_some_and(|pending| !pending.is_empty());
+            let rejected_once = reject_pending_once_promises_for_error(emitter, first_arg);
+            had_listeners = had_listeners || has_error_once || rejected_once;
+            if snapshot.is_empty() && !has_error_once && !rejected_once {
                 perry_runtime::exception::js_throw(first_arg);
             }
         }
@@ -428,10 +522,14 @@ pub unsafe extern "C" fn js_event_emitter_emit(
         // Resolve any pending `events.once` Promises before dispatch.
         drain_pending_once_promises(emitter, &event_name, args_ptr);
 
+        let capture_rejections = emitter.capture_rejections && event_name != "error";
         for l in snapshot {
             if l.callback != 0 {
                 let closure_ptr = l.callback as *const ClosureHeader;
-                js_closure_call1(closure_ptr, first_arg);
+                let result = js_closure_call1(closure_ptr, first_arg);
+                if capture_rejections {
+                    capture_listener_rejection(handle, result);
+                }
             }
         }
     }
@@ -469,16 +567,29 @@ pub unsafe extern "C" fn js_event_emitter_emit0(
         let empty_args = js_array_alloc(0);
         if event_name == "error" {
             dispatch_error_monitor(emitter, None);
-            if snapshot.is_empty() {
+            let has_error_once = emitter
+                .pending_once_promises
+                .get("error")
+                .is_some_and(|pending| !pending.is_empty());
+            let rejected_once = reject_pending_once_promises_for_error(
+                emitter,
+                f64::from_bits(TAG_UNDEFINED_F64_BITS),
+            );
+            had_listeners = had_listeners || has_error_once || rejected_once;
+            if snapshot.is_empty() && !has_error_once && !rejected_once {
                 perry_runtime::exception::js_throw(f64::from_bits(TAG_UNDEFINED_F64_BITS));
             }
         }
         drain_pending_once_promises(emitter, &event_name, empty_args);
 
+        let capture_rejections = emitter.capture_rejections && event_name != "error";
         for l in snapshot {
             if l.callback != 0 {
                 let closure_ptr = l.callback as *const ClosureHeader;
-                js_closure_call0(closure_ptr);
+                let result = js_closure_call0(closure_ptr);
+                if capture_rejections {
+                    capture_listener_rejection(handle, result);
+                }
             }
         }
     }

--- a/test-parity/node-suite/events/once/static-once-error.ts
+++ b/test-parity/node-suite/events/once/static-once-error.ts
@@ -1,0 +1,12 @@
+import { EventEmitter, once } from "node:events";
+
+const ee = new EventEmitter();
+const p = once(ee, "ready").then(() => "resolved", (err: any) => err.message);
+console.log("emit return:", ee.emit("error", new Error("bad")));
+console.log("ready once:", await p);
+
+const ee2 = new EventEmitter();
+const p2 = once(ee2, "error");
+ee2.emit("error", new Error("boom"));
+const args = await p2;
+console.log("error once:", args[0].message);


### PR DESCRIPTION
## Summary
- honor `EventEmitter({ captureRejections: true })` by routing rejected listener promises to `error`
- reject pending `events.once(emitter, name)` promises when an `error` event is emitted for another event
- keep `events.once(emitter, "error")` resolving with the emitted error args

Supersedes #1899 and #1900.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `jq empty test-parity/known_failures.json`
- `cargo test -p perry-stdlib --no-default-features --features "bundled-events crypto" events --lib -- --nocapture`
