### PR TITLE
test(parity): unskip inventory smokes

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -194,18 +194,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory — `node:net` socket-layer surface not implemented (Server/Socket classes, BlockList, SocketAddress). Classification helpers landed via #811. Tracker for surface coverage; flips to PASS as each API lands."
   },
-  "test_parity_os": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:os` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
-  "test_parity_process": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "test_parity_readline": {
     "issue": "793",
     "added": "2026-05-15",
@@ -253,12 +241,6 @@
     "added": "2026-05-15",
     "category": "module-inventory",
     "reason": "Node.js module inventory — `node:tls` surface not fully implemented (Socket-level TLS upgrade works via net.upgradeToTLS; the higher-level tls.connect/Server is partial). Tracker for surface coverage."
-  },
-  "test_parity_url": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:url` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_util": {
     "issue": "793",


### PR DESCRIPTION
## Summary
- Remove stale `test_parity_process`, `test_parity_os`, and `test_parity_url` known-failure entries now that their generated inventory smokes pass on current main.
- Keep the broad process, OS, and URL inventory smokes visible to CI so regressions are no longer masked.
- Consolidates the separate inventory-cleanup PRs into one PR instead of keeping several near-identical known-failure removals open.

## Verification
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD`
- Prior focused parity runs recorded before consolidation:
  - `./run_parity_tests.sh --filter test_parity_process` PASS
  - `./run_parity_tests.sh --filter test_parity_os` PASS
  - `./run_parity_tests.sh --filter test_parity_url` PASS

## Non-goals
- No runtime behavior change.
- No broad module-suite parity claim for residual URL behavior gaps.
