### PR TITLE
test(parity): unskip os inventory smoke

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -194,12 +194,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory — `node:net` socket-layer surface not implemented (Server/Socket classes, BlockList, SocketAddress). Classification helpers landed via #811. Tracker for surface coverage; flips to PASS as each API lands."
   },
-  "test_parity_os": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:os` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "test_parity_process": {
     "issue": "793",
     "added": "2026-05-15",


### PR DESCRIPTION
## Summary
- Remove stale `test_parity_os` known-failure entry after generated `node:os` inventory smoke passes current main.
- Keep broad OS smoke visible to CI for platform/path/constants/userInfo/newer OS API surface.

## Verification
- Before cleanup: `test_parity_os` was listed in `known_failures.json` as a module-inventory expected failure.
- `./run_parity_tests.sh --filter test_parity_os` PASS
- `./run_parity_tests.sh --suite node-suite --module os` PASS 39/39
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- No runtime behavior change.
- No host-dependent or side-effecting OS API claims beyond existing deterministic fixtures.
