### PR TITLE
test(parity): unskip url inventory smoke

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -254,12 +254,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory — `node:tls` surface not fully implemented (Socket-level TLS upgrade works via net.upgradeToTLS; the higher-level tls.connect/Server is partial). Tracker for surface coverage."
   },
-  "test_parity_url": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:url` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "test_parity_util": {
     "issue": "793",
     "added": "2026-05-15",


### PR DESCRIPTION
## Summary
- Remove stale `test_parity_url` known-failure entry after the generated `node:url` inventory smoke passes current main.
- Keep broad URL smoke visible to CI for URL, URLSearchParams, file URL helpers, IDNA helpers, legacy parse/format/resolve, and `urlToHttpOptions` surface probes.

## Verification
- Before cleanup: `test_parity_url` was listed in `known_failures.json` as a module-inventory expected failure.
- `./run_parity_tests.sh --filter test_parity_url` PASS
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS
- Broader context: `./run_parity_tests.sh --suite node-suite --module url` remains 37/48 with 11 residual output mismatches.

## Non-goals
- No runtime behavior change.
- No broad URL suite parity claim. Remaining URL formatting, IDNA/file URL normalization, relative `URL.canParse`, URLSearchParams thisArg, and mutation encoding gaps stay separate.
