### PR TITLE
Add native async promise ABI

### DIFF
--- a/crates/perry-api-manifest/src/lib.rs
+++ b/crates/perry-api-manifest/src/lib.rs
@@ -25,7 +25,8 @@ pub use emit::{emit_dts, emit_markdown};
 pub use entries::{API_MANIFEST, NATIVE_MODULES, NODE_SUBMODULES, RUNTIME_ONLY_MODULES};
 pub use native_abi::{
     native_handle_type_id, NativeAbiParseError, NativeAbiType, NativeHandleAbi,
-    NativeHandleOwnership, NativeHandleThreadAffinity,
+    NativeHandleOwnership, NativeHandleThreadAffinity, NativePromiseAbi, NativePromiseCompletion,
+    NativePromiseThread,
 };
 
 /// One entry in the manifest. Identifies a single named symbol on a

--- a/crates/perry-api-manifest/src/native_abi.rs
+++ b/crates/perry-api-manifest/src/native_abi.rs
@@ -75,6 +75,82 @@ pub struct NativeHandleAbi {
     pub debug_name: String,
 }
 
+/// Completion path used by a Perry promise native ABI descriptor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NativePromiseCompletion {
+    /// The native function returns a normal runtime Promise pointer. This is
+    /// the historical `promise<T>` behavior.
+    Direct,
+    /// The native function participates in Perry's runtime-owned async
+    /// completion-token registry. The JS-visible return remains a Promise.
+    NativeAsync,
+}
+
+impl NativePromiseCompletion {
+    /// Canonical manifest spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Direct => "direct",
+            Self::NativeAsync => "native_async",
+        }
+    }
+}
+
+impl fmt::Display for NativePromiseCompletion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Thread policy for completing a native async promise token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NativePromiseThread {
+    /// Completion may be requested from any thread. Settlement still happens
+    /// on the runtime main-thread pump.
+    Any,
+    /// Completion requests from non-main threads are rejected by the runtime.
+    Main,
+}
+
+impl NativePromiseThread {
+    /// Canonical manifest spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Any => "any",
+            Self::Main => "main",
+        }
+    }
+}
+
+impl fmt::Display for NativePromiseThread {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Runtime contract attached to a `promise` native ABI descriptor.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NativePromiseAbi {
+    /// Optional metadata describing the JavaScript value the promise resolves
+    /// with. Defaults to `jsvalue`.
+    pub result: Box<NativeAbiType>,
+    /// Completion machinery used behind the JS-visible Promise boundary.
+    pub completion: NativePromiseCompletion,
+    /// Thread policy for completion requests.
+    pub thread: NativePromiseThread,
+}
+
+impl NativePromiseAbi {
+    /// Construct a direct promise descriptor with `result` metadata.
+    pub fn direct(result: NativeAbiType) -> Self {
+        Self {
+            result: Box::new(result),
+            completion: NativePromiseCompletion::Direct,
+            thread: NativePromiseThread::Any,
+        }
+    }
+}
+
 impl NativeHandleAbi {
     /// Construct a borrowed, non-null, thread-agnostic descriptor.
     pub fn borrowed(type_name: Option<String>) -> Self {
@@ -154,8 +230,8 @@ pub enum NativeAbiType {
     /// Opaque native handle with runtime ownership, nullability, and thread
     /// validation metadata.
     Handle(NativeHandleAbi),
-    /// Opaque native promise boundary handle with optional result metadata.
-    Promise(Box<NativeAbiType>),
+    /// Opaque native promise boundary handle with completion metadata.
+    Promise(NativePromiseAbi),
     /// No return value. This is valid only as a return descriptor.
     Void,
 }
@@ -181,7 +257,7 @@ impl NativeAbiType {
             "buffer_len" => Ok(Self::BufferLen),
             "buffer+len" => Ok(Self::BufferAndLen),
             "handle" => Ok(Self::Handle(NativeHandleAbi::borrowed(None))),
-            "promise" => Ok(Self::Promise(Box::new(Self::JsValue))),
+            "promise" => Ok(Self::Promise(NativePromiseAbi::direct(Self::JsValue))),
             "void" => Ok(Self::Void),
             _ => {
                 if let Some(inner) = trimmed
@@ -210,7 +286,9 @@ impl NativeAbiType {
                             "promise<T> requires a non-empty T",
                         ));
                     }
-                    return Ok(Self::Promise(Box::new(Self::parse_str(result)?)));
+                    return Ok(Self::Promise(NativePromiseAbi::direct(Self::parse_str(
+                        result,
+                    )?)));
                 }
                 Err(NativeAbiParseError::new(trimmed, "unknown native ABI type"))
             }
@@ -268,7 +346,23 @@ impl NativeAbiType {
     /// Return the optional promise result metadata attached to `promise<T>`.
     pub fn promise_result(&self) -> Option<&NativeAbiType> {
         match self {
-            Self::Promise(result) => Some(result.as_ref()),
+            Self::Promise(abi) => Some(abi.result.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return the promise completion mode attached to `promise<T>`.
+    pub fn promise_completion(&self) -> Option<NativePromiseCompletion> {
+        match self {
+            Self::Promise(abi) => Some(abi.completion),
+            _ => None,
+        }
+    }
+
+    /// Return the promise completion thread policy attached to `promise<T>`.
+    pub fn promise_thread(&self) -> Option<NativePromiseThread> {
+        match self {
+            Self::Promise(abi) => Some(abi.thread),
             _ => None,
         }
     }
@@ -276,6 +370,13 @@ impl NativeAbiType {
     /// True when this descriptor is legal in a parameter list.
     pub fn is_valid_param(&self) -> bool {
         !matches!(self, Self::Void)
+            && !matches!(
+                self,
+                Self::Promise(NativePromiseAbi {
+                    completion: NativePromiseCompletion::NativeAsync,
+                    ..
+                })
+            )
     }
 
     /// True when this descriptor is legal as a return type.
@@ -312,7 +413,7 @@ impl fmt::Display for NativeAbiType {
                 Some(ty) => write!(f, "handle<{ty}>"),
                 None => f.write_str("handle"),
             },
-            Self::Promise(result) => write!(f, "promise<{result}>"),
+            Self::Promise(abi) => write!(f, "promise<{}>", abi.result),
             other => f.write_str(other.canonical_kind()),
         }
     }

--- a/crates/perry-codegen/src/native_value/artifact.rs
+++ b/crates/perry-codegen/src/native_value/artifact.rs
@@ -73,6 +73,8 @@ pub(crate) struct NativeAbiTypeRecord {
     pub handle_type: Option<String>,
     pub native_handle: Option<NativeHandleContractRecord>,
     pub promise_result: Option<String>,
+    pub promise_completion: Option<String>,
+    pub promise_thread: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -124,6 +126,12 @@ impl NativeAbiTypeRecord {
             handle_type: descriptor.handle_type().map(str::to_string),
             native_handle,
             promise_result: descriptor.promise_result().map(ToString::to_string),
+            promise_completion: descriptor
+                .promise_completion()
+                .map(|completion| completion.as_str().to_string()),
+            promise_thread: descriptor
+                .promise_thread()
+                .map(|thread| thread.as_str().to_string()),
         }
     }
 }

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -1069,6 +1069,58 @@ fn native_library_manifest_lowercase_abi_returns_emit_signatures_and_artifacts()
 }
 
 #[test]
+fn native_library_manifest_native_async_promise_artifact_records_metadata() {
+    let ret = perry_api_manifest::NativeAbiType::Promise(perry_api_manifest::NativePromiseAbi {
+        result: Box::new(perry_api_manifest::NativeAbiType::F64),
+        completion: perry_api_manifest::NativePromiseCompletion::NativeAsync,
+        thread: perry_api_manifest::NativePromiseThread::Main,
+    });
+    let opts = native_library_opts_typed(vec![("native_ret_native_async", vec![], ret)]);
+    let module = module(
+        "artifact_native_async_promise_return.ts",
+        vec![Stmt::Return(Some(extern_call(
+            "native_ret_native_async",
+            Vec::new(),
+            Type::Number,
+        )))],
+    );
+
+    let ir = String::from_utf8(compile_module(&module, opts.clone()).unwrap()).unwrap();
+    assert!(
+        ir.contains("declare i64 @native_ret_native_async()"),
+        "native async promise lowering should keep the JS Promise boundary ABI:\n{ir}"
+    );
+
+    let artifact = compile_artifact_json_for_module_with_opts(module, opts);
+    let records = artifact["records"].as_array().unwrap();
+    assert!(
+        records.iter().any(|record| {
+            record["expr_kind"] == "NativeLibraryReturn"
+                && record["consumer"] == "native_library.raw_promise"
+                && record["native_rep_name"] == "promise_boundary"
+                && record["llvm_ty"] == "i64"
+                && record["native_value_state"] == "region_local"
+                && record["native_abi_type"]["canonical_kind"] == "promise"
+                && record["native_abi_type"]["promise_result"] == "f64"
+                && record["native_abi_type"]["promise_completion"] == "native_async"
+                && record["native_abi_type"]["promise_thread"] == "main"
+        }),
+        "expected native async promise ABI metadata in artifact:\n{artifact:#}"
+    );
+    assert!(
+        records.iter().any(|record| {
+            record["consumer"] == "materialize_promise_boundary"
+                && record["native_value_state"] == "materialized"
+                && record["native_abi_transition"]["from_native_rep"] == "promise_boundary"
+                && record["native_abi_transition"]["to_native_rep"] == "js_value"
+                && record["native_abi_transition"]["op"] == "promise_box"
+                && record["native_abi_transition"]["lossy"] == false
+        }),
+        "expected native async promise return to use existing promise boxing:\n{artifact:#}"
+    );
+}
+
+#[test]
 fn native_library_manifest_lowercase_abi_params_emit_c_abi_signature() {
     let opts = native_library_opts(vec![(
         "native_abi_args",

--- a/crates/perry-ffi/src/async_runtime.rs
+++ b/crates/perry-ffi/src/async_runtime.rs
@@ -31,12 +31,22 @@
 
 use std::ffi::c_void;
 
-use crate::{alloc_string, Promise, StringHeader};
+use crate::{alloc_string, NativeAsyncCompletion, Promise, StringHeader};
 
 extern "C" {
     fn perry_ffi_promise_new() -> *mut Promise;
     fn perry_ffi_promise_resolve_bits(promise: *mut Promise, bits: u64);
     fn perry_ffi_promise_reject_bits(promise: *mut Promise, bits: u64);
+    fn perry_ffi_native_async_new(flags: u32) -> *mut NativeAsyncCompletion;
+    fn perry_ffi_native_async_promise(token: *mut NativeAsyncCompletion) -> *mut Promise;
+    fn perry_ffi_native_async_resolve_bits(token: *mut NativeAsyncCompletion, bits: u64) -> i32;
+    fn perry_ffi_native_async_reject_bits(token: *mut NativeAsyncCompletion, bits: u64) -> i32;
+    fn perry_ffi_native_async_cancel(token: *mut NativeAsyncCompletion) -> i32;
+    fn perry_ffi_native_async_attach_handle(
+        token: *mut NativeAsyncCompletion,
+        handle_bits: u64,
+        cleanup_flags: u32,
+    ) -> i32;
     fn perry_ffi_spawn_blocking(ctx: *mut c_void, invoke: extern "C" fn(*mut c_void));
     fn perry_ffi_spawn_blocking_with_reactor(ctx: *mut c_void, invoke: extern "C" fn(*mut c_void));
 }
@@ -54,6 +64,23 @@ const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
 const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
+
+/// Native async operation completed or the handle attachment succeeded.
+pub const PERRY_NATIVE_ASYNC_OK: i32 = 0;
+/// Completion was already requested; the payload was dropped.
+pub const PERRY_NATIVE_ASYNC_ALREADY_COMPLETED: i32 = 1;
+/// A `thread: "main"` token was completed from another thread.
+pub const PERRY_NATIVE_ASYNC_WRONG_THREAD: i32 = 2;
+/// Token or promise pointer was null/invalid.
+pub const PERRY_NATIVE_ASYNC_INVALID: i32 = 3;
+/// Create a token that rejects completion requests from non-main threads.
+pub const PERRY_NATIVE_ASYNC_THREAD_MAIN: u32 = 1 << 0;
+/// Dispose attached cleanup handles when the token rejects.
+pub const PERRY_NATIVE_ASYNC_CLEANUP_ON_REJECT: u32 = 1 << 0;
+/// Dispose attached cleanup handles when the token is cancelled.
+pub const PERRY_NATIVE_ASYNC_CLEANUP_ON_CANCEL: u32 = 1 << 1;
+/// Dispose attached cleanup handles even when the token resolves.
+pub const PERRY_NATIVE_ASYNC_CLEANUP_ON_SUCCESS: u32 = 1 << 2;
 
 /// Opaque handle to a JS Promise allocated in Perry's arena.
 ///
@@ -151,6 +178,86 @@ impl JsPromise {
     pub fn reject_string(self, message: &str) {
         let str_handle = alloc_string(message);
         unsafe { perry_ffi_promise_reject_bits(self.0, nanbox_string_bits(str_handle.as_raw())) };
+    }
+}
+
+/// Runtime-owned native async completion token.
+///
+/// This is the explicit token API behind [`JsPromise`]'s legacy shims. The
+/// JavaScript-visible value remains the [`Promise`] returned by
+/// [`Self::promise`], while the token is safe to move into worker-thread
+/// closures and complete exactly once.
+#[repr(transparent)]
+pub struct JsNativeAsyncCompletion(*mut NativeAsyncCompletion);
+
+// SAFETY: the runtime token owns synchronization and exposes only atomic
+// completion plus main-thread-pumped settlement.
+unsafe impl Send for JsNativeAsyncCompletion {}
+
+impl JsNativeAsyncCompletion {
+    /// Allocate a token with default `thread: "any"` completion policy.
+    pub fn new() -> Self {
+        Self::with_flags(0)
+    }
+
+    /// Allocate a token with explicit native async flags.
+    pub fn with_flags(flags: u32) -> Self {
+        Self(unsafe { perry_ffi_native_async_new(flags) })
+    }
+
+    /// Wrap a raw token pointer obtained from the C ABI.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be a token returned by `perry_ffi_native_async_new`.
+    pub unsafe fn from_raw(ptr: *mut NativeAsyncCompletion) -> Self {
+        Self(ptr)
+    }
+
+    /// Return the raw token pointer for passing through custom FFI layers.
+    pub fn as_raw(&self) -> *mut NativeAsyncCompletion {
+        self.0
+    }
+
+    /// Return the JS Promise associated with this token.
+    pub fn promise(&self) -> *mut Promise {
+        unsafe { perry_ffi_native_async_promise(self.0) }
+    }
+
+    /// Resolve with arbitrary encoded JSValue bits.
+    pub fn resolve_bits(self, bits: u64) -> i32 {
+        unsafe { perry_ffi_native_async_resolve_bits(self.0, bits) }
+    }
+
+    /// Reject with arbitrary encoded JSValue bits.
+    pub fn reject_bits(self, bits: u64) -> i32 {
+        unsafe { perry_ffi_native_async_reject_bits(self.0, bits) }
+    }
+
+    /// Resolve with a number.
+    pub fn resolve_number(self, n: f64) -> i32 {
+        self.resolve_bits(n.to_bits())
+    }
+
+    /// Resolve with `undefined`.
+    pub fn resolve_undefined(self) -> i32 {
+        self.resolve_bits(TAG_UNDEFINED)
+    }
+
+    /// Reject with a string reason.
+    pub fn reject_string(self, message: &str) -> i32 {
+        let str_handle = alloc_string(message);
+        self.reject_bits(nanbox_string_bits(str_handle.as_raw()))
+    }
+
+    /// Cancel the token, rejecting with Perry's default cancellation reason.
+    pub fn cancel(self) -> i32 {
+        unsafe { perry_ffi_native_async_cancel(self.0) }
+    }
+
+    /// Attach a JS native-handle value for runtime cleanup on reject/cancel.
+    pub fn attach_handle(&self, value: crate::JsValue, cleanup_flags: u32) -> i32 {
+        unsafe { perry_ffi_native_async_attach_handle(self.0, value.bits(), cleanup_flags) }
     }
 }
 

--- a/crates/perry-ffi/src/lib.rs
+++ b/crates/perry-ffi/src/lib.rs
@@ -46,13 +46,17 @@
 
 mod async_runtime;
 pub use async_runtime::{
-    nanbox_string_bits, spawn_blocking, spawn_blocking_with_reactor, JsPromise,
+    nanbox_string_bits, spawn_blocking, spawn_blocking_with_reactor, JsNativeAsyncCompletion,
+    JsPromise, PERRY_NATIVE_ASYNC_ALREADY_COMPLETED, PERRY_NATIVE_ASYNC_CLEANUP_ON_CANCEL,
+    PERRY_NATIVE_ASYNC_CLEANUP_ON_REJECT, PERRY_NATIVE_ASYNC_CLEANUP_ON_SUCCESS,
+    PERRY_NATIVE_ASYNC_INVALID, PERRY_NATIVE_ASYNC_OK, PERRY_NATIVE_ASYNC_THREAD_MAIN,
+    PERRY_NATIVE_ASYNC_WRONG_THREAD,
 };
 
 mod types;
 pub use types::{
-    ArrayHeader, BigIntHeader, BufferHeader, ClosureHeader, ObjectHeader, Promise, StringHeader,
-    BIGINT_LIMBS,
+    ArrayHeader, BigIntHeader, BufferHeader, ClosureHeader, NativeAsyncCompletion, ObjectHeader,
+    Promise, StringHeader, BIGINT_LIMBS,
 };
 
 mod handle;

--- a/crates/perry-ffi/src/types.rs
+++ b/crates/perry-ffi/src/types.rs
@@ -83,6 +83,15 @@ pub struct Promise {
     _private: [u8; 0],
 }
 
+/// Opaque runtime-owned native async completion token.
+///
+/// Wrappers pass `*mut NativeAsyncCompletion` through the perry-ffi async
+/// helpers; they must not inspect or allocate this type directly.
+#[repr(C)]
+pub struct NativeAsyncCompletion {
+    _private: [u8; 0],
+}
+
 #[cfg(all(test, feature = "runtime-link"))]
 mod layout_tests {
     use super::*;

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -668,6 +668,7 @@ pub fn gc_init() {
         scan_runtime_handle_roots_mut,
         MutableRootScannerSource::RuntimeHandles,
     );
+    gc_register_mutable_root_scanner(crate::promise::scan_native_async_completion_roots_mut);
     gc_register_mutable_root_scanner(promise_mutable_root_scanner);
     gc_register_mutable_root_scanner(timer_mutable_root_scanner);
     gc_register_mutable_root_scanner(exception_mutable_root_scanner);

--- a/crates/perry-runtime/src/gc/tests/runtime_roots/callback_scanners.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots/callback_scanners.rs
@@ -485,6 +485,69 @@ fn test_promise_contexts_rekey_live_and_drop_dead_from_space_after_copied_minor(
 }
 
 #[test]
+fn test_native_async_completion_token_roots_survive_copied_minor_gc() {
+    let _native_async_guard = crate::promise::native_async::test_native_async_lock();
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    activate_malloc_registry_for_tests();
+    crate::promise::native_async::test_reset_native_async_registry();
+    gc_register_mutable_root_scanner(crate::promise::scan_native_async_completion_roots_mut);
+
+    let token = crate::promise::js_native_async_completion_new(0);
+    let promise = crate::promise::js_native_async_completion_promise(token);
+    let original_promise = promise as usize;
+    let result = crate::string::js_string_from_bytes(b"native-async-result".as_ptr(), 19);
+    let handle = crate::string::js_string_from_bytes(b"native-async-handle".as_ptr(), 19);
+    let result_bits = string_bits(result as usize);
+    let handle_bits = string_bits(handle as usize);
+
+    assert_eq!(
+        crate::promise::js_native_async_completion_attach_handle(
+            token,
+            handle_bits,
+            crate::promise::PERRY_NATIVE_ASYNC_CLEANUP_ON_REJECT
+        ),
+        crate::promise::PERRY_NATIVE_ASYNC_OK
+    );
+    assert_eq!(
+        crate::promise::js_native_async_completion_resolve_bits(token, result_bits),
+        crate::promise::PERRY_NATIVE_ASYNC_OK
+    );
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+
+    let (moved_promise, moved_payload, moved_handles) =
+        crate::promise::native_async::test_native_async_slot_snapshot(token);
+    assert_ne!(
+        moved_promise, original_promise,
+        "token promise slot should be rewritten after copied-minor GC"
+    );
+    assert_ne!(
+        moved_payload.unwrap() & POINTER_MASK,
+        result as u64,
+        "token payload slot should be rewritten after copied-minor GC"
+    );
+    assert_ne!(
+        moved_handles[0] & POINTER_MASK,
+        handle as u64,
+        "token attached handle slot should be rewritten after copied-minor GC"
+    );
+
+    assert_eq!(crate::promise::js_native_async_process_pending(), 1);
+    let promise = moved_promise as *mut crate::promise::Promise;
+    unsafe {
+        assert_eq!((*promise).state, crate::promise::PromiseState::Fulfilled);
+        let value_bits = (*promise).value.to_bits();
+        assert_eq!(value_bits & TAG_MASK, STRING_TAG);
+        assert_string_bytes(
+            (value_bits & POINTER_MASK) as *const crate::StringHeader,
+            b"native-async-result",
+        );
+    }
+}
+
+#[test]
 fn test_microtask_dispatch_handles_survive_callback_gc() {
     let _guard = CopyingNurseryTestGuard::new(0);
     gc_register_mutable_root_scanner(scan_runtime_handle_roots_mut);

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -233,6 +233,7 @@ mod stdlib_pump {
     /// is not linked (no-op in that case).
     #[no_mangle]
     pub extern "C" fn js_run_stdlib_pump() {
+        crate::promise::js_native_async_process_pending();
         // Drain the tty resize-pending flag (#347 Phase 3). Lives in
         // perry-runtime, not stdlib, so it runs even when stdlib isn't
         // linked — a TUI program that uses process.stdout.on('resize')
@@ -261,6 +262,9 @@ mod stdlib_pump {
     /// async ops, etc.). Returns 0 if perry-stdlib is not linked.
     #[no_mangle]
     pub extern "C" fn js_stdlib_has_active_handles() -> i32 {
+        if crate::promise::js_native_async_has_active() != 0 {
+            return 1;
+        }
         let f = STDLIB_HAS_ACTIVE_FN.load(Ordering::Acquire);
         if !f.is_null() {
             unsafe {

--- a/crates/perry-runtime/src/promise/microtasks.rs
+++ b/crates/perry-runtime/src/promise/microtasks.rs
@@ -30,6 +30,9 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
 
     ran += crate::async_hooks::drain_gc_destroy_queue();
 
+    // Native async tokens settle only through the main-thread handoff path.
+    ran += super::native_async::js_native_async_process_pending();
+
     // Process any scheduled resolutions (simulates async completions)
     ran += super::combinators::process_scheduled_resolves();
 

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -21,6 +21,7 @@ use crate::async_context::{
 pub mod async_step;
 pub mod combinators;
 pub mod microtasks;
+pub mod native_async;
 pub mod scanners;
 pub mod then;
 
@@ -39,6 +40,18 @@ pub use combinators::{
     js_promise_rejected, js_promise_schedule_resolve, js_value_is_promise,
 };
 pub use microtasks::js_promise_run_microtasks;
+pub use native_async::{
+    js_native_async_completion_attach_handle, js_native_async_completion_cancel,
+    js_native_async_completion_new, js_native_async_completion_promise,
+    js_native_async_completion_reject_bits, js_native_async_completion_reject_promise_bits,
+    js_native_async_completion_resolve_bits, js_native_async_completion_resolve_promise_bits,
+    js_native_async_has_active, js_native_async_process_pending,
+    scan_native_async_completion_roots_mut, NativeAsyncCompletion,
+    PERRY_NATIVE_ASYNC_ALREADY_COMPLETED, PERRY_NATIVE_ASYNC_CLEANUP_ON_CANCEL,
+    PERRY_NATIVE_ASYNC_CLEANUP_ON_REJECT, PERRY_NATIVE_ASYNC_CLEANUP_ON_SUCCESS,
+    PERRY_NATIVE_ASYNC_INVALID, PERRY_NATIVE_ASYNC_OK, PERRY_NATIVE_ASYNC_THREAD_MAIN,
+    PERRY_NATIVE_ASYNC_WRONG_THREAD,
+};
 pub use scanners::{js_promise_with_resolvers, scan_promise_roots, scan_promise_roots_mut};
 pub(crate) use then::js_promise_attach_handlers;
 pub use then::{
@@ -463,6 +476,13 @@ pub(crate) fn set_promise_callback_context(promise: *mut Promise) {
         return;
     }
     let snapshot = capture_context();
+    set_promise_context_snapshot(promise, snapshot);
+}
+
+pub(crate) fn set_promise_context_snapshot(promise: *mut Promise, snapshot: AsyncContextSnapshot) {
+    if promise.is_null() {
+        return;
+    }
     PROMISE_CONTEXTS.with(|contexts| {
         contexts.borrow_mut().insert(promise as usize, snapshot);
     });

--- a/crates/perry-runtime/src/promise/native_async.rs
+++ b/crates/perry-runtime/src/promise/native_async.rs
@@ -1,0 +1,728 @@
+//! Runtime-owned native async promise completion tokens.
+//!
+//! Native wrappers can hand an opaque token to worker threads and complete it
+//! later. Completion requests are exactly-once, queue a main-thread settlement,
+//! and expose every Promise/result/handle slot through a mutable GC scanner so
+//! copied-minor evacuation can rewrite them.
+
+use std::collections::{HashMap, VecDeque};
+use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use crate::async_context::{capture_context, scan_snapshot_roots_mut, AsyncContextSnapshot};
+
+use super::{set_promise_context_snapshot, Promise};
+
+const STATE_PENDING: u8 = 0;
+const STATE_QUEUED: u8 = 1;
+const STATE_COMPLETED: u8 = 2;
+
+const PAYLOAD_RESOLVE_BITS: u8 = 1;
+const PAYLOAD_REJECT_BITS: u8 = 2;
+const PAYLOAD_CANCEL: u8 = 3;
+const PAYLOAD_WRONG_THREAD: u8 = 4;
+
+const THREAD_ANY: u8 = 0;
+const THREAD_MAIN: u8 = 1;
+
+const DEFAULT_CANCEL_REASON: &str = "Native async operation cancelled";
+const WRONG_THREAD_REASON: &str = "Native async completion requested from the wrong thread";
+
+pub const PERRY_NATIVE_ASYNC_OK: i32 = 0;
+pub const PERRY_NATIVE_ASYNC_ALREADY_COMPLETED: i32 = 1;
+pub const PERRY_NATIVE_ASYNC_WRONG_THREAD: i32 = 2;
+pub const PERRY_NATIVE_ASYNC_INVALID: i32 = 3;
+
+pub const PERRY_NATIVE_ASYNC_THREAD_MAIN: u32 = 1 << 0;
+
+pub const PERRY_NATIVE_ASYNC_CLEANUP_ON_REJECT: u32 = 1 << 0;
+pub const PERRY_NATIVE_ASYNC_CLEANUP_ON_CANCEL: u32 = 1 << 1;
+pub const PERRY_NATIVE_ASYNC_CLEANUP_ON_SUCCESS: u32 = 1 << 2;
+const DEFAULT_CLEANUP_FLAGS: u32 =
+    PERRY_NATIVE_ASYNC_CLEANUP_ON_REJECT | PERRY_NATIVE_ASYNC_CLEANUP_ON_CANCEL;
+
+#[derive(Clone, Copy)]
+struct AttachedHandle {
+    value_bits: u64,
+    cleanup_flags: u32,
+}
+
+#[derive(Clone, Copy)]
+struct PendingPayload {
+    kind: u8,
+    bits: u64,
+}
+
+impl PendingPayload {
+    fn resolve(bits: u64) -> Self {
+        Self {
+            kind: PAYLOAD_RESOLVE_BITS,
+            bits,
+        }
+    }
+
+    fn reject(bits: u64) -> Self {
+        Self {
+            kind: PAYLOAD_REJECT_BITS,
+            bits,
+        }
+    }
+
+    fn cancel() -> Self {
+        Self {
+            kind: PAYLOAD_CANCEL,
+            bits: 0,
+        }
+    }
+
+    fn wrong_thread() -> Self {
+        Self {
+            kind: PAYLOAD_WRONG_THREAD,
+            bits: 0,
+        }
+    }
+}
+
+struct TokenSlots {
+    promise: usize,
+    payload: Option<PendingPayload>,
+    handles: Vec<AttachedHandle>,
+    context: AsyncContextSnapshot,
+}
+
+/// Opaque native async completion token. The allocation is intentionally
+/// leaked after completion so stale duplicate completion attempts can still
+/// read the terminal state and return `ALREADY_COMPLETED` instead of turning
+/// into a use-after-free.
+#[repr(C)]
+pub struct NativeAsyncCompletion {
+    state: AtomicU8,
+    thread_policy: u8,
+    main_thread_id: u64,
+    slots: Mutex<TokenSlots>,
+}
+
+unsafe impl Send for NativeAsyncCompletion {}
+unsafe impl Sync for NativeAsyncCompletion {}
+
+#[derive(Default)]
+struct NativeAsyncRegistry {
+    tokens: Vec<usize>,
+    by_promise: HashMap<usize, usize>,
+    pending: VecDeque<usize>,
+}
+
+static REGISTRY: OnceLock<Mutex<NativeAsyncRegistry>> = OnceLock::new();
+
+fn registry() -> &'static Mutex<NativeAsyncRegistry> {
+    REGISTRY.get_or_init(|| Mutex::new(NativeAsyncRegistry::default()))
+}
+
+fn current_thread_id() -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::thread::current().id().hash(&mut hasher);
+    hasher.finish()
+}
+
+fn token_from_ptr<'a>(token: *mut NativeAsyncCompletion) -> Option<&'a NativeAsyncCompletion> {
+    if token.is_null() {
+        None
+    } else {
+        Some(unsafe { &*token })
+    }
+}
+
+fn enqueue_payload(
+    token_ptr: *mut NativeAsyncCompletion,
+    payload: PendingPayload,
+    return_status: i32,
+) -> i32 {
+    let Some(token) = token_from_ptr(token_ptr) else {
+        return PERRY_NATIVE_ASYNC_INVALID;
+    };
+    if token
+        .state
+        .compare_exchange(
+            STATE_PENDING,
+            STATE_QUEUED,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        )
+        .is_err()
+    {
+        return PERRY_NATIVE_ASYNC_ALREADY_COMPLETED;
+    }
+
+    {
+        let mut registry = crate::gc::lock_gc_root_registry(registry());
+        let mut slots = token
+            .slots
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        slots.payload = Some(payload);
+        registry.pending.push_back(token_ptr as usize);
+    }
+    crate::event_pump::js_notify_main_thread();
+    return_status
+}
+
+fn enqueue_with_thread_policy(
+    token: *mut NativeAsyncCompletion,
+    payload: PendingPayload,
+    return_status: i32,
+) -> i32 {
+    let Some(native_token) = token_from_ptr(token) else {
+        return PERRY_NATIVE_ASYNC_INVALID;
+    };
+    if native_token.thread_policy == THREAD_MAIN
+        && current_thread_id() != native_token.main_thread_id
+    {
+        return enqueue_payload(
+            token,
+            PendingPayload::wrong_thread(),
+            PERRY_NATIVE_ASYNC_WRONG_THREAD,
+        );
+    }
+    enqueue_payload(token, payload, return_status)
+}
+
+fn complete_bits(token: *mut NativeAsyncCompletion, bits: u64, fulfilled: bool) -> i32 {
+    let payload = if fulfilled {
+        PendingPayload::resolve(bits)
+    } else {
+        PendingPayload::reject(bits)
+    };
+    enqueue_with_thread_policy(token, payload, PERRY_NATIVE_ASYNC_OK)
+}
+
+fn string_value_bits(message: &str) -> u64 {
+    let ptr = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    crate::value::JSValue::string_ptr(ptr).bits()
+}
+
+fn payload_to_settlement(payload: PendingPayload) -> (bool, u64, u32) {
+    match payload.kind {
+        PAYLOAD_RESOLVE_BITS => (true, payload.bits, PERRY_NATIVE_ASYNC_CLEANUP_ON_SUCCESS),
+        PAYLOAD_REJECT_BITS => (false, payload.bits, PERRY_NATIVE_ASYNC_CLEANUP_ON_REJECT),
+        PAYLOAD_CANCEL => (
+            false,
+            string_value_bits(DEFAULT_CANCEL_REASON),
+            PERRY_NATIVE_ASYNC_CLEANUP_ON_CANCEL,
+        ),
+        PAYLOAD_WRONG_THREAD => (
+            false,
+            string_value_bits(WRONG_THREAD_REASON),
+            PERRY_NATIVE_ASYNC_CLEANUP_ON_REJECT,
+        ),
+        _ => (
+            false,
+            string_value_bits("Native async operation failed"),
+            PERRY_NATIVE_ASYNC_CLEANUP_ON_REJECT,
+        ),
+    }
+}
+
+fn remove_token_from_registry(token_ptr: usize, promise: usize) {
+    let mut registry = crate::gc::lock_gc_root_registry(registry());
+    registry.tokens.retain(|&candidate| candidate != token_ptr);
+    registry.pending.retain(|&candidate| candidate != token_ptr);
+    if promise != 0 {
+        registry.by_promise.remove(&promise);
+    }
+}
+
+fn make_token_for_promise(
+    promise: *mut Promise,
+    flags: u32,
+    register_by_promise: bool,
+) -> *mut NativeAsyncCompletion {
+    let thread_policy = if flags & PERRY_NATIVE_ASYNC_THREAD_MAIN != 0 {
+        THREAD_MAIN
+    } else {
+        THREAD_ANY
+    };
+    let token = Box::new(NativeAsyncCompletion {
+        state: AtomicU8::new(STATE_PENDING),
+        thread_policy,
+        main_thread_id: current_thread_id(),
+        slots: Mutex::new(TokenSlots {
+            promise: promise as usize,
+            payload: None,
+            handles: Vec::new(),
+            context: capture_context(),
+        }),
+    });
+    let token_ptr = Box::into_raw(token);
+    {
+        let mut registry = crate::gc::lock_gc_root_registry(registry());
+        registry.tokens.push(token_ptr as usize);
+        if register_by_promise && !promise.is_null() {
+            registry
+                .by_promise
+                .insert(promise as usize, token_ptr as usize);
+        }
+    }
+    let context = {
+        let token = unsafe { &*token_ptr };
+        token
+            .slots
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .context
+            .clone()
+    };
+    set_promise_context_snapshot(promise, context);
+    token_ptr
+}
+
+fn adopt_or_get_token_for_promise(promise: *mut Promise) -> *mut NativeAsyncCompletion {
+    if promise.is_null() {
+        return std::ptr::null_mut();
+    }
+    let existing = {
+        let registry = crate::gc::lock_gc_root_registry(registry());
+        registry.by_promise.get(&(promise as usize)).copied()
+    };
+    if let Some(token) = existing {
+        return token as *mut NativeAsyncCompletion;
+    }
+    make_token_for_promise(promise, 0, true)
+}
+
+/// Allocate a native async completion token and its JS-visible Promise.
+#[no_mangle]
+pub extern "C" fn js_native_async_completion_new(flags: u32) -> *mut NativeAsyncCompletion {
+    let promise = super::js_promise_new();
+    make_token_for_promise(promise, flags, true)
+}
+
+/// Return the JS-visible Promise owned by a native async completion token.
+#[no_mangle]
+pub extern "C" fn js_native_async_completion_promise(
+    token: *mut NativeAsyncCompletion,
+) -> *mut Promise {
+    let Some(token) = token_from_ptr(token) else {
+        return std::ptr::null_mut();
+    };
+    let slots = token
+        .slots
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    slots.promise as *mut Promise
+}
+
+/// Resolve a native async token with already-encoded JSValue bits.
+#[no_mangle]
+pub extern "C" fn js_native_async_completion_resolve_bits(
+    token: *mut NativeAsyncCompletion,
+    bits: u64,
+) -> i32 {
+    complete_bits(token, bits, true)
+}
+
+/// Reject a native async token with already-encoded JSValue bits.
+#[no_mangle]
+pub extern "C" fn js_native_async_completion_reject_bits(
+    token: *mut NativeAsyncCompletion,
+    bits: u64,
+) -> i32 {
+    complete_bits(token, bits, false)
+}
+
+/// Cancel a native async token, rejecting its Promise with the default reason.
+#[no_mangle]
+pub extern "C" fn js_native_async_completion_cancel(token: *mut NativeAsyncCompletion) -> i32 {
+    enqueue_with_thread_policy(token, PendingPayload::cancel(), PERRY_NATIVE_ASYNC_OK)
+}
+
+/// Attach a JS native-handle value to a token for cleanup on reject/cancel.
+#[no_mangle]
+pub extern "C" fn js_native_async_completion_attach_handle(
+    token: *mut NativeAsyncCompletion,
+    handle_bits: u64,
+    cleanup_flags: u32,
+) -> i32 {
+    let Some(token) = token_from_ptr(token) else {
+        return PERRY_NATIVE_ASYNC_INVALID;
+    };
+    if token.state.load(Ordering::Acquire) != STATE_PENDING {
+        return PERRY_NATIVE_ASYNC_ALREADY_COMPLETED;
+    }
+    let flags = if cleanup_flags == 0 {
+        DEFAULT_CLEANUP_FLAGS
+    } else {
+        cleanup_flags
+    };
+    let mut slots = token
+        .slots
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if token.state.load(Ordering::Acquire) != STATE_PENDING {
+        return PERRY_NATIVE_ASYNC_ALREADY_COMPLETED;
+    }
+    slots.handles.push(AttachedHandle {
+        value_bits: handle_bits,
+        cleanup_flags: flags,
+    });
+    PERRY_NATIVE_ASYNC_OK
+}
+
+/// Legacy shim: resolve the token associated with a Promise pointer.
+#[no_mangle]
+pub extern "C" fn js_native_async_completion_resolve_promise_bits(
+    promise: *mut Promise,
+    bits: u64,
+) -> i32 {
+    let token = adopt_or_get_token_for_promise(promise);
+    js_native_async_completion_resolve_bits(token, bits)
+}
+
+/// Legacy shim: reject the token associated with a Promise pointer.
+#[no_mangle]
+pub extern "C" fn js_native_async_completion_reject_promise_bits(
+    promise: *mut Promise,
+    bits: u64,
+) -> i32 {
+    let token = adopt_or_get_token_for_promise(promise);
+    js_native_async_completion_reject_bits(token, bits)
+}
+
+/// Drain queued native async completions on the main thread.
+#[no_mangle]
+pub extern "C" fn js_native_async_process_pending() -> i32 {
+    let pending: Vec<usize> = {
+        let mut registry = crate::gc::lock_gc_root_registry(registry());
+        registry.pending.drain(..).collect()
+    };
+    let mut processed = 0i32;
+    for token_ptr in pending {
+        let token = unsafe { &*(token_ptr as *const NativeAsyncCompletion) };
+        let (promise, payload, handles, context) = {
+            let mut slots = token
+                .slots
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let promise = slots.promise;
+            let payload = slots.payload.take();
+            let handles = std::mem::take(&mut slots.handles);
+            let context = std::mem::take(&mut slots.context);
+            slots.promise = 0;
+            (promise, payload, handles, context)
+        };
+        let Some(payload) = payload else {
+            token.state.store(STATE_COMPLETED, Ordering::Release);
+            remove_token_from_registry(token_ptr, promise);
+            continue;
+        };
+
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let promise_handle = scope.root_raw_mut_ptr(promise as *mut Promise);
+        let handle_roots: Vec<_> = handles
+            .iter()
+            .map(|handle| scope.root_nanbox_u64(handle.value_bits))
+            .collect();
+        let context_roots = crate::async_context::root_snapshot(&scope, &context);
+        let (fulfilled, result_bits, cleanup_mask) = payload_to_settlement(payload);
+        let result_handle = scope.root_nanbox_u64(result_bits);
+        let promise_ptr = promise_handle.get_raw_mut_ptr::<Promise>();
+        if !promise_ptr.is_null() {
+            let mut context = context;
+            crate::async_context::refresh_snapshot_from_roots(&mut context, &context_roots);
+            set_promise_context_snapshot(promise_ptr, context);
+            if !fulfilled {
+                for (idx, handle) in handles.iter().enumerate() {
+                    if handle.cleanup_flags & cleanup_mask != 0 {
+                        let bits = handle_roots[idx].get_nanbox_u64();
+                        crate::native_handle::js_native_handle_dispose(f64::from_bits(bits));
+                    }
+                }
+            }
+            if fulfilled {
+                super::js_promise_resolve(
+                    promise_ptr,
+                    f64::from_bits(result_handle.get_nanbox_u64()),
+                );
+            } else {
+                super::js_promise_reject(
+                    promise_ptr,
+                    f64::from_bits(result_handle.get_nanbox_u64()),
+                );
+            }
+            processed += 1;
+        }
+        token.state.store(STATE_COMPLETED, Ordering::Release);
+        remove_token_from_registry(token_ptr, promise);
+    }
+    processed
+}
+
+/// Return 1 while there are live or queued native async completions.
+#[no_mangle]
+pub extern "C" fn js_native_async_has_active() -> i32 {
+    let registry = crate::gc::lock_gc_root_registry(registry());
+    if registry.tokens.is_empty() && registry.pending.is_empty() {
+        0
+    } else {
+        1
+    }
+}
+
+/// Mutable GC scanner for live native async token slots.
+pub fn scan_native_async_completion_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    let mut registry = crate::gc::lock_gc_root_registry(registry());
+    let mut moved_promises = Vec::new();
+    for &token_ptr in &registry.tokens {
+        let token = unsafe { &*(token_ptr as *const NativeAsyncCompletion) };
+        let mut slots = token
+            .slots
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let old_promise = slots.promise;
+        visitor.visit_usize_slot(&mut slots.promise);
+        if old_promise != 0 && old_promise != slots.promise {
+            moved_promises.push((old_promise, slots.promise, token_ptr));
+        }
+        if let Some(payload) = &mut slots.payload {
+            visitor.visit_nanbox_u64_slot(&mut payload.bits);
+        }
+        for handle in &mut slots.handles {
+            visitor.visit_nanbox_u64_slot(&mut handle.value_bits);
+        }
+        scan_snapshot_roots_mut(&mut slots.context, visitor);
+    }
+    for (old_promise, new_promise, token_ptr) in moved_promises {
+        registry.by_promise.remove(&old_promise);
+        if new_promise != 0 {
+            registry.by_promise.insert(new_promise, token_ptr);
+        }
+    }
+}
+
+#[cfg(test)]
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(test)]
+pub(crate) fn test_native_async_lock() -> std::sync::MutexGuard<'static, ()> {
+    TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+pub(crate) fn test_reset_native_async_registry() {
+    let mut registry = crate::gc::lock_gc_root_registry(registry());
+    registry.tokens.clear();
+    registry.by_promise.clear();
+    registry.pending.clear();
+}
+
+#[cfg(test)]
+pub(crate) fn test_native_async_slot_snapshot(
+    token: *mut NativeAsyncCompletion,
+) -> (usize, Option<u64>, Vec<u64>) {
+    let token = unsafe { &*token };
+    let slots = token
+        .slots
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    (
+        slots.promise,
+        slots.payload.map(|payload| payload.bits),
+        slots
+            .handles
+            .iter()
+            .map(|handle| handle.value_bits)
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::c_void;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    static CLEANUP_FINALIZER_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    unsafe extern "C" fn count_cleanup_finalizer(_resource: *mut c_void, _hint: *mut c_void) {
+        CLEANUP_FINALIZER_CALLS.fetch_add(1, AtomicOrdering::SeqCst);
+    }
+
+    fn native_handle_type_id(name: &str) -> i64 {
+        crate::native_handle::js_native_handle_type_id(name.as_ptr(), name.len())
+    }
+
+    fn owned_native_handle(name: &str, resource: i64) -> f64 {
+        crate::native_handle::js_native_handle_new_owned(
+            resource,
+            native_handle_type_id(name),
+            0,
+            0,
+            count_cleanup_finalizer as *mut c_void,
+            name.as_ptr(),
+            name.len() as i64,
+        )
+    }
+
+    unsafe fn assert_heap_string_value(value: f64, expected: &[u8]) {
+        let value = crate::value::JSValue::from_bits(value.to_bits());
+        assert!(value.is_string(), "expected heap string JSValue");
+        let ptr = value.as_string_ptr();
+        assert!(!ptr.is_null(), "expected non-null string pointer");
+        assert_eq!((*ptr).byte_len as usize, expected.len());
+        let data = (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let bytes = std::slice::from_raw_parts(data, expected.len());
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn resolves_once_and_duplicate_returns_status() {
+        let _guard = test_native_async_lock();
+        test_reset_native_async_registry();
+        let token = js_native_async_completion_new(0);
+        let promise = js_native_async_completion_promise(token);
+        assert_eq!(
+            js_native_async_completion_resolve_bits(token, 7.0f64.to_bits()),
+            0
+        );
+        assert_eq!(
+            js_native_async_completion_reject_bits(token, 9.0f64.to_bits()),
+            PERRY_NATIVE_ASYNC_ALREADY_COMPLETED
+        );
+        assert_eq!(js_native_async_process_pending(), 1);
+        assert_eq!(super::super::js_promise_state(promise), 1);
+        assert_eq!(super::super::js_promise_value(promise), 7.0);
+        assert_eq!(
+            js_native_async_completion_resolve_bits(token, 10.0f64.to_bits()),
+            PERRY_NATIVE_ASYNC_ALREADY_COMPLETED
+        );
+    }
+
+    #[test]
+    fn cancel_rejects_with_default_reason() {
+        let _guard = test_native_async_lock();
+        test_reset_native_async_registry();
+        let token = js_native_async_completion_new(0);
+        let promise = js_native_async_completion_promise(token);
+        assert_eq!(
+            js_native_async_completion_cancel(token),
+            PERRY_NATIVE_ASYNC_OK
+        );
+        assert_eq!(js_native_async_process_pending(), 1);
+        assert_eq!(super::super::js_promise_state(promise), 2);
+        assert_ne!(super::super::js_promise_reason(promise).to_bits(), 0);
+    }
+
+    #[test]
+    fn main_thread_token_wrong_thread_rejects() {
+        let _guard = test_native_async_lock();
+        test_reset_native_async_registry();
+        let token = js_native_async_completion_new(PERRY_NATIVE_ASYNC_THREAD_MAIN);
+        let promise = js_native_async_completion_promise(token);
+        let token_addr = token as usize;
+        let status = std::thread::spawn(move || {
+            js_native_async_completion_resolve_bits(
+                token_addr as *mut NativeAsyncCompletion,
+                1.0f64.to_bits(),
+            )
+        })
+        .join()
+        .expect("thread join");
+        assert_eq!(status, PERRY_NATIVE_ASYNC_WRONG_THREAD);
+        assert_eq!(js_native_async_process_pending(), 1);
+        assert_eq!(super::super::js_promise_state(promise), 2);
+    }
+
+    #[test]
+    fn main_thread_token_wrong_thread_cancel_rejects_instead_of_cancelling() {
+        let _guard = test_native_async_lock();
+        test_reset_native_async_registry();
+        CLEANUP_FINALIZER_CALLS.store(0, AtomicOrdering::SeqCst);
+
+        let token = js_native_async_completion_new(PERRY_NATIVE_ASYNC_THREAD_MAIN);
+        let promise = js_native_async_completion_promise(token);
+        let cancel_only_handle = owned_native_handle("NativeAsyncCancelWrongThread", 0x2468);
+        assert_eq!(
+            js_native_async_completion_attach_handle(
+                token,
+                cancel_only_handle.to_bits(),
+                PERRY_NATIVE_ASYNC_CLEANUP_ON_CANCEL,
+            ),
+            PERRY_NATIVE_ASYNC_OK
+        );
+
+        let token_addr = token as usize;
+        let status = std::thread::spawn(move || {
+            js_native_async_completion_cancel(token_addr as *mut NativeAsyncCompletion)
+        })
+        .join()
+        .expect("thread join");
+
+        assert_eq!(status, PERRY_NATIVE_ASYNC_WRONG_THREAD);
+        assert_eq!(js_native_async_process_pending(), 1);
+        assert_eq!(super::super::js_promise_state(promise), 2);
+        unsafe {
+            assert_heap_string_value(
+                super::super::js_promise_reason(promise),
+                WRONG_THREAD_REASON.as_bytes(),
+            );
+        }
+        assert_eq!(CLEANUP_FINALIZER_CALLS.load(AtomicOrdering::SeqCst), 0);
+        assert_eq!(
+            crate::native_handle::js_native_handle_dispose(cancel_only_handle),
+            1
+        );
+        assert_eq!(CLEANUP_FINALIZER_CALLS.load(AtomicOrdering::SeqCst), 1);
+    }
+
+    #[test]
+    fn reject_cleanup_disposes_attached_handles_but_success_keeps_them_live() {
+        let _guard = test_native_async_lock();
+        test_reset_native_async_registry();
+        CLEANUP_FINALIZER_CALLS.store(0, AtomicOrdering::SeqCst);
+
+        let reject_token = js_native_async_completion_new(0);
+        let reject_handle = owned_native_handle("NativeAsyncReject", 0x1234);
+        assert_eq!(
+            js_native_async_completion_attach_handle(
+                reject_token,
+                reject_handle.to_bits(),
+                PERRY_NATIVE_ASYNC_CLEANUP_ON_REJECT,
+            ),
+            PERRY_NATIVE_ASYNC_OK
+        );
+        assert_eq!(
+            js_native_async_completion_reject_bits(reject_token, 2.0f64.to_bits()),
+            PERRY_NATIVE_ASYNC_OK
+        );
+        assert_eq!(js_native_async_process_pending(), 1);
+        assert_eq!(CLEANUP_FINALIZER_CALLS.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(
+            crate::native_handle::js_native_handle_dispose(reject_handle),
+            0
+        );
+
+        let success_token = js_native_async_completion_new(0);
+        let success_handle = owned_native_handle("NativeAsyncSuccess", 0x5678);
+        assert_eq!(
+            js_native_async_completion_attach_handle(
+                success_token,
+                success_handle.to_bits(),
+                PERRY_NATIVE_ASYNC_CLEANUP_ON_REJECT,
+            ),
+            PERRY_NATIVE_ASYNC_OK
+        );
+        assert_eq!(
+            js_native_async_completion_resolve_bits(success_token, 4.0f64.to_bits()),
+            PERRY_NATIVE_ASYNC_OK
+        );
+        assert_eq!(js_native_async_process_pending(), 1);
+        assert_eq!(CLEANUP_FINALIZER_CALLS.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(
+            crate::native_handle::js_native_handle_dispose(success_handle),
+            1
+        );
+        assert_eq!(CLEANUP_FINALIZER_CALLS.load(AtomicOrdering::SeqCst), 2);
+    }
+}

--- a/crates/perry-runtime/src/promise/native_async.rs
+++ b/crates/perry-runtime/src/promise/native_async.rs
@@ -615,6 +615,41 @@ mod tests {
     }
 
     #[test]
+    fn cancel_cleanup_disposes_attached_handle_once() {
+        let _guard = test_native_async_lock();
+        test_reset_native_async_registry();
+        CLEANUP_FINALIZER_CALLS.store(0, AtomicOrdering::SeqCst);
+
+        let token = js_native_async_completion_new(0);
+        let promise = js_native_async_completion_promise(token);
+        let handle = owned_native_handle("NativeAsyncCancel", 0x3456);
+        assert_eq!(
+            js_native_async_completion_attach_handle(
+                token,
+                handle.to_bits(),
+                PERRY_NATIVE_ASYNC_CLEANUP_ON_CANCEL,
+            ),
+            PERRY_NATIVE_ASYNC_OK
+        );
+        assert_eq!(
+            js_native_async_completion_cancel(token),
+            PERRY_NATIVE_ASYNC_OK
+        );
+        assert_eq!(js_native_async_process_pending(), 1);
+
+        assert_eq!(super::super::js_promise_state(promise), 2);
+        unsafe {
+            assert_heap_string_value(
+                super::super::js_promise_reason(promise),
+                DEFAULT_CANCEL_REASON.as_bytes(),
+            );
+        }
+        assert_eq!(CLEANUP_FINALIZER_CALLS.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(crate::native_handle::js_native_handle_dispose(handle), 0);
+        assert_eq!(CLEANUP_FINALIZER_CALLS.load(AtomicOrdering::SeqCst), 1);
+    }
+
+    #[test]
     fn main_thread_token_wrong_thread_rejects() {
         let _guard = test_native_async_lock();
         test_reset_native_async_registry();

--- a/crates/perry-stdlib/src/perry_ffi_async.rs
+++ b/crates/perry-stdlib/src/perry_ffi_async.rs
@@ -25,6 +25,27 @@ use std::ffi::c_void;
 
 use crate::common::async_bridge;
 
+extern "C" {
+    fn js_native_async_completion_new(flags: u32) -> *mut c_void;
+    fn js_native_async_completion_promise(token: *mut c_void) -> *mut perry_runtime::Promise;
+    fn js_native_async_completion_resolve_bits(token: *mut c_void, bits: u64) -> i32;
+    fn js_native_async_completion_reject_bits(token: *mut c_void, bits: u64) -> i32;
+    fn js_native_async_completion_cancel(token: *mut c_void) -> i32;
+    fn js_native_async_completion_attach_handle(
+        token: *mut c_void,
+        handle_bits: u64,
+        cleanup_flags: u32,
+    ) -> i32;
+    fn js_native_async_completion_resolve_promise_bits(
+        promise: *mut perry_runtime::Promise,
+        bits: u64,
+    ) -> i32;
+    fn js_native_async_completion_reject_promise_bits(
+        promise: *mut perry_runtime::Promise,
+        bits: u64,
+    ) -> i32;
+}
+
 /// `perry_ffi_promise_new()` — allocate a fresh Promise.
 ///
 /// Thin pass-through to perry-runtime's allocator. Returned pointer
@@ -43,9 +64,8 @@ use crate::common::async_bridge;
 /// `unpin_promise_after_native_resolution` in `async_bridge`).
 #[no_mangle]
 pub extern "C" fn perry_ffi_promise_new() -> *mut perry_runtime::Promise {
-    let p = perry_runtime::js_promise_new();
-    unsafe { async_bridge::pin_promise_for_native_resolution(p as usize) };
-    p
+    async_bridge::ensure_pump_registered();
+    unsafe { js_native_async_completion_promise(js_native_async_completion_new(0)) }
 }
 
 /// `perry_ffi_promise_resolve_bits(promise, bits)` — resolve the
@@ -58,14 +78,68 @@ pub extern "C" fn perry_ffi_promise_new() -> *mut perry_runtime::Promise {
 /// directly.
 #[no_mangle]
 pub extern "C" fn perry_ffi_promise_resolve_bits(promise: *mut perry_runtime::Promise, bits: u64) {
-    async_bridge::queue_promise_resolution(promise as usize, true, bits);
+    async_bridge::ensure_pump_registered();
+    unsafe {
+        let _ = js_native_async_completion_resolve_promise_bits(promise, bits);
+    }
 }
 
 /// `perry_ffi_promise_reject_bits(promise, bits)` — reject with a
 /// JSValue. Same encoding contract as resolve.
 #[no_mangle]
 pub extern "C" fn perry_ffi_promise_reject_bits(promise: *mut perry_runtime::Promise, bits: u64) {
-    async_bridge::queue_promise_resolution(promise as usize, false, bits);
+    async_bridge::ensure_pump_registered();
+    unsafe {
+        let _ = js_native_async_completion_reject_promise_bits(promise, bits);
+    }
+}
+
+/// `perry_ffi_native_async_new(flags)` — allocate a runtime-owned native
+/// async completion token and its JS-visible Promise.
+#[no_mangle]
+pub extern "C" fn perry_ffi_native_async_new(flags: u32) -> *mut c_void {
+    async_bridge::ensure_pump_registered();
+    unsafe { js_native_async_completion_new(flags) }
+}
+
+/// Return the JS Promise associated with a native async completion token.
+#[no_mangle]
+pub extern "C" fn perry_ffi_native_async_promise(
+    token: *mut c_void,
+) -> *mut perry_runtime::Promise {
+    unsafe { js_native_async_completion_promise(token) }
+}
+
+/// Resolve a native async completion token with encoded JSValue bits.
+#[no_mangle]
+pub extern "C" fn perry_ffi_native_async_resolve_bits(token: *mut c_void, bits: u64) -> i32 {
+    async_bridge::ensure_pump_registered();
+    unsafe { js_native_async_completion_resolve_bits(token, bits) }
+}
+
+/// Reject a native async completion token with encoded JSValue bits.
+#[no_mangle]
+pub extern "C" fn perry_ffi_native_async_reject_bits(token: *mut c_void, bits: u64) -> i32 {
+    async_bridge::ensure_pump_registered();
+    unsafe { js_native_async_completion_reject_bits(token, bits) }
+}
+
+/// Cancel a native async completion token with Perry's default cancellation
+/// reason.
+#[no_mangle]
+pub extern "C" fn perry_ffi_native_async_cancel(token: *mut c_void) -> i32 {
+    async_bridge::ensure_pump_registered();
+    unsafe { js_native_async_completion_cancel(token) }
+}
+
+/// Attach a JS native-handle value for cleanup if the token rejects/cancels.
+#[no_mangle]
+pub extern "C" fn perry_ffi_native_async_attach_handle(
+    token: *mut c_void,
+    handle_bits: u64,
+    cleanup_flags: u32,
+) -> i32 {
+    unsafe { js_native_async_completion_attach_handle(token, handle_bits, cleanup_flags) }
 }
 
 /// `perry_ffi_spawn_blocking(ctx, invoke)` — run `invoke(ctx)` on

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -30,6 +30,7 @@
 use anyhow::{anyhow, Result};
 use perry_api_manifest::{
     NativeAbiType, NativeHandleAbi, NativeHandleOwnership, NativeHandleThreadAffinity,
+    NativePromiseAbi, NativePromiseCompletion, NativePromiseThread,
 };
 use perry_hir::ModuleKind;
 use std::collections::{HashMap, HashSet};
@@ -326,7 +327,7 @@ fn parse_native_library_functions(
                     &name,
                     &format!("params[{param_index}]"),
                     &descriptor.to_string(),
-                    "void is only valid as a return descriptor",
+                    "void and native_async promises are not valid parameter descriptors",
                 ));
             }
             parsed_params.push(descriptor);
@@ -370,6 +371,7 @@ fn parse_native_library_functions(
 enum NativeAbiDescriptorPosition {
     Param,
     Return,
+    Metadata,
 }
 
 fn parse_native_abi_descriptor(
@@ -532,7 +534,7 @@ fn parse_native_abi_descriptor(
                     "handle descriptor `finalizer` requires `ownership: \"owned\"`",
                 ));
             }
-            if finalizer.is_some() && position == NativeAbiDescriptorPosition::Param {
+            if finalizer.is_some() && position != NativeAbiDescriptorPosition::Return {
                 return Err(invalid_native_abi_error(
                     package_json,
                     function_index,
@@ -570,6 +572,19 @@ fn parse_native_abi_descriptor(
             }))
         }
         "promise" => {
+            let allowed = ["kind", "result", "completion", "thread"];
+            for key in object.keys() {
+                if !allowed.contains(&key.as_str()) {
+                    return Err(invalid_native_abi_error(
+                        package_json,
+                        function_index,
+                        function_name,
+                        slot,
+                        &value.to_string(),
+                        &format!("unknown promise descriptor field `{key}`"),
+                    ));
+                }
+            }
             let result = match object.get("result") {
                 Some(result) => parse_native_abi_descriptor(
                     package_json,
@@ -577,11 +592,61 @@ fn parse_native_abi_descriptor(
                     function_name,
                     slot,
                     result,
-                    position,
+                    NativeAbiDescriptorPosition::Metadata,
                 )?,
                 None => NativeAbiType::JsValue,
             };
-            Ok(NativeAbiType::Promise(Box::new(result)))
+            let completion = match object.get("completion") {
+                Some(v) => match v.as_str() {
+                    Some("direct") => NativePromiseCompletion::Direct,
+                    Some("native_async") => NativePromiseCompletion::NativeAsync,
+                    Some(_) | None => {
+                        return Err(invalid_native_abi_error(
+                            package_json,
+                            function_index,
+                            function_name,
+                            slot,
+                            &value.to_string(),
+                            "promise descriptor `completion` must be `direct` or `native_async`",
+                        ));
+                    }
+                },
+                None => NativePromiseCompletion::Direct,
+            };
+            if completion == NativePromiseCompletion::NativeAsync
+                && position != NativeAbiDescriptorPosition::Return
+            {
+                return Err(invalid_native_abi_error(
+                    package_json,
+                    function_index,
+                    function_name,
+                    slot,
+                    &value.to_string(),
+                    "native_async promise completion is valid only on returns",
+                ));
+            }
+            let thread = match object.get("thread") {
+                Some(v) => match v.as_str() {
+                    Some("any") => NativePromiseThread::Any,
+                    Some("main") => NativePromiseThread::Main,
+                    Some(_) | None => {
+                        return Err(invalid_native_abi_error(
+                            package_json,
+                            function_index,
+                            function_name,
+                            slot,
+                            &value.to_string(),
+                            "promise descriptor `thread` must be `any` or `main`",
+                        ));
+                    }
+                },
+                None => NativePromiseThread::Any,
+            };
+            Ok(NativeAbiType::Promise(NativePromiseAbi {
+                result: Box::new(result),
+                completion,
+                thread,
+            }))
         }
         "buffer+len" => Ok(NativeAbiType::BufferAndLen),
         _ => NativeAbiType::parse_str(kind).map_err(|err| {

--- a/crates/perry/src/commands/compile/resolve/tests.rs
+++ b/crates/perry/src/commands/compile/resolve/tests.rs
@@ -178,6 +178,88 @@ mod manifest_parse_tests {
     }
 
     #[test]
+    fn native_async_promise_return_parses_completion_metadata() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let parsed = parse_manifest_from_functions(
+            dir.path(),
+            serde_json::json!([
+                {
+                    "name": "native_async_return",
+                    "params": [],
+                    "returns": {
+                        "kind": "promise",
+                        "result": "f64",
+                        "completion": "native_async",
+                        "thread": "main"
+                    }
+                }
+            ]),
+        )
+        .expect("parse manifest")
+        .expect("manifest");
+
+        let ret = &parsed.functions[0].returns;
+        assert_eq!(ret.to_string(), "promise<f64>");
+        assert_eq!(
+            ret.promise_completion()
+                .map(|completion| completion.as_str()),
+            Some("native_async")
+        );
+        assert_eq!(
+            ret.promise_thread().map(|thread| thread.as_str()),
+            Some("main")
+        );
+        assert_eq!(
+            ret.promise_result().map(ToString::to_string),
+            Some("f64".into())
+        );
+    }
+
+    #[test]
+    fn native_async_promise_param_is_rejected() {
+        let err = parse_manifest_error(serde_json::json!({
+            "name": "bad_native_async_param",
+            "params": [
+                {
+                    "kind": "promise",
+                    "result": "jsvalue",
+                    "completion": "native_async"
+                }
+            ],
+            "returns": "void"
+        }));
+        assert!(err.contains("bad_native_async_param"), "{err}");
+        assert!(err.contains("params[0]"), "{err}");
+        assert!(err.contains("native_async"), "{err}");
+        assert!(err.contains("valid only on returns"), "{err}");
+    }
+
+    #[test]
+    fn native_async_promise_rejects_invalid_completion_and_thread_fields() {
+        let completion_err = parse_manifest_error(serde_json::json!({
+            "name": "bad_promise_completion",
+            "params": [],
+            "returns": {
+                "kind": "promise",
+                "completion": "later"
+            }
+        }));
+        assert!(completion_err.contains("completion"), "{completion_err}");
+        assert!(completion_err.contains("direct"), "{completion_err}");
+
+        let thread_err = parse_manifest_error(serde_json::json!({
+            "name": "bad_promise_thread",
+            "params": [],
+            "returns": {
+                "kind": "promise",
+                "thread": "worker"
+            }
+        }));
+        assert!(thread_err.contains("thread"), "{thread_err}");
+        assert!(thread_err.contains("main"), "{thread_err}");
+    }
+
+    #[test]
     fn native_abi_owned_return_handle_parses_finalizer_contract() {
         let dir = tempfile::tempdir().expect("tempdir");
         let parsed = parse_manifest_from_functions(

--- a/docs/api/manifest.schema.json
+++ b/docs/api/manifest.schema.json
@@ -199,7 +199,7 @@
     "abiStructuredParamDescriptor": {
       "oneOf": [
         { "$ref": "#/$defs/abiParamHandleDescriptor" },
-        { "$ref": "#/$defs/abiPromiseDescriptor" },
+        { "$ref": "#/$defs/abiParamPromiseDescriptor" },
         { "$ref": "#/$defs/abiBufferAndLenDescriptor" },
         { "$ref": "#/$defs/abiScalarDescriptor" }
       ]
@@ -207,7 +207,7 @@
     "abiStructuredReturnDescriptor": {
       "oneOf": [
         { "$ref": "#/$defs/abiReturnHandleDescriptor" },
-        { "$ref": "#/$defs/abiPromiseDescriptor" },
+        { "$ref": "#/$defs/abiReturnPromiseDescriptor" },
         { "$ref": "#/$defs/abiBufferAndLenDescriptor" },
         { "$ref": "#/$defs/abiScalarDescriptor" }
       ]
@@ -215,7 +215,7 @@
     "abiStructuredDescriptor": {
       "oneOf": [
         { "$ref": "#/$defs/abiHandleDescriptor" },
-        { "$ref": "#/$defs/abiPromiseDescriptor" },
+        { "$ref": "#/$defs/abiMetadataPromiseDescriptor" },
         { "$ref": "#/$defs/abiBufferAndLenDescriptor" },
         { "$ref": "#/$defs/abiScalarDescriptor" }
       ]
@@ -234,6 +234,35 @@
     },
     "abiReturnHandleDescriptor": {
       "$ref": "#/$defs/abiHandleDescriptor"
+    },
+    "abiParamPromiseDescriptor": {
+      "allOf": [
+        { "$ref": "#/$defs/abiPromiseDescriptor" },
+        {
+          "not": {
+            "type": "object",
+            "required": ["completion"],
+            "properties": { "completion": { "const": "native_async" } }
+          },
+          "description": "Native async promise completion is only valid on returns."
+        }
+      ]
+    },
+    "abiReturnPromiseDescriptor": {
+      "$ref": "#/$defs/abiPromiseDescriptor"
+    },
+    "abiMetadataPromiseDescriptor": {
+      "allOf": [
+        { "$ref": "#/$defs/abiPromiseDescriptor" },
+        {
+          "not": {
+            "type": "object",
+            "required": ["completion"],
+            "properties": { "completion": { "const": "native_async" } }
+          },
+          "description": "Nested promise metadata cannot opt into native async completion."
+        }
+      ]
     },
     "abiHandleDescriptor": {
       "type": "object",
@@ -300,6 +329,16 @@
         "result": {
           "$ref": "#/$defs/abiDescriptor",
           "description": "Optional metadata describing the JavaScript promise result."
+        },
+        "completion": {
+          "enum": ["direct", "native_async"],
+          "default": "direct",
+          "description": "Promise completion machinery. `native_async` is valid only for return descriptors."
+        },
+        "thread": {
+          "enum": ["any", "main"],
+          "default": "any",
+          "description": "Thread policy for native async completion requests."
         }
       }
     },


### PR DESCRIPTION
## Summary
- add structured native promise ABI metadata for direct vs native_async completion
- add GC-safe native async completion tokens and Promise settlement helpers
- prove cancellation cleanup and copied-minor root safety for native async handles

## Verification
- cargo fmt --check
- git diff --check origin/main...HEAD
- scripts/check_file_size.sh
- cargo test -p perry native_async_promise
- cargo test -p perry-codegen --test native_proof_regressions native_async
- cargo test -p perry-runtime native_async
- CARGO_BUILD_JOBS=2 cargo check -p perry-api-manifest -p perry-codegen -p perry-runtime -p perry-ffi -p perry-stdlib -p perry

Stacked after #1917 native ABI foundation. This is independent of the POD-record PR.