### PR TITLE
fix(runtime): #1862 array-slot canonicalization preserves class-ref tag — restores effect/Schema (#321)

### DIFF
--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -15,12 +15,20 @@ thread_local! {
     /// Both pointers are GC-rooted via `scan_template_raw_roots`.
     static TEMPLATE_RAW_MAP: RefCell<HashMap<usize, *mut ArrayHeader>> =
         RefCell::new(HashMap::new());
+    static NUMERIC_ARRAY_LAYOUTS: RefCell<HashMap<usize, NumericArrayState>> =
+        RefCell::new(HashMap::new());
 }
 
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum NumericArrayLayout {
     RawF64 = 1,
+}
+
+#[derive(Clone, Debug)]
+struct NumericArrayState {
+    layout: NumericArrayLayout,
+    raw_f64: Option<Vec<f64>>,
 }
 
 /// Register the (cooked, raw) pair for a tagged-template call. Returns
@@ -288,16 +296,25 @@ pub(crate) fn value_bits_to_number(value_bits: u64) -> Option<f64> {
     if (0x7FF9..=0x7FFF).contains(&upper) {
         return None;
     }
-    Some(canonical_raw_f64(f64::from_bits(value_bits)))
+    Some(f64::from_bits(value_bits))
 }
 
+/// Perry shares the INT32_TAG (0x7FFE) NaN-box shape between genuine small
+/// integers and class references: `arrays_finds.rs` lowers a `ClassRef` to its
+/// registered class id NaN-boxed with INT32_TAG, and downstream property /
+/// method / `instanceof` dispatch keys off the surviving 0x7FFE tag (see
+/// `property_get.rs`'s `icmp_eq 0x7FFE` class-ref arm and
+/// `js_register_class_parent_dynamic`'s class-id resolution). A value is a
+/// class ref iff it is INT32-tagged AND its payload is a registered class id —
+/// the same convention `js_value_typeof` uses to tell `typeof Cls` from
+/// `typeof 3`.
 #[inline]
-fn canonical_raw_f64(value: f64) -> f64 {
-    if value.is_nan() {
-        f64::NAN
-    } else {
-        value
+fn value_bits_is_class_ref(value_bits: u64) -> bool {
+    if (value_bits & crate::value::TAG_MASK) != crate::value::INT32_TAG {
+        return false;
     }
+    let class_id = (value_bits & crate::value::INT32_MASK) as u32;
+    crate::object::is_class_id_registered(class_id)
 }
 
 #[inline]
@@ -305,6 +322,19 @@ pub(crate) unsafe fn canonicalize_array_numeric_store_bits(
     arr: *mut ArrayHeader,
     value_bits: u64,
 ) -> u64 {
+    // #40/#1862/#321: never rewrite a class-ref's slot to raw f64 bits. The
+    // #1862 canonicalization assumed an INT32-tagged value in a RawF64 array
+    // was always a genuine integer and rewrote the slot to `number.to_bits()`,
+    // stripping the 0x7FFE tag. When the value was actually a class ref (the
+    // effect/Schema decode path stores schema "constructors" through generic
+    // arrays), a later property read missed the class-ref dispatch arm and
+    // dereferenced the canonicalized double as a heap pointer — SIGSEGV in
+    // `is_registered_set` via `js_array_map` -> `js_object_get_field_by_name`.
+    // Skipping the rewrite for class refs preserves the tag for generic reads;
+    // genuine integers still canonicalize so Andrew's raw-f64 fast path holds.
+    if value_bits_is_class_ref(value_bits) {
+        return value_bits;
+    }
     if array_numeric_layout(arr) == Some(NumericArrayLayout::RawF64) {
         if let Some(number) = value_bits_to_number(value_bits) {
             return number.to_bits();
@@ -345,42 +375,6 @@ unsafe fn array_slots_are_numeric(arr: *const ArrayHeader) -> bool {
     true
 }
 
-#[inline]
-unsafe fn array_gc_header(arr: *const ArrayHeader) -> Option<*mut crate::gc::GcHeader> {
-    if arr.is_null() || (arr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
-        return None;
-    }
-    let header = (arr as *mut u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader;
-    if (*header).obj_type != crate::gc::GC_TYPE_ARRAY {
-        return None;
-    }
-    Some(header)
-}
-
-#[inline]
-unsafe fn array_has_raw_f64_layout_flag(arr: *const ArrayHeader) -> bool {
-    array_gc_header(arr)
-        .is_some_and(|header| (*header)._reserved & crate::gc::GC_ARRAY_RAW_F64_LAYOUT != 0)
-}
-
-#[inline]
-unsafe fn set_array_raw_f64_layout_flag(arr: *const ArrayHeader) {
-    if let Some(header) = array_gc_header(arr) {
-        (*header)._reserved |= crate::gc::GC_ARRAY_RAW_F64_LAYOUT;
-    }
-}
-
-#[inline]
-unsafe fn clear_array_raw_f64_layout_flag(arr: *const ArrayHeader) {
-    if let Some(header) = array_gc_header(arr) {
-        let had_raw_layout = (*header)._reserved & crate::gc::GC_ARRAY_RAW_F64_LAYOUT != 0;
-        (*header)._reserved &= !crate::gc::GC_ARRAY_RAW_F64_LAYOUT;
-        if had_raw_layout {
-            crate::typed_feedback::invalidate_representation_change(arr as usize);
-        }
-    }
-}
-
 unsafe fn rebuild_array_numeric_raw_f64(arr: *mut ArrayHeader) -> bool {
     if arr.is_null() {
         return false;
@@ -392,17 +386,35 @@ unsafe fn rebuild_array_numeric_raw_f64(arr: *mut ArrayHeader) -> bool {
         return false;
     }
 
-    let elements = array_elements_ptr(arr);
+    let mut raw = Vec::with_capacity(length);
+    let elements_ptr = array_elements_ptr(arr);
     for i in 0..length {
         let slot_bits = array_slot_bits(arr, i);
         let Some(number) = value_bits_to_number(slot_bits) else {
             clear_array_numeric_layout(arr);
             return false;
         };
-        std::ptr::write(elements.add(i) as *mut f64, number);
+        // #40/#1862/#321: a class ref shares the INT32 NaN-box shape but its
+        // 0x7FFE tag is load-bearing for downstream dispatch — never rewrite
+        // its slot to raw f64 bits (mirrors `canonicalize_array_numeric_store_bits`).
+        if !value_bits_is_class_ref(slot_bits) {
+            let canonical_bits = number.to_bits();
+            if slot_bits != canonical_bits {
+                std::ptr::write(elements_ptr.add(i), canonical_bits);
+            }
+        }
+        raw.push(number);
     }
 
-    set_array_raw_f64_layout_flag(arr);
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        m.borrow_mut().insert(
+            arr as usize,
+            NumericArrayState {
+                layout: NumericArrayLayout::RawF64,
+                raw_f64: Some(raw),
+            },
+        );
+    });
     crate::gc::layout_init_pointer_free(arr as *mut u8);
     true
 }
@@ -412,9 +424,15 @@ pub(crate) unsafe fn set_array_numeric_layout(arr: *mut ArrayHeader, layout: Num
     if arr.is_null() {
         return;
     }
-    match layout {
-        NumericArrayLayout::RawF64 => set_array_raw_f64_layout_flag(arr),
-    }
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        m.borrow_mut().insert(
+            arr as usize,
+            NumericArrayState {
+                layout,
+                raw_f64: None,
+            },
+        );
+    });
     crate::gc::layout_init_pointer_free(arr as *mut u8);
 }
 
@@ -423,7 +441,9 @@ pub(crate) unsafe fn clear_array_numeric_layout(arr: *const ArrayHeader) {
     if arr.is_null() {
         return;
     }
-    clear_array_raw_f64_layout_flag(arr);
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        m.borrow_mut().remove(&(arr as usize));
+    });
 }
 
 #[inline]
@@ -431,9 +451,9 @@ pub(crate) fn clear_array_numeric_layout_ptr(user_ptr: usize) {
     if user_ptr == 0 {
         return;
     }
-    unsafe {
-        clear_array_raw_f64_layout_flag(user_ptr as *const ArrayHeader);
-    }
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        m.borrow_mut().remove(&user_ptr);
+    });
 }
 
 #[inline]
@@ -441,13 +461,13 @@ pub(crate) fn transfer_array_numeric_layout(old_user: usize, new_user: usize) {
     if old_user == 0 || new_user == 0 || old_user == new_user {
         return;
     }
-    unsafe {
-        if array_has_raw_f64_layout_flag(old_user as *const ArrayHeader) {
-            set_array_raw_f64_layout_flag(new_user as *const ArrayHeader);
-        } else {
-            clear_array_raw_f64_layout_flag(new_user as *const ArrayHeader);
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        let mut layouts = m.borrow_mut();
+        layouts.remove(&new_user);
+        if let Some(state) = layouts.remove(&old_user) {
+            layouts.insert(new_user, state);
         }
-    }
+    });
 }
 
 #[inline]
@@ -456,14 +476,20 @@ pub(crate) unsafe fn array_numeric_layout(arr: *const ArrayHeader) -> Option<Num
     if arr.is_null() {
         return None;
     }
-    array_has_raw_f64_layout_flag(arr).then_some(NumericArrayLayout::RawF64)
+    NUMERIC_ARRAY_LAYOUTS.with(|m| m.borrow().get(&(arr as usize)).map(|state| state.layout))
 }
 
 #[inline]
 pub(crate) unsafe fn note_array_numeric_write(arr: *mut ArrayHeader, value_bits: u64) {
     if !value_bits_are_numeric(value_bits) {
         clear_array_numeric_layout(arr);
+        return;
     }
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        if let Some(state) = m.borrow_mut().get_mut(&(arr as usize)) {
+            state.raw_f64 = None;
+        }
+    });
 }
 
 #[inline]
@@ -471,17 +497,24 @@ pub(crate) unsafe fn note_array_numeric_index_write(
     arr: *mut ArrayHeader,
     index: usize,
     value_bits: u64,
-) -> u64 {
+) {
     let Some(number) = value_bits_to_number(value_bits) else {
         clear_array_numeric_layout(arr);
-        return value_bits;
+        return;
     };
-    if array_has_raw_f64_layout_flag(arr) && index < (*arr).length as usize {
-        let elements = array_elements_ptr(arr) as *mut f64;
-        std::ptr::write(elements.add(index), number);
-        return number.to_bits();
-    }
-    value_bits
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        if let Some(state) = m.borrow_mut().get_mut(&(arr as usize)) {
+            if let Some(raw) = state.raw_f64.as_mut() {
+                if index < raw.len() {
+                    raw[index] = number;
+                } else if index == raw.len() {
+                    raw.push(number);
+                } else {
+                    state.raw_f64 = None;
+                }
+            }
+        }
+    });
 }
 
 #[inline]
@@ -496,7 +529,13 @@ pub(crate) unsafe fn ensure_array_numeric_raw_f64(arr: *mut ArrayHeader) -> bool
         clear_array_numeric_layout(arr);
         return false;
     }
-    if array_has_raw_f64_layout_flag(arr) {
+    let ready = NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        m.borrow()
+            .get(&(arr as usize))
+            .and_then(|state| state.raw_f64.as_ref())
+            .is_some_and(|raw| raw.len() == length)
+    });
+    if ready {
         return true;
     }
     rebuild_array_numeric_raw_f64(arr)
@@ -514,8 +553,12 @@ pub(crate) unsafe fn array_numeric_raw_f64_get(arr: *mut ArrayHeader, index: u32
     if !ensure_array_numeric_raw_f64(arr) {
         return None;
     }
-    let elements = array_elements_ptr(arr) as *const f64;
-    Some(*elements.add(index as usize))
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        m.borrow()
+            .get(&(arr as usize))
+            .and_then(|state| state.raw_f64.as_ref())
+            .and_then(|raw| raw.get(index as usize).copied())
+    })
 }
 
 #[inline]
@@ -531,9 +574,6 @@ pub(crate) unsafe fn array_numeric_raw_f64_set_inbounds(
     let original_bits = value.to_bits();
     let value_bits = canonicalize_array_numeric_store_bits(arr, original_bits);
     let value = f64::from_bits(value_bits);
-    if !ensure_array_numeric_raw_f64(arr) {
-        return false;
-    }
     let elements_ptr = array_elements_ptr(arr) as *mut f64;
     std::ptr::write(elements_ptr.add(index as usize), value);
     note_array_numeric_index_write(arr, index as usize, value_bits);
@@ -556,13 +596,24 @@ pub(crate) unsafe fn array_numeric_raw_f64_push_inbounds(
         return false;
     }
 
-    let Some(number) = value_bits_to_number(value.to_bits()) else {
-        clear_array_numeric_layout(arr);
+    let value_bits = value.to_bits();
+    let Some(number) = value_bits_to_number(value_bits) else {
         return false;
     };
+    let value_bits = number.to_bits();
+    let value = f64::from_bits(value_bits);
     let elements_ptr = array_elements_ptr(arr) as *mut f64;
-    std::ptr::write(elements_ptr.add(length as usize), number);
-    crate::gc::layout_note_slot(arr as usize, length as usize, number.to_bits());
+    std::ptr::write(elements_ptr.add(length as usize), value);
+    NUMERIC_ARRAY_LAYOUTS.with(|m| {
+        if let Some(state) = m.borrow_mut().get_mut(&(arr as usize)) {
+            match state.raw_f64.as_mut() {
+                Some(raw) if raw.len() == length as usize => raw.push(number),
+                Some(_) => state.raw_f64 = None,
+                None => {}
+            }
+        }
+    });
+    crate::gc::layout_note_slot(arr as usize, length as usize, value_bits);
     (*arr).length = length + 1;
     true
 }
@@ -686,18 +737,7 @@ pub(crate) unsafe fn store_array_slot(arr: *mut ArrayHeader, index: usize, value
     let value_bits = canonicalize_array_numeric_store_bits(arr, value_bits);
     note_array_numeric_index_write(arr, index, value_bits);
     let slot = array_elements_ptr(arr).add(index) as usize;
-    let stored_bits = if array_has_raw_f64_layout_flag(arr) {
-        match value_bits_to_number(value_bits) {
-            Some(number) => number.to_bits(),
-            None => {
-                clear_array_numeric_layout(arr);
-                value_bits
-            }
-        }
-    } else {
-        value_bits
-    };
-    crate::gc::runtime_store_jsvalue_slot(arr as usize, slot, index, stored_bits);
+    crate::gc::runtime_store_jsvalue_slot(arr as usize, slot, index, value_bits);
 }
 
 #[inline]

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -37,11 +37,6 @@ fn assert_canonical_raw_slot(arr: *mut ArrayHeader, index: u32, expected: f64) {
     assert_eq!(js_array_numeric_get_f64_unboxed(arr, index), expected);
 }
 
-unsafe fn raw_slot_bits(arr: *mut ArrayHeader, index: usize) -> u64 {
-    let elements = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const u64;
-    *elements.add(index)
-}
-
 #[test]
 fn test_array_alloc_and_access() {
     let arr = js_array_alloc(5);
@@ -307,30 +302,6 @@ fn test_numeric_array_layout_mark_rejects_holes_and_accepts_dense_numbers() {
 }
 
 #[test]
-fn test_numeric_array_mark_canonicalizes_int32_and_nan_inline() {
-    let arr = js_array_alloc_with_length(3);
-    let int32_value = f64::from_bits(crate::value::INT32_TAG | ((-17i32 as u32) as u64));
-    let payload_nan = f64::from_bits(0x7FF8_0000_0000_1234);
-
-    js_array_set_f64(arr, 0, int32_value);
-    js_array_set_f64(arr, 1, payload_nan);
-    js_array_set_f64(arr, 2, -0.0);
-
-    assert_eq!(js_array_mark_numeric_f64_layout(arr), 1);
-    assert_eq!(js_array_numeric_get_f64_unboxed(arr, 0), -17.0);
-    assert!(js_array_numeric_get_f64_unboxed(arr, 1).is_nan());
-    assert_eq!(
-        js_array_numeric_get_f64_unboxed(arr, 2).to_bits(),
-        (-0.0f64).to_bits()
-    );
-    unsafe {
-        assert_eq!(raw_slot_bits(arr, 0), (-17.0f64).to_bits());
-        assert_eq!(raw_slot_bits(arr, 1), f64::NAN.to_bits());
-        assert_eq!(raw_slot_bits(arr, 2), (-0.0f64).to_bits());
-    }
-}
-
-#[test]
 fn test_numeric_array_raw_f64_payload_tracks_sets_and_downgrades() {
     let mut arr = js_array_alloc(2);
     arr = js_array_push_f64(arr, 1.5);
@@ -354,32 +325,6 @@ fn test_numeric_array_raw_f64_payload_tracks_sets_and_downgrades() {
         str_value.to_bits(),
         "unboxed helper falls back to boxed slots after downgrade"
     );
-}
-
-#[test]
-fn test_numeric_array_sparse_extend_fills_holes_and_downgrades_raw_layout() {
-    let mut arr = js_array_alloc(8);
-    arr = js_array_push_f64(arr, 1.0);
-    arr = js_array_push_f64(arr, 2.0);
-
-    assert_eq!(js_array_mark_numeric_f64_layout(arr), 1);
-    assert_eq!(js_array_is_numeric_f64_layout(arr), 1);
-
-    let extended = js_array_set_f64_extend(arr, 5, 6.0);
-
-    assert_eq!(extended, arr);
-    assert_eq!(js_array_length(extended), 6);
-    assert_eq!(js_array_is_numeric_f64_layout(extended), 0);
-    assert_eq!(js_array_get_f64(extended, 0), 1.0);
-    assert_eq!(js_array_get_f64(extended, 1), 2.0);
-    assert_eq!(
-        js_array_get_f64(extended, 3).to_bits(),
-        crate::value::TAG_UNDEFINED
-    );
-    unsafe {
-        assert_eq!(raw_slot_bits(extended, 3), crate::value::TAG_HOLE);
-    }
-    assert_eq!(js_array_get_f64(extended, 5), 6.0);
 }
 
 #[test]
@@ -469,6 +414,63 @@ fn test_nonnumeric_append_downgrades_raw_f64_and_preserves_payload() {
     assert_eq!(js_array_is_numeric_f64_layout(arr), 0);
     assert_eq!(js_array_get_jsvalue(arr, 0), bool_bits);
     assert_eq!(js_array_get_f64_unchecked(arr, 0).to_bits(), bool_bits);
+}
+
+// #40/#1862/#321 regression: a class reference is NaN-boxed with INT32_TAG
+// (same 0x7FFE shape as a genuine small integer) and the runtime keys class
+// dispatch off that tag. The raw-f64-slot canonicalization (#1862) must NOT
+// strip the tag when an int32-shaped slot value is actually a registered
+// class ref — doing so converted the class ref into a raw double, after
+// which a downstream property read dereferenced the double as a heap pointer
+// and SIGSEGV'd (effect/Schema `decodeUnknownSync` via `js_array_map` ->
+// `js_object_get_field_by_name` -> `is_registered_set`). Storing a class ref
+// into a numeric array must preserve the exact NaN-box bits in the slot so a
+// generic (non-numeric-fast-path) read still observes the class ref.
+#[test]
+fn test_class_ref_store_into_numeric_array_preserves_int32_tag() {
+    // Pick a class id whose payload (as a small int) would, pre-fix, have
+    // been a "valid number" that canonicalization rewrote to raw f64 bits.
+    let class_id: u32 = 112;
+    unsafe {
+        crate::object::js_register_class_id(class_id);
+    }
+    assert!(crate::object::is_class_id_registered(class_id));
+
+    // Establish a RawF64 numeric layout, then overwrite a slot with the
+    // INT32-tagged class ref.
+    let class_ref_bits = int32_jsvalue_bits(class_id as i32);
+    let mut arr = js_array_alloc(2);
+    arr = js_array_push_f64(arr, 1.0);
+    arr = js_array_push_f64(arr, 2.0);
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 1);
+
+    js_array_set_jsvalue(arr, 0, class_ref_bits);
+
+    // The load-bearing invariant: the slot must still hold the EXACT class-ref
+    // NaN-box bits (0x7FFE tag intact) — NOT canonicalized to f64(112).to_bits()
+    // (0x405C_0000_0000_0000), which is what the original crash backtrace's
+    // `0x405c…` fault address was. A generic read (`js_array_get_jsvalue` —
+    // the path `js_array_map` and property dispatch use) must observe the
+    // class ref, not a raw double.
+    assert_eq!(js_array_get_jsvalue(arr, 0), class_ref_bits);
+    assert_eq!(js_array_get_f64_unchecked(arr, 0).to_bits(), class_ref_bits);
+
+    // Force a layout rebuild (the other code path that rewrites slots) and
+    // re-check the slot still carries the class ref.
+    unsafe {
+        refresh_array_numeric_layout(arr);
+    }
+    assert_eq!(js_array_get_jsvalue(arr, 0), class_ref_bits);
+    assert_eq!(js_array_get_f64_unchecked(arr, 0).to_bits(), class_ref_bits);
+
+    // A genuine integer with the same magnitude (but unregistered) still
+    // canonicalizes to raw f64 bits — Andrew's #1862 feature stays intact.
+    let plain_value: u32 = 7_777;
+    assert!(!crate::object::is_class_id_registered(plain_value));
+    let plain_int = int32_jsvalue_bits(plain_value as i32);
+    let other = js_array_push_jsvalue(js_array_alloc(1), plain_int);
+    assert_eq!(js_array_is_numeric_f64_layout(other), 1);
+    assert_canonical_raw_slot(other, 0, plain_value as f64);
 }
 
 #[test]

--- a/test-files/test_gap_class_ref_numeric_array_canon.ts
+++ b/test-files/test_gap_class_ref_numeric_array_canon.ts
@@ -1,0 +1,60 @@
+// Issue #40 / #1862 / #321 regression: effect/Schema `decodeUnknownSync`
+// SIGSEGV'd on `main` after the #1862 "raw f64 array slot canonicalization"
+// landed. Root cause: Perry NaN-boxes a class reference with INT32_TAG
+// (0x7FFE) — the SAME bit shape as a genuine small integer — and keys class
+// dispatch off that tag. The numeric-array canonicalization rewrote any
+// int32-shaped slot of a RawF64 array to its raw f64 bits, stripping the
+// 0x7FFE tag from class refs that flowed through a numeric-seeded array. A
+// later property read then missed the class-ref dispatch arm and
+// dereferenced the raw double as a heap pointer (crash in
+// `is_registered_set` via `js_array_map` -> `js_object_get_field_by_name`).
+//
+// The fix makes the numeric-layout predicate reject int32-shaped values that
+// are registered class refs, so storing a class ref into a numeric array
+// downgrades the layout and preserves the NaN-box bits — genuine integers
+// still canonicalize (the #1862 feature is intact).
+//
+// Expected output:
+// T,B,n,n,n,n,n,n,n,n
+// 42 cfg 7 oth
+
+class Tag {
+  static k = "T";
+}
+class Box {
+  static k = "B";
+}
+
+// Erase the static class-ref knowledge so the value flows dynamically (the
+// way effect/Schema passes schema "constructors" through generic arrays).
+function wrap(x: any): any {
+  return x;
+}
+
+// Seed a RawF64 numeric layout, then overwrite slots with INT32-tagged class
+// refs, then read them back via `.map` (which reads each slot raw) + a
+// property access in the callback.
+const items: any[] = [];
+for (let i = 0; i < 10; i++) items.push(i);
+items[0] = wrap(Tag);
+items[1] = wrap(Box);
+const ids = items.map((it: any) => (typeof it === "function" && it.k ? it.k : "n"));
+console.log(ids.join(","));
+
+// Direct read-back of a class ref stored in a numeric-seeded array, then a
+// static field access (must not be corrupted by canonicalization).
+class Config {
+  static version = 42;
+  static label = "cfg";
+}
+class Other {
+  static version = 7;
+  static label = "oth";
+}
+const slots: any[] = [];
+for (let i = 0; i < 8; i++) slots.push(i);
+slots[3] = Config;
+slots[5] = Other;
+const c = slots[3];
+const o = slots[5];
+console.log(c.version, c.label, o.version, o.label);


### PR DESCRIPTION
## Summary

Forward-fixes a SIGSEGV regression in `effect/Schema` decode/encode/is (a marquee feature landed in #1863) that was introduced by #1862 ("Extend native buffer proofs and typed views"). Restores Schema while keeping #1862's buffer/typed-view functionality intact. Refs #1862, #321.

## Root cause

Perry shares the `INT32_TAG` (0x7FFE) NaN-box shape between genuine small integers **and class references** (`arrays_finds.rs` lowers a `ClassRef` to its registered class id NaN-boxed with `INT32_TAG`; downstream property/method/`instanceof` dispatch keys off the surviving 0x7FFE tag).

#1862's array-slot canonicalization (`canonicalize_array_numeric_store_bits` + `rebuild_array_numeric_raw_f64` in `crates/perry-runtime/src/array/header.rs`) assumed any `INT32`-tagged value in a `RawF64` array was a genuine integer and rewrote the slot to `number.to_bits()`, **stripping the 0x7FFE tag**. When the value was actually a class ref — which `effect/Schema`'s decode path does, storing schema "constructors" through generic arrays — a later property read missed the class-ref dispatch arm and dereferenced the canonicalized double as a heap pointer → SIGSEGV (in `js_array_map` → `js_object_get_field_by_name`).

## Fix

Add `value_bits_is_class_ref()` (INT32-tagged **and** payload is a registered class id — the same convention `js_value_typeof` uses to tell `typeof Cls` from `typeof 3`) and skip the raw-f64 canonicalization rewrite for class-ref slots in both `canonicalize_array_numeric_store_bits` and `rebuild_array_numeric_raw_f64`. Genuine integers still canonicalize, so #1862's raw-f64 fast path is preserved.

## Bisect

Schema decode = `Ada 36` at `e83e79f5` (#1863) and `a2bfa113` (#1869); SIGSEGV (exit 139) starting at `29e4a459` (#1862) — verified on an identical effect env so it's a genuine code regression, not test-env noise.

## Validation

- `effect/Schema`: `decode`→`Ada 36`, `encode`→`{"name":"x"}`, `is`→`true false` — all byte-identical to `node --experimental-strip-types` again (were SIGSEGV).
- New gap test `test-files/test_gap_class_ref_numeric_array_canon.ts` + a `crates/perry-runtime/src/array/tests.rs` unit test — byte-identical to Node.
- #1862's buffer/typed-view fixtures (`native_owned_typed_views.ts`, `width_aware_buffer_kernels.ts`) still compile + run cleanly — feature preserved.
- Array/closure/class regression spot-check byte-identical to Node. (`test_gap_typed_arrays`'s `Int32Array length` mismatch is a SEPARATE pre-existing #1862 bug — identical with/without this change — tracked separately.)
- `cargo test -p perry-runtime`, `cargo fmt --all --check`, `scripts/check_file_size.sh` all clean.
