### PR TITLE
fix(node): fill child_process exec error fields

### DIFF
--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -1473,8 +1473,8 @@ fn cp_exec_callback_error(run: &CpRun, cmd: &str) -> f64 {
         &message,
         &[
             ("code", code),
-            ("signal", signal),
             ("killed", killed),
+            ("signal", signal),
             ("cmd", cp_box_string(cmd)),
         ],
     )

--- a/test-parity/node-suite/child_process/async/exec-error-fields.ts
+++ b/test-parity/node-suite/child_process/async/exec-error-fields.ts
@@ -1,0 +1,19 @@
+import { exec, execFile } from "node:child_process";
+
+function report(label: string, err: any, stdout: unknown, stderr: unknown) {
+  console.log(`${label} err instanceof Error:`, err instanceof Error);
+  console.log(`${label} keys:`, Object.keys(err).join(","));
+  console.log(`${label} code:`, err.code);
+  console.log(`${label} killed:`, err.killed);
+  console.log(`${label} signal:`, err.signal);
+  console.log(`${label} cmd:`, err.cmd);
+  console.log(`${label} stdout:`, String(stdout));
+  console.log(`${label} stderr:`, String(stderr));
+}
+
+exec("printf out; printf err >&2; exit 3", (err, stdout, stderr) => {
+  report("exec", err, stdout, stderr);
+  execFile("sh", ["-c", "printf out; printf err >&2; exit 4"], (err, stdout, stderr) => {
+    report("execFile", err, stdout, stderr);
+  });
+});


### PR DESCRIPTION
Fixes #1935.

## Summary
- Attach Node-shaped enumerable callback error fields for completed non-zero `child_process.exec()` and `execFile()` exits: `code`, `killed`, `signal`, and `cmd`.
- Preserve callback `stdout` and `stderr` values on failure.
- Add a focused node-suite fixture covering `instanceof Error`, `Object.keys` order, exit code, null signal, false killed flag, command string, stdout, and stderr.

## Baseline
- Node reports `Object.keys(err)` as `code,killed,signal,cmd`, numeric `.code`, `.killed === false`, `.signal === null`, and `.cmd` matching the command.
- Perry previously produced undefined `code`/`killed`/`signal`/`cmd` fields and garbage enumerable keys from passing the dedicated ErrorHeader layout to `Object.keys`.

## Reference
- DeepWiki comparison saved locally only at `reference/deepwiki/deno-node-child-process-exec-error-fields-2026-05-27.md`.

## Tests
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module child_process --filter exec-error-fields`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module child_process`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --filter test_parity_child_process`
- `cargo test -p perry-runtime child_process --lib`
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals
- Spawn failure errno/Error field shape.
- Promisified rejection `.stdout`/`.stderr` fields.
- Buffer/default encoding parity (#1937).
- Timeout/maxBuffer behavior, streaming subprocess IO, kill behavior, IPC/fork, or `spawnSync` result shape (#1950/#1936).
