### PR TITLE
feat(node:child_process): async spawn reactor, fork()+IPC, exec error/encoding parity (#1933–#1938)

### DIFF
--- a/crates/perry-codegen-js/src/emit/exprs_more.rs
+++ b/crates/perry-codegen-js/src/emit/exprs_more.rs
@@ -8,6 +8,7 @@ impl JsEmitter {
             Expr::ChildProcessExecSync { .. }
             | Expr::ChildProcessSpawnSync { .. }
             | Expr::ChildProcessSpawn { .. }
+            | Expr::ChildProcessFork { .. }
             | Expr::ChildProcessExec { .. }
             | Expr::ChildProcessSpawnBackground { .. }
             | Expr::ChildProcessGetProcessStatus(_)

--- a/crates/perry-codegen-wasm/src/emit/expr/net_fetch_crypto.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/net_fetch_crypto.rs
@@ -15,6 +15,7 @@ impl<'a> FuncEmitCtx<'a> {
             Expr::ChildProcessExecSync { .. }
             | Expr::ChildProcessSpawnSync { .. }
             | Expr::ChildProcessSpawn { .. }
+            | Expr::ChildProcessFork { .. }
             | Expr::ChildProcessExec { .. }
             | Expr::ChildProcessSpawnBackground { .. }
             | Expr::ChildProcessGetProcessStatus(_)

--- a/crates/perry-codegen/src/expr/child_proc.rs
+++ b/crates/perry-codegen/src/expr/child_proc.rs
@@ -58,22 +58,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             } else {
                 "0".to_string()
             };
-            // js_child_process_exec_sync(cmd: i64, opts: i64) -> i64 (string handle)
-            // Runtime returns null on error; guard against it by
-            // replacing null with an empty string so `.length` reads 0
-            // instead of crashing.
-            let raw = ctx.block().call(
-                I64,
+            // js_child_process_exec_sync(cmd: i64, opts: i64) -> f64.
+            // #1937/#1938: the runtime returns an already-NaN-boxed value
+            // (Buffer by default, string with `encoding`) and throws on a
+            // non-zero exit, so we pass the result straight through.
+            let result = ctx.block().call(
+                DOUBLE,
                 "js_child_process_exec_sync",
                 &[(I64, &cmd_str), (I64, &opts_str)],
             );
-            let is_null = ctx.block().icmp_eq(I64, &raw, "0");
-            let empty = ctx
-                .block()
-                .call(I64, "js_string_from_bytes", &[(PTR, "null"), (I32, "0")]);
-            let blk = ctx.block();
-            let result = blk.select(crate::types::I1, &is_null, I64, &empty, &raw);
-            Ok(nanbox_string_inline(ctx.block(), &result))
+            Ok(result)
         }
 
         Expr::ChildProcessSpawnSync {
@@ -173,6 +167,37 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(result)
         }
 
+        Expr::ChildProcessFork {
+            module,
+            args,
+            options,
+        } => {
+            // `fork(modulePath[, args][, options])` — like spawn, but the
+            // runtime wires up an IPC channel + send/disconnect/'message'. The
+            // runtime returns an already-NaN-boxed ChildProcess pointer. #1933.
+            let mod_box = lower_expr(ctx, module)?;
+            let blk = ctx.block();
+            let mod_str = unbox_to_i64(blk, &mod_box);
+            let args_str = if let Some(a) = args {
+                let v = lower_expr(ctx, a)?;
+                unbox_to_i64(ctx.block(), &v)
+            } else {
+                "0".to_string()
+            };
+            let opts_str = if let Some(o) = options {
+                let v = lower_expr(ctx, o)?;
+                unbox_to_i64(ctx.block(), &v)
+            } else {
+                "0".to_string()
+            };
+            let result = ctx.block().call(
+                DOUBLE,
+                "js_child_process_fork",
+                &[(I64, &mod_str), (I64, &args_str), (I64, &opts_str)],
+            );
+            Ok(result)
+        }
+
         Expr::ChildProcessExec {
             command,
             options,
@@ -252,9 +277,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             args,
             options,
         } => {
-            // `execFileSync(file[, args][, options])` → stdout string. Runtime
-            // returns null on error; replace with an empty string so `.length`
-            // reads 0 instead of crashing (same guard as execSync).
+            // `execFileSync(file[, args][, options])` → f64. #1937/#1938: the
+            // runtime returns an already-NaN-boxed value (Buffer by default,
+            // string with `encoding`) and throws on a non-zero exit, so we pass
+            // the result straight through.
             let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
             let file_box = lower_expr(ctx, file)?;
             let file_str = unbox_to_i64(ctx.block(), &file_box);
@@ -268,18 +294,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             } else {
                 undef.clone()
             };
-            let raw = ctx.block().call(
-                I64,
+            let result = ctx.block().call(
+                DOUBLE,
                 "js_child_process_exec_file_sync",
                 &[(I64, &file_str), (DOUBLE, &args_v), (DOUBLE, &opts_v)],
             );
-            let is_null = ctx.block().icmp_eq(I64, &raw, "0");
-            let empty = ctx
-                .block()
-                .call(I64, "js_string_from_bytes", &[(PTR, "null"), (I32, "0")]);
-            let blk = ctx.block();
-            let result = blk.select(crate::types::I1, &is_null, I64, &empty, &raw);
-            Ok(nanbox_string_inline(ctx.block(), &result))
+            Ok(result)
         }
 
         Expr::ChildProcessGetProcessStatus(handle) => {

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1842,6 +1842,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ChildProcessSpawnSync { .. }
         | Expr::ChildProcessSpawnBackground { .. }
         | Expr::ChildProcessSpawn { .. }
+        | Expr::ChildProcessFork { .. }
         | Expr::ChildProcessExec { .. }
         | Expr::ChildProcessExecFile { .. }
         | Expr::ChildProcessExecFileSync { .. }

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -393,7 +393,9 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_buffer_write", I32, &[I64, I64, I32, I32]);
 
     // ========== child_process ==========
-    module.declare_function("js_child_process_exec_sync", I64, &[I64, I64]);
+    // execSync → NaN-boxed stdout (Buffer by default / string with `encoding`);
+    // throws on non-zero exit. Returns DOUBLE. #1937/#1938.
+    module.declare_function("js_child_process_exec_sync", DOUBLE, &[I64, I64]);
     // exec(cmd, options?, callback?): cmd string ptr (I64), options + callback
     // as NaN-boxed f64 in either slot; returns undefined (callback form) or the
     // stdout string (no-callback form). See `js_child_process_exec`.
@@ -408,15 +410,20 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_child_process_spawn_sync", I64, &[I64, I64, I64]);
     // #1780: streaming spawn → NaN-boxed ChildProcess pointer (returns DOUBLE).
     module.declare_function("js_child_process_spawn_streams", DOUBLE, &[I64, I64, I64]);
+    // #1933: fork(modulePath, args, options) → NaN-boxed ChildProcess with an
+    // IPC channel (send/disconnect/'message'/connected/channel).
+    module.declare_function("js_child_process_fork", DOUBLE, &[I64, I64, I64]);
     // #1780: execFile (file, args, options, callback) + execFileSync (file, args, options).
     module.declare_function(
         "js_child_process_exec_file",
         DOUBLE,
         &[I64, DOUBLE, DOUBLE, DOUBLE],
     );
+    // execFileSync → NaN-boxed stdout (Buffer by default / string with
+    // `encoding`); throws on non-zero exit. Returns DOUBLE. #1937/#1938.
     module.declare_function(
         "js_child_process_exec_file_sync",
-        I64,
+        DOUBLE,
         &[I64, DOUBLE, DOUBLE],
     );
 

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -847,6 +847,19 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
                 collect_assigned_locals_expr(opts, assigned);
             }
         }
+        Expr::ChildProcessFork {
+            module,
+            args,
+            options,
+        } => {
+            collect_assigned_locals_expr(module, assigned);
+            if let Some(a) = args {
+                collect_assigned_locals_expr(a, assigned);
+            }
+            if let Some(opts) = options {
+                collect_assigned_locals_expr(opts, assigned);
+            }
+        }
         Expr::ChildProcessExec {
             command,
             options,

--- a/crates/perry-hir/src/capability.rs
+++ b/crates/perry-hir/src/capability.rs
@@ -266,6 +266,7 @@ fn required_capability(expr: &Expr) -> Option<(&'static str, &'static str)> {
         Expr::ChildProcessExec { .. } => ("proc:exec", "child_process.exec"),
         Expr::ChildProcessExecSync { .. } => ("proc:exec", "child_process.execSync"),
         Expr::ChildProcessSpawn { .. } => ("proc:exec", "child_process.spawn"),
+        Expr::ChildProcessFork { .. } => ("proc:exec", "child_process.fork"),
         Expr::ChildProcessSpawnSync { .. } => ("proc:exec", "child_process.spawnSync"),
         Expr::ChildProcessSpawnBackground { .. } => ("proc:exec", "child_process.spawnBackground"),
         Expr::ChildProcessGetProcessStatus(_) => ("proc:exec", "child_process.getProcessStatus"),

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1088,6 +1088,12 @@ pub enum Expr {
         args: Option<Box<Expr>>,
         options: Option<Box<Expr>>,
     },
+    ChildProcessFork {
+        // fork(modulePath, args?, opts?) -> ChildProcess with an IPC channel (#1933)
+        module: Box<Expr>,
+        args: Option<Box<Expr>>,
+        options: Option<Box<Expr>>,
+    },
     ChildProcessExec {
         // exec(cmd, opts?, callback?) -> ChildProcess
         command: Box<Expr>,

--- a/crates/perry-hir/src/lockdown.rs
+++ b/crates/perry-hir/src/lockdown.rs
@@ -193,6 +193,7 @@ fn forbidden_call(expr: &Expr) -> Option<&'static str> {
         Expr::ChildProcessExec { .. } => "child_process.exec",
         Expr::ChildProcessExecSync { .. } => "child_process.execSync",
         Expr::ChildProcessSpawn { .. } => "child_process.spawn",
+        Expr::ChildProcessFork { .. } => "child_process.fork",
         Expr::ChildProcessSpawnSync { .. } => "child_process.spawnSync",
         Expr::ChildProcessSpawnBackground { .. } => "child_process.spawnBackground",
         Expr::ChildProcessGetProcessStatus(_) => "child_process.getProcessStatus",

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -387,6 +387,19 @@ pub(super) fn try_global_builtins(
                             }));
                         }
                     }
+                    "fork" => {
+                        if !args.is_empty() {
+                            let mut args_iter = args.into_iter();
+                            let module = args_iter.next().unwrap();
+                            let fork_args = args_iter.next().map(Box::new);
+                            let options = args_iter.next().map(Box::new);
+                            return Ok(Ok(Expr::ChildProcessFork {
+                                module: Box::new(module),
+                                args: fork_args,
+                                options,
+                            }));
+                        }
+                    }
                     "exec" => {
                         if !args.is_empty() {
                             let mut args_iter = args.into_iter();

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -1143,6 +1143,19 @@ pub(super) fn try_module_static_methods(
                                 }));
                             }
                         }
+                        "fork" => {
+                            if !args.is_empty() {
+                                let mut args_iter = args.into_iter();
+                                let module = args_iter.next().unwrap();
+                                let fork_args = args_iter.next().map(Box::new);
+                                let options = args_iter.next().map(Box::new);
+                                return Ok(Ok(Expr::ChildProcessFork {
+                                    module: Box::new(module),
+                                    args: fork_args,
+                                    options,
+                                }));
+                            }
+                        }
                         "exec" => {
                             if !args.is_empty() {
                                 let mut args_iter = args.into_iter();

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -299,6 +299,7 @@ impl SH for Expr {
             Expr::ChildProcessExecSync { command, options } => { tag(h, 236); command.as_ref().hash(h); options.hash(h); }
             Expr::ChildProcessSpawnSync { command, args, options, } => { tag(h, 237); command.as_ref().hash(h); args.hash(h); options.hash(h); }
             Expr::ChildProcessSpawn { command, args, options, } => { tag(h, 238); command.as_ref().hash(h); args.hash(h); options.hash(h); }
+            Expr::ChildProcessFork { module, args, options, } => { tag(h, 11240); module.as_ref().hash(h); args.hash(h); options.hash(h); }
             Expr::ChildProcessExec { command, options, callback, } => { tag(h, 239); command.as_ref().hash(h); options.hash(h); callback.hash(h); }
             Expr::ChildProcessExecFile { file, args, options, callback, } => { tag(h, 11239); file.as_ref().hash(h); args.hash(h); options.hash(h); callback.hash(h); }
             Expr::ChildProcessExecFileSync { file, args, options, } => { tag(h, 11240); file.as_ref().hash(h); args.hash(h); options.hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1161,6 +1161,19 @@ where
                 f(o);
             }
         }
+        Expr::ChildProcessFork {
+            module,
+            args,
+            options,
+        } => {
+            f(module);
+            if let Some(a) = args {
+                f(a);
+            }
+            if let Some(o) = options {
+                f(o);
+            }
+        }
         Expr::ChildProcessExec {
             command,
             options,

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1140,6 +1140,19 @@ where
                 f(o);
             }
         }
+        Expr::ChildProcessFork {
+            module,
+            args,
+            options,
+        } => {
+            f(module);
+            if let Some(a) = args {
+                f(a);
+            }
+            if let Some(o) = options {
+                f(o);
+            }
+        }
         Expr::ChildProcessExec {
             command,
             options,

--- a/crates/perry-runtime/src/child_process/fork.rs
+++ b/crates/perry-runtime/src/child_process/fork.rs
@@ -1,0 +1,211 @@
+//! `child_process.fork(modulePath[, args][, options])` + IPC channel — #1933.
+//!
+//! `fork` is `spawn` plus a duplex IPC channel. Perry compiles ahead-of-time and
+//! has no embedded interpreter to "fork into", so — like Node, whose `fork`
+//! launches `process.execPath` (the `node` binary) on the module — we launch a
+//! configurable interpreter (`options.execPath`, else `$PERRY_FORK_EXECPATH`,
+//! else `node`) on `modulePath`. The IPC channel is a `socketpair(2)`: the
+//! parent keeps one end; the child inherits the other as fd 3 with
+//! `NODE_CHANNEL_FD=3` (Node's convention), so a Node child's
+//! `process.send` / `process.on('message')` interoperate out of the box.
+//!
+//! The returned ChildProcess reuses the #1934 reactor for its lifecycle
+//! (`spawn`/`data`/`end`/`exit`/`close`, live `kill`) and adds
+//! `send` / `disconnect` / `connected` / `channel` plus `'message'` delivery.
+//! Messages are newline-delimited JSON (Node's default `'json'` IPC
+//! serialization). The IPC wiring is Unix-only; on other platforms `fork`
+//! launches the child but reports `connected: false`.
+
+use super::*;
+use std::process::{Command, Stdio};
+
+/// `child_process.fork(modulePath[, args][, options])`. `module_ptr`/`args_ptr`
+/// are raw (unboxed) `StringHeader` / `ArrayHeader` pointers; `opts_ptr` is a
+/// raw heap pointer (or 0). Returns a NaN-boxed ChildProcess.
+#[no_mangle]
+pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr: i64) -> f64 {
+    cp_register_arities();
+
+    reactor::cp_register_reactor_arities();
+
+    let module = unsafe { cp_read_string_header(module_ptr) };
+    let arg_strs = unsafe { cp_read_arg_strings(args_ptr) };
+    let opts_val = if opts_ptr > 0x10000 {
+        cp_box_ptr(opts_ptr as *const u8)
+    } else {
+        cp_undefined()
+    };
+
+    // Launch interpreter: options.execPath → $PERRY_FORK_EXECPATH → "node".
+    let exec_path = cp_value_to_string(cp_get_field(opts_val, b"execPath"))
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            std::env::var("PERRY_FORK_EXECPATH")
+                .ok()
+                .filter(|s| !s.is_empty())
+        })
+        .unwrap_or_else(|| "node".to_string());
+
+    // execArgv (defaults to `--experimental-strip-types` for a `.ts` module
+    // under node, so TS workers run without extra config).
+    let mut exec_argv = cp_args_from_value(cp_get_field(opts_val, b"execArgv"));
+    if exec_argv.is_empty() && module.ends_with(".ts") && exec_path.contains("node") {
+        exec_argv.push("--experimental-strip-types".to_string());
+    }
+
+    // ChildProcess object: EventEmitter + stdio sub-objects + send/disconnect.
+    let stdout_obj = cp_build_readable();
+    let stderr_obj = cp_build_readable();
+    let stdin_obj = cp_build_writable();
+
+    // spawnargs = [execPath, ...execArgv, module, ...args] (matches Node).
+    let mut spawnargs = crate::array::js_array_alloc((arg_strs.len() + exec_argv.len() + 2) as u32);
+    spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(&exec_path));
+    for a in &exec_argv {
+        spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(a));
+    }
+    spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(&module));
+    for a in &arg_strs {
+        spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(a));
+    }
+
+    let cp_methods: [(&str, CpFn); 13] = [
+        ("on", cp_cast2(cp_method_on)),
+        ("once", cp_cast2(cp_method_on)),
+        ("addListener", cp_cast2(cp_method_on)),
+        ("prependListener", cp_cast2(cp_method_on)),
+        ("removeListener", cp_cast2(cp_method_remove_listener)),
+        ("off", cp_cast2(cp_method_remove_listener)),
+        (
+            "removeAllListeners",
+            cp_cast1(cp_method_remove_all_listeners),
+        ),
+        ("emit", cp_cast2(cp_method_emit)),
+        ("kill", cp_cast1(cp_method_kill)),
+        ("ref", cp_cast0(cp_method_this0)),
+        ("unref", cp_cast0(cp_method_this0)),
+        ("send", cp_cast2(cp_method_send)),
+        ("disconnect", cp_cast0(cp_method_disconnect)),
+    ];
+    // Distinct shape band from spawn's ChildProcess (which carries no send/disconnect).
+    let cp_obj = cp_build_object(&cp_methods, CP_SHAPE_ID + 0x20 + cp_methods.len() as u32);
+    let cp = cp_box_ptr(cp_obj as *const u8);
+
+    cp_set_field(cp, b"stdout", stdout_obj);
+    cp_set_field(cp, b"stderr", stderr_obj);
+    cp_set_field(cp, b"stdin", stdin_obj);
+    let mut stdio = crate::array::js_array_alloc(4);
+    stdio = crate::array::js_array_push_f64(stdio, stdin_obj);
+    stdio = crate::array::js_array_push_f64(stdio, stdout_obj);
+    stdio = crate::array::js_array_push_f64(stdio, stderr_obj);
+    stdio = crate::array::js_array_push_f64(stdio, TAG_NULL_F64); // fd 3 = ipc
+    cp_set_field(cp, b"stdio", cp_box_ptr(stdio as *const u8));
+    cp_set_field(cp, b"exitCode", TAG_NULL_F64);
+    cp_set_field(cp, b"signalCode", TAG_NULL_F64);
+    cp_set_field(cp, b"killed", TAG_FALSE_F64);
+    cp_set_field(cp, b"connected", TAG_FALSE_F64);
+    cp_set_field(cp, b"channel", TAG_NULL_F64);
+    cp_set_field(cp, b"spawnargs", cp_box_ptr(spawnargs as *const u8));
+    cp_set_field(cp, b"spawnfile", cp_box_string(&exec_path));
+
+    // Build the command: <execPath> [execArgv] <module> [args].
+    let mut command = Command::new(&exec_path);
+    command.args(&exec_argv);
+    command.arg(&module);
+    command.args(&arg_strs);
+    cp_apply_options(&mut command, opts_val);
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    let launched = fork_launch(cp, stdout_obj, stderr_obj, stdin_obj, command);
+    if !launched {
+        // Spawn failure: emit a deferred `error`, leave `connected` false.
+        let msg = format!("fork failed: {exec_path}");
+        let mp = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+        let err = crate::error::js_error_new_with_message(mp);
+        cp_set_field(
+            cp,
+            b"__cpError",
+            crate::value::js_nanbox_pointer(err as i64),
+        );
+        let emit_closure =
+            crate::closure::js_closure_alloc(reactor::cp_emit_spawn_error as *const u8, 1);
+        crate::closure::js_closure_set_capture_ptr(emit_closure, 0, cp.to_bits() as i64);
+        crate::timer::js_set_immediate_callback(emit_closure as i64);
+    }
+    cp
+}
+
+/// Wire up the IPC socketpair, launch the child, and register it with the
+/// reactor. Returns whether the child spawned. Unix-only IPC; elsewhere the
+/// child is launched without a channel.
+#[cfg(unix)]
+fn fork_launch(
+    cp: f64,
+    stdout_obj: f64,
+    stderr_obj: f64,
+    stdin_obj: f64,
+    mut command: Command,
+) -> bool {
+    use std::os::unix::io::AsRawFd;
+    use std::os::unix::net::UnixStream;
+    use std::os::unix::process::CommandExt;
+
+    let (parent_sock, child_sock) = match UnixStream::pair() {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+
+    // The child inherits `child_sock` across fork; dup it onto fd 3 (which
+    // `dup2` leaves without CLOEXEC, so it survives exec) and advertise it via
+    // NODE_CHANNEL_FD — the convention a Node child reads to enable
+    // `process.send` / `process.on('message')`.
+    let child_fd = child_sock.as_raw_fd();
+    command.env("NODE_CHANNEL_FD", "3");
+    unsafe {
+        command.pre_exec(move || {
+            if libc::dup2(child_fd, 3) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    match command.spawn() {
+        Ok(child) => {
+            // The child now holds fd 3; the parent keeps `parent_sock`.
+            drop(child_sock);
+            cp_set_field(cp, b"connected", TAG_TRUE_F64);
+            let channel = crate::object::js_object_alloc(0, 0);
+            cp_set_field(cp, b"channel", cp_box_ptr(channel as *const u8));
+            reactor::cp_register_live_child(
+                cp,
+                stdout_obj,
+                stderr_obj,
+                stdin_obj,
+                child,
+                Some(parent_sock),
+            );
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn fork_launch(
+    cp: f64,
+    stdout_obj: f64,
+    stderr_obj: f64,
+    stdin_obj: f64,
+    mut command: Command,
+) -> bool {
+    match command.spawn() {
+        Ok(child) => {
+            reactor::cp_register_live_child(cp, stdout_obj, stderr_obj, stdin_obj, child, None);
+            true
+        }
+        Err(_) => false,
+    }
+}

--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -1,5 +1,12 @@
 //! Child Process module - provides process spawning capabilities
 
+// #1934: live-streaming `spawn` reactor (non-blocking child, stdout/stderr
+// pumped through the event loop, live `stdin.write()` / `kill()`).
+pub mod reactor;
+// #1933: `fork()` + IPC channel (parent `send`/`'message'`/`disconnect`, child
+// `process.send`/`process.on('message')`).
+pub mod fork;
+
 use std::collections::HashMap;
 use std::fs::File;
 use std::process::{Command, Stdio};
@@ -318,57 +325,63 @@ pub extern "C" fn js_child_process_kill_process(handle_id_val: f64) -> i32 {
     0
 }
 
-/// Execute a command synchronously and return stdout as a buffer/string
-/// Returns: Buffer containing stdout, or null on error
+/// `child_process.execSync(command[, options])` — run through the shell and
+/// return stdout (a Buffer by default, a string with an `encoding` option).
+/// On a non-zero exit (or spawn failure) Node throws an Error carrying
+/// `status`/`signal`/`pid`/`output`/`stdout`/`stderr`/`cmd`, so this diverges
+/// via `js_throw` rather than returning. Returns a NaN-boxed value. #1937/#1938.
 #[no_mangle]
 pub extern "C" fn js_child_process_exec_sync(
     cmd_ptr: *const StringHeader,
     options_ptr: *const ObjectHeader,
-) -> *mut StringHeader {
+) -> f64 {
+    let opts_val = if options_ptr.is_null() {
+        cp_undefined()
+    } else {
+        cp_box_ptr(options_ptr as *const u8)
+    };
+    let mode = cp_read_output_mode(opts_val, false);
+
     if cmd_ptr.is_null() {
-        return js_string_from_bytes(b"".as_ptr(), 0);
+        return cp_box_output(b"", &mode);
     }
 
-    unsafe {
+    let cmd_str = unsafe {
         let len = (*cmd_ptr).byte_len as usize;
         let data_ptr = (cmd_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
         let cmd_bytes = std::slice::from_raw_parts(data_ptr, len);
+        String::from_utf8_lossy(cmd_bytes).into_owned()
+    };
 
-        let cmd_str = match std::str::from_utf8(cmd_bytes) {
-            Ok(s) => s,
-            Err(_) => return js_string_from_bytes(b"".as_ptr(), 0),
-        };
+    // Execute the command using the shell, honoring `cwd`/`env` options.
+    #[cfg(unix)]
+    let mut command = {
+        let mut c = Command::new("sh");
+        c.arg("-c").arg(&cmd_str);
+        c
+    };
+    #[cfg(windows)]
+    let mut command = {
+        let mut c = Command::new("cmd");
+        c.arg("/C").arg(&cmd_str);
+        c
+    };
+    cp_apply_options(&mut command, opts_val);
 
-        // Execute the command using the shell, honoring `cwd`/`env` options.
-        #[cfg(unix)]
-        let mut command = {
-            let mut c = Command::new("sh");
-            c.arg("-c").arg(cmd_str);
-            c
-        };
-        #[cfg(windows)]
-        let mut command = {
-            let mut c = Command::new("cmd");
-            c.arg("/C").arg(cmd_str);
-            c
-        };
-        if !options_ptr.is_null() {
-            cp_apply_options(&mut command, cp_box_ptr(options_ptr as *const u8));
-        }
-
-        match command.output() {
-            Ok(output) => {
-                // Return stdout as a string
-                let stdout = &output.stdout;
-                js_string_from_bytes(stdout.as_ptr(), stdout.len() as u32)
-            }
-            Err(_) => js_string_from_bytes(b"".as_ptr(), 0),
-        }
+    let run = cp_run_to_completion(command);
+    let stdout_box = cp_box_output(&run.stdout, &mode);
+    if run.success() {
+        return stdout_box;
     }
+    let stderr_box = cp_box_output(&run.stderr, &mode);
+    cp_sync_throw_error(&run, &cmd_str, stdout_box, stderr_box);
 }
 
-/// Execute a command synchronously with more control (spawnSync)
-/// Returns: Object with stdout, stderr, status, etc.
+/// `child_process.spawnSync(command[, args][, options])` — run the file
+/// directly and return the full Node result object: `pid`, `output`
+/// (`[null, stdout, stderr]`), `stdout`, `stderr`, `status`, `signal`, and
+/// `error` (only on spawn failure). `stdout`/`stderr` are Buffers by default
+/// (strings with an `encoding` option). #1936/#1937.
 #[no_mangle]
 pub extern "C" fn js_child_process_spawn_sync(
     cmd_ptr: *const StringHeader,
@@ -379,80 +392,69 @@ pub extern "C" fn js_child_process_spawn_sync(
         return std::ptr::null_mut();
     }
 
-    unsafe {
-        // Get command string
+    let cmd_str = unsafe {
         let cmd_len = (*cmd_ptr).byte_len as usize;
         let cmd_data = (cmd_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-        let cmd_bytes = std::slice::from_raw_parts(cmd_data, cmd_len);
+        String::from_utf8_lossy(std::slice::from_raw_parts(cmd_data, cmd_len)).into_owned()
+    };
 
-        let cmd_str = match std::str::from_utf8(cmd_bytes) {
-            Ok(s) => s,
-            Err(_) => return std::ptr::null_mut(),
-        };
+    let opts_val = if options_ptr.is_null() {
+        cp_undefined()
+    } else {
+        cp_box_ptr(options_ptr as *const u8)
+    };
+    let mode = cp_read_output_mode(opts_val, false);
 
-        // Build command
-        let mut command = Command::new(cmd_str);
+    // Build command (run the file directly — spawnSync does not use a shell
+    // unless `shell` is set).
+    let arg_strs = unsafe { cp_read_arg_strings(args_ptr as i64) };
+    let command = cp_build_command(&cmd_str, &arg_strs, opts_val);
+    let run = cp_run_to_completion(command);
 
-        // Add arguments if provided
-        if !args_ptr.is_null() {
-            let args_len = (*args_ptr).length as usize;
-            let args_data = (args_ptr as *const u8)
-                .add(std::mem::size_of::<crate::array::ArrayHeader>())
-                as *const f64;
+    let stdout_box = cp_box_output(&run.stdout, &mode);
+    let stderr_box = cp_box_output(&run.stderr, &mode);
+    let output = cp_output_array(stdout_box, stderr_box);
+    let status = match run.code {
+        Some(c) => c as f64,
+        None => TAG_NULL_F64,
+    };
+    let signal = match run.signal {
+        Some(s) => cp_box_string(cp_signal_name(s)),
+        None => TAG_NULL_F64,
+    };
+    let pid = match run.pid {
+        Some(p) => p as f64,
+        None => TAG_NULL_F64,
+    };
 
-            for i in 0..args_len {
-                let arg_val = *args_data.add(i);
-                if let Some(arg_str) = extract_string_from_nanboxed(arg_val) {
-                    command.arg(arg_str);
-                }
-            }
-        }
-
-        // Honor `cwd`/`env` options.
-        if !options_ptr.is_null() {
-            cp_apply_options(&mut command, cp_box_ptr(options_ptr as *const u8));
-        }
-
-        // Execute the command
-        match command.output() {
-            Ok(output) => {
-                use crate::array::{js_array_alloc, js_array_push_f64};
-                use crate::value::js_nanbox_string;
-
-                // Create result object with stdout, stderr, status (3 fields)
-                let result = crate::object::js_object_alloc(0, 3);
-
-                // Set stdout as string (field 0)
-                let stdout_str =
-                    js_string_from_bytes(output.stdout.as_ptr(), output.stdout.len() as u32);
-                let stdout_boxed = js_nanbox_string(stdout_str as i64);
-                crate::object::js_object_set_field_f64(result, 0, stdout_boxed);
-
-                // Set stderr as string (field 1)
-                let stderr_str =
-                    js_string_from_bytes(output.stderr.as_ptr(), output.stderr.len() as u32);
-                let stderr_boxed = js_nanbox_string(stderr_str as i64);
-                crate::object::js_object_set_field_f64(result, 1, stderr_boxed);
-
-                // Set status (field 2)
-                let status = output.status.code().unwrap_or(-1) as f64;
-                crate::object::js_object_set_field_f64(result, 2, status);
-
-                // Build keys array for named property access
-                let keys = js_array_alloc(3);
-                let k_stdout = js_string_from_bytes(b"stdout".as_ptr(), 6);
-                let k_stderr = js_string_from_bytes(b"stderr".as_ptr(), 6);
-                let k_status = js_string_from_bytes(b"status".as_ptr(), 6);
-                js_array_push_f64(keys, js_nanbox_string(k_stdout as i64));
-                js_array_push_f64(keys, js_nanbox_string(k_stderr as i64));
-                js_array_push_f64(keys, js_nanbox_string(k_status as i64));
-                crate::object::js_object_set_keys(result, keys);
-
-                result
-            }
-            Err(_) => std::ptr::null_mut(),
-        }
+    // Assemble the result object. `error` is present only on spawn failure
+    // (Node omits it otherwise), so build via named sets rather than a fixed
+    // index layout.
+    let result = crate::object::js_object_alloc(0, 7);
+    let set = |key: &str, value: f64| {
+        let kp = js_string_from_bytes(key.as_ptr(), key.len() as u32);
+        js_object_set_field_by_name(result, kp, value);
+    };
+    set("pid", pid);
+    set("output", output);
+    set("stdout", stdout_box);
+    set("stderr", stderr_box);
+    set("status", status);
+    set("signal", signal);
+    if let Some((code, msg)) = &run.spawn_error {
+        let syscall = format!("spawnSync {cmd_str}");
+        let err = cp_make_error(
+            msg,
+            &[
+                ("code", cp_box_string(code)),
+                ("errno", cp_errno_number(code)),
+                ("syscall", cp_box_string(&syscall)),
+                ("path", cp_box_string(&cmd_str)),
+            ],
+        );
+        set("error", err);
     }
+    result
 }
 
 /// Spawn a process asynchronously
@@ -498,65 +500,58 @@ pub extern "C" fn js_child_process_exec(cmd_ptr: *const StringHeader, arg1: f64,
         }
     };
 
-    let box_string = |bytes: &[u8]| -> f64 {
-        let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
-        crate::value::js_nanbox_string(ptr as i64)
-    };
+    // `exec` defaults to utf8 (callback stdout/stderr are strings); the options
+    // sit in the `arg1` slot, so the encoding is read from there. When `arg1`
+    // is the callback the lookup no-ops and the default applies.
+    let mode = cp_read_output_mode(arg1, true);
 
     if cmd_ptr.is_null() {
+        let empty = cp_box_output(b"", &mode);
         if cb.is_null() {
-            return box_string(b"");
+            return empty;
         }
-        crate::closure::js_closure_call3(cb, TAG_NULL_F64, box_string(b""), box_string(b""));
+        crate::closure::js_closure_call3(cb, TAG_NULL_F64, empty, cp_box_output(b"", &mode));
         return f64::from_bits(TAG_UNDEFINED_BITS);
     }
 
-    let (stdout_bytes, stderr_bytes, success) = unsafe {
+    let cmd_str = unsafe {
         let len = (*cmd_ptr).byte_len as usize;
         let data_ptr = (cmd_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
         let cmd_bytes = std::slice::from_raw_parts(data_ptr, len);
-        match std::str::from_utf8(cmd_bytes) {
-            Ok(cmd_str) => {
-                // `exec` always runs through the shell. The options object sits
-                // in the `arg1` slot (`exec(cmd, options, cb)`); when `arg1` is
-                // the callback (`exec(cmd, cb)`) it's a closure, so the helper
-                // no-ops. `cwd`/`env` from the options are applied here.
-                #[cfg(unix)]
-                let mut command = {
-                    let mut c = Command::new("sh");
-                    c.arg("-c").arg(cmd_str);
-                    c
-                };
-                #[cfg(windows)]
-                let mut command = {
-                    let mut c = Command::new("cmd");
-                    c.arg("/C").arg(cmd_str);
-                    c
-                };
-                cp_apply_options(&mut command, arg1);
-                match command.output() {
-                    Ok(o) => (o.stdout, o.stderr, o.status.success()),
-                    Err(e) => (Vec::new(), e.to_string().into_bytes(), false),
-                }
-            }
-            Err(_) => (Vec::new(), Vec::new(), false),
-        }
+        String::from_utf8_lossy(cmd_bytes).into_owned()
     };
 
-    let stdout_box = box_string(&stdout_bytes);
+    // `exec` always runs through the shell. The options object sits in the
+    // `arg1` slot (`exec(cmd, options, cb)`); when `arg1` is the callback
+    // (`exec(cmd, cb)`) it's a closure, so `cp_apply_options` no-ops. `cwd`/
+    // `env` from the options are applied here.
+    #[cfg(unix)]
+    let mut command = {
+        let mut c = Command::new("sh");
+        c.arg("-c").arg(&cmd_str);
+        c
+    };
+    #[cfg(windows)]
+    let mut command = {
+        let mut c = Command::new("cmd");
+        c.arg("/C").arg(&cmd_str);
+        c
+    };
+    cp_apply_options(&mut command, arg1);
+    let run = cp_run_to_completion(command);
+
+    let stdout_box = cp_box_output(&run.stdout, &mode);
     if cb.is_null() {
-        // Legacy no-callback shape — return the stdout string.
+        // Legacy no-callback shape — return stdout (Buffer or string per
+        // `encoding`).
         return stdout_box;
     }
 
-    let stderr_box = box_string(&stderr_bytes);
-    let err_val = if success {
+    let stderr_box = cp_box_output(&run.stderr, &mode);
+    let err_val = if run.success() {
         TAG_NULL_F64
     } else {
-        let msg = "Command failed";
-        let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-        let err_ptr = crate::error::js_error_new_with_message(msg_ptr);
-        crate::value::js_nanbox_pointer(err_ptr as i64)
+        cp_exec_callback_error(&run, &cmd_str)
     };
     crate::closure::js_closure_call3(cb, err_val, stdout_box, stderr_box);
     f64::from_bits(TAG_UNDEFINED_BITS)
@@ -775,8 +770,17 @@ extern "C" fn cp_method_this0(closure: *const ClosureHeader) -> f64 {
 extern "C" fn cp_method_this1(closure: *const ClosureHeader, _a: f64) -> f64 {
     cp_this(closure)
 }
-extern "C" fn cp_method_kill(closure: *const ClosureHeader, _signal: f64) -> f64 {
-    cp_set_field(cp_this(closure), b"killed", TAG_TRUE_F64);
+extern "C" fn cp_method_kill(closure: *const ClosureHeader, signal: f64) -> f64 {
+    let this = cp_this(closure);
+    cp_set_field(this, b"killed", TAG_TRUE_F64);
+    // #1934: signal the live child if one is still running. `__cpHandle` is the
+    // reactor registry key set by `spawn`. Returns true when the signal was
+    // delivered (Node's `kill()` returns a boolean).
+    if let Some(handle) = cp_handle_of(this) {
+        if reactor::cp_live_kill(handle, signal) {
+            return TAG_TRUE_F64;
+        }
+    }
     TAG_TRUE_F64
 }
 /// `removeListener(event, cb)` / `off(event, cb)` — rebuild the `event`
@@ -835,46 +839,101 @@ extern "C" fn cp_method_read(_closure: *const ClosureHeader, _n: f64) -> f64 {
 extern "C" fn cp_method_pipe(_closure: *const ClosureHeader, dest: f64) -> f64 {
     dest
 }
-extern "C" fn cp_method_write2(_closure: *const ClosureHeader, _chunk: f64, _enc: f64) -> f64 {
+/// `child.stdin.write(chunk[, encoding][, callback])` — #1934. The `this` is
+/// the stdin Writable; route the bytes to the live child's stdin via the
+/// reactor. Returns `true` (Node's `write` returns whether the buffer can take
+/// more — `true` for our synchronous pipe write).
+extern "C" fn cp_method_write2(closure: *const ClosureHeader, chunk: f64, _enc: f64) -> f64 {
+    let this = cp_this(closure);
+    if let Some(handle) = cp_handle_of(this) {
+        let bytes = cp_value_to_bytes(chunk);
+        reactor::cp_live_stdin_write(handle, &bytes);
+    }
     TAG_TRUE_F64
 }
 
-/// Deferred emission body, scheduled via `setImmediate` from `spawn`. Slot 0
-/// captures the ChildProcess value.
-extern "C" fn cp_emit_all(closure: *const ClosureHeader) -> f64 {
-    let cp = cp_this(closure);
-
-    // A spawn failure (e.g. ENOENT) surfaces as a single `error` event; Node
-    // never fires `spawn`/`exit` in that case.
-    let err = cp_get_field(cp, b"__cpError");
-    if !JSValue::from_bits(err.to_bits()).is_undefined() {
-        cp_emit(cp, "error", &[err]);
-        return cp_undefined();
+/// `child.send(message[, sendHandle][, options][, callback])` — serialize
+/// `message` and write it to the IPC channel of a `fork()`ed child (#1933). The
+/// `this` is the ChildProcess. Returns `true` (Node returns whether the channel
+/// can take more — always `true` for our synchronous write).
+extern "C" fn cp_method_send(closure: *const ClosureHeader, message: f64, _arg: f64) -> f64 {
+    let this = cp_this(closure);
+    if let Some(handle) = cp_handle_of(this) {
+        reactor::cp_ipc_send(handle, message);
     }
+    TAG_TRUE_F64
+}
 
-    cp_emit(cp, "spawn", &[]);
-
-    // Flush each output stream: a single `data` chunk (when non-empty) then `end`.
-    for field in [b"stdout".as_slice(), b"stderr".as_slice()] {
-        let stream = cp_get_field(cp, field);
-        if cp_object_ptr(stream).is_none() {
-            continue;
-        }
-        let chunk = cp_get_field(stream, b"__cpChunk");
-        if !JSValue::from_bits(chunk.to_bits()).is_undefined() {
-            cp_emit(stream, "data", &[chunk]);
-        }
-        cp_emit(stream, "end", &[]);
+/// `child.disconnect()` — close the IPC channel (#1933). Flips `connected` to
+/// `false`, `channel` to `null`, and emits a `disconnect` event.
+extern "C" fn cp_method_disconnect(closure: *const ClosureHeader) -> f64 {
+    let this = cp_this(closure);
+    if let Some(handle) = cp_handle_of(this) {
+        reactor::cp_ipc_disconnect(handle);
     }
-
-    // Node populates `exitCode`/`signalCode` before emitting `exit`, then `close`.
-    let code = cp_get_field(cp, b"__cpExitCode");
-    let signal = cp_get_field(cp, b"__cpSignal");
-    cp_set_field(cp, b"exitCode", code);
-    cp_set_field(cp, b"signalCode", signal);
-    cp_emit(cp, "exit", &[code, signal]);
-    cp_emit(cp, "close", &[code, signal]);
+    cp_set_field(this, b"connected", TAG_FALSE_F64);
+    cp_set_field(this, b"channel", TAG_NULL_F64);
+    cp_emit(this, "disconnect", &[]);
     cp_undefined()
+}
+
+/// `child.stdin.end([chunk])` — write the optional final chunk, then close the
+/// pipe so the child sees EOF (#1934). The `this` is the stdin Writable.
+extern "C" fn cp_method_stdin_end(closure: *const ClosureHeader, chunk: f64) -> f64 {
+    let this = cp_this(closure);
+    if let Some(handle) = cp_handle_of(this) {
+        // Optional final data chunk. Skip `undefined`, the `0.0` arg-padding
+        // sentinel, and a callback argument (`end(cb)`).
+        let bits = chunk.to_bits();
+        if !JSValue::from_bits(bits).is_undefined()
+            && bits != 0
+            && crate::fs::extract_closure_ptr(chunk).is_null()
+        {
+            let bytes = cp_value_to_bytes(chunk);
+            if !bytes.is_empty() {
+                reactor::cp_live_stdin_write(handle, &bytes);
+            }
+        }
+        reactor::cp_live_stdin_close(handle);
+    }
+    this
+}
+
+/// Read the reactor registry key (`__cpHandle`) off a ChildProcess / stdio
+/// sub-object, set by `spawn`. `None` when absent (e.g. a buffered child).
+fn cp_handle_of(this: f64) -> Option<u64> {
+    let h = cp_get_field(this, b"__cpHandle");
+    if JSValue::from_bits(h.to_bits()).is_undefined() {
+        return None;
+    }
+    if h.is_finite() && h >= 0.0 {
+        Some(h as u64)
+    } else {
+        None
+    }
+}
+
+/// Best-effort decode of a `write()` chunk (Buffer or string) to raw bytes.
+fn cp_value_to_bytes(value: f64) -> Vec<u8> {
+    // Buffer fast-path.
+    let bits = value.to_bits();
+    if JSValue::from_bits(bits).is_pointer() {
+        let raw = (bits & crate::value::POINTER_MASK) as usize;
+        if raw >= 0x10000 && crate::buffer::is_registered_buffer(raw) {
+            let buf = raw as *const crate::buffer::BufferHeader;
+            unsafe {
+                let len = (*buf).length as usize;
+                let data =
+                    (buf as *const u8).add(std::mem::size_of::<crate::buffer::BufferHeader>());
+                return std::slice::from_raw_parts(data, len).to_vec();
+            }
+        }
+    }
+    // Otherwise stringify.
+    cp_value_to_string(value)
+        .or_else(|| Some(cp_coerce_string(value)))
+        .unwrap_or_default()
+        .into_bytes()
 }
 
 // ----- object construction -----
@@ -904,7 +963,9 @@ fn cp_register_arities() {
     js_register_closure_arity(cp_method_read as *const u8, 1);
     js_register_closure_arity(cp_method_pipe as *const u8, 1);
     js_register_closure_arity(cp_method_write2 as *const u8, 2);
-    js_register_closure_arity(cp_emit_all as *const u8, 0);
+    js_register_closure_arity(cp_method_stdin_end as *const u8, 1);
+    js_register_closure_arity(cp_method_send as *const u8, 2);
+    js_register_closure_arity(cp_method_disconnect as *const u8, 0);
 }
 
 /// Allocate a heap object whose method-name fields each hold a closure capturing
@@ -964,7 +1025,7 @@ fn cp_build_writable() -> f64 {
         ("off", cp_cast2(cp_method_remove_listener)),
         ("emit", cp_cast2(cp_method_emit)),
         ("write", cp_cast2(cp_method_write2)),
-        ("end", cp_cast1(cp_method_this1)),
+        ("end", cp_cast1(cp_method_stdin_end)),
         ("destroy", cp_cast0(cp_method_this0)),
         ("cork", cp_cast0(cp_method_this0)),
         ("uncork", cp_cast0(cp_method_this0)),
@@ -1015,175 +1076,6 @@ unsafe fn cp_read_arg_strings(args_ptr: i64) -> Vec<String> {
         }
     }
     out
-}
-
-/// `child_process.spawn(command[, args][, options])` — returns a streaming
-/// ChildProcess. `cmd_ptr`/`args_ptr` are raw (unboxed) `StringHeader` /
-/// `ArrayHeader` pointers; `opts_ptr` is currently unused (no shell, default
-/// stdio). #1780.
-#[no_mangle]
-pub extern "C" fn js_child_process_spawn_streams(
-    cmd_ptr: i64,
-    args_ptr: i64,
-    opts_ptr: i64,
-) -> f64 {
-    cp_register_arities();
-
-    let (cmd_str, arg_strs) = unsafe {
-        (
-            cp_read_string_header(cmd_ptr),
-            cp_read_arg_strings(args_ptr),
-        )
-    };
-
-    // `opts_ptr` arrives as a raw (unboxed) heap pointer; re-box it so the
-    // options helpers can read `cwd`/`env`/`shell`. Small values mean
-    // no-options (codegen passes 0) — leave it undefined then.
-    let opts_val = if opts_ptr > 0x10000 {
-        cp_box_ptr(opts_ptr as *const u8)
-    } else {
-        cp_undefined()
-    };
-
-    // Build the command (honoring `shell`/`cwd`/`env`) and capture its output
-    // synchronously.
-    let mut command = cp_build_command(&cmd_str, &arg_strs, opts_val);
-    command.stdin(Stdio::piped());
-    command.stdout(Stdio::piped());
-    command.stderr(Stdio::piped());
-
-    let (pid, stdout_bytes, stderr_bytes, exit_code, signal_opt, spawn_err) = match command.spawn()
-    {
-        Ok(child) => {
-            let pid = child.id();
-            match child.wait_with_output() {
-                Ok(out) => {
-                    let code = out.status.code();
-                    #[cfg(unix)]
-                    let sig = {
-                        use std::os::unix::process::ExitStatusExt;
-                        out.status.signal()
-                    };
-                    #[cfg(not(unix))]
-                    let sig: Option<i32> = None;
-                    (Some(pid), out.stdout, out.stderr, code, sig, None)
-                }
-                Err(e) => (
-                    Some(pid),
-                    Vec::new(),
-                    Vec::new(),
-                    None,
-                    None,
-                    Some(e.to_string()),
-                ),
-            }
-        }
-        Err(e) => (
-            None,
-            Vec::new(),
-            Vec::new(),
-            None,
-            None,
-            Some(e.to_string()),
-        ),
-    };
-
-    // stdout/stderr Readable + stdin Writable sub-objects.
-    let stdout_obj = cp_build_readable();
-    let stderr_obj = cp_build_readable();
-    let stdin_obj = cp_build_writable();
-    if !stdout_bytes.is_empty() {
-        cp_set_field(stdout_obj, b"__cpChunk", cp_make_buffer(&stdout_bytes));
-    }
-    if !stderr_bytes.is_empty() {
-        cp_set_field(stderr_obj, b"__cpChunk", cp_make_buffer(&stderr_bytes));
-    }
-
-    // spawnargs = [command, ...args]
-    let mut spawnargs = crate::array::js_array_alloc((arg_strs.len() + 1) as u32);
-    spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(&cmd_str));
-    for a in &arg_strs {
-        spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(a));
-    }
-
-    let cp_methods: [(&str, CpFn); 11] = [
-        ("on", cp_cast2(cp_method_on)),
-        ("once", cp_cast2(cp_method_on)),
-        ("addListener", cp_cast2(cp_method_on)),
-        ("prependListener", cp_cast2(cp_method_on)),
-        ("removeListener", cp_cast2(cp_method_remove_listener)),
-        ("off", cp_cast2(cp_method_remove_listener)),
-        (
-            "removeAllListeners",
-            cp_cast1(cp_method_remove_all_listeners),
-        ),
-        ("emit", cp_cast2(cp_method_emit)),
-        ("kill", cp_cast1(cp_method_kill)),
-        ("ref", cp_cast0(cp_method_this0)),
-        ("unref", cp_cast0(cp_method_this0)),
-    ];
-    let cp_obj = cp_build_object(&cp_methods, CP_SHAPE_ID + cp_methods.len() as u32);
-    let cp = cp_box_ptr(cp_obj as *const u8);
-
-    cp_set_field(cp, b"stdout", stdout_obj);
-    cp_set_field(cp, b"stderr", stderr_obj);
-    cp_set_field(cp, b"stdin", stdin_obj);
-
-    let mut stdio = crate::array::js_array_alloc(3);
-    stdio = crate::array::js_array_push_f64(stdio, stdin_obj);
-    stdio = crate::array::js_array_push_f64(stdio, stdout_obj);
-    stdio = crate::array::js_array_push_f64(stdio, stderr_obj);
-    cp_set_field(cp, b"stdio", cp_box_ptr(stdio as *const u8));
-
-    cp_set_field(
-        cp,
-        b"pid",
-        match pid {
-            Some(p) => p as f64,
-            None => cp_undefined(),
-        },
-    );
-    cp_set_field(cp, b"exitCode", TAG_NULL_F64);
-    cp_set_field(cp, b"signalCode", TAG_NULL_F64);
-    cp_set_field(cp, b"killed", TAG_FALSE_F64);
-    cp_set_field(cp, b"connected", TAG_FALSE_F64);
-    cp_set_field(cp, b"spawnargs", cp_box_ptr(spawnargs as *const u8));
-    cp_set_field(cp, b"spawnfile", cp_box_string(&cmd_str));
-
-    // Hidden state consumed by the deferred emission.
-    cp_set_field(
-        cp,
-        b"__cpExitCode",
-        match exit_code {
-            Some(c) => c as f64,
-            None => TAG_NULL_F64,
-        },
-    );
-    cp_set_field(
-        cp,
-        b"__cpSignal",
-        match signal_opt {
-            Some(s) => cp_box_string(cp_signal_name(s)),
-            None => TAG_NULL_F64,
-        },
-    );
-    if let Some(msg) = spawn_err {
-        let mp = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-        let err = crate::error::js_error_new_with_message(mp);
-        cp_set_field(
-            cp,
-            b"__cpError",
-            crate::value::js_nanbox_pointer(err as i64),
-        );
-    }
-
-    // Defer spawn/data/end/exit/close until the next tick so handlers registered
-    // synchronously after this call are present when the events fire.
-    let emit_closure = js_closure_alloc(cp_emit_all as *const u8, 1);
-    js_closure_set_capture_ptr(emit_closure, 0, cp.to_bits() as i64);
-    crate::timer::js_set_immediate_callback(emit_closure as i64);
-
-    cp
 }
 
 /// Collect a NaN-boxed args value (array of strings) into owned Rust strings.
@@ -1312,11 +1204,336 @@ fn cp_build_command(cmd: &str, args: &[String], opts_val: f64) -> Command {
     command
 }
 
+// ============================================================================
+// Output encoding + error shape — #1935 / #1936 / #1937 / #1938
+// ============================================================================
+//
+// These helpers are shared by exec / execFile and the synchronous forms.
+// `exec`/`execFile` default to `"utf8"` (callback stdout/stderr are strings);
+// `execSync`/`execFileSync`/`spawnSync` default to `"buffer"`. `encoding:
+// "buffer"` or `null` always yields Buffers; any other named encoding decodes
+// the bytes with it. On a non-zero exit Node attaches diagnostic properties to
+// the error (`code`/`signal`/`killed`/`cmd` for the callback form;
+// `status`/`signal`/`pid`/`output`/`stdout`/`stderr`/`cmd` for the sync throw).
+
+/// Resolved form for captured stdout/stderr bytes.
+enum CpOutput {
+    Buffer,
+    Text(String),
+}
+
+/// Read the `encoding` option off a NaN-boxed options value. `default_text`
+/// picks the default when `encoding` is absent (exec/execFile → utf8 text;
+/// the sync forms → Buffer). `null` / `"buffer"` always mean Buffer.
+fn cp_read_output_mode(opts_val: f64, default_text: bool) -> CpOutput {
+    let enc = cp_get_field(opts_val, b"encoding");
+    let bits = enc.to_bits();
+    if JSValue::from_bits(bits).is_undefined() {
+        return if default_text {
+            CpOutput::Text("utf8".to_string())
+        } else {
+            CpOutput::Buffer
+        };
+    }
+    if bits == TAG_NULL_BITS {
+        return CpOutput::Buffer;
+    }
+    match cp_value_to_string(enc) {
+        Some(s) if s.eq_ignore_ascii_case("buffer") => CpOutput::Buffer,
+        Some(s) => CpOutput::Text(s),
+        // Non-string, non-null, non-undefined encoding — fall back to Buffer.
+        None => CpOutput::Buffer,
+    }
+}
+
+/// Decode raw bytes to a `StringHeader` using a Node encoding name.
+fn cp_encode_text(bytes: &[u8], enc: &str) -> *mut StringHeader {
+    match enc.to_ascii_lowercase().as_str() {
+        "hex" => crate::buffer::hex_encode_into_string(bytes),
+        "base64" => crate::buffer::base64_encode_into_string(bytes),
+        "base64url" => crate::buffer::base64url_encode_into_string(bytes),
+        "latin1" | "binary" => {
+            // latin1: each byte maps to a code point in U+0000..U+00FF.
+            let s: String = bytes.iter().map(|&b| b as char).collect();
+            js_string_from_bytes(s.as_ptr(), s.len() as u32)
+        }
+        // utf8 / utf-8 / ascii / unknown — store as UTF-8 (lossy for invalid).
+        _ => {
+            let s = String::from_utf8_lossy(bytes);
+            js_string_from_bytes(s.as_ptr(), s.len() as u32)
+        }
+    }
+}
+
+/// Box captured bytes per the resolved output mode (Buffer or decoded string).
+fn cp_box_output(bytes: &[u8], mode: &CpOutput) -> f64 {
+    match mode {
+        CpOutput::Buffer => cp_make_buffer(bytes),
+        CpOutput::Text(enc) => crate::value::js_nanbox_string(cp_encode_text(bytes, enc) as i64),
+    }
+}
+
+/// Decoded exit disposition of a finished child.
+struct CpExit {
+    /// Exit code when the child exited normally; `None` when killed by signal.
+    code: Option<i32>,
+    /// Signal number when the child was killed by a signal (Unix only).
+    signal: Option<i32>,
+}
+
+fn cp_decode_status(status: &std::process::ExitStatus) -> CpExit {
+    #[cfg(unix)]
+    let signal = {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal()
+    };
+    #[cfg(not(unix))]
+    let signal: Option<i32> = None;
+    CpExit {
+        code: status.code(),
+        signal,
+    }
+}
+
+/// Map a spawn-failure `io::Error` to the Node errno-style `code` string.
+fn cp_io_error_code(e: &std::io::Error) -> &'static str {
+    use std::io::ErrorKind;
+    match e.kind() {
+        ErrorKind::NotFound => "ENOENT",
+        ErrorKind::PermissionDenied => "EACCES",
+        ErrorKind::AlreadyExists => "EEXIST",
+        ErrorKind::BrokenPipe => "EPIPE",
+        ErrorKind::TimedOut => "ETIMEDOUT",
+        ErrorKind::ConnectionRefused => "ECONNREFUSED",
+        _ => "UNKNOWN",
+    }
+}
+
+/// Node's `errno` is the negative libc errno value for the failure code.
+fn cp_errno_number(code: &str) -> f64 {
+    #[cfg(unix)]
+    let n = match code {
+        "ENOENT" => libc::ENOENT,
+        "EACCES" => libc::EACCES,
+        "EEXIST" => libc::EEXIST,
+        "EPIPE" => libc::EPIPE,
+        "ETIMEDOUT" => libc::ETIMEDOUT,
+        "ECONNREFUSED" => libc::ECONNREFUSED,
+        _ => 0,
+    };
+    #[cfg(not(unix))]
+    let n = 0;
+    -(n as f64)
+}
+
+/// Outcome of running a child to completion (buffered).
+struct CpRun {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    code: Option<i32>,
+    signal: Option<i32>,
+    pid: Option<u32>,
+    /// `Some((code, message))` when the child could not be spawned at all.
+    spawn_error: Option<(&'static str, String)>,
+}
+
+impl CpRun {
+    fn success(&self) -> bool {
+        self.spawn_error.is_none() && self.code == Some(0)
+    }
+}
+
+/// Spawn `command` with piped stdout/stderr (and a closed stdin so children
+/// that read stdin see EOF instead of blocking), run it to completion, and
+/// capture stdout/stderr/exit/pid. Used by the synchronous + buffered-callback
+/// entry points.
+fn cp_run_to_completion(mut command: Command) -> CpRun {
+    command.stdin(Stdio::null());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+    match command.spawn() {
+        Ok(child) => {
+            let pid = child.id();
+            match child.wait_with_output() {
+                Ok(o) => {
+                    let CpExit { code, signal } = cp_decode_status(&o.status);
+                    CpRun {
+                        stdout: o.stdout,
+                        stderr: o.stderr,
+                        code,
+                        signal,
+                        pid: Some(pid),
+                        spawn_error: None,
+                    }
+                }
+                Err(e) => CpRun {
+                    stdout: Vec::new(),
+                    stderr: Vec::new(),
+                    code: None,
+                    signal: None,
+                    pid: Some(pid),
+                    spawn_error: Some((cp_io_error_code(&e), e.to_string())),
+                },
+            }
+        }
+        Err(e) => CpRun {
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+            code: None,
+            signal: None,
+            pid: None,
+            spawn_error: Some((cp_io_error_code(&e), e.to_string())),
+        },
+    }
+}
+
+/// Build an error-like heap object. `ErrorHeader` rejects dynamic-property
+/// writes, so for the rich shape Node attaches we use a regular object whose
+/// class extends `Error` (so `instanceof Error` / `typeof` still report
+/// error-ish) and set the props by name. Returns a NaN-boxed pointer.
+fn cp_make_error(message: &str, extra: &[(&str, f64)]) -> f64 {
+    static REGISTER_ERROR: std::sync::Once = std::sync::Once::new();
+    REGISTER_ERROR.call_once(|| {
+        crate::object::js_register_class_extends_error(crate::error::CLASS_ID_ERROR);
+    });
+    let obj =
+        crate::object::js_object_alloc(crate::error::CLASS_ID_ERROR, (extra.len() + 2) as u32);
+    let set = |key: &str, value: f64| {
+        let kp = js_string_from_bytes(key.as_ptr(), key.len() as u32);
+        js_object_set_field_by_name(obj, kp, value);
+    };
+    set("name", cp_box_string("Error"));
+    set("message", cp_box_string(message));
+    // `name`/`message` are non-enumerable on a Node Error (only the diagnostic
+    // props are enumerable), so keep them out of `Object.keys(err)`.
+    let attrs = crate::object::PropertyAttrs::new(true, false, true);
+    crate::object::set_property_attrs(obj as usize, "name".to_string(), attrs);
+    crate::object::set_property_attrs(obj as usize, "message".to_string(), attrs);
+    for (k, v) in extra {
+        set(k, *v);
+    }
+    cp_box_ptr(obj as *const u8)
+}
+
+/// `[null, stdout, stderr]` — the Node `output` array shared by spawnSync and
+/// the execSync throw error.
+fn cp_output_array(stdout: f64, stderr: f64) -> f64 {
+    let mut arr = crate::array::js_array_alloc(3);
+    arr = crate::array::js_array_push_f64(arr, TAG_NULL_F64);
+    arr = crate::array::js_array_push_f64(arr, stdout);
+    arr = crate::array::js_array_push_f64(arr, stderr);
+    cp_box_ptr(arr as *const u8)
+}
+
+/// The `(code, signal, killed)` callback-error fields, matching Node: `code` is
+/// the numeric exit code, or the signal name when the child was killed by a
+/// signal (and on spawn failure, the errno string); `signal` is the signal name
+/// or `null`; `killed` is `true` only when terminated by a signal.
+fn cp_error_code_signal(run: &CpRun) -> (f64, f64, f64) {
+    if let Some((errno_code, _)) = run.spawn_error {
+        return (cp_box_string(errno_code), TAG_NULL_F64, TAG_FALSE_F64);
+    }
+    match (run.code, run.signal) {
+        (_, Some(sig)) => {
+            let name = cp_box_string(cp_signal_name(sig));
+            (name, name, TAG_TRUE_F64)
+        }
+        (Some(c), None) => (c as f64, TAG_NULL_F64, TAG_FALSE_F64),
+        (None, None) => (TAG_NULL_F64, TAG_NULL_F64, TAG_FALSE_F64),
+    }
+}
+
+/// Build the `(err, stdout, stderr)` callback error for a failed exec/execFile
+/// run — Node attaches `code`/`signal`/`killed`/`cmd` (plus `errno`/`syscall`/
+/// `path` on spawn failure). `cmd` is the human-readable command string. #1935.
+fn cp_exec_callback_error(run: &CpRun, cmd: &str) -> f64 {
+    if let Some((errno_code, _)) = run.spawn_error {
+        let syscall = format!("spawn {cmd}");
+        let message = format!("{syscall} {errno_code}");
+        return cp_make_error(
+            &message,
+            &[
+                ("code", cp_box_string(errno_code)),
+                ("errno", cp_errno_number(errno_code)),
+                ("syscall", cp_box_string(&syscall)),
+                ("path", cp_box_string(cmd)),
+                ("cmd", cp_box_string(cmd)),
+                ("killed", TAG_FALSE_F64),
+                ("signal", TAG_NULL_F64),
+            ],
+        );
+    }
+    let (code, signal, killed) = cp_error_code_signal(run);
+    // Node's message is `Command failed: <cmd>\n<stderr>`.
+    let message = format!(
+        "Command failed: {cmd}\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    cp_make_error(
+        &message,
+        &[
+            ("code", code),
+            ("signal", signal),
+            ("killed", killed),
+            ("cmd", cp_box_string(cmd)),
+        ],
+    )
+}
+
+/// Throw the error Node raises from a failed execSync/execFileSync — carries
+/// `status`/`signal`/`pid`/`output`/`stdout`/`stderr`/`cmd`. Diverges. #1938.
+fn cp_sync_throw_error(run: &CpRun, cmd: &str, stdout: f64, stderr: f64) -> ! {
+    let status = match run.code {
+        Some(c) => c as f64,
+        None => TAG_NULL_F64,
+    };
+    let signal = match run.signal {
+        Some(s) => cp_box_string(cp_signal_name(s)),
+        None => TAG_NULL_F64,
+    };
+    let pid = match run.pid {
+        Some(p) => p as f64,
+        None => TAG_NULL_F64,
+    };
+    let output = cp_output_array(stdout, stderr);
+    // Node's execSync/execFileSync error enumerates exactly
+    // status/signal/output/pid/stdout/stderr (no `cmd` own prop — that is on the
+    // async exec callback error). The command is still surfaced in `message`.
+    let message = match &run.spawn_error {
+        Some((code, _)) => format!("Command failed: {cmd} {code}"),
+        None => format!("Command failed: {cmd}"),
+    };
+    let err = cp_make_error(
+        &message,
+        &[
+            ("status", status),
+            ("signal", signal),
+            ("pid", pid),
+            ("output", output),
+            ("stdout", stdout),
+            ("stderr", stderr),
+        ],
+    );
+    crate::exception::js_throw(err)
+}
+
+/// `file arg1 arg2…` — the human-readable command string Node uses for the
+/// execFile error `.cmd`.
+fn cp_file_cmd_display(file: &str, args: &[String]) -> String {
+    if args.is_empty() {
+        file.to_string()
+    } else {
+        format!("{} {}", file, args.join(" "))
+    }
+}
+
 /// `child_process.execFile(file[, args][, options][, callback])` — like `exec`
 /// but runs `file` directly (no shell). The callback fires with
-/// `(err, stdout, stderr)`; with no callback the stdout string is returned.
-/// The callback may sit in the options slot (`execFile(file, args, cb)`), so it
-/// is located the same way `exec` disambiguates. #1780.
+/// `(err, stdout, stderr)`; with no callback the stdout (Buffer/string per
+/// `encoding`) is returned. The callback may sit in the options slot
+/// (`execFile(file, args, cb)`), so it is located the same way `exec`
+/// disambiguates. On failure the error carries `code`/`signal`/`killed`/`cmd`.
+/// #1780/#1935/#1937.
 #[no_mangle]
 pub extern "C" fn js_child_process_exec_file(
     file_ptr: i64,
@@ -1333,61 +1550,65 @@ pub extern "C" fn js_child_process_exec_file(
             extract_closure_ptr(opts_val)
         }
     };
-    let box_string = |bytes: &[u8]| -> f64 {
-        let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
-        crate::value::js_nanbox_string(ptr as i64)
-    };
 
     let file_str = unsafe { cp_read_string_header(file_ptr) };
     let arg_strs = cp_args_from_value(args_val);
+    // execFile defaults to utf8 (callback stdout/stderr are strings).
+    let mode = cp_read_output_mode(opts_val, true);
 
     // `cwd`/`env` come from the options slot; when `opts_val` is the callback
     // (`execFile(file, args, cb)`) it's a closure, so the helper no-ops.
     let mut command = Command::new(&file_str);
     command.args(&arg_strs);
     cp_apply_options(&mut command, opts_val);
-    let (stdout_bytes, stderr_bytes, success) = match command.output() {
-        Ok(o) => (o.stdout, o.stderr, o.status.success()),
-        Err(e) => (Vec::new(), e.to_string().into_bytes(), false),
-    };
+    let run = cp_run_to_completion(command);
 
-    let stdout_box = box_string(&stdout_bytes);
+    let stdout_box = cp_box_output(&run.stdout, &mode);
     if cb.is_null() {
         return stdout_box;
     }
-    let stderr_box = box_string(&stderr_bytes);
-    let err_val = if success {
+    let stderr_box = cp_box_output(&run.stderr, &mode);
+    let err_val = if run.success() {
         TAG_NULL_F64
     } else {
-        let msg = "Command failed";
-        let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-        let err_ptr = crate::error::js_error_new_with_message(msg_ptr);
-        crate::value::js_nanbox_pointer(err_ptr as i64)
+        cp_exec_callback_error(&run, &cp_file_cmd_display(&file_str, &arg_strs))
     };
     crate::closure::js_closure_call3(cb, err_val, stdout_box, stderr_box);
     f64::from_bits(TAG_UNDEFINED_BITS)
 }
 
 /// `child_process.execFileSync(file[, args][, options])` — runs `file`
-/// directly (no shell) and returns its stdout. #1780.
+/// directly (no shell) and returns its stdout (Buffer by default, string with
+/// an `encoding` option). Throws on a non-zero exit / spawn failure, carrying
+/// the same shape as `execSync`. Returns a NaN-boxed value. #1780/#1937/#1938.
 #[no_mangle]
 pub extern "C" fn js_child_process_exec_file_sync(
     file_ptr: i64,
     args_val: f64,
     opts_val: f64,
-) -> *mut StringHeader {
+) -> f64 {
     let file_str = unsafe { cp_read_string_header(file_ptr) };
+    let mode = cp_read_output_mode(opts_val, false);
     if file_str.is_empty() {
-        return js_string_from_bytes(b"".as_ptr(), 0);
+        return cp_box_output(b"", &mode);
     }
     let arg_strs = cp_args_from_value(args_val);
     let mut command = Command::new(&file_str);
     command.args(&arg_strs);
     cp_apply_options(&mut command, opts_val);
-    match command.output() {
-        Ok(o) => js_string_from_bytes(o.stdout.as_ptr(), o.stdout.len() as u32),
-        Err(_) => js_string_from_bytes(b"".as_ptr(), 0),
+    let run = cp_run_to_completion(command);
+
+    let stdout_box = cp_box_output(&run.stdout, &mode);
+    if run.success() {
+        return stdout_box;
     }
+    let stderr_box = cp_box_output(&run.stderr, &mode);
+    cp_sync_throw_error(
+        &run,
+        &cp_file_cmd_display(&file_str, &arg_strs),
+        stdout_box,
+        stderr_box,
+    );
 }
 
 // ============================================================================
@@ -1493,9 +1714,46 @@ mod tests {
         let cmd_ptr = js_string_from_bytes(cmd.as_ptr(), cmd.len() as u32);
         let result = js_child_process_exec_sync(cmd_ptr, std::ptr::null());
 
-        assert!(!result.is_null());
+        // #1937: execSync returns a Buffer by default; verify it carries the
+        // echoed bytes.
+        assert!(JSValue::from_bits(result.to_bits()).is_pointer());
+        let buf =
+            (result.to_bits() & crate::value::POINTER_MASK) as *const crate::buffer::BufferHeader;
+        assert!(!buf.is_null());
         unsafe {
-            assert!((*result).byte_len > 0);
+            assert!((*buf).length > 0);
         }
+    }
+
+    #[test]
+    fn test_spawn_sync_result_fields() {
+        // #1936: spawnSync result carries pid / output / stdout / stderr /
+        // status / signal.
+        let cmd = "echo";
+        let cmd_ptr = js_string_from_bytes(cmd.as_ptr(), cmd.len() as u32);
+        let args = crate::array::js_array_alloc(1);
+        let hi = js_string_from_bytes(b"hi".as_ptr(), 2);
+        crate::array::js_array_push_f64(args, crate::value::js_nanbox_string(hi as i64));
+
+        let result = js_child_process_spawn_sync(cmd_ptr, args, std::ptr::null());
+        assert!(!result.is_null());
+        let get = |name: &[u8]| -> f64 {
+            let k = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            js_object_get_field_by_name_f64(result, k)
+        };
+        // status should be the numeric exit code 0.
+        assert_eq!(get(b"status"), 0.0);
+        // pid is a positive number.
+        assert!(get(b"pid") > 0.0);
+        // output / stdout / stderr are present (pointers, not undefined).
+        for f in [
+            b"output".as_slice(),
+            b"stdout".as_slice(),
+            b"stderr".as_slice(),
+        ] {
+            assert!(JSValue::from_bits(get(f).to_bits()).is_pointer());
+        }
+        // signal is null on a clean exit.
+        assert_eq!(get(b"signal").to_bits(), TAG_NULL_BITS);
     }
 }

--- a/crates/perry-runtime/src/child_process/reactor.rs
+++ b/crates/perry-runtime/src/child_process/reactor.rs
@@ -1,0 +1,702 @@
+//! Async subprocess reactor for `child_process.spawn` — #1934.
+//!
+//! The buffered `spawn` (pre-#1934) ran the child to completion synchronously
+//! and replayed a single `data` chunk + `exit`/`close` on the next tick. That
+//! is observationally correct for short commands but precludes a *live* child:
+//! `stdin.write()` had nothing to write to, `kill()` had nothing to signal, and
+//! stdout arrived in one post-exit lump.
+//!
+//! This reactor launches the child without blocking and wires three background
+//! threads per child:
+//!   * a stdout reader and a stderr reader that read pipe chunks and push them
+//!     onto [`CP_EVENT_QUEUE`], and
+//!   * a waiter that blocks on `Child::wait()` and pushes the exit status.
+//! Each producer calls [`js_notify_main_thread`] so the event loop wakes
+//! immediately. The main-thread [`cp_reactor_pump`] (driven from
+//! `js_run_stdlib_pump`, which both the end-of-main event loop and the `await`
+//! poll loop call) drains the queue, builds `Buffer`s, and emits `spawn` /
+//! `data` / `end` / `exit` / `close` on the ChildProcess. Live children keep
+//! the event loop alive via [`cp_reactor_has_live`] (wired into
+//! `js_stdlib_has_active_handles`).
+//!
+//! Background threads never touch JSValues (those are thread-local); they move
+//! only raw bytes / exit codes across the boundary. The ChildProcess object is
+//! kept reachable across ticks by [`cp_reactor_scan_roots_mut`], a registered
+//! GC mutable-root scanner.
+
+use std::collections::HashMap;
+use std::io::{BufRead, Read, Write};
+use std::process::{Child, ChildStdin, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, PoisonError};
+
+// Brings in the `cp_*` helpers, `CpFn`, `CP_SHAPE_ID`, the `TAG_*` consts, and
+// (since this is a descendant module) `mod.rs`'s `use` bindings such as
+// `ClosureHeader` / `JSValue`.
+use super::*;
+
+/// Monotonic registry key for live children.
+static CP_NEXT_LIVE_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Number of live (spawned, not-yet-`close`d) children. A lock-free fast-path
+/// gate: the pump and the active-handle check both bail on zero without taking
+/// any lock, so the hot async loop pays a single relaxed load per tick.
+static CP_LIVE_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// An event produced by a child's background thread, consumed by the pump.
+enum CpEvent {
+    /// A stdout (`stderr == false`) or stderr chunk.
+    Data {
+        handle: u64,
+        stderr: bool,
+        bytes: Vec<u8>,
+    },
+    /// End-of-file on a stream — the reader thread finished.
+    Eof { handle: u64, stderr: bool },
+    /// The child process terminated (`code` xor `signal`).
+    Exited {
+        handle: u64,
+        code: Option<i32>,
+        signal: Option<i32>,
+    },
+    /// #1933: one IPC line (`process.send` on the child side) — raw JSON to be
+    /// parsed + delivered as a `'message'` event on the main thread.
+    Message { handle: u64, json: String },
+    /// #1933: the IPC channel closed (child disconnected or exited) — flip
+    /// `connected`/`channel` and emit `'disconnect'`.
+    IpcClosed { handle: u64 },
+}
+
+static CP_EVENT_QUEUE: Mutex<Vec<CpEvent>> = Mutex::new(Vec::new());
+
+/// Per-child reactor state. The `Child` itself is owned by the waiter thread
+/// (so reaping blocks off the main thread); here we keep only what the main
+/// thread needs: the GC-rooted ChildProcess value, the live `pid` for
+/// `kill()`, the writable `stdin`, and progress flags.
+struct LiveChild {
+    /// NaN-boxed ChildProcess object — a GC root (see `cp_reactor_scan_roots_mut`).
+    cp_bits: u64,
+    pid: i32,
+    stdin: Option<ChildStdin>,
+    stdout_open: bool,
+    stderr_open: bool,
+    /// Whether the `spawn` event has been emitted yet.
+    spawned: bool,
+    /// `Some((code, signal))` once the waiter reported termination.
+    exited: Option<(Option<i32>, Option<i32>)>,
+    /// Whether `exit`/`close` have been emitted (terminal state).
+    closed: bool,
+    /// #1933: the parent end of the IPC socket for a `fork()`ed child (a clone
+    /// for `child.send()` / `child.disconnect()`; the reader thread owns
+    /// another clone). `None` for plain `spawn`.
+    ipc_send: Option<std::os::unix::net::UnixStream>,
+}
+
+static CP_LIVE: Mutex<Option<HashMap<u64, LiveChild>>> = Mutex::new(None);
+
+thread_local! {
+    /// Re-entrancy guard — an emitted handler may itself drive the event loop
+    /// (`await`), which re-enters `js_run_stdlib_pump` → `cp_reactor_pump`.
+    static CP_PUMPING: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[inline]
+fn cp_live_lock() -> std::sync::MutexGuard<'static, Option<HashMap<u64, LiveChild>>> {
+    CP_LIVE.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+#[inline]
+fn cp_queue_lock() -> std::sync::MutexGuard<'static, Vec<CpEvent>> {
+    CP_EVENT_QUEUE
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
+fn cp_push_event(ev: CpEvent) {
+    cp_queue_lock().push(ev);
+    crate::event_pump::js_notify_main_thread();
+}
+
+/// Spawn a reader thread that streams `pipe` to the event queue until EOF.
+fn cp_spawn_reader<R: Read + Send + 'static>(handle: u64, mut pipe: R, stderr: bool) {
+    std::thread::spawn(move || {
+        let mut buf = [0u8; 8192];
+        loop {
+            match pipe.read(&mut buf) {
+                Ok(0) | Err(_) => {
+                    cp_push_event(CpEvent::Eof { handle, stderr });
+                    break;
+                }
+                Ok(n) => {
+                    cp_push_event(CpEvent::Data {
+                        handle,
+                        stderr,
+                        bytes: buf[..n].to_vec(),
+                    });
+                }
+            }
+        }
+    });
+}
+
+/// Spawn the waiter thread that reaps `child` and reports its exit status.
+fn cp_spawn_waiter(handle: u64, mut child: Child) {
+    std::thread::spawn(move || {
+        let (code, signal) = match child.wait() {
+            Ok(status) => {
+                #[cfg(unix)]
+                let signal = {
+                    use std::os::unix::process::ExitStatusExt;
+                    status.signal()
+                };
+                #[cfg(not(unix))]
+                let signal: Option<i32> = None;
+                (status.code(), signal)
+            }
+            Err(_) => (Some(-1), None),
+        };
+        cp_push_event(CpEvent::Exited {
+            handle,
+            code,
+            signal,
+        });
+    });
+}
+
+/// IPC reader (#1933): read newline-delimited JSON from the parent socket and
+/// push each line for main-thread parse + `'message'` delivery.
+fn cp_spawn_ipc_reader(handle: u64, sock: std::os::unix::net::UnixStream) {
+    std::thread::spawn(move || {
+        let reader = std::io::BufReader::new(sock);
+        for line in reader.lines() {
+            match line {
+                Ok(l) if !l.is_empty() => cp_push_event(CpEvent::Message { handle, json: l }),
+                Ok(_) => {} // blank keep-alive line
+                Err(_) => break,
+            }
+        }
+        // Channel closed (child disconnected / exited).
+        cp_push_event(CpEvent::IpcClosed { handle });
+    });
+}
+
+/// Register a freshly-spawned child: take its stdio pipes, insert the registry
+/// entry (with the optional IPC socket for `fork`), start the reader/waiter (+
+/// IPC reader) threads, and set `pid`/`__cpHandle` on the ChildProcess + stdio
+/// sub-objects. Shared by `spawn` (#1934) and `fork` (#1933). Returns the
+/// registry handle.
+pub(super) fn cp_register_live_child(
+    cp: f64,
+    stdout_obj: f64,
+    stderr_obj: f64,
+    stdin_obj: f64,
+    mut child: Child,
+    ipc: Option<std::os::unix::net::UnixStream>,
+) -> u64 {
+    let pid = child.id();
+    cp_set_field(cp, b"pid", pid as f64);
+
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let stdin_pipe = child.stdin.take();
+    let stdout_open = stdout_pipe.is_some();
+    let stderr_open = stderr_pipe.is_some();
+
+    let handle = CP_NEXT_LIVE_ID.fetch_add(1, Ordering::SeqCst);
+    let handle_f = handle as f64;
+    cp_set_field(cp, b"__cpHandle", handle_f);
+    cp_set_field(stdin_obj, b"__cpHandle", handle_f);
+    cp_set_field(stdout_obj, b"__cpHandle", handle_f);
+    cp_set_field(stderr_obj, b"__cpHandle", handle_f);
+
+    // For fork, keep a clone of the IPC socket for send/disconnect; the reader
+    // thread owns the original.
+    let ipc_send = ipc.as_ref().and_then(|s| s.try_clone().ok());
+
+    {
+        let mut guard = cp_live_lock();
+        let map = guard.get_or_insert_with(HashMap::new);
+        map.insert(
+            handle,
+            LiveChild {
+                cp_bits: cp.to_bits(),
+                pid: pid as i32,
+                stdin: stdin_pipe,
+                stdout_open,
+                stderr_open,
+                spawned: false,
+                exited: None,
+                closed: false,
+                ipc_send,
+            },
+        );
+    }
+    CP_LIVE_COUNT.fetch_add(1, Ordering::SeqCst);
+
+    if let Some(o) = stdout_pipe {
+        cp_spawn_reader(handle, o, false);
+    }
+    if let Some(e) = stderr_pipe {
+        cp_spawn_reader(handle, e, true);
+    }
+    cp_spawn_waiter(handle, child);
+    if let Some(sock) = ipc {
+        cp_spawn_ipc_reader(handle, sock);
+    }
+    // Wake the loop so 'spawn' fires on the next tick.
+    crate::event_pump::js_notify_main_thread();
+    handle
+}
+
+/// `child.send(message)` — serialize `message` to JSON (main thread) and write
+/// it newline-delimited to the IPC socket. Returns whether the write
+/// succeeded. #1933.
+pub(super) fn cp_ipc_send(handle: u64, message: f64) -> bool {
+    let sh = unsafe { crate::json::js_json_stringify(message, 0) };
+    if sh.is_null() {
+        return false;
+    }
+    let mut line = unsafe {
+        let len = (*sh).byte_len as usize;
+        let data = (sh as *const u8).add(std::mem::size_of::<StringHeader>());
+        std::slice::from_raw_parts(data, len).to_vec()
+    };
+    line.push(b'\n');
+    let mut guard = cp_live_lock();
+    if let Some(map) = guard.as_mut() {
+        if let Some(lc) = map.get_mut(&handle) {
+            if let Some(sock) = lc.ipc_send.as_mut() {
+                return sock.write_all(&line).is_ok();
+            }
+        }
+    }
+    false
+}
+
+/// `child.disconnect()` — shut the IPC socket down (the reader thread then sees
+/// EOF and exits). Returns whether a channel was present. #1933.
+pub(super) fn cp_ipc_disconnect(handle: u64) -> bool {
+    let mut guard = cp_live_lock();
+    if let Some(map) = guard.as_mut() {
+        if let Some(lc) = map.get_mut(&handle) {
+            if let Some(sock) = lc.ipc_send.take() {
+                let _ = sock.shutdown(std::net::Shutdown::Both);
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// `child_process.spawn(command[, args][, options])` — returns a live streaming
+/// ChildProcess (#1934). `cmd_ptr`/`args_ptr` are raw (unboxed) `StringHeader`
+/// / `ArrayHeader` pointers; `opts_ptr` is a raw heap pointer (or 0). The
+/// object SHAPE matches the former buffered implementation (`pid`, `exitCode`,
+/// `signalCode`, `killed`, `connected`, `spawnargs`, `spawnfile`, `stdout`,
+/// `stderr`, `stdin`, `stdio`) plus the hidden `__cpHandle` registry key.
+#[no_mangle]
+pub extern "C" fn js_child_process_spawn_streams(
+    cmd_ptr: i64,
+    args_ptr: i64,
+    opts_ptr: i64,
+) -> f64 {
+    cp_register_arities();
+    cp_register_reactor_arities();
+
+    let (cmd_str, arg_strs) = unsafe {
+        (
+            cp_read_string_header(cmd_ptr),
+            cp_read_arg_strings(args_ptr),
+        )
+    };
+
+    // `opts_ptr` arrives as a raw (unboxed) heap pointer; re-box it so the
+    // options helpers can read `cwd`/`env`/`shell`. Small values mean
+    // no-options (codegen passes 0) — leave it undefined then.
+    let opts_val = if opts_ptr > 0x10000 {
+        cp_box_ptr(opts_ptr as *const u8)
+    } else {
+        cp_undefined()
+    };
+
+    // stdout/stderr Readable + stdin Writable sub-objects.
+    let stdout_obj = cp_build_readable();
+    let stderr_obj = cp_build_readable();
+    let stdin_obj = cp_build_writable();
+
+    // spawnargs = [command, ...args]
+    let mut spawnargs = crate::array::js_array_alloc((arg_strs.len() + 1) as u32);
+    spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(&cmd_str));
+    for a in &arg_strs {
+        spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(a));
+    }
+
+    let cp_methods: [(&str, CpFn); 11] = [
+        ("on", cp_cast2(cp_method_on)),
+        ("once", cp_cast2(cp_method_on)),
+        ("addListener", cp_cast2(cp_method_on)),
+        ("prependListener", cp_cast2(cp_method_on)),
+        ("removeListener", cp_cast2(cp_method_remove_listener)),
+        ("off", cp_cast2(cp_method_remove_listener)),
+        (
+            "removeAllListeners",
+            cp_cast1(cp_method_remove_all_listeners),
+        ),
+        ("emit", cp_cast2(cp_method_emit)),
+        ("kill", cp_cast1(cp_method_kill)),
+        ("ref", cp_cast0(cp_method_this0)),
+        ("unref", cp_cast0(cp_method_this0)),
+    ];
+    let cp_obj = cp_build_object(&cp_methods, CP_SHAPE_ID + cp_methods.len() as u32);
+    let cp = cp_box_ptr(cp_obj as *const u8);
+
+    cp_set_field(cp, b"stdout", stdout_obj);
+    cp_set_field(cp, b"stderr", stderr_obj);
+    cp_set_field(cp, b"stdin", stdin_obj);
+
+    let mut stdio = crate::array::js_array_alloc(3);
+    stdio = crate::array::js_array_push_f64(stdio, stdin_obj);
+    stdio = crate::array::js_array_push_f64(stdio, stdout_obj);
+    stdio = crate::array::js_array_push_f64(stdio, stderr_obj);
+    cp_set_field(cp, b"stdio", cp_box_ptr(stdio as *const u8));
+
+    cp_set_field(cp, b"exitCode", TAG_NULL_F64);
+    cp_set_field(cp, b"signalCode", TAG_NULL_F64);
+    cp_set_field(cp, b"killed", TAG_FALSE_F64);
+    cp_set_field(cp, b"connected", TAG_FALSE_F64);
+    cp_set_field(cp, b"spawnargs", cp_box_ptr(spawnargs as *const u8));
+    cp_set_field(cp, b"spawnfile", cp_box_string(&cmd_str));
+
+    // Build + launch the child (honoring `shell`/`cwd`/`env`), non-blocking.
+    let mut command = cp_build_command(&cmd_str, &arg_strs, opts_val);
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    match command.spawn() {
+        Ok(child) => {
+            cp_register_live_child(cp, stdout_obj, stderr_obj, stdin_obj, child, None);
+        }
+        Err(e) => {
+            // Spawn failure (e.g. ENOENT): Node emits a single `error` event and
+            // never `spawn`/`exit`. Defer it so a synchronously-registered
+            // handler is present.
+            cp_set_field(cp, b"pid", cp_undefined());
+            let msg = e.to_string();
+            let mp = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+            let err = crate::error::js_error_new_with_message(mp);
+            cp_set_field(
+                cp,
+                b"__cpError",
+                crate::value::js_nanbox_pointer(err as i64),
+            );
+            let emit_closure =
+                crate::closure::js_closure_alloc(cp_emit_spawn_error as *const u8, 1);
+            crate::closure::js_closure_set_capture_ptr(emit_closure, 0, cp.to_bits() as i64);
+            crate::timer::js_set_immediate_callback(emit_closure as i64);
+        }
+    }
+
+    cp
+}
+
+/// Deferred single-`error` emit for the spawn/fork failure path. Slot 0
+/// captures the ChildProcess value.
+pub(super) extern "C" fn cp_emit_spawn_error(closure: *const ClosureHeader) -> f64 {
+    let cp = cp_this(closure);
+    let err = cp_get_field(cp, b"__cpError");
+    if !JSValue::from_bits(err.to_bits()).is_undefined() {
+        cp_emit(cp, "error", &[err]);
+    }
+    cp_undefined()
+}
+
+pub(super) fn cp_register_reactor_arities() {
+    crate::closure::js_register_closure_arity(cp_emit_spawn_error as *const u8, 0);
+}
+
+// ============================================================================
+// Main-thread pump
+// ============================================================================
+
+/// Drive the reactor one tick: emit pending `spawn`/`data`/`end`/`exit`/`close`
+/// for all live children. Called from `js_run_stdlib_pump`.
+pub(crate) fn cp_reactor_pump() {
+    if CP_LIVE_COUNT.load(Ordering::Relaxed) == 0 {
+        return;
+    }
+    if CP_PUMPING.with(|p| p.replace(true)) {
+        return; // already pumping (re-entrant await inside a handler)
+    }
+    cp_reactor_pump_inner();
+    CP_PUMPING.with(|p| p.set(false));
+}
+
+fn cp_reactor_pump_inner() {
+    // --- Phase 0: emit `spawn` for newly-registered children. ---
+    // Snapshot under a brief lock, then emit OUTSIDE the lock (emit calls user
+    // callbacks which allocate / can trigger GC; the GC root scanner also locks
+    // CP_LIVE, so holding it across an allocation would deadlock the same
+    // thread).
+    let to_spawn: Vec<(u64, u64)> = {
+        let guard = cp_live_lock();
+        match guard.as_ref() {
+            Some(map) => map
+                .iter()
+                .filter(|(_, lc)| !lc.spawned)
+                .map(|(h, lc)| (*h, lc.cp_bits))
+                .collect(),
+            None => Vec::new(),
+        }
+    };
+    for (handle, cp_bits) in to_spawn {
+        cp_emit(f64::from_bits(cp_bits), "spawn", &[]);
+        if let Some(map) = cp_live_lock().as_mut() {
+            if let Some(lc) = map.get_mut(&handle) {
+                lc.spawned = true;
+            }
+        }
+    }
+
+    // --- Phase A: drain queued data/eof/exited events. ---
+    let events = std::mem::take(&mut *cp_queue_lock());
+    for ev in events {
+        match ev {
+            CpEvent::Data {
+                handle,
+                stderr,
+                bytes,
+            } => {
+                if let Some(cp_bits) = cp_lookup_cp_bits(handle) {
+                    let cp = f64::from_bits(cp_bits);
+                    let stream = cp_get_field(cp, cp_stream_field(stderr));
+                    if super::cp_object_ptr(stream).is_some() {
+                        let buf = cp_make_buffer(&bytes);
+                        cp_emit(stream, "data", &[buf]);
+                    }
+                }
+            }
+            CpEvent::Eof { handle, stderr } => {
+                if let Some(map) = cp_live_lock().as_mut() {
+                    if let Some(lc) = map.get_mut(&handle) {
+                        if stderr {
+                            lc.stderr_open = false;
+                        } else {
+                            lc.stdout_open = false;
+                        }
+                    }
+                }
+                if let Some(cp_bits) = cp_lookup_cp_bits(handle) {
+                    let cp = f64::from_bits(cp_bits);
+                    let stream = cp_get_field(cp, cp_stream_field(stderr));
+                    if super::cp_object_ptr(stream).is_some() {
+                        cp_emit(stream, "end", &[]);
+                    }
+                }
+            }
+            CpEvent::Exited {
+                handle,
+                code,
+                signal,
+            } => {
+                if let Some(map) = cp_live_lock().as_mut() {
+                    if let Some(lc) = map.get_mut(&handle) {
+                        lc.exited = Some((code, signal));
+                    }
+                }
+            }
+            CpEvent::Message { handle, json } => {
+                // #1933: parse the IPC line on the main thread and deliver it as
+                // a `'message'` event on the ChildProcess.
+                if let Some(cp_bits) = cp_lookup_cp_bits(handle) {
+                    let cp = f64::from_bits(cp_bits);
+                    let sh = crate::string::js_string_from_bytes(json.as_ptr(), json.len() as u32);
+                    let msg = f64::from_bits(unsafe { crate::json::js_json_parse(sh) }.bits());
+                    cp_emit(cp, "message", &[msg]);
+                }
+            }
+            CpEvent::IpcClosed { handle } => {
+                // #1933: child disconnected / exited — flip connected/channel
+                // and emit `disconnect` once.
+                if let Some(cp_bits) = cp_lookup_cp_bits(handle) {
+                    let cp = f64::from_bits(cp_bits);
+                    if cp_get_field(cp, b"connected").to_bits() == TAG_TRUE_F64.to_bits() {
+                        cp_set_field(cp, b"connected", TAG_FALSE_F64);
+                        cp_set_field(cp, b"channel", TAG_NULL_F64);
+                        if let Some(map) = cp_live_lock().as_mut() {
+                            if let Some(lc) = map.get_mut(&handle) {
+                                lc.ipc_send = None;
+                            }
+                        }
+                        cp_emit(cp, "disconnect", &[]);
+                    }
+                }
+            }
+        }
+    }
+
+    // --- Phase B: emit `exit`+`close` once a child has exited AND both
+    // streams have hit EOF, so all `data`/`end` have already fired. ---
+    let to_close: Vec<(u64, u64, Option<i32>, Option<i32>)> = {
+        let mut guard = cp_live_lock();
+        let mut out = Vec::new();
+        if let Some(map) = guard.as_mut() {
+            for (h, lc) in map.iter_mut() {
+                if lc.closed || !lc.spawned {
+                    continue;
+                }
+                if let Some((code, signal)) = lc.exited {
+                    if !lc.stdout_open && !lc.stderr_open {
+                        lc.closed = true;
+                        out.push((*h, lc.cp_bits, code, signal));
+                    }
+                }
+            }
+        }
+        out
+    };
+    for (handle, cp_bits, code, signal) in to_close {
+        let cp = f64::from_bits(cp_bits);
+        let code_f = code.map(|c| c as f64).unwrap_or(TAG_NULL_F64);
+        let signal_f = signal
+            .map(|s| cp_box_string(cp_signal_name(s)))
+            .unwrap_or(TAG_NULL_F64);
+        // Node populates exitCode/signalCode before emitting `exit`, then `close`.
+        cp_set_field(cp, b"exitCode", code_f);
+        cp_set_field(cp, b"signalCode", signal_f);
+        cp_emit(cp, "exit", &[code_f, signal_f]);
+        cp_emit(cp, "close", &[code_f, signal_f]);
+        if let Some(map) = cp_live_lock().as_mut() {
+            map.remove(&handle);
+        }
+        CP_LIVE_COUNT.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+#[inline]
+fn cp_stream_field(stderr: bool) -> &'static [u8] {
+    if stderr {
+        b"stderr"
+    } else {
+        b"stdout"
+    }
+}
+
+fn cp_lookup_cp_bits(handle: u64) -> Option<u64> {
+    cp_live_lock()
+        .as_ref()
+        .and_then(|map| map.get(&handle).map(|lc| lc.cp_bits))
+}
+
+// ============================================================================
+// Live `stdin.write()` / `kill()` — called from the mod.rs method bodies.
+// ============================================================================
+
+/// Write `bytes` to a live child's stdin. Returns whether the write succeeded.
+pub(super) fn cp_live_stdin_write(handle: u64, bytes: &[u8]) -> bool {
+    let mut guard = cp_live_lock();
+    if let Some(map) = guard.as_mut() {
+        if let Some(lc) = map.get_mut(&handle) {
+            if let Some(stdin) = lc.stdin.as_mut() {
+                return stdin.write_all(bytes).is_ok();
+            }
+        }
+    }
+    false
+}
+
+/// Close a live child's stdin (`stdin.end()`), dropping the pipe so the child
+/// sees EOF. No-op if already closed / unknown.
+pub(super) fn cp_live_stdin_close(handle: u64) {
+    if let Some(map) = cp_live_lock().as_mut() {
+        if let Some(lc) = map.get_mut(&handle) {
+            lc.stdin = None;
+        }
+    }
+}
+
+/// Signal a live child. `signal` is the JS `kill([signal])` argument (a signal
+/// name string, a number, or — for the no-arg / default case — undefined or the
+/// `0.0` arg-padding, both treated as `SIGTERM`). Returns whether the signal
+/// was delivered.
+pub(super) fn cp_live_kill(handle: u64, signal: f64) -> bool {
+    let pid = {
+        let guard = cp_live_lock();
+        match guard.as_ref().and_then(|map| map.get(&handle)) {
+            // Skip if already reaped — the pid may have been recycled by the OS.
+            Some(lc) if lc.exited.is_none() => lc.pid,
+            _ => return false,
+        }
+    };
+    #[cfg(unix)]
+    {
+        let signum = cp_parse_signal(signal);
+        unsafe { libc::kill(pid, signum) == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+/// Map a JS `kill` signal argument to a Unix signal number. Default / no-arg
+/// (`undefined` or the `0.0` padding) → `SIGTERM`.
+#[cfg(unix)]
+fn cp_parse_signal(signal: f64) -> i32 {
+    const SIGTERM: i32 = libc::SIGTERM;
+    if JSValue::from_bits(signal.to_bits()).is_undefined() {
+        return SIGTERM;
+    }
+    if let Some(name) = cp_value_to_string(signal) {
+        return cp_signal_number(&name).unwrap_or(SIGTERM);
+    }
+    if signal.is_finite() {
+        let n = signal as i32;
+        // 0 is the "no-arg" padding sentinel — treat as the default SIGTERM.
+        return if n == 0 { SIGTERM } else { n };
+    }
+    SIGTERM
+}
+
+/// Inverse of `super::cp_signal_name` for the common signals.
+#[cfg(unix)]
+fn cp_signal_number(name: &str) -> Option<i32> {
+    Some(match name {
+        "SIGHUP" => libc::SIGHUP,
+        "SIGINT" => libc::SIGINT,
+        "SIGQUIT" => libc::SIGQUIT,
+        "SIGABRT" => libc::SIGABRT,
+        "SIGKILL" => libc::SIGKILL,
+        "SIGTERM" => libc::SIGTERM,
+        "SIGUSR1" => libc::SIGUSR1,
+        "SIGUSR2" => libc::SIGUSR2,
+        "SIGSTOP" => libc::SIGSTOP,
+        "SIGCONT" => libc::SIGCONT,
+        _ => return None,
+    })
+}
+
+// ============================================================================
+// Event-loop integration hooks (wired from lib.rs / gc/mod.rs).
+// ============================================================================
+
+/// Whether any live child is keeping the event loop alive — OR'd into
+/// `js_stdlib_has_active_handles`.
+pub(crate) fn cp_reactor_has_live() -> bool {
+    CP_LIVE_COUNT.load(Ordering::Relaxed) > 0
+}
+
+/// GC mutable-root scanner: keep every live ChildProcess (and its reachable
+/// stdio sub-objects + listener arrays) alive across collections, and rewrite
+/// the stored pointer on evacuation.
+pub(crate) fn cp_reactor_scan_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    if CP_LIVE_COUNT.load(Ordering::Relaxed) == 0 {
+        return;
+    }
+    if let Some(map) = cp_live_lock().as_mut() {
+        for lc in map.values_mut() {
+            visitor.visit_nanbox_u64_slot(&mut lc.cp_bits);
+        }
+    }
+}

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -686,6 +686,11 @@ pub fn gc_init() {
     // under concurrent load) must rewrite the cell, or the body's next
     // `this`-derived dispatch derefs a relocated receiver → SIGSEGV.
     gc_register_mutable_root_scanner(crate::object::scan_implicit_this_roots_mut);
+    // #1934: live `child_process.spawn` ChildProcess objects are reachable only
+    // from the reactor's registry (the event loop holds no JSValue root for a
+    // fire-and-forget spawn). Scan + rewrite them so a GC between ticks doesn't
+    // reclaim the object whose `data`/`exit` handlers are still pending.
+    gc_register_mutable_root_scanner(crate::child_process::reactor::cp_reactor_scan_roots_mut);
     gc_register_mutable_root_scanner(json_parse_mutable_root_scanner);
     gc_register_mutable_root_scanner(intern_table_mutable_root_scanner);
     gc_register_mutable_root_scanner(small_int_cache_mutable_root_scanner);

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -240,6 +240,11 @@ mod stdlib_pump {
         // without importing any stdlib module still sees its callback
         // fire on SIGWINCH.
         crate::tty::js_tty_resize_drain();
+        // #1934: drive the child_process spawn reactor — emit pending
+        // spawn/data/end/exit/close for live children. Lives in perry-runtime,
+        // so it runs even when perry-stdlib isn't linked. Zero-cost (one relaxed
+        // atomic load) when there are no live children.
+        crate::child_process::reactor::cp_reactor_pump();
         let f = STDLIB_PUMP_FN.load(Ordering::Acquire);
         if !f.is_null() {
             unsafe {
@@ -262,6 +267,11 @@ mod stdlib_pump {
     /// async ops, etc.). Returns 0 if perry-stdlib is not linked.
     #[no_mangle]
     pub extern "C" fn js_stdlib_has_active_handles() -> i32 {
+        // #1934: a live spawn-reactor child keeps the event loop alive even when
+        // perry-stdlib isn't linked (or reports no handles).
+        if crate::child_process::reactor::cp_reactor_has_live() {
+            return 1;
+        }
         let f = STDLIB_HAS_ACTIVE_FN.load(Ordering::Acquire);
         if !f.is_null() {
             unsafe {

--- a/test-files/test_issue_1933_fork_ipc.ts
+++ b/test-files/test_issue_1933_fork_ipc.ts
@@ -1,0 +1,45 @@
+// #1933 — child_process.fork() + IPC channel: send / 'message' / disconnect /
+// connected. The forked module runs under the configured interpreter (default
+// `node`, which speaks the NODE_CHANNEL_FD IPC protocol), so this is byte-for-
+// byte vs `node --experimental-strip-types` when node is on PATH.
+import * as cp from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// A tiny IPC echo child: ping -> pong, bye -> disconnect.
+const childSrc = [
+  "process.on('message', (m) => {",
+  "  if (m && m.cmd === 'ping') process.send({ pong: m.n });",
+  "  if (m && m.cmd === 'bye') process.disconnect();",
+  "});",
+].join("\n");
+const childPath = path.join(os.tmpdir(), "perry_fork_child_" + process.pid + ".mjs");
+fs.writeFileSync(childPath, childSrc);
+
+const child = cp.fork(childPath);
+console.log("fork typeof:", typeof child);
+console.log("send typeof:", typeof child.send);
+console.log("disconnect typeof:", typeof child.disconnect);
+console.log("connected initially:", child.connected);
+
+await new Promise<void>((resolve) => {
+  const got: number[] = [];
+  child.on("message", (m: any) => {
+    got.push(m.pong);
+    if (got.length === 3) {
+      console.log("pongs:", got.join(","));
+      child.send({ cmd: "bye" });
+    }
+  });
+  child.on("exit", () => {
+    console.log("child exited; connected:", child.connected);
+    resolve();
+  });
+  child.send({ cmd: "ping", n: 1 });
+  child.send({ cmd: "ping", n: 2 });
+  child.send({ cmd: "ping", n: 3 });
+});
+
+fs.unlinkSync(childPath);
+console.log("fork done");

--- a/test-files/test_issue_1934_spawn_reactor.ts
+++ b/test-files/test_issue_1934_spawn_reactor.ts
@@ -1,0 +1,58 @@
+// #1934 — async subprocess reactor: live streaming stdout, stdin.write() to a
+// running child, and kill() on a running process. Byte-for-byte vs
+// `node --experimental-strip-types`.
+import * as cp from "node:child_process";
+
+// (1) Incremental streaming: spawn / data / end / exit / close all fire, and
+// stdout is observed before exit.
+{
+  const sp = cp.spawn("/bin/echo", ["stream-hello"]);
+  let buf = "";
+  const seen: string[] = [];
+  sp.on("spawn", () => seen.push("spawn"));
+  sp.stdout.on("data", (c: any) => {
+    buf += c.toString();
+    if (!seen.includes("data")) seen.push("data");
+  });
+  sp.stdout.on("end", () => seen.push("end"));
+  sp.on("exit", () => seen.push("exit"));
+  await new Promise<void>((resolve) => {
+    sp.on("close", () => {
+      seen.push("close");
+      resolve();
+    });
+  });
+  console.log("stream stdout:", buf.trim());
+  console.log("stream events:", seen.join(","));
+}
+
+// (2) Live stdin.write()/end() to a running `cat`, which echoes it back.
+{
+  const c = cp.spawn("/bin/cat", []);
+  let out = "";
+  c.stdout.on("data", (d: any) => {
+    out += d.toString();
+  });
+  await new Promise<void>((resolve) => {
+    c.on("close", () => resolve());
+    c.stdin.write("piped-stdin\n");
+    c.stdin.end();
+  });
+  console.log("cat echoed:", out.trim());
+}
+
+// (3) kill() a long-running child — exit reports the terminating signal.
+{
+  const s = cp.spawn("/bin/sleep", ["30"]);
+  await new Promise<void>((resolve) => {
+    s.on("exit", (code: any, signal: any) => {
+      console.log("killed code:", code, "signal:", signal);
+      resolve();
+    });
+    setTimeout(() => {
+      s.kill();
+    }, 50);
+  });
+}
+
+console.log("reactor done");

--- a/test-files/test_issue_1935_1938_exec_errors.ts
+++ b/test-files/test_issue_1935_1938_exec_errors.ts
@@ -1,0 +1,61 @@
+// #1935/#1936/#1937/#1938 — child_process exec/sync error shape, spawnSync
+// result fields, encoding option, and execSync throw-on-non-zero. Byte-for-byte
+// vs `node --experimental-strip-types`. Avoids printing pid values (per-run).
+import * as cp from "node:child_process";
+
+// #1935 — exec failure callback Error carries code/signal/killed/cmd.
+await new Promise<void>((resolve) => {
+  cp.exec("exit 3", (e: any) => {
+    console.log("exec code:", e && e.code);
+    console.log("exec signal:", e && e.signal);
+    console.log("exec killed:", e && e.killed);
+    console.log("exec cmd:", e && e.cmd);
+    console.log("exec keys:", e ? Object.keys(e).sort().join(",") : "");
+    resolve();
+  });
+});
+
+// #1935 — execFile failure Error carries code + cmd (file + args).
+await new Promise<void>((resolve) => {
+  cp.execFile("/bin/sh", ["-c", "exit 4"], (e: any) => {
+    console.log("execFile code:", e && e.code);
+    console.log("execFile cmd:", e && e.cmd);
+    resolve();
+  });
+});
+
+// #1936 — spawnSync result object fields (pid/signal/output + Buffer stdout).
+const r = cp.spawnSync("/bin/echo", ["sync-hi"]);
+console.log("spawnSync keys:", Object.keys(r).sort().join(","));
+console.log("spawnSync status:", r.status);
+console.log("spawnSync signal:", r.signal);
+console.log("spawnSync pid typeof:", typeof r.pid);
+console.log("spawnSync output len:", r.output.length);
+console.log("spawnSync output[0]:", r.output[0]);
+console.log("spawnSync stdout isBuffer:", Buffer.isBuffer(r.stdout));
+console.log("spawnSync stdout:", r.stdout.toString().trim());
+
+// #1937 — encoding option: utf8 yields strings, default yields Buffers.
+const rb = cp.spawnSync("/bin/echo", ["enc"], { encoding: "utf8" });
+console.log("spawnSync utf8 isString:", typeof rb.stdout === "string");
+console.log("spawnSync utf8 stdout:", rb.stdout.trim());
+console.log("execSync default isBuffer:", Buffer.isBuffer(cp.execSync("echo dflt")));
+const es = cp.execSync("echo enc2", { encoding: "utf8" });
+console.log("execSync utf8 isString:", typeof es === "string", es.trim());
+
+// #1938 — execSync/execFileSync throw on a non-zero exit.
+try {
+  cp.execSync("exit 5");
+  console.log("execSync did not throw (WRONG)");
+} catch (e: any) {
+  console.log("execSync threw status:", e.status);
+  console.log("execSync threw keys:", Object.keys(e).sort().join(","));
+}
+try {
+  cp.execFileSync("/bin/sh", ["-c", "exit 6"]);
+  console.log("execFileSync did not throw (WRONG)");
+} catch (e: any) {
+  console.log("execFileSync threw status:", e.status);
+}
+
+console.log("errors done");


### PR DESCRIPTION
## Summary

Completes the remaining `node:child_process` work tracked under #1780 — closes **#1933, #1934, #1935, #1936, #1937, #1938**. All six are verified **byte-for-byte against `node --experimental-strip-types`**.

## What landed

### #1934 — async subprocess reactor
`spawn()` no longer runs the child to completion synchronously. It launches non-blocking and pumps output through the event loop:
- per-child **stdout/stderr reader threads** + a **waiter thread** push events; the main-thread pump (driven from `js_run_stdlib_pump`, which both the end-of-main loop and the `await` poll loop call) emits `spawn`/`data`/`end`/`exit`/`close`.
- **`stdin.write()` / `stdin.end()`** reach a live child; **`kill(signal)`** signals a running process (Unix `kill(2)`, default `SIGTERM`).
- live children keep the loop alive (`js_stdlib_has_active_handles`) and are kept reachable by a registered **GC mutable-root scanner**.
- the existing `spawn` event/shape contract is preserved (the #1780 tests stay byte-identical).

### #1933 — fork() + IPC
`fork(modulePath[, args][, options])` returns a ChildProcess with a real IPC channel: **`send` / `on('message')` / `disconnect` / `connected` / `channel`**. The channel is a `socketpair`; the child inherits it as fd 3 with `NODE_CHANNEL_FD=3` (Node's convention), launched via a configurable interpreter (`options.execPath` → `$PERRY_FORK_EXECPATH` → `node`), so a Node child interoperates out of the box. Messages are newline-delimited JSON. Lifecycle reuses the #1934 reactor. (IPC is Unix-only.)

### #1935 — exec/execFile failure Error shape
The `(err, stdout, stderr)` callback Error now carries `code` / `signal` / `killed` / `cmd` (and `errno`/`syscall`/`path` on spawn failure). Built as an error-like object (the `Error` header rejects dynamic-property writes), with `name`/`message` non-enumerable so `Object.keys(err)` matches Node.

### #1936 — spawnSync result fields
Adds `pid`, `signal`, `output` (`[null, stdout, stderr]`), and `error` (on spawn failure).

### #1937 — encoding option
`exec`/`execFile`/`execSync`/`execFileSync`/`spawnSync` honor `encoding`: Buffers by default for the sync forms (utf8 strings for `exec`/`execFile`), decoded strings for named encodings (`hex`/`base64`/`latin1`/…).

### #1938 — execSync/execFileSync throw on non-zero exit
Now throw an Error carrying `status`/`signal`/`pid`/`output`/`stdout`/`stderr` (matching Node). **Compat note:** this changes the previously-lenient behavior (always returned stdout); programs calling `execSync` on commands that can fail without `try/catch` will now throw — matching Node.

## Notes
- `child_process.rs` was split into `child_process/{mod,reactor,fork}.rs` to stay under the file-size gate.
- `execSync`/`execFileSync` runtime ABI changed from returning a string handle to a NaN-boxed value (Buffer/string); codegen + FFI decls updated to match.
- Remaining follow-up (not required by these tickets): the *child*-side `process.send`/`process.on('message')` for when a **compiled-Perry** binary is itself the fork target (the tested/realistic fork target is `node`, which speaks `NODE_CHANNEL_FD` natively).

## Tests
New gap tests, each diffed byte-for-byte against Node:
- `test-files/test_issue_1934_spawn_reactor.ts` — live streaming, `stdin.write()`, `kill()`
- `test-files/test_issue_1935_1938_exec_errors.ts` — error fields, spawnSync fields, encoding, sync throw
- `test-files/test_issue_1933_fork_ipc.ts` — fork send/message/disconnect/connected

Existing `test_parity_child_process` + `test_issue_1780_*` + promisify tests remain byte-identical. Runtime unit tests pass; `cargo fmt --all -- --check` clean.
