### PR TITLE
fix(node): honor child_process exec buffer encoding

### DIFF
--- a/crates/perry-runtime/src/child_process.rs
+++ b/crates/perry-runtime/src/child_process.rs
@@ -559,16 +559,12 @@ pub extern "C" fn js_child_process_exec(cmd_ptr: *const StringHeader, arg1: f64,
         }
     };
 
-    let box_string = |bytes: &[u8]| -> f64 {
-        let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
-        crate::value::js_nanbox_string(ptr as i64)
-    };
-
     if cmd_ptr.is_null() {
         if cb.is_null() {
-            return box_string(b"");
+            return cp_box_output(b"", arg1);
         }
-        crate::closure::js_closure_call3(cb, TAG_NULL_F64, box_string(b""), box_string(b""));
+        let output = cp_box_output(b"", arg1);
+        crate::closure::js_closure_call3(cb, TAG_NULL_F64, output, output);
         return f64::from_bits(TAG_UNDEFINED_BITS);
     }
 
@@ -604,13 +600,13 @@ pub extern "C" fn js_child_process_exec(cmd_ptr: *const StringHeader, arg1: f64,
         }
     };
 
-    let stdout_box = box_string(&stdout_bytes);
+    let stdout_box = cp_box_output(&stdout_bytes, arg1);
     if cb.is_null() {
         // Legacy no-callback shape — return the stdout string.
         return stdout_box;
     }
 
-    let stderr_box = box_string(&stderr_bytes);
+    let stderr_box = cp_box_output(&stderr_bytes, arg1);
     let err_val = if success {
         TAG_NULL_F64
     } else {
@@ -722,6 +718,28 @@ fn cp_get_field(value: f64, name: &[u8]) -> f64 {
 fn cp_set_field(value: f64, name: &[u8], field_value: f64) {
     if let Some(obj) = cp_object_ptr(value) {
         js_object_set_field_by_name(obj, cp_str_key(name), field_value);
+    }
+}
+
+fn cp_encoding_wants_buffer(opts_val: f64) -> bool {
+    if cp_object_ptr(opts_val).is_none() {
+        return false;
+    }
+    let encoding = cp_get_field(opts_val, b"encoding");
+    if encoding.to_bits() == TAG_NULL_BITS {
+        return true;
+    }
+    match cp_value_to_string(encoding) {
+        Some(s) => s.eq_ignore_ascii_case("buffer"),
+        None => false,
+    }
+}
+
+fn cp_box_output(bytes: &[u8], opts_val: f64) -> f64 {
+    if cp_encoding_wants_buffer(opts_val) {
+        cp_make_buffer(bytes)
+    } else {
+        cp_box_string_bytes(bytes)
     }
 }
 
@@ -1394,11 +1412,6 @@ pub extern "C" fn js_child_process_exec_file(
             extract_closure_ptr(opts_val)
         }
     };
-    let box_string = |bytes: &[u8]| -> f64 {
-        let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
-        crate::value::js_nanbox_string(ptr as i64)
-    };
-
     let file_str = unsafe { cp_read_string_header(file_ptr) };
     let arg_strs = cp_args_from_value(args_val);
 
@@ -1412,11 +1425,11 @@ pub extern "C" fn js_child_process_exec_file(
         Err(e) => (Vec::new(), e.to_string().into_bytes(), false),
     };
 
-    let stdout_box = box_string(&stdout_bytes);
+    let stdout_box = cp_box_output(&stdout_bytes, opts_val);
     if cb.is_null() {
         return stdout_box;
     }
-    let stderr_box = box_string(&stderr_bytes);
+    let stderr_box = cp_box_output(&stderr_bytes, opts_val);
     let err_val = if success {
         TAG_NULL_F64
     } else {

--- a/test-parity/node-suite/child_process/async/exec-encoding-buffer.ts
+++ b/test-parity/node-suite/child_process/async/exec-encoding-buffer.ts
@@ -1,0 +1,30 @@
+import { exec, execFile } from "node:child_process";
+
+function report(label: string, err: unknown, stdout: any, stderr: any) {
+  console.log(`${label} err:`, err === null ? "null" : (err as any)?.constructor?.name);
+  console.log(`${label} stdout isBuffer:`, Buffer.isBuffer(stdout));
+  console.log(`${label} stdout ctor:`, stdout?.constructor?.name);
+  console.log(`${label} stdout text:`, stdout.toString("utf8"));
+  console.log(`${label} stdout hex:`, stdout.toString("hex"));
+  console.log(`${label} stderr isBuffer:`, Buffer.isBuffer(stderr));
+  console.log(`${label} stderr text:`, stderr.toString("utf8"));
+  console.log(`${label} stderr hex:`, stderr.toString("hex"));
+}
+
+exec("printf out; printf err >&2", { encoding: "buffer" }, (err, stdout, stderr) => {
+  report("exec-buffer", err, stdout, stderr);
+  execFile(
+    "sh",
+    ["-c", "printf file; printf ferr >&2"],
+    { encoding: null },
+    (err, stdout, stderr) => {
+      report("execFile-null", err, stdout, stderr);
+      exec("printf str; printf serr >&2", (err, stdout, stderr) => {
+        console.log("exec-default err:", err === null ? "null" : (err as any)?.constructor?.name);
+        console.log("exec-default stdout isBuffer:", Buffer.isBuffer(stdout));
+        console.log("exec-default stdout:", stdout);
+        console.log("exec-default stderr:", stderr);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Fixes part of #1937.

## Summary
- Honor async `child_process.exec()` / `execFile()` `encoding: "buffer"` and `encoding: null` for callback stdout/stderr values.
- Route those outputs through Perry's existing Buffer allocator while preserving the default string output path.
- Add a focused node-suite fixture covering `exec(..., { encoding: "buffer" })`, `execFile(..., { encoding: null })`, and default string output.

## Baseline
- Node passed Buffers for stdout/stderr under `encoding: "buffer"` and `encoding: null`.
- Perry previously passed strings, so `Buffer.isBuffer(stdout)` was false and `stdout.toString("hex")` returned the original text instead of hex bytes.

## Reference
- DeepWiki comparison saved locally only at `reference/deepwiki/deno-node-child-process-exec-encoding-buffer-2026-05-27.md`.
- Extracted invariant: default output is UTF-8 strings; `encoding: "buffer"` or `null` produces Buffer stdout/stderr; `exec` shares `execFile` encoding behavior.

## Tests
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module child_process --filter exec-encoding-buffer`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module child_process`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --filter test_parity_child_process`
- `cargo test -p perry-runtime child_process --lib`
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals
- Sync `execSync` / `execFileSync` return ABI changes.
- `spawnSync` Buffer-vs-string result output shape.
- Named non-UTF8 encodings such as `hex`, unknown-encoding fallback behavior, or full encoding validation.
- Promisified exec output, timeout/maxBuffer handling, streaming subprocess IO, kill behavior, or IPC/fork.
