### PR TITLE
fix(mysql2): build query result on the main thread, not the tokio blocking worker (worker-thread JSValue construction is UB)

### DIFF
--- a/crates/perry-ext-mysql2/src/lib.rs
+++ b/crates/perry-ext-mysql2/src/lib.rs
@@ -556,7 +556,11 @@ unsafe fn run_connection_query(
                 }
             });
         match outcome {
-            Ok(out) => promise.resolve(outcome_to_jsvalue(&out)),
+            // #1824: build the JS result on the MAIN thread. outcome_to_jsvalue
+            // allocates arrays/objects/strings, which is UB on this blocking-pool
+            // thread (worker thread-local arena → dangling on the main thread once
+            // the pooled thread idles out). `out` is plain Send Rust data.
+            Ok(out) => promise.resolve_with(move || outcome_to_jsvalue(&out)),
             Err(e) => promise.reject_string(&e),
         }
     });
@@ -749,7 +753,11 @@ unsafe fn run_pool_query(pool_handle: Handle, sql_ptr: *const u8, params_f: f64)
                 }
             });
         match outcome {
-            Ok(out) => promise.resolve(outcome_to_jsvalue(&out)),
+            // #1824: build the JS result on the MAIN thread. outcome_to_jsvalue
+            // allocates arrays/objects/strings, which is UB on this blocking-pool
+            // thread (worker thread-local arena → dangling on the main thread once
+            // the pooled thread idles out). `out` is plain Send Rust data.
+            Ok(out) => promise.resolve_with(move || outcome_to_jsvalue(&out)),
             Err(e) => promise.reject_string(&e),
         }
     });
@@ -867,7 +875,11 @@ unsafe fn run_pool_conn_query(
                 }
             });
         match outcome {
-            Ok(out) => promise.resolve(outcome_to_jsvalue(&out)),
+            // #1824: build the JS result on the MAIN thread. outcome_to_jsvalue
+            // allocates arrays/objects/strings, which is UB on this blocking-pool
+            // thread (worker thread-local arena → dangling on the main thread once
+            // the pooled thread idles out). `out` is plain Send Rust data.
+            Ok(out) => promise.resolve_with(move || outcome_to_jsvalue(&out)),
             Err(e) => promise.reject_string(&e),
         }
     });

--- a/crates/perry-ffi/src/async_runtime.rs
+++ b/crates/perry-ffi/src/async_runtime.rs
@@ -37,6 +37,15 @@ extern "C" {
     fn perry_ffi_promise_new() -> *mut Promise;
     fn perry_ffi_promise_resolve_bits(promise: *mut Promise, bits: u64);
     fn perry_ffi_promise_reject_bits(promise: *mut Promise, bits: u64);
+    // Resolve by running `invoke(ctx)` on the MAIN thread (during the
+    // resolution pump) to produce the result bits. For results that require
+    // constructing JSValues (objects/arrays/strings) — which is UB on a
+    // blocking-pool thread. See `JsPromise::resolve_with`.
+    fn perry_ffi_promise_resolve_deferred(
+        promise: *mut Promise,
+        ctx: *mut c_void,
+        invoke: extern "C" fn(*mut c_void) -> u64,
+    );
     fn perry_ffi_spawn_blocking(ctx: *mut c_void, invoke: extern "C" fn(*mut c_void));
     fn perry_ffi_spawn_blocking_with_reactor(ctx: *mut c_void, invoke: extern "C" fn(*mut c_void));
 }
@@ -137,6 +146,40 @@ impl JsPromise {
     /// or returning objects / arrays.
     pub fn resolve(self, value: crate::JsValue) {
         unsafe { perry_ffi_promise_resolve_bits(self.0, value.bits()) };
+    }
+
+    /// Resolve by building the result JSValue on the **main thread**.
+    ///
+    /// `spawn_blocking` closures run on a tokio blocking-pool thread, where
+    /// perry-runtime's thread-local arena makes constructing JSValues
+    /// (objects / arrays / hand-built strings) undefined behaviour — the
+    /// objects land in a worker arena that is freed when the pooled thread
+    /// idles out, leaving the main thread with dangling pointers (issue
+    /// #1824). Bindings that return complex values (DB row sets, parsed
+    /// payloads, …) must therefore defer the JS construction: do the Rust
+    /// work on the worker, then hand a `Send` closure here. It runs once, on
+    /// the main thread, during the resolution pump.
+    ///
+    /// `f` must be `Send` (it crosses to the main thread) and `'static`.
+    pub fn resolve_with<F>(self, f: F)
+    where
+        F: FnOnce() -> crate::JsValue + Send + 'static,
+    {
+        // Box twice for a thin pointer across the FFI boundary, mirroring
+        // `spawn_blocking`. The trampoline runs the closure on the main
+        // thread and returns the NaN-boxed result bits.
+        let boxed: Box<dyn FnOnce() -> u64 + Send> = Box::new(move || f().bits());
+        let thin: Box<Box<dyn FnOnce() -> u64 + Send>> = Box::new(boxed);
+        let ctx = Box::into_raw(thin) as *mut c_void;
+
+        extern "C" fn invoke(ctx: *mut c_void) -> u64 {
+            let thin: Box<Box<dyn FnOnce() -> u64 + Send>> =
+                unsafe { Box::from_raw(ctx as *mut Box<dyn FnOnce() -> u64 + Send>) };
+            let f: Box<dyn FnOnce() -> u64 + Send> = *thin;
+            f()
+        }
+
+        unsafe { perry_ffi_promise_resolve_deferred(self.0, ctx, invoke) };
     }
 
     /// Reject with an arbitrary [`crate::JsValue`]. Mirror of

--- a/crates/perry-stdlib/src/perry_ffi_async.rs
+++ b/crates/perry-stdlib/src/perry_ffi_async.rs
@@ -68,6 +68,32 @@ pub extern "C" fn perry_ffi_promise_reject_bits(promise: *mut perry_runtime::Pro
     async_bridge::queue_promise_resolution(promise as usize, false, bits);
 }
 
+/// `perry_ffi_promise_resolve_deferred(promise, ctx, invoke)` — resolve the
+/// promise by running `invoke(ctx)` on the MAIN thread during the resolution
+/// pump (`js_stdlib_process_pending`), using its return value as the result
+/// bits. This is the safe path for native bindings that need to *construct*
+/// JSValues (objects/arrays/strings) for the result: doing that on a tokio
+/// blocking-pool thread allocates from a worker thread-local arena that is
+/// freed when the pooled thread idles out, leaving dangling objects on the
+/// main thread (issue #1824). The worker keeps the JS-building closure boxed
+/// (carrying only `Send` Rust data) and this defers its execution to the main
+/// thread via the existing deferred-resolution queue. perry-ffi's
+/// `JsPromise::resolve_with` builds the `ctx`/`invoke` pair.
+#[no_mangle]
+pub extern "C" fn perry_ffi_promise_resolve_deferred(
+    promise: *mut perry_runtime::Promise,
+    ctx: *mut std::ffi::c_void,
+    invoke: extern "C" fn(*mut std::ffi::c_void) -> u64,
+) {
+    // `ctx` is a raw pointer (not Send); carry it as usize into the converter
+    // closure, which runs on the main thread where `invoke` decodes + runs the
+    // boxed JS-builder and returns the NaN-boxed result bits.
+    let ctx_addr = ctx as usize;
+    async_bridge::queue_deferred_resolution(promise as usize, true, move || {
+        invoke(ctx_addr as *mut std::ffi::c_void)
+    });
+}
+
 /// `perry_ffi_spawn_blocking(ctx, invoke)` — run `invoke(ctx)` on
 /// the global tokio runtime's blocking pool. The caller is expected
 /// to box a closure into `ctx` before calling, and write a thin


### PR DESCRIPTION
## Summary

`perry-ext-mysql2`'s row-returning queries build the JS result **on a tokio blocking-pool thread**. In each of the three row-returning query paths the worker does:

```rust
spawn_blocking(move || {
    let outcome = /* run SQL */;
    match outcome {
        Ok(out) => promise.resolve(outcome_to_jsvalue(&out)), // <-- on the worker thread
        ...
    }
});
```

`outcome_to_jsvalue` → `raws_to_result_tuple` allocates the result with `js_array_alloc` / `js_array_push` / `raw_row_to_js_object` (objects + column strings). But perry-ffi's own `spawn_blocking` docs are explicit:

> the closure runs on a blocking-pool thread, so it must NOT touch perry-runtime's thread-local arena directly … **constructing JSValues by hand on the blocking thread will trigger UB**.

perry-runtime's heap allocator is `thread_local!`, so the row objects land in the **worker thread's** arena. They're reachable from the main thread only until that pooled thread idles out (tokio's default ~10s), at which point the arena is dropped and the objects dangle. Under sustained query load this is a use-after-free — the main thread later faults in `js_object_get_field_by_name` reading a freed row object. Low-volume callers (a few fast queries per request) don't notice because the pooled thread stays alive across the request; a long-running job doing hundreds of queries does.

## Fix

Add a main-thread deferral path so bindings can return complex values safely:

- **perry-ffi**: `JsPromise::resolve_with<F: FnOnce() -> JsValue + Send>(f)` — boxes the JS-builder closure and hands it across `perry_ffi_promise_resolve_deferred`. The closure runs **once, on the main thread**, at resolution time.
- **perry-stdlib**: implement `perry_ffi_promise_resolve_deferred` on top of the existing `queue_deferred_resolution` / `js_stdlib_process_pending` pump (the converter already runs on the main thread there).
- **perry-ext-mysql2**: switch the three row-returning queries from `promise.resolve(outcome_to_jsvalue(&out))` to `promise.resolve_with(move || outcome_to_jsvalue(&out))`. The worker now produces only the `Send` Rust `QueryOutcome`; the JSValue is built on the main thread.

## Verification

- `cargo check` passes for `perry-ffi`, `perry-stdlib`, `perry-ext-mysql2`.
- Built into a deployed Fastify + `@perryts/mysql` service; its mysql-backed endpoints return correct row data (37-row result verified) with the change in place.

## Notes

- `perry-ext-pg` has the identical `spawn_blocking` + `outcome_to_jsvalue` pattern and should adopt `resolve_with` too — left as a follow-up to keep this PR focused/verified.
- Found while debugging a separate, still-open crash in the same service (a long-running background job segfaults after the second batch of work). That one is a distinct async-frame issue under investigation and is **not** addressed here; this PR fixes the clearly-incorrect worker-thread JSValue construction, which is a real latent corruption bug on its own.
