### PR TITLE
fix(node): honor child_process sync buffer encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1032 — child_process execSync/execFileSync buffer-encoding parity test (#1958)
+
+Add a node-suite parity test (`child_process/sync/sync-encoding-buffer.ts`)
+covering `execSync`/`execFileSync` return-value encoding: Buffer by default and
+on `encoding: "buffer"`/`encoding: null`, string on `encoding: "utf8"` —
+including `Buffer.isBuffer`, `constructor.name`, and `toString("utf8"|"hex")`.
+The runtime/codegen for this already shipped with #1955 (both sync helpers
+return a NaN-boxed Buffer-or-string via `cp_read_output_mode`/`cp_box_output`),
+so #1958's runtime+codegen changes were superseded and dropped at merge; only
+the net-new test is kept. Matches Node byte-for-byte. Test authored by
+@andrewtdiz.
+
 ## v0.5.1031 — node:worker_threads getEnvironmentData/setEnvironmentData (#1951)
 
 Implement `worker_threads.getEnvironmentData(key)` / `setEnvironmentData(key,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1031
+**Current Version:** 0.5.1032
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4880,7 +4880,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "anyhow",
  "base64",
@@ -4935,14 +4935,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "cc",
  "libc",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "anyhow",
  "log",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "anyhow",
  "base64",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "serde",
  "serde_json",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1031"
+version = "0.5.1032"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "anyhow",
  "clap",
@@ -5056,14 +5056,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "chrono",
  "cron",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5162,14 +5162,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "base64",
  "image",
@@ -5354,14 +5354,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5388,7 +5388,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "brotli",
  "flate2",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5446,7 +5446,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "anyhow",
  "base64",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5570,11 +5570,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1031"
+version = "0.5.1032"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "base64",
  "itoa",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5601,7 +5601,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5624,7 +5624,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "base64",
  "block2",
@@ -5640,7 +5640,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "base64",
  "block2",
@@ -5659,11 +5659,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1031"
+version = "0.5.1032"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "base64",
  "block2",
@@ -5679,7 +5679,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "base64",
  "block2",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "block2",
  "libc",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "base64",
  "libc",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5738,7 +5738,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1031"
+version = "0.5.1032"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1031"
+version = "0.5.1032"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/test-parity/node-suite/child_process/sync/sync-encoding-buffer.ts
+++ b/test-parity/node-suite/child_process/sync/sync-encoding-buffer.ts
@@ -1,0 +1,29 @@
+import { execFileSync, execSync } from "node:child_process";
+
+function report(label: string, value: any) {
+  console.log(`${label} isBuffer:`, Buffer.isBuffer(value));
+  console.log(`${label} ctor:`, value?.constructor?.name);
+  console.log(`${label} text:`, value.toString("utf8"));
+  console.log(`${label} hex:`, value.toString("hex"));
+}
+
+report("execSync-default", execSync("printf def"));
+report("execSync-buffer", execSync("printf out", { encoding: "buffer" }));
+report("execSync-null", execSync("printf nul", { encoding: null }));
+report("execFileSync-default", execFileSync("sh", ["-c", "printf file"]));
+report(
+  "execFileSync-buffer",
+  execFileSync("sh", ["-c", "printf buff"], { encoding: "buffer" }),
+);
+report(
+  "execFileSync-null",
+  execFileSync("sh", ["-c", "printf nil"], { encoding: null }),
+);
+
+const execText = execSync("printf text", { encoding: "utf8" });
+console.log("execSync-utf8 isBuffer:", Buffer.isBuffer(execText));
+console.log("execSync-utf8:", execText);
+
+const execFileText = execFileSync("sh", ["-c", "printf text-file"], { encoding: "utf8" });
+console.log("execFileSync-utf8 isBuffer:", Buffer.isBuffer(execFileText));
+console.log("execFileSync-utf8:", execFileText);


### PR DESCRIPTION
Fixes part of #1937.

## Summary
- Make `child_process.execSync()` and `execFileSync()` return Buffers by default, and for `encoding: "buffer"` / `encoding: null`.
- Preserve string output for `encoding: "utf8"`.
- Change the sync child-process runtime/codegen ABI to return a NaN-boxed JS value so the result can be either Buffer or string.
- Add a focused node-suite fixture covering default, `buffer`, `null`, and `utf8` output for both sync APIs.

## Baseline
- Node returns Buffer stdout for sync calls by default and when `encoding` is `"buffer"` or `null`.
- Perry previously returned strings for every sync case, so `Buffer.isBuffer(...)` was false and `.toString("hex")` returned the original text.

## Reference
- DeepWiki comparison saved locally only at `reference/deepwiki/deno-node-child-process-sync-encoding-buffer-2026-05-27.md`.
- Extracted invariant: sync helpers default to Buffer output, `encoding: "utf8"` opts into strings, which differs from async `exec`/`execFile` whose callback output defaults to strings.

## Tests
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module child_process --filter sync-encoding-buffer`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module child_process`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --filter test_parity_child_process`
- `cargo test -p perry-runtime child_process --lib`
- `cargo test -p perry-codegen --test manifest_consistency`
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals
- Sync thrown Error `.stdout` / `.stderr` encoding.
- `spawnSync` Buffer-vs-string output shape.
- Async callback encoding, covered separately by #1956.
- Named non-UTF8 encodings such as `hex`, unknown-encoding validation, timeout/maxBuffer behavior, streaming subprocess IO, kill behavior, or IPC/fork.
