### PR TITLE
fix(node): honor child_process spawnSync buffer encoding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,9 +172,12 @@ jobs:
           # thread pool lets one test's `js_notify_main_thread` / timer
           # scheduling perturb another's wait budget (the event_pump timing
           # flakes) and races the GC/threading tests into intermittent SIGSEGV.
-          # Run perry-runtime single-threaded so the tests can't interfere; the
-          # rest of the workspace still runs in parallel.
+          # Run perry-runtime single-threaded so the tests can't interfere.
           RUST_TEST_THREADS=1 cargo test -p perry-runtime
+          # The remaining workspace includes large `perry` / `perry-stdlib`
+          # test binaries. On ubuntu-latest, concurrent links have crashed lld
+          # with SIGBUS, so keep Cargo build jobs serialized for this phase.
+          export CARGO_BUILD_JOBS=1
           cargo test --workspace \
             --exclude perry-runtime \
             --exclude perry-ui-macos \

--- a/test-parity/node-suite/child_process/sync/spawn-sync-encoding-buffer.ts
+++ b/test-parity/node-suite/child_process/sync/spawn-sync-encoding-buffer.ts
@@ -1,0 +1,28 @@
+import { spawnSync } from "node:child_process";
+
+function report(label: string, result: any) {
+  console.log(`${label} stdout isBuffer:`, Buffer.isBuffer(result.stdout));
+  console.log(`${label} stdout ctor:`, result.stdout?.constructor?.name);
+  console.log(`${label} stdout text:`, result.stdout?.toString("utf8"));
+  console.log(`${label} stdout hex:`, result.stdout?.toString("hex"));
+  console.log(`${label} stderr isBuffer:`, Buffer.isBuffer(result.stderr));
+  console.log(`${label} stderr ctor:`, result.stderr?.constructor?.name);
+  console.log(`${label} stderr text:`, result.stderr?.toString("utf8"));
+  console.log(`${label} stderr hex:`, result.stderr?.toString("hex"));
+}
+
+report("spawnSync-default", spawnSync("sh", ["-c", "printf out; printf err >&2"]));
+report(
+  "spawnSync-buffer",
+  spawnSync("sh", ["-c", "printf bout; printf berr >&2"], { encoding: "buffer" }),
+);
+report(
+  "spawnSync-null",
+  spawnSync("sh", ["-c", "printf nout; printf nerr >&2"], { encoding: null }),
+);
+
+const text = spawnSync("sh", ["-c", "printf text; printf terr >&2"], { encoding: "utf8" });
+console.log("spawnSync-utf8 stdout isBuffer:", Buffer.isBuffer(text.stdout));
+console.log("spawnSync-utf8 stdout:", text.stdout);
+console.log("spawnSync-utf8 stderr isBuffer:", Buffer.isBuffer(text.stderr));
+console.log("spawnSync-utf8 stderr:", text.stderr);


### PR DESCRIPTION
## Summary

- Fix `child_process.spawnSync()` stdout/stderr output boxing so default, `encoding: "buffer"`, and `encoding: null` return Buffers.
- Preserve string output for `encoding: "utf8"`.
- Add a focused parity fixture covering stdout/stderr type, constructor, text, and hex output.

Fixes part of #1937.

## Baseline

`PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module child_process --filter spawn-sync-encoding-buffer`

Failed before the runtime change:

```text
Node.js: spawnSync-default stdout isBuffer: true
Perry:   spawnSync-default stdout isBuffer: false
```

## DeepWiki

Queried `denoland/deno` once for Node-compatible `spawnSync` encoding behavior. Saved locally only at:

`reference/deepwiki/deno-node-child-process-spawnsync-encoding-buffer-2026-05-27.md`

Extracted invariant: `spawnSync` starts from raw stdout/stderr bytes, returns Buffers by default and for `encoding: "buffer"`/`null`, and converts to strings only when a string encoding such as `utf8` is requested.

## Verification

- `node --experimental-strip-types test-parity/node-suite/child_process/sync/spawn-sync-encoding-buffer.ts`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module child_process --filter spawn-sync-encoding-buffer`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module child_process`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --filter test_parity_child_process`
- `cargo test -p perry-runtime child_process --lib` (passes with pre-existing warnings)
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals

- Full `spawnSync` result-field expansion (#1950)
- Sync `execSync` / `execFileSync` output encoding (#1958)
- Async `exec` / `execFile` callback encoding (#1956)
- Named non-UTF8 encodings such as `hex`
- Unknown-encoding validation, timeout/maxBuffer behavior, streaming subprocess IO, kill behavior, or IPC/fork
