### PR TITLE
feat(perry/ui): #1865 onFrame / cancelFrame display-link callbacks

### DIFF
--- a/crates/perry-codegen-wasm/src/emit/ui_method_map.rs
+++ b/crates/perry-codegen-wasm/src/emit/ui_method_map.rs
@@ -79,6 +79,10 @@ pub(super) fn map_ui_method(method: &str, class_name: Option<&str>) -> &'static 
         // `promptAction.showToast` through the runtime drain queue).
         // Now wires to a JS-side fade-in/out div in wasm_runtime.js.
         "showToast" => "perry_ui_show_toast",
+        // Issue #1865: display-link frame callbacks. On web these map to
+        // requestAnimationFrame / cancelAnimationFrame via wasm_runtime.js.
+        "onFrame" => "perry_ui_on_frame",
+        "cancelFrame" => "perry_ui_cancel_frame",
         // Text decoration (issue #185 Phase B). 0=none, 1=underline,
         // 2=strikethrough on the canonical FFI; CSS-side translates.
         "textSetDecoration" | "text_set_decoration" => "perry_ui_text_set_decoration",

--- a/crates/perry-codegen-wasm/src/wasm_runtime.js
+++ b/crates/perry-codegen-wasm/src/wasm_runtime.js
@@ -3054,6 +3054,24 @@ function perry_ui_animate_position(h, dx, dy, durationSecs) {
 }
 
 // ---------- Events ----------
+// Issue #1865: display-link callbacks. One-shot per registration, like
+// requestAnimationFrame. The id we return matches the rAF id so cancelFrame
+// can hand it straight to cancelAnimationFrame. timestampMs is rAF's
+// DOMHighResTimeStamp; deltaMs is computed per-closure (idiomatic
+// `function loop(t,dt){ ...; onFrame(loop); }` gets accurate deltas).
+const __perryFrameLastByClosure = new WeakMap();
+function perry_ui_on_frame(callback) {
+  if (!callback || typeof callback.funcIdx === 'undefined') return 0;
+  const id = requestAnimationFrame((ts) => {
+    const prev = __perryFrameLastByClosure.get(callback);
+    const dt = (typeof prev === 'number' && ts >= prev) ? ts - prev : 0;
+    __perryFrameLastByClosure.set(callback, ts);
+    callWasmClosure(callback, ts, dt);
+  });
+  return id;
+}
+function perry_ui_cancel_frame(id) { cancelAnimationFrame(id); }
+
 function perry_ui_set_on_click(h, callback) {
   const el = uiGet(h); if (el) el.addEventListener("click", () => callWasmClosure(callback));
 }
@@ -3987,6 +4005,8 @@ const __perryUiDispatch = {
   perry_ui_animate_opacity, perry_ui_animate_position,
   // #1546: showToast on web
   perry_ui_show_toast,
+  // #1865: display-link callbacks (requestAnimationFrame)
+  perry_ui_on_frame, perry_ui_cancel_frame,
   // Events
   perry_ui_set_on_click, perry_ui_set_on_hover, perry_ui_set_on_double_click,
   // State

--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -797,6 +797,37 @@ pub(crate) fn lower_native_method_call(
     // cross-platform code compiles, but only harmonyos shows visual
     // feedback. Future v3 follow-up: route to NSAlert/UIAlertController/
     // GtkPopover on the desktop UI backends.
+    // perry/ui.onFrame(cb) — one-shot display-link callback. Issue #1865.
+    // The callback fires once on the next vsync with (timestampMs, deltaMs).
+    // Idiomatic loop: re-register from inside the callback.
+    if module == "perry/ui" && method == "onFrame" && object.is_none() {
+        if args.len() != 1 {
+            return Ok(double_literal(f64::from_bits(0x7FFC_0000_0000_0001)));
+        }
+        let cb_box = lower_expr(ctx, &args[0])?;
+        ctx.pending_declares
+            .push(("js_on_frame_callback".to_string(), I64, vec![I64]));
+        let blk = ctx.block();
+        let cb_handle = unbox_to_i64(blk, &cb_box);
+        let id = blk.call(I64, "js_on_frame_callback", &[(I64, &cb_handle)]);
+        return Ok(nanbox_pointer_inline(ctx.block(), &id));
+    }
+
+    // perry/ui.cancelFrame(id) — cancel a pending onFrame registration.
+    // Accepts the pointer-tagged handle returned by `onFrame`.
+    if module == "perry/ui" && method == "cancelFrame" && object.is_none() {
+        if args.len() != 1 {
+            return Ok(double_literal(f64::from_bits(0x7FFC_0000_0000_0001)));
+        }
+        let id_box = lower_expr(ctx, &args[0])?;
+        ctx.pending_declares
+            .push(("js_cancel_frame".to_string(), crate::types::VOID, vec![I64]));
+        let blk = ctx.block();
+        let id_handle = unbox_to_i64(blk, &id_box);
+        blk.call_void("js_cancel_frame", &[(I64, &id_handle)]);
+        return Ok(double_literal(f64::from_bits(0x7FFC_0000_0000_0001)));
+    }
+
     if module == "perry/ui" && method == "showToast" && object.is_none() {
         if args.is_empty() {
             return Ok(double_literal(f64::from_bits(0x7FFC_0000_0000_0001)));

--- a/crates/perry-runtime/src/frame.rs
+++ b/crates/perry-runtime/src/frame.rs
@@ -1,0 +1,197 @@
+//! Display-link frame callbacks for `perry/ui` `onFrame` / `cancelFrame`.
+//!
+//! One-shot per registration, like `requestAnimationFrame`. The callback fires
+//! the next time `js_frame_tick(timestamp_ms)` is invoked by the platform's
+//! display-link driver (CADisplayLink on Apple, Choreographer on Android,
+//! GTK4 tick callback on Linux, DwmFlush thread on Windows,
+//! `requestAnimationFrame` in WASM). Subscribers fire in registration order.
+//!
+//! Per-subscriber `deltaMs` is computed off the most recent fire time
+//! recorded for the same closure pointer — so the idiomatic
+//! `function loop(t, dt) { ...; onFrame(loop); }` pattern gets accurate
+//! deltas without bookkeeping. The very first call to a closure-pointer
+//! gets `deltaMs = 0`.
+
+use crate::closure::ClosureHeader;
+use std::collections::HashMap;
+use std::os::raw::c_int;
+use std::sync::Mutex;
+
+struct FrameCallback {
+    id: i64,
+    callback: i64,
+    context: crate::async_context::AsyncContextSnapshot,
+    cleared: bool,
+}
+
+// SAFETY: closure pointers point to global compiled code / GC-rooted data.
+unsafe impl Send for FrameCallback {}
+
+static FRAME_CALLBACKS: Mutex<Vec<FrameCallback>> = Mutex::new(Vec::new());
+static NEXT_FRAME_ID: Mutex<i64> = Mutex::new(1);
+static LAST_FIRE_BY_CLOSURE: Mutex<Option<HashMap<i64, f64>>> = Mutex::new(None);
+
+fn next_frame_id() -> i64 {
+    let mut next = NEXT_FRAME_ID.lock().unwrap();
+    let current = *next;
+    *next += 1;
+    current
+}
+
+fn with_frame_uncaught_trap<F: FnOnce()>(f: F) {
+    let trap_buf = crate::exception::js_try_push();
+    let jumped = unsafe { crate::ffi::setjmp::setjmp(trap_buf as *mut c_int) };
+    if jumped == 0 {
+        f();
+    } else {
+        let exc = crate::exception::js_get_exception();
+        crate::exception::js_clear_exception();
+        crate::os::emit_process_uncaught_exception(exc);
+    }
+    crate::exception::js_try_end();
+}
+
+/// Register a one-shot frame callback. Returns an id usable with
+/// `js_cancel_frame`. The callback is invoked as `cb(timestampMs, deltaMs)`
+/// from `js_frame_tick`.
+#[no_mangle]
+pub extern "C" fn js_on_frame_callback(callback: i64) -> i64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let cb_handle = scope.root_raw_const_ptr(callback as *const ClosureHeader);
+
+    let id = next_frame_id();
+
+    FRAME_CALLBACKS.lock().unwrap().push(FrameCallback {
+        id,
+        callback: cb_handle.get_raw_const_ptr::<ClosureHeader>() as i64,
+        context: crate::async_context::capture_context(),
+        cleared: false,
+    });
+
+    id
+}
+
+/// Cancel a previously-registered frame callback. No-op if `id` is unknown
+/// or already fired.
+#[no_mangle]
+pub extern "C" fn js_cancel_frame(id: i64) {
+    let mut queue = FRAME_CALLBACKS.lock().unwrap();
+    for cb in queue.iter_mut() {
+        if cb.id == id {
+            cb.cleared = true;
+            break;
+        }
+    }
+    queue.retain(|c| !c.cleared);
+}
+
+/// Whether any frame callbacks are currently pending. Lets the platform's
+/// display-link driver park itself when there's nothing to do.
+#[no_mangle]
+pub extern "C" fn js_frame_has_pending() -> i32 {
+    let q = FRAME_CALLBACKS.lock().unwrap();
+    if q.iter().any(|t| !t.cleared) {
+        1
+    } else {
+        0
+    }
+}
+
+/// Fire all pending frame callbacks once with the supplied vsync timestamp
+/// (milliseconds, monotonic since app start). Returns the number of
+/// callbacks that fired.
+#[no_mangle]
+pub extern "C" fn js_frame_tick(timestamp_ms: f64) -> i32 {
+    use crate::closure::js_closure_call2;
+
+    let pending: Vec<FrameCallback> = {
+        let mut queue = FRAME_CALLBACKS.lock().unwrap();
+        queue.drain(..).filter(|t| !t.cleared).collect()
+    };
+
+    let mut fired = 0;
+    for cb in pending {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let cb_handle = scope.root_raw_const_ptr(cb.callback as *const ClosureHeader);
+
+        let delta_ms = {
+            let mut slot = LAST_FIRE_BY_CLOSURE.lock().unwrap();
+            let map = slot.get_or_insert_with(HashMap::new);
+            let prev = map.insert(cb.callback, timestamp_ms);
+            match prev {
+                Some(p) if timestamp_ms >= p => timestamp_ms - p,
+                _ => 0.0,
+            }
+        };
+
+        let previous = crate::async_context::enter_context(&cb.context);
+        let mut previous = previous;
+        let previous_roots = crate::async_context::root_snapshot(&scope, &previous);
+        let cb_ptr = cb_handle.get_raw_const_ptr::<ClosureHeader>();
+        with_frame_uncaught_trap(|| {
+            js_closure_call2(cb_ptr, timestamp_ms, delta_ms);
+        });
+        crate::async_context::refresh_snapshot_from_roots(&mut previous, &previous_roots);
+        crate::async_context::restore_context(previous);
+        fired += 1;
+    }
+
+    fired
+}
+
+/// Convenience pump: tick using `js_timer_now()` for the timestamp. Useful
+/// for platforms whose driver doesn't supply its own vsync timestamp
+/// (Windows DwmFlush, Android Choreographer fallback) and for tests.
+#[no_mangle]
+pub extern "C" fn js_frame_pump_default() -> i32 {
+    js_frame_tick(crate::timer::js_timer_now())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tests share the global FRAME_CALLBACKS queue, so serialize them.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear_state() {
+        FRAME_CALLBACKS.lock().unwrap().clear();
+        if let Some(map) = LAST_FIRE_BY_CLOSURE.lock().unwrap().as_mut() {
+            map.clear();
+        }
+    }
+
+    #[test]
+    fn registration_assigns_unique_ids_and_marks_pending() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        clear_state();
+        // Use distinct dummy callback bits — `js_frame_tick` is not invoked
+        // here so the pointers never get dereferenced.
+        let id_a = js_on_frame_callback(0x1000);
+        let id_b = js_on_frame_callback(0x2000);
+        assert_ne!(id_a, id_b);
+        assert_eq!(js_frame_has_pending(), 1);
+        clear_state();
+        assert_eq!(js_frame_has_pending(), 0);
+    }
+
+    #[test]
+    fn cancel_frame_removes_pending_callback() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        clear_state();
+        let id = js_on_frame_callback(0x3000);
+        assert_eq!(js_frame_has_pending(), 1);
+        js_cancel_frame(id);
+        assert_eq!(js_frame_has_pending(), 0);
+    }
+
+    #[test]
+    fn cancel_unknown_id_is_noop() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        clear_state();
+        js_on_frame_callback(0x4000);
+        js_cancel_frame(999_999);
+        assert_eq!(js_frame_has_pending(), 1);
+        clear_state();
+    }
+}

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -41,6 +41,7 @@ pub mod event_pump;
 pub mod exception;
 pub mod fast_hash;
 pub mod ffi;
+pub mod frame;
 pub mod fs;
 pub mod gc;
 pub mod map;

--- a/crates/perry-ui-android/src/app.rs
+++ b/crates/perry-ui-android/src/app.rs
@@ -161,6 +161,7 @@ extern "C" {
     fn js_callback_timer_tick() -> i32;
     fn js_interval_timer_tick() -> i32;
     fn js_promise_run_microtasks() -> i32;
+    fn js_frame_pump_default() -> i32;
 }
 
 /// Start the timer pump that drives setInterval/setTimeout/Promise callbacks.
@@ -222,6 +223,10 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativePumpTick(
         js_stdlib_process_pending();
         js_callback_timer_tick();
         js_interval_timer_tick();
+        // Issue #1865: perry/ui `onFrame` display-link callbacks. Real
+        // Choreographer.postFrameCallback wiring is a follow-up; for now
+        // the same 8ms pump drives one-shot frame callbacks.
+        js_frame_pump_default();
         js_promise_run_microtasks();
     }
     // perry/media (#351) — drive state polling on the UI thread so the

--- a/crates/perry-ui-gtk4/src/app.rs
+++ b/crates/perry-ui-gtk4/src/app.rs
@@ -76,6 +76,7 @@ extern "C" {
     fn js_callback_timer_tick() -> i32;
     fn js_interval_timer_tick() -> i32;
     fn js_run_ext_pump();
+    fn js_frame_pump_default() -> i32;
 }
 
 /// Extract a &str from a *const StringHeader pointer.
@@ -314,6 +315,9 @@ pub fn app_run(_app_handle: i64) {
             unsafe {
                 js_callback_timer_tick();
                 js_interval_timer_tick();
+                // Issue #1865: perry/ui `onFrame` display-link callbacks.
+                // Real gtk_widget_add_tick_callback wiring is a follow-up.
+                js_frame_pump_default();
                 js_run_ext_pump();
                 js_run_stdlib_pump();
                 js_promise_run_microtasks();

--- a/crates/perry-ui-ios/src/app.rs
+++ b/crates/perry-ui-ios/src/app.rs
@@ -609,6 +609,7 @@ extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_callback_timer_tick() -> i32;
     fn js_interval_timer_tick() -> i32;
+    fn js_frame_pump_default() -> i32;
 }
 
 // ============================================
@@ -630,6 +631,8 @@ define_class!(
                 unsafe {
                     js_callback_timer_tick();
                     js_interval_timer_tick();
+                    // Issue #1865: perry/ui `onFrame` display-link callbacks.
+                    js_frame_pump_default();
                     js_promise_run_microtasks();
                     // Drain deferred promise resolutions from perry-stdlib
                     // tokio workers (async fetch/network completions). Without

--- a/crates/perry-ui-macos/src/app.rs
+++ b/crates/perry-ui-macos/src/app.rs
@@ -1213,6 +1213,7 @@ extern "C" {
     fn js_promise_run_microtasks() -> i32;
     fn js_callback_timer_tick() -> i32;
     fn js_interval_timer_tick() -> i32;
+    fn js_frame_pump_default() -> i32;
 }
 
 pub struct PerryTimerTargetIvars {
@@ -1272,6 +1273,10 @@ define_class!(
                 unsafe {
                     js_callback_timer_tick();
                     js_interval_timer_tick();
+                    // Issue #1865: perry/ui `onFrame` one-shot display-link
+                    // callbacks. Driven off the same ~8ms pump for now;
+                    // CADisplayLink-quality vsync alignment is a follow-up.
+                    js_frame_pump_default();
                     js_promise_run_microtasks();
                     // Process deferred promise resolutions from perry-stdlib tokio workers.
                     // No-op if perry-stdlib is not linked (function pointer not registered).

--- a/crates/perry-ui-tvos/src/app.rs
+++ b/crates/perry-ui-tvos/src/app.rs
@@ -445,6 +445,7 @@ extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_callback_timer_tick() -> i32;
     fn js_interval_timer_tick() -> i32;
+    fn js_frame_pump_default() -> i32;
 }
 
 // ============================================
@@ -466,6 +467,8 @@ define_class!(
                 unsafe {
                     js_callback_timer_tick();
                     js_interval_timer_tick();
+                    // Issue #1865: perry/ui `onFrame` display-link callbacks.
+                    js_frame_pump_default();
                     js_promise_run_microtasks();
                     #[cfg(feature = "geisterhand")]
                     {

--- a/crates/perry-ui-visionos/src/app.rs
+++ b/crates/perry-ui-visionos/src/app.rs
@@ -306,6 +306,7 @@ extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_callback_timer_tick() -> i32;
     fn js_interval_timer_tick() -> i32;
+    fn js_frame_pump_default() -> i32;
 }
 
 // ============================================
@@ -327,6 +328,8 @@ define_class!(
                 unsafe {
                     js_callback_timer_tick();
                     js_interval_timer_tick();
+                    // Issue #1865: perry/ui `onFrame` display-link callbacks.
+                    js_frame_pump_default();
                     js_promise_run_microtasks();
                     #[cfg(feature = "geisterhand")]
                     {

--- a/crates/perry-ui-windows/src/app.rs
+++ b/crates/perry-ui-windows/src/app.rs
@@ -33,6 +33,7 @@ extern "C" {
     fn js_nanbox_get_pointer(value: f64) -> i64;
     fn js_callback_timer_tick() -> i32;
     fn js_interval_timer_tick() -> i32;
+    fn js_frame_pump_default() -> i32;
 }
 
 /// Timer ID for periodic tick that processes setTimeout/setInterval queues.
@@ -452,6 +453,10 @@ pub fn app_run(app_handle: i64) {
                     unsafe {
                         js_callback_timer_tick();
                         js_interval_timer_tick();
+                        // Issue #1865: perry/ui `onFrame` display-link
+                        // callbacks. Real DwmFlush-aligned vsync driver is
+                        // a follow-up.
+                        js_frame_pump_default();
                     }
                 }
                 // perry/media (#351) — UI-thread state poll for active

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -47,6 +47,7 @@
 - [Dialogs](ui/dialogs.md)
 - [Table](ui/table.md)
 - [Animation](ui/animation.md)
+- [Frame Callbacks](ui/on-frame.md)
 - [Multi-Window](ui/multi-window.md)
 - [Theming](ui/theming.md)
 - [Camera](ui/camera.md)

--- a/docs/src/ui/on-frame.md
+++ b/docs/src/ui/on-frame.md
@@ -1,0 +1,50 @@
+# Frame Callbacks (`onFrame`)
+
+`onFrame` subscribes a callback to the next display-link "tick". Use it for
+time-based rendering — animations driven from code, simulations, games,
+real-time data visualizations, or custom `Canvas` transitions — where you
+need a frame-aligned tick with an accurate timestamp instead of
+`setInterval(cb, 16)`.
+
+```typescript
+import { onFrame, cancelFrame } from "perry/ui";
+
+function loop(timestampMs: number, deltaMs: number) {
+  // advance simulation, redraw...
+  onFrame(loop); // schedule the next frame
+}
+
+const id = onFrame(loop);
+// later, to stop:
+cancelFrame(id);
+```
+
+## Semantics
+
+- **One-shot.** The callback fires *once*. To keep a loop running, call
+  `onFrame` again from inside the callback (this mirrors the web's
+  idiomatic `requestAnimationFrame` shape and avoids the "how do I stop a
+  recurring callback" footgun).
+- **`timestampMs`** is monotonic time since app start, in milliseconds,
+  double precision.
+- **`deltaMs`** is the time since the previous fire of *this* callback (0
+  on the first call). Tracking is keyed off the callback identity so the
+  idiomatic `onFrame(loop)` pattern gets accurate deltas without the app
+  bookkeeping anything.
+- **Order.** Subscribers fire in registration order each frame.
+- **Pause when invisible.** The web backend uses `requestAnimationFrame`,
+  which is paused automatically when the tab is hidden. The native
+  backends drive frames from their main-loop pump; treat that as a soft
+  guarantee for now and a real per-platform display-link driver is a
+  follow-up.
+
+## Platform mapping
+
+| Platform | Driver |
+|---|---|
+| Web (WASM) | `requestAnimationFrame` |
+| macOS | Main-thread pump (CADisplayLink wiring TBD) |
+| iOS / tvOS / visionOS | Main-thread pump (CADisplayLink wiring TBD) |
+| Android | Main-thread pump (Choreographer wiring TBD) |
+| GTK4 (Linux) | Main-loop pump (`gtk_widget_add_tick_callback` TBD) |
+| Windows | WM_TIMER pump (DwmFlush vsync wiring TBD) |


### PR DESCRIPTION
## Summary

Closes #1865. Adds module-level `onFrame(cb)` / `cancelFrame(id)` to `perry/ui` so apps doing time-based rendering (animations, simulations, Canvas transitions) have a frame-aligned tick with an accurate timestamp instead of `setInterval(cb, 16)`.

- One-shot per registration (matches `requestAnimationFrame`); idiomatic loop is `onFrame(loop)` from inside the callback.
- Callback signature: `(timestampMs: number, deltaMs: number)`. `deltaMs` is keyed off the callback identity, so the natural loop pattern gets accurate deltas without app bookkeeping. `0` on first call.
- Subscribers fire in registration order.

## Implementation

- **Runtime** (`crates/perry-runtime/src/frame.rs`): new module with `js_on_frame_callback`, `js_cancel_frame`, `js_frame_tick(timestamp_ms)`, `js_frame_pump_default`, `js_frame_has_pending`. Mirrors the `timer.rs` patterns (`RuntimeHandleScope`, `with_*_uncaught_trap`, async-context capture/restore).
- **Codegen** (`crates/perry-codegen/src/lower_call/native/mod.rs`): dispatch arms for `perry/ui.onFrame` / `perry/ui.cancelFrame`.
- **Native platforms**: each platform's main-loop pump (macOS, iOS, tvOS, visionOS, GTK4, Android, Windows) now also calls `js_frame_pump_default()`. Real per-platform display-link drivers (CADisplayLink, Choreographer, gtk_widget_add_tick_callback, DwmFlush) are flagged as follow-ups — the API works everywhere immediately.
- **Web/WASM**: `crates/perry-codegen-wasm/src/emit/ui_method_map.rs` maps `onFrame`/`cancelFrame` to `perry_ui_on_frame`/`perry_ui_cancel_frame`, implemented in `wasm_runtime.js` via `requestAnimationFrame` / `cancelAnimationFrame`. The web backend naturally pauses when the tab is hidden.
- **Docs**: new `docs/src/ui/on-frame.md` with semantics, examples, and the platform-mapping table; registered in `SUMMARY.md`.

Open questions in the issue resolved as: app-scoped API (no window arg); ordering by registration (no priority hint, can be added non-breaking later).

## Test plan

- [x] \`cargo test --release -p perry-runtime --lib frame::\` — 3 unit tests (registration uniqueness, cancel, no-op cancel of unknown id).
- [x] \`cargo build --release -p perry-runtime -p perry-codegen -p perry-codegen-wasm -p perry-ui-macos -p perry\` — clean.
- [x] \`cargo fmt --check\` — clean across the workspace.
- [x] Smoke compile + run on macOS of a TS file using \`onFrame\` / \`cancelFrame\`.
- [ ] Live display-link firing on a real animation example — recommend follow-up issues for per-platform CADisplayLink/Choreographer/DwmFlush vsync alignment.