### PR TITLE
fix(runtime): preserve class-ref tag in raw-f64 numeric-array layout (#321 effect Schema SIGSEGV)

### DIFF
--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -282,6 +282,25 @@ pub(crate) fn value_bits_are_numeric(value_bits: u64) -> bool {
 pub(crate) fn value_bits_to_number(value_bits: u64) -> Option<f64> {
     if (value_bits & crate::value::TAG_MASK) == crate::value::INT32_TAG {
         let lower = (value_bits & crate::value::INT32_MASK) as u32;
+        // #321/effect-Schema: a class reference shares the INT32_TAG (0x7FFE)
+        // NaN-box shape with genuine small integers — `arrays_finds.rs` lowers
+        // a `ClassRef` to its registered class id NaN-boxed with INT32_TAG, and
+        // downstream property / method / `instanceof` dispatch keys off the
+        // surviving 0x7FFE tag. A class ref is NOT a numeric array element, so
+        // treating it as the integer `class_id` here let the raw-f64 numeric
+        // layout canonicalize the slot to `class_id.to_bits()`, stripping the
+        // tag (`canonicalize_array_numeric_store_bits` /
+        // `note_array_numeric_index_write`). That turned a class value passed
+        // through a rest parameter — `Union(...members)` in effect's Schema,
+        // whose `members.map((m) => m.ast)` then dereferenced the bare number
+        // as an object — into a SIGSEGV. Reporting class refs as non-numeric
+        // keeps such arrays off the raw-f64 fast path and preserves the tag.
+        // A genuine integer whose value coincides with a registered class id
+        // only loses the raw-f64 *optimization* (it is still a valid number
+        // when read back), so correctness is never at stake.
+        if crate::object::is_class_id_registered(lower) {
+            return None;
+        }
         return Some((lower as i32) as f64);
     }
     let upper = value_bits >> 48;

--- a/test-files/test_gap_class_ref_numeric_array_canon.ts
+++ b/test-files/test_gap_class_ref_numeric_array_canon.ts
@@ -1,0 +1,60 @@
+// Issue #40 / #1862 / #321 regression: effect/Schema `decodeUnknownSync`
+// SIGSEGV'd on `main` after the #1862 "raw f64 array slot canonicalization"
+// landed. Root cause: Perry NaN-boxes a class reference with INT32_TAG
+// (0x7FFE) — the SAME bit shape as a genuine small integer — and keys class
+// dispatch off that tag. The numeric-array canonicalization rewrote any
+// int32-shaped slot of a RawF64 array to its raw f64 bits, stripping the
+// 0x7FFE tag from class refs that flowed through a numeric-seeded array. A
+// later property read then missed the class-ref dispatch arm and
+// dereferenced the raw double as a heap pointer (crash in
+// `is_registered_set` via `js_array_map` -> `js_object_get_field_by_name`).
+//
+// The fix makes the numeric-layout predicate reject int32-shaped values that
+// are registered class refs, so storing a class ref into a numeric array
+// downgrades the layout and preserves the NaN-box bits — genuine integers
+// still canonicalize (the #1862 feature is intact).
+//
+// Expected output:
+// T,B,n,n,n,n,n,n,n,n
+// 42 cfg 7 oth
+
+class Tag {
+  static k = "T";
+}
+class Box {
+  static k = "B";
+}
+
+// Erase the static class-ref knowledge so the value flows dynamically (the
+// way effect/Schema passes schema "constructors" through generic arrays).
+function wrap(x: any): any {
+  return x;
+}
+
+// Seed a RawF64 numeric layout, then overwrite slots with INT32-tagged class
+// refs, then read them back via `.map` (which reads each slot raw) + a
+// property access in the callback.
+const items: any[] = [];
+for (let i = 0; i < 10; i++) items.push(i);
+items[0] = wrap(Tag);
+items[1] = wrap(Box);
+const ids = items.map((it: any) => (typeof it === "function" && it.k ? it.k : "n"));
+console.log(ids.join(","));
+
+// Direct read-back of a class ref stored in a numeric-seeded array, then a
+// static field access (must not be corrupted by canonicalization).
+class Config {
+  static version = 42;
+  static label = "cfg";
+}
+class Other {
+  static version = 7;
+  static label = "oth";
+}
+const slots: any[] = [];
+for (let i = 0; i < 8; i++) slots.push(i);
+slots[3] = Config;
+slots[5] = Other;
+const c = slots[3];
+const o = slots[5];
+console.log(c.version, c.label, o.version, o.label);


### PR DESCRIPTION
## Summary

Fixes the `effect/Schema` `decodeUnknownSync` SIGSEGV (blocker on the Effect end-to-end track, #321). `Union(...)` / `Tuple(...)` schema combinators were producing garbage, crashing in `is_registered_set` via `js_array_map → js_object_get_field_by_name`.

## Root cause

Perry NaN-boxes a **class reference** with `INT32_TAG` (`0x7FFE`) — the **same** bit shape as a genuine small integer — and keys class property/method/`instanceof` dispatch off that surviving tag. But `value_bits_to_number()`'s INT32 branch reported *any* INT32-shaped value as the number `payload as f64`. So the raw-f64 numeric-array canonicalization (`canonicalize_array_numeric_store_bits` / `note_array_numeric_index_write`) rewrote a class-ref slot to `class_id.to_bits()`, **stripping the `0x7FFE` tag**.

The trigger is a class value passed through a **rest parameter**: effect's `Union(...members)` collects schema *classes* into `members`, the array gets optimized to the raw-f64 layout, and `members.map((m) => m.ast)` then dereferences the bare `class_id` number as an object pointer.

Minimal repro (no Effect):
```ts
class A { static ast = { tag: "A" }; }
class B { static ast = { tag: "B" }; }
function rest(...m: any[]): any { return m.map((x: any) => x.ast); }
rest(A, B); // was [null, null] (class_ids 1, 2 stripped to numbers); now [{tag:"A"},{tag:"B"}]
```

## Fix

Reject INT32-shaped values whose payload is a **registered class id** in `value_bits_to_number` — the single chokepoint all numeric-layout decisions funnel through. Storing a class ref into a numeric array now downgrades the layout and preserves the tag.

A genuine integer that happens to coincide with a registered class id only loses the raw-f64 **optimization** (it is still a valid number when read back), so correctness is never at stake.

## Verification

- `effect/Schema` `S.Struct({name,age})` + `decodeUnknownSync` → `Ada 36` (was SIGSEGV)
- Minimal class-as-rest-arg repro matrix: all cases correct
- New gap test `test_gap_class_ref_numeric_array_canon.ts` — byte-identical to Node
- `perry-runtime` lib suite: 671 passed / 0 failed (single-threaded); `gc::tests::layout_trace` 37/37
