### PR TITLE
fix(node:stream): implement EventEmitter listener lifecycle

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -682,8 +682,8 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     // Narrow node:stream instance-method wiring used by the current
     // stream/promises stubs. These keep Perry's hidden stream state in sync
     // when typed `new PassThrough()` / `new Writable()` instances call the
-    // methods directly; full stream event/backpressure behavior remains
-    // deferred to #1532.
+    // methods directly so Perry's hidden stream state and EventEmitter
+    // listener registry stay in sync on typed stream instances.
     NativeModSig {
         module: "stream",
         has_receiver: true,
@@ -707,7 +707,7 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         has_receiver: true,
         method: "once",
         class_filter: None,
-        runtime: "js_node_stream_method_on",
+        runtime: "js_node_stream_method_once",
         args: &[NA_F64, NA_F64],
         ret: NR_F64,
     },
@@ -716,8 +716,8 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         has_receiver: true,
         method: "emit",
         class_filter: None,
-        runtime: "js_node_stream_method_emit",
-        args: &[NA_F64, NA_F64],
+        runtime: "js_node_stream_method_emit_args",
+        args: &[NA_F64, NA_VARARGS],
         ret: NR_F64,
     },
     NativeModSig {
@@ -838,8 +838,35 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         has_receiver: true,
         method: "prependOnceListener",
         class_filter: None,
-        runtime: "js_node_stream_method_prepend_listener",
+        runtime: "js_node_stream_method_prepend_once_listener",
         args: &[NA_F64, NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
+        method: "off",
+        class_filter: None,
+        runtime: "js_node_stream_method_off",
+        args: &[NA_F64, NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
+        method: "removeListener",
+        class_filter: None,
+        runtime: "js_node_stream_method_remove_listener",
+        args: &[NA_F64, NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
+        method: "removeAllListeners",
+        class_filter: None,
+        runtime: "js_node_stream_method_remove_all_listeners",
+        args: &[NA_F64],
         ret: NR_F64,
     },
     NativeModSig {

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -35,15 +35,20 @@ mod async_iterator;
 
 #[path = "node_stream_event_emitter.rs"]
 mod event_emitter;
+use event_emitter::{
+    call_listener_args, emit_stream_event, emit_stream_event_from_array, is_callable_value,
+    ns_event_names, ns_get_max_listeners, ns_listener_count, ns_listeners, ns_off2, ns_on2,
+    ns_once2, ns_prepend_listener2, ns_prepend_once_listener2, ns_raw_listeners,
+    ns_remove_all_listeners1, ns_remove_listener2, ns_set_max_listeners,
+    stream_listener_count_for_event,
+};
 pub use event_emitter::{
     js_node_stream_method_event_names, js_node_stream_method_get_max_listeners,
     js_node_stream_method_listener_count, js_node_stream_method_listeners,
-    js_node_stream_method_on, js_node_stream_method_prepend_listener,
-    js_node_stream_method_raw_listeners, js_node_stream_method_set_max_listeners,
-};
-use event_emitter::{
-    ns_event_names, ns_get_max_listeners, ns_listener_count, ns_listeners, ns_raw_listeners,
-    ns_set_max_listeners,
+    js_node_stream_method_off, js_node_stream_method_on, js_node_stream_method_once,
+    js_node_stream_method_prepend_listener, js_node_stream_method_prepend_once_listener,
+    js_node_stream_method_raw_listeners, js_node_stream_method_remove_all_listeners,
+    js_node_stream_method_remove_listener, js_node_stream_method_set_max_listeners,
 };
 
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
@@ -69,8 +74,6 @@ const READABLE_ERROR_KEY: &[u8] = b"__perryReadableError";
 const READABLE_SIGNAL_KEY: &[u8] = b"__perryReadableSignal";
 const READABLE_READ_KEY: &[u8] = b"__perryReadableRead";
 const READABLE_READ_INVOKED_KEY: &[u8] = b"__perryReadableReadInvoked";
-const STREAM_DATA_LISTENERS_KEY: &[u8] = b"__perryStreamDataListeners";
-const STREAM_END_LISTENERS_KEY: &[u8] = b"__perryStreamEndListeners";
 const STREAM_DRAIN_SCHEDULED_KEY: &[u8] = b"__perryStreamDrainScheduled";
 const STREAM_END_EMITTED_KEY: &[u8] = b"__perryStreamEndEmitted";
 const STREAM_ENDED_KEY: &[u8] = b"__perryStreamEnded";
@@ -122,21 +125,6 @@ extern "C" fn ns_chain3(closure: *const ClosureHeader, _a: f64, _b: f64, _c: f64
     this_value(closure)
 }
 
-extern "C" fn ns_on2(closure: *const ClosureHeader, event: f64, cb: f64) -> f64 {
-    let stream = this_value(closure);
-    add_stream_listener_for_event(stream, event, cb);
-    stream
-}
-
-fn add_stream_listener_for_event(stream: f64, event: f64, cb: f64) {
-    if string_value_eq(event, b"data") {
-        add_stream_listener(stream, hidden_data_listeners_key(), cb);
-        schedule_readable_from_drain(stream);
-    } else if string_value_eq(event, b"end") {
-        add_stream_listener(stream, hidden_end_listeners_key(), cb);
-    }
-}
-
 extern "C" fn ns_readable_from_drain(closure: *const ClosureHeader) -> f64 {
     if closure.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
@@ -152,11 +140,20 @@ extern "C" fn ns_readable_from_drain(closure: *const ClosureHeader) -> f64 {
 }
 
 extern "C" fn ns_emit2(closure: *const ClosureHeader, event: f64, arg: f64) -> f64 {
-    if string_value_eq(event, b"error") {
-        set_hidden_value(this_value(closure), hidden_error_key(), arg);
-        return f64::from_bits(TAG_TRUE);
+    let stream = this_value(closure);
+    let mut args = crate::array::js_array_alloc(0);
+    if arg.to_bits() != TAG_UNDEFINED {
+        args = crate::array::js_array_push_f64(args, arg);
     }
-    f64::from_bits(TAG_FALSE)
+    emit_stream_event_from_array(stream, event, args)
+}
+
+extern "C" fn ns_emit_rest(closure: *const ClosureHeader, event: f64, rest: f64) -> f64 {
+    emit_stream_event_from_array(
+        this_value(closure),
+        event,
+        raw_ptr_from_value(rest) as *const _,
+    )
 }
 extern "C" fn ns_resume0(closure: *const ClosureHeader) -> f64 {
     let stream = this_value(closure);
@@ -234,6 +231,26 @@ extern "C" fn writable_write_callback_noop(_closure: *const ClosureHeader) -> f6
 
 extern "C" fn ns_write2(closure: *const ClosureHeader, chunk: f64, enc: f64) -> f64 {
     let stream = this_value(closure);
+    invoke_writable_write(stream, chunk, enc);
+    emit_writable_chunk(stream, chunk);
+    f64::from_bits(TAG_TRUE)
+}
+
+extern "C" fn ns_end1(closure: *const ClosureHeader, chunk: f64) -> f64 {
+    let callback = if is_callable_value(chunk) {
+        Some(chunk)
+    } else {
+        None
+    };
+    if callback.is_none() && !JSValue::from_bits(chunk.to_bits()).is_undefined() {
+        let _ = ns_write2(closure, chunk, f64::from_bits(TAG_UNDEFINED));
+    }
+    let stream = this_value(closure);
+    finish_stream(stream, callback);
+    stream
+}
+
+fn invoke_writable_write(stream: f64, chunk: f64, enc: f64) {
     if let Some(write) = writable_hidden_write(stream) {
         let cb = js_closure_alloc(writable_write_callback_noop as *const u8, 0);
         let cb_value = f64::from_bits(JSValue::pointer(cb as *const u8).bits());
@@ -244,15 +261,25 @@ extern "C" fn ns_write2(closure: *const ClosureHeader, chunk: f64, enc: f64) -> 
         }
         crate::object::js_implicit_this_set(prev_this);
     }
-    f64::from_bits(TAG_TRUE)
 }
-extern "C" fn ns_end1(closure: *const ClosureHeader, chunk: f64) -> f64 {
-    if !JSValue::from_bits(chunk.to_bits()).is_undefined() {
-        let _ = ns_write2(closure, chunk, f64::from_bits(TAG_UNDEFINED));
+
+fn emit_writable_chunk(stream: f64, chunk: f64) {
+    if has_truthy_hidden(stream, hidden_readable_flag_key()) {
+        mark_disturbed(stream);
+        let _ = emit_stream_event(stream, string_value(b"data"), &[chunk]);
     }
-    let stream = this_value(closure);
+}
+
+fn finish_stream(stream: f64, callback: Option<f64>) {
     set_hidden_value(stream, hidden_ended_key(), f64::from_bits(TAG_TRUE));
-    stream
+    if !has_truthy_hidden(stream, hidden_end_emitted_key()) {
+        set_hidden_value(stream, hidden_end_emitted_key(), f64::from_bits(TAG_TRUE));
+        let _ = emit_stream_event(stream, string_value(b"end"), &[]);
+    }
+    let _ = emit_stream_event(stream, string_value(b"finish"), &[]);
+    if let Some(callback) = callback {
+        call_listener_args(stream, callback, &[]);
+    }
 }
 
 fn stream_value_from_handle(stream_handle: i64) -> f64 {
@@ -266,12 +293,24 @@ fn stream_value_from_handle(stream_handle: i64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_emit(stream_handle: i64, event: f64, arg: f64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
-    if string_value_eq(event, b"error") {
-        set_hidden_value(stream, hidden_error_key(), arg);
-        f64::from_bits(TAG_TRUE)
-    } else {
-        f64::from_bits(TAG_FALSE)
+    let mut args = crate::array::js_array_alloc(0);
+    if arg.to_bits() != TAG_UNDEFINED {
+        args = crate::array::js_array_push_f64(args, arg);
     }
+    emit_stream_event_from_array(stream, event, args)
+}
+
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_emit_args(
+    stream_handle: i64,
+    event: f64,
+    args_ptr: i64,
+) -> f64 {
+    emit_stream_event_from_array(
+        stream_value_from_handle(stream_handle),
+        event,
+        args_ptr as *const crate::array::ArrayHeader,
+    )
 }
 
 /// `readable.push(chunk)` on a typed stream instance (#1539). Tracks the
@@ -320,26 +359,23 @@ pub extern "C" fn js_node_stream_method_resume(stream_handle: i64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_write(stream_handle: i64, chunk: f64, enc: f64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
-    if let Some(write) = writable_hidden_write(stream) {
-        let cb = js_closure_alloc(writable_write_callback_noop as *const u8, 0);
-        let cb_value = f64::from_bits(JSValue::pointer(cb as *const u8).bits());
-        let args = [chunk, enc, cb_value];
-        let prev_this = crate::object::js_implicit_this_set(stream);
-        unsafe {
-            let _ = crate::closure::js_native_call_value(write, args.as_ptr(), args.len());
-        }
-        crate::object::js_implicit_this_set(prev_this);
-    }
+    invoke_writable_write(stream, chunk, enc);
+    emit_writable_chunk(stream, chunk);
     f64::from_bits(TAG_TRUE)
 }
 
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_end(stream_handle: i64, chunk: f64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
-    if !JSValue::from_bits(chunk.to_bits()).is_undefined() {
+    let callback = if is_callable_value(chunk) {
+        Some(chunk)
+    } else {
+        None
+    };
+    if callback.is_none() && !JSValue::from_bits(chunk.to_bits()).is_undefined() {
         let _ = js_node_stream_method_write(stream_handle, chunk, f64::from_bits(TAG_UNDEFINED));
     }
-    set_hidden_value(stream, hidden_ended_key(), f64::from_bits(TAG_TRUE));
+    finish_stream(stream, callback);
     stream
 }
 extern "C" fn ns_undefined0(_closure: *const ClosureHeader) -> f64 {
@@ -878,8 +914,15 @@ fn register_stub_arities() {
     register(ns_chain2 as *const u8, 2);
     register(ns_chain3 as *const u8, 3);
     register(ns_on2 as *const u8, 2);
+    register(ns_once2 as *const u8, 2);
+    register(ns_prepend_listener2 as *const u8, 2);
+    register(ns_prepend_once_listener2 as *const u8, 2);
+    register(ns_remove_listener2 as *const u8, 2);
+    register(ns_off2 as *const u8, 2);
+    register(ns_remove_all_listeners1 as *const u8, 1);
     register(ns_readable_from_drain as *const u8, 0);
     register(ns_emit2 as *const u8, 2);
+    crate::closure::js_register_closure_rest(ns_emit_rest as *const u8, 1);
     register(ns_resume0 as *const u8, 0);
     register(ns_read1 as *const u8, 1);
     register(ns_pipe1 as *const u8, 1);
@@ -953,16 +996,6 @@ fn hidden_read_key() -> *mut crate::string::StringHeader {
 #[inline]
 fn hidden_read_invoked_key() -> *mut crate::string::StringHeader {
     hidden_key(READABLE_READ_INVOKED_KEY)
-}
-
-#[inline]
-fn hidden_data_listeners_key() -> *mut crate::string::StringHeader {
-    hidden_key(STREAM_DATA_LISTENERS_KEY)
-}
-
-#[inline]
-fn hidden_end_listeners_key() -> *mut crate::string::StringHeader {
-    hidden_key(STREAM_END_LISTENERS_KEY)
 }
 
 #[inline]
@@ -1073,54 +1106,6 @@ fn set_hidden_value(value: f64, key: *mut crate::string::StringHeader, field_val
     }
 }
 
-fn add_stream_listener(stream: f64, key: *mut crate::string::StringHeader, cb: f64) {
-    if raw_ptr_from_value(cb) < 0x10000 {
-        return;
-    }
-    let listeners = get_hidden_value(stream, key).unwrap_or_else(|| {
-        let arr = crate::array::js_array_alloc(0);
-        let arr_value = box_pointer(arr as *const u8);
-        set_hidden_value(stream, key, arr_value);
-        arr_value
-    });
-    if !is_array_like_value(listeners) {
-        return;
-    }
-    let arr = raw_ptr_from_value(listeners) as *mut crate::array::ArrayHeader;
-    let arr = crate::array::js_array_push_f64(arr, cb);
-    set_hidden_value(stream, key, box_pointer(arr as *const u8));
-}
-
-fn listener_snapshot(stream: f64, key: *mut crate::string::StringHeader) -> Vec<f64> {
-    let Some(listeners) = get_hidden_value(stream, key) else {
-        return Vec::new();
-    };
-    if !is_array_like_value(listeners) {
-        return Vec::new();
-    }
-    let arr = raw_ptr_from_value(listeners) as *const crate::array::ArrayHeader;
-    let len = crate::array::js_array_length(arr);
-    let mut out = Vec::with_capacity(len as usize);
-    for i in 0..len {
-        out.push(crate::array::js_array_get_f64(arr, i));
-    }
-    out
-}
-
-fn call_listener0(listener: f64) {
-    let raw = raw_ptr_from_value(listener);
-    if raw >= 0x10000 {
-        crate::closure::js_closure_call0(raw as *const ClosureHeader);
-    }
-}
-
-fn call_listener1(listener: f64, arg: f64) {
-    let raw = raw_ptr_from_value(listener);
-    if raw >= 0x10000 {
-        crate::closure::js_closure_call1(raw as *const ClosureHeader, arg);
-    }
-}
-
 fn has_truthy_hidden(stream: f64, key: *mut crate::string::StringHeader) -> bool {
     get_hidden_value(stream, key).is_some_and(|v| crate::value::js_is_truthy(v) != 0)
 }
@@ -1142,25 +1127,21 @@ fn schedule_readable_from_drain(stream: f64) {
 }
 
 fn drain_readable_from_events(stream: f64) {
-    let data_listeners = listener_snapshot(stream, hidden_data_listeners_key());
-    if data_listeners.is_empty() {
+    let data_event = string_value(b"data");
+    if stream_listener_count_for_event(stream, data_event) == 0 {
         return;
     }
     if let Some(chunks) = readable_hidden_chunks(stream) {
         let mut values = Vec::new();
         push_chunk_values(chunks, &mut values, 0);
         for chunk in values {
-            for listener in &data_listeners {
-                call_listener1(*listener, chunk);
-            }
+            let _ = emit_stream_event(stream, data_event, &[chunk]);
         }
     }
     if !has_truthy_hidden(stream, hidden_end_emitted_key()) {
         set_hidden_value(stream, hidden_end_emitted_key(), f64::from_bits(TAG_TRUE));
         set_hidden_value(stream, hidden_ended_key(), f64::from_bits(TAG_TRUE));
-        for listener in listener_snapshot(stream, hidden_end_listeners_key()) {
-            call_listener0(listener);
-        }
+        let _ = emit_stream_event(stream, string_value(b"end"), &[]);
     }
 }
 
@@ -1475,14 +1456,14 @@ pub(crate) fn js_node_stream_readable_chunks_result(stream: f64) -> Result<Optio
 fn readable_methods() -> [(&'static str, StubFn); 37] {
     [
         ("on", cast2(ns_on2)),
-        ("once", cast2(ns_on2)),
-        ("prependListener", cast2(ns_on2)),
-        ("prependOnceListener", cast2(ns_on2)),
-        ("off", cast2(ns_chain2)),
+        ("once", cast2(ns_once2)),
+        ("prependListener", cast2(ns_prepend_listener2)),
+        ("prependOnceListener", cast2(ns_prepend_once_listener2)),
+        ("off", cast2(ns_off2)),
         ("addListener", cast2(ns_on2)),
-        ("removeListener", cast2(ns_chain2)),
-        ("removeAllListeners", cast1(ns_chain1)),
-        ("emit", cast2(ns_emit2)),
+        ("removeListener", cast2(ns_remove_listener2)),
+        ("removeAllListeners", cast1(ns_remove_all_listeners1)),
+        ("emit", cast2(ns_emit_rest)),
         ("setMaxListeners", cast1(ns_set_max_listeners)),
         ("getMaxListeners", cast0(ns_get_max_listeners)),
         ("eventNames", cast0(ns_event_names)),
@@ -1523,14 +1504,14 @@ fn readable_methods() -> [(&'static str, StubFn); 37] {
 fn writable_methods() -> [(&'static str, StubFn); 22] {
     [
         ("on", cast2(ns_on2)),
-        ("once", cast2(ns_on2)),
-        ("prependListener", cast2(ns_on2)),
-        ("prependOnceListener", cast2(ns_on2)),
-        ("off", cast2(ns_chain2)),
+        ("once", cast2(ns_once2)),
+        ("prependListener", cast2(ns_prepend_listener2)),
+        ("prependOnceListener", cast2(ns_prepend_once_listener2)),
+        ("off", cast2(ns_off2)),
         ("addListener", cast2(ns_on2)),
-        ("removeListener", cast2(ns_chain2)),
-        ("removeAllListeners", cast1(ns_chain1)),
-        ("emit", cast2(ns_emit2)),
+        ("removeListener", cast2(ns_remove_listener2)),
+        ("removeAllListeners", cast1(ns_remove_all_listeners1)),
+        ("emit", cast2(ns_emit_rest)),
         ("setMaxListeners", cast1(ns_set_max_listeners)),
         ("getMaxListeners", cast0(ns_get_max_listeners)),
         ("eventNames", cast0(ns_event_names)),
@@ -1553,14 +1534,14 @@ fn duplex_methods() -> [(&'static str, StubFn); 28] {
     // destroy` appear once each).
     [
         ("on", cast2(ns_on2)),
-        ("once", cast2(ns_on2)),
-        ("prependListener", cast2(ns_on2)),
-        ("prependOnceListener", cast2(ns_on2)),
-        ("off", cast2(ns_chain2)),
+        ("once", cast2(ns_once2)),
+        ("prependListener", cast2(ns_prepend_listener2)),
+        ("prependOnceListener", cast2(ns_prepend_once_listener2)),
+        ("off", cast2(ns_off2)),
         ("addListener", cast2(ns_on2)),
-        ("removeListener", cast2(ns_chain2)),
-        ("removeAllListeners", cast1(ns_chain1)),
-        ("emit", cast2(ns_emit2)),
+        ("removeListener", cast2(ns_remove_listener2)),
+        ("removeAllListeners", cast1(ns_remove_all_listeners1)),
+        ("emit", cast2(ns_emit_rest)),
         ("setMaxListeners", cast1(ns_set_max_listeners)),
         ("getMaxListeners", cast0(ns_get_max_listeners)),
         ("eventNames", cast0(ns_event_names)),

--- a/crates/perry-runtime/src/node_stream_destroy_state.rs
+++ b/crates/perry-runtime/src/node_stream_destroy_state.rs
@@ -15,6 +15,11 @@ pub(super) extern "C" fn ns_destroy_error_microtask(closure: *const ClosureHeade
     let stream = f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64);
     let err = js_closure_get_capture_f64(closure, 1);
     set_hidden_value(stream, hidden_error_key(), err);
+    let error = super::string_value(b"error");
+    if super::event_emitter::stream_listener_count_for_event(stream, error) > 0 {
+        let _ = super::event_emitter::emit_stream_event(stream, error, &[err]);
+    }
+    let _ = super::event_emitter::emit_stream_event(stream, super::string_value(b"close"), &[]);
     f64::from_bits(TAG_UNDEFINED)
 }
 

--- a/crates/perry-runtime/src/node_stream_event_emitter.rs
+++ b/crates/perry-runtime/src/node_stream_event_emitter.rs
@@ -1,6 +1,10 @@
 use crate::closure::ClosureHeader;
 use crate::value::JSValue;
 
+const STREAM_EVENT_NAMES_KEY: &[u8] = b"__perryStreamEventNames";
+const STREAM_LISTENERS_PREFIX: &[u8] = b"__perryStreamListeners:";
+const STREAM_ONCE_PREFIX: &[u8] = b"__perryStreamOnce:";
+
 pub(super) extern "C" fn ns_set_max_listeners(closure: *const ClosureHeader, value: f64) -> f64 {
     set_stream_max_listeners(super::this_value(closure), value)
 }
@@ -28,10 +32,72 @@ fn stream_max_listeners(stream: f64) -> f64 {
     super::get_hidden_value(stream, super::hidden_max_listeners_key()).unwrap_or(10.0)
 }
 
+pub(super) extern "C" fn ns_on2(closure: *const ClosureHeader, event: f64, cb: f64) -> f64 {
+    let stream = super::this_value(closure);
+    add_stream_listener_for_event(stream, event, cb);
+    stream
+}
+
+pub(super) extern "C" fn ns_once2(closure: *const ClosureHeader, event: f64, cb: f64) -> f64 {
+    let stream = super::this_value(closure);
+    add_stream_listener_for_event_with_options(stream, event, cb, true, false);
+    stream
+}
+
+pub(super) extern "C" fn ns_prepend_listener2(
+    closure: *const ClosureHeader,
+    event: f64,
+    cb: f64,
+) -> f64 {
+    let stream = super::this_value(closure);
+    add_stream_listener_for_event_with_options(stream, event, cb, false, true);
+    stream
+}
+
+pub(super) extern "C" fn ns_prepend_once_listener2(
+    closure: *const ClosureHeader,
+    event: f64,
+    cb: f64,
+) -> f64 {
+    let stream = super::this_value(closure);
+    add_stream_listener_for_event_with_options(stream, event, cb, true, true);
+    stream
+}
+
+pub(super) extern "C" fn ns_remove_listener2(
+    closure: *const ClosureHeader,
+    event: f64,
+    cb: f64,
+) -> f64 {
+    let stream = super::this_value(closure);
+    remove_stream_listener_for_event(stream, event, cb);
+    stream
+}
+
+pub(super) extern "C" fn ns_off2(closure: *const ClosureHeader, event: f64, cb: f64) -> f64 {
+    ns_remove_listener2(closure, event, cb)
+}
+
+pub(super) extern "C" fn ns_remove_all_listeners1(
+    closure: *const ClosureHeader,
+    event: f64,
+) -> f64 {
+    let stream = super::this_value(closure);
+    remove_all_stream_listeners_for_event(stream, event);
+    stream
+}
+
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_on(stream_handle: i64, event: f64, cb: f64) -> f64 {
     let stream = super::stream_value_from_handle(stream_handle);
-    super::add_stream_listener_for_event(stream, event, cb);
+    add_stream_listener_for_event(stream, event, cb);
+    stream
+}
+
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_once(stream_handle: i64, event: f64, cb: f64) -> f64 {
+    let stream = super::stream_value_from_handle(stream_handle);
+    add_stream_listener_for_event_with_options(stream, event, cb, true, false);
     stream
 }
 
@@ -41,81 +107,553 @@ pub extern "C" fn js_node_stream_method_prepend_listener(
     event: f64,
     cb: f64,
 ) -> f64 {
-    js_node_stream_method_on(stream_handle, event, cb)
+    let stream = super::stream_value_from_handle(stream_handle);
+    add_stream_listener_for_event_with_options(stream, event, cb, false, true);
+    stream
 }
 
-fn listener_key_for_event(event: f64) -> Option<*mut crate::string::StringHeader> {
-    if super::string_value_eq(event, b"data") {
-        Some(super::hidden_data_listeners_key())
-    } else if super::string_value_eq(event, b"end") {
-        Some(super::hidden_end_listeners_key())
-    } else {
-        None
-    }
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_prepend_once_listener(
+    stream_handle: i64,
+    event: f64,
+    cb: f64,
+) -> f64 {
+    let stream = super::stream_value_from_handle(stream_handle);
+    add_stream_listener_for_event_with_options(stream, event, cb, true, true);
+    stream
+}
+
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_remove_listener(
+    stream_handle: i64,
+    event: f64,
+    cb: f64,
+) -> f64 {
+    let stream = super::stream_value_from_handle(stream_handle);
+    remove_stream_listener_for_event(stream, event, cb);
+    stream
+}
+
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_off(stream_handle: i64, event: f64, cb: f64) -> f64 {
+    js_node_stream_method_remove_listener(stream_handle, event, cb)
+}
+
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_remove_all_listeners(
+    stream_handle: i64,
+    event: f64,
+) -> f64 {
+    let stream = super::stream_value_from_handle(stream_handle);
+    remove_all_stream_listeners_for_event(stream, event);
+    stream
 }
 
 pub(super) extern "C" fn ns_listener_count(closure: *const ClosureHeader, event: f64) -> f64 {
-    let stream = super::this_value(closure);
-    listener_count_for_event(stream, event)
+    stream_listener_count_for_event(super::this_value(closure), event) as f64
 }
 
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_listener_count(stream_handle: i64, event: f64) -> f64 {
-    listener_count_for_event(super::stream_value_from_handle(stream_handle), event)
-}
-
-fn listener_count_for_event(stream: f64, event: f64) -> f64 {
-    listener_key_for_event(event)
-        .map(|key| super::listener_snapshot(stream, key).len() as f64)
-        .unwrap_or(0.0)
+    stream_listener_count_for_event(super::stream_value_from_handle(stream_handle), event) as f64
 }
 
 pub(super) extern "C" fn ns_event_names(closure: *const ClosureHeader) -> f64 {
     let stream = super::this_value(closure);
-    f64::from_bits(JSValue::pointer(event_names_array(stream) as *const u8).bits())
+    f64::from_bits(JSValue::pointer(stream_event_names_array(stream) as *const u8).bits())
 }
 
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_event_names(stream_handle: i64) -> i64 {
-    event_names_array(super::stream_value_from_handle(stream_handle)) as i64
-}
-
-fn event_names_array(stream: f64) -> *mut crate::array::ArrayHeader {
-    let mut arr = crate::array::js_array_alloc(0);
-    if !super::listener_snapshot(stream, super::hidden_data_listeners_key()).is_empty() {
-        arr = crate::array::js_array_push_f64(arr, super::string_value(b"data"));
-    }
-    if !super::listener_snapshot(stream, super::hidden_end_listeners_key()).is_empty() {
-        arr = crate::array::js_array_push_f64(arr, super::string_value(b"end"));
-    }
-    arr
+    stream_event_names_array(super::stream_value_from_handle(stream_handle)) as i64
 }
 
 pub(super) extern "C" fn ns_listeners(closure: *const ClosureHeader, event: f64) -> f64 {
     let stream = super::this_value(closure);
-    f64::from_bits(JSValue::pointer(listeners_array_for_event(stream, event) as *const u8).bits())
+    f64::from_bits(
+        JSValue::pointer(stream_listeners_array_for_event(stream, event, false) as *const u8)
+            .bits(),
+    )
 }
 
 pub(super) extern "C" fn ns_raw_listeners(closure: *const ClosureHeader, event: f64) -> f64 {
-    ns_listeners(closure, event)
+    let stream = super::this_value(closure);
+    f64::from_bits(
+        JSValue::pointer(stream_listeners_array_for_event(stream, event, true) as *const u8).bits(),
+    )
 }
 
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_listeners(stream_handle: i64, event: f64) -> i64 {
-    listeners_array_for_event(super::stream_value_from_handle(stream_handle), event) as i64
+    stream_listeners_array_for_event(super::stream_value_from_handle(stream_handle), event, false)
+        as i64
 }
 
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_raw_listeners(stream_handle: i64, event: f64) -> i64 {
-    js_node_stream_method_listeners(stream_handle, event)
+    stream_listeners_array_for_event(super::stream_value_from_handle(stream_handle), event, true)
+        as i64
 }
 
-fn listeners_array_for_event(stream: f64, event: f64) -> *mut crate::array::ArrayHeader {
-    let mut arr = crate::array::js_array_alloc(0);
-    if let Some(key) = listener_key_for_event(event) {
-        for listener in super::listener_snapshot(stream, key) {
-            arr = crate::array::js_array_push_f64(arr, listener);
+pub(super) fn is_callable_value(value: f64) -> bool {
+    let raw = super::raw_ptr_from_value(value);
+    raw >= 0x10000 && !crate::closure::get_valid_func_ptr(raw as *const ClosureHeader).is_null()
+}
+
+pub(super) fn add_stream_listener_for_event(stream: f64, event: f64, cb: f64) {
+    add_stream_listener_for_event_with_options(stream, event, cb, false, false);
+}
+
+fn add_stream_listener_for_event_with_options(
+    stream: f64,
+    event: f64,
+    cb: f64,
+    once: bool,
+    prepend: bool,
+) {
+    if event_identity_bytes(event).is_none() || !is_callable_value(cb) {
+        return;
+    }
+    add_stream_listener(stream, event, cb, once, prepend);
+    if super::string_value_eq(event, b"data") {
+        super::schedule_readable_from_drain(stream);
+    }
+}
+
+fn string_bytes(value: f64) -> Option<Vec<u8>> {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if !jsval.is_any_string() {
+        return None;
+    }
+    let ptr = crate::value::js_get_string_pointer_unified(value) as *const crate::StringHeader;
+    if ptr.is_null() || (ptr as usize) < 0x1000 {
+        return None;
+    }
+    unsafe {
+        let len = (*ptr).byte_len as usize;
+        let data = (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        Some(std::slice::from_raw_parts(data, len).to_vec())
+    }
+}
+
+fn event_identity_bytes(event: f64) -> Option<Vec<u8>> {
+    if unsafe { crate::symbol::js_is_symbol(event) } != 0 {
+        let mut out = b"sym:".to_vec();
+        out.extend_from_slice(super::raw_ptr_from_value(event).to_string().as_bytes());
+        return Some(out);
+    }
+    let mut out = b"str:".to_vec();
+    out.extend_from_slice(&string_bytes(event)?);
+    Some(out)
+}
+
+fn event_key(prefix: &[u8], event: f64) -> Option<*mut crate::string::StringHeader> {
+    let mut key = prefix.to_vec();
+    key.extend_from_slice(&event_identity_bytes(event)?);
+    Some(super::hidden_key(&key))
+}
+
+fn hidden_event_names_key() -> *mut crate::string::StringHeader {
+    super::hidden_key(STREAM_EVENT_NAMES_KEY)
+}
+
+fn event_names_value(stream: f64) -> f64 {
+    super::get_hidden_value(stream, hidden_event_names_key()).unwrap_or_else(|| {
+        let arr = crate::array::js_array_alloc(0);
+        let value = super::box_pointer(arr as *const u8);
+        super::set_hidden_value(stream, hidden_event_names_key(), value);
+        value
+    })
+}
+
+fn event_names_snapshot(stream: f64) -> Vec<f64> {
+    let names = event_names_value(stream);
+    if !super::is_array_like_value(names) {
+        return Vec::new();
+    }
+    let arr = super::raw_ptr_from_value(names) as *const crate::array::ArrayHeader;
+    let len = crate::array::js_array_length(arr);
+    let mut out = Vec::with_capacity(len as usize);
+    for i in 0..len {
+        out.push(crate::array::js_array_get_f64(arr, i));
+    }
+    out
+}
+
+fn event_name_index(stream: f64, event: f64) -> Option<u32> {
+    let wanted = event_identity_bytes(event)?;
+    let names = event_names_value(stream);
+    if !super::is_array_like_value(names) {
+        return None;
+    }
+    let arr = super::raw_ptr_from_value(names) as *const crate::array::ArrayHeader;
+    let len = crate::array::js_array_length(arr);
+    for i in 0..len {
+        let existing = crate::array::js_array_get_f64(arr, i);
+        if event_identity_bytes(existing).is_some_and(|bytes| bytes == wanted) {
+            return Some(i);
         }
     }
-    arr
+    None
+}
+
+fn note_event_name(stream: f64, event: f64) {
+    if event_name_index(stream, event).is_some() {
+        return;
+    }
+    let names = event_names_value(stream);
+    if !super::is_array_like_value(names) {
+        return;
+    }
+    let arr = super::raw_ptr_from_value(names) as *mut crate::array::ArrayHeader;
+    let arr = crate::array::js_array_push_f64(arr, event);
+    super::set_hidden_value(
+        stream,
+        hidden_event_names_key(),
+        super::box_pointer(arr as *const u8),
+    );
+}
+
+fn listener_storage(stream: f64, event: f64) -> Option<(f64, f64)> {
+    let listeners = super::get_hidden_value(stream, event_key(STREAM_LISTENERS_PREFIX, event)?)?;
+    let once = super::get_hidden_value(stream, event_key(STREAM_ONCE_PREFIX, event)?)?;
+    Some((listeners, once))
+}
+
+fn ensure_listener_storage(stream: f64, event: f64) -> Option<(f64, f64)> {
+    let listener_key = event_key(STREAM_LISTENERS_PREFIX, event)?;
+    let once_key = event_key(STREAM_ONCE_PREFIX, event)?;
+    let listeners = super::get_hidden_value(stream, listener_key).unwrap_or_else(|| {
+        let arr = crate::array::js_array_alloc(0);
+        let value = super::box_pointer(arr as *const u8);
+        super::set_hidden_value(stream, listener_key, value);
+        value
+    });
+    let once = super::get_hidden_value(stream, once_key).unwrap_or_else(|| {
+        let arr = crate::array::js_array_alloc(0);
+        let value = super::box_pointer(arr as *const u8);
+        super::set_hidden_value(stream, once_key, value);
+        value
+    });
+    Some((listeners, once))
+}
+
+fn set_listener_storage(stream: f64, event: f64, listeners: f64, once: f64) {
+    if let Some(listener_key) = event_key(STREAM_LISTENERS_PREFIX, event) {
+        super::set_hidden_value(stream, listener_key, listeners);
+    }
+    if let Some(once_key) = event_key(STREAM_ONCE_PREFIX, event) {
+        super::set_hidden_value(stream, once_key, once);
+    }
+}
+
+fn add_stream_listener(stream: f64, event: f64, cb: f64, once: bool, prepend: bool) {
+    emit_meta_event(stream, b"newListener", &[event, cb]);
+    note_event_name(stream, event);
+    let Some((listeners, once_flags)) = ensure_listener_storage(stream, event) else {
+        return;
+    };
+    if !super::is_array_like_value(listeners) || !super::is_array_like_value(once_flags) {
+        return;
+    }
+    let listeners_arr = super::raw_ptr_from_value(listeners) as *const crate::array::ArrayHeader;
+    let once_arr = super::raw_ptr_from_value(once_flags) as *const crate::array::ArrayHeader;
+    let len = crate::array::js_array_length(listeners_arr);
+    let mut out_listeners = crate::array::js_array_alloc(len + 1);
+    let mut out_once = crate::array::js_array_alloc(len + 1);
+    if prepend {
+        out_listeners = crate::array::js_array_push_f64(out_listeners, cb);
+        out_once = crate::array::js_array_push_f64(out_once, bool_value(once));
+    }
+    for i in 0..len {
+        out_listeners = crate::array::js_array_push_f64(
+            out_listeners,
+            crate::array::js_array_get_f64(listeners_arr, i),
+        );
+        out_once =
+            crate::array::js_array_push_f64(out_once, crate::array::js_array_get_f64(once_arr, i));
+    }
+    if !prepend {
+        out_listeners = crate::array::js_array_push_f64(out_listeners, cb);
+        out_once = crate::array::js_array_push_f64(out_once, bool_value(once));
+    }
+    set_listener_storage(
+        stream,
+        event,
+        super::box_pointer(out_listeners as *const u8),
+        super::box_pointer(out_once as *const u8),
+    );
+}
+
+fn bool_value(value: bool) -> f64 {
+    f64::from_bits(if value {
+        super::TAG_TRUE
+    } else {
+        super::TAG_FALSE
+    })
+}
+
+fn listener_snapshot(stream: f64, event: f64) -> Vec<(f64, bool)> {
+    let Some((listeners, once_flags)) = listener_storage(stream, event) else {
+        return Vec::new();
+    };
+    if !super::is_array_like_value(listeners) || !super::is_array_like_value(once_flags) {
+        return Vec::new();
+    }
+    let listeners_arr = super::raw_ptr_from_value(listeners) as *const crate::array::ArrayHeader;
+    let once_arr = super::raw_ptr_from_value(once_flags) as *const crate::array::ArrayHeader;
+    let len = crate::array::js_array_length(listeners_arr);
+    let mut out = Vec::with_capacity(len as usize);
+    for i in 0..len {
+        out.push((
+            crate::array::js_array_get_f64(listeners_arr, i),
+            crate::value::js_is_truthy(crate::array::js_array_get_f64(once_arr, i)) != 0,
+        ));
+    }
+    out
+}
+
+fn remove_event_name(stream: f64, event: f64) {
+    let Some(remove_idx) = event_name_index(stream, event) else {
+        return;
+    };
+    let names = event_names_value(stream);
+    if !super::is_array_like_value(names) {
+        return;
+    }
+    let arr = super::raw_ptr_from_value(names) as *const crate::array::ArrayHeader;
+    let len = crate::array::js_array_length(arr);
+    let mut out = crate::array::js_array_alloc(len.saturating_sub(1));
+    for i in 0..len {
+        if i != remove_idx {
+            out = crate::array::js_array_push_f64(out, crate::array::js_array_get_f64(arr, i));
+        }
+    }
+    super::set_hidden_value(
+        stream,
+        hidden_event_names_key(),
+        super::box_pointer(out as *const u8),
+    );
+}
+
+fn prune_event_if_empty(stream: f64, event: f64) {
+    if stream_listener_count_for_event(stream, event) == 0 {
+        remove_event_name(stream, event);
+    }
+}
+
+fn remove_stream_listener_for_event(stream: f64, event: f64, cb: f64) -> bool {
+    let Some((listeners, once_flags)) = listener_storage(stream, event) else {
+        return false;
+    };
+    if !super::is_array_like_value(listeners) || !super::is_array_like_value(once_flags) {
+        return false;
+    }
+    let listeners_arr = super::raw_ptr_from_value(listeners) as *const crate::array::ArrayHeader;
+    let once_arr = super::raw_ptr_from_value(once_flags) as *const crate::array::ArrayHeader;
+    let len = crate::array::js_array_length(listeners_arr);
+    let mut remove_idx = None;
+    for i in (0..len).rev() {
+        let listener = crate::array::js_array_get_f64(listeners_arr, i);
+        if listener.to_bits() == cb.to_bits() {
+            remove_idx = Some(i);
+            break;
+        }
+    }
+    let Some(remove_idx) = remove_idx else {
+        return false;
+    };
+    let mut out_listeners = crate::array::js_array_alloc(len);
+    let mut out_once = crate::array::js_array_alloc(len);
+    for i in 0..len {
+        let listener = crate::array::js_array_get_f64(listeners_arr, i);
+        if i == remove_idx {
+            continue;
+        }
+        out_listeners = crate::array::js_array_push_f64(out_listeners, listener);
+        out_once =
+            crate::array::js_array_push_f64(out_once, crate::array::js_array_get_f64(once_arr, i));
+    }
+    set_listener_storage(
+        stream,
+        event,
+        super::box_pointer(out_listeners as *const u8),
+        super::box_pointer(out_once as *const u8),
+    );
+    prune_event_if_empty(stream, event);
+    emit_meta_event(stream, b"removeListener", &[event, cb]);
+    true
+}
+
+fn remove_all_stream_listeners_for_event(stream: f64, event: f64) {
+    if event_identity_bytes(event).is_none() {
+        for name in event_names_snapshot(stream) {
+            remove_all_stream_listeners_for_event(stream, name);
+        }
+        super::set_hidden_value(
+            stream,
+            hidden_event_names_key(),
+            super::box_pointer(crate::array::js_array_alloc(0) as *const u8),
+        );
+        return;
+    }
+    let removed = listener_snapshot(stream, event);
+    let empty_listeners = super::box_pointer(crate::array::js_array_alloc(0) as *const u8);
+    let empty_once = super::box_pointer(crate::array::js_array_alloc(0) as *const u8);
+    set_listener_storage(stream, event, empty_listeners, empty_once);
+    remove_event_name(stream, event);
+    for (listener, _) in removed {
+        emit_meta_event(stream, b"removeListener", &[event, listener]);
+    }
+}
+
+fn remove_once_listeners(stream: f64, event: f64) {
+    let Some((listeners, once_flags)) = listener_storage(stream, event) else {
+        return;
+    };
+    if !super::is_array_like_value(listeners) || !super::is_array_like_value(once_flags) {
+        return;
+    }
+    let listeners_arr = super::raw_ptr_from_value(listeners) as *const crate::array::ArrayHeader;
+    let once_arr = super::raw_ptr_from_value(once_flags) as *const crate::array::ArrayHeader;
+    let len = crate::array::js_array_length(listeners_arr);
+    let mut out_listeners = crate::array::js_array_alloc(len);
+    let mut out_once = crate::array::js_array_alloc(len);
+    let mut removed = Vec::new();
+    for i in 0..len {
+        let listener = crate::array::js_array_get_f64(listeners_arr, i);
+        if crate::value::js_is_truthy(crate::array::js_array_get_f64(once_arr, i)) == 0 {
+            out_listeners = crate::array::js_array_push_f64(out_listeners, listener);
+            out_once = crate::array::js_array_push_f64(
+                out_once,
+                crate::array::js_array_get_f64(once_arr, i),
+            );
+        } else {
+            removed.push(listener);
+        }
+    }
+    set_listener_storage(
+        stream,
+        event,
+        super::box_pointer(out_listeners as *const u8),
+        super::box_pointer(out_once as *const u8),
+    );
+    prune_event_if_empty(stream, event);
+    for listener in removed {
+        emit_meta_event(stream, b"removeListener", &[event, listener]);
+    }
+}
+
+pub(super) fn stream_listener_count_for_event(stream: f64, event: f64) -> usize {
+    listener_snapshot(stream, event).len()
+}
+
+fn stream_event_names_array(stream: f64) -> *mut crate::array::ArrayHeader {
+    let mut out = crate::array::js_array_alloc(0);
+    for name in event_names_snapshot(stream) {
+        if stream_listener_count_for_event(stream, name) > 0 {
+            out = crate::array::js_array_push_f64(out, name);
+        }
+    }
+    out
+}
+
+fn stream_listeners_array_for_event(
+    stream: f64,
+    event: f64,
+    raw: bool,
+) -> *mut crate::array::ArrayHeader {
+    let snapshot = listener_snapshot(stream, event);
+    let mut out = crate::array::js_array_alloc(snapshot.len() as u32);
+    for (listener, once) in snapshot {
+        if raw && once {
+            let obj = crate::object::js_object_alloc(0, 1);
+            crate::object::js_object_set_field_by_name(
+                obj,
+                super::hidden_key(b"listener"),
+                listener,
+            );
+            out = crate::array::js_array_push_f64(out, super::box_pointer(obj as *const u8));
+        } else {
+            out = crate::array::js_array_push_f64(out, listener);
+        }
+    }
+    out
+}
+
+pub(super) fn call_listener_args(stream: f64, listener: f64, args: &[f64]) {
+    if !is_callable_value(listener) {
+        return;
+    }
+    let prev = crate::object::js_implicit_this_set(stream);
+    unsafe {
+        let _ = crate::closure::js_native_call_value(listener, args.as_ptr(), args.len());
+    }
+    crate::object::js_implicit_this_set(prev);
+}
+
+pub(super) fn emit_stream_event_from_array(
+    stream: f64,
+    event: f64,
+    args_arr: *const crate::array::ArrayHeader,
+) -> f64 {
+    let len = if args_arr.is_null() {
+        0
+    } else {
+        crate::array::js_array_length(args_arr)
+    };
+    let mut args = Vec::with_capacity(len as usize);
+    for i in 0..len {
+        args.push(crate::array::js_array_get_f64(args_arr, i));
+    }
+    emit_stream_event(stream, event, &args)
+}
+
+pub(super) fn emit_stream_event(stream: f64, event: f64, args: &[f64]) -> f64 {
+    if event_identity_bytes(event).is_none() {
+        return f64::from_bits(super::TAG_FALSE);
+    }
+    if super::string_value_eq(event, b"error") {
+        if let Some(first) = args.first() {
+            super::set_hidden_value(stream, super::hidden_error_key(), *first);
+        }
+        let monitor_event = error_monitor_event();
+        let monitor_snapshot = listener_snapshot(stream, monitor_event);
+        if monitor_snapshot.iter().any(|(_, once)| *once) {
+            remove_once_listeners(stream, monitor_event);
+        }
+        for (listener, _) in monitor_snapshot {
+            call_listener_args(stream, listener, args);
+        }
+    }
+
+    let snapshot = listener_snapshot(stream, event);
+    if snapshot.is_empty() {
+        if super::string_value_eq(event, b"error") {
+            let err = args
+                .first()
+                .copied()
+                .unwrap_or_else(|| f64::from_bits(super::TAG_UNDEFINED));
+            crate::exception::js_throw(err);
+        }
+        return f64::from_bits(super::TAG_FALSE);
+    }
+    if snapshot.iter().any(|(_, once)| *once) {
+        remove_once_listeners(stream, event);
+    }
+    for (listener, _) in snapshot {
+        call_listener_args(stream, listener, args);
+    }
+    f64::from_bits(super::TAG_TRUE)
+}
+
+fn error_monitor_event() -> f64 {
+    unsafe { crate::symbol::js_symbol_for(super::string_value(b"events.errorMonitor")) }
+}
+
+fn emit_meta_event(stream: f64, name: &[u8], args: &[f64]) {
+    let event = super::string_value(name);
+    if stream_listener_count_for_event(stream, event) > 0 {
+        let _ = emit_stream_event(stream, event, args);
+    }
 }

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -12,6 +12,9 @@
 #[used]
 static KEEP_NS_METHOD_EMIT: extern "C" fn(i64, f64, f64) -> f64 = super::js_node_stream_method_emit;
 #[used]
+static KEEP_NS_METHOD_EMIT_ARGS: extern "C" fn(i64, f64, i64) -> f64 =
+    super::js_node_stream_method_emit_args;
+#[used]
 static KEEP_NS_METHOD_READ: extern "C" fn(i64, f64) -> f64 = super::js_node_stream_method_read;
 #[used]
 static KEEP_NS_METHOD_PUSH: extern "C" fn(i64, f64) -> f64 = super::js_node_stream_method_push;
@@ -40,8 +43,21 @@ static KEEP_NS_METHOD_GET_MAX_LISTENERS: extern "C" fn(i64) -> f64 =
 #[used]
 static KEEP_NS_METHOD_ON: extern "C" fn(i64, f64, f64) -> f64 = super::js_node_stream_method_on;
 #[used]
+static KEEP_NS_METHOD_ONCE: extern "C" fn(i64, f64, f64) -> f64 = super::js_node_stream_method_once;
+#[used]
 static KEEP_NS_METHOD_PREPEND_LISTENER: extern "C" fn(i64, f64, f64) -> f64 =
     super::js_node_stream_method_prepend_listener;
+#[used]
+static KEEP_NS_METHOD_PREPEND_ONCE_LISTENER: extern "C" fn(i64, f64, f64) -> f64 =
+    super::js_node_stream_method_prepend_once_listener;
+#[used]
+static KEEP_NS_METHOD_OFF: extern "C" fn(i64, f64, f64) -> f64 = super::js_node_stream_method_off;
+#[used]
+static KEEP_NS_METHOD_REMOVE_LISTENER: extern "C" fn(i64, f64, f64) -> f64 =
+    super::js_node_stream_method_remove_listener;
+#[used]
+static KEEP_NS_METHOD_REMOVE_ALL_LISTENERS: extern "C" fn(i64, f64) -> f64 =
+    super::js_node_stream_method_remove_all_listeners;
 #[used]
 static KEEP_NS_METHOD_EVENT_NAMES: extern "C" fn(i64) -> i64 =
     super::js_node_stream_method_event_names;

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -367,6 +367,8 @@ fn stream_native_receiver_methods_update_hidden_state() {
     let stream = js_node_stream_passthrough_new(f64::from_bits(TAG_UNDEFINED));
     let handle = raw_ptr_from_value(stream) as i64;
     let err = string_value("boom");
+    let cb = box_pointer(js_closure_alloc(noop_listener as *const u8, 0) as *const u8);
+    let _ = js_node_stream_method_on(handle, string_value("error"), cb);
 
     assert_eq!(
         js_node_stream_method_emit(handle, string_value("error"), err).to_bits(),

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -849,6 +849,21 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
 
 /// Get a field by its string key name
 /// Returns the field value or undefined if the key is not found
+unsafe fn closure_dynamic_prop_by_key(obj: usize, key: *const crate::StringHeader) -> Option<f64> {
+    if key.is_null() {
+        return None;
+    }
+    let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    let key_len = (*key).byte_len as usize;
+    let name = std::str::from_utf8(std::slice::from_raw_parts(key_ptr, key_len)).ok()?;
+    let val = crate::closure::closure_get_dynamic_prop(obj, name);
+    if val.to_bits() == crate::value::TAG_UNDEFINED {
+        None
+    } else {
+        Some(val)
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn js_object_get_field_by_name(
     obj: *const ObjectHeader,
@@ -1167,6 +1182,9 @@ pub extern "C" fn js_object_get_field_by_name(
         return JSValue::undefined();
     }
     unsafe {
+        if let Some(val) = closure_dynamic_prop_by_key(obj as usize, key) {
+            return JSValue::from_bits(val.to_bits());
+        }
         // Buffers: BufferHeader is allocated via raw `alloc()` (no GcHeader)
         // and tracked in BUFFER_REGISTRY. Detect first so the GC header check
         // below doesn't read garbage one word before the BufferHeader.
@@ -2098,6 +2116,11 @@ pub extern "C" fn js_object_get_field_ic_miss(
     }
     if obj.is_null() || key.is_null() {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    unsafe {
+        if let Some(val) = closure_dynamic_prop_by_key(obj as usize, key) {
+            return val;
+        }
     }
     // Issue #340: small-handle receivers (axios, fastify, ioredis,
     // ...) are passed here from the codegen IC miss path with the

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -191,6 +191,14 @@ pub(crate) fn bound_native_callable_export_value(module_name: &str, property_nam
         );
     }
 
+    if module_name == "events" && property_name == "EventEmitter" {
+        crate::closure::closure_set_dynamic_prop(
+            (value.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize,
+            "defaultMaxListeners",
+            10.0,
+        );
+    }
+
     NATIVE_CALLABLE_EXPORTS.with(|c| {
         c.borrow_mut().insert(key, value.to_bits());
     });

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -308,12 +308,6 @@
     "category": "bug-open",
     "reason": "node:stream: PassThrough instance lacks .readable/.writable flags. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/passthrough/echo": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: PassThrough does not propagate write→data→end events. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipeline/basic": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -446,12 +440,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline with intermediate transform doesn't propagate data → end. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/listener-management": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: EventEmitter listener-management methods on stream instances don't track properly. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/flags/readable-flowing": {
     "issue": "1531",
     "added": "2026-05-23",
@@ -505,12 +493,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: Readable() with no read() option should emit error on read(); error event doesn't deliver. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/once-vs-on": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: once() vs on() semantics — event delivery doesn't fire listeners. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/backpressure/write-returns-false": {
     "issue": "1531",
@@ -650,18 +632,6 @@
     "category": "bug-open",
     "reason": "node:stream: setEncoding(hex) + data delivery doesn't fire. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/prepend-listener": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: prependListener doesn't insert listener at front (order wrong). Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/events/remove-all-listeners": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: removeAllListeners doesn't clear listenerCount. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/push/typed-array": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -800,12 +770,6 @@
     "category": "bug-open",
     "reason": "node:stream: pause/resume events don't fire. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/raw-listeners": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: rawListeners() vs listeners() distinction not tracked. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/finished/options-config": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -836,18 +800,6 @@
     "category": "bug-open",
     "reason": "node:stream: class extends Writable + _write doesn't deliver finish. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/ee/new-listener-event": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: newListener/removeListener inherited EE events don't fire on streams. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/ee/listener-count-no-arg": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: listenerCount(name) returns wrong type/value. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/duplex/allow-half-open-default": {
     "issue": "1531",
     "added": "2026-05-23",
@@ -865,18 +817,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: finish/close event ordering doesn't deliver. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/ee/prepend-once-listener": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: prependOnceListener insertion order not honored. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/ee/emit-multi-args": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: emit(event, a, b, c) doesn't pass all trailing args to listeners. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/encoding/latin1": {
     "issue": "1532",
@@ -913,18 +853,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: destroy() with no error doesn't fire close event. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/ee/emit-returns": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: emit() return value (true/false based on listener presence) wrong. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/ee/on-returns-this": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: on()/removeListener() should return the emitter for chaining; Perry returns wrong value. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/object-mode/read-single-object": {
     "issue": "1532",
@@ -967,18 +895,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: destroy(symbol) does not deliver via error event. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/ee/add-listener-alias": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: addListener / off aliases do not mirror the on / removeListener counts. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/ee/set-max-listeners-infinity": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: setMaxListeners(Infinity) and (0) not honored on streams. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/pipe/four-stage-chain": {
     "issue": "1532",
@@ -1436,12 +1352,6 @@
     "category": "bug-open",
     "reason": "node:stream: events.once(stream, 'end') — Promise-returning form does not resolve correctly. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/prepend-listener-order": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: prependListener(event, fn) — fn does not fire before existing on() listeners. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/compose/error-mid-chain": {
     "issue": "1531",
     "added": "2026-05-24",
@@ -1454,23 +1364,11 @@
     "category": "bug-open",
     "reason": "node:stream: pause()/resume()/destroy() don't all return `this` — chainability broken on one or more. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/setmaxlisteners-effective": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: setMaxListeners(n) — cap not actually raised, or listenerCount mismatches. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/tostring-tag-web-classes": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: ReadableStream/WritableStream/TransformStream lack Symbol.toStringTag — Object.prototype.toString.call() returns '[object Object]'. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/events/emit-return-value": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: emit() return value — does not return false for no-listener case or true for present-listener case. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/iter-helpers/to-array-erroring": {
     "issue": "1558",
@@ -1556,12 +1454,6 @@
     "category": "bug-open",
     "reason": "node:stream/promises: pipeline with signal does not reject on abort. Flips to PASS when #1533 lands."
   },
-  "node-suite/stream/events/remove-listener-event": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: 'removeListener' meta-event not emitted when removeListener() is called. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/strategies-imported": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -1585,12 +1477,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Readable.from(Buffer) — Buffer is iterated byte-by-byte instead of emitted as single chunk. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/error-monitor-symbol": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: events.errorMonitor symbol observer not invoked on stream error. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/iter-helpers/map-async-rejection": {
     "issue": "1558",
@@ -1646,12 +1532,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline(src, async fn) — fn-as-sink form not yet wired (cb not called, collected is empty). Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/new-listener-meta-event": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: 'newListener' meta-event not emitted when a listener is added. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/pipe-to-locks-and-releases": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -1663,18 +1543,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: unshift() after end — does not emit 'error' / ERR_STREAM_PUSH_AFTER_EOF. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/raw-listeners-once-wrapped": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: rawListeners() — once-wrapper does not expose .listener pointing at original fn. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/emit-multiple-args-stream": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: emit(event, a, b, c) — listeners receive wrong number of args (variadic args lost). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/async-handler-promise": {
     "issue": "1531",
@@ -1694,12 +1562,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: getReader({mode:'byob'}) on non-byte stream does not throw TypeError. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/events/remove-all-listeners-no-arg": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: removeAllListeners() with no arg — does not clear every event's listeners. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/iter-helpers/map-with-thisarg": {
     "issue": "1558",
     "added": "2026-05-24",
@@ -1711,12 +1573,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Writable defaultEncoding option — encoding arg seen by _write differs from 'hex'. Flips to PASS when #1539 lands."
-  },
-  "node-suite/stream/events/event-names-returns-array": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: eventNames() — returns wrong shape or missing event names. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/classes/readable-no-read-fn": {
     "issue": "1531",
@@ -1748,12 +1604,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipe to multiple destinations — data delivered to only one or wrong counts. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/on-returns-this-chained": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: on() chained — return value not the emitter, breaking chained registration. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/flow/pause-resume-cycle": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1784,18 +1634,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: TransformStream.readable/.writable not correctly typed as ReadableStream/WritableStream instances. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/events/listener-count-symbol-events": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: listenerCount(Symbol) — does not count Symbol-keyed listeners. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/prepend-once-listener": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: prependOnceListener — wrong order or no auto-removal after firing. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/compose/instance-chain": {
     "issue": "1531",
     "added": "2026-05-24",
@@ -1825,12 +1663,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: read() before any push — should return null, returns wrong value. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/event-names-order-insertion": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: eventNames() — order does not match listener-insertion order. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/read-n-consumes-exactly-n": {
     "issue": "1532",
@@ -1873,12 +1705,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pipe error semantics — destination error or source close state differs from Node. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/error-before-data-immediate-destroy": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: immediate destroy(err) — event ordering/set ('data'/'end' should NOT fire) wrong. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/meta/stream-prototype-ee": {
     "issue": "1532",
@@ -2096,12 +1922,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.from(empty) — 'end' event not fired or fires with wrong count. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/once-removed-after-fire": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: once() listener not removed after firing — second emit invokes it again. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/iter-helpers/find-returns-promise": {
     "issue": "1558",
     "added": "2026-05-24",
@@ -2119,12 +1939,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: destroyed flag not synchronously true after destroy(). Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/listener-removal-during-emit": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: removeListener() during emit() — the snapshot semantics differ (other listener not fired or fires twice). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/promises/pipeline-returns-undefined": {
     "issue": "1533",
@@ -2161,12 +1975,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: pipeThrough(transform, {preventClose:true}) — transform.writable should remain unlocked. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/events/once-with-symbol-event": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: once() with Symbol event name (e.g. errorMonitor) — fires wrong count or doesn't auto-remove. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/readable-no-sync-iterator": {
     "issue": "1545",
@@ -2300,12 +2108,6 @@
     "category": "bug-open",
     "reason": "node:stream: pure-end Readable (push(null) only) — 'end' fires with wrong data count or doesn't fire. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/get-events-set-equality": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: removeListener of un-registered listener — eventNames count wrong, or unexpected error. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/from-async-generator-function": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -2432,23 +2234,11 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.from(['a','b','c']) — each string not a separate chunk. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/emit-returns-false-no-listeners": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: emit() — no-listener returns wrong value (not false). Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/tee-after-getReader-throws": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: tee() on locked stream does not throw TypeError. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/events/remove-all-listeners-error-event": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: removeAllListeners('error') — does not zero the count. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/flow/paused-no-data-flow": {
     "issue": "1532",
@@ -2468,23 +2258,11 @@
     "category": "bug-open",
     "reason": "node:stream: read() in non-encoded mode — does not return Buffer instance. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/error-arg-is-error-instance": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: 'error' listener arg — wrong instance / message. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipe/pipe-autodestroy-default": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pipe() autoDestroy default — src or dst not destroyed after pipe. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/set-max-listeners-zero": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: setMaxListeners(0) — max not 0 (unlimited) per Node. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipe/three-stage-mid-error": {
     "issue": "1532",
@@ -2510,12 +2288,6 @@
     "category": "bug-open",
     "reason": "node:stream: flatMap(asyncGenFn) — multi-yield per input not flattened. Flips to PASS when #1558 lands."
   },
-  "node-suite/stream/events/error-listener-once-cleanup": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: once('error', fn) — listener not auto-removed after fire. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/from-rejected-promise-in-array": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -2533,12 +2305,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: readable.iterator({destroyOnReturn:false}) — early return still destroys. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/events/listeners-empty-array": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: listeners() with no listeners — not an empty array or wrong type. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/iter-helpers/every-async-rejection": {
     "issue": "1558",
@@ -2563,12 +2329,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: find(asyncFn) — returns wrong value. Flips to PASS when #1558 lands."
-  },
-  "node-suite/stream/events/remove-listener-by-reference": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: removeListener(event, fn) — does not decrement listener count correctly by-reference. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/writable/uncork-twice-after-cork": {
     "issue": "1539",
@@ -2600,12 +2360,6 @@
     "category": "bug-open",
     "reason": "node:stream: some instance method reports wrong typeof (not 'function'). Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/error-via-pipe": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: src.emit('error') during pipe — src or dst error tracking wrong. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/from-iterator-throws": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -2618,12 +2372,6 @@
     "category": "bug-open",
     "reason": "node:stream: some(asyncFn) — rejection in fn does not propagate. Flips to PASS when #1558 lands."
   },
-  "node-suite/stream/events/get-listeners-instance-method": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: listeners(event) — wrong array shape or count. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/transform-readable-cancel-propagates": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -2635,12 +2383,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: finished(alreadyEnded) — does not resolve immediately. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/error-emit-sync": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: emit('error') — listener does not fire synchronously. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/readable-property-shape": {
     "issue": "1532",
@@ -2822,12 +2564,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose(transform).toArray() — chain produces wrong result. Flips to PASS when #1558 lands."
   },
-  "node-suite/stream/events/listener-add-during-emit": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: listener added during emit — fires this round (should NOT in EE spec). Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/iter-and-data-listener": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -2882,12 +2618,6 @@
     "category": "bug-open",
     "reason": "node:stream: objectMode 'readable' event — read() returns wrong object values. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/emit-with-arg-array": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: emit(event, a, b, c, d) — listeners receive wrong args. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/many-pushes-accumulate": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -2905,12 +2635,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: RS.from(asyncGen throws mid) — read() does not reject. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/events/listener-throw-does-not-stop-others": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: listener throw in emit — second listener may or may not fire (Perry differs from Node). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/cancel-during-pull": {
     "issue": "1545",
@@ -2941,12 +2665,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: destroy(err) — 'error' fires after 'close', or order wrong. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/listener-count-by-symbol-event": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: listenerCount(Symbol) — count wrong for Symbol-keyed listeners. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/iter-helpers/some-finds-match": {
     "issue": "1558",
@@ -2990,12 +2708,6 @@
     "category": "bug-open",
     "reason": "node:stream: Writable destroyed false after 'finish' (autoDestroy default true). Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/multiple-events-event-names": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: eventNames does not include all registered event names. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/writable/end-cb-fires-after-flush": {
     "issue": "1539",
     "added": "2026-05-24",
@@ -3013,12 +2725,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: encoding option in ctor — readableEncoding wrong or data not string. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/new-listener-fires-before-add": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: 'newListener' fires after the listener is added (should be before). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipe/pipe-to-plain-writable": {
     "issue": "1532",
@@ -3050,12 +2756,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipe() src pause/resume events on backpressure — wrong order/missing. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/remove-listener-after-removal": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: 'removeListener' meta-event fires before removal (should be after). Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/compose/three-stages-order": {
     "issue": "1531",
     "added": "2026-05-24",
@@ -3067,12 +2767,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Duplex write side — received array empty / wrong order. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/remove-non-registered-listener": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: removeListener of non-registered fn — returns wrong value or eventNames non-empty. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipeline/async-source-throws-mid": {
     "issue": "1532",
@@ -3110,12 +2804,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.from(Buffer) — not single Buffer chunk (iterates byte-by-byte). Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/listener-cleanup-after-once-fires": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: once() — rawListeners count after fire not zero. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/push-string-with-encoding-set": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -3133,12 +2821,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Readable.from(Set) — iteration order or count wrong. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/emit-different-events-isolated": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: emit different events — count interference across event keys. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/cancel-with-undefined-reason": {
     "issue": "1545",
@@ -3170,12 +2852,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.from(arguments) — Array-like iteration fails. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/setMaxListeners-stays-applied": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: setMaxListeners(50) — value not preserved across operations. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/iter-helpers/reduce-with-initial": {
     "issue": "1558",
     "added": "2026-05-24",
@@ -3187,12 +2863,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: forEach() on empty — calls non-zero or result not undefined. Flips to PASS when #1558 lands."
-  },
-  "node-suite/stream/events/set-max-listeners-chainable": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: setMaxListeners returns wrong value (should return emitter). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/readable-stream-id-properties": {
     "issue": "1532",
@@ -3217,12 +2887,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pipe with 20 chunks — order or count wrong. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/emit-error-multi-listener": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: emit('error') multi-listener — wrong call counts. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/strategy-size-non-number": {
     "issue": "1545",
@@ -3253,12 +2917,6 @@
     "added": "2026-05-25",
     "category": "bug-open",
     "reason": "node:stream: Readable.from('text') — chunk shape/count wrong. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/eventNames-with-symbols": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: eventNames does not include Symbol event keys. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/iter-helpers/map-async-with-concurrency": {
     "issue": "1558",
@@ -3314,23 +2972,11 @@
     "category": "bug-open",
     "reason": "node:stream: generator with explicit return — values yielded after return statement aren't reached. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/listener-closure-counter": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: listener with closure counter — count wrong. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipe/four-stage-chain-v2": {
     "issue": "1532",
     "added": "2026-05-25",
     "category": "bug-open",
     "reason": "node:stream: 4-stage pipe — wrong output. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/listener-added-fires-on-emit": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: listener after add — does not fire on emit. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipe/many-listeners-on-dst": {
     "issue": "1532",

--- a/test-parity/node-suite/stream/events/distinct-symbol-events.ts
+++ b/test-parity/node-suite/stream/events/distinct-symbol-events.ts
@@ -1,0 +1,19 @@
+import { Readable } from "node:stream";
+
+// Symbols with the same description are still distinct event names.
+const r = new Readable({ read() {} });
+const a = Symbol("shared");
+const b = Symbol("shared");
+let seenA = 0;
+let seenB = 0;
+
+r.on(a, () => seenA++);
+r.on(b, () => seenB++);
+
+r.emit(a);
+
+console.log("a count:", seenA);
+console.log("b count:", seenB);
+console.log("listenerCount a:", r.listenerCount(a));
+console.log("listenerCount b:", r.listenerCount(b));
+console.log("eventNames length:", r.eventNames().length);

--- a/test-parity/node-suite/stream/events/remove-listener-removes-latest.ts
+++ b/test-parity/node-suite/stream/events/remove-listener-removes-latest.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+
+const r = new Readable({ read() {} });
+const calls: string[] = [];
+const fn = () => calls.push("fn");
+
+r.on("custom", fn);
+r.on("custom", () => calls.push("middle"));
+r.on("custom", fn);
+
+r.removeListener("custom", fn);
+r.emit("custom");
+
+console.log("count:", r.listenerCount("custom"));
+console.log("calls:", calls.join(","));


### PR DESCRIPTION
## Summary

- Implement stream instance EventEmitter listener lifecycle: once/prepend/remove/removeAll/listenerCount/eventNames/listeners/rawListeners, symbol-keyed events, meta events, and error/errorMonitor semantics.
- Wire variadic stream emit plus basic write/end event delivery for PassThrough-style flows.
- Expose EventEmitter.defaultMaxListeners through callable native-module properties.
- Remove stale stream parity known failures covered by passing fixtures.

## Tests

- cargo fmt --all -- --check
- git diff --check HEAD~1..HEAD
- jq empty test-parity/known_failures.json
- ./scripts/check_file_size.sh
- cargo check -q -p perry-runtime -p perry-codegen
- cargo test -p perry-runtime node_stream -- --nocapture
- cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib
- focused parity sweep for 59 removed known failures plus distinct-symbol-events and remove-listener-removes-latest: pass=61 fail=0 compile_fail=0 node_fail=0
- PERRY_NO_AUTO_OPTIMIZE=1 PERRY_ALLOW_UNIMPLEMENTED=1 target/release/perry run test-parity/node-suite/stream/events/remove-listener-removes-latest.ts
- PERRY_NO_AUTO_OPTIMIZE=1 PERRY_ALLOW_UNIMPLEMENTED=1 target/release/perry run test-parity/node-suite/stream/events/distinct-symbol-events.ts
- PERRY_NO_AUTO_OPTIMIZE=1 PERRY_ALLOW_UNIMPLEMENTED=1 target/release/perry run test-parity/node-suite/stream/events/get-max-listeners-default.ts

## Non-goals

- captureRejections
- EventEmitter static helpers beyond defaultMaxListeners
- promise-returning events.once()
- full readable/pause/pipe lifecycle
- TypeError behavior for non-function listeners
