### PR TITLE
fix(async): lower awaits inside labeled and do-while loops (#1824)

### DIFF
--- a/crates/perry-transform/src/generator/break_continue.rs
+++ b/crates/perry-transform/src/generator/break_continue.rs
@@ -251,6 +251,19 @@ pub fn body_contains_yield(stmts: &[Stmt]) -> bool {
                     return true;
                 }
             }
+            // A yield buried in a do-while or labeled loop must still be seen
+            // by the enclosing construct's linearization (#1824), otherwise it
+            // is never split into resume states.
+            Stmt::DoWhile { body, .. } => {
+                if body_contains_yield(body) {
+                    return true;
+                }
+            }
+            Stmt::Labeled { body, .. } => {
+                if body_contains_yield(std::slice::from_ref(&**body)) {
+                    return true;
+                }
+            }
             Stmt::For { body, .. } => {
                 if body_contains_yield(body) {
                     return true;
@@ -312,6 +325,18 @@ pub fn collect_vars_recursive(stmts: &[Stmt], vars: &mut Vec<(LocalId, String, T
                 }
             }
             Stmt::While { body, .. } => collect_vars_recursive(body, vars),
+            // `do { ... } while (cond)` — a `let` declared in the body that is
+            // live across an `await` must be hoisted just like a `while` body,
+            // otherwise its box is never preallocated and the value is lost
+            // across the state-machine split (#1824).
+            Stmt::DoWhile { body, .. } => collect_vars_recursive(body, vars),
+            // A labeled statement (`outer: for (...) { ... }`) wraps its loop
+            // in `Stmt::Labeled`; descend into the wrapped statement so the
+            // loop-body `let`s are still hoisted (#1824). Without this, every
+            // local inside a labeled loop is dropped across an `await`.
+            Stmt::Labeled { body, .. } => {
+                collect_vars_recursive(std::slice::from_ref(&**body), vars)
+            }
             Stmt::For { init, body, .. } => {
                 if let Some(init) = init {
                     collect_vars_recursive(&[(**init).clone()], vars);

--- a/crates/perry-transform/src/generator/id_scan.rs
+++ b/crates/perry-transform/src/generator/id_scan.rs
@@ -419,6 +419,11 @@ pub fn scan_stmt_for_max_func(stmt: &Stmt, max_id: &mut FuncId) {
             }
         }
         Stmt::While { body, .. } => scan_stmts_for_max_func(body, max_id),
+        // Mirror scan_stmt_for_max_local: a closure declared inside a
+        // do-while or labeled loop must still bump the max func id, or the
+        // generator transform can mint a colliding func id (#1824 gap class).
+        Stmt::DoWhile { body, .. } => scan_stmts_for_max_func(body, max_id),
+        Stmt::Labeled { body, .. } => scan_stmt_for_max_func(body, max_id),
         Stmt::For { body, .. } => scan_stmts_for_max_func(body, max_id),
         Stmt::Try {
             body,

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -883,10 +883,133 @@ pub fn linearize_body(
                 });
             }
 
+            // `do { B } while (C)` containing yield(s): desugar to a flagged
+            // `while` so the existing While arm splits the embedded yield into
+            // resume states (#1824 — previously this fell through to the
+            // catch-all and the yield was never lifted, so the loop-body
+            // locals were lost across the await).
+            //
+            //   __dw_first = true                 (extra local, auto-boxed)
+            //   while (__dw_first || C) {
+            //     __dw_first = false;
+            //     B
+            //   }
+            //
+            // The flag makes the first iteration run unconditionally while
+            // keeping `continue` correct (it jumps to the condition; the flag
+            // is already false so C is re-checked) and short-circuiting C on
+            // the first iteration (matching do-while, where C is not evaluated
+            // before the first body run).
+            Stmt::DoWhile { body, condition } if body_contains_yield(body) => {
+                let first_id = alloc_local(next_local_id);
+                current.push(Stmt::Expr(Expr::LocalSet(
+                    first_id,
+                    Box::new(Expr::Bool(true)),
+                )));
+                let mut while_body = Vec::with_capacity(body.len() + 1);
+                while_body.push(Stmt::Expr(Expr::LocalSet(
+                    first_id,
+                    Box::new(Expr::Bool(false)),
+                )));
+                while_body.extend(body.iter().cloned());
+                let while_stmt = Stmt::While {
+                    condition: Expr::Logical {
+                        op: LogicalOp::Or,
+                        left: Box::new(Expr::LocalGet(first_id)),
+                        right: Box::new(condition.clone()),
+                    },
+                    body: while_body,
+                };
+                linearize_body(
+                    std::slice::from_ref(&while_stmt),
+                    states,
+                    current,
+                    state_num,
+                    state_id,
+                    next_local_id,
+                    sent_id,
+                    catches,
+                );
+            }
+
+            // `label: <loop>` containing yield(s): linearize the wrapped loop
+            // so the embedded yield is split into resume states (#1824 —
+            // previously the whole labeled statement fell through to the
+            // catch-all and was emitted unsplit). `break label` / `continue
+            // label` that target this loop from its own body level are first
+            // rewritten to plain break/continue, which the loop's own
+            // linearization then maps to its state targets. (Labeled
+            // break/continue from a *nested* loop is left unconverted — the
+            // single-sentinel scheme can't yet distinguish targets; this was
+            // already unsupported before this arm existed, so no regression.)
+            Stmt::Labeled { label, body } if body_contains_yield(std::slice::from_ref(&**body)) => {
+                let mut inner = (**body).clone();
+                match &mut inner {
+                    Stmt::For { body, .. }
+                    | Stmt::While { body, .. }
+                    | Stmt::DoWhile { body, .. } => {
+                        rewrite_labeled_bc_in_stmts(body, label);
+                    }
+                    _ => {}
+                }
+                linearize_body(
+                    std::slice::from_ref(&inner),
+                    states,
+                    current,
+                    state_num,
+                    state_id,
+                    next_local_id,
+                    sent_id,
+                    catches,
+                );
+            }
+
             // Regular statement (no yield) - accumulate
             other => {
                 current.push(other.clone());
             }
+        }
+    }
+}
+
+/// Within a labeled loop's body, rewrite `break label` / `continue label`
+/// that target THIS label into plain `break` / `continue`, so the loop's own
+/// For/While linearization (which only knows about plain break/continue) maps
+/// them to the loop's state targets. Descends only through `if` / `try`
+/// (which don't capture break/continue), mirroring the scoping of
+/// `rewrite_break_continue_in_stmt`. Stops at nested loops and `switch` —
+/// a `break label` from inside one of those still targets this loop, but the
+/// current single-sentinel scheme can't express that, so those are left
+/// as-is (pre-existing limitation).
+fn rewrite_labeled_bc_in_stmts(stmts: &mut [Stmt], label: &str) {
+    for s in stmts.iter_mut() {
+        match s {
+            Stmt::LabeledBreak(l) if l == label => *s = Stmt::Break,
+            Stmt::LabeledContinue(l) if l == label => *s = Stmt::Continue,
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                rewrite_labeled_bc_in_stmts(then_branch, label);
+                if let Some(eb) = else_branch.as_mut() {
+                    rewrite_labeled_bc_in_stmts(eb, label);
+                }
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                rewrite_labeled_bc_in_stmts(body, label);
+                if let Some(c) = catch.as_mut() {
+                    rewrite_labeled_bc_in_stmts(&mut c.body, label);
+                }
+                if let Some(f) = finally.as_mut() {
+                    rewrite_labeled_bc_in_stmts(f, label);
+                }
+            }
+            _ => {}
         }
     }
 }

--- a/test-files/test_async_labeled_dowhile_loops.ts
+++ b/test-files/test_async_labeled_dowhile_loops.ts
@@ -1,0 +1,81 @@
+// Regression test for #1824: `await` inside a labeled loop or a do-while loop.
+//
+// The async→generator transform splits the function body into a state machine
+// at each `await`. Before the fix, labeled loops (`outer: for (...)`) and
+// `do { ... } while (...)` loops were not recognized by the body walkers, so:
+//   - their loop-body `let`s were never hoisted/boxed (lost across the await),
+//   - and the loop itself was never linearized (the embedded `await` was not
+//     split into a resume state).
+// When the lost slot held an object, the resumed continuation dereferenced a
+// garbage pointer (the SIGSEGV reported in #1824). With a number it silently
+// produced a wrong result.
+//
+// Each case keeps a value alive across the await inside the loop and is byte
+// compared against `node --experimental-strip-types`.
+
+async function ident(x: number): Promise<number> {
+  return x;
+}
+
+// 1) Labeled for-loop: `base` is computed before the await and read after,
+//    in the nested expression `(total + base) + got`.
+async function labeledFor(n: number): Promise<number> {
+  let total = 0;
+  outer: for (let i = 0; i < n; i++) {
+    const base = i * 10;
+    const got = await ident(i);
+    total = total + base + got;
+  }
+  return total;
+}
+
+// 2) Labeled for-loop using `continue label` and `break label`.
+async function labeledBreakContinue(n: number): Promise<number> {
+  let total = 0;
+  outer: for (let i = 0; i < n; i++) {
+    const got = await ident(i);
+    if (got === 2) continue outer; // skip adding 2
+    if (got === 5) break outer; // stop before 5
+    total = total + got;
+  }
+  return total;
+}
+
+// 3) do-while with an await and a cross-await accumulator.
+async function doWhileSum(n: number): Promise<number> {
+  let total = 0;
+  let i = 0;
+  do {
+    const base = i * 10;
+    const got = await ident(i);
+    total = total + base + got;
+    i++;
+  } while (i < n);
+  return total;
+}
+
+// 4) The #1824 shape: an object accumulator created before the await and
+//    field-mutated after resume. A lost slot here is a garbage object pointer.
+async function objectAccumulator(n: number): Promise<number> {
+  const agg: { clicks: number }[] = [];
+  for (let i = 0; i < n; i++) {
+    const row = { clicks: i * 5 };
+    const got = await ident(i);
+    if (agg.length === 0) {
+      agg.push({ clicks: row.clicks + got });
+    } else {
+      const existing = agg[0];
+      existing.clicks = existing.clicks + row.clicks + got;
+    }
+  }
+  return agg[0].clicks;
+}
+
+async function main(): Promise<void> {
+  console.log("labeledFor:", await labeledFor(3)); // 0+(10+1)+(20+2)=33
+  console.log("labeledBreakContinue:", await labeledBreakContinue(6)); // 0+1+3+4=8
+  console.log("doWhileSum:", await doWhileSum(3)); // 33
+  console.log("objectAccumulator:", await objectAccumulator(4)); // 0..3: 0+5+10+15 + 0+1+2+3 = 36
+}
+
+await main();


### PR DESCRIPTION
## Summary

Fixes #1824 — a frame slot live across an `await` inside a loop was lost on resume (SIGSEGV when the slot held an object, wrong value when it held a number).

The async→generator transform splits an async function body into a state machine at each `await`. Its body walkers were written for `For`/`While`/`If`/`Try`/`Switch` and **never handled `Stmt::DoWhile` or `Stmt::Labeled`**. So an `await` inside `do { ... } while (c)` or `label: for (...) { ... }` was mishandled in three places:

- **`collect_vars_recursive`** (hoisting) skipped those bodies → loop-body `let`s were never boxed → lost across the await.
- **`body_contains_yield`** missed the buried yield → an enclosing construct wouldn't be split.
- **`linearize_body`** had no arm for them → the whole loop fell through to the catch-all and was emitted *unsplit*, so the embedded `await` never became a resume state.

When the lost slot held an object, the resumed continuation dereferenced a garbage pointer — the `js_object_get_field_by_name` SIGSEGV on `0x200000000` reported in #1824. With a number it silently produced a wrong result.

## Fix

- `collect_vars_recursive`, `body_contains_yield`, `scan_stmt_for_max_func`: descend into `DoWhile` and `Labeled` bodies.
- `linearize_body`:
  - A `do { B } while (C)` containing a yield is desugared to a flagged `while (__first || C) { __first = false; B }` — preserving do-while semantics (first iteration runs unconditionally; `continue` re-checks `C`; `C` is short-circuited on the first iteration) — so the existing While arm splits it. The `__first` flag is an `alloc_local` extra local, so it's auto-boxed/captured.
  - A `label: <loop>` containing a yield linearizes its wrapped loop, after rewriting `break label` / `continue label` that target it (from the loop's own body level, through `if`/`try`) into plain `break`/`continue`, which the loop's own linearization maps to its state targets.

### Known limitation (pre-existing, not a regression)

`break label` / `continue label` from a **nested** loop to an outer labeled loop is left unconverted — the single-sentinel break/continue scheme can't yet distinguish per-label targets. This case was already fully broken before this PR (the whole labeled loop was emitted unsplit), so there is no regression; it can be a follow-up.

## Testing

New `test-files/test_async_labeled_dowhile_loops.ts` covers labeled-for, labeled `break`/`continue`, do-while, and the #1824 object-accumulator shape, all byte-compared against `node --experimental-strip-types`:

```
labeledFor: 33
labeledBreakContinue: 8
doWhileSum: 33
objectAccumulator: 36
```

Validated with a clean isolated build (the shared symlinked target was being clobbered by parallel `main` builds, which produced misleading intermittent results). Existing `test_async*.ts` pass unchanged; `cargo test -p perry-transform` green (23/23); `cargo fmt --check` clean.

## Note on the original #1824 report

The reporter's *minimal* repro (plain nested `for`, no labels) completed cleanly, and they suspected a cumulative/heap trigger. This PR fixes a concrete, deterministic frame-loss bug in exactly the symptom class (object slot lost across `await` in a loop → garbage-pointer deref). Whether the real `buildSummaryCache` hits it depends on whether it uses a labeled or do-while loop (common in DB-aggregation scans with `continue outer`). I've asked on the issue for confirmation against the deterministic gscmaster-api service.
