### PR TITLE
fix(node): expose legacy stream constructor

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2412,6 +2412,11 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     class("stream", "Duplex"),
     class("stream", "Transform"),
     class("stream", "PassThrough"),
+    // Legacy base class (extends EventEmitter); modern classes hang off it as
+    // statics. `stream.Stream === stream.default`. #1966.
+    class("stream", "Stream"),
+    // `node:stream`'s default export is the legacy `Stream` class itself.
+    method("stream", "default", false, None),
     method("stream", "pipeline", false, None),
     method("stream", "finished", false, None),
     property("stream", "promises"),

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -377,6 +377,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("stream", "Duplex")
             | ("stream", "Transform")
             | ("stream", "PassThrough")
+            | ("stream", "Stream")
             | ("string_decoder", "StringDecoder")
             | ("assert", "ok")
             | ("assert", "fail")
@@ -1651,6 +1652,7 @@ pub(crate) unsafe fn get_native_module_constant(
             _ => None,
         },
         "stream" => match property {
+            "Stream" | "default" => Some(bound_native_callable_export_value("stream", "Stream")),
             "promises" => Some(unsafe {
                 crate::node_submodules::js_node_submodule_namespace(
                     b"stream_promises".as_ptr(),

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1361 entries across 82 modules
+// Coverage: 1363 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1866,6 +1866,8 @@ declare module "stream" {
   /** stdlib */
   export class Readable { [key: string]: any; }
   /** stdlib */
+  export class Stream { [key: string]: any; }
+  /** stdlib */
   export class Transform { [key: string]: any; }
   /** stdlib */
   export class Writable { [key: string]: any; }
@@ -1879,6 +1881,8 @@ declare module "stream" {
   export function addAbortSignal(...args: any[]): any;
   /** stdlib */
   export function compose(...args: any[]): any;
+  /** stdlib */
+  export default function (...args: any[]): any;
   /** stdlib */
   export function duplexPair(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1361 entries across 82 modules.
+Total: 1363 entries across 82 modules.
 
 ## Modules
 
@@ -1699,6 +1699,7 @@ Total: 1361 entries across 82 modules.
 - `Duplex`
 - `PassThrough`
 - `Readable`
+- `Stream`
 - `Transform`
 - `Writable`
 
@@ -1707,6 +1708,7 @@ Total: 1361 entries across 82 modules.
 - `addAbortSignal` — module
 - `addListener` — instance
 - `compose` — module
+- `default` — module
 - `destroy` — instance
 - `destroyed` — instance
 - `duplexPair` — module

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -932,12 +932,6 @@
     "category": "bug-open",
     "reason": "node:stream: cork / uncork return type wrong. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/constructor/stream-legacy": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: stream.Stream legacy constructor not exposed as the default export. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/destroy/destroy-string": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- expose node:stream's legacy `Stream` export as a callable native export
- align `stream.Stream` and `stream.default` identity for the legacy constructor surface
- remove the now-passing `node-suite/stream/constructor/stream-legacy` known failure

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream-legacy`
- `cargo test -p perry-runtime native_module --lib`
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## DeepWiki
- local reference: `reference/deepwiki/deno-node-stream-legacy-constructor-2026-05-27.md`

## Non-goals
- `new Stream()` / callable `Stream()` runtime behavior
- `Stream.Stream` or `Stream.Readable`/`Writable`/`Duplex` static compatibility properties
- stream prototype inheritance, EventEmitter behavior, or dataflow semantics