### PR TITLE
fix(runtime): correct .length/.byteLength for multi-byte numeric-length typed arrays (#1862 regression)

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -124,10 +124,30 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 _ => unreachable!(),
             };
             let (ptr_slot, _scope) = ctx.buffer_data_slots.get(&arr_id).cloned().unwrap();
+            // The length field's byte offset relative to `data_ptr` differs by
+            // header layout: an 8-byte `BufferHeader` keeps it at `data-8`, but
+            // a 16-byte `TypedArrayHeader` (Int32Array/Float64Array/... numeric
+            // -length constructors) keeps it at `data-16`. #1862 began
+            // registering multi-byte typed arrays in `buffer_data_slots` with a
+            // data_ptr 16 bytes past the header, so the hardcoded `-8` here read
+            // the packed `kind|elem_size` bytes (Int32→0x404=1028,
+            // Float64→0x807=2055) instead of `.length`. Prefer the co-registered
+            // `buffer_view_slots` entry, which carries the correct
+            // `length_offset_from_data` (and a `length_slot` for native views).
+            let view = ctx.buffer_view_slots.get(&arr_id).cloned();
+            let length_slot = view.as_ref().and_then(|v| v.length_slot.clone());
+            let length_offset = view
+                .as_ref()
+                .map(|v| v.length_offset_from_data)
+                .unwrap_or(-8);
             let blk = ctx.block();
-            let data_ptr = blk.load(PTR, &ptr_slot);
-            let header_ptr = blk.gep(I8, &data_ptr, &[(I32, "-8")]);
-            let len_i32 = blk.load_invariant(I32, &header_ptr);
+            let len_i32 = if let Some(length_slot) = length_slot.as_ref() {
+                blk.load(I32, length_slot)
+            } else {
+                let data_ptr = blk.load(PTR, &ptr_slot);
+                let header_ptr = blk.gep(I8, &data_ptr, &[(I32, &length_offset.to_string())]);
+                blk.load_invariant(I32, &header_ptr)
+            };
             let lowered = LoweredValue::buffer_len(len_i32);
             ctx.record_lowered_value(
                 "Buffer.length",

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1265,6 +1265,38 @@ pub extern "C" fn js_object_get_field_by_name(
             }
             return JSValue::undefined();
         }
+        // Typed arrays (Int32Array/Float64Array/...): the `TypedArrayHeader` is
+        // `std::alloc`'d (small) or GC-old-allocated (large), but in both cases
+        // tracked in TYPED_ARRAY_REGISTRY, so detect via the side table before
+        // the GC-header read below (which would read garbage for the small
+        // `std::alloc` case). `.length`, `.byteLength`, `.byteOffset`, and
+        // `.BYTES_PER_ELEMENT` lower as generic PropertyGet for multi-byte
+        // numeric-length views whose static type the codegen doesn't recognize;
+        // pre-fix, only Uint8Array worked (it's a registered buffer) so
+        // multi-byte `.byteLength` returned undefined.
+        if let Some(kind) = crate::typedarray::lookup_typed_array_kind(obj as usize) {
+            if !key.is_null() {
+                let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                let key_len = (*key).byte_len as usize;
+                let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
+                let ta = obj as *const crate::typedarray::TypedArrayHeader;
+                let elem_size = crate::typedarray::elem_size_for_kind(kind);
+                match key_bytes {
+                    b"length" => {
+                        let len = crate::typedarray::js_typed_array_length(ta);
+                        return JSValue::number(len as f64);
+                    }
+                    b"byteLength" => {
+                        let len = crate::typedarray::js_typed_array_length(ta);
+                        return JSValue::number((len as usize * elem_size) as f64);
+                    }
+                    b"byteOffset" => return JSValue::number(0.0),
+                    b"BYTES_PER_ELEMENT" => return JSValue::number(elem_size as f64),
+                    _ => {}
+                }
+            }
+            return JSValue::undefined();
+        }
         // Sets: SetHeader is allocated via raw `alloc()` (no GcHeader),
         // so we can't safely read the byte preceding the pointer to
         // determine its type. Detect via the SET_REGISTRY first and

--- a/test-files/test_gap_typed_array_numeric_length.ts
+++ b/test-files/test_gap_typed_array_numeric_length.ts
@@ -1,0 +1,44 @@
+// Gap test: multi-byte numeric-length typed-array .length / .byteLength
+// Run: node --experimental-strip-types test_gap_typed_array_numeric_length.ts
+//
+// Regression coverage for the #1862 typed-view rewrite, which began
+// registering `new Int32Array(N)` / `new Float64Array(N)` (multi-byte,
+// numeric-length, non-mutated) bindings in `buffer_data_slots`. The Buffer
+// `.length` fast path hardcoded a `data-8` header read (valid for an 8-byte
+// BufferHeader / Uint8Array) but a TypedArrayHeader is 16 bytes, so it read the
+// packed `kind|elem_size` bytes instead: Int32 -> 1028 (0x404),
+// Float64 -> 2055 (0x807), regardless of N. `.byteLength` returned undefined
+// because the generic runtime getter had no typed-array branch. These bindings
+// are intentionally NOT mutated before the read so the buffer-view fast path
+// fires (mutation disables it).
+
+const d = new Int32Array(5);
+console.log("Int32Array(5):", d.length, "byteLength:", d.byteLength, "d[0]:", d[0], "d[4]:", d[4]);
+
+const e = new Float64Array(3);
+console.log("Float64Array(3):", e.length, "byteLength:", e.byteLength);
+
+const f = new Uint8Array(10);
+console.log("Uint8Array(10):", f.length, "byteLength:", f.byteLength);
+
+const g = new Int32Array(0);
+console.log("Int32Array(0):", g.length, "byteLength:", g.byteLength);
+
+const h = new Int32Array([1, 2, 3]);
+console.log("Int32Array([1,2,3]):", h.length, "byteLength:", h.byteLength);
+
+const i16 = new Int16Array(4);
+console.log("Int16Array(4):", i16.length, "byteLength:", i16.byteLength);
+
+const u32 = new Uint32Array(6);
+console.log("Uint32Array(6):", u32.length, "byteLength:", u32.byteLength);
+
+const f32 = new Float32Array(7);
+console.log("Float32Array(7):", f32.length, "byteLength:", f32.byteLength);
+
+// BYTES_PER_ELEMENT instance property
+console.log("Int32 BYTES_PER_ELEMENT:", d.BYTES_PER_ELEMENT);
+console.log("Float64 BYTES_PER_ELEMENT:", e.BYTES_PER_ELEMENT);
+
+// byteOffset of a freshly-constructed view is 0
+console.log("Int32 byteOffset:", d.byteOffset);


### PR DESCRIPTION
## Summary

Regression from #1862 (squash `29e4a4598`, "Extend native buffer proofs and typed views"). The multi-byte **numeric-length** typed-array constructor (`new Int32Array(N)`, `new Float64Array(N)`, ...) returned a view whose `.length` was a constant garbage value (independent of `N`) and whose `.byteLength` was `undefined`.

Observed before the fix:
- `new Int32Array(5).length` -> `1028` (should be `5`)
- `new Float64Array(3).length` -> `2055` (should be `3`)
- `.byteLength` -> `undefined`

`new Uint8Array(N)` and `new Int32Array([...])` (from-array) were unaffected.

## Root cause

#1862 began registering non-mutated `new <TypedArray>(N)` bindings in `ctx.buffer_data_slots` (alongside `ctx.buffer_view_slots`). The codegen Buffer `.length` fast path (`expr/property_get.rs`) hardcoded a `data_ptr - 8` header read. That is correct for an 8-byte `BufferHeader` (where the data starts 8 bytes past the header, so `data - 8` = the `length: u32` at offset 0), but a `TypedArrayHeader` is **16 bytes**:

```
TypedArrayHeader { length: u32 @0, capacity: u32 @4, kind: u8 @8, elem_size: u8 @9, _pad: [u8;6] @10 }
```

So for a typed array (data starts 16 bytes past the header), `data - 8` lands on offset 8 = the packed `kind|elem_size` bytes. Read as a little-endian `i32`:
- Int32Array: `kind=4, elem_size=4` -> `0x00000404` = **1028**
- Float64Array: `kind=7, elem_size=8` -> `0x00000807` = **2055**

That is exactly the constant garbage observed. The from-array constructor and `Uint8Array` (8-byte data offset) avoided the bug. `.byteLength` returned `undefined` because the generic runtime field getter had no typed-array branch at all — `Uint8Array.byteLength` only worked because a `Uint8Array` is also a registered buffer.

## Fix

- `crates/perry-codegen/src/expr/property_get.rs`: the `.length` fast path now reads the length using the co-registered `buffer_view_slots` entry's `length_offset_from_data` (`-16` for `TypedArrayNew`, `-8` for Buffer/Uint8Array) and its `length_slot` when present (native arena views), instead of a hardcoded `-8`.
- `crates/perry-runtime/src/object/field_get_set.rs`: the generic field getter `js_object_get_field_by_name` now has a typed-array branch (detected via `TYPED_ARRAY_REGISTRY`, before the GC-header read that would be UB for the small `std::alloc`'d case) handling `.length`, `.byteLength`, `.byteOffset`, and `.BYTES_PER_ELEMENT`.

No band-aid: the codegen path uses the layout fact already tracked per view; the runtime path adds the missing typed-array property dispatch.

## Tests

- New `test-files/test_gap_typed_array_numeric_length.ts` — byte-identical to `node --experimental-strip-types`.
- `cargo test -p perry-codegen`: `native_proof_buffer_views` 21/21, `native_proof_regressions` 33/33, all suites 0 failures.
- `cargo test -p perry-runtime --lib -- --test-threads=1`: 675/675, 0 failures.
- Existing `test_gap_typed_arrays.ts` and `test_gap_buffer_ops.ts` remain byte-identical to Node.
- `cargo fmt --all -- --check` clean.
