### PR TITLE
fix(runtime): bind this to receiver for inherited symbol-keyed method calls (#321 effect Context/Layer)

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -83,7 +83,8 @@ pub unsafe extern "C" fn js_native_call_method_value(
     // Non-string key: read the property value, then invoke it with `this`
     // bound to the receiver (the codegen `Expr::This` fallback reads
     // `IMPLICIT_THIS` when there's no lexical `this`).
-    let field = if crate::symbol::js_is_symbol(key) != 0 {
+    let is_symbol_key = crate::symbol::js_is_symbol(key) != 0;
+    let field = if is_symbol_key {
         crate::symbol::js_object_get_symbol_property(object, key)
     } else {
         crate::object::js_object_get_index_polymorphic(object.to_bits() as i64, key)
@@ -92,6 +93,31 @@ pub unsafe extern "C" fn js_native_call_method_value(
     if fv.is_undefined() || fv.is_null() {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
+
+    // #321 (effect Context/Layer): a symbol-keyed method INHERITED via
+    // `Object.create(proto)` is stored under the *prototype's* identity, and
+    // object-literal computed-key methods bake their receiver into a reserved
+    // `this` capture slot at construction time (see
+    // `symbol.rs::js_object_set_symbol_method` /
+    // `dynamic_props.rs::clone_closure_rebind_this`). So when `o = Object.create(P)`
+    // resolves `o[SYM]()`, the closure we get back carries `this === P`, not
+    // `this === o`, and `IMPLICIT_THIS` alone can't override the baked-in slot.
+    // When the symbol method is NOT an OWN property of the receiver (i.e. it was
+    // inherited through the prototype chain), rebind its `this` slot to the
+    // receiver before invoking. `clone_closure_rebind_this` is a no-op for
+    // non-`captures_this` closures and for non-closure values, so own methods
+    // (whose slot is already the receiver), effect's Tag-class symbol *statics*
+    // (plain data values), and any closure that doesn't read `this` are all left
+    // untouched — keeping the #1758/#36/#321 closure-proto-chain paths intact.
+    let field = if is_symbol_key && crate::symbol::own_symbol_property(object, key).is_none() {
+        f64::from_bits(crate::closure::clone_closure_rebind_this(
+            field.to_bits(),
+            object,
+        ))
+    } else {
+        field
+    };
+
     let prev_this = IMPLICIT_THIS.with(|c| c.replace(object.to_bits()));
     let result = crate::closure::js_native_call_value(field, args_ptr, args_len);
     IMPLICIT_THIS.with(|c| c.set(prev_this));


### PR DESCRIPTION
## Summary

Fixes a `this`-binding bug for **Symbol-keyed methods inherited via `Object.create(proto)`**: the method was invoked with `this` bound to the **prototype** instead of the **receiver**, contradicting JS semantics. This is a real-world blocker for the `effect` framework's `Context`/`Layer` dependency-injection (issue #321), whose Tag/Effectable prototypes use exactly this shape.

## Root cause

Object-literal computed-key methods are lowered with `captures_this: true` and have their reserved (last) capture slot **patched to the literal object at construction time** (`symbol.rs::js_object_set_symbol_method`). When `o = Object.create(P)` resolves `o[SYM]()`:

1. `js_native_call_method_value` correctly sets `IMPLICIT_THIS = o` (the receiver).
2. It resolves the symbol field via `js_object_get_symbol_property(o, SYM)`, which (own miss) walks `o`'s prototype chain and returns **P's** method closure verbatim.
3. That closure's baked-in `this`-slot points at **P**, and the closure body reads its captured slot — not `IMPLICIT_THIS`. So `this === P`, and `P.v` is `undefined`.

Own symbol methods (slot already = receiver) and class symbol methods (dispatched via the class vtable, not this path) were unaffected — only inheritance through `Object.create` exposed the gap.

## Fix

In `js_native_call_method_value`, when a symbol-keyed method is **NOT an OWN property** of the receiver (i.e. inherited through the prototype chain), rebind its `this`-slot to the receiver via the existing `clone_closure_rebind_this` helper before invoking.

`clone_closure_rebind_this` is a no-op for non-`captures_this` closures and for non-closure values, so the following are all left untouched:
- own symbol methods,
- class symbol methods,
- effect's Tag-class symbol *statics* (plain data values),
- the `#1758`/`#36`/`#321` closure-proto-chain symbol-resolution paths.

One file changed: `crates/perry-runtime/src/object/native_call_method.rs` (+27/-1).

## Verification

Minimal repro (`/tmp/eqmin2.ts`) — Node prints `9`, pre-fix Perry printed `undefined`:

```ts
const EQ = Symbol.for("eq");
const P: any = { [EQ](this: any) { return this.v; } };
const o = Object.create(P); o.v = 9;
console.log(o[EQ]());   // now: 9
```

Broader matrix (`/tmp/symthis2.ts`) is now **byte-identical to `node`**:

```
b1 own:       object:7
b2 inherited: object:9   (was object:undefined)
b4 class:     object:3
```

- `cargo test --release -p perry-runtime --lib -- --test-threads=1` → **675 passed, 0 failed**.
- `cargo fmt --all -- --check` → clean.

## Scope note — effect survey items not yet green

This is a verified, necessary fix (bisection confirmed: on clean `main` `survey/nlay.ts` fails earlier with `Cannot read properties of undefined (reading 'size')` — the symbol-`this` bug; with the fix it progresses past that). It is **not sufficient on its own** to make the two effect survey items print their expected output — they now hit two further, independent blockers:

1. `arr.splice(start, deleteCount)` on a genuine `any`-typed array reaches the dynamic dispatch tower in `js_native_call_method` which has **no `splice` arm**, so it throws `splice is not a function`. (Same class as the existing defensive `slice`/`sort`/`reverse` arms.)
2. Behind that, effect's FiberRuntime op-loop then SIGSEGVs in `js_object_get_field_by_name` reading `.length` on a non-pointer value (`0x9080000201`) — a value-representation/codegen issue in the same area being actively investigated elsewhere.

Those are left out of this PR to keep it focused on the diagnosed `this`-binding bug; they are tracked under #321 as the next blockers.
