### PR TITLE
test(node): unskip readable iterator symbol parity

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -992,12 +992,6 @@
     "category": "bug-open",
     "reason": "node:stream: stream.compose(single-transform) does not deliver data through. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/symbol/no-sync-iterator": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Readable instance exposes Symbol.iterator incorrectly (should be undefined; only asyncIterator). Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/dispose/async-dispose": {
     "issue": "1531",
     "added": "2026-05-23",
@@ -1700,12 +1694,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: pipeTo() return value — not a Promise<undefined>. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/meta/readable-no-sync-iterator": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Readable should NOT expose Symbol.iterator (only Symbol.asyncIterator) — typeof differs from Node. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipeline/promise-form": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -2179,12 +2167,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: paused source still emits data after push. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/sync-iterator-not-exposed": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Symbol.iterator exposed on Readable (should be undefined). Flips to PASS when #1531 lands."
   },
   "node-suite/stream/readable/read-returns-buffer-default": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- remove three stale known-failure entries for classic `node:stream` `Readable` iterator-symbol parity
- keep the cleanup limited to classic Readable instances exposing `Symbol.asyncIterator` while leaving `Symbol.iterator` undefined
- leave the separate `node:stream/web` iterator failure tracked

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter symbol/no-sync-iterator`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter meta/readable-no-sync-iterator`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter readable/sync-iterator-not-exposed`
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## DeepWiki
- local reference: `reference/deepwiki/deno-node-stream-readable-iterator-symbols-2026-05-27.md`

## Non-goals
- no runtime changes
- no `node:stream/web` `ReadableStream` iterator behavior changes; `node-suite/stream/web/readable-no-sync-iterator` still fails under the broader `sync-iterator` filter