### PR TITLE
test(node): unskip zlib brotli decompression parity

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1418,12 +1418,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory — `node:stream/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
-  "test_zlib_brotli_decompress": {
-    "issue": null,
-    "added": "2026-05-18",
-    "category": "ci-env",
-    "reason": "Brotli decompression path under node:zlib not yet implemented (cf. existing test_parity_zlib module-inventory entry). Same failure observed on #1038 pre-merge — not a regression."
-  },
   "node-suite/stream/imports/promises-ns": {
     "issue": "1533",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- remove the stale `test_zlib_brotli_decompress` known-failure entry
- leave broad `test_parity_zlib` listed because it still fails on remaining zlib surface gaps

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --filter test_zlib_brotli_decompress`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

Guardrail checked before editing: `PERRY_NO_CACHE=1 ./run_parity_tests.sh --filter test_parity_zlib` still fails, so that module-inventory known failure remains in place.

DeepWiki local reference: `reference/deepwiki/deno-node-zlib-brotli-decompress-2026-05-27.md` (not staged).

Non-goals: broad `node:zlib` module-inventory cleanup, compression parameter coverage, streaming zlib/Brotli classes, and async callback/promisify semantics.