### PR TITLE
fix(runtime): add splice arm to dynamic method dispatch (#321 effect Context/Layer)

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1060,6 +1060,55 @@ pub unsafe extern "C" fn js_native_call_method(
                         let result = crate::array::js_array_slice(arr, start, end);
                         return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
                     }
+                    // Issue #321 (effect Context/Layer): defensive `splice`
+                    // arm for any-typed arrays that reach the generic dispatch
+                    // tower. The sibling `slice`/`sort`/`reverse` arms exist
+                    // but `splice` was missing, so effect's FiberRuntime op
+                    // queue (`(arr as any).splice(start, deleteCount)`) threw
+                    // "splice is not a function". Mirrors JS semantics:
+                    // mutates the receiver in place and returns a new array of
+                    // the removed elements. Extra args after deleteCount are
+                    // inserted at `start`.
+                    "splice" => {
+                        let arr = raw_ptr as *mut crate::array::ArrayHeader;
+                        let arg_i32 = |i: usize| -> i32 {
+                            if i < args_len && !args_ptr.is_null() {
+                                let v = *args_ptr.add(i);
+                                if v.is_nan() || v.is_infinite() {
+                                    0
+                                } else {
+                                    v as i32
+                                }
+                            } else {
+                                0
+                            }
+                        };
+                        let start = if args_len >= 1 { arg_i32(0) } else { 0 };
+                        // Per spec: omitted deleteCount deletes through the end.
+                        // `js_array_splice` clamps to the live length.
+                        let delete_count = if args_len >= 2 { arg_i32(1) } else { i32::MAX };
+                        // Items to insert are args[2..].
+                        let items: Vec<f64> = if args_len > 2 && !args_ptr.is_null() {
+                            std::slice::from_raw_parts(args_ptr.add(2), args_len - 2).to_vec()
+                        } else {
+                            Vec::new()
+                        };
+                        let items_ptr = if items.is_empty() {
+                            std::ptr::null()
+                        } else {
+                            items.as_ptr()
+                        };
+                        let mut out_arr: *mut crate::array::ArrayHeader = std::ptr::null_mut();
+                        let deleted = crate::array::js_array_splice(
+                            arr,
+                            start,
+                            delete_count,
+                            items_ptr,
+                            items.len() as u32,
+                            &mut out_arr,
+                        );
+                        return f64::from_bits(JSValue::pointer(deleted as *mut u8).bits());
+                    }
                     // Issue #515 followup: defensive `with` arm for arrays that
                     // reach the generic dispatch tower because the HIR fold
                     // bailed (untyped receiver, chained call returning Array,

--- a/test-files/test_gap_array_splice_dispatch.ts
+++ b/test-files/test_gap_array_splice_dispatch.ts
@@ -1,0 +1,41 @@
+// Gap test: Array.prototype.splice reached via the dynamic dispatch tower.
+// Run: node --experimental-strip-types test_gap_array_splice_dispatch.ts
+//
+// When the receiver is genuinely `any`-typed, `arr.splice(...)` lowers through
+// the runtime method-dispatch tower (`js_native_call_method`) rather than the
+// HIR array fast path. Before the fix, that tower had arms for slice/sort/
+// reverse but NOT splice, so `(arr as any).splice(...)` threw
+// "splice is not a function". (#321 effect Context/Layer surfaced this.)
+
+// --- delete in the middle ---
+const a1: any = [1, 2, 3, 4, 5];
+const removed1 = a1.splice(1, 2);
+console.log("removed:", removed1); // [2, 3]
+console.log("after:", a1); // [1, 4, 5]
+
+// --- insert without deleting ---
+const a2: any = [1, 2, 5];
+const removed2 = a2.splice(2, 0, 3, 4);
+console.log("removed (insert):", removed2); // []
+console.log("after (insert):", a2); // [1, 2, 3, 4, 5]
+
+// --- replace (delete + insert) ---
+const a3: any = [1, 2, 3];
+const removed3 = a3.splice(1, 1, 99);
+console.log("removed (replace):", removed3); // [2]
+console.log("after (replace):", a3); // [1, 99, 3]
+
+// --- negative start ---
+const a5: any = [1, 2, 3, 4];
+const removed5 = a5.splice(-2, 1);
+console.log("removed (neg start):", removed5); // [3]
+console.log("after (neg start):", a5); // [1, 2, 4]
+
+// --- splice on a fresh array returned from an any-typed call ---
+function makeArr(): any {
+  return ["a", "b", "c", "d"];
+}
+const a6: any = makeArr();
+const removed6 = a6.splice(1, 2, "X");
+console.log("removed (call recv):", removed6); // ['b', 'c']
+console.log("after (call recv):", a6); // ['a', 'X', 'd']


### PR DESCRIPTION
## Summary

The runtime dynamic-method-dispatch tower (`js_native_call_method` in `crates/perry-runtime/src/object/native_call_method.rs`) carries defensive arms for `slice` / `sort` / `reverse` / `with` / `map` / `filter` / etc. on genuinely `any`-typed array receivers — the ones whose static type the codegen array-fold couldn't prove. But there was **no `splice` arm**, so when an `any`-shaped receiver reached the tower, `arr.splice(start, deleteCount)` threw `splice is not a function`.

This surfaced compiling the `effect` framework (#321 Context/Layer): `FiberRuntime`'s op queue does `this._queue.splice(0, 1)[0]` where `this._queue` is a class field whose array type is lost across the prototype-based class, so the call lands in the dynamic tower.

## Fix

Add a `splice` arm that mirrors the sibling `slice`/`sort`/`reverse` arms and wires the existing `js_array_splice` runtime function:
- mutates the receiver in place and returns a new array of the removed elements (JS semantics);
- omitted `deleteCount` deletes through the end (`js_array_splice` clamps to the live length);
- extra args after `deleteCount` are inserted at `start`.

## Tests

- New `test-files/test_gap_array_splice_dispatch.ts` — exercises `(arr as any).splice(...)` across delete-in-middle, insert-only, replace, negative-start, and a fresh-array-from-an-`any`-call receiver. Byte-identical to `node --experimental-strip-types`.
- `cargo test --release -p perry-runtime --lib -- --test-threads=1` → 675 passed, 0 failed.
- `cargo fmt --all -- --check` clean.
- `test_gap_array_methods.ts` regression check still byte-identical.
