### PR TITLE
fix(runtime): route Map/Set receivers in array entries/keys/values dispatch (#321 effect Context/Layer)

### DIFF
--- a/crates/perry-runtime/src/array/flat_clone.rs
+++ b/crates/perry-runtime/src/array/flat_clone.rs
@@ -2,6 +2,29 @@
 use super::*;
 use std::ptr;
 
+/// Read the GC object-type byte for an already-range-validated heap pointer
+/// (the value returned by `clean_arr_ptr`, which guarantees the address is in
+/// the live heap window). Returns `0` if the pointer is too low to hold a
+/// preceding `GcHeader`.
+///
+/// Used by `entries`/`keys`/`values` to detect when the codegen `.entries()`
+/// catch-all (`Expr::ArrayEntries`, lowered for any non-class receiver because
+/// the static type was lost — see perry-hir `array_only_methods.rs` #597) was
+/// actually handed a Map or Set rather than an Array. Effect's
+/// `FiberRefs.diff` does `for (const [k, v] of newValue.locals.entries())`
+/// where `locals` is a `Map`; without this dispatch the Map was reinterpreted
+/// as an Array and its entry buffer read out as garbage `[index, value]`
+/// pairs, segfaulting downstream on `pairs.length` (#321 effect Context/Layer).
+#[inline]
+unsafe fn receiver_gc_type(ptr: *const ArrayHeader) -> u8 {
+    let addr = ptr as usize;
+    if addr < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return 0;
+    }
+    let gc_header = (addr - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    (*gc_header).obj_type
+}
+
 /// `Array.prototype.flat(depth)` — flatten up to `depth` levels deep
 /// (ECMA-262 §23.1.3.10).
 #[no_mangle]
@@ -333,6 +356,36 @@ pub extern "C" fn js_array_entries(arr: *const ArrayHeader) -> *mut ArrayHeader 
         return js_array_alloc(0);
     }
     unsafe {
+        // The codegen `.entries()` catch-all (Expr::ArrayEntries) lowers any
+        // non-class receiver here. When the runtime value is actually a Map or
+        // Set, route to the correct iterator materialization instead of
+        // reinterpreting its buffer as an Array (#321 effect Context/Layer).
+        match receiver_gc_type(arr) {
+            t if t == crate::gc::GC_TYPE_MAP => {
+                return crate::map::js_map_entries(arr as *const crate::map::MapHeader);
+            }
+            t if t == crate::gc::GC_TYPE_SET => {
+                // Set entries yield `[value, value]` pairs in JS.
+                let values = crate::set::js_set_to_array(arr as *const crate::set::SetHeader);
+                let len = (*values).length;
+                let result = js_array_alloc(len);
+                (*result).length = len;
+                clear_array_numeric_layout(result);
+                for i in 0..len as usize {
+                    let v = js_array_get_f64(values, i as u32);
+                    let pair = js_array_alloc(2);
+                    (*pair).length = 2;
+                    store_array_slot(pair, 0, v.to_bits());
+                    store_array_slot(pair, 1, v.to_bits());
+                    rebuild_array_layout(pair);
+                    let pair_value = crate::value::js_nanbox_pointer(pair as i64);
+                    store_array_slot(result, i, pair_value.to_bits());
+                }
+                rebuild_array_layout(result);
+                return result;
+            }
+            _ => {}
+        }
         let len = (*arr).length;
         let result = js_array_alloc(len);
         (*result).length = len;
@@ -365,6 +418,18 @@ pub extern "C" fn js_array_keys(arr: *const ArrayHeader) -> *mut ArrayHeader {
         return js_array_alloc(0);
     }
     unsafe {
+        // Map/Set receivers reaching the `.keys()` catch-all (see
+        // js_array_entries) — route to the correct keys. (#321)
+        match receiver_gc_type(arr) {
+            t if t == crate::gc::GC_TYPE_MAP => {
+                return crate::map::js_map_keys(arr as *const crate::map::MapHeader);
+            }
+            t if t == crate::gc::GC_TYPE_SET => {
+                // Set `.keys()` is an alias for `.values()`.
+                return crate::set::js_set_to_array(arr as *const crate::set::SetHeader);
+            }
+            _ => {}
+        }
         let len = (*arr).length;
         let result = js_array_alloc(len);
         (*result).length = len;
@@ -386,6 +451,17 @@ pub extern "C" fn js_array_values(arr: *const ArrayHeader) -> *mut ArrayHeader {
         return js_array_alloc(0);
     }
     unsafe {
+        // Map/Set receivers reaching the `.values()` catch-all (see
+        // js_array_entries) — route to the correct values. (#321)
+        match receiver_gc_type(arr) {
+            t if t == crate::gc::GC_TYPE_MAP => {
+                return crate::map::js_map_values(arr as *const crate::map::MapHeader);
+            }
+            t if t == crate::gc::GC_TYPE_SET => {
+                return crate::set::js_set_to_array(arr as *const crate::set::SetHeader);
+            }
+            _ => {}
+        }
         let len = (*arr).length;
         let result = js_array_alloc(len);
         if len > 0 {

--- a/test-files/test_gap_map_set_entries_dispatch.ts
+++ b/test-files/test_gap_map_set_entries_dispatch.ts
@@ -1,0 +1,67 @@
+// Gap test: Map/Set .entries()/.keys()/.values() reached via the `any`-typed
+// `Expr::ArrayEntries` catch-all in codegen.
+// Run: node --experimental-strip-types test_gap_map_set_entries_dispatch.ts
+//
+// When the receiver's static type is lost (e.g. a `Map` read off an `any`-typed
+// field or returned from an `any` function), codegen lowers `.entries()` to the
+// Array fast path (`js_array_entries`). Before the fix, that helper
+// reinterpreted the Map/Set buffer as an Array, producing garbage `[index,
+// value]` pairs and segfaulting downstream on `pairs.length`. Effect's
+// `FiberRefs.diff` does `for (const [k, v] of newValue.locals.entries())` where
+// `locals` is a `Map`. (#321 effect Context/Layer.)
+
+function getMap(): any {
+  const m = new Map<any, any>();
+  m.set("k1", [[1, "a"], [2, "b"]]);
+  m.set("k2", [[3, "c"]]);
+  return m;
+}
+
+const anyMap: any = getMap();
+
+for (const [k, pairs] of anyMap.entries()) {
+  console.log("map entries:", k, pairs.length, pairs[0][1]);
+}
+// map entries: k1 2 a
+// map entries: k2 1 c
+
+const mapKeys: any[] = [];
+for (const k of anyMap.keys()) {
+  mapKeys.push(k);
+}
+console.log("map keys:", mapKeys); // ['k1', 'k2']
+
+const mapValLens: number[] = [];
+for (const v of anyMap.values()) {
+  mapValLens.push(v.length);
+}
+console.log("map value lengths:", mapValLens); // [2, 1]
+
+function getSet(): any {
+  const s = new Set<any>();
+  s.add(10);
+  s.add(20);
+  s.add(30);
+  return s;
+}
+
+const anySet: any = getSet();
+
+for (const [a, b] of anySet.entries()) {
+  console.log("set entries:", a, b);
+}
+// set entries: 10 10
+// set entries: 20 20
+// set entries: 30 30
+
+const setVals: number[] = [];
+for (const v of anySet.values()) {
+  setVals.push(v);
+}
+console.log("set values:", setVals); // [10, 20, 30]
+
+const setKeys: number[] = [];
+for (const k of anySet.keys()) {
+  setKeys.push(k);
+}
+console.log("set keys:", setKeys); // [10, 20, 30]


### PR DESCRIPTION
## Summary

This is the deeper of the two `effect` Context/Layer blockers (#321): a SIGSEGV in `js_object_get_field_by_name` reading `.length` on a non-pointer garbage value (observed bits `0x9080000201`).

### Root cause

When a `Map`'s static type is lost — e.g. a `Map` read off an `any`-typed field, or returned from an `any` function — codegen lowers `.entries()` / `.keys()` / `.values()` to the **Array** fast path (`Expr::ArrayEntries` → `js_array_entries`) through the `#597` non-class catch-all in perry-hir (`lower/expr_call/array_only_methods.rs`). The comment there claims `js_array_entries` "tolerates non-array receivers (returns empty)", but that is **false for Map/Set receivers**: `js_array_entries` does `(*arr).length` (which reads the Map's `size`) and then reinterprets the Map's flat entry buffer as Array element slots — yielding garbage `[index, value]` pairs.

Effect's `FiberRefs.diff` does:

```ts
for (const [fiberRef, pairs] of newValue.locals.entries()) {
  const newValue = Arr.headNonEmpty(pairs)[1]   // pairs.length read here
```

`newValue.locals` is a `Map`, but its type is lost (it's a `.locals` field off a `FiberRefs` parameter), so `.entries()` folded to `js_array_entries`. The corrupt `pairs` (`0x9080000201`, top16 == 0 so treated as a raw pointer, but a bogus ~620 GB address) then reached the `.length` PropertyGet, which routed to `js_object_get_field_by_name_f64` and dereferenced it as a heap pointer → SIGSEGV. (Confirmed via `--trace llvm`: the for-of emitted `js_array_entries`, not `js_map_entries`; and the crash is GC-mode-independent, so not a GC/evacuation bug.)

### Fix

`js_array_entries` / `js_array_keys` / `js_array_values` now inspect the receiver's `GcHeader.obj_type` (the pointer is already range-validated by `clean_arr_ptr`, so reading `ptr - GC_HEADER_SIZE` is safe) and route:
- `GC_TYPE_MAP` → `js_map_entries` / `js_map_keys` / `js_map_values`
- `GC_TYPE_SET` → `[value, value]` pairs for `entries`; `js_set_to_array` for `keys`/`values`

Codegen genuinely cannot recover the lost type at the call site, so the robust place to discriminate Array vs Map vs Set is the runtime helper. This makes the `#597` catch-all's "tolerates non-array receivers" contract actually hold.

## Tests

- New `test-files/test_gap_map_set_entries_dispatch.ts` — exercises Map and Set `.entries()`/`.keys()`/`.values()` reached through `any`-typed receivers. Byte-identical to `node --experimental-strip-types`.
- `cargo test --release -p perry-runtime --lib -- --test-threads=1` → 675 passed, 0 failed.
- `cargo fmt --all -- --check` clean.
- `test_gap_array_methods.ts` (real-array `.entries()`/`.keys()`/`.values()`) regression check still byte-identical.

## Effect status after this + the splice arm PR

With both fixes the original SIGSEGV is gone; the `effect` Context/Layer survey items (`nlay.ts`, `real3_context_layer.ts`) now progress through `FiberRefs.diff` and fail cleanly at a **separate, newly-surfaced third blocker** (not a crash): `Cannot read properties of undefined (reading '_tag')` in the Layer/Scope path. `Effect.provideService` (Context without Layer/Scope) already prints `42` correctly. The third blocker is `this.<dynamicField>` reading `undefined` inside methods on an `Object.create(proto)` instance (effect's `ScopeImpl`); it is distinct from the two blockers fixed here and tracked for follow-up.
