### PR TITLE
fix(node): expose stream event method aliases

### DIFF
--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -81,6 +81,36 @@ fn is_map_method_name(name: &str) -> bool {
     )
 }
 
+fn is_classic_stream_method_name(name: &str) -> bool {
+    matches!(
+        name,
+        "on" | "addListener"
+            | "once"
+            | "prependListener"
+            | "prependOnceListener"
+            | "emit"
+            | "listeners"
+            | "rawListeners"
+            | "eventNames"
+            | "listenerCount"
+            | "removeListener"
+            | "off"
+            | "removeAllListeners"
+            | "setMaxListeners"
+            | "getMaxListeners"
+    )
+}
+
+fn is_classic_stream_instance_method(ctx: &FnCtx<'_>, object: &Expr, property: &str) -> bool {
+    if !is_classic_stream_method_name(property) {
+        return false;
+    }
+    matches!(
+        receiver_class_name(ctx, object).as_deref(),
+        Some("Readable" | "Writable" | "Duplex" | "Transform" | "PassThrough" | "Stream")
+    )
+}
+
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::Integer(i) => Ok(double_literal(*i as f64)),
@@ -156,6 +186,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     if (is_set_expr(ctx, object) && is_set_method_name(property))
                         || (is_map_expr(ctx, object) && is_map_method_name(property))
                     {
+                        Some("function")
+                    } else if is_classic_stream_instance_method(ctx, object, property) {
                         Some("function")
                     } else if let Expr::ExternFuncRef { name, .. } = object.as_ref() {
                         if ctx.namespace_imports.contains(name)

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -101,6 +101,11 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                 ty = Type::Named("TextEncoder".to_string());
                             } else if class_name == "TextDecoder" {
                                 ty = Type::Named("TextDecoder".to_string());
+                            } else if matches!(
+                                class_name,
+                                "Readable" | "Writable" | "Duplex" | "Transform" | "PassThrough"
+                            ) {
+                                ty = Type::Named(class_name.to_string());
                             } else if class_name == "Uint8Array" || class_name == "Buffer" {
                                 ty = Type::Named("Uint8Array".to_string());
                             } else if matches!(

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -841,6 +841,16 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 {
                     // Fall through — let the regular member access path
                     // below handle the user-declared subclass field.
+                } else if module_name == "stream" && is_classic_stream_method_name(&property_name) {
+                    // Classic Node streams materialize EventEmitter methods as
+                    // closure-valued fields on the stream object. A bare method
+                    // read (`r.on`, `r.addListener`) must return that callable
+                    // value, not invoke the native receiver method with no args.
+                    let object_expr = lower_expr(ctx, &member.obj)?;
+                    return Ok(Expr::PropertyGet {
+                        object: Box::new(object_expr),
+                        property: property_name,
+                    });
                 } else if matches!(
                     module_name.as_str(),
                     "readable_stream"
@@ -1513,6 +1523,26 @@ fn is_stream_api_member(module: &str, prop: &str) -> bool {
         "transform_stream" => matches!(prop, "readable" | "writable"),
         _ => false,
     }
+}
+
+fn is_classic_stream_method_name(prop: &str) -> bool {
+    matches!(
+        prop,
+        "on" | "addListener"
+            | "once"
+            | "prependListener"
+            | "prependOnceListener"
+            | "emit"
+            | "listeners"
+            | "rawListeners"
+            | "eventNames"
+            | "listenerCount"
+            | "removeListener"
+            | "off"
+            | "removeAllListeners"
+            | "setMaxListeners"
+            | "getMaxListeners"
+    )
 }
 
 /// #1378: `process.features` literal. Boolean capability flags Node

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -892,12 +892,22 @@ fn build_object(methods: &[(&str, StubFn)], shape_id: u32) -> *mut ObjectHeader 
     // the f64 form for `return this` semantics.
     let this_bits = JSValue::pointer(obj as *const u8).bits();
 
-    for (i, (_name, func)) in methods.iter().enumerate() {
+    let mut on_method: Option<JSValue> = None;
+    for (i, (name, func)) in methods.iter().enumerate() {
+        if *name == "addListener" {
+            if let Some(val) = on_method {
+                js_object_set_field(obj, i as u32, val);
+                continue;
+            }
+        }
         let closure = js_closure_alloc(*func as *const u8, 1);
         // Reuse `set_capture_ptr` (i64 payload). We only need 64 bits
         // and the NaN-boxed pattern fits cleanly when reinterpreted.
         crate::closure::js_closure_set_capture_ptr(closure, 0, this_bits as i64);
         let val = JSValue::pointer(closure as *const u8);
+        if *name == "on" {
+            on_method = Some(val);
+        }
         js_object_set_field(obj, i as u32, val);
     }
     obj

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -267,6 +267,8 @@ fn stream_listener_count_and_listeners_reflect_data_end_storage() {
     let on = js_object_get_field_by_name_f64(obj, hidden_key(b"on"));
     let listener_count = js_object_get_field_by_name_f64(obj, hidden_key(b"listenerCount"));
     let listeners = js_object_get_field_by_name_f64(obj, hidden_key(b"listeners"));
+    let add_listener = js_object_get_field_by_name_f64(obj, hidden_key(b"addListener"));
+    assert_eq!(on.to_bits(), add_listener.to_bits());
 
     let cb1 = box_pointer(js_closure_alloc(noop_listener as *const u8, 0) as *const u8);
     let cb2 = box_pointer(js_closure_alloc(noop_listener as *const u8, 0) as *const u8);

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2576,12 +2576,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline with multiple async-gen stages — fails to deliver final collected output. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/add-listener-is-on-alias": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: addListener !== on (should be same function reference). Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/from-empty-map": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
Summary:
- Treat bare classic stream EventEmitter method reads (`r.on`, `r.addListener`) as callable property values rather than zero-arg native method calls.
- Infer classic stream constructor result types for `Readable`, `Writable`, `Duplex`, `Transform`, and `PassThrough` so typed stream method reads can keep method-value shape.
- Reuse the same runtime closure for `addListener` and `on`.
- Remove the now-passing `node-suite/stream/events/add-listener-is-on-alias` known-failure entry.

Verification:
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter add-listener-is-on-alias` PASS
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter listener-fires-with-this-emitter` FAIL as an adjacent non-goal guardrail
- `cargo test -p perry-runtime node_stream --lib` PASS
- `cargo test -p perry-hir var_decl --lib` PASS, 0 matching tests
- `cargo test -p perry-codegen literals_vars --lib` PASS, 0 matching tests
- `cargo fmt --all -- --check` PASS
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

DeepWiki:
- Local-only reference: `reference/deepwiki/deno-node-stream-event-method-aliases-2026-05-27.md`

Non-goals:
- Listener callback `this` binding
- Listener invocation/dataflow
- Non-function listener validation
- `off === removeListener`
- Full EventEmitter prototype inheritance
- Web Streams