### PR TITLE
fix(runtime): bind this to receiver for inherited string-keyed method calls (#321 effect Layer/Scope)

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1432,9 +1432,32 @@ pub unsafe extern "C" fn js_native_call_method(
                                     method_key as *const crate::StringHeader,
                                 );
                                 if !field_val.is_undefined() && !field_val.is_null() {
+                                    // #321 (effect Context/Layer/Scope): the
+                                    // method we just read is an *inherited*
+                                    // own-property of the prototype object
+                                    // `proto_obj`, not of the receiver. When
+                                    // it is an object-literal method
+                                    // (`captures_this:true`), its reserved
+                                    // capture slot was baked to the PROTOTYPE
+                                    // at construction time, so invoking it
+                                    // with `IMPLICIT_THIS = receiver` still
+                                    // reads `this === proto`. Rebind the
+                                    // closure's `this` slot to the receiver
+                                    // first (same treatment as the symbol path
+                                    // #1969 and the `#809` arm below).
+                                    // `clone_closure_rebind_this` is a no-op
+                                    // for closures that don't capture `this`
+                                    // (e.g. effect's `EffectPrototype.pipe`,
+                                    // which reads `this` from `IMPLICIT_THIS`)
+                                    // and for non-closure values, so those
+                                    // paths are unaffected.
+                                    let bound = crate::closure::clone_closure_rebind_this(
+                                        field_val.bits(),
+                                        f64::from_bits(jsval.bits()),
+                                    );
                                     let prev_this = IMPLICIT_THIS.with(|c| c.replace(jsval.bits()));
                                     let result = crate::closure::js_native_call_value(
-                                        f64::from_bits(field_val.bits()),
+                                        f64::from_bits(bound),
                                         args_ptr,
                                         args_len,
                                     );
@@ -1470,9 +1493,34 @@ pub unsafe extern "C" fn js_native_call_method(
                     resolve_proto_chain_field(class_id, method_key as *const crate::StringHeader)
                 {
                     if !field_val.is_undefined() && !field_val.is_null() {
+                        // #321 (effect Context/Layer/Scope): the closure we
+                        // just resolved is an *inherited* method — by
+                        // construction `resolve_proto_chain_field` only walks
+                        // the prototype chain (the receiver's OWN fields are
+                        // handled by the earlier keys-array scan), so this is
+                        // never an own method. Object-literal methods are
+                        // lowered with `captures_this:true` and have their
+                        // reserved (last) capture slot patched to the literal
+                        // object — i.e. the PROTOTYPE — at construction time
+                        // (see `expr.rs::lower_object_literal` /
+                        // `symbol.rs::js_object_set_symbol_method`). So when
+                        // `o = Object.create(P)` resolves `o.method()`, the
+                        // closure carries `this === P`, not `this === o`, and
+                        // setting `IMPLICIT_THIS = o` can't override the
+                        // baked-in slot that the body reads. Rebind the slot
+                        // to the receiver before invoking. This mirrors the
+                        // symbol-keyed fix (#1969) for the string-keyed
+                        // static-member call path. `clone_closure_rebind_this`
+                        // is a no-op for non-`captures_this` closures and for
+                        // non-closure values, so inherited *data* properties
+                        // and arrow/`this`-free function values are untouched.
+                        let bound = crate::closure::clone_closure_rebind_this(
+                            field_val.bits(),
+                            f64::from_bits(jsval.bits()),
+                        );
                         let prev_this = IMPLICIT_THIS.with(|c| c.replace(jsval.bits()));
                         let result = crate::closure::js_native_call_value(
-                            f64::from_bits(field_val.bits()),
+                            f64::from_bits(bound),
                             args_ptr,
                             args_len,
                         );

--- a/test-files/test_gap_object_create_method_this.ts
+++ b/test-files/test_gap_object_create_method_this.ts
@@ -1,0 +1,83 @@
+// #321 (effect Context/Layer/Scope): a STRING-KEYED method INHERITED via
+// `Object.create(proto)` must run with `this` bound to the RECEIVER, not the
+// prototype it is defined on.
+//
+//   const Proto = { getState(this: any) { return this.state } }
+//   const o = Object.create(Proto); o.state = { tag: "X" }
+//   o.getState()   // Node -> { tag: 'X' };  pre-fix Perry -> undefined
+//
+// Root cause: object-literal methods are lowered with `captures_this:true` and
+// have their reserved capture slot patched to the LITERAL object (the
+// prototype) at construction time. Resolving `o.method()` walked the prototype
+// chain and returned the prototype's closure verbatim — whose baked `this`
+// slot points at the prototype, so the body read `this === proto` and
+// `this.<field>` was undefined (the receiver's own field lived on `o`).
+// Setting `IMPLICIT_THIS = o` couldn't override the baked-in slot.
+//
+// Fix: when a string-keyed method is resolved off the prototype chain (i.e. it
+// is INHERITED, not an own field), rebind the closure's `this` slot to the
+// receiver before invoking — the same treatment the symbol-keyed path got in
+// #1969. Own methods (whose baked slot already IS the receiver) and class
+// methods are untouched.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+// (1) inherited method reading `this.state` (whole object) and a nested field.
+const Proto: any = {
+  getState(this: any) {
+    return this.state;
+  },
+  tagOf(this: any) {
+    return this.state && this.state.tag;
+  },
+};
+const o = Object.create(Proto);
+o.state = { tag: "X" };
+console.log("external read:", o.state.tag); // X
+console.log("method this.state:", o.getState()); // { tag: 'X' }
+console.log("method tagOf:", o.tagOf()); // X
+
+// (2) own string method — `this` is the object itself (must NOT regress).
+const own: any = {
+  state: { tag: "OWN" },
+  getState(this: any) {
+    return this.state.tag;
+  },
+};
+console.log("own:", own.getState()); // OWN
+
+// (3) class method — `this` is the instance (must NOT regress).
+class C {
+  state = { tag: "CLASS" };
+  getState() {
+    return this.state.tag;
+  }
+}
+console.log("class:", new C().getState()); // CLASS
+
+// (4) two-level Object.create chain — `this` is the leaf receiver, with a
+//     mid-level field correctly shadowed by the leaf.
+const Base: any = {
+  describe(this: any) {
+    return this.label + ":" + this.n;
+  },
+};
+const Mid = Object.create(Base);
+Mid.n = 0;
+const leaf = Object.create(Mid);
+leaf.label = "LEAF";
+leaf.n = 7;
+console.log("proto2:", leaf.describe()); // LEAF:7
+
+// (5) inherited method that calls ANOTHER inherited method through `this`.
+const P2: any = {
+  base() {
+    return "B";
+  },
+  wrap(this: any) {
+    return "[" + this.base() + this.suffix + "]";
+  },
+};
+const child = Object.create(P2);
+child.suffix = "S";
+console.log("nested-this:", child.wrap()); // [BS]


### PR DESCRIPTION
## What

A string-keyed method INHERITED via Object.create(proto) was invoked with `this` bound to the prototype, not the receiver, so any `this.<field>` read inside it returned undefined.

Repro (Node prints the object / "X"; pre-fix Perry printed undefined):

    const Proto: any = { getState(this: any) { return this.state; } };
    const o = Object.create(Proto); o.state = { tag: "X" };
    console.log(o.getState());   // Node: { tag: 'X' }   pre-fix Perry: undefined

External field reads (`o.state.tag`) always worked; only the in-method `this` was wrong.

## Root cause

Object-literal methods are lowered with `captures_this:true` and have their reserved (last) capture slot patched to the literal object — i.e. the PROTOTYPE — at construction time (see `expr.rs::lower_object_literal` / `symbol.rs::js_object_set_symbol_method`). When `o = Object.create(P)` resolves `o.method()`, the dynamic dispatch tower (`js_native_call_method`) walks the prototype chain and returns P's closure verbatim, whose baked `this` slot points at P. Setting `IMPLICIT_THIS = o` cannot override the slot the closure body actually reads.

Two arms of `js_native_call_method` resolve an inherited method off the prototype chain and hit this:
- the #711-part-2 proto-object arm (reached when a class exists anywhere, so `CLASS_VTABLE_REGISTRY` is `Some`), and
- the #809 synthetic-class-id arm (reached when the program has no user classes).

Both only ever see INHERITED methods — the receiver's OWN fields are caught earlier by the keys-array scan, which already binds correctly because the own-method closure's baked slot IS the receiver.

## Fix

In both arms, rebind the resolved closure's `this` slot to the receiver via `clone_closure_rebind_this` before invoking. This is the string-keyed analogue of the symbol-keyed fix #1969. The helper is a no-op for non-`captures_this` closures and for non-closure values, so own methods, class methods, inherited data properties, and `this`-free / arrow functions (incl. effect's `EffectPrototype.pipe`, which reads `this` from `IMPLICIT_THIS`) are all untouched.

Files changed: `crates/perry-runtime/src/object/native_call_method.rs` (2 arms, +50/-2).

## Verification

- New gap test `test-files/test_gap_object_create_method_this.ts` byte-identical to `node --experimental-strip-types`. Covers: inherited string method `this`, own method (no regress), class method (no regress), 2-level Object.create chain with shadowed field, and an inherited method calling another inherited method through `this`.
- `cargo test --release -p perry-runtime --lib -- --test-threads=1`: 675 passed, 0 failed.
- `cargo fmt --all -- --check`: clean.
- Related gap tests `test_gap_object_create_chain_symbol` and `test_gap_class_expr_extends_static_call_this` remain byte-identical (no regression).

## #321 effect survey status

This unblocks one layer of the Context/Layer path; the two survey items (`nlay.ts`, `real3_context_layer.ts`) now reach a DIFFERENT, deeper blocker (documented below for follow-up). `Effect.provideService` (no Layer) already works and returns 42 byte-identical to Node; `Context.make`/`get`/`merge` of typed Maps and `GenericTag.key` all work. The remaining failure is isolated to the Layer/Scope build path:

NEXT BLOCKER: `for...of` directly over a `Map` value whose static type Perry cannot prove is a `Map` (e.g. an `any`-typed property like `context.unsafeMap`) yields ZERO iterations instead of dispatching to the Map default iterator. Minimal repro:

    const obj: any = { m: new Map([["k", 1]]) };
    let n = 0; for (const e of obj.m) n++;   // Node: 1, Perry: 0

The typed-local case (`const m: Map<...> = ...; for (const e of m)`) and the explicit `.entries()` case (`for (const e of obj.m.entries())`) both work — only the implicit default-iterator path on an untyped Map receiver is broken. This breaks effect's `Context.merge` (`for (const [tag, s] of that.unsafeMap)`), which `scopeExtend` uses to inject the Scope service, so `Layer.build` throws `Service not found: effect/Scope`. This is a separate codegen/runtime bug to be picked up next.
