### PR TITLE
Fix WASM void closure return decoding

### DIFF
--- a/crates/perry-codegen-wasm/src/wasm_runtime.js
+++ b/crates/perry-codegen-wasm/src/wasm_runtime.js
@@ -2587,7 +2587,10 @@ function callWasmClosure(closureVal, ...extraArgs) {
     const fn = wasmInstance.exports.__indirect_function_table.get(closure.funcIdx | 0);
     // Extra args need to be BigInt (i64) for WASM functions. Captures are already BigInt.
     const wasmArgs = extraArgs.map(v => __jsValueToBits(v));
-    if (fn) return __bitsToJsValue(fn(...(closure.captures || []), ...wasmArgs));
+    if (fn) {
+      const result = fn(...(closure.captures || []), ...wasmArgs);
+      return (typeof result === 'bigint') ? __bitsToJsValue(result) : undefined;
+    }
   }
   return u64ToF64(TAG_UNDEFINED);
 }


### PR DESCRIPTION
## Summary
- Guard WASM closure return decoding so `void` callbacks do not pass `undefined` into `__bitsToJsValue`
- Preserve existing NaN-boxed return decoding for normal `i64`/BigInt closure results

## Root cause
`callWasmClosure` unconditionally decoded every WASM closure return with `__bitsToJsValue`. Void-returning callbacks such as `onFrame` produce `undefined`, which cannot be shifted against BigInt tags inside the decoder.

## Validation
- `cargo test -p perry-codegen-wasm`
- Compiled the issue repro with `cargo run -p perry -- compile repro.ts -o repro --target wasm` and verified the generated runtime includes the guard

Fixes #1978
