### PR TITLE
Fix web onFrame delta tracking

### DIFF
--- a/crates/perry-codegen-wasm/src/wasm_runtime.js
+++ b/crates/perry-codegen-wasm/src/wasm_runtime.js
@@ -3057,15 +3057,18 @@ function perry_ui_animate_position(h, dx, dy, durationSecs) {
 // Issue #1865: display-link callbacks. One-shot per registration, like
 // requestAnimationFrame. The id we return matches the rAF id so cancelFrame
 // can hand it straight to cancelAnimationFrame. timestampMs is rAF's
-// DOMHighResTimeStamp; deltaMs is computed per-closure (idiomatic
-// `function loop(t,dt){ ...; onFrame(loop); }` gets accurate deltas).
-const __perryFrameLastByClosure = new WeakMap();
+// DOMHighResTimeStamp; deltaMs is computed per stable WASM function-table
+// index because the JS closure wrapper crossing the WASM boundary is freshly
+// allocated on each call. This keeps the idiomatic
+// `function loop(t,dt){ ...; onFrame(loop); }` pattern accurate.
+const __perryFrameLastByFuncIdx = new Map();
 function perry_ui_on_frame(callback) {
   if (!callback || typeof callback.funcIdx === 'undefined') return 0;
+  const key = callback.funcIdx | 0;
   const id = requestAnimationFrame((ts) => {
-    const prev = __perryFrameLastByClosure.get(callback);
+    const prev = __perryFrameLastByFuncIdx.get(key);
     const dt = (typeof prev === 'number' && ts >= prev) ? ts - prev : 0;
-    __perryFrameLastByClosure.set(callback, ts);
+    __perryFrameLastByFuncIdx.set(key, ts);
     callWasmClosure(callback, ts, dt);
   });
   return id;

--- a/tests/wasm/24_on_frame_delta.expected
+++ b/tests/wasm/24_on_frame_delta.expected
@@ -1,0 +1,4 @@
+frame 1 dt=0
+frame 2 dt=16
+frame 3 dt=16
+done

--- a/tests/wasm/24_on_frame_delta.ts
+++ b/tests/wasm/24_on_frame_delta.ts
@@ -1,0 +1,22 @@
+// onFrame on the web/wasm target must preserve deltaMs across the
+// idiomatic self-rescheduling loop. The WASM bridge creates a fresh JS
+// closure wrapper for each onFrame(loop) call, so runtime delta tracking
+// must not be keyed by JS object identity.
+import { onFrame } from "perry/ui";
+
+let frames = 0;
+
+function loop(_timestampMs: number, deltaMs: number): number {
+  frames += 1;
+  console.log("frame " + frames + " dt=" + deltaMs);
+  if (frames < 3) {
+    onFrame(loop);
+  }
+  return 0;
+}
+
+onFrame(loop);
+
+setTimeout(() => {
+  console.log("done");
+}, 80);

--- a/tests/wasm/run_wasm_tests.sh
+++ b/tests/wasm/run_wasm_tests.sh
@@ -53,6 +53,21 @@ const _stub = { id: '', appendChild: () => {}, getElementById: () => null, style
 const _doc = { createElement: () => Object.assign({}, _stub), getElementById: () => null, title: '' };
 _doc.head = _stub; _doc.body = _stub;
 globalThis.document = _doc;
+let __rafNow = 0;
+const __rafTimers = new Map();
+globalThis.requestAnimationFrame = (cb) => {
+  const id = setTimeout(() => {
+    __rafTimers.delete(id);
+    __rafNow += 16;
+    cb(__rafNow);
+  }, 0);
+  __rafTimers.set(id, id);
+  return id;
+};
+globalThis.cancelAnimationFrame = (id) => {
+  clearTimeout(id);
+  __rafTimers.delete(id);
+};
 const fs = require('fs');
 const html = fs.readFileSync('$html_file', 'utf8');
 const scripts = [];


### PR DESCRIPTION
## Summary
- Fix web/WASM `onFrame` delta tracking by keying previous frame timestamps by stable WASM `funcIdx` instead of transient JS closure wrapper identity.
- Add a deterministic `requestAnimationFrame` polyfill to the WASM Node test harness.
- Add a regression test for the idiomatic self-rescheduling `onFrame(loop)` pattern.

Closes #1979

## Tests
- `cargo build --release -p perry`
- `./tests/wasm/run_wasm_tests.sh` (new `24_on_frame_delta` passes; existing unrelated failures remain: `05_objects_arrays`, `10_higher_order`, `11_map_set_json`, `14_regex_date`, `17_class_field_splice`, `18_module_splice`, `19_ffi_imports`)
