### PR TITLE
fix(node): async iterate readable from chunks

### DIFF
--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -188,6 +188,10 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                             && obj_id.sym.as_ref() == "ReadableStream"
                                         {
                                             ty = Type::Named("ReadableStream".to_string());
+                                        } else if method == "from"
+                                            && obj_id.sym.as_ref() == "Readable"
+                                        {
+                                            ty = Type::Named("Readable".to_string());
                                         }
                                     }
                                 }
@@ -1244,6 +1248,13 @@ pub(crate) fn lower_var_decl_with_destructuring(
             };
 
             let init = decl.init.as_ref().map(|e| lower_expr(ctx, e)).transpose()?;
+            if matches!(ty, Type::Any) {
+                if let Some(Expr::NativeMethodCall { module, method, .. }) = &init {
+                    if module == "stream" && method == "from" {
+                        ty = Type::Named("Readable".to_string());
+                    }
+                }
+            }
             // #321: a generator function EXPRESSION bound to a name (`const g =
             // function*(){}`) — register the name so `for (x of g())` / `[...g()]`
             // take the iterator-protocol path, matching named `function* g(){}`

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -67,6 +67,54 @@ fn is_web_readable_stream_expr(ctx: &LoweringContext, expr: &ast::Expr) -> bool 
     }
 }
 
+fn strip_for_of_expr_wrappers(mut expr: &ast::Expr) -> &ast::Expr {
+    loop {
+        expr = match expr {
+            ast::Expr::TsAs(x) => &x.expr,
+            ast::Expr::TsNonNull(x) => &x.expr,
+            ast::Expr::TsConstAssertion(x) => &x.expr,
+            ast::Expr::Paren(x) => &x.expr,
+            _ => return expr,
+        };
+    }
+}
+
+fn is_node_readable_class_ref(expr: &ast::Expr) -> bool {
+    match strip_for_of_expr_wrappers(expr) {
+        ast::Expr::Ident(ident) => ident.sym.as_ref() == "Readable",
+        ast::Expr::Member(member) => {
+            matches!(&member.prop, ast::MemberProp::Ident(prop) if prop.sym.as_ref() == "Readable")
+        }
+        _ => false,
+    }
+}
+
+fn is_node_readable_static_factory(expr: &ast::Expr) -> bool {
+    let ast::Expr::Call(call) = strip_for_of_expr_wrappers(expr) else {
+        return false;
+    };
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return false;
+    };
+    let ast::Expr::Member(member) = strip_for_of_expr_wrappers(callee.as_ref()) else {
+        return false;
+    };
+    let ast::MemberProp::Ident(prop) = &member.prop else {
+        return false;
+    };
+    matches!(prop.sym.as_ref(), "from" | "of") && is_node_readable_class_ref(&member.obj)
+}
+
+fn is_node_readable_for_await_target(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    if is_node_readable_static_factory(expr) {
+        return true;
+    }
+    matches!(
+        crate::lower_types::infer_type_from_expr(strip_for_of_expr_wrappers(expr), ctx),
+        Type::Named(name) if name == "Readable"
+    )
+}
+
 pub(crate) fn lower_stmt_for_of(
     ctx: &mut LoweringContext,
     module: &mut Module,
@@ -159,10 +207,18 @@ pub(crate) fn lower_stmt_for_of(
             None
         };
 
-    if is_generator_call || iter_from_class.is_some() || is_timer_promises_interval_call {
+    let is_node_readable_for_await =
+        for_of_stmt.is_await && is_node_readable_for_await_target(ctx, &for_of_stmt.right);
+
+    if is_generator_call
+        || iter_from_class.is_some()
+        || is_timer_promises_interval_call
+        || is_node_readable_for_await
+    {
         // Lower to iterator protocol:
         //   let __iter = genFunc(...);                     // generator-fn path
         //   let __iter = __perry_iter_Range(new Range(...));  // class path
+        //   let __iter = readable.iterator();              // node:stream path
         //   let __result = __iter.next();
         //   while (!__result.done) { const x = __result.value; body; __result = __iter.next(); }
         let for_scope_mark = ctx.push_block_scope();
@@ -174,6 +230,15 @@ pub(crate) fn lower_stmt_for_of(
             Expr::Call {
                 callee: Box::new(Expr::FuncRef(iter_fn_id)),
                 args: vec![iter_expr],
+                type_args: vec![],
+            }
+        } else if is_node_readable_for_await {
+            Expr::Call {
+                callee: Box::new(Expr::PropertyGet {
+                    object: Box::new(iter_expr),
+                    property: "iterator".to_string(),
+                }),
+                args: vec![],
                 type_args: vec![],
             }
         } else {

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -63,6 +63,54 @@ fn is_web_readable_stream_expr(ctx: &LoweringContext, expr: &ast::Expr) -> bool 
     }
 }
 
+fn strip_for_of_expr_wrappers(mut expr: &ast::Expr) -> &ast::Expr {
+    loop {
+        expr = match expr {
+            ast::Expr::TsAs(x) => &x.expr,
+            ast::Expr::TsNonNull(x) => &x.expr,
+            ast::Expr::TsConstAssertion(x) => &x.expr,
+            ast::Expr::Paren(x) => &x.expr,
+            _ => return expr,
+        };
+    }
+}
+
+fn is_node_readable_class_ref(expr: &ast::Expr) -> bool {
+    match strip_for_of_expr_wrappers(expr) {
+        ast::Expr::Ident(ident) => ident.sym.as_ref() == "Readable",
+        ast::Expr::Member(member) => {
+            matches!(&member.prop, ast::MemberProp::Ident(prop) if prop.sym.as_ref() == "Readable")
+        }
+        _ => false,
+    }
+}
+
+fn is_node_readable_static_factory(expr: &ast::Expr) -> bool {
+    let ast::Expr::Call(call) = strip_for_of_expr_wrappers(expr) else {
+        return false;
+    };
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return false;
+    };
+    let ast::Expr::Member(member) = strip_for_of_expr_wrappers(callee.as_ref()) else {
+        return false;
+    };
+    let ast::MemberProp::Ident(prop) = &member.prop else {
+        return false;
+    };
+    matches!(prop.sym.as_ref(), "from" | "of") && is_node_readable_class_ref(&member.obj)
+}
+
+fn is_node_readable_for_await_target(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    if is_node_readable_static_factory(expr) {
+        return true;
+    }
+    matches!(
+        crate::lower_types::infer_type_from_expr(strip_for_of_expr_wrappers(expr), ctx),
+        Type::Named(name) if name == "Readable"
+    )
+}
+
 pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Vec<Stmt>> {
     let mut result = Vec::new();
 
@@ -976,13 +1024,29 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     None
                 };
 
-            if is_generator_call || iter_from_class.is_some() || is_timer_promises_interval_call {
+            let is_node_readable_for_await =
+                for_of_stmt.is_await && is_node_readable_for_await_target(ctx, &for_of_stmt.right);
+
+            if is_generator_call
+                || iter_from_class.is_some()
+                || is_timer_promises_interval_call
+                || is_node_readable_for_await
+            {
                 let scope_mark = ctx.push_block_scope();
                 let iter_expr_raw = lower_expr(ctx, &for_of_stmt.right)?;
                 let iter_expr = if let Some(iter_fn_id) = iter_from_class {
                     Expr::Call {
                         callee: Box::new(Expr::FuncRef(iter_fn_id)),
                         args: vec![iter_expr_raw],
+                        type_args: vec![],
+                    }
+                } else if is_node_readable_for_await {
+                    Expr::Call {
+                        callee: Box::new(Expr::PropertyGet {
+                            object: Box::new(iter_expr_raw),
+                            property: "iterator".to_string(),
+                        }),
+                        args: vec![],
                         type_args: vec![],
                     }
                 } else {

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -576,6 +576,10 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                     match (class_name.as_str(), method_name) {
                         ("TextEncoder", "encode") => return Type::Named("Uint8Array".into()),
                         ("TextDecoder", "decode") => return Type::String,
+                        (
+                            "Readable",
+                            "map" | "filter" | "flatMap" | "take" | "drop" | "compose",
+                        ) => return Type::Named("Readable".into()),
                         _ => {}
                     }
                 }
@@ -711,6 +715,16 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                             "isBuffer" => Type::Boolean,
                             "byteLength" => Type::Number,
                             "compare" => Type::Number,
+                            _ => Type::Any,
+                        };
+                    }
+                    // `Readable.from(...)` produces a classic node:stream
+                    // Readable. Typing it lets `for await (... of r)` lower
+                    // through the stream iterator instead of the generic
+                    // array-index fallback.
+                    if obj_name == "Readable" {
+                        return match method_name {
+                            "from" | "of" => Type::Named("Readable".to_string()),
                             _ => Type::Any,
                         };
                     }

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -1388,6 +1388,22 @@ fn uint8array_byte_chunks(raw: usize) -> f64 {
     }
 }
 
+fn typed_uint8array_byte_chunks(raw: usize) -> Option<f64> {
+    if crate::typedarray::lookup_typed_array_kind(raw) != Some(crate::typedarray::KIND_UINT8) {
+        return None;
+    }
+    let ta = raw as *const crate::typedarray::TypedArrayHeader;
+    let len = crate::typedarray::js_typed_array_length(ta).max(0) as u32;
+    let mut out = crate::array::js_array_alloc(len);
+    for i in 0..len {
+        out = crate::array::js_array_push_f64(
+            out,
+            crate::typedarray::js_typed_array_get(ta, i as i32),
+        );
+    }
+    Some(box_pointer(out as *const u8))
+}
+
 fn normalize_readable_from_input(iterable: f64) -> f64 {
     if let Some(chunks) = readable_hidden_chunks(iterable) {
         return chunks;
@@ -1399,6 +1415,9 @@ fn normalize_readable_from_input(iterable: f64) -> f64 {
         && !crate::buffer::is_array_buffer(raw)
     {
         return uint8array_byte_chunks(raw);
+    }
+    if let Some(chunks) = typed_uint8array_byte_chunks(raw) {
+        return chunks;
     }
     if is_array_like_value(iterable) {
         return iterable;

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -101,6 +101,23 @@ fn readable_from_retains_buffer_chunks_for_consumers() {
 }
 
 #[test]
+fn readable_from_typed_uint8array_retains_numeric_byte_chunks() {
+    let mut arr = crate::array::js_array_alloc(3);
+    arr = crate::array::js_array_push_f64(arr, 1.0);
+    arr = crate::array::js_array_push_f64(arr, 2.0);
+    arr = crate::array::js_array_push_f64(arr, 3.0);
+    let typed =
+        crate::typedarray::js_typed_array_new_from_array(crate::typedarray::KIND_UINT8 as i32, arr);
+
+    let readable = js_node_stream_readable_from(box_pointer(typed as *const u8));
+    let chunks = readable_hidden_chunks(readable).expect("readable chunks");
+    let mut values = Vec::new();
+    push_chunk_values(chunks, &mut values, 0);
+
+    assert_eq!(values, vec![1.0, 2.0, 3.0]);
+}
+
+#[test]
 fn writable_options_write_callback_is_invoked_by_stub_write() {
     WRITE_CAPTURED.with(|captured| captured.borrow_mut().clear());
     let opts = crate::object::js_object_alloc(0, 1);

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -632,18 +632,6 @@
     "category": "bug-open",
     "reason": "node:stream: transform() callback with Error doesn't propagate as `error` event. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/from-string": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.from(string) doesn't deliver string chunk via async iteration. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/from-buffer": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.from(Buffer) doesn't deliver chunk via async iteration. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/wrap-old-stream": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -1940,12 +1928,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline async-fn throwing — cb does not receive the error. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/from-array-many-items": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.from(50-item array) — count, sum or first/last value wrong. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/iter-helpers/filter-then-toarray": {
     "issue": "1558",
     "added": "2026-05-24",
@@ -2251,12 +2233,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: second [Symbol.asyncIterator]() call — does not return immediately-done iterator. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/readable/from-typed-array": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.from(Uint8Array) — iteration count or first-byte value wrong. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/writer-write-resolves-after-sink": {
     "issue": "1545",


### PR DESCRIPTION
## Summary

- Treat non-Buffer `Uint8Array` input to classic `Readable.from(...)` as numeric byte chunks while keeping Buffer input as a single chunk.
- Teach HIR typing/lowering that classic `Readable.from(...)` and stored `Readable` values use the stream async iterator path for `for await`, instead of array-like `length`/index lowering.
- Remove exact now-green known-failure entries for `from-typed-array`, `from-string`, `from-buffer`, and `from-array-many-items`.

## DeepWiki

Local reference only, not staged: `reference/deepwiki/deno-node-stream-readable-from-typed-array-2026-05-27.md`.

Extracted invariant: `Readable.from(Uint8Array)` treats the typed array as an iterable of numeric byte values; Buffer input remains a single Buffer chunk.

## Verification

Baseline before fix:
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/readable/from-typed-array` failed with Node `count: 3`, Perry `count: 0` (`parity_report_20260527_044710.json`).

After fix:
- `cargo test -p perry-runtime readable_from_typed_uint8array_retains_numeric_byte_chunks --lib`
- `cargo build --release --bin perry`
- `PERRY_NO_CACHE=1 target/release/perry compile test-parity/node-suite/stream/readable/from-typed-array.ts --print-hir --no-link -o /tmp/perry_from_typed_array_debug`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/readable/from-typed-array`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/readable/from-buffer-direct`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/readable/from-array-many-items`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/readable/from-buffer`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/readable/from-string`
- `cargo test -p perry-runtime node_stream --lib`
- `cargo test -p perry-hir stmt_loops --lib`
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals

- Non-Uint8 typed arrays.
- Map/Set/custom iterator normalization in `Readable.from`.
- Web Streams.
- Pipe/transform dataflow.
- Full async iterator cleanup/destroy behavior.
- Stale known-failure cleanup unrelated to this slice.
