### PR TITLE
fix(node:events): support EventTarget listeners

### DIFF
--- a/crates/perry-codegen/src/expr/helpers.rs
+++ b/crates/perry-codegen/src/expr/helpers.rs
@@ -302,6 +302,7 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
             | "URLSearchParams"
             | "AbortController"
             | "AbortSignal"
+            | "EventTarget"
             | "FormData"
             | "Blob"
             | "Headers"

--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -165,6 +165,14 @@ pub(super) fn lower_builtin_new(
             let handle = blk.call(I64, "js_event_emitter_new_with_options", &[(DOUBLE, &opts)]);
             Ok(Some(nanbox_pointer_inline(blk, &handle)))
         }
+        "EventTarget" => {
+            for a in args {
+                let _ = lower_expr(ctx, a)?;
+            }
+            let blk = ctx.block();
+            let handle = blk.call(I64, "js_event_target_new", &[]);
+            Ok(Some(nanbox_pointer_inline(blk, &handle)))
+        }
         // node:perf_hooks — `new PerformanceObserver(cb)` registers the
         // observer and returns its `perf_observer` namespace object (already
         // NaN-boxed). `cb` is passed through so the runtime can invoke it on

--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -20,6 +20,10 @@ use super::{
     lower_fetch_native_method,
 };
 
+fn is_event_target_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
+    matches!(receiver_class_name(ctx, e).as_deref(), Some("EventTarget"))
+}
+
 /// Try to lower a `Call { callee: PropertyGet { .. } }` via the
 /// string/array/class/Map/Set/Promise/fetch/static/instance method
 /// dispatch tower. Returns `Ok(None)` when the callee shape doesn't
@@ -656,6 +660,35 @@ pub fn try_lower_property_get_method_call(
     // interception because the class isn't in `ctx.classes`.
     if let Some(val) = lower_abort_controller_call(ctx, object, property, args)? {
         return Ok(Some(val));
+    }
+
+    // ── EventTarget dispatch ──
+    // `new EventTarget()` is a runtime object, not a HIR class, so calls to
+    // its listener methods need the same explicit interception pattern as
+    // AbortSignal above.
+    if is_event_target_expr(ctx, object) && args.len() >= 2 {
+        if property == "addEventListener" || property == "removeEventListener" {
+            let target_box = lower_expr(ctx, object)?;
+            let event_box = lower_expr(ctx, &args[0])?;
+            let listener_box = lower_expr(ctx, &args[1])?;
+            let blk = ctx.block();
+            let target = unbox_to_i64(blk, &target_box);
+            let event = blk.call(
+                I64,
+                "js_get_string_pointer_unified",
+                &[(DOUBLE, &event_box)],
+            );
+            let listener = unbox_to_i64(blk, &listener_box);
+            let runtime = if property == "addEventListener" {
+                "js_event_target_add_event_listener"
+            } else {
+                "js_event_target_remove_event_listener"
+            };
+            blk.call_void(runtime, &[(I64, &target), (I64, &event), (I64, &listener)]);
+            return Ok(Some(double_literal(f64::from_bits(
+                crate::nanbox::TAG_UNDEFINED,
+            ))));
+        }
     }
 
     // ── Chained Web Fetch dispatch ──

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1796,6 +1796,17 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_abort_controller_abort_reason", VOID, &[I64, DOUBLE]);
     module.declare_function("js_abort_signal_add_listener", VOID, &[I64, DOUBLE, DOUBLE]);
     module.declare_function("js_abort_signal_timeout", I64, &[DOUBLE]);
+    module.declare_function("js_event_target_new", I64, &[]);
+    module.declare_function("js_event_target_add_event_listener", VOID, &[I64, I64, I64]);
+    module.declare_function(
+        "js_event_target_remove_event_listener",
+        VOID,
+        &[I64, I64, I64],
+    );
+    module.declare_function("js_event_target_is_event_target", I32, &[I64]);
+    module.declare_function("js_event_target_get_event_listeners", I64, &[I64, I64]);
+    module.declare_function("js_event_target_get_max_listeners", DOUBLE, &[I64]);
+    module.declare_function("js_event_target_set_max_listeners", I32, &[I64, DOUBLE]);
 
     declare_phase_b_arrays(module);
 }

--- a/crates/perry-ext-events/src/lib.rs
+++ b/crates/perry-ext-events/src/lib.rs
@@ -28,6 +28,7 @@ use perry_ffi::{
 use std::collections::HashMap;
 
 const MIN_HEAP_POINTER: u64 = 0x1000;
+const EVENT_TARGET_MIN_HEAP_POINTER: u64 = 0x10000;
 const MAX_HEAP_POINTER: u64 = 0x0000_FFFF_FFFF_FFFF;
 
 // Direct hook into perry-runtime's sync Promise resolve.
@@ -58,6 +59,13 @@ extern "C" {
     // #1557: AbortSignal listener attachment for events.addAbortListener.
     fn js_string_from_bytes(data: *const u8, len: u32) -> *mut StringHeader;
     fn js_abort_signal_add_listener(signal: *mut u8, event: f64, listener: f64);
+    fn js_event_target_is_event_target(target: *const u8) -> i32;
+    fn js_event_target_get_event_listeners(
+        target: *mut u8,
+        event: *const StringHeader,
+    ) -> *mut ArrayHeader;
+    fn js_event_target_get_max_listeners(target: *mut u8) -> f64;
+    fn js_event_target_set_max_listeners(target: *mut u8, n: f64) -> i32;
 }
 
 const TAG_UNDEFINED_F64_BITS: u64 = 0x7FFC_0000_0000_0001;
@@ -175,6 +183,27 @@ fn is_heap_pointer_candidate(callback: i64) -> bool {
     }
     let addr = callback as u64;
     (MIN_HEAP_POINTER..=MAX_HEAP_POINTER).contains(&addr) && addr & 0x7 == 0
+}
+
+unsafe fn event_target_ptr(handle: Handle) -> Option<*mut u8> {
+    let addr = handle as u64;
+    if !(EVENT_TARGET_MIN_HEAP_POINTER..=MAX_HEAP_POINTER).contains(&addr) || addr & 0x7 != 0 {
+        return None;
+    }
+    let ptr = handle as *mut u8;
+    if js_event_target_is_event_target(ptr as *const u8) != 0 {
+        Some(ptr)
+    } else {
+        None
+    }
+}
+
+fn handle_from_js_value_bits(bits: u64) -> Handle {
+    if (bits & 0xFFFF_0000_0000_0000) == POINTER_TAG {
+        (bits & POINTER_MASK) as Handle
+    } else {
+        bits as Handle
+    }
 }
 
 unsafe fn read_str(ptr: *const StringHeader) -> Option<String> {
@@ -730,7 +759,13 @@ pub unsafe extern "C" fn js_events_get_event_listeners(
     handle: Handle,
     event_name_ptr: *const StringHeader,
 ) -> *mut ArrayHeader {
-    js_event_emitter_listeners(handle, event_name_ptr)
+    if get_handle_mut::<EventEmitterHandle>(handle).is_some() {
+        return js_event_emitter_listeners(handle, event_name_ptr);
+    }
+    if let Some(target) = event_target_ptr(handle) {
+        return js_event_target_get_event_listeners(target, event_name_ptr);
+    }
+    js_array_alloc(0)
 }
 
 /// `events.listenerCount(emitter, eventName)` — alias.
@@ -749,16 +784,32 @@ pub unsafe extern "C" fn js_events_listener_count(
 /// `events.getMaxListeners(emitter)` — alias.
 #[no_mangle]
 pub unsafe extern "C" fn js_events_get_max_listeners(handle: Handle) -> f64 {
-    js_event_emitter_get_max_listeners(handle)
+    if let Some(emitter) = get_handle_mut::<EventEmitterHandle>(handle) {
+        return emitter.max_listeners as f64;
+    }
+    if let Some(target) = event_target_ptr(handle) {
+        return js_event_target_get_max_listeners(target);
+    }
+    10.0
 }
 
 /// `events.setMaxListeners(n, ...emitters)` — Perry FFI takes a single
-/// emitter handle. Multi-target callers should emit N FFI calls; for
-/// the single-emitter case below this is exactly the right shape.
+/// array of target handles from the codegen varargs lowering.
 #[no_mangle]
-pub unsafe extern "C" fn js_events_set_max_listeners(n: f64, handle: Handle) -> f64 {
-    if let Some(emitter) = get_handle_mut::<EventEmitterHandle>(handle) {
-        emitter.max_listeners = n as i32;
+pub unsafe extern "C" fn js_events_set_max_listeners(
+    n: f64,
+    handles_ptr: *const ArrayHeader,
+) -> f64 {
+    if !handles_ptr.is_null() {
+        let len = (*handles_ptr).length;
+        for i in 0..len {
+            let handle = handle_from_js_value_bits(js_array_get(handles_ptr, i).bits());
+            if let Some(emitter) = get_handle_mut::<EventEmitterHandle>(handle) {
+                emitter.max_listeners = n as i32;
+            } else if let Some(target) = event_target_ptr(handle) {
+                let _ = js_event_target_set_max_listeners(target, n);
+            }
+        }
     }
     f64::from_bits(0x7FFC_0000_0000_0001)
 }

--- a/crates/perry-runtime/src/event_target.rs
+++ b/crates/perry-runtime/src/event_target.rs
@@ -1,0 +1,210 @@
+//! Minimal WHATWG `EventTarget` storage used by Node's `events` helpers.
+//!
+//! Perry models `EventTarget` as a regular runtime object with hidden fields:
+//! a marker, a listener-bag object keyed by event type, and a max-listener
+//! number. Keeping the listener arrays in object fields lets the normal GC
+//! trace callbacks without a separate native handle registry.
+
+use crate::{
+    js_array_alloc, js_array_get, js_array_length, js_array_push_f64, js_nanbox_pointer,
+    js_object_alloc, js_object_get_field_by_name_f64, js_object_set_field_by_name,
+    js_string_from_bytes, ArrayHeader, JSValue, ObjectHeader, StringHeader,
+};
+
+fn key(bytes: &[u8]) -> *mut StringHeader {
+    js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
+}
+
+fn boxed_ptr<T>(ptr: *mut T) -> f64 {
+    js_nanbox_pointer(ptr as i64)
+}
+
+fn value_as_ptr<T>(value: f64) -> Option<*mut T> {
+    let value = JSValue::from_bits(value.to_bits());
+    if value.is_pointer() {
+        Some(value.as_pointer::<T>() as *mut T)
+    } else {
+        None
+    }
+}
+
+unsafe fn is_event_target(target: *const ObjectHeader) -> bool {
+    if target.is_null() {
+        return false;
+    }
+    if (target as usize) < crate::gc::GC_HEADER_SIZE + 0x10000 {
+        return false;
+    }
+    let gc_header =
+        (target as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    if (*gc_header).obj_type != crate::gc::GC_TYPE_OBJECT {
+        return false;
+    }
+    let marker = js_object_get_field_by_name_f64(target, key(b"_eventTarget"));
+    marker.to_bits() == JSValue::bool(true).bits()
+}
+
+unsafe fn listeners_bag(target: *mut ObjectHeader) -> Option<*mut ObjectHeader> {
+    if !is_event_target(target) {
+        return None;
+    }
+    let bag = js_object_get_field_by_name_f64(target, key(b"_eventTargetListeners"));
+    value_as_ptr::<ObjectHeader>(bag)
+}
+
+unsafe fn event_array(
+    bag: *mut ObjectHeader,
+    event_name_ptr: *const StringHeader,
+    create: bool,
+) -> Option<*mut ArrayHeader> {
+    if bag.is_null() || event_name_ptr.is_null() {
+        return None;
+    }
+    let existing = js_object_get_field_by_name_f64(bag, event_name_ptr);
+    if let Some(arr) = value_as_ptr::<ArrayHeader>(existing) {
+        return Some(arr);
+    }
+    if !create {
+        return None;
+    }
+    let arr = js_array_alloc(0);
+    js_object_set_field_by_name(bag, event_name_ptr, boxed_ptr(arr));
+    Some(arr)
+}
+
+/// `new EventTarget()`.
+#[no_mangle]
+pub extern "C" fn js_event_target_new() -> *mut ObjectHeader {
+    let target = js_object_alloc(0, 0);
+    let bag = js_object_alloc(0, 0);
+    js_object_set_field_by_name(
+        target,
+        key(b"_eventTarget"),
+        f64::from_bits(JSValue::bool(true).bits()),
+    );
+    js_object_set_field_by_name(target, key(b"_eventTargetListeners"), boxed_ptr(bag));
+    js_object_set_field_by_name(target, key(b"_eventTargetMaxListeners"), 10.0);
+    target
+}
+
+/// `target.addEventListener(type, listener)`.
+#[no_mangle]
+pub unsafe extern "C" fn js_event_target_add_event_listener(
+    target: *mut ObjectHeader,
+    event_name_ptr: *const StringHeader,
+    callback_ptr: i64,
+) {
+    if callback_ptr == 0 {
+        return;
+    }
+    let Some(bag) = listeners_bag(target) else {
+        return;
+    };
+    let Some(arr) = event_array(bag, event_name_ptr, true) else {
+        return;
+    };
+    let listener = boxed_ptr(callback_ptr as *mut u8);
+    let len = js_array_length(arr);
+    for i in 0..len {
+        if js_array_get(arr, i).bits() == listener.to_bits() {
+            return;
+        }
+    }
+    let updated = js_array_push_f64(arr, listener);
+    if updated != arr {
+        js_object_set_field_by_name(bag, event_name_ptr, boxed_ptr(updated));
+    }
+}
+
+/// `target.removeEventListener(type, listener)`.
+#[no_mangle]
+pub unsafe extern "C" fn js_event_target_remove_event_listener(
+    target: *mut ObjectHeader,
+    event_name_ptr: *const StringHeader,
+    callback_ptr: i64,
+) {
+    if callback_ptr == 0 {
+        return;
+    }
+    let Some(bag) = listeners_bag(target) else {
+        return;
+    };
+    let Some(arr) = event_array(bag, event_name_ptr, false) else {
+        return;
+    };
+    let listener = boxed_ptr(callback_ptr as *mut u8);
+    let out = js_array_alloc(0);
+    let len = js_array_length(arr);
+    let mut changed = false;
+    let mut result = out;
+    for i in 0..len {
+        let current = js_array_get(arr, i);
+        if current.bits() == listener.to_bits() {
+            changed = true;
+            continue;
+        }
+        result = js_array_push_f64(result, f64::from_bits(current.bits()));
+    }
+    if changed {
+        js_object_set_field_by_name(bag, event_name_ptr, boxed_ptr(result));
+    }
+}
+
+/// Runtime predicate used by the Node `events` module helpers.
+#[no_mangle]
+pub unsafe extern "C" fn js_event_target_is_event_target(target: *const ObjectHeader) -> i32 {
+    if is_event_target(target) {
+        1
+    } else {
+        0
+    }
+}
+
+/// `events.getEventListeners(target, type)` for EventTarget receivers.
+#[no_mangle]
+pub unsafe extern "C" fn js_event_target_get_event_listeners(
+    target: *mut ObjectHeader,
+    event_name_ptr: *const StringHeader,
+) -> *mut ArrayHeader {
+    let out = js_array_alloc(0);
+    let Some(bag) = listeners_bag(target) else {
+        return out;
+    };
+    let Some(arr) = event_array(bag, event_name_ptr, false) else {
+        return out;
+    };
+    let len = js_array_length(arr);
+    let mut result = out;
+    for i in 0..len {
+        let current = js_array_get(arr, i);
+        result = js_array_push_f64(result, f64::from_bits(current.bits()));
+    }
+    result
+}
+
+/// `events.getMaxListeners(target)` for EventTarget receivers.
+#[no_mangle]
+pub unsafe extern "C" fn js_event_target_get_max_listeners(target: *mut ObjectHeader) -> f64 {
+    if !is_event_target(target) {
+        return 10.0;
+    }
+    let value = js_object_get_field_by_name_f64(target, key(b"_eventTargetMaxListeners"));
+    if JSValue::from_bits(value.to_bits()).is_number() {
+        value
+    } else {
+        10.0
+    }
+}
+
+/// `events.setMaxListeners(n, target)` for EventTarget receivers.
+#[no_mangle]
+pub unsafe extern "C" fn js_event_target_set_max_listeners(
+    target: *mut ObjectHeader,
+    n: f64,
+) -> i32 {
+    if !is_event_target(target) {
+        return 0;
+    }
+    js_object_set_field_by_name(target, key(b"_eventTargetMaxListeners"), n);
+    1
+}

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -38,6 +38,7 @@ pub mod color_parse;
 pub mod date;
 pub mod error;
 pub mod event_pump;
+pub mod event_target;
 pub mod exception;
 pub mod fast_hash;
 pub mod ffi;

--- a/crates/perry-stdlib/src/events.rs
+++ b/crates/perry-stdlib/src/events.rs
@@ -30,12 +30,27 @@ use std::collections::HashMap;
 const TAG_FALSE_F64: f64 = f64::from_bits(0x7FFC_0000_0000_0003);
 const TAG_TRUE_F64: f64 = f64::from_bits(0x7FFC_0000_0000_0004);
 const ERROR_MONITOR_EVENT_NAME: &str = "Symbol(events.errorMonitor)";
+const MIN_HEAP_POINTER: u64 = 0x10000;
+const MAX_HEAP_POINTER: u64 = 0x0000_FFFF_FFFF_FFFF;
 
 fn bool_to_js(value: bool) -> f64 {
     if value {
         TAG_TRUE_F64
     } else {
         TAG_FALSE_F64
+    }
+}
+
+unsafe fn event_target_ptr(handle: Handle) -> Option<*mut ObjectHeader> {
+    let addr = handle as u64;
+    if !(MIN_HEAP_POINTER..=MAX_HEAP_POINTER).contains(&addr) || addr & 0x7 != 0 {
+        return None;
+    }
+    let ptr = handle as *mut ObjectHeader;
+    if perry_runtime::event_target::js_event_target_is_event_target(ptr) != 0 {
+        Some(ptr)
+    } else {
+        None
     }
 }
 
@@ -926,6 +941,12 @@ pub unsafe extern "C" fn js_events_get_event_listeners(
     handle: Handle,
     event_name_ptr: *const StringHeader,
 ) -> *mut ArrayHeader {
+    if let Some(target) = event_target_ptr(handle) {
+        return perry_runtime::event_target::js_event_target_get_event_listeners(
+            target,
+            event_name_ptr,
+        );
+    }
     js_event_emitter_listeners(handle, event_name_ptr)
 }
 
@@ -942,13 +963,15 @@ pub unsafe extern "C" fn js_events_listener_count(
 /// `events.getMaxListeners(emitter)` — alias.
 #[no_mangle]
 pub unsafe extern "C" fn js_events_get_max_listeners(handle: Handle) -> f64 {
+    if let Some(target) = event_target_ptr(handle) {
+        return perry_runtime::event_target::js_event_target_get_max_listeners(target);
+    }
     js_event_emitter_get_max_listeners(handle)
 }
 
-/// `events.setMaxListeners(n, ...emitters)` — Perry FFI takes a single
-/// emitter handle. The codegen wraps multi-target calls by emitting
-/// one FFI call per target; for the common single-emitter case below
-/// this is exactly the right shape.
+/// `events.setMaxListeners(n, ...targets)` — codegen passes the varargs
+/// target list as a Perry array of EventEmitter handles and EventTarget
+/// object pointers.
 #[no_mangle]
 pub unsafe extern "C" fn js_events_set_max_listeners(
     n: f64,
@@ -968,6 +991,8 @@ pub unsafe extern "C" fn js_events_set_max_listeners(
             };
             if let Some(emitter) = get_handle_mut::<EventEmitterHandle>(handle) {
                 emitter.max_listeners = n;
+            } else if let Some(target) = event_target_ptr(handle) {
+                let _ = perry_runtime::event_target::js_event_target_set_max_listeners(target, n);
             }
         }
     }

--- a/test-parity/node-suite/events/listeners/event-target-dedup-remove.ts
+++ b/test-parity/node-suite/events/listeners/event-target-dedup-remove.ts
@@ -1,0 +1,10 @@
+import { getEventListeners } from "node:events";
+
+const target = new EventTarget();
+function listener() {}
+
+target.addEventListener("x", listener);
+target.addEventListener("x", listener);
+console.log("dedup:", getEventListeners(target, "x").length);
+target.removeEventListener("x", listener);
+console.log("removed:", getEventListeners(target, "x").length);


### PR DESCRIPTION
## Summary
- add runtime-backed global `EventTarget` listener storage with duplicate listener suppression and removal
- lower `new EventTarget()`, `addEventListener`, and `removeEventListener` to the runtime helpers
- teach `node:events` `getEventListeners`, `getMaxListeners`, and `setMaxListeners` to handle EventTarget targets alongside EventEmitter handles

## Tests
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `cargo check -p perry-runtime -p perry-codegen -p perry-stdlib -p perry-ext-events`
- `./run_parity_tests.sh --suite node-suite --module events --filter listeners/static-event-target`
- `./run_parity_tests.sh --suite node-suite --module events --filter listeners/event-target-dedup-remove`
- `./run_parity_tests.sh --suite node-suite --module events --filter max-listeners/static-multiple-targets`

## Notes
- This intentionally does not implement `events.on` / `events.once` AbortSignal rejection semantics; the abort-related parity failures are separate work.
- I did not rerun the full `events` module because inventory found the existing `node-suite/events/once/abort-and-error` hang.
