### PR TITLE
fix(node): return undefined for missing submodule exports

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -754,6 +754,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     // directly to the per-(submodule, export) function
                     // singleton; same value the named-import would
                     // produce, so `ns.setTimeout === setTimeout` holds.
+                    // Missing namespace properties must return undefined,
+                    // not the named-import fallback TAG_TRUE sentinel.
                     // Done before the class_ids check below because
                     // none of the recognized submodules export classes
                     // by name today; if/when they do (e.g.
@@ -768,7 +770,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         let blk = ctx.block();
                         return Ok(blk.call(
                             DOUBLE,
-                            "js_node_submodule_export_as_function",
+                            "js_node_submodule_namespace_member",
                             &[
                                 (PTR, &submod_label),
                                 (I32, &submod_len.to_string()),

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1074,6 +1074,13 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
         DOUBLE,
         &[PTR, I32, PTR, I32],
     );
+    // Namespace member reads for known Node submodules. Unlike direct
+    // named-import fallback, missing properties return undefined.
+    module.declare_function(
+        "js_node_submodule_namespace_member",
+        DOUBLE,
+        &[PTR, I32, PTR, I32],
+    );
     // Issue #841 companion: per-submodule namespace stub object. Returns
     // a NaN-boxed ObjectHeader pointer whose fields are the function
     // singletons emitted by `js_node_submodule_export_as_function`.

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -865,6 +865,45 @@ pub unsafe extern "C" fn js_node_submodule_export_as_function(
     f64::from_bits(JSValue::pointer(closure_ptr as *const u8).bits())
 }
 
+/// Returns a namespace-member value for a known Node submodule namespace import.
+///
+/// This differs from `js_node_submodule_export_as_function`: direct named-import
+/// fallback behavior still uses the historical `TAG_TRUE` sentinel for
+/// unlisted exports, but namespace property reads must behave like ordinary JS
+/// objects and return `undefined` for absent properties.
+#[no_mangle]
+pub unsafe extern "C" fn js_node_submodule_namespace_member(
+    submod_key_ptr: *const u8,
+    submod_key_len: u32,
+    name_ptr: *const u8,
+    name_len: u32,
+) -> f64 {
+    let submod_bytes = std::slice::from_raw_parts(submod_key_ptr, submod_key_len as usize);
+    let name_bytes = std::slice::from_raw_parts(name_ptr, name_len as usize);
+    let submod_key = match std::str::from_utf8(submod_bytes) {
+        Ok(s) => s,
+        Err(_) => return f64::from_bits(crate::value::TAG_UNDEFINED),
+    };
+    let name = match std::str::from_utf8(name_bytes) {
+        Ok(s) => s,
+        Err(_) => return f64::from_bits(crate::value::TAG_UNDEFINED),
+    };
+    let submod = match find_submodule(submod_key) {
+        Some(s) => s,
+        None => return f64::from_bits(crate::value::TAG_UNDEFINED),
+    };
+    if submod.key == "stream_promises" && name == "default" {
+        let obj = ensure_namespace_singleton(submod);
+        return f64::from_bits(JSValue::pointer(obj as *const u8).bits());
+    }
+    let export = match find_export(submod, name) {
+        Some(e) => e,
+        None => return f64::from_bits(crate::value::TAG_UNDEFINED),
+    };
+    let closure_ptr = ensure_export_singleton(submod, export);
+    f64::from_bits(JSValue::pointer(closure_ptr as *const u8).bits())
+}
+
 /// Returns a NaN-boxed namespace stub object for the given submodule.
 /// Each known named export of that submodule is exposed as an own
 /// property on the object whose value is the export singleton
@@ -1002,6 +1041,34 @@ mod tests {
             get_object_property(ns_value, b"default").unwrap().to_bits(),
             ns_value.to_bits()
         );
+    }
+
+    #[test]
+    fn namespace_member_missing_export_returns_undefined() {
+        let value = unsafe {
+            js_node_submodule_namespace_member(
+                b"diagnostics_channel".as_ptr(),
+                "diagnostics_channel".len() as u32,
+                b"boundedChannel".as_ptr(),
+                "boundedChannel".len() as u32,
+            )
+        };
+
+        assert_eq!(value.to_bits(), crate::value::TAG_UNDEFINED);
+    }
+
+    #[test]
+    fn direct_missing_export_keeps_legacy_true_sentinel() {
+        let value = unsafe {
+            js_node_submodule_export_as_function(
+                b"diagnostics_channel".as_ptr(),
+                "diagnostics_channel".len() as u32,
+                b"boundedChannel".as_ptr(),
+                "boundedChannel".len() as u32,
+            )
+        };
+
+        assert_eq!(value.to_bits(), crate::value::TAG_TRUE);
     }
 
     #[test]

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -146,12 +146,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory — `node:dgram` (UDP) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
-  "test_parity_diagnostics_channel": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:diagnostics_channel` not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "test_parity_dns": {
     "issue": "793",
     "added": "2026-05-15",

--- a/test-parity/node-suite/diagnostics_channel/imports/missing-export-undefined.ts
+++ b/test-parity/node-suite/diagnostics_channel/imports/missing-export-undefined.ts
@@ -1,0 +1,4 @@
+import dcDefault, * as dc from "node:diagnostics_channel";
+
+console.log("namespace boundedChannel typeof:", typeof (dc as any).boundedChannel);
+console.log("default boundedChannel typeof:", typeof (dcDefault as any).boundedChannel);


### PR DESCRIPTION
## Summary

- Add a runtime/codegen path for known Node submodule namespace-member reads that returns `undefined` for absent properties.
- Keep the older direct named-import missing-export fallback unchanged, so this only affects namespace property reads like `diagnostics_channel.boundedChannel`.
- Add a focused diagnostics_channel fixture and remove the now-green `test_parity_diagnostics_channel` known-failure entry.

## DeepWiki

Local reference only, not staged: `reference/deepwiki/deno-node-diagnostics-channel-missing-export-2026-05-27.md`.

Extracted invariant: Deno explicitly exports `channel`, `hasSubscribers`, `subscribe`, `tracingChannel`, `unsubscribe`, and `Channel` from `node:diagnostics_channel`; unsupported namespace properties such as `boundedChannel` are absent and read as `undefined`.

## Verification

Baseline before fix:
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module diagnostics_channel --filter missing-export-undefined` failed with Node `namespace boundedChannel typeof: undefined`, Perry `namespace boundedChannel typeof: boolean` (`parity_report_20260527_051900.json`).
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --filter test_parity_diagnostics_channel` failed on the same `boundedChannel` type probe (`parity_report_20260527_051659.json`).

After fix:
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module diagnostics_channel --filter missing-export-undefined`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --filter test_parity_diagnostics_channel`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module diagnostics_channel --filter imports`
- `cargo test -p perry-runtime namespace_member_missing_export_returns_undefined --lib`
- `cargo test -p perry-runtime direct_missing_export_keeps_legacy_true_sentinel --lib`
- `cargo test -p perry-runtime node_submodules --lib`
- `cargo test -p perry-codegen property_get --lib`
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

I also attempted the full `node-suite/diagnostics_channel`; it was manually stopped after hanging in the pre-existing `thread/worker-main-publish` worker fixture. Channel/imports/instrumentation/stores fixtures observed before that point were green.

## Non-goals

- Implementing `boundedChannel`.
- Changing direct named-import fallback semantics.
- Expanding diagnostics_channel stores/tracing behavior.
- Fixing worker/thread diagnostics fixtures.
