### PR TITLE
fix(codegen): dispatch for-of over untyped receivers to the runtime default iterator (#321 effect Layer/Scope)

### DIFF
--- a/crates/perry-codegen-js/src/emit/exprs_more.rs
+++ b/crates/perry-codegen-js/src/emit/exprs_more.rs
@@ -1019,6 +1019,15 @@ impl JsEmitter {
                 self.emit_expr(val);
                 self.output.push(')');
             }
+            // #321: untyped `for...of` materialization. `Array.from`
+            // already drives any iterable (Map → [k,v] pairs, Set →
+            // values, Array, string, custom Symbol.iterator), matching
+            // the native runtime's `js_for_of_to_array`.
+            Expr::ForOfToArray(val) => {
+                self.output.push_str("Array.from(");
+                self.emit_expr(val);
+                self.output.push(')');
+            }
             Expr::ArrayFromMapped { iterable, map_fn } => {
                 self.output.push_str("Array.from(");
                 self.emit_expr(iterable);

--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -359,6 +359,7 @@ pub fn check_escapes_in_expr(
         | Expr::JsonStringify(operand)
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)
+        | Expr::ForOfToArray(operand)
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
         | Expr::FinalizationRegistryNew(operand)

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -248,6 +248,7 @@ fn collect_used_new_fields_in_expr(
         | Expr::JsonStringify(operand)
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)
+        | Expr::ForOfToArray(operand)
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
         | Expr::FinalizationRegistryNew(operand)

--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -1109,6 +1109,7 @@ pub fn collect_localset_ids_in_expr_filtered(
         | Expr::Uint8ArrayFrom(operand)
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)
+        | Expr::ForOfToArray(operand)
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
         | Expr::StructuredClone(operand)

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -214,6 +214,7 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         | Expr::Uint8ArrayFrom(operand)
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)
+        | Expr::ForOfToArray(operand)
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
         | Expr::StructuredClone(operand)

--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -513,6 +513,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let v = lower_expr(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "js_get_iterator", &[(DOUBLE, &v)]))
         }
+        Expr::ForOfToArray(o) => {
+            // #321: materialize an untyped `for...of` receiver into a plain
+            // Array. Runtime inspects the value's GC kind (Map → [k,v]
+            // pairs, Set → values, Array → itself, string → chars, else
+            // drive `[Symbol.iterator]`) and returns a NaN-boxed array
+            // JSValue the index loop can read via `.length` / `arr[i]`.
+            let v = lower_expr(ctx, o)?;
+            Ok(ctx
+                .block()
+                .call(DOUBLE, "js_for_of_to_array", &[(DOUBLE, &v)]))
+        }
         Expr::WeakRefDeref(o) => {
             // `ref.deref()` — returns the wrapped target (or undefined if
             // collected; GC never clears the stub slot, so always returns

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1533,6 +1533,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::FsMkdirSync(..)
         | Expr::IteratorToArray(..)
         | Expr::GetIterator(..)
+        | Expr::ForOfToArray(..)
         | Expr::WeakRefDeref(..)
         | Expr::Uint8ArrayNew(..)
         | Expr::Uint8ArrayLength(..)

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -118,6 +118,10 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // #1831: `yield*` iterator resolution — `operand[Symbol.iterator]()` or the
     // operand itself when already an iterator. Returns a NaN-boxed JSValue.
     module.declare_function("js_get_iterator", DOUBLE, &[DOUBLE]);
+    // #321: materialize an untyped `for...of` receiver into a plain Array by
+    // inspecting its runtime GC kind (Map/Set/Array/string/iterable).
+    // Returns a NaN-boxed array JSValue.
+    module.declare_function("js_for_of_to_array", DOUBLE, &[DOUBLE]);
 
     declare_phase_b_objects(module);
 }

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1794,6 +1794,16 @@ pub enum Expr {
     /// `operand[Symbol.iterator]()` when iterable, else the operand itself (a
     /// generator object already *is* its iterator). Lowers to `js_get_iterator`.
     GetIterator(Box<Expr>),
+    /// #321: materialize an UNTYPED `for...of` receiver into a plain Array
+    /// by inspecting its runtime kind. The `for...of` desugar uses an
+    /// index loop (`for (i=0; i<arr.length; i++) item = arr[i]`); when the
+    /// receiver's static type can't be proven (an `any`-typed Map/Set, an
+    /// untyped JS-source value), this routes through `js_for_of_to_array`
+    /// so a Map yields `[k,v]` pairs, a Set yields values, an Array is
+    /// returned unchanged, a string yields code-point chars, and anything
+    /// else drives its `[Symbol.iterator]`. Without it the index loop read
+    /// `.length` off a raw Map/Set handle (→ 0) and iterated zero times.
+    ForOfToArray(Box<Expr>),
     /// Array.from(iterable, mapFn) -> Array
     /// Creates a new array by applying mapFn to each element of the iterable.
     ArrayFromMapped {

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -647,6 +647,32 @@ pub(crate) fn lower_stmt_for_of(
             | "Float32Array" | "Float64Array"
         )
     );
+    // #321: the for-of desugar reads `__arr.length` / `__arr[i]` and so
+    // assumes the iterable is a plain Array. When the receiver's static
+    // type can NOT be proven to be an Array — an `any`-typed Map/Set
+    // (effect's `for (const [tag, s] of self.unsafeMap)`), an untyped
+    // JS-source value, a `Type::Object` / class instance carrying a
+    // custom `[Symbol.iterator]`, etc. — that assumption silently reads
+    // `.length` off the wrong handle (Map/Set → 0) and iterates zero
+    // times. Detect "the type proves a plain Array" so everything else
+    // routes through the runtime default-iterator (`js_for_of_to_array`).
+    //
+    // We deliberately DON'T wrap the statically-resolved kinds handled
+    // above (Map/Set/typed-array via their own materializers, strings via
+    // the string index-loop, Headers/URLSearchParams via their entries
+    // rewrite) nor proven arrays — those keep their existing fast paths.
+    let proven_array = match &iterable_type {
+        Some(Type::Array(_)) => true,
+        Some(Type::Generic { base, .. }) => base == "Array",
+        _ => false,
+    };
+    let needs_runtime_iterator = !is_string_iter
+        && !is_headers_iter
+        && !is_urlsp_iter
+        && !is_iterable_map
+        && !is_iterable_set
+        && !is_iterable_typed_array
+        && !proven_array;
     let arr_expr = if is_iterable_map {
         if let Some(args) = map_type_args.as_ref() {
             if args.len() >= 2 {
@@ -667,6 +693,8 @@ pub(crate) fn lower_stmt_for_of(
         }
     } else if is_iterable_typed_array {
         Expr::ArrayFrom(Box::new(arr_expr))
+    } else if needs_runtime_iterator {
+        Expr::ForOfToArray(Box::new(arr_expr))
     } else {
         arr_expr
     };

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -1200,6 +1200,27 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     | "Float32Array" | "Float64Array"
                 )
             );
+            // #321: when the receiver's static type can NOT be proven to
+            // be a plain Array — an `any`-typed Map/Set (effect's
+            // `for (const [tag, s] of that.unsafeMap)`, where `that` is an
+            // untyped function parameter), an object carrying a custom
+            // `[Symbol.iterator]`, etc. — the index-based loop below would
+            // read `.length` off the wrong handle (Map/Set → 0) and
+            // iterate zero times. Route those through the runtime default
+            // iterator (`js_for_of_to_array`). Strings, typed arrays, and
+            // statically-proven Map/Set/Array keep their existing fast
+            // paths. Mirrors the module-init path in
+            // `lower::stmt_loops::lower_stmt_for_of`.
+            let proven_array = match &iterable_type {
+                Some(Type::Array(_)) => true,
+                Some(Type::Generic { base, .. }) => base == "Array",
+                _ => false,
+            };
+            let needs_runtime_iterator = !is_string_iter
+                && !is_iterable_map
+                && !is_iterable_set
+                && !is_iterable_typed_array
+                && !proven_array;
             let arr_expr = if is_iterable_map {
                 if map_kv_fastpath {
                     arr_expr
@@ -1214,6 +1235,8 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 }
             } else if is_iterable_typed_array {
                 Expr::ArrayFrom(Box::new(arr_expr))
+            } else if needs_runtime_iterator {
+                Expr::ForOfToArray(Box::new(arr_expr))
             } else {
                 arr_expr
             };

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -488,6 +488,7 @@ impl SH for Expr {
             Expr::ArrayFrom(e) => { tag(h, 397); e.as_ref().hash(h); }
             Expr::IteratorToArray(e) => { tag(h, 398); e.as_ref().hash(h); }
             Expr::GetIterator(e) => { tag(h, 11238); e.as_ref().hash(h); }
+            Expr::ForOfToArray(e) => { tag(h, 11243); e.as_ref().hash(h); }
             Expr::ArrayFromMapped { iterable, map_fn } => { tag(h, 399); iterable.as_ref().hash(h); map_fn.as_ref().hash(h); }
             Expr::ParseInt { string, radix } => { tag(h, 400); string.as_ref().hash(h); radix.hash(h); }
             Expr::ParseFloat(e) => { tag(h, 401); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -228,6 +228,7 @@ where
         | Expr::ArrayFrom(v)
         | Expr::IteratorToArray(v)
         | Expr::GetIterator(v)
+        | Expr::ForOfToArray(v)
         | Expr::ObjectRest { object: v, .. }
         | Expr::ProxyRevoke(v)
         | Expr::ReflectOwnKeys(v)

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -229,6 +229,7 @@ where
         | Expr::ArrayFrom(v)
         | Expr::IteratorToArray(v)
         | Expr::GetIterator(v)
+        | Expr::ForOfToArray(v)
         | Expr::ObjectRest { object: v, .. }
         | Expr::ProxyRevoke(v)
         | Expr::ReflectOwnKeys(v)

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -1,6 +1,115 @@
 //! Iterator-protocol → array converter.
 use super::*;
 
+/// Materialize an arbitrary iterable into a plain Array, used by the
+/// `for...of` desugar when the receiver's static type can NOT be proven
+/// (an `any`-typed property, an untyped JS-source value, etc.). The HIR
+/// loop iterates the returned array by index (`for (i=0; i<arr.length;
+/// i++) item = arr[i]`), so this helper must hand back an Array whose
+/// elements are exactly what `for...of` would yield in JS:
+///
+///   * Array / lazy-array  → returned unchanged (no copy; the index
+///                           loop reads it directly).
+///   * Map                 → array of `[key, value]` pair arrays
+///                           (matches `map[Symbol.iterator]()` ===
+///                           `map.entries()`), so `for (const [k,v] of
+///                           m)` destructures correctly.
+///   * Set                 → array of values.
+///   * String              → array of code-point substrings (JS spreads
+///                           a string by code point, not UTF-16 unit).
+///   * anything else        → drive the iterator protocol: obtain the
+///                           default iterator via `js_get_iterator`
+///                           (custom `[Symbol.iterator]`, perry
+///                           generator objects, …) and collect `.value`s
+///                           with [`js_iterator_to_array`].
+///
+/// Returns a NaN-boxed (POINTER_TAG) Array JSValue. Returning the boxed
+/// f64 (rather than a raw pointer) keeps the HIR `Stmt::Let` holder typed
+/// as a normal array value so `.length` / `arr[i]` lower through the
+/// usual array fast paths.
+///
+/// Refs #321 (effect Context/Layer iterate `for (const [tag, s] of
+/// self.unsafeMap)` over an untyped Map).
+#[no_mangle]
+pub extern "C" fn js_for_of_to_array(val_f64: f64) -> f64 {
+    use crate::gc::{
+        GcHeader, GC_HEADER_SIZE, GC_TYPE_ARRAY, GC_TYPE_LAZY_ARRAY, GC_TYPE_MAP, GC_TYPE_SET,
+    };
+    use crate::value::{js_nanbox_pointer, JSValue};
+
+    let jsv = JSValue::from_bits(val_f64.to_bits());
+
+    // Strings: iterate by code point. `is_any_string` covers both heap
+    // STRING_TAG and inline SSO short strings. `js_get_string_pointer_unified`
+    // returns a real `*const StringHeader` for either representation
+    // (materializing SSO onto the heap); re-box with STRING_TAG so
+    // `js_string_to_char_array` (which masks POINTER_MASK off the bits)
+    // reads it correctly. The resulting array yields single-char
+    // substrings exactly like `for (const c of "abc")`.
+    if jsv.is_any_string() {
+        let str_ptr = crate::value::js_get_string_pointer_unified(val_f64);
+        let str_bits = crate::value::STRING_TAG | (str_ptr as u64 & crate::value::POINTER_MASK);
+        let arr_i64 = crate::string::js_string_to_char_array(str_bits as i64);
+        return js_nanbox_pointer(arr_i64);
+    }
+
+    // Non-pointer scalars (number/bool/null/undefined) are not iterable;
+    // hand back an empty array so the loop runs zero times rather than
+    // dereferencing a non-pointer.
+    let raw_ptr = crate::value::js_nanbox_get_pointer(val_f64);
+    if raw_ptr == 0 {
+        return js_nanbox_pointer(js_array_alloc(0) as i64);
+    }
+
+    // Inspect the GC header's object kind to dispatch Array / Map / Set
+    // without consulting any static type.
+    let obj_type = unsafe {
+        let gc_header = (raw_ptr as *const u8).sub(GC_HEADER_SIZE) as *const GcHeader;
+        (*gc_header).obj_type
+    };
+
+    match obj_type {
+        // Already an array: return unchanged — the index loop reads it in
+        // place, no allocation. Lazy arrays are arrays from the iterator's
+        // perspective and `js_array_length` / indexing materialize lazily.
+        t if t == GC_TYPE_ARRAY || t == GC_TYPE_LAZY_ARRAY => val_f64,
+        // Map → `[k, v]` pair array (=== `map.entries()` spread).
+        GC_TYPE_MAP => {
+            let arr = js_map_entries_for_for_of(raw_ptr);
+            js_nanbox_pointer(arr as i64)
+        }
+        // Set → values array.
+        GC_TYPE_SET => {
+            let arr = js_set_to_array_for_for_of(raw_ptr);
+            js_nanbox_pointer(arr as i64)
+        }
+        // Generic objects / generator objects / anything carrying a
+        // custom `[Symbol.iterator]` or a `.next()`: walk the iterator
+        // protocol. `js_get_iterator` returns the operand's
+        // `Symbol.iterator()` result when iterable, or the operand
+        // unchanged when it already is an iterator (perry generators).
+        _ => {
+            let iter = crate::symbol::js_get_iterator(val_f64);
+            let arr = js_iterator_to_array(iter);
+            js_nanbox_pointer(arr as i64)
+        }
+    }
+}
+
+/// Thin wrappers so this module can reach the Map/Set materializers
+/// without importing their concrete header types (they live in sibling
+/// runtime modules and take typed pointers). `raw_ptr` is the cleaned
+/// payload pointer already extracted by `js_nanbox_get_pointer`.
+#[inline]
+fn js_map_entries_for_for_of(raw_ptr: i64) -> *mut ArrayHeader {
+    crate::map::js_map_entries(raw_ptr as *const crate::map::MapHeader)
+}
+
+#[inline]
+fn js_set_to_array_for_for_of(raw_ptr: i64) -> *mut ArrayHeader {
+    crate::set::js_set_to_array(raw_ptr as *const crate::set::SetHeader)
+}
+
 /// Convert any iterator-protocol object (has `.next()` method) to an array.
 /// Used by spread on generators, Array.from on generators, etc.
 /// Calls `.next()` in a loop until `.done` is true, collecting `.value` entries.

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -50,7 +50,7 @@ pub use self::iter_methods::{
     js_array_find_last, js_array_find_last_index, js_array_flatMap, js_array_forEach,
     js_array_join, js_array_map, js_array_map_discard, js_array_reduce, js_array_some,
 };
-pub use self::iterator::js_iterator_to_array;
+pub use self::iterator::{js_for_of_to_array, js_iterator_to_array};
 pub use self::jsvalue_api::{
     js_array_from_jsvalue, js_array_get, js_array_get_jsvalue, js_array_push,
     js_array_push_jsvalue, js_array_set, js_array_set_jsvalue, js_array_set_jsvalue_extend,

--- a/test-files/test_gap_for_of_untyped_map_set.ts
+++ b/test-files/test_gap_for_of_untyped_map_set.ts
@@ -1,0 +1,91 @@
+// Test: `for...of` over a receiver whose static type can NOT be proven
+// (an `any`-typed Map/Set, an untyped JS-source value). The for-of desugar
+// reads `__arr.length` / `__arr[i]` and so assumes a plain Array; when the
+// receiver is actually a Map/Set the loop read `.length` off the wrong
+// handle (→ 0) and iterated zero times. The fix routes unproven receivers
+// through the runtime default iterator (`js_for_of_to_array`): a Map yields
+// `[k, v]` pairs (=== `map.entries()`), a Set yields values, an Array is
+// returned unchanged, a string yields code-point chars, and anything else
+// drives its `[Symbol.iterator]`. This is the last `effect` Context/Layer
+// blocker (#321): effect iterates `for (const [tag, s] of self.unsafeMap)`
+// over an untyped Map. Validated byte-for-byte against
+// `node --experimental-strip-types`.
+
+// --- untyped Map: simple binding yields [k, v] pairs ---
+const obj: any = { m: new Map([["k", 1], ["j", 2]]) };
+let n = 0;
+for (const e of obj.m) n++;
+console.log("untyped map count:", n); // 2
+
+// --- untyped Map: destructuring [k, v] ---
+const o2: any = { m: new Map([["a", 1], ["b", 2]]) };
+const pairs: string[] = [];
+for (const [k, v] of o2.m) pairs.push(`${k}=${v}`);
+console.log("map pairs:", pairs.join(",")); // a=1,b=2
+
+// --- untyped Set ---
+const s: any = { set: new Set([10, 20, 30]) };
+let sum = 0;
+for (const x of s.set) sum += x;
+console.log("untyped set sum:", sum); // 60
+
+// --- explicit .entries() still works (regression guard) ---
+let e2 = 0;
+for (const e of obj.m.entries()) e2++;
+console.log("explicit entries count:", e2); // 2
+
+// --- typed Map / Set fast paths still work (regression guard) ---
+const tm: Map<string, number> = new Map([["x", 1]]);
+let tc = 0;
+for (const e of tm) tc++;
+console.log("typed map count:", tc); // 1
+
+const ts: Set<number> = new Set([1, 2, 3, 4]);
+let tsc = 0;
+for (const x of ts) tsc++;
+console.log("typed set count:", tsc); // 4
+
+// --- untyped string iterates by code point ---
+const sv: any = "ab😀c";
+const chars: string[] = [];
+for (const c of sv) chars.push(c);
+console.log("string chars:", chars.join("|"), chars.length); // a|b|😀|c 4
+
+// --- untyped value carrying a custom [Symbol.iterator] ---
+const custom: any = {
+  [Symbol.iterator]() {
+    let i = 0;
+    return {
+      next: () => (i < 3 ? { value: i++, done: false } : { value: undefined, done: true }),
+    };
+  },
+};
+let cs = 0;
+for (const x of custom) cs += x;
+console.log("custom iter sum:", cs); // 3
+
+// --- generator object held in an `any` ---
+function* g() {
+  yield 100;
+  yield 200;
+}
+const gv: any = g();
+let gs = 0;
+for (const x of gv) gs += x;
+console.log("gen sum:", gs); // 300
+
+// --- empty untyped Map iterates zero times ---
+const em: any = new Map();
+let ec = 0;
+for (const e of em) ec++;
+console.log("empty map count:", ec); // 0
+
+// --- array fast paths unchanged ---
+let al = 0;
+for (const x of [1, 2, 3]) al += x;
+console.log("array literal sum:", al); // 6
+
+const aa: any = [4, 5, 6];
+let aas = 0;
+for (const x of aa) aas += x;
+console.log("untyped array sum:", aas); // 15


### PR DESCRIPTION
## Summary

Fixes the last `effect` framework **Context** blocker (#321): a `for...of` over a receiver whose static type cannot be proven to be an Array yielded **zero iterations** instead of dispatching to the value's default iterator.

The `for...of` desugar lowers to an index loop (`for (i=0; i<arr.length; i++) item = arr[i]`) and so assumes a plain Array. When the receiver's static type is unknown — an `any`-typed Map/Set (effect iterates `for (const [tag, s] of self.unsafeMap)` over an untyped Map), an untyped JS-source value, an object with a custom `[Symbol.iterator]` — the loop read `.length` off the wrong handle (Map/Set handle to 0) and silently iterated zero times. The typed-local form and the explicit `.entries()` form both already worked; the gap was the implicit default-iterator dispatch when the receiver type is unknown.

## Root cause

Two parallel `for...of` lowering paths (module-init `lower::stmt_loops::lower_stmt_for_of` and function-body `lower_decl::body_stmt`) resolve an `iterable_type` only for provable shapes (typed local, `this.field`, inferred object property). When the receiver is `any` (or an untyped JS-source value) the type is `None`, every static special-case (Map/Set/typed-array/string/Headers/URLSearchParams) is skipped, and the expression falls through to the plain-Array index loop.

## Fix

When the receiver's static type does NOT prove a plain Array (and isn't one of the statically-handled iterable kinds), wrap it in a new HIR `Expr::ForOfToArray` that lowers to a new runtime helper `js_for_of_to_array`. The helper inspects the value's GC object-kind at runtime and returns a plain Array the index loop can read:

- Array / lazy-array — returned unchanged (no copy)
- Map — key/value pair array (equivalent to spreading `map.entries()`), so destructuring `for (const [k, v] of m)` works
- Set — values array
- string — code-point char array (matches JS code-point iteration)
- anything else — drive the default iterator via `js_get_iterator` + `js_iterator_to_array` (custom `[Symbol.iterator]`, perry generator objects)

Statically-proven arrays, the Map/Set fast paths, typed arrays, strings, Headers and URLSearchParams keep their existing fast paths untouched, so the perf-sensitive array path is unchanged.

## Verification

Standalone repro byte-identical to `node`:

- untyped Map for-of to 2; typed to 1; explicit `.entries()` to 2; untyped Set to 3
- Map destructuring `for (const [k, v] of o.m)` yields correct pairs
- untyped string iterates by code point (emoji-safe); custom `[Symbol.iterator]` and generators held in `any` iterate correctly
- no regression: plain array literal and untyped-array for-of still iterate

New gap test `test-files/test_gap_for_of_untyped_map_set.ts` is byte-identical to `node --experimental-strip-types` (both optimized and `PERRY_NO_AUTO_OPTIMIZE=1`).

Tests: `cargo test --release -p perry-runtime --lib` 687 passed / 0 failed; `cargo test --release -p perry-hir` all pass; `cargo fmt --all -- --check` clean.

### Effect impact

With this fix the effect **Context** path works end-to-end: `Effect.runSync(Effect.provide(prog, Context.make(Svc, { v: 41 })))` prints `42` (previously threw `Service not found: Svc` because `Context.merge`'s `for (const [tag, s] of that.unsafeMap)` iterated zero times and never populated the merged map).

The two survey items (`nlay.ts`, `real3_context_layer.ts`) do not yet print their final line — but the blocker is now a **distinct 6th issue**, not for-of. They go through `Effect.provide(prog, Layer.succeed(...))`, and the failure is isolated to the Layer build path: `Effect.runSync(Effect.scoped(Layer.build(layer)))` throws `value is not a function` (a method dispatch on a non-callable inside the Scope / FiberRuntime / MemoMap machinery). Provide-with-a-Context (no Layer) returns 42 correctly, confirming the for-of fix fully resolves the Context path. The Layer/Scope execution blocker is a separate follow-up.
