### PR TITLE
Fix perry UI const enum lowering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5425,6 +5425,7 @@ dependencies = [
  "perry-diagnostics",
  "perry-parser",
  "perry-types",
+ "perry-ui-model",
  "serde",
  "serde_json",
  "swc_common",
@@ -5571,6 +5572,9 @@ dependencies = [
 [[package]]
 name = "perry-ui"
 version = "0.5.1032"
+dependencies = [
+ "perry-ui-model",
+]
 
 [[package]]
 name = "perry-ui-android"
@@ -5652,6 +5656,10 @@ dependencies = [
  "perry-ui",
  "perry-ui-testkit",
 ]
+
+[[package]]
+name = "perry-ui-model"
+version = "0.5.1032"
 
 [[package]]
 name = "perry-ui-test"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "crates/perry-stdlib",
     "crates/perry-diagnostics",
     "crates/perry-ui",
+    "crates/perry-ui-model",
     "crates/perry-ui-macos",
     "crates/perry-ui-ios",
     "crates/perry-ui-visionos",
@@ -309,6 +310,7 @@ perry-ext-pdf = { path = "crates/perry-ext-pdf" }
 perry-ext-ads = { path = "crates/perry-ext-ads" }
 perry-stdlib = { path = "crates/perry-stdlib" }
 perry-diagnostics = { path = "crates/perry-diagnostics" }
+perry-ui-model = { path = "crates/perry-ui-model" }
 perry-wasm-host = { path = "crates/perry-wasm-host" }
 perry-codegen-js = { path = "crates/perry-codegen-js" }
 perry-codegen-swiftui = { path = "crates/perry-codegen-swiftui" }

--- a/crates/perry-hir/Cargo.toml
+++ b/crates/perry-hir/Cargo.toml
@@ -9,6 +9,7 @@ description = "High-level intermediate representation for Perry"
 perry-types.workspace = true
 perry-diagnostics.workspace = true
 perry-api-manifest.workspace = true
+perry-ui-model.workspace = true
 # #1679: HIR lowering parses synthesized function-literal source for
 # const-foldable `new Function(...)` bodies, so the parser is a regular
 # (not dev-only) dependency. No cycle: perry-parser does not depend on

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -128,6 +128,41 @@ pub(crate) fn lower_module_decl(
                                     (source.clone(), Some(imported.clone()))
                                 };
                             ctx.register_native_module(local.clone(), native_module, native_method);
+                            // #1991: `perry/ui` exposes these as numeric
+                            // `const enum`s in `types/perry/ui/index.d.ts`.
+                            // Native modules do not have source HIR enum
+                            // declarations, so register the imported binding as
+                            // a real HIR enum at the import site. That lets the
+                            // existing enum-member lowering/codegen path handle
+                            // `Key.Space`, including aliases like
+                            // `import { Key as K } from "perry/ui"; K.Space`,
+                            // instead of treating it as a runtime property read
+                            // from a non-existent native-module object.
+                            if source == "perry/ui" {
+                                if let Some(model_members) =
+                                    perry_ui_model::const_enum_members(&imported)
+                                {
+                                    let enum_id = ctx.fresh_enum();
+                                    let members: Vec<EnumMember> = model_members
+                                        .into_iter()
+                                        .map(|member| EnumMember {
+                                            name: member.name.to_string(),
+                                            value: EnumValue::Number(member.value),
+                                        })
+                                        .collect();
+                                    let member_values = members
+                                        .iter()
+                                        .map(|m| (m.name.clone(), m.value.clone()))
+                                        .collect();
+                                    ctx.define_enum(local.clone(), enum_id, member_values);
+                                    module.enums.push(Enum {
+                                        id: enum_id,
+                                        name: local.clone(),
+                                        members,
+                                        is_exported: false,
+                                    });
+                                }
+                            }
                             // Auto-register parentPort from worker_threads as a native instance
                             // (it's a singleton, not created via `new`)
                             if source == "worker_threads" && imported == "parentPort" {

--- a/crates/perry-ui-model/Cargo.toml
+++ b/crates/perry-ui-model/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "perry-ui-model"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Shared Perry UI constants and public model metadata"
+
+[dependencies]

--- a/crates/perry-ui-model/src/lib.rs
+++ b/crates/perry-ui-model/src/lib.rs
@@ -1,0 +1,296 @@
+//! Shared Perry UI constants and public model metadata.
+//!
+//! This crate is intentionally tiny: it holds stable values that are consumed by
+//! both runtime UI backends and HIR lowering. Keeping the public enum numbers in
+//! one place prevents `types/perry/ui/index.d.ts`, compiler lowering, and the
+//! event runtime from drifting silently.
+
+/// One member of Perry's public `Key` const enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyMember {
+    /// Stable numeric `Key` enum value.
+    pub value: u16,
+    /// TypeScript enum member name, e.g. `ArrowLeft` or `Digit0`.
+    pub enum_name: &'static str,
+    /// Runtime event/key name, e.g. `ArrowLeft`, `0`, or `a`.
+    pub event_name: &'static str,
+}
+
+/// One member of a numeric Perry UI const enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UiConstEnumMember {
+    /// TypeScript enum member name.
+    pub name: &'static str,
+    /// Stable numeric enum value.
+    pub value: i64,
+}
+
+/// Canonical public `Key` const-enum values and runtime key names.
+///
+/// `KEY_MEMBERS` and `KEY_TABLE` are expanded from this single source so the
+/// compiler-facing enum values and runtime event names cannot drift inside Rust.
+macro_rules! key_members {
+    (
+        ($unknown_value:literal, $unknown_enum_name:literal, $unknown_event_name:literal),
+        $(($value:literal, $enum_name:literal, $event_name:literal)),+ $(,)?
+    ) => {
+        /// Canonical public `Key` const-enum values and runtime key names.
+        pub const KEY_MEMBERS: &[KeyMember] = &[
+            KeyMember {
+                value: $unknown_value,
+                enum_name: $unknown_enum_name,
+                event_name: $unknown_event_name,
+            },
+            $(KeyMember {
+                value: $value,
+                enum_name: $enum_name,
+                event_name: $event_name,
+            }),+
+        ];
+
+        /// All `(KeyCode, name)` pairs in id order, excluding `Unknown`.
+        pub const KEY_TABLE: &[(u16, &str)] = &[
+            $(($value, $event_name)),+
+        ];
+    };
+}
+
+key_members!(
+    (0, "Unknown", ""),
+    (1, "A", "a"),
+    (2, "B", "b"),
+    (3, "C", "c"),
+    (4, "D", "d"),
+    (5, "E", "e"),
+    (6, "F", "f"),
+    (7, "G", "g"),
+    (8, "H", "h"),
+    (9, "I", "i"),
+    (10, "J", "j"),
+    (11, "K", "k"),
+    (12, "L", "l"),
+    (13, "M", "m"),
+    (14, "N", "n"),
+    (15, "O", "o"),
+    (16, "P", "p"),
+    (17, "Q", "q"),
+    (18, "R", "r"),
+    (19, "S", "s"),
+    (20, "T", "t"),
+    (21, "U", "u"),
+    (22, "V", "v"),
+    (23, "W", "w"),
+    (24, "X", "x"),
+    (25, "Y", "y"),
+    (26, "Z", "z"),
+    (27, "Digit0", "0"),
+    (28, "Digit1", "1"),
+    (29, "Digit2", "2"),
+    (30, "Digit3", "3"),
+    (31, "Digit4", "4"),
+    (32, "Digit5", "5"),
+    (33, "Digit6", "6"),
+    (34, "Digit7", "7"),
+    (35, "Digit8", "8"),
+    (36, "Digit9", "9"),
+    (37, "F1", "F1"),
+    (38, "F2", "F2"),
+    (39, "F3", "F3"),
+    (40, "F4", "F4"),
+    (41, "F5", "F5"),
+    (42, "F6", "F6"),
+    (43, "F7", "F7"),
+    (44, "F8", "F8"),
+    (45, "F9", "F9"),
+    (46, "F10", "F10"),
+    (47, "F11", "F11"),
+    (48, "F12", "F12"),
+    (49, "ArrowUp", "ArrowUp"),
+    (50, "ArrowDown", "ArrowDown"),
+    (51, "ArrowLeft", "ArrowLeft"),
+    (52, "ArrowRight", "ArrowRight"),
+    (53, "Space", "Space"),
+    (54, "Enter", "Enter"),
+    (55, "Tab", "Tab"),
+    (56, "Escape", "Escape"),
+    (57, "Backspace", "Backspace"),
+    (58, "Delete", "Delete"),
+    (59, "Home", "Home"),
+    (60, "End", "End"),
+    (61, "PageUp", "PageUp"),
+    (62, "PageDown", "PageDown"),
+    (63, "Insert", "Insert"),
+    (64, "Minus", "Minus"),
+    (65, "Equal", "Equal"),
+    (66, "BracketLeft", "BracketLeft"),
+    (67, "BracketRight", "BracketRight"),
+    (68, "Backslash", "Backslash"),
+    (69, "Semicolon", "Semicolon"),
+    (70, "Quote", "Quote"),
+    (71, "Comma", "Comma"),
+    (72, "Period", "Period"),
+    (73, "Slash", "Slash"),
+    (74, "Backquote", "Backquote"),
+    (75, "F13", "F13"),
+    (76, "F14", "F14"),
+    (77, "F15", "F15"),
+    (78, "F16", "F16"),
+    (79, "F17", "F17"),
+    (80, "F18", "F18"),
+    (81, "F19", "F19"),
+    (82, "F20", "F20"),
+    (83, "Numpad0", "Numpad0"),
+    (84, "Numpad1", "Numpad1"),
+    (85, "Numpad2", "Numpad2"),
+    (86, "Numpad3", "Numpad3"),
+    (87, "Numpad4", "Numpad4"),
+    (88, "Numpad5", "Numpad5"),
+    (89, "Numpad6", "Numpad6"),
+    (90, "Numpad7", "Numpad7"),
+    (91, "Numpad8", "Numpad8"),
+    (92, "Numpad9", "Numpad9"),
+    (93, "NumpadDecimal", "NumpadDecimal"),
+    (94, "NumpadEnter", "NumpadEnter"),
+    (95, "NumpadAdd", "NumpadAdd"),
+    (96, "NumpadSubtract", "NumpadSubtract"),
+    (97, "NumpadMultiply", "NumpadMultiply"),
+    (98, "NumpadDivide", "NumpadDivide"),
+    (99, "NumpadEqual", "NumpadEqual"),
+    (100, "NumpadClear", "NumpadClear"),
+);
+
+/// Canonical public `Modifier` const-enum values.
+pub const MODIFIER_MEMBERS: &[UiConstEnumMember] = &[
+    UiConstEnumMember {
+        name: "None",
+        value: 0,
+    },
+    UiConstEnumMember {
+        name: "Cmd",
+        value: 1,
+    },
+    UiConstEnumMember {
+        name: "Shift",
+        value: 2,
+    },
+    UiConstEnumMember {
+        name: "Alt",
+        value: 4,
+    },
+    UiConstEnumMember {
+        name: "Ctrl",
+        value: 8,
+    },
+];
+
+/// Canonical public `MouseButton` const-enum values.
+pub const MOUSE_BUTTON_MEMBERS: &[UiConstEnumMember] = &[
+    UiConstEnumMember {
+        name: "Left",
+        value: 0,
+    },
+    UiConstEnumMember {
+        name: "Middle",
+        value: 1,
+    },
+    UiConstEnumMember {
+        name: "Right",
+        value: 2,
+    },
+    UiConstEnumMember {
+        name: "Back",
+        value: 3,
+    },
+    UiConstEnumMember {
+        name: "Forward",
+        value: 4,
+    },
+];
+
+/// Returns the numeric const-enum members for a Perry UI enum visible to TS.
+pub fn const_enum_members(enum_name: &str) -> Option<Vec<UiConstEnumMember>> {
+    match enum_name {
+        "Key" => Some(
+            KEY_MEMBERS
+                .iter()
+                .map(|member| UiConstEnumMember {
+                    name: member.enum_name,
+                    value: member.value as i64,
+                })
+                .collect(),
+        ),
+        "Modifier" => Some(MODIFIER_MEMBERS.to_vec()),
+        "MouseButton" => Some(MOUSE_BUTTON_MEMBERS.to_vec()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    const UI_DTS: &str = include_str!("../../../types/perry/ui/index.d.ts");
+
+    fn parse_const_enum(name: &str) -> BTreeMap<String, i64> {
+        let needle = format!("export const enum {name} {{");
+        let start = UI_DTS.find(&needle).expect("enum exists in d.ts") + needle.len();
+        let rest = &UI_DTS[start..];
+        let end = rest.find("}\n").expect("enum closes");
+        let body = &rest[..end];
+        let mut out = BTreeMap::new();
+        for raw_line in body.lines() {
+            let line = raw_line.trim().trim_end_matches(',');
+            if line.is_empty() {
+                continue;
+            }
+            for part in line.split(',') {
+                let part = part.trim();
+                if part.is_empty() {
+                    continue;
+                }
+                let Some((member, value)) = part.split_once('=') else {
+                    continue;
+                };
+                out.insert(
+                    member.trim().to_string(),
+                    value.trim().parse::<i64>().expect("numeric enum value"),
+                );
+            }
+        }
+        out
+    }
+
+    fn model_const_enum(name: &str) -> BTreeMap<String, i64> {
+        const_enum_members(name)
+            .expect("known model enum")
+            .into_iter()
+            .map(|member| (member.name.to_string(), member.value))
+            .collect()
+    }
+
+    #[test]
+    fn key_values_match_dts() {
+        assert_eq!(model_const_enum("Key"), parse_const_enum("Key"));
+    }
+
+    #[test]
+    fn modifier_values_match_dts() {
+        assert_eq!(model_const_enum("Modifier"), parse_const_enum("Modifier"));
+    }
+
+    #[test]
+    fn mouse_button_values_match_dts() {
+        assert_eq!(
+            model_const_enum("MouseButton"),
+            parse_const_enum("MouseButton")
+        );
+    }
+
+    #[test]
+    fn runtime_key_names_are_id_ordered() {
+        for (index, member) in KEY_MEMBERS.iter().enumerate() {
+            assert_eq!(member.value as usize, index);
+        }
+    }
+}

--- a/crates/perry-ui/Cargo.toml
+++ b/crates/perry-ui/Cargo.toml
@@ -7,3 +7,4 @@ edition.workspace = true
 crate-type = ["rlib"]
 
 [dependencies]
+perry-ui-model.workspace = true

--- a/crates/perry-ui/src/keys.rs
+++ b/crates/perry-ui/src/keys.rs
@@ -49,95 +49,29 @@ pub mod modifiers {
     pub const CTRL: u32 = 8;
 }
 
-macro_rules! key_table {
-    ( $( $id:literal => $name:literal ),* $(,)? ) => {
-        /// All `(KeyCode, name)` pairs in id order. `id == index + 1`.
-        pub const KEY_TABLE: &[(u16, &str)] = &[ $( ($id, $name) ),* ];
+/// All `(KeyCode, name)` pairs in id order, excluding `Unknown`.
+pub const KEY_TABLE: &[(u16, &str)] = perry_ui_model::KEY_TABLE;
 
-        /// Lookup a canonical key name from its id. Returns `""` for unknown.
-        #[inline]
-        pub fn name(code: KeyCode) -> &'static str {
-            let idx = code.0 as usize;
-            if idx == 0 || idx > KEY_TABLE.len() { return ""; }
-            KEY_TABLE[idx - 1].1
-        }
-
-        /// Lookup a canonical key id from a name. Returns `KeyCode::UNKNOWN` if not found.
-        pub fn from_name(s: &str) -> KeyCode {
-            // Linear scan: ~80 entries, dominated by 1-3 char compares. Faster
-            // than HashMap on this size and no allocation at startup.
-            for &(id, n) in KEY_TABLE {
-                if n == s { return KeyCode(id); }
-            }
-            KeyCode::UNKNOWN
-        }
-    };
+/// Lookup a canonical key name from its id. Returns `""` for unknown.
+#[inline]
+pub fn name(code: KeyCode) -> &'static str {
+    perry_ui_model::KEY_MEMBERS
+        .get(code.0 as usize)
+        .filter(|member| member.value == code.0)
+        .map(|member| member.event_name)
+        .unwrap_or("")
 }
 
-key_table! {
-    // Letters (1-26) — lowercase to match Web KeyboardEvent.key when unmodified.
-    1  => "a",  2  => "b",  3  => "c",  4  => "d",  5  => "e",  6  => "f",
-    7  => "g",  8  => "h",  9  => "i",  10 => "j",  11 => "k",  12 => "l",
-    13 => "m",  14 => "n",  15 => "o",  16 => "p",  17 => "q",  18 => "r",
-    19 => "s",  20 => "t",  21 => "u",  22 => "v",  23 => "w",  24 => "x",
-    25 => "y",  26 => "z",
-
-    // Digits (27-36).
-    27 => "0", 28 => "1", 29 => "2", 30 => "3", 31 => "4",
-    32 => "5", 33 => "6", 34 => "7", 35 => "8", 36 => "9",
-
-    // Function keys (37-48).
-    37 => "F1", 38 => "F2", 39 => "F3", 40 => "F4", 41 => "F5",  42 => "F6",
-    43 => "F7", 44 => "F8", 45 => "F9", 46 => "F10", 47 => "F11", 48 => "F12",
-
-    // Arrows + whitespace + edit.
-    49 => "ArrowUp",
-    50 => "ArrowDown",
-    51 => "ArrowLeft",
-    52 => "ArrowRight",
-    53 => "Space",
-    54 => "Enter",
-    55 => "Tab",
-    56 => "Escape",
-    57 => "Backspace",
-    58 => "Delete",
-
-    // Navigation.
-    59 => "Home",
-    60 => "End",
-    61 => "PageUp",
-    62 => "PageDown",
-    63 => "Insert",
-
-    // Standard punctuation that needs a name (the rest comes through onTextInput).
-    64 => "Minus",
-    65 => "Equal",
-    66 => "BracketLeft",
-    67 => "BracketRight",
-    68 => "Backslash",
-    69 => "Semicolon",
-    70 => "Quote",
-    71 => "Comma",
-    72 => "Period",
-    73 => "Slash",
-    74 => "Backquote",
-
-    // Extended function keys (full-size keyboards / external ones).
-    75 => "F13", 76 => "F14", 77 => "F15", 78 => "F16",
-    79 => "F17", 80 => "F18", 81 => "F19", 82 => "F20",
-
-    // Numeric keypad (distinct from top-row digits so apps can tell them apart).
-    83 => "Numpad0", 84 => "Numpad1", 85 => "Numpad2", 86 => "Numpad3",
-    87 => "Numpad4", 88 => "Numpad5", 89 => "Numpad6", 90 => "Numpad7",
-    91 => "Numpad8", 92 => "Numpad9",
-    93 => "NumpadDecimal",
-    94 => "NumpadEnter",
-    95 => "NumpadAdd",
-    96 => "NumpadSubtract",
-    97 => "NumpadMultiply",
-    98 => "NumpadDivide",
-    99 => "NumpadEqual",
-    100 => "NumpadClear",
+/// Lookup a canonical key id from a name. Returns `KeyCode::UNKNOWN` if not found.
+pub fn from_name(s: &str) -> KeyCode {
+    // Linear scan: ~100 entries, dominated by 1-3 char compares. Faster
+    // than HashMap on this size and no allocation at startup.
+    for member in perry_ui_model::KEY_MEMBERS {
+        if member.event_name == s {
+            return KeyCode(member.value);
+        }
+    }
+    KeyCode::UNKNOWN
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Fix `perry/ui` native imports for public numeric `const enum`s by registering imported enum bindings in HIR lowering.
- Add a small shared `perry-ui-model` crate as the single Rust source for `Key`, `Modifier`, and `MouseButton` values used by both HIR and UI runtime key lookup.
- Add drift tests that compare the shared model against `types/perry/ui/index.d.ts` so enum values cannot silently diverge.

Closes #1991

## Testing
- `cargo fmt --check`
- `cargo test -p perry-ui-model`
- `cargo test -p perry-ui`
- `cargo check -p perry-hir`
- `cargo check -p perry-ui`
- `cargo run -q -p perry -- compile /tmp/perry_issue_1991.ts --target web -o /tmp/perry_issue_1991.html`
