### PR TITLE
fix(node): validate stream listener callbacks

### DIFF
--- a/crates/perry-runtime/src/node_stream_event_emitter.rs
+++ b/crates/perry-runtime/src/node_stream_event_emitter.rs
@@ -211,13 +211,26 @@ fn add_stream_listener_for_event_with_options(
     once: bool,
     prepend: bool,
 ) {
-    if event_identity_bytes(event).is_none() || !is_callable_value(cb) {
+    if event_identity_bytes(event).is_none() {
         return;
+    }
+    if !is_callable_value(cb) {
+        throw_invalid_listener_type();
     }
     add_stream_listener(stream, event, cb, once, prepend);
     if super::string_value_eq(event, b"data") {
         super::schedule_readable_from_drain(stream);
     }
+}
+
+#[cold]
+fn throw_invalid_listener_type() -> ! {
+    let msg = b"The \"listener\" argument must be of type function";
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    crate::node_submodules::register_error_code(s, "ERR_INVALID_ARG_TYPE");
+    let err = crate::error::js_typeerror_new(s);
+    let bits = JSValue::pointer(err as *const u8).bits();
+    crate::exception::js_throw(f64::from_bits(bits))
 }
 
 fn string_bytes(value: f64) -> Option<Vec<u8>> {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2462,12 +2462,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: ReadableStream.from(customIterable) — value or done wrong. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/events/on-non-function-throws": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: on(event, non-function) — does not throw TypeError as expected. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/iterator-empty-after-consumed": {
     "issue": "1531",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- throw a catchable `TypeError` when stream EventEmitter registration receives a non-callable listener
- register `ERR_INVALID_ARG_TYPE` for the thrown listener-validation error
- remove the now-passing `node-suite/stream/events/on-non-function-throws` known-failure entry

## DeepWiki
- checked Deno `node:stream` / EventEmitter behavior; invariant is that `Readable` inherits EventEmitter listener validation and invalid listeners throw `ERR_INVALID_ARG_TYPE`
- kept the DeepWiki response local under `reference/deepwiki/deno-node-stream-listener-validation-2026-05-27.md`

## Tests
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter on-non-function-throws`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter on-returns-this-chained`
- `cargo test -p perry-runtime node_stream --lib`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals
- changing stream event-name validation or coercion behavior
- broad EventEmitter validation outside the stream registration path
- broader stream dataflow, backpressure, or listener-order behavior