### PR TITLE
fix(node): defer writable finish emission

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -80,6 +80,8 @@ const STREAM_END_EMITTED_KEY: &[u8] = b"__perryStreamEndEmitted";
 const STREAM_ENDED_KEY: &[u8] = b"__perryStreamEnded";
 const STREAM_MAX_LISTENERS_KEY: &[u8] = b"__perryStreamMaxListeners";
 const WRITABLE_WRITE_KEY: &[u8] = b"__perryWritableWrite";
+const WRITABLE_FINISH_SCHEDULED_KEY: &[u8] = b"__perryWritableFinishScheduled";
+const WRITABLE_FINISH_EMITTED_KEY: &[u8] = b"__perryWritableFinishEmitted";
 // #1534: direction + disturbed bits so the static introspection helpers
 // (`Readable.isReadable` / `isDisturbed` / `isErrored`) answer per-stream
 // instead of with a uniform stub. Set at construction / on first read.
@@ -151,6 +153,31 @@ extern "C" fn ns_readable_end_microtask(closure: *const ClosureHeader) -> f64 {
         f64::from_bits(TAG_FALSE),
     );
     emit_readable_end_once(stream);
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn ns_writable_finish_microtask(closure: *const ClosureHeader) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let stream = f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64);
+    let callback = f64::from_bits(js_closure_get_capture_ptr(closure, 1) as u64);
+    set_hidden_value(
+        stream,
+        hidden_finish_scheduled_key(),
+        f64::from_bits(TAG_FALSE),
+    );
+    if !has_truthy_hidden(stream, hidden_finish_emitted_key()) {
+        set_hidden_value(
+            stream,
+            hidden_finish_emitted_key(),
+            f64::from_bits(TAG_TRUE),
+        );
+        let _ = emit_stream_event(stream, string_value(b"finish"), &[]);
+    }
+    if is_callable_value(callback) {
+        call_listener_args(stream, callback, &[]);
+    }
     f64::from_bits(TAG_UNDEFINED)
 }
 
@@ -300,10 +327,7 @@ fn finish_stream(stream: f64, callback: Option<f64>) {
         set_hidden_value(stream, hidden_end_emitted_key(), f64::from_bits(TAG_TRUE));
         let _ = emit_stream_event(stream, string_value(b"end"), &[]);
     }
-    let _ = emit_stream_event(stream, string_value(b"finish"), &[]);
-    if let Some(callback) = callback {
-        call_listener_args(stream, callback, &[]);
-    }
+    schedule_writable_finish(stream, callback);
 }
 
 fn stream_value_from_handle(stream_handle: i64) -> f64 {
@@ -956,6 +980,7 @@ fn register_stub_arities() {
     register(ns_remove_all_listeners1 as *const u8, 1);
     register(ns_readable_from_drain as *const u8, 0);
     register(ns_readable_end_microtask as *const u8, 0);
+    register(ns_writable_finish_microtask as *const u8, 0);
     register(ns_emit2 as *const u8, 2);
     crate::closure::js_register_closure_rest(ns_emit_rest as *const u8, 1);
     register(ns_resume0 as *const u8, 0);
@@ -1061,6 +1086,16 @@ fn hidden_max_listeners_key() -> *mut crate::string::StringHeader {
 #[inline]
 fn hidden_write_key() -> *mut crate::string::StringHeader {
     hidden_key(WRITABLE_WRITE_KEY)
+}
+
+#[inline]
+fn hidden_finish_scheduled_key() -> *mut crate::string::StringHeader {
+    hidden_key(WRITABLE_FINISH_SCHEDULED_KEY)
+}
+
+#[inline]
+fn hidden_finish_emitted_key() -> *mut crate::string::StringHeader {
+    hidden_key(WRITABLE_FINISH_EMITTED_KEY)
 }
 
 #[inline]
@@ -1175,6 +1210,29 @@ fn schedule_readable_end(stream: f64) {
     set_hidden_value(stream, hidden_end_scheduled_key(), f64::from_bits(TAG_TRUE));
     let closure = js_closure_alloc(ns_readable_end_microtask as *const u8, 1);
     js_closure_set_capture_ptr(closure, 0, stream.to_bits() as i64);
+    crate::builtins::js_queue_microtask(closure as i64);
+}
+
+fn schedule_writable_finish(stream: f64, callback: Option<f64>) {
+    if has_truthy_hidden(stream, hidden_finish_emitted_key())
+        || has_truthy_hidden(stream, hidden_finish_scheduled_key())
+    {
+        return;
+    }
+    set_hidden_value(
+        stream,
+        hidden_finish_scheduled_key(),
+        f64::from_bits(TAG_TRUE),
+    );
+    let closure = js_closure_alloc(ns_writable_finish_microtask as *const u8, 2);
+    js_closure_set_capture_ptr(closure, 0, stream.to_bits() as i64);
+    js_closure_set_capture_ptr(
+        closure,
+        1,
+        callback
+            .unwrap_or_else(|| f64::from_bits(TAG_UNDEFINED))
+            .to_bits() as i64,
+    );
     crate::builtins::js_queue_microtask(closure as i64);
 }
 

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -332,12 +332,6 @@
     "category": "bug-open",
     "reason": "node:stream: Transform.write → transform() → data event chain does not deliver. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/writable/write-end-callback": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Writable does not invoke its write() option callback / finish event. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/object-mode": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -2935,11 +2929,5 @@
     "added": "2026-05-25",
     "category": "bug-open",
     "reason": "node:stream/consumers: buffer() from raw-byte Buffer chunks — byte sequence or Array.from output differs from Node. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/static/is-writable-after-end-false": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: isWritable() itself is implemented (#1746) and returns false synchronously after end(); this test stays failing because it reads the value inside a 'finish' event handler, and finish/end events don't fire yet. Flips to PASS when #1532 (stream events) lands."
   }
 }


### PR DESCRIPTION
## Summary
- queue writable `finish` emission through Perry microtasks instead of firing synchronously inside `end()`
- keep the writable ended flag immediate so `stream.isWritable(w)` becomes false after `end()` while listeners attached right after `end()` can still observe `finish`
- remove now-passing known-failure entries for `is-writable-after-end-false` and `write-end-callback`

## DeepWiki
- checked Deno `node:stream` writable behavior; invariant is that `Writable.end()` marks ending/ended state immediately while `finish` is dispatched asynchronously enough for immediate post-`end()` listeners
- kept the DeepWiki response local under `reference/deepwiki/deno-node-stream-writable-finish-after-end-2026-05-27.md`

## Tests
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter is-writable-after-end-false`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter write-end-callback`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter is-writable-on-writable`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter end-returns-this`
- `cargo test -p perry-runtime node_stream --lib`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals
- implementing `end(chunk, encoding, callback)` argument handling; `node-suite/stream/writable/end-with-chunk-and-cb` still fails separately
- close-event ordering, `_final`, cork/uncork, or full writable backpressure semantics
- changing readable `end` scheduling or broader stream lifecycle behavior