### PR TITLE
fix(node): normalize writable end callback args

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -802,8 +802,8 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         has_receiver: true,
         method: "end",
         class_filter: None,
-        runtime: "js_node_stream_method_end",
-        args: &[NA_F64],
+        runtime: "js_node_stream_method_end3",
+        args: &[NA_F64, NA_F64, NA_F64],
         ret: NR_F64,
     },
     NativeModSig {

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -260,17 +260,9 @@ extern "C" fn ns_write2(closure: *const ClosureHeader, chunk: f64, enc: f64) -> 
     f64::from_bits(TAG_TRUE)
 }
 
-extern "C" fn ns_end1(closure: *const ClosureHeader, chunk: f64) -> f64 {
-    let callback = if is_callable_value(chunk) {
-        Some(chunk)
-    } else {
-        None
-    };
-    if callback.is_none() && !JSValue::from_bits(chunk.to_bits()).is_undefined() {
-        let _ = ns_write2(closure, chunk, f64::from_bits(TAG_UNDEFINED));
-    }
+extern "C" fn ns_end3(closure: *const ClosureHeader, chunk: f64, encoding: f64, cb: f64) -> f64 {
     let stream = this_value(closure);
-    finish_stream(stream, callback);
+    finish_stream_with_args(stream, chunk, encoding, cb);
     stream
 }
 
@@ -304,6 +296,39 @@ fn finish_stream(stream: f64, callback: Option<f64>) {
     if let Some(callback) = callback {
         call_listener_args(stream, callback, &[]);
     }
+}
+
+fn finish_stream_with_args(stream: f64, chunk: f64, encoding: f64, cb: f64) {
+    let (chunk, encoding, callback) = normalize_end_args(chunk, encoding, cb);
+    if has_end_chunk(chunk) {
+        invoke_writable_write(stream, chunk, encoding);
+        emit_writable_chunk(stream, chunk);
+    }
+    finish_stream(stream, callback);
+}
+
+fn normalize_end_args(chunk: f64, encoding: f64, cb: f64) -> (f64, f64, Option<f64>) {
+    if is_callable_value(chunk) {
+        return (
+            f64::from_bits(TAG_UNDEFINED),
+            f64::from_bits(TAG_UNDEFINED),
+            Some(chunk),
+        );
+    }
+    if is_callable_value(encoding) {
+        return (chunk, f64::from_bits(TAG_UNDEFINED), Some(encoding));
+    }
+    let callback = if is_callable_value(cb) {
+        Some(cb)
+    } else {
+        None
+    };
+    (chunk, encoding, callback)
+}
+
+fn has_end_chunk(chunk: f64) -> bool {
+    let value = JSValue::from_bits(chunk.to_bits());
+    !value.is_null() && !value.is_undefined()
 }
 
 fn stream_value_from_handle(stream_handle: i64) -> f64 {
@@ -391,15 +416,24 @@ pub extern "C" fn js_node_stream_method_write(stream_handle: i64, chunk: f64, en
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_end(stream_handle: i64, chunk: f64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
-    let callback = if is_callable_value(chunk) {
-        Some(chunk)
-    } else {
-        None
-    };
-    if callback.is_none() && !JSValue::from_bits(chunk.to_bits()).is_undefined() {
-        let _ = js_node_stream_method_write(stream_handle, chunk, f64::from_bits(TAG_UNDEFINED));
-    }
-    finish_stream(stream, callback);
+    finish_stream_with_args(
+        stream,
+        chunk,
+        f64::from_bits(TAG_UNDEFINED),
+        f64::from_bits(TAG_UNDEFINED),
+    );
+    stream
+}
+
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_end3(
+    stream_handle: i64,
+    chunk: f64,
+    encoding: f64,
+    cb: f64,
+) -> f64 {
+    let stream = stream_value_from_handle(stream_handle);
+    finish_stream_with_args(stream, chunk, encoding, cb);
     stream
 }
 extern "C" fn ns_undefined0(_closure: *const ClosureHeader) -> f64 {
@@ -963,7 +997,7 @@ fn register_stub_arities() {
     register(ns_pipe1 as *const u8, 1);
     register(writable_write_callback_noop as *const u8, 0);
     register(ns_write2 as *const u8, 2);
-    register(ns_end1 as *const u8, 1);
+    register(ns_end3 as *const u8, 3);
     register(ns_set_max_listeners as *const u8, 1);
     register(ns_get_max_listeners as *const u8, 0);
     register(ns_event_names as *const u8, 0);
@@ -1575,7 +1609,7 @@ fn writable_methods() -> [(&'static str, StubFn); 22] {
         ("listeners", cast1(ns_listeners)),
         ("rawListeners", cast1(ns_raw_listeners)),
         ("write", cast2(ns_write2)),
-        ("end", cast1(ns_end1)),
+        ("end", cast3(ns_end3)),
         ("cork", cast0(ns_chain0)),
         ("uncork", cast0(ns_chain0)),
         ("destroy", cast1(ns_destroy1)),
@@ -1612,7 +1646,7 @@ fn duplex_methods() -> [(&'static str, StubFn); 28] {
         ("setEncoding", cast1(ns_chain1)),
         ("isPaused", cast0(ns_undefined0)),
         ("write", cast2(ns_write2)),
-        ("end", cast1(ns_end1)),
+        ("end", cast3(ns_end3)),
         ("cork", cast0(ns_chain0)),
         ("uncork", cast0(ns_chain0)),
         ("destroy", cast1(ns_destroy1)),

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -35,6 +35,9 @@ static KEEP_NS_METHOD_WRITE: extern "C" fn(i64, f64, f64) -> f64 =
 #[used]
 static KEEP_NS_METHOD_END: extern "C" fn(i64, f64) -> f64 = super::js_node_stream_method_end;
 #[used]
+static KEEP_NS_METHOD_END3: extern "C" fn(i64, f64, f64, f64) -> f64 =
+    super::js_node_stream_method_end3;
+#[used]
 static KEEP_NS_METHOD_SET_MAX_LISTENERS: extern "C" fn(i64, f64) -> f64 =
     super::js_node_stream_method_set_max_listeners;
 #[used]

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -153,7 +153,12 @@ fn readable_options_read_callback_this_is_rebound_to_stream() {
 fn stream_methods_use_implicit_this_without_closure_capture() {
     let stream = js_node_stream_passthrough_new(f64::from_bits(TAG_UNDEFINED));
     let prev_this = crate::object::js_implicit_this_set(stream);
-    let _ = ns_end1(std::ptr::null(), f64::from_bits(TAG_UNDEFINED));
+    let _ = ns_end3(
+        std::ptr::null(),
+        f64::from_bits(TAG_UNDEFINED),
+        f64::from_bits(TAG_UNDEFINED),
+        f64::from_bits(TAG_UNDEFINED),
+    );
     crate::object::js_implicit_this_set(prev_this);
 
     assert!(js_node_stream_is_stub_ended_after_read(stream));
@@ -474,8 +479,8 @@ fn stream_native_receiver_methods_update_hidden_state() {
 fn stream_stub_arities_are_registered_per_thread() {
     let _ = js_node_stream_passthrough_new(f64::from_bits(TAG_UNDEFINED));
     assert_eq!(
-        crate::closure::lookup_closure_arity(ns_end1 as *const u8),
-        Some(1)
+        crate::closure::lookup_closure_arity(ns_end3 as *const u8),
+        Some(3)
     );
     assert_eq!(
         crate::closure::lookup_closure_arity(ns_destroy1 as *const u8),
@@ -489,8 +494,8 @@ fn stream_stub_arities_are_registered_per_thread() {
     std::thread::spawn(|| {
         let _ = js_node_stream_passthrough_new(f64::from_bits(TAG_UNDEFINED));
         assert_eq!(
-            crate::closure::lookup_closure_arity(ns_end1 as *const u8),
-            Some(1)
+            crate::closure::lookup_closure_arity(ns_end3 as *const u8),
+            Some(3)
         );
         assert_eq!(
             crate::closure::lookup_closure_arity(ns_destroy1 as *const u8),

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -464,12 +464,6 @@
     "category": "bug-open",
     "reason": "node:stream: read(n) doesn't return buffered chunk (push/read pipeline not wired). Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/writable/end-with-chunk-and-cb": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: end(chunk, cb) doesn't invoke callback / write final chunk. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipe/returns-target": {
     "issue": "1531",
     "added": "2026-05-23",
@@ -1621,12 +1615,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: read(N) — consumes wrong byte count from buffered stream. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/writable/end-with-chunk-writes-before-finish": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: end(chunk) ordering — chunk write happens after 'finish' event or not at all. Flips to PASS when #1539 lands."
   },
   "node-suite/stream/flow/sequential-reads": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- widen Perry's stream `end` native path to normalize `end(cb)`, `end(chunk, cb)`, and `end(chunk, encoding, cb)`
- write the final non-null chunk before finishing and invoke the normalized callback
- remove exact known failures for `node-suite/stream/writable/end-with-chunk-and-cb` and `node-suite/stream/writable/end-with-chunk-writes-before-finish`

## DeepWiki
- `reference/deepwiki/deno-node-stream-writable-end-args-2026-05-27.md`

## Tests
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter end-with-chunk-and-cb`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter end-with-chunk-writes-before-finish`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter end-returns-this`
- `cargo test -p perry-runtime node_stream --lib`
- `cargo test -p perry-codegen native_table --lib`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals
- `node-suite/stream/writable/end-three-arg` still needs deferred finish listener timing on this base; that is covered separately by #2000
- no broader `_final`, `close`, cork/uncork, or backpressure lifecycle work