### PR TITLE
fix(node): expose stream methods as callable values

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -868,10 +868,11 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // Fall through — let the regular member access path
                     // below handle the user-declared subclass field.
                 } else if module_name == "stream" && is_classic_stream_method_name(&property_name) {
-                    // Classic Node streams materialize EventEmitter methods as
-                    // closure-valued fields on the stream object. A bare method
-                    // read (`r.on`, `r.addListener`) must return that callable
-                    // value, not invoke the native receiver method with no args.
+                    // Classic Node streams materialize core stream and
+                    // EventEmitter methods as closure-valued fields on the
+                    // stream object. A bare method read (`r.read`, `r.on`)
+                    // must return that callable value, not invoke the native
+                    // receiver method with no args.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
                         object: Box::new(object_expr),
@@ -1554,7 +1555,23 @@ fn is_stream_api_member(module: &str, prop: &str) -> bool {
 fn is_classic_stream_method_name(prop: &str) -> bool {
     matches!(
         prop,
-        "on" | "addListener"
+        "read"
+            | "push"
+            | "pipe"
+            | "unpipe"
+            | "pause"
+            | "resume"
+            | "destroy"
+            | "setEncoding"
+            | "isPaused"
+            | "write"
+            | "end"
+            | "cork"
+            | "uncork"
+            | "setDefaultEncoding"
+            | "compose"
+            | "on"
+            | "addListener"
             | "once"
             | "prependListener"
             | "prependOnceListener"

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2264,12 +2264,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: ReadableStream.from(arrayOfBuffers) — chunk count or type wrong. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/readable/method-typeof-function": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: some instance method reports wrong typeof (not 'function'). Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/from-iterator-throws": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- route bare classic stream method reads like `r.read`, `r.push`, `r.pipe`, and `r.destroy` through object property reads instead of zero-arg native receiver calls
- keep existing method-call dispatch unchanged while making `typeof readable.method` observe `function`
- remove the exact known failure for `node-suite/stream/readable/method-typeof-function`

## DeepWiki
- `reference/deepwiki/deno-node-stream-readable-method-shape-2026-05-27.md`

## Tests
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter method-typeof-function`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter add-listener-is-on-alias`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter push-return-value`
- `cargo test -p perry-hir expr_member --lib`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals
- no stream dataflow, buffering, backpressure, or lifecycle semantics changes
- no prototype inheritance cleanup beyond returning existing callable method fields for bare reads