### PR TITLE
test(node): unskip passing readable from buffer cases

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1412,12 +1412,6 @@
     "category": "bug-open",
     "reason": "node:stream: objectMode Readable.read() does not return single object per call. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/from-buffer-direct": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.from(Buffer) — Buffer is iterated byte-by-byte instead of emitted as single chunk. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/iter-helpers/map-async-rejection": {
     "issue": "1558",
     "added": "2026-05-24",
@@ -2695,12 +2689,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: compose 2-stage err — composite 'error' event not fired. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/readable/from-buffer-emits-single": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.from(Buffer) — not single Buffer chunk (iterates byte-by-byte). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/push-string-with-encoding-set": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- remove stale known-failure entries for the exact `Readable.from(Buffer)` parity fixtures that now pass
- keep the broader `node-suite/stream/readable/from-buffer` entry listed because the mixed filter still reports it failing

## DeepWiki
- `reference/deepwiki/deno-node-stream-readable-from-buffer-fixtures-2026-05-27.md`

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter from-buffer`
  - PASS `node-suite/stream/consumers/text-from-buffer-chunks`
  - PASS `node-suite/stream/readable/from-buffer-direct`
  - PASS `node-suite/stream/readable/from-buffer-emits-single`
  - FAIL `node-suite/stream/readable/from-buffer` (still listed)
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter from-buffer-direct`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter from-buffer-emits-single`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals
- no runtime/compiler stream behavior changes
- no broad `from-buffer` known-failure cleanup
