### PR TITLE
Destroy node:stream instances from AbortSignal

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -91,8 +91,8 @@ const STREAM_DISTURBED_KEY: &[u8] = b"__perryStreamDisturbed";
 const READABLE_BUFFERED_KEY: &[u8] = b"__perryReadableBuffered";
 const READABLE_HWM_KEY: &[u8] = b"__perryReadableHwm";
 
+use destroy_state::{destroy_stream, ns_destroy1, ns_destroy_error_microtask};
 pub use destroy_state::{js_node_stream_method_destroy, js_node_stream_method_destroyed};
-use destroy_state::{ns_destroy1, ns_destroy_error_microtask};
 
 // ─────────────────────────────────────────────────────────────────
 // Stub method bodies. Each receives the closure pointer (slot 0
@@ -545,6 +545,15 @@ extern "C" fn ns_deferred_resolve(closure: *const ClosureHeader) -> f64 {
     f64::from_bits(TAG_UNDEFINED)
 }
 
+extern "C" fn ns_stream_abort_listener(closure: *const ClosureHeader) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let stream = f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64);
+    destroy_stream(stream, abort_error());
+    f64::from_bits(TAG_UNDEFINED)
+}
+
 /// Build a pending Promise for a consuming helper running under a
 /// not-yet-aborted signal: an abort listener rejects it with an
 /// AbortError, while a queued microtask fulfills it with `value` if no
@@ -944,6 +953,7 @@ fn register_stub_arities() {
     register(ns_chain0 as *const u8, 0);
     register(ns_chain1 as *const u8, 1);
     register(ns_destroy_error_microtask as *const u8, 0);
+    register(ns_stream_abort_listener as *const u8, 0);
     register(ns_destroy1 as *const u8, 1);
     register(ns_chain2 as *const u8, 2);
     register(ns_chain3 as *const u8, 3);
@@ -1751,6 +1761,12 @@ fn init_writable_state(stream: f64, opts: f64) {
     set_hidden_value(stream, hidden_key(b"writableHighWaterMark"), w_hwm);
 }
 
+fn init_abort_signal_state(stream: f64, opts: f64) {
+    if let Some(signal) = options_signal(opts) {
+        attach_abort_signal(signal, stream);
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn js_node_stream_readable_new(opts: f64) -> f64 {
     register_iter_helper_arities();
@@ -1763,6 +1779,7 @@ pub extern "C" fn js_node_stream_readable_new(opts: f64) -> f64 {
     init_lifecycle_state(readable);
     init_constructor(readable, "Readable");
     init_readable_state(readable, opts);
+    init_abort_signal_state(readable, opts);
     async_iterator::install_readable_async_iterator_symbol(readable);
     readable
 }
@@ -1782,6 +1799,7 @@ pub extern "C" fn js_node_stream_writable_new(opts: f64) -> f64 {
     init_lifecycle_state(writable);
     init_constructor(writable, "Writable");
     init_writable_state(writable, opts);
+    init_abort_signal_state(writable, opts);
     writable
 }
 
@@ -1797,6 +1815,7 @@ pub extern "C" fn js_node_stream_duplex_new(opts: f64) -> f64 {
     init_constructor(duplex, "Duplex");
     init_readable_state(duplex, opts);
     init_writable_state(duplex, opts);
+    init_abort_signal_state(duplex, opts);
     async_iterator::install_readable_async_iterator_symbol(duplex);
     duplex
 }
@@ -1924,15 +1943,29 @@ pub extern "C" fn js_node_stream_set_default_hwm(object_mode: f64, value: f64) -
     f64::from_bits(TAG_UNDEFINED)
 }
 
-/// #1541: `stream.addAbortSignal(signal, stream)` — Node wires the
-/// AbortSignal so aborting it destroys the stream, and returns the
-/// stream for chaining. Perry's stream stubs don't implement the
-/// destroy / abort propagation yet, so the helper just returns the
-/// stream verbatim and ignores the signal. Caller chains
-/// (`r = addAbortSignal(s, r)`) keep working with the same stream
-/// reference they passed in.
+fn attach_abort_signal(signal: f64, stream: f64) {
+    if signal_is_aborted(signal) {
+        destroy_stream(stream, abort_error());
+        return;
+    }
+    let Some(signal_obj) = object_ptr_from_value(signal) else {
+        return;
+    };
+    let listener = js_closure_alloc(ns_stream_abort_listener as *const u8, 1);
+    js_closure_set_capture_ptr(listener, 0, stream.to_bits() as i64);
+    crate::url::js_abort_signal_add_listener(
+        signal_obj,
+        string_value(b"abort"),
+        box_pointer(listener as *const u8),
+    );
+}
+
+/// #1541: `stream.addAbortSignal(signal, stream)` — wire an AbortSignal so
+/// aborting it destroys the stream with an AbortError, then return the same
+/// stream for chaining.
 #[no_mangle]
-pub extern "C" fn js_node_stream_add_abort_signal(_signal: f64, stream: f64) -> f64 {
+pub extern "C" fn js_node_stream_add_abort_signal(signal: f64, stream: f64) -> f64 {
+    attach_abort_signal(signal, stream);
     stream
 }
 

--- a/crates/perry-runtime/src/node_stream_destroy_state.rs
+++ b/crates/perry-runtime/src/node_stream_destroy_state.rs
@@ -4,8 +4,8 @@ use crate::closure::{
 };
 
 use super::{
-    get_hidden_value, hidden_error_key, hidden_key, set_hidden_value, stream_value_from_handle,
-    this_value, TAG_FALSE, TAG_NULL, TAG_UNDEFINED,
+    get_hidden_value, has_truthy_hidden, hidden_error_key, hidden_key, set_hidden_value,
+    stream_value_from_handle, this_value, TAG_FALSE, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,
 };
 
 pub(super) extern "C" fn ns_destroy_error_microtask(closure: *const ClosureHeader) -> f64 {
@@ -14,28 +14,32 @@ pub(super) extern "C" fn ns_destroy_error_microtask(closure: *const ClosureHeade
     }
     let stream = f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64);
     let err = js_closure_get_capture_f64(closure, 1);
-    set_hidden_value(stream, hidden_error_key(), err);
-    let error = super::string_value(b"error");
-    if super::event_emitter::stream_listener_count_for_event(stream, error) > 0 {
-        let _ = super::event_emitter::emit_stream_event(stream, error, &[err]);
+    let bits = err.to_bits();
+    if bits != TAG_UNDEFINED && bits != TAG_NULL {
+        set_hidden_value(stream, hidden_error_key(), err);
+        let error = super::string_value(b"error");
+        if super::event_emitter::stream_listener_count_for_event(stream, error) > 0 {
+            let _ = super::event_emitter::emit_stream_event(stream, error, &[err]);
+        }
     }
     let _ = super::event_emitter::emit_stream_event(stream, super::string_value(b"close"), &[]);
     f64::from_bits(TAG_UNDEFINED)
 }
 
-fn schedule_destroy_error(stream: f64, err: f64) {
-    let bits = err.to_bits();
-    if bits != TAG_UNDEFINED && bits != TAG_NULL {
-        let closure = js_closure_alloc(ns_destroy_error_microtask as *const u8, 2);
-        js_closure_set_capture_ptr(closure, 0, stream.to_bits() as i64);
-        js_closure_set_capture_f64(closure, 1, err);
-        crate::builtins::js_queue_microtask(closure as i64);
+pub(super) fn destroy_stream(stream: f64, err: f64) {
+    if has_truthy_hidden(stream, hidden_key(b"destroyed")) {
+        return;
     }
+    set_hidden_value(stream, hidden_key(b"destroyed"), f64::from_bits(TAG_TRUE));
+    let closure = js_closure_alloc(ns_destroy_error_microtask as *const u8, 2);
+    js_closure_set_capture_ptr(closure, 0, stream.to_bits() as i64);
+    js_closure_set_capture_f64(closure, 1, err);
+    crate::builtins::js_queue_microtask(closure as i64);
 }
 
 pub(super) extern "C" fn ns_destroy1(closure: *const ClosureHeader, err: f64) -> f64 {
     let stream = this_value(closure);
-    schedule_destroy_error(stream, err);
+    destroy_stream(stream, err);
     stream
 }
 
@@ -49,6 +53,6 @@ pub extern "C" fn js_node_stream_method_destroyed(stream_handle: i64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_destroy(stream_handle: i64, err: f64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
-    schedule_destroy_error(stream, err);
+    destroy_stream(stream, err);
     stream
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -356,12 +356,6 @@
     "category": "bug-open",
     "reason": "node:stream: pause()/resume()/isPaused() not functioning on instance. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/readable/destroyed-flag": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: destroyed flag + destroy() not wired on instance. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/readable/unshift-chunk": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -373,12 +367,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: cork()/uncork() not functioning + finish event missing. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/writable/destroyed-flag": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Writable destroyed flag + destroy() not wired. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/writable/drain-event": {
     "issue": "1532",
@@ -548,12 +536,6 @@
     "category": "bug-open",
     "reason": "node:stream: calling PassThrough() without `new` should auto-instantiate; Perry behavior differs. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/destroy/destroy-emits-close": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: destroy() doesn't async-emit close event. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/destroy/destroy-returns-this": {
     "issue": "1531",
     "added": "2026-05-23",
@@ -710,12 +692,6 @@
     "category": "bug-open",
     "reason": "node:stream: autoDestroy default behavior doesn't fire close after end. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/abort/signal-aborts-stream": {
-    "issue": "1541",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: addAbortSignal wires the signal but aborting doesn't emit 'error' with the AbortError on a later tick. Reopened #1541 for abort->event wiring."
-  },
   "node-suite/stream/compose/multiple-transforms": {
     "issue": "1539",
     "added": "2026-05-24",
@@ -824,29 +800,11 @@
     "category": "bug-open",
     "reason": "node:stream: destroy(err) + error listener doesn't deliver the message to handler. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/destroy/destroy-non-error": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: destroy() with no error doesn't fire close event. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/object-mode/read-single-object": {
     "issue": "1532",
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: read() on objectMode stream should return one object per call. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/options/signal-readable": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: new Readable({signal}) constructor option not honored (no abort wire-up). Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/options/signal-writable": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: new Writable({signal}) constructor option not honored. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/async-iter/two-iterators-error": {
     "issue": "1532",
@@ -1754,12 +1712,6 @@
     "category": "bug-open",
     "reason": "node:stream: read(undefined) — not equivalent to read() no-arg form. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/destroy/destroy-twice-idempotent": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: destroy() called twice — fires duplicate 'close' or errors. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/iter-yields-buffer-no-encoding": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -2125,12 +2077,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: filter(fn).toArray() — chain produces wrong result. Flips to PASS when #1558 lands."
-  },
-  "node-suite/stream/events/close-fires-on-destroy": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: 'close' event after destroy — fires 0 or 2+ times (should be exactly 1). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/from-async-iter-mixed-values": {
     "issue": "1532",

--- a/test-parity/node-suite/stream/abort/already-aborted-add-abort-signal.ts
+++ b/test-parity/node-suite/stream/abort/already-aborted-add-abort-signal.ts
@@ -1,0 +1,16 @@
+import * as stream from "node:stream";
+import { Readable } from "node:stream";
+
+const ctrl = new AbortController();
+ctrl.abort();
+
+const r = new Readable({ read() {} });
+let name = "";
+r.on("error", (err) => (name = (err as Error).name));
+
+(stream as any).addAbortSignal(ctrl.signal, r);
+
+setImmediate(() => {
+  console.log("pre-aborted error:", name);
+  console.log("destroyed:", r.destroyed);
+});


### PR DESCRIPTION
## Summary
- Wire `stream.addAbortSignal(signal, stream)` and stream constructor `{ signal }` options to destroy streams with `AbortError` on abort.
- Make stream destruction idempotent, set `destroyed` immediately, emit `error` only when an error is supplied, and always emit `close` asynchronously.
- Add a parity case for pre-aborted signals passed to `addAbortSignal` and remove now-passing stream known-failure entries.

## Tests
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty test-parity/known_failures.json`
- `cargo check -p perry-runtime`
- `./run_parity_tests.sh --suite node-suite --module stream --filter add-abort-signal`
- `./run_parity_tests.sh --suite node-suite --module stream --filter abort/signal-aborts-stream`
- `./run_parity_tests.sh --suite node-suite --module stream --filter options/signal-readable`
- `./run_parity_tests.sh --suite node-suite --module stream --filter options/signal-writable`
- `./run_parity_tests.sh --suite node-suite --module stream --filter destroyed-flag`
- `./run_parity_tests.sh --suite node-suite --module stream --filter destroy/destroy-non-error`
- `./run_parity_tests.sh --suite node-suite --module stream --filter destroy/destroy-emits-close`
- `./run_parity_tests.sh --suite node-suite --module stream --filter destroy/destroy-twice`
- `./run_parity_tests.sh --suite node-suite --module stream --filter close-fires-on-destroy`

## Non-goals
- Callback `stream.finished(..., { signal })` and broader stream pipeline/web abort gaps are left for separate slices.
