### PR TITLE
test(node): unskip readable iterator shape cases

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -728,12 +728,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline for already-ended source doesn't invoke callback. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/async-iterator-symbol": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Readable[Symbol.asyncIterator]() doesn't return a working async iterator. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/readable/double-iterate-empty": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -1087,12 +1081,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: Duplex.from(asyncIterable) — async-gen → Duplex form not yet wired. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/iterator-method": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: readable.iterator({destroyOnReturn:false}) — instance method alias for Symbol.asyncIterator not exposed. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/flags/readable-encoding": {
     "issue": "1531",
@@ -1981,12 +1969,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Transform._flush — not called exactly once after end. Flips to PASS when #1539 lands."
-  },
-  "node-suite/stream/readable/symbol-async-iter-returns-iterator": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: [Symbol.asyncIterator]() — missing next/return method or not self-iterable. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/promises/finished-rejects-on-error": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- remove stale known-failure entries for Readable async iterator shape fixtures that now pass
- keep `node-suite/stream/readable/iterator-empty-after-consumed` listed because it still fails on fresh `origin/main`

## DeepWiki
- `reference/deepwiki/deno-node-stream-readable-async-iterator-method-2026-05-27.md`

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter async-iterator-symbol`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter symbol-async-iter-returns-iterator`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter iterator-method`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals
- no runtime/compiler stream behavior changes
- no cleanup for consumed-iterator behavior (`iterator-empty-after-consumed` still fails)
