### PR TITLE
test(node): unskip readable push read basics

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -620,12 +620,6 @@
     "category": "bug-open",
     "reason": "node:stream: setEncoding(hex) + data delivery doesn't fire. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/read-empty-returns-null": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: read() on empty buffer should return null. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/write/after-end-emits-error": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -1826,12 +1820,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: second getWriter() on locked WritableStream does not throw TypeError. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/readable/push-returns-true-initial": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: push() under HWM does not return true. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/writable/write-returns-false-at-hwm": {
     "issue": "1539",
     "added": "2026-05-24",
@@ -2839,12 +2827,6 @@
     "added": "2026-05-25",
     "category": "bug-open",
     "reason": "node:stream/web: RS.from(bigint) — should throw TypeError. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/readable/push-empty-string-no-end": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: push('') — treats empty string as end signal. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/writable/write-encoded-buffer": {
     "issue": "1539",


### PR DESCRIPTION
## Summary
- remove stale known-failure entries for basic classic Readable push/read fixtures that now pass
- keep adjacent end/encoding/buffering cases listed because they still fail on fresh `origin/main`

## DeepWiki
- `reference/deepwiki/deno-node-stream-readable-push-read-basics-2026-05-27.md`

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter push-returns-true-initial`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter push-empty-string-no-end`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter read-empty-returns-null`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals
- no runtime/compiler stream behavior changes
- no cleanup for still-failing `empty-pure-end`, `many-pushes-accumulate`, `read-after-end`, `readable-flag-after-end`, or `push-string-with-encoding-set`
