### PR TITLE
fix(runtime): construct instances from class-ref values held as first-class values (#321)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -849,6 +849,36 @@ pub unsafe extern "C" fn js_new_function_construct(
             return crate::value::js_nanbox_pointer(inst as i64);
         }
     }
+
+    // #321 (effect Layer/Scope): `new C(args)` where `C` is a *class
+    // reference held as a first-class value* — the INT32-tagged form a bare
+    // `class` identifier lowers to (`Expr::ClassRef` → `INT32_TAG |
+    // class_id`). This reaches the dynamic-new helper via the
+    // `Expr::LocalGet` callee route in `new_dynamic.rs` whenever a class is
+    // aliased through a variable / field / cross-module argument
+    // (`const C = Svc; new C()`, or effect's `flatMap(self, …)` storing a
+    // `Context.Tag` subclass into `effect_instruction_i0`). Pre-fix this
+    // value was neither a heap class-object (the `is_class_object_value`
+    // arm above) nor a pointer-shaped closure (so
+    // `synthetic_class_id_for_function` returned 0 — it requires
+    // `is_pointer()`), leaving the instance stamped with class_id 0: every
+    // inherited prototype method then threw `<m> is not a function`.
+    // Stamp the registered class id so method dispatch walks the parent
+    // chain. Mirrors the #1789 heap-class-object arm above: the constructor
+    // body / field initializers are emitted on the static `new ClassName()`
+    // codegen path (there is no constructor-by-class_id runtime entry), so a
+    // dynamically-constructed instance starts with no own props — fields
+    // written afterward and prototype methods work.
+    {
+        let bits = func_value.to_bits();
+        if (bits >> 48) == 0x7FFE {
+            let class_cid = (bits & 0xFFFF_FFFF) as u32;
+            if class_cid != 0 && is_class_id_registered(class_cid) {
+                let inst = js_object_alloc(class_cid, 0);
+                return crate::value::js_nanbox_pointer(inst as i64);
+            }
+        }
+    }
     let cid = synthetic_class_id_for_function(func_value);
     // Allocate the instance with the synthetic class id (or 0 if the
     // value isn't callable). The object starts with no own props; the

--- a/test-files/test_gap_class_ref_new_dynamic.ts
+++ b/test-files/test_gap_class_ref_new_dynamic.ts
@@ -1,0 +1,41 @@
+// A class held as a first-class value (aliased through a local variable or
+// an object field), then constructed via `new <value>()`, must produce an
+// instance whose inherited prototype methods dispatch.
+//
+// Perry lowers a bare `class` identifier used as a *value* to an INT32-tagged
+// class-ref (`INT32_TAG | class_id`). When that value reaches the dynamic
+// `new` helper (`js_new_function_construct`) via a `LocalGet` / `PropertyGet`
+// callee, it was neither a heap class-object nor a pointer-shaped closure, so
+// the synthetic-class-id lookup returned 0 and the instance was stamped with
+// class_id 0 — losing every inherited prototype method
+// (`<m> is not a function`). This is the same class-as-value family that
+// blocks effect's Layer/Scope machinery (#321), where a `Context.Tag`
+// subclass is passed through generic combinators.
+class Animal {
+  kind(): string {
+    return "animal";
+  }
+}
+class Dog extends Animal {
+  static species = "canine";
+  bark(): string {
+    return "woof";
+  }
+}
+
+// Alias the class through a plain local, then construct.
+const C: any = Dog;
+const d = new C();
+console.log(d.bark());
+console.log(d.kind());
+console.log(d instanceof Dog);
+console.log(d instanceof Animal);
+
+// Alias through an object field, then construct.
+const holder: any = { ctor: Dog };
+const d2 = new holder.ctor();
+console.log(d2.bark());
+console.log(d2.kind());
+
+// Static read still works on the aliased reference.
+console.log(C.species);


### PR DESCRIPTION
## Summary

Fixes a class-as-first-class-value defect surfaced while chasing the effect Layer/Scope blocker (#321): constructing an instance from a class **held as a value** (aliased through a local, an object field, or a cross-module function argument) lost all inherited prototype methods.

A bare `class` identifier used as a value lowers to an INT32-tagged class-ref (`INT32_TAG | class_id`). When that value reached the dynamic `new` helper (`js_new_function_construct`) via a `LocalGet` / `PropertyGet` callee, it matched neither:

- the heap class-object arm (#1789, for class-*expression* values), nor
- the pointer-shaped closure path — `synthetic_class_id_for_function` returns 0 for non-pointer values (it requires `is_pointer()`).

So the instance was stamped with `class_id` 0 and every inherited prototype method threw `<m> is not a function`.

## Fix

In `js_new_function_construct`, detect the INT32 class-ref shape (top16 == `0x7FFE` with a registered class id) and allocate the instance with that class id so method dispatch walks the parent chain. Mirrors the #1789 heap-class-object arm: the constructor body / field initializers are emitted on the static `new ClassName()` codegen path (there is no constructor-by-class_id runtime entry), so a dynamically-constructed instance starts with no own props — fields written afterward and prototype methods work.

One file changed: `crates/perry-runtime/src/object/class_registry.rs` (+30, additive — a new guarded branch before the existing fallback).

## Verification

- New gap test `test-files/test_gap_class_ref_new_dynamic.ts` is byte-identical to `node --experimental-strip-types` (class aliased through local + object field, `new`, inherited method dispatch, instanceof, static read).
- `cargo test --release -p perry-runtime --lib -- --test-threads=1` → 688 passed, 0 failed.
- `cargo fmt --all -- --check` clean.
- Existing class gap tests re-checked, no regression (`test_gap_class_advanced` remains a documented known failure, #1635, static blocks — unrelated to this change).

## Scope note (#321)

This fix resolves the construction sub-case of the class-as-value family. It is NOT the full effect Layer/Scope unblock: the effect `Layer.succeed` + `Layer.build` survey still hits a deeper blocker (a `Context.Tag` class-ref ends up in a Scope finalizer slot and is called as a function). That next blocker is documented separately for follow-up; this PR lands the isolated, standalone-verified construction fix.
