### PR TITLE
Expose node:stream readableAborted

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2510,6 +2510,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("stream", "push", true, None),
     method("stream", "readableHighWaterMark", true, None),
     method("stream", "writableHighWaterMark", true, None),
+    method("stream", "readableAborted", true, None),
     method("stream", "destroyed", true, None),
     // --- child_process (synchronous + async exec surface;
     //     spawn/fork are documented but not yet codegen'd) ---

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -764,6 +764,15 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "stream",
         has_receiver: true,
+        method: "readableAborted",
+        class_filter: None,
+        runtime: "js_node_stream_method_readable_aborted",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
         method: "destroyed",
         class_filter: None,
         runtime: "js_node_stream_method_destroyed",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -871,6 +871,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_to_web", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_from_web", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_method_destroyed", DOUBLE, &[I64]);
+    module.declare_function("js_node_stream_method_readable_aborted", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroy", DOUBLE, &[I64, DOUBLE]);
 
     // ========== Event emitter ==========

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -413,6 +413,25 @@ pub extern "C" fn js_node_stream_method_writable_hwm(stream_handle: i64) -> f64 
     get_hidden_value(stream, hidden_key(b"writableHighWaterMark")).unwrap_or(16384.0)
 }
 
+/// `stream.readableAborted` property getter on typed readable streams.
+/// Node exposes it as a boolean: false on a fresh stream, true once the
+/// readable side was destroyed before a natural end.
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_readable_aborted(stream_handle: i64) -> f64 {
+    let stream = stream_value_from_handle(stream_handle);
+    if !has_truthy_hidden(stream, hidden_readable_flag_key()) {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let aborted_before_end = !stream_hidden_ended(stream)
+        && (has_truthy_hidden(stream, hidden_key(b"destroyed"))
+            || readable_hidden_error(stream).is_some());
+    f64::from_bits(if aborted_before_end {
+        TAG_TRUE
+    } else {
+        TAG_FALSE
+    })
+}
+
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_read(stream_handle: i64, _n: f64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -23,6 +23,9 @@ static KEEP_NS_READABLE_HWM: extern "C" fn(i64) -> f64 = super::js_node_stream_m
 #[used]
 static KEEP_NS_WRITABLE_HWM: extern "C" fn(i64) -> f64 = super::js_node_stream_method_writable_hwm;
 #[used]
+static KEEP_NS_READABLE_ABORTED: extern "C" fn(i64) -> f64 =
+    super::js_node_stream_method_readable_aborted;
+#[used]
 static KEEP_NS_METHOD_RESUME: extern "C" fn(i64) -> f64 = super::js_node_stream_method_resume;
 #[used]
 static KEEP_NS_METHOD_DESTROY: extern "C" fn(i64, f64) -> f64 =

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1363 entries across 82 modules
+// Coverage: 1364 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1363 entries across 82 modules.
+Total: 1364 entries across 82 modules.
 
 ## Modules
 
@@ -1735,6 +1735,7 @@ Total: 1363 entries across 82 modules.
 - `push` — instance
 - `rawListeners` — instance
 - `read` — instance
+- `readableAborted` — instance
 - `readableHighWaterMark` — instance
 - `removeAllListeners` — instance
 - `removeListener` — instance

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -992,12 +992,6 @@
     "category": "bug-open",
     "reason": "node:stream: readable.readableEncoding getter — returns wrong value (does not reflect constructor option or setEncoding()). Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/flags/readable-aborted": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: readable.readableAborted getter — returns wrong value after destroy(err). Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/flags/writable-finished": {
     "issue": "1531",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- Add a typed `readableAborted` stream property getter that returns Node-style booleans for readable streams.
- Wire the getter through native dispatch, FFI declarations, symbol retention, and the API manifest.
- Regenerate API docs and remove the now-passing `node-suite/stream/flags/readable-aborted` known-failure entry.

## Tests
- `node - <<'NODE' ...` reference probe for fresh/destroyed readable streams and writable `readableAborted`
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty test-parity/known_failures.json`
- `scripts/regen_api_docs.sh`
- `cargo check -p perry-runtime -p perry-codegen -p perry-api-manifest`
- `cargo test -p perry-codegen --test manifest_consistency`
- `./run_parity_tests.sh --suite node-suite --module stream --filter flags/readable-aborted`
