### PR TITLE
fix(hir): erase TS explicit `this` parameter in object-literal and class methods (#321 effect Layer/Scope)

### DIFF
--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -140,6 +140,18 @@ fn lower_method_prop(
     let mut params = Vec::new();
     for param in method.function.params.iter() {
         let param_name = get_pat_name(&param.pat)?;
+        // TypeScript's `this: T` is a TYPE-only marker (SWC emits it as a
+        // regular `Param { pat: Ident("this") }`), so skip it — it must not
+        // become a runtime parameter. Mirrors the `fn_decl.rs` /
+        // `expr_function.rs` sites. Without this skip, an object-literal
+        // method `m(this: T, fin) {}` is lowered as a 2-arg function, so
+        // when it dispatches through the `Object.create(proto)` chain (which
+        // binds `this` separately) the real `fin` arg lands in the `this`
+        // slot and the declared `fin` reads undefined (effect's
+        // `ScopeImplProto.addFinalizer(this, fin)` Layer/Scope blocker, #321).
+        if param_name == "this" {
+            continue;
+        }
         let param_type = extract_param_type_with_ctx(&param.pat, Some(ctx));
         let param_default = get_param_default(ctx, &param.pat)?;
         let param_id = ctx.define_local(param_name.clone(), param_type.clone());

--- a/crates/perry-hir/src/lower_decl/class_members.rs
+++ b/crates/perry-hir/src/lower_decl/class_members.rs
@@ -470,6 +470,16 @@ pub fn lower_class_method(
     let mut destructuring_params: Vec<(LocalId, ast::Pat)> = Vec::new();
     for param in &method.function.params {
         let param_name = get_pat_name(&param.pat)?;
+        // TypeScript's `this: T` is a TYPE-only marker (SWC emits it as a
+        // regular `Param { pat: Ident("this") }`), so skip it — it must not
+        // become a runtime parameter. `this` is already bound above via
+        // `define_local("this", ...)` for instance methods. Mirrors the
+        // `fn_decl.rs` / `expr_object.rs` sites. Without this skip, a class
+        // method `m(this: C, fin) {}` is lowered as a 2-arg function and the
+        // real `fin` arg lands in the `this` slot (#321).
+        if param_name == "this" {
+            continue;
+        }
         let param_type = extract_param_type_with_ctx(&param.pat, Some(ctx));
         let param_default = get_param_default(ctx, &param.pat)?;
         let is_rest = is_rest_param(&param.pat);
@@ -720,6 +730,11 @@ pub fn lower_setter_method(
     let mut destructuring_params: Vec<(LocalId, ast::Pat)> = Vec::new();
     for param in &method.function.params {
         let param_name = get_pat_name(&param.pat)?;
+        // Skip the TypeScript `this: T` TYPE-only marker (see the method loop
+        // above). `this` is already bound for instance setters.
+        if param_name == "this" {
+            continue;
+        }
         let param_type = extract_param_type_with_ctx(&param.pat, Some(ctx));
         let param_id = ctx.define_local(param_name.clone(), param_type.clone());
         params.push(Param {

--- a/test-files/test_gap_this_param_annotation.ts
+++ b/test-files/test_gap_this_param_annotation.ts
@@ -1,0 +1,60 @@
+// Gap test: TypeScript explicit `this: T` parameter annotation must be
+// erased — it is a TYPE-only marker, never a runtime parameter. Without
+// erasure, a method `m(this: T, fin)` is lowered as a 2-arg function and
+// the real first argument lands in the `this` slot, so `fin` reads
+// undefined. This is the effect Layer/Scope blocker (#321): every
+// `ScopeImplProto` method uses `(this: ScopeImpl, fin)` and dispatches
+// through `Object.create(proto)`.
+// Run: node --experimental-strip-types test_gap_this_param_annotation.ts
+
+// --- object-literal method with explicit `this` param, called directly ---
+const litObj = {
+  m(this: any, fin: any) {
+    return typeof fin;
+  },
+};
+console.log("literal direct:", litObj.m(42)); // number
+
+// --- object-literal method reached via Object.create prototype chain ---
+const Proto = {
+  describe(this: any, label: string, n: number) {
+    return label + ":" + n;
+  },
+};
+const inst: any = Object.create(Proto);
+console.log("Object.create proto:", inst.describe("count", 7)); // count:7
+
+// --- a method body that reads `this` AND a forwarded arg ---
+const Counter = {
+  base: 100,
+  add(this: any, delta: number) {
+    return this.base + delta;
+  },
+};
+const counter: any = Object.create(Counter);
+console.log("this + arg:", counter.add(5)); // 105
+
+// --- class method with explicit `this` param ---
+class Greeter {
+  prefix = "Hello, ";
+  greet(this: Greeter, name: string): string {
+    return this.prefix + name;
+  }
+}
+const g = new Greeter();
+console.log("class method:", g.greet("Ada")); // Hello, Ada
+
+// --- multiple args after `this` ---
+const Math2 = {
+  combine(this: any, a: number, b: number, c: number) {
+    return a * 100 + b * 10 + c;
+  },
+};
+const m2: any = Object.create(Math2);
+console.log("multi-arg:", m2.combine(1, 2, 3)); // 123
+
+// --- plain function with `this` param + Function.prototype.call ---
+function tag(this: any, suffix: string): string {
+  return "tagged-" + suffix;
+}
+console.log("fn.call:", tag.call({}, "x")); // tagged-x


### PR DESCRIPTION
## Summary

Fixes the next `effect` Layer/Scope blocker (#321). Root cause is general (not effect-specific): the TypeScript explicit `this` parameter annotation was not being erased in object-literal methods and class methods, so it became a real runtime parameter and shifted all the user arguments by one slot.

## Root cause

In TypeScript, `function m(this: T, realArg) {}` — the first parameter named exactly `this` is a TYPE-only marker. SWC emits it as a regular `Param { pat: Ident("this") }`, and it must be dropped during lowering (Node strip-types and tsc both erase it).

`fn_decl.rs` (function declarations) and `expr_function.rs` (function/arrow expressions) already skip it. But two method-lowering sites did not:

- `crates/perry-hir/src/lower/expr_object.rs` — object-literal methods
- `crates/perry-hir/src/lower_decl/class_members.rs` — class methods and setters

So a method `m(this: T, fin)` was lowered as a 2-arg HIR function (`params: 2` — `this` at index 0, `fin` at index 1). When that method dispatches through the `Object.create(proto)` prototype chain — which binds `this` separately via the synthetic-class-id rebind in `js_native_call_method` — the real first argument lands in the `this` slot and the declared `fin` reads undefined.

## Why this is the effect Layer/Scope blocker

Every `ScopeImplProto` method in effect's `fiberRuntime.ts` is declared with an explicit `this` parameter: `addFinalizer(this: ScopeImpl, fin)`, `close(this: ScopeImpl, exit)`, `fork(this: ScopeImpl, strategy)`, and the scope is created via `Object.create(ScopeImplProto)`.

When `Layer.build` adds its finalizer (a function) via `core.scopeAddFinalizerExit(scope, finalizer)` which calls `self.addFinalizer(finalizer)`, the finalizer arrived inside `addFinalizer` as undefined (its real arg fell into the `this` slot). The finalizer runner `(fin) => core.exit(fin(exit))` then called that wrong value and threw "value is not a function". Instrumentation confirmed: at `scopeAddFinalizerExit` the value is `typeof === function`, but inside the `addFinalizer` body the `fin` parameter is undefined.

## Fix

Skip the `this` parameter at the two remaining method-lowering sites, mirroring the existing `fn_decl.rs` skip.

## Verification

Minimal standalone repro (no effect), byte-identical to `node --experimental-strip-types`:
- object-literal method with `this` param, direct call and via `Object.create(proto)`
- method reading `this` plus a forwarded arg
- class method with `this` param
- multiple args after `this`
- plain function with `this` param via `Function.prototype.call`

New gap test `test-files/test_gap_this_param_annotation.ts` covers all of the above and is byte-identical to Node.

Effect programs (from the survey env):
- `survey/nlay.ts` (`Effect.map` + `Layer.succeed` + `Layer.build`) now prints `provide: 42` (matches Node).
- `survey/real3_context_layer.ts` still does not match — but the remaining gap there is in the `Effect.gen` generator path (`yield* Tag`), independent of this fix: a minimal `Effect.gen` + `Context.make` program (no Layer) also produces empty output, while Context DI via `Effect.map` already works. That is a separate, pre-existing generator blocker.

Test suites:
- `cargo test --release -p perry-hir` — 0 failures
- `cargo test --release -p perry-runtime --lib -- --test-threads=1` — 688 passed, 0 failed
- `cargo fmt --all -- --check` — clean
- Gap-test sweep (excluding known_failures): 74 pass, no real regressions (the single non-match, `test_gap_derived_param_props`, is a case Node strip-types cannot parse at all — Perry compiles it correctly).
