### PR TITLE
fix(node): expose readable aborted flag

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2512,6 +2512,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("stream", "readable", true, None),
     method("stream", "readableEnded", true, None),
     method("stream", "writableHighWaterMark", true, None),
+    method("stream", "readableAborted", true, None),
     method("stream", "destroyed", true, None),
     // --- child_process (synchronous + async exec surface;
     //     spawn/fork are documented but not yet codegen'd) ---

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -782,6 +782,15 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "stream",
         has_receiver: true,
+        method: "readableAborted",
+        class_filter: None,
+        runtime: "js_node_stream_method_readable_aborted",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
         method: "destroyed",
         class_filter: None,
         runtime: "js_node_stream_method_destroyed",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -870,6 +870,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // #1540: Readable/Writable .toWeb / .fromWeb — return fresh Duplex stubs.
     module.declare_function("js_node_stream_to_web", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_from_web", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_node_stream_method_readable_aborted", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroyed", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroy", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_node_stream_method_readable", DOUBLE, &[I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -200,6 +200,7 @@ extern "C" fn ns_emit_rest(closure: *const ClosureHeader, event: f64, rest: f64)
 extern "C" fn ns_resume0(closure: *const ClosureHeader) -> f64 {
     let stream = this_value(closure);
     mark_stream_ended(stream);
+    refresh_readable_aborted_flag(stream);
     mark_disturbed(stream);
     stream
 }
@@ -207,6 +208,7 @@ extern "C" fn ns_resume0(closure: *const ClosureHeader) -> f64 {
 extern "C" fn ns_read1(closure: *const ClosureHeader, _n: f64) -> f64 {
     let stream = this_value(closure);
     mark_stream_ended(stream);
+    refresh_readable_aborted_flag(stream);
     mark_disturbed(stream);
     f64::from_bits(TAG_NULL)
 }
@@ -219,6 +221,7 @@ fn push_chunk(stream: f64, chunk: f64) -> f64 {
     let jsval = JSValue::from_bits(chunk.to_bits());
     if jsval.is_null() || jsval.is_undefined() {
         mark_stream_ended(stream);
+        refresh_readable_aborted_flag(stream);
         schedule_readable_end(stream);
         return f64::from_bits(TAG_FALSE);
     }
@@ -315,8 +318,10 @@ fn emit_writable_chunk(stream: f64, chunk: f64) {
 
 fn finish_stream(stream: f64, callback: Option<f64>) {
     mark_stream_ended(stream);
+    refresh_readable_aborted_flag(stream);
     if !has_truthy_hidden(stream, hidden_end_emitted_key()) {
         set_hidden_value(stream, hidden_end_emitted_key(), f64::from_bits(TAG_TRUE));
+        refresh_readable_aborted_flag(stream);
         let _ = emit_stream_event(stream, string_value(b"end"), &[]);
     }
     schedule_writable_finish(stream, callback);
@@ -431,10 +436,17 @@ pub extern "C" fn js_node_stream_method_writable_hwm(stream_handle: i64) -> f64 
     get_hidden_value(stream, hidden_key(b"writableHighWaterMark")).unwrap_or(16384.0)
 }
 
+/// `stream.readableAborted` property getter on a typed readable-side instance.
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_readable_aborted(stream_handle: i64) -> f64 {
+    readable_aborted_value(stream_value_from_handle(stream_handle))
+}
+
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_read(stream_handle: i64, _n: f64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
     mark_stream_ended(stream);
+    refresh_readable_aborted_flag(stream);
     mark_disturbed(stream);
     f64::from_bits(TAG_NULL)
 }
@@ -443,6 +455,7 @@ pub extern "C" fn js_node_stream_method_read(stream_handle: i64, _n: f64) -> f64
 pub extern "C" fn js_node_stream_method_resume(stream_handle: i64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
     mark_stream_ended(stream);
+    refresh_readable_aborted_flag(stream);
     mark_disturbed(stream);
     stream
 }
@@ -1302,6 +1315,7 @@ fn emit_readable_end_once(stream: f64) {
     if !has_truthy_hidden(stream, hidden_end_emitted_key()) {
         set_hidden_value(stream, hidden_end_emitted_key(), f64::from_bits(TAG_TRUE));
         mark_stream_ended(stream);
+        refresh_readable_aborted_flag(stream);
         let _ = emit_stream_event(stream, string_value(b"end"), &[]);
     }
 }
@@ -1344,6 +1358,30 @@ fn readable_hidden_error(value: f64) -> Option<f64> {
 
 fn stream_hidden_ended(value: f64) -> bool {
     get_hidden_value(value, hidden_ended_key()).is_some_and(|v| crate::value::js_is_truthy(v) != 0)
+}
+
+fn readable_aborted_value(stream: f64) -> f64 {
+    if get_hidden_value(stream, hidden_readable_flag_key()).is_none() {
+        return f64::from_bits(TAG_FALSE);
+    }
+    let destroyed = has_truthy_hidden(stream, hidden_key(b"destroyed"));
+    let errored = readable_hidden_error(stream).is_some();
+    let ended = stream_hidden_ended(stream) || has_truthy_hidden(stream, hidden_end_emitted_key());
+    if (destroyed || errored) && !ended {
+        f64::from_bits(TAG_TRUE)
+    } else {
+        f64::from_bits(TAG_FALSE)
+    }
+}
+
+fn refresh_readable_aborted_flag(stream: f64) {
+    if get_hidden_value(stream, hidden_readable_flag_key()).is_some() {
+        set_hidden_value(
+            stream,
+            hidden_key(b"readableAborted"),
+            readable_aborted_value(stream),
+        );
+    }
 }
 
 fn writable_hidden_write(value: f64) -> Option<f64> {
@@ -1896,6 +1934,11 @@ fn mark_stream_ended(stream: f64) {
 fn init_readable_state(stream: f64, opts: f64) {
     set_hidden_value(stream, hidden_readable_flag_key(), f64::from_bits(TAG_TRUE));
     set_hidden_value(stream, hidden_key(b"destroyed"), f64::from_bits(TAG_FALSE));
+    set_hidden_value(
+        stream,
+        hidden_key(b"readableAborted"),
+        f64::from_bits(TAG_FALSE),
+    );
     set_hidden_value(stream, hidden_buffered_key(), 0.0);
     let r_hwm = resolve_hwm(opts, b"readableHighWaterMark", b"readableObjectMode");
     set_hidden_value(stream, hidden_hwm_key(), r_hwm);

--- a/crates/perry-runtime/src/node_stream_destroy_state.rs
+++ b/crates/perry-runtime/src/node_stream_destroy_state.rs
@@ -31,6 +31,7 @@ pub(super) fn destroy_stream(stream: f64, err: f64) {
         return;
     }
     set_hidden_value(stream, hidden_key(b"destroyed"), f64::from_bits(TAG_TRUE));
+    super::refresh_readable_aborted_flag(stream);
     let closure = js_closure_alloc(ns_destroy_error_microtask as *const u8, 2);
     js_closure_set_capture_ptr(closure, 0, stream.to_bits() as i64);
     js_closure_set_capture_f64(closure, 1, err);

--- a/crates/perry-runtime/src/node_stream_event_emitter.rs
+++ b/crates/perry-runtime/src/node_stream_event_emitter.rs
@@ -629,6 +629,7 @@ pub(super) fn emit_stream_event(stream: f64, event: f64, args: &[f64]) -> f64 {
     if super::string_value_eq(event, b"error") {
         if let Some(first) = args.first() {
             super::set_hidden_value(stream, super::hidden_error_key(), *first);
+            super::refresh_readable_aborted_flag(stream);
         }
         let monitor_event = error_monitor_event();
         let monitor_snapshot = listener_snapshot(stream, monitor_event);

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -28,6 +28,9 @@ static KEEP_NS_METHOD_READABLE_ENDED: extern "C" fn(i64) -> f64 =
 #[used]
 static KEEP_NS_WRITABLE_HWM: extern "C" fn(i64) -> f64 = super::js_node_stream_method_writable_hwm;
 #[used]
+static KEEP_NS_READABLE_ABORTED: extern "C" fn(i64) -> f64 =
+    super::js_node_stream_method_readable_aborted;
+#[used]
 static KEEP_NS_METHOD_RESUME: extern "C" fn(i64) -> f64 = super::js_node_stream_method_resume;
 #[used]
 static KEEP_NS_METHOD_DESTROY: extern "C" fn(i64, f64) -> f64 =

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -502,6 +502,47 @@ fn stream_destroy_with_error_marks_errored_state() {
 }
 
 #[test]
+fn readable_aborted_reflects_destroy_before_end() {
+    let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let obj = raw_ptr_from_value(stream) as *const ObjectHeader;
+    let err = string_value("abort");
+
+    assert_eq!(
+        js_node_stream_method_readable_aborted(handle).to_bits(),
+        TAG_FALSE
+    );
+    assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"readableAborted")).to_bits(),
+        TAG_FALSE
+    );
+
+    let _ = js_node_stream_method_destroy(handle, err);
+    assert_eq!(
+        js_node_stream_method_readable_aborted(handle).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"readableAborted")).to_bits(),
+        TAG_TRUE
+    );
+    let _ = crate::promise::js_promise_run_microtasks();
+    assert_eq!(
+        js_node_stream_method_readable_aborted(handle).to_bits(),
+        TAG_TRUE
+    );
+
+    let ended = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let ended_handle = raw_ptr_from_value(ended) as i64;
+    let _ = js_node_stream_method_push(ended_handle, f64::from_bits(TAG_NULL));
+    let _ = js_node_stream_method_destroy(ended_handle, err);
+    assert_eq!(
+        js_node_stream_method_readable_aborted(ended_handle).to_bits(),
+        TAG_FALSE
+    );
+}
+
+#[test]
 fn stream_native_receiver_methods_update_hidden_state() {
     let stream = js_node_stream_passthrough_new(f64::from_bits(TAG_UNDEFINED));
     let handle = raw_ptr_from_value(stream) as i64;

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1365 entries across 82 modules
+// Coverage: 1366 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1365 entries across 82 modules.
+Total: 1366 entries across 82 modules.
 
 ## Modules
 
@@ -1736,6 +1736,7 @@ Total: 1365 entries across 82 modules.
 - `rawListeners` — instance
 - `read` — instance
 - `readable` — instance
+- `readableAborted` — instance
 - `readableEnded` — instance
 - `readableHighWaterMark` — instance
 - `removeAllListeners` — instance

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -986,12 +986,6 @@
     "category": "bug-open",
     "reason": "node:stream: readable.readableEncoding getter — returns wrong value (does not reflect constructor option or setEncoding()). Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/flags/readable-aborted": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: readable.readableAborted getter — returns wrong value after destroy(err). Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/flags/writable-finished": {
     "issue": "1531",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- expose classic `Readable.readableAborted` through typed receiver dispatch and the visible stream field
- derive the flag from readable-side `destroyed` / `errored` state before the stream has ended
- remove the now-green `flags/readable-aborted` known-failure entry

## DeepWiki
- `reference/deepwiki/deno-node-stream-readable-aborted-flag-2026-05-27.md`

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter flags/readable-aborted`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter abort` (guardrail: `flags/readable-aborted` passes; residual pipeline/Web abort mismatches remain)
- `cargo test -p perry-runtime readable_aborted_reflects_destroy_before_end --lib`
- `cargo test -p perry-runtime node_stream --lib`
- `cargo test -p perry-codegen native_table --lib`
- `cargo test -p perry-codegen --test manifest_consistency`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals
- no pipeline abort teardown behavior
- no Web Stream `pipeTo` pre-aborted-signal behavior
- no broader readable lifecycle or stream state-machine changes