### PR TITLE
test(node): unskip stream promises abort fixture

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2474,12 +2474,6 @@
     "category": "bug-open",
     "reason": "node:stream: promises.pipeline(array, dst) — sync iterable source not collected. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/promises/finished-abortable-signal-abort": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: promises.finished({signal}) — abort doesn't reject with AbortError. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/promises/pipeline-with-transform-collect": {
     "issue": "1532",
     "added": "2026-05-25",


### PR DESCRIPTION
## Summary
- revalidate `stream/promises.finished(..., { signal })` abort behavior on current `origin/main`
- remove the now-green `finished-abortable-signal-abort` known-failure entry

## DeepWiki
- `reference/deepwiki/deno-node-stream-promises-finished-abort-signal-2026-05-27.md`

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter promises/finished-abortable-signal-abort`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals
- no runtime/compiler changes
- no cleanup for remaining stream/promises pipeline failures
- no pipeline teardown or Web Stream abort behavior changes