### PR TITLE
test(node): unskip stream promises finished cases

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1286,12 +1286,6 @@
     "category": "bug-open",
     "reason": "node:stream/promises: pipeline doesn't reject with the underlying Error. Flips to PASS when #1533 lands."
   },
-  "node-suite/stream/promises/finished-with-signal": {
-    "issue": "1533",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/promises: finished with signal does not reject on abort. Flips to PASS when #1533 lands."
-  },
   "node-suite/stream/promises/pipeline-with-signal": {
     "issue": "1533",
     "added": "2026-05-23",
@@ -1724,12 +1718,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: pipeThrough(transform, {preventClose:true}) — transform.writable should remain unlocked. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/promises/finished-returns-promise": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: promises.finished(stream) — return value not a Promise or doesn't resolve. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/cancel-during-pipeto": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -2089,12 +2077,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: TS readable.cancel — writable.write does not reject after. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/promises/finished-stream-already-ended": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: finished(alreadyEnded) — does not resolve immediately. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/readable-property-shape": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- revalidate `stream/promises.finished(...)` promise-shape fixtures on current `origin/main`
- remove the now-green `finished-returns-promise`, `finished-stream-already-ended`, and `finished-with-signal` known-failure entries
- leave `finished-rejects-on-error` listed because it still mismatches

## DeepWiki
- `reference/deepwiki/deno-node-stream-promises-finished-basics-2026-05-27.md`

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter promises/finished` (`finished-rejects-on-error` remains the only mismatch)
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals
- no runtime/compiler changes
- no cleanup for `finished-rejects-on-error`
- no stream pipeline behavior changes