### PR TITLE
test(node): unskip stream promises pipeline cases

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1184,24 +1184,6 @@
     "category": "bug-open",
     "reason": "node:stream: stream.promises namespace is undefined (used for `await pipeline()` / `await finished()`). Flips to PASS when #1533 lands."
   },
-  "node-suite/stream/promises/pipeline-await": {
-    "issue": "1533",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: stream/promises pipeline await doesn't resolve correctly (depends on streams + promises ns). Flips to PASS when #1533 lands."
-  },
-  "node-suite/stream/promises/pipeline-rejects-on-error": {
-    "issue": "1533",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/promises: pipeline doesn't reject with the underlying Error. Flips to PASS when #1533 lands."
-  },
-  "node-suite/stream/promises/pipeline-with-signal": {
-    "issue": "1533",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/promises: pipeline with signal does not reject on abort. Flips to PASS when #1533 lands."
-  },
   "node-suite/stream/pipe/returns-destination": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1573,12 +1555,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: getReader({mode:'byob'}) on bytes-type stream fails or returns wrong shape. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/promises/pipeline-returns-undefined": {
-    "issue": "1533",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/promises: pipeline resolves with the wrong value. Flips to PASS when #1533 lands."
   },
   "node-suite/stream/async-iter/single-iteration-only": {
     "issue": "1531",


### PR DESCRIPTION
## Summary
- revalidate basic `stream/promises.pipeline(...)` promise fixtures on current `origin/main`
- remove the now-green `pipeline-await`, `pipeline-rejects-on-error`, `pipeline-returns-undefined`, and `pipeline-with-signal` known-failure entries
- leave iterable-source and transform collection pipeline failures listed

## DeepWiki
- `reference/deepwiki/deno-node-stream-promises-pipeline-basics-2026-05-27.md`

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter promises/pipeline-await`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter promises/pipeline-rejects-on-error`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter promises/pipeline-returns-undefined`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter promises/pipeline-with-signal`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter promises/pipeline` (guardrail: target fixtures pass; collection/transform residuals remain)
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Non-goals
- no runtime/compiler changes
- no cleanup for iterable-source or transform collection pipeline failures