### PR TITLE
fix(runtime): bind `this` to receiver in js_get_iterator for yield*-over-a-Context-Tag (#321)

### DIFF
--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -913,7 +913,18 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
         let sym_f64 = f64::from_bits(crate::value::JSValue::pointer(iter_wk as *const u8).bits());
         let iter_fn = unsafe { js_object_get_symbol_property(val_f64, sym_f64) };
         if iter_fn.to_bits() != TAG_UNDEFINED {
-            let fn_ptr = crate::value::js_nanbox_get_pointer(iter_fn)
+            // #321: the `[Symbol.iterator]` method may be INHERITED from a
+            // prototype object literal (effect's `EffectPrototype`), in which
+            // case codegen baked `this` to the prototype object at definition
+            // time (CAPTURES_THIS_FLAG). Per spec `iterable[Symbol.iterator]()`
+            // must run with `this === iterable`, so the method reads the real
+            // receiver — effect's body is `new SingleShotGen(new YieldWrap(this))`
+            // and wraps the wrong value if `this` stays the prototype. Rebind
+            // `this` to the original value; a no-op for closures that don't
+            // capture `this`.
+            let rebound = crate::closure::clone_closure_rebind_this(iter_fn.to_bits(), val_f64);
+            let call_target = f64::from_bits(rebound);
+            let fn_ptr = crate::value::js_nanbox_get_pointer(call_target)
                 as *const crate::closure::ClosureHeader;
             if !fn_ptr.is_null() {
                 return crate::closure::js_closure_call0(fn_ptr);

--- a/test-files/test_gap_yieldstar_inherited_iterator_this.ts
+++ b/test-files/test_gap_yieldstar_inherited_iterator_this.ts
@@ -1,0 +1,52 @@
+// yield* over a value whose [Symbol.iterator] is INHERITED from a prototype
+// object literal, where the method reads `this` (mirrors effect's
+// EffectPrototype[Symbol.iterator] = () => new SingleShotGen(new YieldWrap(this))).
+// The generator must yield the receiver (via `this`), not the prototype object.
+
+class SingleShotGen {
+  called = false;
+  self: any;
+  constructor(self: any) { this.self = self; }
+  next(a: any) {
+    return this.called
+      ? { value: a, done: true }
+      : (this.called = true, { value: this.self, done: false });
+  }
+  [Symbol.iterator]() { return new SingleShotGen(this.self); }
+}
+
+// EffectPrototype analog: an object literal used as a prototype. Its
+// [Symbol.iterator] wraps `this` so the receiver flows through yield*.
+const EffectProto = {
+  [Symbol.iterator]() { return new SingleShotGen(this); },
+};
+
+// Tag analog: a function whose prototype is EffectProto (Object.setPrototypeOf).
+function Tag(name: string) {
+  function TagClass() {}
+  Object.setPrototypeOf(TagClass, EffectProto);
+  (TagClass as any).key = name;
+  return TagClass;
+}
+
+class Greeter extends (Tag("Greeter") as any) {}
+
+// Drive a generator the way effect's fiber does: pull, resolve the yielded
+// receiver to a service, resume with the service.
+function runFiber(gen: Generator, resolve: (tag: any) => any) {
+  let r = gen.next();
+  while (!r.done) {
+    r = gen.next(resolve(r.value));
+  }
+  return r.value;
+}
+
+const program = function* () {
+  const g = yield* (Greeter as any);
+  return (g as any).greet("Ada");
+};
+
+const services = new Map<any, any>();
+services.set(Greeter, { greet: (n: string) => "Hello, " + n });
+
+console.log(runFiber(program(), (tag) => services.get(tag)));


### PR DESCRIPTION
## Problem

`Effect.gen` over a `Context.Tag` yielded **empty**. The last `effect` survey blocker:

```ts
const program = Effect.gen(function* () {
  const g = yield* Greeter;        // Greeter is a Context.Tag class
  return g.greet("Ada");
});
const result = Effect.runSync(Effect.provide(program, GreeterLive));
console.log("ctx/layer:", result);  // Node: "ctx/layer: Hello, Ada"  Perry: (empty)
```

`Effect.map` over a Tag and Layer DI already worked; basic `Effect.gen` + `yield* Effect.succeed(x)` already worked. The break was specifically `yield* <ContextTag>` — a Tag is a class-as-value that is itself a yieldable Effect.

## Root cause

A Context.Tag is yieldable because `Context.Tag(id)` sets the class's prototype to `TagProto = { ...EffectPrototype, ... }`, and `EffectPrototype[Symbol.iterator]` is:

```js
[Symbol.iterator]() { return new SingleShotGen(new YieldWrap(this)); }
```

This is an **object-literal method inherited via the prototype chain** whose body reads `this`. Perry codegen bakes `this` for object-literal methods to the defining literal (the `CAPTURES_THIS_FLAG` reserved slot — correct for `[Symbol.toPrimitive]` reading own fields). When the `yield*` desugar calls `js_get_iterator(Greeter)`, the inherited `[Symbol.iterator]` was invoked via `js_closure_call0` with **no receiver**, so `this` stayed the prototype object instead of the Tag.

Consequence: `new YieldWrap(this)` wrapped the prototype, not the Tag. `yieldWrapGet(state.value)` in effect's fiber `OP_ITERATOR` loop returned a non-Effect (`_op` was `undefined`), so the fiber never resolved it to the service and never resumed the generator — empty output.

Isolated with a manual generator drive (no fiber):
- Node: `yieldWrapGet(it.next().value)._op === "Tag"`
- Perry (before): `..._op === undefined`

And reproduced with **no effect at all** (object-literal prototype method reading `this`, called with a receiver -> Perry bound `this` to the prototype, Node to the receiver).

## Fix

In `js_get_iterator`, rebind the resolved `[Symbol.iterator]` closure's `this` to the original iterable (via the existing `clone_closure_rebind_this`) before calling it — matching the spec that `iterable[Symbol.iterator]()` runs with `this === iterable`. It is a no-op for iterator methods that do not capture `this` (real generators, arrays, Map/Set/string iteration unaffected).

One runtime file changed (`crates/perry-runtime/src/symbol.rs`, +12/-1) plus a standalone gap test.

## Verification

- `survey/real3_context_layer.ts` -> `ctx/layer: Hello, Ada` (was empty)
- `survey/nlay.ts` -> `provide: 42` (Layer DI, no regression)
- `survey/05_gen.ts` -> `30` (no generator regression)
- `survey/ctx_works.ts` -> `provide: 42`; minimal `Effect.gen` + `Context.make` (no Layer) -> `min: Hi Ada`
- 12 other effect survey items (succeed/map/flatMap/pipe/fail_catch/all/sync/either/option/data/nref/real4_ref) byte-identical to Node
- `test-files/test_gap_yieldstar_inherited_iterator_this.ts` (standalone, no effect) byte-identical to Node
- Iteration regression sweep (for-of array/gen/Map/Set/string, yield*-over-generator, spread) byte-identical to Node
- `cargo test --release -p perry-runtime --lib -- --test-threads=1` -> 690 passed, 0 failed
- `cargo fmt --all -- --check` clean
