### PR TITLE
fix(runtime): Node arg-validation errors on fs + assert.throws code/name matching (#2013, #2014)

### DIFF
--- a/crates/perry-runtime/src/fs/dirent.rs
+++ b/crates/perry-runtime/src/fs/dirent.rs
@@ -291,6 +291,7 @@ pub(crate) fn collect_readdir_recursive_dirents(
 /// Returns an empty array on error.
 #[no_mangle]
 pub extern "C" fn js_fs_readdir_sync(path_value: f64, options_value: f64) -> f64 {
+    crate::fs::validate::validate_path("path", path_value);
     use crate::array::{js_array_alloc, js_array_push_f64};
 
     unsafe {

--- a/crates/perry-runtime/src/fs/fd_ops.rs
+++ b/crates/perry-runtime/src/fs/fd_ops.rs
@@ -23,6 +23,7 @@ pub(crate) fn array_ptr_from_value(value: f64) -> *const crate::array::ArrayHead
 /// `fs.openSync(path, flags)` — small fd registry for deterministic tests.
 #[no_mangle]
 pub extern "C" fn js_fs_open_sync(path_value: f64, flags_value: f64) -> f64 {
+    crate::fs::validate::validate_path("path", path_value);
     unsafe {
         let path_str = match decode_path_value(path_value) {
             Some(s) => s,

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -30,6 +30,7 @@ mod stats;
 pub use stats::*;
 mod dirent;
 pub use dirent::*;
+pub(crate) mod validate;
 
 thread_local! {
     static FD_REGISTRY: RefCell<StdHashMap<i32, fs::File>> = RefCell::new(StdHashMap::new());
@@ -39,6 +40,16 @@ thread_local! {
     static NEXT_FD: RefCell<i32> = const { RefCell::new(100) };
     static DIR_REGISTRY: RefCell<StdHashMap<usize, DirState>> = RefCell::new(StdHashMap::new());
     static NEXT_DIR_ID: RefCell<usize> = const { RefCell::new(1) };
+}
+
+/// True if `fd` is a Perry-tracked open file descriptor (one returned by
+/// `openSync`/`open` and not yet closed). Perry uses a synthetic fd registry
+/// — `NEXT_FD` starts at 100 — so a raw OS-level check (e.g. `fcntl`) is
+/// meaningless here; membership in `FD_REGISTRY` is the source of truth.
+/// Used by `validate::validate_path_or_fd` to surface `EBADF` for an unknown
+/// numeric fd (#2013).
+pub(crate) fn fd_is_registered(fd: i32) -> bool {
+    FD_REGISTRY.with(|r| r.borrow().contains_key(&fd))
 }
 
 struct DirState {
@@ -105,6 +116,7 @@ pub extern "C" fn js_fs_read_file_sync_options(
     path_value: f64,
     options_value: f64,
 ) -> *mut StringHeader {
+    validate::validate_path_or_fd("path", path_value, "read");
     unsafe {
         let path_str_for_log = decode_path_value(path_value).unwrap_or_default();
 
@@ -297,6 +309,7 @@ pub extern "C" fn js_fs_write_file_sync_options(
     content_value: f64,
     options_value: f64,
 ) -> i32 {
+    validate::validate_path_or_fd("path", path_value, "write");
     unsafe {
         if let Some(fd) = numeric_fd_value(path_value) {
             let content_bytes = bytes_from_value(content_value);
@@ -465,6 +478,7 @@ pub extern "C" fn js_fs_mkdir_sync(path_value: f64) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn js_fs_mkdir_sync_options(path_value: f64, options_value: f64) -> i32 {
+    validate::validate_path("path", path_value);
     unsafe {
         let path_str = match decode_path_value(path_value) {
             Some(s) => s,
@@ -511,6 +525,7 @@ pub extern "C" fn js_fs_is_directory(path_value: f64) -> i32 {
 /// Accepts NaN-boxed string path
 #[no_mangle]
 pub extern "C" fn js_fs_unlink_sync(path_value: f64) -> i32 {
+    validate::validate_path("path", path_value);
     unsafe {
         let path_str = match decode_path_value(path_value) {
             Some(s) => s,
@@ -564,6 +579,7 @@ pub extern "C" fn js_fs_read_file_binary_options(
     path_value: f64,
     options_value: f64,
 ) -> *mut crate::buffer::BufferHeader {
+    validate::validate_path_or_fd("path", path_value, "read");
     unsafe {
         match read_file_bytes_with_options(path_value, options_value) {
             Some(bytes) => {
@@ -1115,6 +1131,7 @@ pub extern "C" fn js_fs_rmdir_sync(path_value: f64) -> i32 {
 /// supplied. Returns i32 status.
 #[no_mangle]
 pub extern "C" fn js_fs_rmdir_sync_options(path_value: f64, options_value: f64) -> i32 {
+    validate::validate_path("path", path_value);
     unsafe {
         let path_str = match decode_path_value(path_value) {
             Some(s) => s,
@@ -1503,6 +1520,7 @@ pub extern "C" fn js_fs_readlink_sync(path_value: f64) -> i64 {
 
 #[no_mangle]
 pub extern "C" fn js_fs_readlink_sync_options(path_value: f64, options_value: f64) -> i64 {
+    validate::validate_path("path", path_value);
     let bytes = readlink_bytes(path_value);
     let enc = fs_encoding_option(options_value).unwrap_or_else(|| "utf8".to_string());
     encoded_string_ptr(&bytes, &enc) as i64
@@ -1510,6 +1528,7 @@ pub extern "C" fn js_fs_readlink_sync_options(path_value: f64, options_value: f6
 
 #[no_mangle]
 pub extern "C" fn js_fs_readlink_dispatch(path_value: f64, options_value: f64) -> f64 {
+    validate::validate_path("path", path_value);
     readlink_value(path_value, options_value)
 }
 
@@ -1573,6 +1592,7 @@ pub extern "C" fn js_fs_access_sync_throw(path_value: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_fs_access_sync_throw_mode(path_value: f64, mode_value: f64) -> f64 {
+    validate::validate_path("path", path_value);
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
     if js_fs_access_sync_mode(path_value, mode_value) == 1 {
         return f64::from_bits(TAG_UNDEFINED);

--- a/crates/perry-runtime/src/fs/stats.rs
+++ b/crates/perry-runtime/src/fs/stats.rs
@@ -267,6 +267,7 @@ pub extern "C" fn js_fs_stat_sync(path_value: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_fs_stat_sync_options(path_value: f64, options_value: f64) -> f64 {
+    crate::fs::validate::validate_path("path", path_value);
     let bigint = unsafe { options_bool_field(options_value, b"bigint") };
     unsafe {
         let path_str = match decode_path_value(path_value) {
@@ -327,6 +328,7 @@ pub extern "C" fn js_fs_lstat_sync(path_value: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_fs_lstat_sync_options(path_value: f64, options_value: f64) -> f64 {
+    crate::fs::validate::validate_path("path", path_value);
     let bigint = unsafe { options_bool_field(options_value, b"bigint") };
     unsafe {
         let path_str = match decode_path_value(path_value) {

--- a/crates/perry-runtime/src/fs/validate.rs
+++ b/crates/perry-runtime/src/fs/validate.rs
@@ -1,0 +1,157 @@
+//! Node-compatible argument validation for the `fs` module (#2013).
+//!
+//! Node throws synchronously on invalid `fs` arguments with a specific
+//! `.code`: a non path-like first argument yields `TypeError
+//! [ERR_INVALID_ARG_TYPE]`, and the `fd`-accepting readers/writers
+//! (`readFileSync`/`writeFileSync`) treat a numeric first argument as a file
+//! descriptor — an invalid one fails with `Error [EBADF]`. Perry's `fs`
+//! helpers previously returned a sentinel (empty string, `-1`, a zeroed
+//! stats object) and never threw, so `assert.throws`-style tests saw
+//! "Missing expected exception" once #1924 stopped masking the no-throw case.
+//!
+//! These helpers are the reusable validation surface called from the top of
+//! the `fs` sync entry points. The error `.code` is recorded in the
+//! per-message side table (`node_submodules`) so the `.code` getter recovers
+//! it on the caught error — the same mechanism `fs` already uses for POSIX
+//! errors like `ENOENT`.
+
+use crate::string::{js_string_from_bytes, StringHeader};
+use crate::value::JSValue;
+
+/// True if `value` is a valid Node "path-like" — a string (including inline
+/// SSO short strings), a `Buffer`, or a `file:` URL object. Mirrors the type
+/// acceptance of Node's internal `getValidatedPath`.
+pub(crate) fn is_path_like(value: f64) -> bool {
+    let jv = JSValue::from_bits(value.to_bits());
+    if jv.is_any_string() {
+        return true;
+    }
+    if crate::buffer::js_buffer_is_buffer(value.to_bits() as i64) == 1 {
+        return true;
+    }
+    if jv.is_pointer() {
+        let obj = jv.as_pointer::<crate::object::ObjectHeader>();
+        if !obj.is_null() {
+            let protocol = crate::url::get_string_content(unsafe {
+                crate::object::js_object_get_field_f64(obj, crate::url::parse::URL_PROTOCOL)
+            });
+            if protocol == "file:" {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// True if `value` is a JS number (a plain IEEE double *or* an INT32-tagged
+/// small integer). `JSValue::is_number` deliberately excludes the INT32 tag,
+/// so both must be checked.
+fn is_numeric(jv: JSValue) -> bool {
+    jv.is_number() || jv.is_int32()
+}
+
+fn numeric_to_i32(jv: JSValue) -> i32 {
+    if jv.is_int32() {
+        jv.as_int32()
+    } else {
+        jv.as_number() as i32
+    }
+}
+
+/// Node's `Received …` clause for an `ERR_INVALID_ARG_TYPE` message.
+fn describe_received(value: f64) -> String {
+    let jv = JSValue::from_bits(value.to_bits());
+    if jv.is_undefined() {
+        return "undefined".to_string();
+    }
+    if jv.is_null() {
+        return "null".to_string();
+    }
+    if jv.is_bool() {
+        return format!("type boolean ({})", jv.as_bool());
+    }
+    if is_numeric(jv) {
+        let n = if jv.is_int32() {
+            jv.as_int32() as f64
+        } else {
+            jv.as_number()
+        };
+        if n.fract() == 0.0 && n.is_finite() {
+            return format!("type number ({})", n as i64);
+        }
+        return format!("type number ({})", n);
+    }
+    if jv.is_pointer() {
+        let ptr = jv.as_pointer::<u8>();
+        if !ptr.is_null() && (ptr as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+            let gc_header =
+                unsafe { &*(ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader) };
+            if gc_header.obj_type == crate::gc::GC_TYPE_ARRAY {
+                return "an instance of Array".to_string();
+            }
+        }
+        return "an instance of Object".to_string();
+    }
+    "an unsupported value".to_string()
+}
+
+/// Throw `TypeError [ERR_INVALID_ARG_TYPE]` for a bad path argument, matching
+/// Node's message shape. Diverges via `js_throw`.
+pub(crate) fn throw_invalid_path_arg(arg_name: &str, value: f64) -> ! {
+    let message = format!(
+        "The \"{}\" argument must be of type string or an instance of Buffer or URL. Received {}",
+        arg_name,
+        describe_received(value)
+    );
+    throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+/// Throw `Error [EBADF]` for a numeric fd that is not an open descriptor.
+fn throw_ebadf(syscall: &'static str) -> ! {
+    let message = format!("EBADF: bad file descriptor, {}", syscall);
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    crate::node_submodules::register_error_code_pub(msg, "EBADF");
+    crate::node_submodules::register_error_syscall(msg, syscall);
+    let err = crate::error::js_error_new_with_message(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+fn throw_type_error_with_code(message: &str, code: &'static str) -> ! {
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    crate::node_submodules::register_error_code_pub(msg, code);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+/// Validate the first argument of a path-only `fs` sync function (one that
+/// does NOT accept a file descriptor — `accessSync`, `statSync`, `mkdirSync`,
+/// `readdirSync`, `unlinkSync`, …). Throws `ERR_INVALID_ARG_TYPE` on any
+/// non path-like value (including numbers). No-op when the value is valid.
+pub(crate) fn validate_path(arg_name: &str, value: f64) {
+    if !is_path_like(value) {
+        throw_invalid_path_arg(arg_name, value);
+    }
+}
+
+/// Validate the first argument of an fd-accepting reader/writer
+/// (`readFileSync`, `writeFileSync`). A path-like value is accepted as-is; a
+/// numeric value is treated as a file descriptor and, if it is not open,
+/// throws `EBADF` (matching `fs.readFileSync(123)`); anything else throws
+/// `ERR_INVALID_ARG_TYPE`. `syscall` names the operation for the EBADF error.
+pub(crate) fn validate_path_or_fd(arg_name: &str, value: f64, syscall: &'static str) {
+    if is_path_like(value) {
+        return;
+    }
+    let jv = JSValue::from_bits(value.to_bits());
+    if is_numeric(jv) {
+        // A numeric first argument is a file descriptor. Perry's readers and
+        // writers already serve a *registered* fd (`numeric_fd_value` +
+        // `FD_REGISTRY`); the validation contract here is only to reject an
+        // unknown/closed fd with `EBADF` (e.g. `fs.readFileSync(123)`).
+        if !crate::fs::fd_is_registered(numeric_to_i32(jv)) {
+            throw_ebadf(syscall);
+        }
+        return;
+    }
+    throw_invalid_path_arg(arg_name, value);
+}

--- a/crates/perry-runtime/src/node_submodules/diagnostics.rs
+++ b/crates/perry-runtime/src/node_submodules/diagnostics.rs
@@ -392,6 +392,86 @@ pub fn error_path_for_message(message_ptr: *const StringHeader) -> Option<String
     ERROR_MESSAGE_PATHS.with(|m| m.borrow().get(&(message_ptr as usize)).cloned())
 }
 
+/// A user-assigned own property value on an `Error` object. String values are
+/// stored as an owned `String` (GC-safe — reconstructed into a fresh
+/// `StringHeader` on read, exactly like [`ERROR_MESSAGE_PATHS`]); everything
+/// else is stored as raw NaN-box bits. Immediates (number/bool/null/undefined)
+/// carry no live heap reference so this is fully safe for the common cases
+/// (`err.code = "X"`, `err.errno = -2`). Heap-object-valued props are stored
+/// by bits as a best-effort and may not survive a GC move of the referent;
+/// errors rarely carry object-valued own properties.
+#[derive(Clone)]
+pub enum ErrUserProp {
+    Str(String),
+    Bits(u64),
+}
+
+thread_local! {
+    /// User-assigned own properties on `Error` objects, keyed by the error
+    /// object pointer.
+    ///
+    /// `ErrorHeader` is a fixed `#[repr(C)]` struct with no overflow-field
+    /// region, so a plain `err.foo = bar` had nowhere to land: the object
+    /// setter dropped it and the getter returned `undefined`. That broke
+    /// Node parity — e.g. `assert.throws(fn, { code })` could not read a
+    /// user-assigned `.code` (#2014). This side table gives errors arbitrary
+    /// string/primitive own properties. Stale entries after a GC move of the
+    /// error are harmless (same model as the message-keyed tables above): a
+    /// lookup at the new address simply misses.
+    pub(crate) static ERROR_USER_PROPS: RefCell<HashMap<usize, HashMap<String, ErrUserProp>>> =
+        RefCell::new(HashMap::new());
+}
+
+unsafe fn error_user_prop_string(value: f64) -> String {
+    let ptr = crate::value::js_jsvalue_to_string(value);
+    if ptr.is_null() {
+        return String::new();
+    }
+    let len = (*ptr).byte_len as usize;
+    let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+    String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned()
+}
+
+/// Record a user-assigned own property on an `Error` object. `error_ptr` is
+/// the `ErrorHeader` pointer (the NaN-box pointer payload). Called from the
+/// `GC_TYPE_ERROR` branch of `js_object_set_field_by_name`.
+pub fn set_error_user_prop(error_ptr: usize, key: &str, value: f64) {
+    if error_ptr == 0 {
+        return;
+    }
+    let stored = if JSValue::from_bits(value.to_bits()).is_any_string() {
+        ErrUserProp::Str(unsafe { error_user_prop_string(value) })
+    } else {
+        ErrUserProp::Bits(value.to_bits())
+    };
+    ERROR_USER_PROPS.with(|m| {
+        m.borrow_mut()
+            .entry(error_ptr)
+            .or_default()
+            .insert(key.to_string(), stored);
+    });
+}
+
+/// Look up a user-assigned own property on an `Error` object, materialising it
+/// back into a NaN-boxed `f64`. Returns `None` if no such property was set.
+/// Called from the `GC_TYPE_ERROR` branch of `js_object_get_field_by_name`.
+pub fn error_user_prop(error_ptr: usize, key: &str) -> Option<f64> {
+    if error_ptr == 0 {
+        return None;
+    }
+    ERROR_USER_PROPS.with(|m| {
+        m.borrow().get(&error_ptr).and_then(|props| {
+            props.get(key).map(|v| match v {
+                ErrUserProp::Str(s) => {
+                    let ptr = js_string_from_bytes(s.as_ptr(), s.len() as u32);
+                    f64::from_bits(crate::js_nanbox_string(ptr as i64).to_bits())
+                }
+                ErrUserProp::Bits(b) => f64::from_bits(*b),
+            })
+        })
+    })
+}
+
 pub(crate) fn throw_invalid_arg() -> ! {
     let msg = b"The argument is invalid";
     let s = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);

--- a/crates/perry-runtime/src/object/assert.rs
+++ b/crates/perry-runtime/src/object/assert.rs
@@ -104,9 +104,10 @@ fn object_matcher_matches(actual: f64, expected: f64) -> bool {
         }
         saw_expected_key = true;
         let actual_prop = read_property(actual, key);
-        if is_null_or_undefined(actual_prop) && matches!(key, "code" | "errno") {
-            continue;
-        }
+        // Node compares every key the validator object specifies: if it
+        // names `code`/`errno`/`name`/`message`, the thrown error must carry
+        // an equal value. A missing or mismatching value on the thrown error
+        // is a mismatch (#2014) — there is no "optional code" carve-out.
         if !assert_same_value(actual_prop, expected_prop)
             && crate::value::js_jsvalue_loose_equals(actual_prop, expected_prop) == 0
         {
@@ -174,13 +175,20 @@ fn expected_error_matches(thrown: f64, expected: f64) -> bool {
             return true;
         }
     }
+    // A plain object validator (e.g. `{ code: "ERR_X" }`) is a property-bag
+    // matcher, never a constructor — its own enumerable keys must each equal
+    // the thrown error's. Do NOT fall through to the instanceof /
+    // builtin-constructor checks below: those can spuriously accept *any*
+    // error (e.g. `js_instanceof_dynamic` against a plain object, or a
+    // validator carrying `name: "Error"`) and would mask a wrong `code`
+    // (#2014).
+    if is_plain_matcher_object(expected) {
+        return object_matcher_matches(thrown, expected);
+    }
     if crate::value::js_is_truthy(crate::object::js_instanceof_dynamic(thrown, expected)) != 0 {
         return true;
     }
-    if constructor_name_matches_builtin_error(thrown, expected) {
-        return true;
-    }
-    object_matcher_matches(thrown, expected)
+    constructor_name_matches_builtin_error(thrown, expected)
 }
 
 fn call_block_capturing_throw(block: f64) -> Result<f64, f64> {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1429,6 +1429,17 @@ pub extern "C" fn js_object_get_field_by_name(
                 let key_len = (*key).byte_len as usize;
                 let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
                 let err_ptr = obj as *mut crate::error::ErrorHeader;
+                // User-assigned own properties (`err.code = "X"`,
+                // `err.errno = -2`, custom fields) take precedence over the
+                // built-in accessors below — they were recorded in the
+                // per-error side table by the setter (#2014).
+                if let Ok(key_str) = std::str::from_utf8(key_bytes) {
+                    if let Some(v) =
+                        crate::node_submodules::error_user_prop(err_ptr as usize, key_str)
+                    {
+                        return JSValue::from_bits(v.to_bits());
+                    }
+                }
                 match key_bytes {
                     b"message" => {
                         let s = crate::error::js_error_get_message(err_ptr);

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -260,6 +260,26 @@ pub extern "C" fn js_object_set_field_by_name(
         let gc_header =
             (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
         let gc_type = (*gc_header).obj_type;
+        // Error objects have a fixed `#[repr(C)]` layout with no field-storage
+        // region (`message`/`name`/`stack`/`cause`/`errors` are dedicated
+        // slots), so a user assignment like `err.code = "X"` or
+        // `err.errno = -2` has nowhere to land in the header. Route it to the
+        // per-error user-property side table so the matching getter — and
+        // `assert.throws(fn, { code })` (#2014) — can read it back. The getter
+        // checks this table first, so this also lets a user override the
+        // built-in message/name accessors, matching Node.
+        if gc_type == crate::gc::GC_TYPE_ERROR {
+            if !key.is_null() {
+                let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                let name_len = (*key).byte_len as usize;
+                if let Ok(name_str) =
+                    std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len))
+                {
+                    crate::node_submodules::set_error_user_prop(obj as usize, name_str, value);
+                }
+            }
+            return;
+        }
         if gc_type != crate::gc::GC_TYPE_OBJECT && gc_type != crate::gc::GC_TYPE_CLOSURE {
             if !is_valid_obj_ptr(obj as *const u8) {
                 return;


### PR DESCRIPTION
## Summary

Addresses the cross-cutting Node error-validation parity theme surfaced by the #800 sweep after #1924 fixed `assert.throws`. Two coupled issues:

- **#2014** — `assert.throws(fn, validator)` accepted a wrong-`code` error as a pass.
- **#2013** — `fs` APIs returned sentinels instead of throwing Node's `ERR_INVALID_ARG_TYPE` / `EBADF` on bad input.

They're handled together because verifying #2013 honestly requires #2014's matcher to actually compare error codes.

## #2014 — `assert.throws` object validator

- **Error objects now hold user-assigned own properties.** `ErrorHeader` is a fixed `#[repr(C)]` struct with no field-storage region, so `err.code = "X"` / `err.errno = -2` / custom fields were silently dropped and read back as `undefined`. A per-error side table (keyed by the error pointer, owned-`String` for string values / raw bits for immediates — GC-safe) now backs these; the object setter routes `GC_TYPE_ERROR` sets to it, and the `.code`/`.name`/… getters check it first (so a user override also works).
- **`object_matcher_matches`**: dropped the over-lenient carve-out that treated a *missing* actual `code`/`errno` as a match — a wrong/absent code is now a mismatch, matching Node.
- **`expected_error_matches`**: a plain object validator (`{ code: … }`) now matches *only* via its own keys; it no longer falls through to the `instanceof` / builtin-constructor checks that could spuriously accept any error.

```ts
const e: any = new Error("x"); e.code = "ERR_A";
assert.throws(() => { throw e; }, { code: "ERR_B" });  // before: passed (bug) — now: throws ✓
```

## #2013 — `fs` argument validation

New reusable `fs::validate` module:

- `validate_path` (path-only functions) → `ERR_INVALID_ARG_TYPE` (TypeError) on any non path-like input (string / Buffer / `file:` URL are accepted).
- `validate_path_or_fd` (`readFileSync` / `writeFileSync`) → treats a number as a file descriptor and throws `EBADF` for an unregistered/closed fd, otherwise `ERR_INVALID_ARG_TYPE`. fd validity is checked against Perry's synthetic `FD_REGISTRY` (fds start at 100), **not** the OS — an early `fcntl`-based version wrongly rejected valid Perry fds and broke the fd read/write tests; fixed.

Wired into `accessSync`, `statSync`, `lstatSync`, `readdirSync`, `mkdirSync`, `unlinkSync`, `rmdirSync`, `readlinkSync`, `openSync`, `readFileSync`, `writeFileSync`.

```ts
fs.readFileSync(123 as any);  // before: returned ""    — now: throws EBADF ✓
fs.accessSync(true as any);   // before: code=undefined — now: ERR_INVALID_ARG_TYPE ✓
```

## Verification

- Byte-identical to Node v25 across the full fs validation matrix (path-only → `ERR_INVALID_ARG_TYPE`; `readFile`/`writeFile` number → `EBADF`, other bad types → `ERR_INVALID_ARG_TYPE`) and the `assert.throws` repro/positive/negative cases.
- No regressions in the `fs` or `assert` node-suites. Remaining failures are pre-existing and unrelated to this change: `assert.rejects` is unimplemented; `deepStrictEqual` Map/Set/cause gaps; `CallTracker` (removed in Node 20); `cp` symlink-deref; `rmdirSync({recursive})` removal error.
- `cargo fmt --all -- --check` clean.

## Follow-ups (not in scope here)

- The same `validate_path` helper extends naturally to the remaining `fs` functions and the other APIs in #2013 (buffer / net / http / zlib / crypto / process).
- `assert.rejects` / `assert.doesNotReject` (async) is still unimplemented — would flip the 3 `rejects` node-suite tests; worth its own issue.
