### PR TITLE
Fix native Canvas command buffer replay

### DIFF
--- a/crates/perry-ui-android/src/widgets/canvas.rs
+++ b/crates/perry-ui-android/src/widgets/canvas.rs
@@ -21,12 +21,22 @@ struct CanvasState {
     height: i32,
     density: f32,
     cmds: Vec<DrawCmd>,
+    last_cmds: Vec<DrawCmd>,
 }
 
 // Global (not thread-local) because canvas is created on the perry-native thread
 // but drawing commands arrive from the UI thread via setInterval callbacks.
 static CANVAS_STATES: LazyLock<Mutex<HashMap<i64, CanvasState>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn command_batch_renders(commands: &[DrawCmd]) -> bool {
+    commands.iter().any(|cmd| {
+        matches!(
+            cmd,
+            DrawCmd::Clear | DrawCmd::Stroke(..) | DrawCmd::FillGradient(..)
+        )
+    })
+}
 
 pub fn create(width: f64, height: f64) -> i64 {
     let mut env = jni_bridge::get_env();
@@ -123,6 +133,7 @@ pub fn create(width: f64, height: f64) -> i64 {
             height: h,
             density,
             cmds: Vec::new(),
+            last_cmds: Vec::new(),
         },
     );
 
@@ -168,10 +179,17 @@ fn create_and_set_bitmap(env: &mut jni::JNIEnv, image_view: &JObject, w: i32, h:
 
 fn repaint(handle: i64) {
     let cmds = {
-        let states = CANVAS_STATES.lock().unwrap();
-        states
-            .get(&handle)
-            .map(|st| (st.width, st.height, st.cmds.clone()))
+        let mut states = CANVAS_STATES.lock().unwrap();
+        states.get_mut(&handle).map(|st| {
+            let cmds = if st.cmds.is_empty() || !command_batch_renders(&st.cmds) {
+                st.last_cmds.clone()
+            } else {
+                let cmds = std::mem::take(&mut st.cmds);
+                st.last_cmds = cmds.clone();
+                cmds
+            };
+            (st.width, st.height, cmds)
+        })
     };
 
     if let Some((w, h, cmds)) = cmds {
@@ -428,6 +446,7 @@ pub fn clear(handle: i64) {
         let mut states = CANVAS_STATES.lock().unwrap();
         if let Some(state) = states.get_mut(&handle) {
             state.cmds.clear();
+            state.last_cmds.clear();
             state.cmds.push(DrawCmd::Clear);
         }
     }

--- a/crates/perry-ui-gtk4/src/widgets/canvas.rs
+++ b/crates/perry-ui-gtk4/src/widgets/canvas.rs
@@ -37,9 +37,20 @@ enum DrawCommand {
     },
 }
 
+fn command_batch_renders(commands: &[DrawCommand]) -> bool {
+    commands.iter().any(|cmd| {
+        matches!(
+            cmd,
+            DrawCommand::Stroke { .. } | DrawCommand::FillGradient { .. }
+        )
+    })
+}
+
 thread_local! {
-    /// Canvas command buffers, keyed by widget handle
+    /// Pending canvas commands, keyed by widget handle
     static CANVAS_COMMANDS: RefCell<HashMap<i64, Vec<DrawCommand>>> = RefCell::new(HashMap::new());
+    /// Last rendered command batch, used for native repaints that arrive before new commands.
+    static CANVAS_LAST_FRAME: RefCell<HashMap<i64, Vec<DrawCommand>>> = RefCell::new(HashMap::new());
     /// Canvas sizes (width, height), keyed by widget handle
     static CANVAS_SIZES: RefCell<HashMap<i64, (f64, f64)>> = RefCell::new(HashMap::new());
 }
@@ -57,6 +68,9 @@ pub fn create(width: f64, height: f64) -> i64 {
     CANVAS_COMMANDS.with(|cmds| {
         cmds.borrow_mut().insert(handle, Vec::new());
     });
+    CANVAS_LAST_FRAME.with(|last| {
+        last.borrow_mut().insert(handle, Vec::new());
+    });
     CANVAS_SIZES.with(|s| {
         s.borrow_mut().insert(handle, (width, height));
     });
@@ -66,95 +80,109 @@ pub fn create(width: f64, height: f64) -> i64 {
         let (canvas_w, canvas_h) =
             CANVAS_SIZES.with(|s| s.borrow().get(&handle).copied().unwrap_or((0.0, 0.0)));
 
-        CANVAS_COMMANDS.with(|cmds| {
-            let cmds = cmds.borrow();
-            if let Some(commands) = cmds.get(&handle) {
-                // Track current path points for gradient fill
-                let mut path_points: Vec<(f64, f64)> = Vec::new();
+        let commands = CANVAS_COMMANDS
+            .with(|cmds| {
+                let mut cmds = cmds.borrow_mut();
+                cmds.get_mut(&handle).and_then(|pending| {
+                    if pending.is_empty() || !command_batch_renders(pending) {
+                        None
+                    } else {
+                        let commands = std::mem::take(pending);
+                        CANVAS_LAST_FRAME.with(|last| {
+                            last.borrow_mut().insert(handle, commands.clone());
+                        });
+                        Some(commands)
+                    }
+                })
+            })
+            .or_else(|| CANVAS_LAST_FRAME.with(|last| last.borrow().get(&handle).cloned()));
 
-                for cmd in commands.iter() {
-                    match cmd {
-                        DrawCommand::BeginPath => {
-                            path_points.clear();
-                        }
-                        DrawCommand::MoveTo(x, y) => {
-                            // GTK4/Cairo origin is top-left — same as TypeScript expects.
-                            // No Y-flip needed (unlike macOS which is bottom-left).
-                            path_points.push((*x, *y));
-                        }
-                        DrawCommand::LineTo(x, y) => {
-                            path_points.push((*x, *y));
-                        }
-                        DrawCommand::Stroke {
-                            r,
-                            g,
-                            b,
-                            a,
-                            line_width,
-                        } => {
-                            if path_points.len() >= 2 {
-                                cr.save().ok();
-                                cr.set_source_rgba(*r, *g, *b, *a);
-                                cr.set_line_width(*line_width);
-                                cr.set_line_cap(gtk4::cairo::LineCap::Round);
-                                cr.set_line_join(gtk4::cairo::LineJoin::Round);
-                                cr.new_path();
-                                cr.move_to(path_points[0].0, path_points[0].1);
-                                for pt in &path_points[1..] {
-                                    cr.line_to(pt.0, pt.1);
-                                }
-                                cr.stroke().ok();
-                                cr.restore().ok();
+        if let Some(commands) = commands {
+            // Track current path points for gradient fill
+            let mut path_points: Vec<(f64, f64)> = Vec::new();
+
+            for cmd in commands.iter() {
+                match cmd {
+                    DrawCommand::BeginPath => {
+                        path_points.clear();
+                    }
+                    DrawCommand::MoveTo(x, y) => {
+                        // GTK4/Cairo origin is top-left — same as TypeScript expects.
+                        // No Y-flip needed (unlike macOS which is bottom-left).
+                        path_points.push((*x, *y));
+                    }
+                    DrawCommand::LineTo(x, y) => {
+                        path_points.push((*x, *y));
+                    }
+                    DrawCommand::Stroke {
+                        r,
+                        g,
+                        b,
+                        a,
+                        line_width,
+                    } => {
+                        if path_points.len() >= 2 {
+                            cr.save().ok();
+                            cr.set_source_rgba(*r, *g, *b, *a);
+                            cr.set_line_width(*line_width);
+                            cr.set_line_cap(gtk4::cairo::LineCap::Round);
+                            cr.set_line_join(gtk4::cairo::LineJoin::Round);
+                            cr.new_path();
+                            cr.move_to(path_points[0].0, path_points[0].1);
+                            for pt in &path_points[1..] {
+                                cr.line_to(pt.0, pt.1);
                             }
+                            cr.stroke().ok();
+                            cr.restore().ok();
                         }
-                        DrawCommand::FillGradient {
-                            r1,
-                            g1,
-                            b1,
-                            a1,
-                            r2,
-                            g2,
-                            b2,
-                            a2,
-                            direction,
-                        } => {
-                            if path_points.len() >= 2 {
-                                cr.save().ok();
+                    }
+                    DrawCommand::FillGradient {
+                        r1,
+                        g1,
+                        b1,
+                        a1,
+                        r2,
+                        g2,
+                        b2,
+                        a2,
+                        direction,
+                    } => {
+                        if path_points.len() >= 2 {
+                            cr.save().ok();
 
-                                // Build closed path for clipping — area under/beside the line
-                                cr.new_path();
-                                cr.move_to(path_points[0].0, path_points[0].1);
-                                for pt in &path_points[1..] {
-                                    cr.line_to(pt.0, pt.1);
-                                }
-                                // Close to bottom edge (top-left origin, so canvas_h is bottom)
-                                let last_x = path_points[path_points.len() - 1].0;
-                                let first_x = path_points[0].0;
-                                cr.line_to(last_x, canvas_h);
-                                cr.line_to(first_x, canvas_h);
-                                cr.close_path();
-                                cr.clip();
-
-                                // Draw linear gradient
-                                let gradient = if *direction < 0.5 {
-                                    // Vertical: top to bottom
-                                    gtk4::cairo::LinearGradient::new(0.0, 0.0, 0.0, canvas_h)
-                                } else {
-                                    // Horizontal: left to right
-                                    gtk4::cairo::LinearGradient::new(0.0, 0.0, canvas_w, 0.0)
-                                };
-                                gradient.add_color_stop_rgba(0.0, *r1, *g1, *b1, *a1);
-                                gradient.add_color_stop_rgba(1.0, *r2, *g2, *b2, *a2);
-                                cr.set_source(&gradient).ok();
-                                cr.paint().ok();
-
-                                cr.restore().ok();
+                            // Build closed path for clipping — area under/beside the line
+                            cr.new_path();
+                            cr.move_to(path_points[0].0, path_points[0].1);
+                            for pt in &path_points[1..] {
+                                cr.line_to(pt.0, pt.1);
                             }
+                            // Close to bottom edge (top-left origin, so canvas_h is bottom)
+                            let last_x = path_points[path_points.len() - 1].0;
+                            let first_x = path_points[0].0;
+                            cr.line_to(last_x, canvas_h);
+                            cr.line_to(first_x, canvas_h);
+                            cr.close_path();
+                            cr.clip();
+
+                            // Draw linear gradient
+                            let gradient = if *direction < 0.5 {
+                                // Vertical: top to bottom
+                                gtk4::cairo::LinearGradient::new(0.0, 0.0, 0.0, canvas_h)
+                            } else {
+                                // Horizontal: left to right
+                                gtk4::cairo::LinearGradient::new(0.0, 0.0, canvas_w, 0.0)
+                            };
+                            gradient.add_color_stop_rgba(0.0, *r1, *g1, *b1, *a1);
+                            gradient.add_color_stop_rgba(1.0, *r2, *g2, *b2, *a2);
+                            cr.set_source(&gradient).ok();
+                            cr.paint().ok();
+
+                            cr.restore().ok();
                         }
                     }
                 }
             }
-        });
+        }
     });
 
     handle
@@ -164,6 +192,11 @@ pub fn create(width: f64, height: f64) -> i64 {
 pub fn clear(handle: i64) {
     CANVAS_COMMANDS.with(|cmds| {
         if let Some(commands) = cmds.borrow_mut().get_mut(&handle) {
+            commands.clear();
+        }
+    });
+    CANVAS_LAST_FRAME.with(|last| {
+        if let Some(commands) = last.borrow_mut().get_mut(&handle) {
             commands.clear();
         }
     });

--- a/crates/perry-ui-ios/src/widgets/canvas.rs
+++ b/crates/perry-ui-ios/src/widgets/canvas.rs
@@ -114,9 +114,25 @@ enum DrawCommand {
     },
 }
 
+fn command_batch_renders(commands: &[DrawCommand]) -> bool {
+    commands.iter().any(|cmd| {
+        matches!(
+            cmd,
+            DrawCommand::Stroke { .. }
+                | DrawCommand::FillGradient { .. }
+                | DrawCommand::StrokePath
+                | DrawCommand::FillPath
+                | DrawCommand::FillRect { .. }
+                | DrawCommand::StrokeRect { .. }
+        )
+    })
+}
+
 thread_local! {
-    /// Canvas command buffers, keyed by view address
+    /// Pending canvas commands, keyed by view address.
     static CANVAS_COMMANDS: RefCell<HashMap<usize, Vec<DrawCommand>>> = RefCell::new(HashMap::new());
+    /// Last rendered command batch, used for native repaints that arrive before new commands.
+    static CANVAS_LAST_FRAME: RefCell<HashMap<usize, Vec<DrawCommand>>> = RefCell::new(HashMap::new());
     /// Canvas sizes (width, height), keyed by view address
     static CANVAS_SIZES: RefCell<HashMap<usize, (f64, f64)>> = RefCell::new(HashMap::new());
 }
@@ -146,10 +162,28 @@ define_class!(
                 s.borrow().get(&key).copied().unwrap_or((0.0, 0.0))
             });
 
-            // Replay command buffer
-            CANVAS_COMMANDS.with(|cmds| {
-                let cmds = cmds.borrow();
-                if let Some(commands) = cmds.get(&key) {
+            // Drain pending commands for this paint. Canvas calls between paints
+            // form a single frame, so frame-loop apps don't replay every historical
+            // command. Keep only the last rendered batch for native repaint events
+            // that arrive before the app submits new canvas commands.
+            let commands = CANVAS_COMMANDS
+                .with(|cmds| {
+                    let mut cmds = cmds.borrow_mut();
+                    cmds.get_mut(&key).and_then(|pending| {
+                        if pending.is_empty() || !command_batch_renders(pending) {
+                            None
+                        } else {
+                            let commands = std::mem::take(pending);
+                            CANVAS_LAST_FRAME.with(|last| {
+                                last.borrow_mut().insert(key, commands.clone());
+                            });
+                            Some(commands)
+                        }
+                    })
+                })
+                .or_else(|| CANVAS_LAST_FRAME.with(|last| last.borrow().get(&key).cloned()));
+
+            if let Some(commands) = commands {
                     // Track current path points for gradient fill
                     let mut path_points: Vec<(f64, f64)> = Vec::new();
                     let mut in_path = false;
@@ -312,8 +346,7 @@ define_class!(
                         }
                     }
                 }
-            });
-        }
+            }
     }
 );
 
@@ -364,6 +397,9 @@ pub fn create(width: f64, height: f64) -> i64 {
     CANVAS_COMMANDS.with(|cmds| {
         cmds.borrow_mut().insert(key, Vec::new());
     });
+    CANVAS_LAST_FRAME.with(|last| {
+        last.borrow_mut().insert(key, Vec::new());
+    });
     CANVAS_SIZES.with(|s| {
         s.borrow_mut().insert(key, (width, height));
     });
@@ -382,6 +418,11 @@ pub fn clear(handle: i64) {
     if let Some(key) = get_canvas_key(handle) {
         CANVAS_COMMANDS.with(|cmds| {
             if let Some(commands) = cmds.borrow_mut().get_mut(&key) {
+                commands.clear();
+            }
+        });
+        CANVAS_LAST_FRAME.with(|last| {
+            if let Some(commands) = last.borrow_mut().get_mut(&key) {
                 commands.clear();
             }
         });

--- a/crates/perry-ui-macos/src/widgets/canvas.rs
+++ b/crates/perry-ui-macos/src/widgets/canvas.rs
@@ -115,9 +115,25 @@ enum DrawCommand {
     },
 }
 
+fn command_batch_renders(commands: &[DrawCommand]) -> bool {
+    commands.iter().any(|cmd| {
+        matches!(
+            cmd,
+            DrawCommand::Stroke { .. }
+                | DrawCommand::FillGradient { .. }
+                | DrawCommand::StrokePath
+                | DrawCommand::FillPath
+                | DrawCommand::FillRect { .. }
+                | DrawCommand::StrokeRect { .. }
+        )
+    })
+}
+
 thread_local! {
-    /// Canvas command buffers, keyed by view address
+    /// Pending canvas commands, keyed by view address.
     static CANVAS_COMMANDS: RefCell<HashMap<usize, Vec<DrawCommand>>> = RefCell::new(HashMap::new());
+    /// Last rendered command batch, used for native repaints that arrive before new commands.
+    static CANVAS_LAST_FRAME: RefCell<HashMap<usize, Vec<DrawCommand>>> = RefCell::new(HashMap::new());
     /// Canvas sizes (width, height), keyed by view address
     static CANVAS_SIZES: RefCell<HashMap<usize, (f64, f64)>> = RefCell::new(HashMap::new());
 }
@@ -154,10 +170,28 @@ define_class!(
                 s.borrow().get(&key).copied().unwrap_or((0.0, 0.0))
             });
 
-            // Replay command buffer
-            CANVAS_COMMANDS.with(|cmds| {
-                let cmds = cmds.borrow();
-                if let Some(commands) = cmds.get(&key) {
+            // Drain pending commands for this paint. Canvas calls between paints
+            // form a single frame, so frame-loop apps don't replay every historical
+            // command. Keep only the last rendered batch for native repaint events
+            // that arrive before the app submits new canvas commands.
+            let commands = CANVAS_COMMANDS
+                .with(|cmds| {
+                    let mut cmds = cmds.borrow_mut();
+                    cmds.get_mut(&key).and_then(|pending| {
+                        if pending.is_empty() || !command_batch_renders(pending) {
+                            None
+                        } else {
+                            let commands = std::mem::take(pending);
+                            CANVAS_LAST_FRAME.with(|last| {
+                                last.borrow_mut().insert(key, commands.clone());
+                            });
+                            Some(commands)
+                        }
+                    })
+                })
+                .or_else(|| CANVAS_LAST_FRAME.with(|last| last.borrow().get(&key).cloned()));
+
+            if let Some(commands) = commands {
                     // Track current path points for gradient fill.
                     // #854: an `in_path: bool` companion used to live here
                     // but was only ever written, never read. Removed.
@@ -321,8 +355,7 @@ define_class!(
                         }
                     }
                 }
-            });
-        }
+            }
 
         #[unsafe(method(isFlipped))]
         fn is_flipped(&self) -> bool {
@@ -374,6 +407,9 @@ pub fn create(width: f64, height: f64) -> i64 {
     CANVAS_COMMANDS.with(|cmds| {
         cmds.borrow_mut().insert(key, Vec::new());
     });
+    CANVAS_LAST_FRAME.with(|last| {
+        last.borrow_mut().insert(key, Vec::new());
+    });
     CANVAS_SIZES.with(|s| {
         s.borrow_mut().insert(key, (width, height));
     });
@@ -392,6 +428,11 @@ pub fn clear(handle: i64) {
     if let Some(key) = get_canvas_key(handle) {
         CANVAS_COMMANDS.with(|cmds| {
             if let Some(commands) = cmds.borrow_mut().get_mut(&key) {
+                commands.clear();
+            }
+        });
+        CANVAS_LAST_FRAME.with(|last| {
+            if let Some(commands) = last.borrow_mut().get_mut(&key) {
                 commands.clear();
             }
         });

--- a/crates/perry-ui-tvos/src/widgets/canvas.rs
+++ b/crates/perry-ui-tvos/src/widgets/canvas.rs
@@ -80,9 +80,20 @@ enum DrawCommand {
     },
 }
 
+fn command_batch_renders(commands: &[DrawCommand]) -> bool {
+    commands.iter().any(|cmd| {
+        matches!(
+            cmd,
+            DrawCommand::Stroke { .. } | DrawCommand::FillGradient { .. }
+        )
+    })
+}
+
 thread_local! {
-    /// Canvas command buffers, keyed by view address
+    /// Pending canvas commands, keyed by view address.
     static CANVAS_COMMANDS: RefCell<HashMap<usize, Vec<DrawCommand>>> = RefCell::new(HashMap::new());
+    /// Last rendered command batch, used for native repaints that arrive before new commands.
+    static CANVAS_LAST_FRAME: RefCell<HashMap<usize, Vec<DrawCommand>>> = RefCell::new(HashMap::new());
     /// Canvas sizes (width, height), keyed by view address
     static CANVAS_SIZES: RefCell<HashMap<usize, (f64, f64)>> = RefCell::new(HashMap::new());
 }
@@ -112,10 +123,28 @@ define_class!(
                 s.borrow().get(&key).copied().unwrap_or((0.0, 0.0))
             });
 
-            // Replay command buffer
-            CANVAS_COMMANDS.with(|cmds| {
-                let cmds = cmds.borrow();
-                if let Some(commands) = cmds.get(&key) {
+            // Drain pending commands for this paint. Canvas calls between paints
+            // form a single frame, so frame-loop apps don't replay every historical
+            // command. Keep only the last rendered batch for native repaint events
+            // that arrive before the app submits new canvas commands.
+            let commands = CANVAS_COMMANDS
+                .with(|cmds| {
+                    let mut cmds = cmds.borrow_mut();
+                    cmds.get_mut(&key).and_then(|pending| {
+                        if pending.is_empty() || !command_batch_renders(pending) {
+                            None
+                        } else {
+                            let commands = std::mem::take(pending);
+                            CANVAS_LAST_FRAME.with(|last| {
+                                last.borrow_mut().insert(key, commands.clone());
+                            });
+                            Some(commands)
+                        }
+                    })
+                })
+                .or_else(|| CANVAS_LAST_FRAME.with(|last| last.borrow().get(&key).cloned()));
+
+            if let Some(commands) = commands {
                     // Track current path points for gradient fill
                     let mut path_points: Vec<(f64, f64)> = Vec::new();
                     let mut in_path = false;
@@ -204,8 +233,7 @@ define_class!(
                         }
                     }
                 }
-            });
-        }
+            }
     }
 );
 
@@ -256,6 +284,9 @@ pub fn create(width: f64, height: f64) -> i64 {
     CANVAS_COMMANDS.with(|cmds| {
         cmds.borrow_mut().insert(key, Vec::new());
     });
+    CANVAS_LAST_FRAME.with(|last| {
+        last.borrow_mut().insert(key, Vec::new());
+    });
     CANVAS_SIZES.with(|s| {
         s.borrow_mut().insert(key, (width, height));
     });
@@ -274,6 +305,11 @@ pub fn clear(handle: i64) {
     if let Some(key) = get_canvas_key(handle) {
         CANVAS_COMMANDS.with(|cmds| {
             if let Some(commands) = cmds.borrow_mut().get_mut(&key) {
+                commands.clear();
+            }
+        });
+        CANVAS_LAST_FRAME.with(|last| {
+            if let Some(commands) = last.borrow_mut().get_mut(&key) {
                 commands.clear();
             }
         });

--- a/crates/perry-ui-visionos/src/widgets/canvas.rs
+++ b/crates/perry-ui-visionos/src/widgets/canvas.rs
@@ -80,9 +80,20 @@ enum DrawCommand {
     },
 }
 
+fn command_batch_renders(commands: &[DrawCommand]) -> bool {
+    commands.iter().any(|cmd| {
+        matches!(
+            cmd,
+            DrawCommand::Stroke { .. } | DrawCommand::FillGradient { .. }
+        )
+    })
+}
+
 thread_local! {
-    /// Canvas command buffers, keyed by view address
+    /// Pending canvas commands, keyed by view address.
     static CANVAS_COMMANDS: RefCell<HashMap<usize, Vec<DrawCommand>>> = RefCell::new(HashMap::new());
+    /// Last rendered command batch, used for native repaints that arrive before new commands.
+    static CANVAS_LAST_FRAME: RefCell<HashMap<usize, Vec<DrawCommand>>> = RefCell::new(HashMap::new());
     /// Canvas sizes (width, height), keyed by view address
     static CANVAS_SIZES: RefCell<HashMap<usize, (f64, f64)>> = RefCell::new(HashMap::new());
 }
@@ -112,10 +123,28 @@ define_class!(
                 s.borrow().get(&key).copied().unwrap_or((0.0, 0.0))
             });
 
-            // Replay command buffer
-            CANVAS_COMMANDS.with(|cmds| {
-                let cmds = cmds.borrow();
-                if let Some(commands) = cmds.get(&key) {
+            // Drain pending commands for this paint. Canvas calls between paints
+            // form a single frame, so frame-loop apps don't replay every historical
+            // command. Keep only the last rendered batch for native repaint events
+            // that arrive before the app submits new canvas commands.
+            let commands = CANVAS_COMMANDS
+                .with(|cmds| {
+                    let mut cmds = cmds.borrow_mut();
+                    cmds.get_mut(&key).and_then(|pending| {
+                        if pending.is_empty() || !command_batch_renders(pending) {
+                            None
+                        } else {
+                            let commands = std::mem::take(pending);
+                            CANVAS_LAST_FRAME.with(|last| {
+                                last.borrow_mut().insert(key, commands.clone());
+                            });
+                            Some(commands)
+                        }
+                    })
+                })
+                .or_else(|| CANVAS_LAST_FRAME.with(|last| last.borrow().get(&key).cloned()));
+
+            if let Some(commands) = commands {
                     // Track current path points for gradient fill
                     let mut path_points: Vec<(f64, f64)> = Vec::new();
                     let mut in_path = false;
@@ -204,8 +233,7 @@ define_class!(
                         }
                     }
                 }
-            });
-        }
+            }
     }
 );
 
@@ -256,6 +284,9 @@ pub fn create(width: f64, height: f64) -> i64 {
     CANVAS_COMMANDS.with(|cmds| {
         cmds.borrow_mut().insert(key, Vec::new());
     });
+    CANVAS_LAST_FRAME.with(|last| {
+        last.borrow_mut().insert(key, Vec::new());
+    });
     CANVAS_SIZES.with(|s| {
         s.borrow_mut().insert(key, (width, height));
     });
@@ -274,6 +305,11 @@ pub fn clear(handle: i64) {
     if let Some(key) = get_canvas_key(handle) {
         CANVAS_COMMANDS.with(|cmds| {
             if let Some(commands) = cmds.borrow_mut().get_mut(&key) {
+                commands.clear();
+            }
+        });
+        CANVAS_LAST_FRAME.with(|last| {
+            if let Some(commands) = last.borrow_mut().get_mut(&key) {
                 commands.clear();
             }
         });

--- a/crates/perry-ui-windows/src/widgets/canvas.rs
+++ b/crates/perry-ui-windows/src/widgets/canvas.rs
@@ -27,8 +27,18 @@ pub enum DrawCmd {
     Clear,
 }
 
+fn command_batch_renders(commands: &[DrawCmd]) -> bool {
+    commands.iter().any(|cmd| {
+        matches!(
+            cmd,
+            DrawCmd::Clear | DrawCmd::Stroke(..) | DrawCmd::FillGradient(..)
+        )
+    })
+}
+
 thread_local! {
     static CANVAS_CMDS: RefCell<HashMap<i64, Vec<DrawCmd>>> = RefCell::new(HashMap::new());
+    static CANVAS_LAST_FRAME: RefCell<HashMap<i64, Vec<DrawCmd>>> = RefCell::new(HashMap::new());
 }
 
 #[cfg(target_os = "windows")]
@@ -83,100 +93,114 @@ fn paint_canvas(handle: i64, hwnd: HWND) {
         let mut ps = PAINTSTRUCT::default();
         let hdc = BeginPaint(hwnd, &mut ps);
 
-        CANVAS_CMDS.with(|cmds| {
-            let cmds = cmds.borrow();
-            if let Some(cmd_list) = cmds.get(&handle) {
-                let mut current_pen = HPEN::default();
-                let mut path_points: Vec<(i32, i32)> = Vec::new();
+        let cmd_list = CANVAS_CMDS
+            .with(|cmds| {
+                let mut cmds = cmds.borrow_mut();
+                cmds.get_mut(&handle).and_then(|pending| {
+                    if pending.is_empty() || !command_batch_renders(pending) {
+                        None
+                    } else {
+                        let commands = std::mem::take(pending);
+                        CANVAS_LAST_FRAME.with(|last| {
+                            last.borrow_mut().insert(handle, commands.clone());
+                        });
+                        Some(commands)
+                    }
+                })
+            })
+            .or_else(|| CANVAS_LAST_FRAME.with(|last| last.borrow().get(&handle).cloned()));
 
-                for cmd in cmd_list {
-                    match cmd {
-                        DrawCmd::Clear => {
-                            let mut rect = RECT::default();
-                            let _ = GetClientRect(hwnd, &mut rect);
-                            let brush = GetStockObject(WHITE_BRUSH);
-                            let _ = FillRect(hdc, &rect, HBRUSH(brush.0));
-                        }
-                        DrawCmd::BeginPath => {
-                            path_points.clear();
-                        }
-                        DrawCmd::MoveTo(x, y) => {
-                            MoveToEx(hdc, *x as i32, *y as i32, None);
-                            path_points.push((*x as i32, *y as i32));
-                        }
-                        DrawCmd::LineTo(x, y) => {
-                            LineTo(hdc, *x as i32, *y as i32);
-                            path_points.push((*x as i32, *y as i32));
-                        }
-                        DrawCmd::Stroke(r, g, b, _a, width) => {
-                            let color =
-                                COLORREF((*r as u32) | ((*g as u32) << 8) | ((*b as u32) << 16));
-                            let pen = CreatePen(PS_SOLID, *width as i32, color);
-                            let old_pen = SelectObject(hdc, pen);
+        if let Some(cmd_list) = cmd_list {
+            let mut current_pen = HPEN::default();
+            let mut path_points: Vec<(i32, i32)> = Vec::new();
 
-                            // Replay path with the pen
-                            let mut first = true;
-                            for &(px, py) in &path_points {
-                                if first {
-                                    MoveToEx(hdc, px, py, None);
-                                    first = false;
-                                } else {
-                                    LineTo(hdc, px, py);
-                                }
-                            }
+            for cmd in cmd_list {
+                match cmd {
+                    DrawCmd::Clear => {
+                        let mut rect = RECT::default();
+                        let _ = GetClientRect(hwnd, &mut rect);
+                        let brush = GetStockObject(WHITE_BRUSH);
+                        let _ = FillRect(hdc, &rect, HBRUSH(brush.0));
+                    }
+                    DrawCmd::BeginPath => {
+                        path_points.clear();
+                    }
+                    DrawCmd::MoveTo(x, y) => {
+                        MoveToEx(hdc, *x as i32, *y as i32, None);
+                        path_points.push((*x as i32, *y as i32));
+                    }
+                    DrawCmd::LineTo(x, y) => {
+                        LineTo(hdc, *x as i32, *y as i32);
+                        path_points.push((*x as i32, *y as i32));
+                    }
+                    DrawCmd::Stroke(r, g, b, _a, width) => {
+                        let color =
+                            COLORREF((*r as u32) | ((*g as u32) << 8) | ((*b as u32) << 16));
+                        let pen = CreatePen(PS_SOLID, *width as i32, color);
+                        let old_pen = SelectObject(hdc, pen);
 
-                            SelectObject(hdc, old_pen);
-                            if !current_pen.is_invalid() {
-                                let _ = DeleteObject(current_pen);
-                            }
-                            current_pen = pen;
-                        }
-                        DrawCmd::FillGradient(r1, g1, b1, _a1, r2, g2, b2, _a2, direction) => {
-                            // Fill entire canvas with gradient
-                            let mut rect = RECT::default();
-                            let _ = GetClientRect(hwnd, &mut rect);
-                            let vertical = *direction < 0.5;
-
-                            let steps = if vertical {
-                                (rect.bottom - rect.top).max(1)
+                        // Replay path with the pen
+                        let mut first = true;
+                        for &(px, py) in &path_points {
+                            if first {
+                                MoveToEx(hdc, px, py, None);
+                                first = false;
                             } else {
-                                (rect.right - rect.left).max(1)
-                            };
-
-                            for i in 0..steps {
-                                let t = i as f64 / steps as f64;
-                                let cr = (*r1 as f64 * (1.0 - t) + *r2 as f64 * t) as u32;
-                                let cg = (*g1 as f64 * (1.0 - t) + *g2 as f64 * t) as u32;
-                                let cb = (*b1 as f64 * (1.0 - t) + *b2 as f64 * t) as u32;
-                                let color = COLORREF(cr | (cg << 8) | (cb << 16));
-                                let brush = CreateSolidBrush(color);
-                                let band = if vertical {
-                                    RECT {
-                                        left: rect.left,
-                                        top: rect.top + i,
-                                        right: rect.right,
-                                        bottom: rect.top + i + 1,
-                                    }
-                                } else {
-                                    RECT {
-                                        left: rect.left + i,
-                                        top: rect.top,
-                                        right: rect.left + i + 1,
-                                        bottom: rect.bottom,
-                                    }
-                                };
-                                let _ = FillRect(hdc, &band, brush);
-                                let _ = DeleteObject(brush);
+                                LineTo(hdc, px, py);
                             }
+                        }
+
+                        SelectObject(hdc, old_pen);
+                        if !current_pen.is_invalid() {
+                            let _ = DeleteObject(current_pen);
+                        }
+                        current_pen = pen;
+                    }
+                    DrawCmd::FillGradient(r1, g1, b1, _a1, r2, g2, b2, _a2, direction) => {
+                        // Fill entire canvas with gradient
+                        let mut rect = RECT::default();
+                        let _ = GetClientRect(hwnd, &mut rect);
+                        let vertical = *direction < 0.5;
+
+                        let steps = if vertical {
+                            (rect.bottom - rect.top).max(1)
+                        } else {
+                            (rect.right - rect.left).max(1)
+                        };
+
+                        for i in 0..steps {
+                            let t = i as f64 / steps as f64;
+                            let cr = (*r1 as f64 * (1.0 - t) + *r2 as f64 * t) as u32;
+                            let cg = (*g1 as f64 * (1.0 - t) + *g2 as f64 * t) as u32;
+                            let cb = (*b1 as f64 * (1.0 - t) + *b2 as f64 * t) as u32;
+                            let color = COLORREF(cr | (cg << 8) | (cb << 16));
+                            let brush = CreateSolidBrush(color);
+                            let band = if vertical {
+                                RECT {
+                                    left: rect.left,
+                                    top: rect.top + i,
+                                    right: rect.right,
+                                    bottom: rect.top + i + 1,
+                                }
+                            } else {
+                                RECT {
+                                    left: rect.left + i,
+                                    top: rect.top,
+                                    right: rect.left + i + 1,
+                                    bottom: rect.bottom,
+                                }
+                            };
+                            let _ = FillRect(hdc, &band, brush);
+                            let _ = DeleteObject(brush);
                         }
                     }
                 }
-
-                if !current_pen.is_invalid() {
-                    let _ = DeleteObject(current_pen);
-                }
             }
-        });
+
+            if !current_pen.is_invalid() {
+                let _ = DeleteObject(current_pen);
+            }
+        }
 
         let _ = EndPaint(hwnd, &ps);
     }
@@ -212,6 +236,9 @@ pub fn create(width: f64, height: f64) -> i64 {
             CANVAS_CMDS.with(|cmds| {
                 cmds.borrow_mut().insert(handle, Vec::new());
             });
+            CANVAS_LAST_FRAME.with(|last| {
+                last.borrow_mut().insert(handle, Vec::new());
+            });
             handle
         }
     }
@@ -222,6 +249,9 @@ pub fn create(width: f64, height: f64) -> i64 {
         let handle = register_widget_with_layout(0, WidgetKind::Canvas, 0.0, (0.0, 0.0, 0.0, 0.0));
         CANVAS_CMDS.with(|cmds| {
             cmds.borrow_mut().insert(handle, Vec::new());
+        });
+        CANVAS_LAST_FRAME.with(|last| {
+            last.borrow_mut().insert(handle, Vec::new());
         });
         handle
     }
@@ -259,6 +289,11 @@ pub fn clear(handle: i64) {
         if let Some(list) = cmds.get_mut(&handle) {
             list.clear();
             list.push(DrawCmd::Clear);
+        }
+    });
+    CANVAS_LAST_FRAME.with(|last| {
+        if let Some(list) = last.borrow_mut().get_mut(&handle) {
+            list.clear();
         }
     });
     invalidate(handle);


### PR DESCRIPTION
## Summary
- Fix native Canvas command buffering so frame-loop drawing does not replay every historical command.
- Keep pending commands separate from the last rendered frame, so native repaint events can redraw without unbounded buffer growth.
- Apply the same bounded-buffer behavior across macOS, iOS, tvOS, visionOS, GTK4, Android, and Windows Canvas backends.

## Root cause
Native Canvas backends recorded drawing calls into a command buffer and replayed the whole buffer on each paint/repaint. Frame-loop apps continuously appended to that buffer, causing native targets to slow down, freeze, or render blank.

## Validation
- `cargo fmt --check`
- `cargo check -p perry-ui-macos`
- `cargo check -p perry-ui-android`
- `cargo check -p perry-ui-ios -p perry-ui-tvos -p perry-ui-visionos`

Note: local GTK4 checking is blocked by missing system libraries (`gtk4`, `graphene-gobject-1.0`, `gstreamer-1.0`). Local Windows checking is blocked by existing `webview2-com-sys` / `windows_core` dependency resolution errors before this code is compiled.

Fixes #2023
