### PR TITLE
test(node): unskip readable destroy cases

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1664,12 +1664,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: getReader({mode:'byob'}) on bytes-type stream fails or returns wrong shape. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/readable/destroyed-true-immediately": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: destroyed flag not synchronously true after destroy(). Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/promises/pipeline-returns-undefined": {
     "issue": "1533",
     "added": "2026-05-23",
@@ -2006,12 +2000,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipe() with no args — does not throw TypeError. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/double-destroy-still-destroyed": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: destroy() twice — destroyed flag still true after both calls. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/iter-helpers/find-async-fn": {
     "issue": "1558",
     "added": "2026-05-24",
@@ -2161,12 +2149,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: cork()+uncork() with no writes — 'finish' doesn't fire. Flips to PASS when #1539 lands."
-  },
-  "node-suite/stream/readable/destroyed-after-error": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: destroyed flag false after 'error' event handler fires. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipe/pipe-after-pause": {
     "issue": "1532",
@@ -2318,12 +2300,6 @@
     "category": "bug-open",
     "reason": "node:stream: src.on('error') during pipe — handler receives wrong error / not called. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/destroy-emits-error-event": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: destroy(err) — 'error' fires after 'close', or order wrong. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/iter-helpers/some-finds-match": {
     "issue": "1558",
     "added": "2026-05-24",
@@ -2383,12 +2359,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pipe() to plain Writable — collected wrong / empty. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/destroy-without-error": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: destroy() no arg — destroyed flag wrong or error event fires. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/byob-reader-method-shape": {
     "issue": "1545",


### PR DESCRIPTION
## Summary
- Remove five now-green classic Readable destroy known-failure entries.
- Keep `destroyed-after-finish` and `destroyed-during-data-flow` listed because they still mismatch Node.
- No runtime or compiler changes.

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter readable/destroy`
  - Expected below-threshold residuals: `destroyed-after-finish`, `destroyed-during-data-flow`
  - Targets pass: `destroy-emits-error-event`, `destroy-without-error`, `destroyed-after-error`, `destroyed-true-immediately`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter readable/double-destroy-still-destroyed`
- `jq empty test-parity/known_failures.json`
- `git diff --check -- test-parity/known_failures.json`

## DeepWiki
- Local reference only: `reference/deepwiki/deno-node-stream-readable-destroy-basics-2026-05-27.md`

## Non-goals
- No cleanup for `destroyed-after-finish`.
- No cleanup for `destroyed-during-data-flow`.
