### PR TITLE
test(node): unskip readable constructor cases

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -266,12 +266,6 @@
     "category": "bug-open",
     "reason": "node:stream EventEmitter wiring incomplete — re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS. Real Perry gap (not ci-env); rolled under the open stream-events tracker #1532."
   },
-  "node-suite/stream/classes/readable-constructor": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Readable instance lacks .readable flag + push/read/pipe methods as functions. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/classes/writable-constructor": {
     "issue": "1531",
     "added": "2026-05-23",
@@ -1369,12 +1363,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Writable defaultEncoding option — encoding arg seen by _write differs from 'hex'. Flips to PASS when #1539 lands."
-  },
-  "node-suite/stream/classes/readable-no-read-fn": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: new Readable({}) without read fn — push-based usage produces wrong output. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/readable/from-map-entries": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- Remove two now-green classic Readable constructor known-failure entries.
- Keep Writable, Duplex, Transform, and PassThrough constructor entries listed because they still mismatch Node.
- No runtime or compiler changes.

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter classes/readable-constructor`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter classes/readable-no-read-fn`
- `jq empty test-parity/known_failures.json`
- `git diff --check -- test-parity/known_failures.json`

## DeepWiki
- Local reference only: `reference/deepwiki/deno-node-stream-readable-constructor-basics-2026-05-27.md`

## Non-goals
- No cleanup for `node-suite/stream/classes/writable-constructor`.
- No cleanup for `node-suite/stream/classes/duplex-constructor`.
- No cleanup for `node-suite/stream/classes/transform-constructor`.
- No cleanup for `node-suite/stream/classes/passthrough-constructor`.
