### PR TITLE
fix(node:assert): hide removed CallTracker export

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2386,7 +2386,6 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("assert", "default", false, None),
     method("assert", "strict", false, None),
     property("assert", "strict"),
-    class("assert", "CallTracker"),
     class("assert", "AssertionError"),
     method("assert/strict", "ok", false, None),
     method("assert/strict", "fail", false, None),

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -394,7 +394,6 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("assert", "throws")
             | ("assert", "doesNotThrow")
             | ("assert", "ifError")
-            | ("assert", "CallTracker")
             | ("assert/strict", "ok")
             | ("assert/strict", "fail")
             | ("assert/strict", "equal")

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1372 entries across 82 modules
+// Coverage: 1371 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -25,8 +25,6 @@ declare module "argon2" {
 declare module "assert" {
   /** stdlib */
   export class AssertionError { [key: string]: any; }
-  /** stdlib */
-  export class CallTracker { [key: string]: any; }
   /** stdlib */
   export const strict: any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1372 entries across 82 modules.
+Total: 1371 entries across 82 modules.
 
 ## Modules
 
@@ -113,7 +113,6 @@ Total: 1372 entries across 82 modules.
 ### Classes
 
 - `AssertionError`
-- `CallTracker`
 
 ### Methods
 


### PR DESCRIPTION
## Summary
- Stop exposing deprecated/removed `assert.CallTracker` as a callable export.
- Remove the stale `assert.CallTracker` API manifest entry.
- Keep `assert.rejects` / `assert.doesNotReject` promise assertion behavior out of scope.

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module assert --filter calltracker-shape`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --filter test_parity_assert`
  - Expected residual failure: `rejects` / `doesNotReject` missing failure semantics.
  - `assert.CallTracker typeof` now matches Node.
- `cargo fmt --check`
- `cargo test -p perry-api-manifest`
- `cargo test -p perry-runtime assert --lib`
- `git diff --check HEAD~1..HEAD`

## DeepWiki
- Local reference only: `reference/deepwiki/nodejs-node-assert-calltracker-export-shape-2026-05-27.md`

## Non-goals
- No implementation of `assert.rejects` resolved-promise failure semantics.
- No implementation of `assert.doesNotReject` rejected-promise failure semantics.
- No generated docs/reference updates.
