### PR TITLE
chore(hono-server): publish as @perryts/hono-server + release workflow

### DIFF
--- a/.github/workflows/release-hono-server.yml
+++ b/.github/workflows/release-hono-server.yml
@@ -1,0 +1,59 @@
+name: Release @perryts/hono-server
+
+# Independent release path for the packages/hono-perry-server workspace package
+# (@perryts/hono-server). Deliberately decoupled from the compiler's
+# `release-packages.yml` (`v*` tag → 120-min gated Homebrew/apt/winget/npm-CLI
+# pipeline): bumping a ~50-line adapter must not cut a full Perry release.
+#
+# Trigger: push a `hono-server-v<version>` tag whose version matches
+# packages/hono-perry-server/package.json (e.g. `hono-server-v0.1.1`).
+on:
+  push:
+    tags:
+      - "hono-server-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # REQUIRED for OIDC Trusted Publisher + npm --provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/hono-perry-server
+    steps:
+      - uses: actions/checkout@v6
+
+      # Node 24 ships npm 11.x. OIDC Trusted Publishing needs npm >= 11.5.1;
+      # Node 22's npm 10.x silently fails the OIDC handshake and the registry
+      # returns a misleading 404 on PUT. Do NOT set `registry-url` here — it
+      # writes a token-based .npmrc that contradicts OIDC (the publish targets
+      # the default registry.npmjs.org regardless).
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Upgrade npm (OIDC Trusted Publisher requires >= 11.5.1)
+        run: npm install -g npm@latest
+
+      # Guard against a mislabeled release: the tag's version must equal the
+      # version in package.json. Tag-pushes only — workflow_dispatch (manual
+      # republish of current main) skips this.
+      - name: Verify tag matches package version
+        if: github.ref_type == 'tag'
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#hono-server-v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME implies $TAG_VERSION but package.json is $PKG_VERSION"
+            exit 1
+          fi
+          echo "Publishing @perryts/hono-server@$PKG_VERSION"
+
+      # `access: public` is set in package.json publishConfig, so no --access
+      # flag is needed. --provenance attaches the signed build attestation
+      # (visible on the npm package page).
+      - name: Publish to npm (provenance via OIDC)
+        run: npm publish --provenance

--- a/docs/src/stdlib/http.md
+++ b/docs/src/stdlib/http.md
@@ -126,15 +126,15 @@ The `node:http` server FFIs and the Web Fetch `Headers` / `Request` /
 turnkey adapter, prefer [perry's Fastify binding](#fastify-server) with a
 single catch-all route delegating to `app.fetch`.
 
-### `@hono/perry-server`
+### `@perryts/hono-server`
 
-`@hono/perry-server` (in-tree at `packages/hono-perry-server`) packages that
+`@perryts/hono-server` (in-tree at `packages/hono-perry-server`) packages that
 catch-all-over-Fastify shim as Hono's standard `serve({ fetch, port })`
 contract — the Perry counterpart to `@hono/node-server` / `@hono/bun`:
 
 ```typescript,no-test
 import { Hono } from "hono"
-import { serve } from "@hono/perry-server"
+import { serve } from "@perryts/hono-server"
 
 const app = new Hono()
 app.get("/", (c) => c.json({ ok: true }))

--- a/packages/hono-perry-server/README.md
+++ b/packages/hono-perry-server/README.md
@@ -1,4 +1,4 @@
-# @hono/perry-server
+# @perryts/hono-server
 
 Hono's standard `serve({ fetch, port })` adapter contract for **Perry-native**
 compile, wrapping Perry's bundled [Fastify](https://www.fastify.io/).
@@ -13,7 +13,7 @@ its own shim.
 
 ```ts
 import { Hono } from 'hono'
-import { serve } from '@hono/perry-server'
+import { serve } from '@perryts/hono-server'
 
 const app = new Hono()
 app.get('/', (c) => c.json({ ok: true }))

--- a/packages/hono-perry-server/examples/serve_smoke.ts
+++ b/packages/hono-perry-server/examples/serve_smoke.ts
@@ -1,4 +1,4 @@
-// Smoke test / example for `@hono/perry-server`. Drives the adapter with a
+// Smoke test / example for `@perryts/hono-server`. Drives the adapter with a
 // minimal hand-rolled fetch handler (no `hono` dependency) so it can be
 // compiled and run standalone in CI:
 //

--- a/packages/hono-perry-server/package.json
+++ b/packages/hono-perry-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hono/perry-server",
+  "name": "@perryts/hono-server",
   "version": "0.1.0",
   "description": "Hono server adapter for Perry-native compile — serve({ fetch, port }) over Perry's bundled Fastify",
   "type": "module",
@@ -12,6 +12,10 @@
     }
   },
   "files": ["src"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/PerryTS/perry/tree/main/packages/hono-perry-server#readme",
   "peerDependencies": {
     "hono": ">=4"
   },

--- a/packages/hono-perry-server/src/index.ts
+++ b/packages/hono-perry-server/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * `@hono/perry-server` — Hono's standard `serve({ fetch, port })` adapter
+ * `@perryts/hono-server` — Hono's standard `serve({ fetch, port })` adapter
  * contract on Perry-native, wrapping Perry's bundled Fastify.
  *
  * Hono is runtime-agnostic: the same `(request: Request) => Response` handler
@@ -11,7 +11,7 @@
  * Usage:
  * ```ts
  * import { Hono } from 'hono'
- * import { serve } from '@hono/perry-server'
+ * import { serve } from '@perryts/hono-server'
  *
  * const app = new Hono()
  * app.get('/', (c) => c.json({ ok: true }))

--- a/packages/hono-perry-server/tsconfig.json
+++ b/packages/hono-perry-server/tsconfig.json
@@ -8,7 +8,7 @@
     "lib": ["ES2020", "DOM"],
     "baseUrl": ".",
     "paths": {
-      "@hono/perry-server": ["./src/index.ts"]
+      "@perryts/hono-server": ["./src/index.ts"]
     }
   },
   "include": ["src/**/*.ts", "examples/**/*.ts"],


### PR DESCRIPTION
## Why

The in-tree Hono adapter (`packages/hono-perry-server`) was named **`@hono/perry-server`** — but the `@hono` npm scope belongs to the Hono org, so we can't publish into it (`npm publish` 403s). It's been stuck at 404 on npm as a result.

This renames it to the PerryTS-owned scope **`@perryts/hono-server`** (free; same shape as `@perryts/mysql` / `@perryts/perry`) and wires up an independent publish path.

## What

- **`package.json`**: `name` → `@perryts/hono-server`; add `publishConfig.access: public` (so scoped publishes don't need a flag) + `homepage`. No build change — still source-only (`perry`/`types`/`default` → `./src/index.ts`, `files: ["src"]`).
- Rename remaining live refs: `README.md`, `tsconfig.json` path, `src/index.ts` header, `examples/serve_smoke.ts`, and `docs/src/stdlib/http.md`. `CHANGELOG.md` left intact (historical).
- **New `.github/workflows/release-hono-server.yml`**: Trusted-Publisher (OIDC) npm publish with `--provenance`, triggered on **`hono-server-v*`** tags. Deliberately **decoupled** from the compiler's `v*` release (`release-packages.yml`) so bumping a ~50-line adapter never cuts a full gated Perry release. Node 24 (npm ≥ 11.5.1 for OIDC); no `setup-node` `registry-url` (it writes a token `.npmrc` that contradicts OIDC).

## Notes

- Trusted Publisher for `@perryts/hono-server` is already registered on npmjs.com → `PerryTS/perry` + `release-hono-server.yml`.
- `npm pack --dry-run` ships 3 files (`README.md`, `package.json`, `src/index.ts`), 2.7 kB.
- Non-breaking: no references to the old name in `perry-landing-skelpo` or `skelpo-cms`.

## Release flow after merge

`v0.1.0` will be published manually first. Subsequent releases: bump `package.json`, tag `hono-server-v<version>`, push → the new workflow publishes with provenance.