### PR TITLE
test(node): unskip stream class constructors

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -266,30 +266,6 @@
     "category": "bug-open",
     "reason": "node:stream EventEmitter wiring incomplete — re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS. Real Perry gap (not ci-env); rolled under the open stream-events tracker #1532."
   },
-  "node-suite/stream/classes/writable-constructor": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Writable instance lacks .writable flag + write/end methods. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/classes/duplex-constructor": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Duplex instance lacks .readable/.writable flags. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/classes/transform-constructor": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Transform instance lacks .readable/.writable flags. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/classes/passthrough-constructor": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: PassThrough instance lacks .readable/.writable flags. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/pipeline/basic": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- Remove stale known-failure entries for classic stream class constructor basics:
  - `node-suite/stream/classes/writable-constructor`
  - `node-suite/stream/classes/duplex-constructor`
  - `node-suite/stream/classes/transform-constructor`
  - `node-suite/stream/classes/passthrough-constructor`
- No runtime/compiler changes.

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter classes` shows all classic `stream/classes/*constructor` targets PASS; the command exits successfully at 88.8% with only unrelated `node-suite/stream/web/tostring-tag-web-classes` still mismatching. Final report: `parity_report_20260527_110050.json`.
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter constructor` also shows the removed classic constructor entries PASS; unrelated `without-new`, `captureRejections-constructor`, and `encoding-via-constructor` remain red and out of scope.
- `jq empty test-parity/known_failures.json`
- `git diff --check HEAD~1..HEAD`

## Reference
- DeepWiki saved locally: `reference/deepwiki/nodejs-node-stream-class-constructor-basics-2026-05-27.md`

## Non-goals
- No Web Streams toStringTag cleanup.
- No constructor call-without-new behavior.
- No `captureRejections` constructor semantics.
- No readable encoding constructor option changes.