### PR TITLE
fix(runtime): Object.getPrototypeOf returns null for closure receivers, not self (#489)

### DIFF
--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1131,12 +1131,26 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
     if top16 == 0x7FFD {
         let raw_addr = bits & 0x0000_FFFF_FFFF_FFFF;
         if raw_addr != 0 && raw_addr >= (crate::gc::GC_HEADER_SIZE as u64) + 0x1000 {
-            // #1175: objects allocated with a null prototype
-            // (Object.create(null), querystring.parse) report null here.
             unsafe {
                 let obj = raw_addr as *const ObjectHeader;
                 let gc = gc_header_for(obj);
+                // #1175: objects allocated with a null prototype
+                // (Object.create(null), querystring.parse) report null here.
                 if (*gc)._reserved & crate::gc::OBJ_FLAG_NULL_PROTO != 0 {
+                    return f64::from_bits(TAG_NULL);
+                }
+                // #489: a function/constructor receiver has no walkable
+                // [[Prototype]] in Perry's model. This is reached when a
+                // prototype-chain walk hits a built-in constructor — e.g.
+                // drizzle's `is(value, type)` does
+                // `cls = Object.getPrototypeOf(arr).constructor` (the global
+                // `Array` closure) then loops `cls = Object.getPrototypeOf(cls)`
+                // until it hits null. Returning the closure itself here makes
+                // `getPrototypeOf(cls) === cls`, an infinite self-cycle that
+                // hangs the walk. JS terminates it at null (Function.prototype
+                // → Object.prototype → null); Perry doesn't model those, so
+                // return null directly to break the cycle.
+                if (*gc).obj_type == crate::gc::GC_TYPE_CLOSURE {
                     return f64::from_bits(TAG_NULL);
                 }
             }
@@ -1149,6 +1163,11 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                 let obj = bits as *const ObjectHeader;
                 let gc = gc_header_for(obj);
                 if (*gc)._reserved & crate::gc::OBJ_FLAG_NULL_PROTO != 0 {
+                    return f64::from_bits(TAG_NULL);
+                }
+                // #489: function/constructor receiver — see the 0x7FFD branch
+                // above. Break the prototype-chain self-cycle with null.
+                if (*gc).obj_type == crate::gc::GC_TYPE_CLOSURE {
                     return f64::from_bits(TAG_NULL);
                 }
             }

--- a/test-files/test_issue_489_array_proto_walk.ts
+++ b/test-files/test_issue_489_array_proto_walk.ts
@@ -1,0 +1,35 @@
+// Refs #489 (drizzle + DB end-to-end): drizzle's `is(value, type)` walks
+// the prototype chain via `cls = Object.getPrototypeOf(value).constructor`
+// then loops `cls = Object.getPrototypeOf(cls)` until it reaches null. When
+// `value` is a plain array (drizzle passes array chunks of column values
+// through `is()` while building an INSERT), `cls` becomes the global
+// `Array` constructor.
+//
+// Pre-fix, Perry's `Object.getPrototypeOf` returned the closure *itself*
+// for a function/constructor receiver, so `Object.getPrototypeOf(Array)
+// === Array` — an infinite self-cycle that hung the walk forever and made
+// `db.insert(...).values([...]).run()` never return. Node terminates the
+// walk at null (Array → Function.prototype → Object.prototype → null);
+// Perry doesn't model those intermediate prototypes but now also
+// terminates at null. The booleans below are identical across both
+// runtimes; a regression flips them (and would hang an unbounded walk).
+
+const arr = [1, 2, 3];
+const ctor = Object.getPrototypeOf(arr).constructor; // the global Array
+
+// The load-bearing invariant: a constructor must not be its own prototype.
+console.log("array ctor self-cycle:", Object.getPrototypeOf(ctor) === ctor);
+
+// A bounded walk up from the array constructor must terminate well under
+// the cap. Pre-fix this spun until the cap (cls stayed === ctor forever).
+let cls: any = ctor;
+let steps = 0;
+while (cls && steps < 50) {
+    steps++;
+    cls = Object.getPrototypeOf(cls);
+}
+console.log("array ctor walk terminated:", steps < 50);
+
+// Same for a plain object literal's constructor.
+const objCtor = Object.getPrototypeOf({ a: 1 }).constructor;
+console.log("object ctor self-cycle:", objCtor ? Object.getPrototypeOf(objCtor) === objCtor : false);


### PR DESCRIPTION
## What

Fixes an infinite hang when compiling **drizzle-orm** programs that issue a query (#489). `db.insert(users).values([...]).run()` never returned — the process spun forever with no output.

## Root cause

drizzle's `is(value, type)` (`entity.js`) walks a prototype chain to do entity-kind dispatch:

```js
let cls = Object.getPrototypeOf(value).constructor;
while (cls) { /* ... */ cls = Object.getPrototypeOf(cls); }
```

During INSERT query building, drizzle passes array chunks of column values through `is()`. For an array, `Object.getPrototypeOf(arr).constructor` resolves to the global `Array` constructor. Perry's `Object.getPrototypeOf` returned **the receiver itself** for any function/heap value, so `Object.getPrototypeOf(Array) === Array` — a self-cycle. The `while (cls)` loop never terminated.

## Fix

In `js_object_get_prototype_of`, when the heap receiver is a `GC_TYPE_CLOSURE` (a function/constructor), return `null` instead of the value itself. JS terminates such a walk at `null` (`Function.prototype → Object.prototype → null`); Perry doesn't model those intermediate prototypes, so returning `null` directly breaks the cycle and matches the chain-termination semantics callers rely on.

Both internal callers of `js_object_get_prototype_of` (the `Reflect.getMetadata` chain walks in `proxy.rs`) already stop on either `next == null` **or** `next == current`, so closure→null is equivalent to the old closure→self for them.

## Verification

- `tests/release/packages/drizzle-sqlite/` fixture: **PASS** (byte-identical `count=3 / alice.age=30`), previously hung at 60s timeout.
- All 7 existing `getPrototypeOf` gap tests still match Node.
- `perry-runtime` unit tests: 563 passed.
- New deterministic regression test `test-files/test_issue_489_array_proto_walk.ts` (matches Node byte-for-byte; a regression flips the asserted booleans / hangs an unbounded walk).

## Out of scope

While building the regression test I found two unrelated pre-existing bugs in `JSON.stringify` of function-returned arrays, filed separately as #2047 (returns `undefined`) and #2048 (memory-unsafety). They do not affect drizzle.
