### PR TITLE
test(node): unskip writable cork basics

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -332,12 +332,6 @@
     "category": "bug-open",
     "reason": "node:stream: unshift+data chain doesn't deliver. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/writable/cork-uncork": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: cork()/uncork() not functioning + finish event missing. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/writable/drain-event": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -1670,12 +1664,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose(src, PassThrough) — data not preserved through PT in composite. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/writable/uncork-without-cork": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: uncork() with no prior cork() — error or breaks finish. Flips to PASS when #1539 lands."
-  },
   "node-suite/stream/web/byte-stream-non-buffer-throws": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -1814,12 +1802,6 @@
     "category": "bug-open",
     "reason": "node:stream: find(asyncFn) — returns wrong value. Flips to PASS when #1558 lands."
   },
-  "node-suite/stream/writable/uncork-twice-after-cork": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: cork(); uncork(); uncork() — second uncork errors or breaks finish. Flips to PASS when #1539 lands."
-  },
   "node-suite/stream/readable/from-gen-yield-order": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1933,12 +1915,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: post-pipe-end destroyed flags wrong on source or destination. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/writable/cork-empty": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: cork()+uncork() with no writes — 'finish' doesn't fire. Flips to PASS when #1539 lands."
   },
   "node-suite/stream/pipe/pipe-after-pause": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- remove four stale known-failure entries for classic Writable cork/uncork basics
- keep `_writev` batching and chunk-shape failures listed because they still fail
- no runtime/compiler changes

## Verification
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter cork` PASS 9/9
  - report: `test-parity/reports/parity_report_20260527_110829.json`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter writev` expected FAIL 0/3
  - report: `test-parity/reports/parity_report_20260527_110851.json`
  - residuals: `node-suite/stream/writable/_writev-vs-write`, `node-suite/stream/write/writev-batch`, `node-suite/stream/write/writev-chunk-shape`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## DeepWiki
- Local reference only, not staged: `reference/deepwiki/nodejs-node-stream-writable-cork-basics-2026-05-27.md`
- Invariant used: `cork()`/`uncork()` balance cork state and safe no-op uncork cases; `_writev` batching remains separate.

## Non-goals
- `_writev` batching dispatch
- `writev` chunk-shape behavior
- drain/backpressure semantics
