### PR TITLE
fix(runtime): real array iterator object for value-level arr[Symbol.iterator]() (#321 effect ManagedRuntime)

### DIFF
--- a/crates/perry-runtime/src/array/flat_clone.rs
+++ b/crates/perry-runtime/src/array/flat_clone.rs
@@ -297,6 +297,49 @@ pub extern "C" fn js_array_clone(src: *const ArrayHeader) -> *mut ArrayHeader {
                     return ptr;
                 }
             }
+            // #321: per ECMA-262 §23.1.2.1, `Array.from` prefers the ITERATOR
+            // protocol (`obj[Symbol.iterator]`) over the array-like `.length`
+            // path. An effect `Chunk` carries BOTH a `.length` field AND a
+            // `[Symbol.iterator]` that delegates to `backing.array`'s iterator,
+            // so the pre-fix array-like fallback read `.length`=N and `obj[i]`
+            // (which a Chunk doesn't store positionally) → N undefined elements.
+            // That surfaced downstream as `Cannot read properties of undefined
+            // (reading '_tag')` in effect's `exitZipWith`. Drive the iterator
+            // protocol when the object is iterable, or when it IS an iterator
+            // (the runtime array-iterator class id / a stored `.next` closure).
+            unsafe {
+                let iter_f64 = crate::value::js_nanbox_pointer(raw_addr as i64);
+                let is_array_iterator = (*obj).class_id == ARRAY_ITERATOR_CLASS_ID;
+                let is_iterable = is_array_iterator || {
+                    let iter_sym = crate::symbol::well_known_symbol("iterator");
+                    if iter_sym.is_null() {
+                        false
+                    } else {
+                        let sym_f64 = f64::from_bits(
+                            crate::value::JSValue::pointer(iter_sym as *const u8).bits(),
+                        );
+                        let iter_fn =
+                            crate::symbol::js_object_get_symbol_property(iter_f64, sym_f64);
+                        iter_fn.to_bits() != crate::value::TAG_UNDEFINED
+                    }
+                };
+                // Also catch a bare iterator object that exposes `.next()` as a
+                // stored closure field but no `[Symbol.iterator]` (uncommon).
+                let has_next_field = {
+                    let next_key = crate::string::js_string_from_bytes(b"next".as_ptr(), 4);
+                    let next_val = crate::object::js_object_get_field_by_name(
+                        obj as *const crate::ObjectHeader,
+                        next_key,
+                    );
+                    let next_ptr =
+                        crate::value::js_nanbox_get_pointer(f64::from_bits(next_val.bits()))
+                            as usize;
+                    !next_val.is_undefined() && crate::closure::is_closure_ptr(next_ptr)
+                };
+                if is_iterable || has_next_field {
+                    return js_iterator_to_array(crate::symbol::js_get_iterator(iter_f64));
+                }
+            }
             return unsafe { js_array_from_arraylike(raw_addr as *const crate::ObjectHeader) };
         }
     }

--- a/crates/perry-runtime/src/array/iter_object.rs
+++ b/crates/perry-runtime/src/array/iter_object.rs
@@ -1,0 +1,178 @@
+//! #321 (effect `ManagedRuntime` / `Exit.all`): a real array iterator
+//! object so a value-level `arr[Symbol.iterator]()` / `arr.values()` /
+//! `arr.keys()` / `arr.entries()` call returns a `.next()`-bearing
+//! iterator (matching Node), not an eager array clone.
+//!
+//! Background: Perry's `for...of` over an array is special-cased to an
+//! indexed length/[i] loop, and codegen's `Expr::ArrayValues` fast path
+//! materializes `arr.values()` as a plain array clone. That covers the
+//! common cases. But when an array's `[Symbol.iterator]` is invoked
+//! dynamically through the runtime dispatch tower (`js_native_call_method`)
+//! — e.g. effect's `Chunk[Symbol.iterator]()` delegates to
+//! `backing.array[Symbol.iterator]()`, and `Array.from(chunk)` /
+//! `Arr.reduce` then drive `.next()` on the result — the pre-fix tower had
+//! no `values`/`keys`/`entries`/`@@iterator` arm, so the call fell through
+//! to the object-field scan and returned `undefined`. `Array.from(undefined)`
+//! yields nothing (or undefined elements), which surfaced downstream as
+//! `Cannot read properties of undefined (reading '_tag')` in effect's
+//! `exitZipWith`.
+//!
+//! Representation mirrors `buffer/iter.rs`: a regular `ObjectHeader` with a
+//! dedicated `ARRAY_ITERATOR_CLASS_ID`. Field 0 holds the backing array
+//! (NaN-boxed pointer, so the object scanner keeps it alive), field 1 the
+//! cursor index, field 2 the iterator kind. Dispatch lives in
+//! `object/native_call_method.rs` via the class-id check next to the
+//! Buffer iterator one.
+
+use super::*;
+use crate::object::{js_object_alloc, js_object_get_field, js_object_set_field, ObjectHeader};
+use crate::value::{js_nanbox_get_pointer, js_nanbox_pointer, JSValue, TAG_UNDEFINED};
+
+/// Class id reserved for array iterators. Sits adjacent to the Buffer
+/// iterator id (0xFFFF0005) in the 0xFFFF prefix reserved for
+/// runtime-defined classes.
+pub const ARRAY_ITERATOR_CLASS_ID: u32 = 0xFFFF_0006;
+
+/// Iterator kind tags — matches the i32 stored in field 2.
+const KIND_VALUES: i32 = 0;
+const KIND_KEYS: i32 = 1;
+const KIND_ENTRIES: i32 = 2;
+
+/// Clean a NaN-boxed array pointer to a raw `*mut ArrayHeader`, or null.
+fn unbox_array_ptr(value: f64) -> *mut ArrayHeader {
+    let raw = js_nanbox_get_pointer(value);
+    if raw < (crate::gc::GC_HEADER_SIZE as i64 + 0x1000) {
+        return std::ptr::null_mut();
+    }
+    raw as *mut ArrayHeader
+}
+
+unsafe fn alloc_iterator(arr_ptr: *mut ArrayHeader, kind: i32) -> f64 {
+    let obj = js_object_alloc(ARRAY_ITERATOR_CLASS_ID, 3);
+    // Field 0: backing array (NaN-boxed pointer so the GC scanner keeps it).
+    let arr_nan = js_nanbox_pointer(arr_ptr as i64);
+    js_object_set_field(obj, 0, JSValue::from_bits(arr_nan.to_bits()));
+    // Field 1: cursor index, starts at 0.
+    js_object_set_field(obj, 1, JSValue::number(0.0));
+    // Field 2: iterator kind.
+    js_object_set_field(obj, 2, JSValue::number(kind as f64));
+    js_nanbox_pointer(obj as i64)
+}
+
+/// `arr.values()` iterator — yields each element value.
+pub fn array_values_iter(arr_f64: f64) -> f64 {
+    let arr_ptr = unbox_array_ptr(arr_f64);
+    if arr_ptr.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    unsafe { alloc_iterator(arr_ptr, KIND_VALUES) }
+}
+
+/// `arr.keys()` iterator — yields each index `0..length`.
+pub fn array_keys_iter(arr_f64: f64) -> f64 {
+    let arr_ptr = unbox_array_ptr(arr_f64);
+    if arr_ptr.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    unsafe { alloc_iterator(arr_ptr, KIND_KEYS) }
+}
+
+/// `arr.entries()` iterator — yields `[index, value]` pairs.
+pub fn array_entries_iter(arr_f64: f64) -> f64 {
+    let arr_ptr = unbox_array_ptr(arr_f64);
+    if arr_ptr.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    unsafe { alloc_iterator(arr_ptr, KIND_ENTRIES) }
+}
+
+/// Build the `{ value, done }` iterator-result object. `value` arrives as
+/// a NaN-boxed JSValue; `done` is a JS boolean.
+unsafe fn make_iter_result(value: JSValue, done: bool) -> f64 {
+    let obj = js_object_alloc(0, 2);
+
+    // keys array so destructuring + property reads find named slots.
+    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+    let done_key = crate::string::js_string_from_bytes(b"done".as_ptr(), 4);
+    let keys = crate::array::js_array_alloc(2);
+    crate::array::js_array_push(keys, JSValue::string_ptr(value_key));
+    crate::array::js_array_push(keys, JSValue::string_ptr(done_key));
+    crate::object::js_object_set_keys(obj, keys);
+
+    js_object_set_field(obj, 0, value);
+    js_object_set_field(obj, 1, JSValue::bool(done));
+    js_nanbox_pointer(obj as i64)
+}
+
+unsafe fn make_pair_array(idx: u32, value: f64) -> f64 {
+    let pair = crate::array::js_array_alloc(2);
+    (*pair).length = 2;
+    let elems = (pair as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+    *elems.add(0) = idx as f64;
+    *elems.add(1) = value;
+    crate::array::note_array_slot(pair, 0, (idx as f64).to_bits());
+    crate::array::note_array_slot(pair, 1, value.to_bits());
+    js_nanbox_pointer(pair as i64)
+}
+
+/// Dispatch `.next()` / `[Symbol.iterator]()` on an array iterator object.
+/// Routed from `js_native_call_method`'s class-id check.
+pub unsafe fn dispatch_array_iterator_method(
+    iter_obj: *mut ObjectHeader,
+    method_name: &str,
+) -> f64 {
+    match method_name {
+        "next" => {
+            // Field 0: backing array pointer (NaN-boxed).
+            let backing_field = js_object_get_field(iter_obj, 0);
+            let backing_f64 = f64::from_bits(backing_field.bits());
+            let arr_ptr = js_nanbox_get_pointer(backing_f64) as *const ArrayHeader;
+            // Field 1: current index.
+            let idx_field = js_object_get_field(iter_obj, 1);
+            let idx = f64::from_bits(idx_field.bits()) as u32;
+            // Field 2: iterator kind.
+            let kind_field = js_object_get_field(iter_obj, 2);
+            let kind = f64::from_bits(kind_field.bits()) as i32;
+
+            let len = if arr_ptr.is_null() {
+                0u32
+            } else {
+                crate::array::js_array_length(arr_ptr)
+            };
+
+            if idx >= len {
+                return make_iter_result(JSValue::undefined(), true);
+            }
+
+            // Advance the stored cursor before computing the value so a
+            // subsequent `.next()` call sees the bumped index.
+            js_object_set_field(iter_obj, 1, JSValue::number((idx + 1) as f64));
+
+            let elem = if arr_ptr.is_null() {
+                f64::from_bits(TAG_UNDEFINED)
+            } else {
+                crate::array::js_array_get_f64(arr_ptr, idx)
+            };
+
+            let value = match kind {
+                KIND_VALUES => JSValue::from_bits(elem.to_bits()),
+                KIND_KEYS => JSValue::number(idx as f64),
+                KIND_ENTRIES => {
+                    let pair = make_pair_array(idx, elem);
+                    JSValue::from_bits(pair.to_bits())
+                }
+                _ => JSValue::undefined(),
+            };
+            make_iter_result(value, false)
+        }
+        // Iterators are themselves iterable — `[Symbol.iterator]()` on one
+        // returns the same iterator (matches Node, and lets `js_get_iterator`
+        // / `for (const v of arr.values())` re-enter without a wrapper).
+        "Symbol.iterator" | "@@iterator" | "values" => js_nanbox_pointer(iter_obj as i64),
+        // `return`/`throw` are part of the iterator spec; Node's array
+        // iterator inherits them from %IteratorPrototype%. Return a
+        // `{ value: undefined, done: true }` shape for early-exit code.
+        "return" | "throw" => make_iter_result(JSValue::undefined(), true),
+        _ => f64::from_bits(TAG_UNDEFINED),
+    }
+}

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -130,19 +130,23 @@ pub extern "C" fn js_iterator_to_array(iter_f64: f64) -> *mut ArrayHeader {
     }
     let iter_obj = iter_ptr as *const ObjectHeader;
 
-    // Look up the "next" method on the iterator object
+    // Look up the "next" method on the iterator object as a stored closure
+    // FIELD (the common case for generator objects / effect's `SingleShotGen`,
+    // which store `next` as an own callable property).
     let next_key = js_string_from_bytes(b"next".as_ptr(), 4);
     let next_val = js_object_get_field_by_name(iter_obj, next_key);
-    if next_val.is_undefined() {
-        return arr;
-    }
-
-    // next_val should be a closure pointer
     let next_f64 = unsafe { f64::from_bits(std::mem::transmute::<_, u64>(next_val)) };
-    let next_ptr = js_nanbox_get_pointer(next_f64) as *const closure::ClosureHeader;
-    if next_ptr.is_null() {
-        return arr;
-    }
+    let next_ptr = if next_val.is_undefined() {
+        std::ptr::null::<closure::ClosureHeader>()
+    } else {
+        js_nanbox_get_pointer(next_f64) as *const closure::ClosureHeader
+    };
+    // #321: some iterators (perry's runtime array iterator with
+    // `ARRAY_ITERATOR_CLASS_ID`, Buffer iterators) dispatch `.next()` through
+    // the class-id method tower in `js_native_call_method` rather than storing
+    // a `next` closure field, so the field lookup above misses. Fall back to a
+    // method-call dispatch in that case instead of bailing with an empty array.
+    let use_method_dispatch = next_ptr.is_null();
 
     // Iterate: call next() until done
     let done_key = js_string_from_bytes(b"done".as_ptr(), 4);
@@ -151,8 +155,20 @@ pub extern "C" fn js_iterator_to_array(iter_f64: f64) -> *mut ArrayHeader {
 
     for _ in 0..100_000 {
         // safety limit
-        // Call next()
-        let result_f64 = closure::js_closure_call1(next_ptr, f64::from_bits(TAG_UNDEFINED));
+        // Call next() — stored-closure fast path, or class-id method dispatch.
+        let result_f64 = if use_method_dispatch {
+            unsafe {
+                crate::object::js_native_call_method(
+                    iter_f64,
+                    b"next".as_ptr() as *const i8,
+                    4,
+                    std::ptr::null(),
+                    0,
+                )
+            }
+        } else {
+            closure::js_closure_call1(next_ptr, f64::from_bits(TAG_UNDEFINED))
+        };
         let result_ptr = js_nanbox_get_pointer(result_f64);
         if result_ptr == 0 {
             break;

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -7,6 +7,7 @@ mod immutable;
 mod indexing;
 mod is_array;
 mod iter_methods;
+mod iter_object;
 mod iterator;
 mod jsvalue_api;
 mod push_pop;
@@ -49,6 +50,10 @@ pub use self::iter_methods::{
     js_array_at, js_array_every, js_array_filter, js_array_find, js_array_findIndex,
     js_array_find_last, js_array_find_last_index, js_array_flatMap, js_array_forEach,
     js_array_join, js_array_map, js_array_map_discard, js_array_reduce, js_array_some,
+};
+pub use self::iter_object::{
+    array_entries_iter, array_keys_iter, array_values_iter, dispatch_array_iterator_method,
+    ARRAY_ITERATOR_CLASS_ID,
 };
 pub use self::iterator::{js_for_of_to_array, js_iterator_to_array};
 pub use self::jsvalue_api::{

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1281,6 +1281,25 @@ pub unsafe extern "C" fn js_native_call_method(
                         let s = crate::array::js_array_join(arr, sep_ptr);
                         return f64::from_bits(JSValue::string_ptr(s).bits());
                     }
+                    // #321: a value-level `arr[Symbol.iterator]()` resolves to
+                    // the array's bound `values` method (see symbol.rs), and
+                    // `arr.values()`/`.keys()`/`.entries()` reaching the runtime
+                    // dispatch tower (not codegen's eager `Expr::ArrayValues`
+                    // fast path) must return a real `.next()`-bearing iterator,
+                    // not an eager array clone. Effect's `Chunk[Symbol.iterator]`
+                    // delegates to `backing.array[Symbol.iterator]()` and then
+                    // `Array.from`/`Arr.reduce` drive `.next()` on the result;
+                    // without this the call returned `undefined` and surfaced as
+                    // `Cannot read properties of undefined (reading '_tag')`.
+                    "values" | "Symbol.iterator" | "@@iterator" => {
+                        return crate::array::array_values_iter(object);
+                    }
+                    "keys" => {
+                        return crate::array::array_keys_iter(object);
+                    }
+                    "entries" => {
+                        return crate::array::array_entries_iter(object);
+                    }
                     _ => {} // not a handled array method — fall through to object dispatch
                 }
             }
@@ -1304,6 +1323,16 @@ pub unsafe extern "C" fn js_native_call_method(
             // closure-field scan below.
             if (*obj).class_id == crate::buffer::BUFFER_ITERATOR_CLASS_ID {
                 return crate::buffer::dispatch_buffer_iterator_method(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                );
+            }
+            // #321: array iterators returned from a value-level
+            // `arr.values()`/`.keys()`/`.entries()`/`[Symbol.iterator]()`
+            // carry a dedicated class id so `.next()` lands in the iterator
+            // dispatcher (matching the Buffer iterator above).
+            if (*obj).class_id == crate::array::ARRAY_ITERATOR_CLASS_ID {
+                return crate::array::dispatch_array_iterator_method(
                     obj as *mut ObjectHeader,
                     method_name,
                 );
@@ -1662,6 +1691,13 @@ pub unsafe extern "C" fn js_native_call_method(
             // a bitcast) still routes through the iterator dispatcher.
             if (*obj).class_id == crate::buffer::BUFFER_ITERATOR_CLASS_ID {
                 return crate::buffer::dispatch_buffer_iterator_method(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                );
+            }
+            // #321: same array-iterator class-id check as the NaN-boxed path.
+            if (*obj).class_id == crate::array::ARRAY_ITERATOR_CLASS_ID {
+                return crate::array::dispatch_array_iterator_method(
                     obj as *mut ObjectHeader,
                     method_name,
                 );

--- a/test-files/test_gap_array_iterator_next.ts
+++ b/test-files/test_gap_array_iterator_next.ts
@@ -1,0 +1,58 @@
+// #321 (effect `ManagedRuntime` / `Exit.all`): a value-level
+// `arr[Symbol.iterator]()` / `arr.values()` / `arr.keys()` / `arr.entries()`
+// call must return a real `.next()`-bearing iterator (matching Node), and
+// `Array.from` must prefer the iterator protocol over an array-like `.length`.
+//
+// Before the fix the runtime dispatch tower had no `values`/`keys`/`entries`/
+// `@@iterator` arm for arrays, so a dynamic `arr[Symbol.iterator]()` returned
+// `undefined`; and `Array.from(obj)` over an iterable carrying a `.length`
+// (e.g. effect's `Chunk`) read `.length`/`obj[i]` and produced N `undefined`
+// elements. That surfaced as `Cannot read properties of undefined (reading
+// '_tag')` inside effect's `exitZipWith`.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+const arr = [10, 20, 30];
+
+// (1) arr[Symbol.iterator]() returns an iterator with a working .next().
+const it = arr[Symbol.iterator]();
+const a = it.next();
+const b = it.next();
+console.log("next0:", a.done, a.value);
+console.log("next1:", b.done, b.value);
+
+// (2) arr.values()/keys()/entries() drive the same iterator protocol when
+//     consumed via Array.from / spread.
+console.log("values:", Array.from(arr.values()).join(","));
+console.log("keys:", Array.from(arr.keys()).join(","));
+console.log("entries:", JSON.stringify(Array.from(arr.entries())));
+
+// (3) Array.from over a custom iterable that DELEGATES to a backing array's
+//     iterator (the effect Chunk shape).
+const backing = [{ tag: "A" }, { tag: "B" }];
+const iterable: Iterable<{ tag: string }> = {
+  [Symbol.iterator]() {
+    return backing[Symbol.iterator]();
+  },
+};
+const fromIter = Array.from(iterable);
+console.log("fromIter len:", fromIter.length);
+console.log("fromIter tags:", fromIter.map((x) => x.tag).join(","));
+
+// (4) spread of the same iterable.
+const spread = [...iterable];
+console.log("spread tags:", spread.map((x) => x.tag).join(","));
+
+// (5) Array.from over an object that is BOTH array-like (.length) AND iterable
+//     must take the iterator path (spec §23.1.2.1), not the .length path.
+const dual: any = {
+  length: 99, // a lie — the iterator yields the real elements
+  [Symbol.iterator]() {
+    return [7, 8, 9][Symbol.iterator]();
+  },
+};
+console.log("dual:", Array.from(dual).join(","));
+
+// (6) reduce over an array iterator's materialized values still works.
+const total = Array.from(arr.values()).reduce((acc, n) => acc + n, 0);
+console.log("reduce total:", total);


### PR DESCRIPTION
## Summary

Fixes the first blocker in Effect's **ManagedRuntime** (#321):
`ManagedRuntime.make(...).runSync(...)` threw `Cannot read properties of undefined (reading '_tag')`.

## Root cause

The crash traced to effect's `Exit.all` -> `exitCollectAllInternal` -> `Arr.reduce` over a **Chunk** -> `exitZipWith(self, that)` reading `self._tag` on `undefined`. Narrowed to a pure, effect-free repro:

```ts
const backing = [{ tag: "A" }, { tag: "B" }];
const obj = { [Symbol.iterator]() { return backing[Symbol.iterator](); } };
Array.from(obj);            // Node: length 2; Perry (pre-fix): length 0
backing[Symbol.iterator](); // .next() gave { done: undefined, value: undefined }
```

Two related runtime bugs:

1. A value-level `arr[Symbol.iterator]()` resolves (via `symbol.rs`) to the array's bound `values` method, which dispatches through `js_native_call_method`. The array dispatch tower in `object/native_call_method.rs` had **no `values`/`keys`/`entries`/`@@iterator` arm**, so the call fell through to the object-field scan and returned `undefined`.
2. `Array.from(obj)` (and spread) lower to `js_array_clone`, which for a `GC_TYPE_OBJECT` source always took the **array-like `.length`/`obj[i]`** path. An effect `Chunk` carries both a `.length` field and a `[Symbol.iterator]`, so it read `.length`=N and `chunk[i]` (which a Chunk does not store positionally) -> N `undefined` elements. Per ECMA-262 section 23.1.2.1, `Array.from` must prefer the iterator protocol.

`Array.from(undefined-elements)` flowed into `exitZipWith`, which read `_tag` on `undefined`.

## Fix (perry-runtime only — no codegen/HIR changes)

- **New `array/iter_object.rs`**: a real array iterator object (dedicated `ARRAY_ITERATOR_CLASS_ID`, mirrors `buffer/iter.rs`) with a working `.next()` returning `{ value, done }`, self-`[Symbol.iterator]`, and `values`/`keys`/`entries` kinds.
- **`object/native_call_method.rs`**: the array dispatch tower now returns that iterator for `values`/`keys`/`entries`/`Symbol.iterator`/`@@iterator`, and routes `ARRAY_ITERATOR_CLASS_ID` to the iterator dispatcher (both the NaN-boxed and raw-pointer dispatch sites, next to the existing Buffer-iterator checks).
- **`array/flat_clone.rs`**: `js_array_clone` now drives the iterator protocol when the `GC_TYPE_OBJECT` source is iterable (`Symbol.iterator` present) or is itself an iterator, before the array-like `.length` fallback.
- **`array/iterator.rs`**: `js_iterator_to_array` falls back to class-id `.next()` method dispatch (`js_native_call_method`) when the iterator stores no `next` closure field, so it can drive the new array iterator and Buffer iterators.

The codegen `Expr::ArrayValues` / for-of fast paths (eager array clone) are untouched — no regression to existing for-of or spread over array literals.

## Verification

- New gap test `test-files/test_gap_array_iterator_next.ts` is **byte-identical** to `node --experimental-strip-types`.
- Effect survey probe `fr_managedruntime.ts` -> `managed: 99` (matches Node), was throwing pre-fix.
- No regression: `nlay.ts` -> `provide: 42`, `21_schema_decode.ts` -> `Ada 36`.
- Existing `test_gap_array_symbol_iterator` / `test_gap_array_methods` / `test_gap_array_splice_dispatch` still byte-identical to Node.
- `cargo test --release -p perry-runtime --lib -- --test-threads=1` -> 695 passed, 0 failed.
- `cargo fmt --all -- --check` clean.

Refs #321.
