### PR TITLE
fix(node:http): keep a listening server alive — chained createServer().listen() + variadic listen() overloads (#2041)

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/http.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/http.rs
@@ -113,7 +113,14 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         method: "listen",
         class_filter: Some("HttpServer"),
         runtime: "js_node_http_server_listen",
-        args: &[NA_F64, NA_PTR],
+        // Node's `listen()` is variadic: listen(port[, host][, backlog][, cb]),
+        // listen(options[, cb]), listen(cb). Positional NativeArgKinds can't
+        // express "the callback floats to whichever position it's in", so pass
+        // every user arg as a JS array and let the runtime resolve the overload
+        // by value type (string→host, function→callback). Pre-#2041 the fixed
+        // `[NA_F64, NA_PTR]` mis-routed a host string into the callback slot and
+        // dropped the real callback. Issue #2041.
+        args: &[NA_VARARGS],
         ret: NR_VOID,
     },
     NativeModSig {
@@ -594,7 +601,8 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         method: "listen",
         class_filter: Some("HttpsServer"),
         runtime: "js_node_https_server_listen",
-        args: &[NA_F64, NA_PTR],
+        // Variadic listen() overloads — see the http `listen` row. Issue #2041.
+        args: &[NA_VARARGS],
         ret: NR_VOID,
     },
     NativeModSig {
@@ -631,7 +639,8 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         method: "listen",
         class_filter: Some("Http2SecureServer"),
         runtime: "js_node_http2_server_listen",
-        args: &[NA_F64, NA_PTR],
+        // Variadic listen() overloads — see the http `listen` row. Issue #2041.
+        args: &[NA_VARARGS],
         ret: NR_VOID,
     },
     NativeModSig {

--- a/crates/perry-ext-http-server/src/http2_server.rs
+++ b/crates/perry-ext-http-server/src/http2_server.rs
@@ -123,15 +123,18 @@ pub unsafe extern "C" fn js_node_http2_create_secure_server(opts_f64: f64, handl
     })
 }
 
-/// `http2SecureServer.listen({ port, host? }, cb?)`.
+/// `http2SecureServer.listen(port?, host?, backlog?, cb?)`. `args_array`
+/// carries the variadic `listen()` arguments; see `js_node_http_server_listen`
+/// / `parse_listen_args` for the overload resolution. Issue #2041.
 #[no_mangle]
-pub unsafe extern "C" fn js_node_http2_server_listen(
-    server_handle: i64,
-    opts_f64: f64,
-    callback: i64,
-) {
+pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_array: i64) {
+    let parsed = crate::types::parse_listen_args(args_array);
+    let opts_f64 = parsed.opts;
     let port = extract_port(opts_f64, 443);
-    let host = extract_host(opts_f64, "0.0.0.0");
+    let host = parsed
+        .host
+        .unwrap_or_else(|| extract_host(opts_f64, "0.0.0.0"));
+    let callback = parsed.callback;
 
     let (request_tx, request_rx) = mpsc::channel::<HttpPendingRequest>(1024);
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();

--- a/crates/perry-ext-http-server/src/https_server.rs
+++ b/crates/perry-ext-http-server/src/https_server.rs
@@ -147,16 +147,19 @@ pub struct HttpsServer {
     pub base: HttpServer,
 }
 
-/// `httpsServer.listen({ port, host? }, cb?)` — binds + starts
-/// accepting TLS-wrapped connections.
+/// `httpsServer.listen(port?, host?, backlog?, cb?)` — binds + starts
+/// accepting TLS-wrapped connections. `args_array` carries the variadic
+/// `listen()` arguments; see `js_node_http_server_listen` / `parse_listen_args`
+/// for the overload resolution. Issue #2041.
 #[no_mangle]
-pub unsafe extern "C" fn js_node_https_server_listen(
-    server_handle: i64,
-    opts_f64: f64,
-    callback: i64,
-) {
+pub unsafe extern "C" fn js_node_https_server_listen(server_handle: i64, args_array: i64) {
+    let parsed = crate::types::parse_listen_args(args_array);
+    let opts_f64 = parsed.opts;
     let port = extract_port(opts_f64, 443);
-    let host = extract_host(opts_f64, "0.0.0.0");
+    let host = parsed
+        .host
+        .unwrap_or_else(|| extract_host(opts_f64, "0.0.0.0"));
+    let callback = parsed.callback;
 
     let (request_tx, request_rx) = mpsc::channel::<HttpPendingRequest>(1024);
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -99,23 +99,25 @@ pub extern "C" fn js_node_http_create_server(handler: i64) -> i64 {
     })
 }
 
-/// `server.listen(port, host?, backlog?, cb?)` — bind + start
-/// accepting. Blocks the calling thread (main TS thread) for the
-/// process lifetime, draining pending requests and dispatching to
-/// the user handler.
+/// `server.listen(port?, host?, backlog?, cb?)` — bind + start accepting.
+/// Returns immediately after spawning the accept loop on the tokio runtime
+/// (non-blocking since #604); requests are drained from the main thread by
+/// `js_node_http_server_process_pending`.
 ///
-/// `opts_f64` accepts either a bare numeric port, an object literal
-/// (`{ port, host, backlog }`), or undefined for "default" (3000).
-/// The TS-side wrapper normalizes Node's many `listen()` overloads
-/// into this single shape.
+/// `args_array` is a raw `*const ArrayHeader` carrying every user-supplied
+/// `listen()` argument (codegen packs them via the `NA_VARARGS` arg kind).
+/// `parse_listen_args` resolves Node's variadic overloads by value type — a
+/// bare numeric/options/path first arg, an optional standalone host string,
+/// and the (single) function callback wherever it lands. Issue #2041.
 #[no_mangle]
-pub unsafe extern "C" fn js_node_http_server_listen(
-    server_handle: i64,
-    opts_f64: f64,
-    callback: i64,
-) {
+pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_array: i64) {
+    let parsed = crate::types::parse_listen_args(args_array);
+    let opts_f64 = parsed.opts;
     let port = extract_port(opts_f64, 3000);
-    let host = extract_host(opts_f64, "0.0.0.0");
+    let host = parsed
+        .host
+        .unwrap_or_else(|| extract_host(opts_f64, "0.0.0.0"));
+    let callback = parsed.callback;
 
     let (request_tx, request_rx) = mpsc::channel::<HttpPendingRequest>(1024);
     let (upgrade_tx, upgrade_rx) = mpsc::channel::<HttpPendingUpgrade>(256);

--- a/crates/perry-ext-http-server/src/types.rs
+++ b/crates/perry-ext-http-server/src/types.rs
@@ -1,7 +1,7 @@
 //! Shared NaN-boxing constants, runtime extern declarations, and
 //! port/host extraction helpers.
 
-use perry_ffi::{BufferHeader, JsValue, StringHeader};
+use perry_ffi::{ArrayHeader, BufferHeader, JsValue, StringHeader};
 
 pub const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
 pub const PTR_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
@@ -21,6 +21,13 @@ extern "C" {
     /// NaN-boxed with POINTER_TAG and stripped to a raw pointer). Defined
     /// in `crates/perry-runtime/src/buffer.rs::js_buffer_is_buffer`.
     pub fn js_buffer_is_buffer(ptr: i64) -> i32;
+    /// Issue #2041 — returns 1 when the NaN-boxed value bits are a
+    /// closure/function (POINTER_TAG + CLOSURE_MAGIC), 0 otherwise. Lets
+    /// `parse_listen_args` pick the `server.listen()` completion callback out
+    /// of the argument array by type rather than position, and distinguish it
+    /// from an options-object argument. Defined in
+    /// `crates/perry-runtime/src/closure/dynamic_props.rs::js_value_is_closure`.
+    pub fn js_value_is_closure(value_bits: i64) -> i32;
 }
 
 /// Opaque marker for the runtime's Promise struct — pass pointers
@@ -87,6 +94,78 @@ pub unsafe fn extract_host(opts: f64, default_host: &str) -> String {
         }
     }
     default_host.to_string()
+}
+
+/// Parsed shape of Node's variadic `server.listen(...)` overloads, shared by
+/// the http / https / http2 bind paths. Issue #2041.
+pub struct ListenArgs {
+    /// First positional argument — a bare port number, an options object
+    /// (`{ port, host, backlog }`), or `undefined`. Fed to `extract_port`
+    /// and `extract_host`.
+    pub opts: f64,
+    /// A standalone host string argument (the `listen(port, host, ...)`
+    /// overload). Takes precedence over a `host` field inside an options
+    /// object when both are present.
+    pub host: Option<String>,
+    /// Raw `*const ClosureHeader` pointer for the completion callback, or `0`
+    /// when no function argument was supplied.
+    pub callback: i64,
+}
+
+/// Normalize the JS-side `server.listen(...)` argument array into the
+/// `(opts, host, callback)` triple the bind path consumes.
+///
+/// `args_array` is a raw `*const ArrayHeader` (NOT NaN-boxed) holding every
+/// user-supplied `listen()` argument — codegen packs them via the `NA_VARARGS`
+/// arg kind. Resolution mirrors Node's type-directed overload handling: the
+/// first arg is the port / options / path; a later string arg is the host; the
+/// single function arg is the completion callback regardless of its position
+/// (`listen(port, cb)` vs `listen(port, host, cb)`); a numeric backlog arg is
+/// accepted and ignored (Perry exposes no backlog knob). The degenerate
+/// `listen(cb)` form (first and only arg is a function) is handled too.
+///
+/// # Safety
+/// `args_array` must be `0`/null or a valid Perry-runtime `ArrayHeader`.
+pub unsafe fn parse_listen_args(args_array: i64) -> ListenArgs {
+    let mut out = ListenArgs {
+        opts: f64::from_bits(TAG_UNDEFINED),
+        host: None,
+        callback: 0,
+    };
+    let arr_ptr = args_array as *const ArrayHeader;
+    if arr_ptr.is_null() {
+        return out;
+    }
+    // Codegen passes a clean raw pointer; reject a stray NaN-boxed value
+    // rather than dereferencing tag bits as an address.
+    if (args_array as u64) >> 48 != 0 {
+        return out;
+    }
+    let len = (*arr_ptr).length as usize;
+    let elements = (arr_ptr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const u64;
+    for i in 0..len {
+        let bits = *elements.add(i);
+        let v = JsValue::from_bits(bits);
+        // The completion callback is the (single) function argument — match it
+        // by value type, not position, so it's picked up wherever it floats.
+        let is_callback = js_value_is_closure(bits as i64) != 0;
+        if is_callback {
+            out.callback = (bits & PTR_MASK) as i64;
+            continue;
+        }
+        if i == 0 {
+            // port / options / path.
+            out.opts = f64::from_bits(bits);
+            continue;
+        }
+        if v.is_string() {
+            if let Some(s) = jsvalue_to_owned_string(f64::from_bits(bits)) {
+                out.host = Some(s);
+            }
+        }
+        // A numeric backlog (or anything else) at i > 0 is ignored.
+    }
+    out
 }
 
 /// Read a NaN-boxed JsValue as an owned String. Used for both
@@ -269,5 +348,66 @@ mod tests {
         // a wrong, low-numbered port).
         let port = unsafe { extract_port(70000.0_f64, 8080) };
         assert_eq!(port, 8080);
+    }
+
+    // Build a JS array from a slice of JsValues, the shape codegen's
+    // `NA_VARARGS` arg kind hands `js_node_http_server_listen` /
+    // `parse_listen_args`.
+    unsafe fn make_args(vals: &[JsValue]) -> i64 {
+        let mut arr = perry_ffi::js_array_alloc(vals.len() as u32);
+        for v in vals {
+            arr = perry_ffi::js_array_push(arr, *v);
+        }
+        arr as i64
+    }
+
+    #[test]
+    fn listen_null_array_is_all_defaults() {
+        // No args → no opts/host/callback; the bind path falls back to its
+        // module default port + 0.0.0.0.
+        let parsed = unsafe { parse_listen_args(0) };
+        assert!(JsValue::from_bits(parsed.opts.to_bits()).is_undefined());
+        assert!(parsed.host.is_none());
+        assert_eq!(parsed.callback, 0);
+    }
+
+    #[test]
+    fn listen_port_then_host_string_overload() {
+        // `listen(port, host)` — the standalone host string (#2041) must land
+        // in `host`, not be mistaken for a callback, and `opts` keeps the port.
+        let args = unsafe {
+            make_args(&[
+                JsValue::from_number(44500.0),
+                JsValue::from_string_ptr(perry_ffi::alloc_string("127.0.0.1").as_raw()),
+            ])
+        };
+        let parsed = unsafe { parse_listen_args(args) };
+        assert_eq!(unsafe { extract_port(parsed.opts, 3000) }, 44500);
+        assert_eq!(parsed.host.as_deref(), Some("127.0.0.1"));
+        assert_eq!(
+            parsed.callback, 0,
+            "a host string must not be read as a callback"
+        );
+    }
+
+    #[test]
+    fn listen_non_closure_pointer_is_not_mistaken_for_callback() {
+        // The first arg of `listen(options)` / `listen(path-ish)` is a heap
+        // pointer (POINTER_TAG, like a closure) but NOT a closure. It must stay
+        // in `opts` and must not be captured as the callback — guards the
+        // `js_value_is_closure` check that tells `listen(options)` apart from
+        // `listen(cb)`. An array stands in for any non-closure heap pointer.
+        let inner = unsafe { perry_ffi::js_array_alloc(0) };
+        let args = unsafe { make_args(&[JsValue::from_object_ptr(inner)]) };
+        let parsed = unsafe { parse_listen_args(args) };
+        assert_eq!(
+            parsed.callback, 0,
+            "a non-closure pointer must not be read as a callback"
+        );
+        assert!(parsed.host.is_none());
+        assert!(
+            JsValue::from_bits(parsed.opts.to_bits()).is_pointer(),
+            "the pointer arg should be retained as opts, not dropped"
+        );
     }
 }

--- a/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
@@ -129,6 +129,35 @@ pub(super) fn try_static_method_and_instance(
             }
         }
 
+        // Chained native-factory receiver: `createServer(handler).listen(...)`
+        // (and the https/http2 variants). The receiver is the inline factory
+        // CALL result, not an Ident the native-instance table can resolve, so
+        // the `if let ast::Expr::Ident` arm above misses it. Without this branch
+        // the chained `.listen(...)` falls through to the generic dynamic
+        // dispatch, the NativeModSig with `class_filter = Some("HttpServer")` is
+        // never matched, and the native listen fn is never called — so the
+        // server never binds and the process exits immediately. The variable
+        // form (`const s = createServer(...); s.listen(...)`) already works
+        // because the let-stmt arm tags `s`; only the chained form was broken.
+        // Issue #2041.
+        if let ast::Expr::Call(inner_call) = member.obj.as_ref() {
+            if let ast::MemberProp::Ident(method_ident) = &member.prop {
+                if let Some((module_name, class_name)) =
+                    native_class_from_factory_call(ctx, inner_call)
+                {
+                    let method_name = method_ident.sym.to_string();
+                    let object_expr = lower_expr(ctx, &member.obj)?;
+                    return Ok(Ok(Expr::NativeMethodCall {
+                        module: module_name.to_string(),
+                        class_name: Some(class_name.to_string()),
+                        object: Some(Box::new(object_expr)),
+                        method: method_name,
+                        args,
+                    }));
+                }
+            }
+        }
+
         // issue #195: WidgetCtor(...).modifierName(...) is silently dropped.
         // Reject at compile time so users discover the options-object form.
         if let ast::Expr::Call(inner_call) = member.obj.as_ref() {
@@ -300,4 +329,49 @@ pub(super) fn try_static_method_and_instance(
     }
 
     Ok(Err(args))
+}
+
+/// Resolve the native `(module, class)` produced by an inline factory call
+/// like `createServer(...)` / `http.createServer(...)` /
+/// `http2.createSecureServer(...)`, so a method chained directly on the result
+/// (`createServer(...).listen(...)`) can dispatch against the right
+/// NativeModSig `class_filter`. Mirrors the variable-binding factory maps in
+/// `module_decl.rs` / `destructuring/var_decl.rs` / `lower/stmt.rs`. Returns
+/// `None` for any other call so non-factory chains fall through unchanged.
+/// Issue #2041.
+fn native_class_from_factory_call(
+    ctx: &LoweringContext,
+    call: &ast::CallExpr,
+) -> Option<(&'static str, &'static str)> {
+    let callee_expr = match &call.callee {
+        ast::Callee::Expr(e) => e.as_ref(),
+        _ => return None,
+    };
+    // Resolve to `(module, method)`, handling both the named-import form
+    // (`createServer(...)`) and the namespace form (`http.createServer(...)`).
+    let (module, method): (String, String) = match callee_expr {
+        ast::Expr::Member(member) => {
+            let obj_ident = match member.obj.as_ref() {
+                ast::Expr::Ident(i) => i,
+                _ => return None,
+            };
+            let (module, _) = ctx.lookup_native_module(obj_ident.sym.as_ref())?;
+            let method = match &member.prop {
+                ast::MemberProp::Ident(i) => i.sym.to_string(),
+                _ => return None,
+            };
+            (module.to_string(), method)
+        }
+        ast::Expr::Ident(ident) => {
+            let (module, method_opt) = ctx.lookup_native_module(ident.sym.as_ref())?;
+            (module.to_string(), method_opt?.to_string())
+        }
+        _ => return None,
+    };
+    match (module.as_str(), method.as_str()) {
+        ("http", "createServer") => Some(("http", "HttpServer")),
+        ("https", "createServer") => Some(("https", "HttpsServer")),
+        ("http2", "createSecureServer") => Some(("http2", "Http2SecureServer")),
+        _ => None,
+    }
 }

--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -154,6 +154,28 @@ pub fn is_closure_ptr(ptr: usize) -> bool {
     }
 }
 
+/// C-ABI predicate: returns 1 when `value_bits` (a NaN-boxed JSValue passed as
+/// raw bits) is a closure/function — a `POINTER_TAG` value whose pointee
+/// carries `CLOSURE_MAGIC` — and 0 for objects, arrays, strings, numbers, and
+/// everything else. Exposed for external wrapper crates that link the runtime
+/// only by C ABI (e.g. perry-ext-http-server's `parse_listen_args`, #2041),
+/// which need to tell a callback argument apart from an options-object
+/// argument without a Cargo dependency on perry-runtime.
+#[no_mangle]
+pub extern "C" fn js_value_is_closure(value_bits: i64) -> i32 {
+    const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+    const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+    let bits = value_bits as u64;
+    if (bits & !POINTER_MASK) != POINTER_TAG {
+        return 0;
+    }
+    if is_closure_ptr((bits & POINTER_MASK) as usize) {
+        1
+    } else {
+        0
+    }
+}
+
 /// Get a dynamic property stored on a closure.
 /// Returns TAG_UNDEFINED if not found.
 pub fn closure_get_dynamic_prop(ptr: usize, prop: &str) -> f64 {

--- a/tests/release/packages/node-http-serve/entry.ts
+++ b/tests/release/packages/node-http-serve/entry.ts
@@ -1,0 +1,19 @@
+// #2041 acceptance fixture — the exact shape from the issue report: a chained
+// `createServer(...).listen(port, host, cb)` with a three-argument `listen`
+// (port number, host string, completion callback).
+//
+// Pre-#2041 this compiled and linked cleanly but the binary exited before
+// serving: the inline-factory receiver was never tagged `HttpServer`, so the
+// chained `.listen(...)` never dispatched to the native listen fn — which also
+// meant the event-loop's active-handle pump was never registered, so `main()`
+// returned and the process terminated in <1s. On top of that, the 3-arg
+// overload mis-routed the host string into the callback slot and dropped the
+// real callback. The driver fixture.sh launches this, curls it, and asserts a
+// 200 "ok".
+import { createServer } from "node:http";
+
+createServer((_req, res) => {
+  res.statusCode = 200;
+  res.setHeader("content-type", "text/plain");
+  res.end("ok");
+}).listen(44599, "127.0.0.1", () => console.log("listening on 44599"));

--- a/tests/release/packages/node-http-serve/fixture.sh
+++ b/tests/release/packages/node-http-serve/fixture.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# node-http-serve — #2041 live-socket smoke for `node:http`.
+#
+# The other compile+run+diff fixtures drive programs that run and exit; an HTTP
+# server stays up, so (like fastify-replay) this fixture has a bespoke driver:
+# it compiles entry.ts, launches the binary, curls the listening socket, and
+# asserts a 200 "ok". This is the only node:http coverage that asserts a *live*
+# socket — the test-files/test_node_http_*.ts fixtures are compile/link-only.
+#
+# entry.ts uses the exact shape from the issue: a chained
+# `createServer(...).listen(port, host, cb)`. Pre-#2041 that compiled+linked
+# but exited before binding the port (the chained `.listen` never dispatched,
+# so the active-handle pump was never armed; and the host string was mis-routed
+# into the callback slot). A regression there makes the curl below fail to
+# connect.
+set -uo pipefail
+cd "$(dirname "$0")"
+. "$(dirname "$0")/../_fixture_lib.sh"
+
+NAME="node-http-serve"
+PORT="${NODE_HTTP_SERVE_PORT:-44599}"
+
+fixture_setup "$NAME" || exit 1
+
+if ! command -v curl >/dev/null 2>&1; then
+    fixture_skip "$NAME" "curl not on PATH"
+fi
+
+# Compile.
+if ! "$PERRY_BIN" compile entry.ts -o out > perry-compile.log 2>&1; then
+    echo "FAIL $NAME — compile failed"
+    tail -20 perry-compile.log | sed 's/^/    /'
+    exit 1
+fi
+
+# Launch the server in the background; ensure it's reaped on every exit path.
+./out > perry-run.log 2>&1 &
+SRV_PID=$!
+cleanup() { kill "$SRV_PID" 2>/dev/null; wait "$SRV_PID" 2>/dev/null; }
+trap cleanup EXIT
+
+# Poll the socket — the accept loop binds asynchronously after listen() returns.
+BODY=""
+CODE=""
+for _ in $(seq 1 50); do
+    if ! kill -0 "$SRV_PID" 2>/dev/null; then
+        echo "FAIL $NAME — server exited before binding (the #2041 regression)"
+        tail -20 perry-run.log | sed 's/^/    /'
+        exit 1
+    fi
+    BODY="$(curl -fsS --max-time 2 "http://127.0.0.1:${PORT}/" 2>/dev/null)" || { sleep 0.2; continue; }
+    CODE="$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 2 "http://127.0.0.1:${PORT}/" 2>/dev/null)" || true
+    break
+done
+
+if [[ "$BODY" == "ok" && "$CODE" == "200" ]]; then
+    echo "PASS $NAME — GET / => 200 \"ok\""
+    exit 0
+fi
+
+echo "FAIL $NAME — expected 200 \"ok\", got code='${CODE}' body='${BODY}'"
+echo "    --- perry-run.log ---"
+tail -20 perry-run.log | sed 's/^/    /'
+exit 1


### PR DESCRIPTION
## What

Fixes #2041 — a `node:http` server compiled with `perry compile` now stays alive and serves requests. Before this, the exact repro from the issue (`createServer(...).listen(port, host, cb)`) compiled and linked cleanly (#1652) but exited in <1s, never binding the port.

## Root cause (two bugs)

The issue hypothesized the active-handle pump wasn't counting a listening server. The real cause was upstream of that: **`server.listen(...)` was never dispatched to the native listen fn for the issue's call shape**, so the pump — which registers from inside `listen` via `spawn_blocking_with_reactor` → `ensure_pump_registered` — never armed, `main()` returned, and the process exited.

**1. Chained-factory receiver.** The native-instance method-call lowering inferred the `HttpServer` class only for an *Ident* receiver (`const s = createServer(...); s.listen(...)`), not for the inline factory-call receiver (`createServer(...).listen(...)`). So the chained `.listen(...)` fell through to generic dispatch and the native fn was never called. Fix: infer the native `(module, class)` of an inline `createServer()` / `createSecureServer()` receiver in `try_static_method_and_instance` (covers http / https / http2).

**2. Variadic `listen()` overloads.** The native signature was fixed at `[NA_F64, NA_PTR]`, so `listen(port, host, cb)` mis-routed the host string into the callback slot and dropped the real callback. Positional arg kinds can't model Node's floating callback, so `listen` now passes every user arg as a JS array (`NA_VARARGS`) and the runtime resolves the overload by value type — a standalone string is the host, the single function is the callback, wherever it lands — via a new `js_value_is_closure` C-ABI predicate. Applied to http, https, and http2.

## Verification

Every `listen()` shape now stays alive and serves `200 "ok"`, with the callback firing and the host parsed:

| shape | result |
|---|---|
| `createServer(...).listen(port, host, cb)` (the repro) | alive, 200 "ok", binds 127.0.0.1 |
| `const s = ...; s.listen(port, host, cb)` | ok |
| `createServer(...).listen(port, cb)` | ok |
| `createServer(...).listen(port)` | ok |
| `s.listen({ port, host }, cb)` | ok |
| `s.listen(port, cb)` (baseline, previously working) | ok |

## Tests

- `tests/release/packages/node-http-serve/` — the first `node:http` fixture that compiles + runs + **curls a live socket** (acceptance criterion #3; the existing `test_node_http_*.ts` are compile/link-only).
- `parse_listen_args` unit tests covering the host-override and non-closure-pointer (`listen(options)` vs `listen(cb)`) paths.

## Out of scope

`@hono/node-server` end-to-end (acceptance criterion #2) additionally depends on #1651 (http2 named exports the adapter imports) and is not addressed here.
