### PR TITLE
fix(node:stream): batch corked writable writev

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -84,6 +84,7 @@ const WRITABLE_FINISH_SCHEDULED_KEY: &[u8] = b"__perryWritableFinishScheduled";
 const WRITABLE_FINISH_EMITTED_KEY: &[u8] = b"__perryWritableFinishEmitted";
 const WRITABLE_CORKED_KEY: &[u8] = b"__perryWritableCorked";
 const WRITABLE_BUFFERED_KEY: &[u8] = b"__perryWritableBuffered";
+const WRITABLE_WRITEV_KEY: &[u8] = b"__perryWritableWritev";
 // #1534: direction + disturbed bits so the static introspection helpers
 // (`Readable.isReadable` / `isDisturbed` / `isErrored`) answer per-stream
 // instead of with a uniform stub. Set at construction / on first read.
@@ -314,6 +315,19 @@ fn invoke_writable_write(stream: f64, chunk: f64, enc: f64) {
         let prev_this = crate::object::js_implicit_this_set(stream);
         unsafe {
             let _ = crate::closure::js_native_call_value(write, args.as_ptr(), args.len());
+        }
+        crate::object::js_implicit_this_set(prev_this);
+    }
+}
+
+fn invoke_writable_writev(stream: f64, chunks: f64) {
+    if let Some(writev) = writable_hidden_writev(stream) {
+        let cb = js_closure_alloc(writable_write_callback_noop as *const u8, 0);
+        let cb_value = f64::from_bits(JSValue::pointer(cb as *const u8).bits());
+        let args = [chunks, cb_value];
+        let prev_this = crate::object::js_implicit_this_set(stream);
+        unsafe {
+            let _ = crate::closure::js_native_call_value(writev, args.as_ptr(), args.len());
         }
         crate::object::js_implicit_this_set(prev_this);
     }
@@ -1261,6 +1275,11 @@ fn hidden_writable_buffered_key() -> *mut crate::string::StringHeader {
 }
 
 #[inline]
+fn hidden_writev_key() -> *mut crate::string::StringHeader {
+    hidden_key(WRITABLE_WRITEV_KEY)
+}
+
+#[inline]
 fn hidden_readable_flag_key() -> *mut crate::string::StringHeader {
     hidden_key(READABLE_FLAG_KEY)
 }
@@ -1475,6 +1494,10 @@ fn writable_hidden_write(value: f64) -> Option<f64> {
     get_hidden_value(value, hidden_write_key())
 }
 
+fn writable_hidden_writev(value: f64) -> Option<f64> {
+    get_hidden_value(value, hidden_writev_key())
+}
+
 fn writable_corked_count(value: f64) -> f64 {
     get_hidden_value(value, hidden_writable_corked_key()).unwrap_or(0.0)
 }
@@ -1519,6 +1542,40 @@ fn buffer_writable_write(stream: f64, chunk: f64, enc: f64) {
     set_hidden_value(stream, hidden_writable_buffered_key(), buffered);
 }
 
+fn writev_record_chunk(chunk: f64, enc: f64) -> (f64, f64) {
+    if JSValue::from_bits(chunk.to_bits()).is_any_string() {
+        let buffer = crate::buffer::js_buffer_from_value(chunk.to_bits() as i64, 0);
+        (box_pointer(buffer as *const u8), string_value(b"buffer"))
+    } else {
+        let raw = raw_ptr_from_value(chunk);
+        if raw >= 0x10000 && crate::buffer::is_registered_buffer(raw) {
+            (chunk, string_value(b"buffer"))
+        } else {
+            (chunk, enc)
+        }
+    }
+}
+
+fn build_writev_chunks(buffered: *const crate::array::ArrayHeader, len: u32) -> f64 {
+    let mut chunks = crate::array::js_array_alloc(0);
+    let mut i = 0;
+    while i < len {
+        let chunk = crate::array::js_array_get_f64(buffered, i);
+        let enc = if i + 1 < len {
+            crate::array::js_array_get_f64(buffered, i + 1)
+        } else {
+            f64::from_bits(TAG_UNDEFINED)
+        };
+        let (chunk, encoding) = writev_record_chunk(chunk, enc);
+        let record = crate::object::js_object_alloc(0, 2);
+        js_object_set_field_by_name(record, hidden_key(b"chunk"), chunk);
+        js_object_set_field_by_name(record, hidden_key(b"encoding"), encoding);
+        chunks = crate::array::js_array_push_f64(chunks, box_pointer(record as *const u8));
+        i += 2;
+    }
+    box_pointer(chunks as *const u8)
+}
+
 fn flush_writable_buffered(stream: f64) {
     let Some(buffered) = buffered_writable_writes(stream) else {
         return;
@@ -1534,6 +1591,16 @@ fn flush_writable_buffered(stream: f64) {
         hidden_writable_buffered_key(),
         box_pointer(crate::array::js_array_alloc(0) as *const u8),
     );
+    if len > 2 && writable_hidden_writev(stream).is_some() {
+        let chunks = build_writev_chunks(arr, len);
+        invoke_writable_writev(stream, chunks);
+        let mut i = 0;
+        while i < len {
+            emit_writable_chunk(stream, crate::array::js_array_get_f64(arr, i));
+            i += 2;
+        }
+        return;
+    }
     let mut i = 0;
     while i < len {
         let chunk = crate::array::js_array_get_f64(arr, i);
@@ -1561,6 +1628,10 @@ fn read_callback_from_options(opts: f64) -> Option<f64> {
 
 fn write_callback_from_options(opts: f64) -> Option<f64> {
     get_hidden_value(opts, hidden_key(b"write"))
+}
+
+fn writev_callback_from_options(opts: f64) -> Option<f64> {
+    get_hidden_value(opts, hidden_key(b"writev"))
 }
 
 fn invoke_read_once(stream: f64) {
@@ -2195,6 +2266,13 @@ pub extern "C" fn js_node_stream_writable_new(opts: f64) -> f64 {
             rebind_callback_this(write, writable),
         );
     }
+    if let Some(writev) = writev_callback_from_options(opts) {
+        js_object_set_field_by_name(
+            obj,
+            hidden_writev_key(),
+            rebind_callback_this(writev, writable),
+        );
+    }
     init_lifecycle_state(writable);
     init_constructor(writable, "Writable");
     init_writable_state(writable, opts);
@@ -2209,6 +2287,13 @@ pub extern "C" fn js_node_stream_duplex_new(opts: f64) -> f64 {
     let duplex = f64::from_bits(JSValue::pointer(obj as *const u8).bits());
     if let Some(write) = write_callback_from_options(opts) {
         js_object_set_field_by_name(obj, hidden_write_key(), rebind_callback_this(write, duplex));
+    }
+    if let Some(writev) = writev_callback_from_options(opts) {
+        js_object_set_field_by_name(
+            obj,
+            hidden_writev_key(),
+            rebind_callback_this(writev, duplex),
+        );
     }
     init_lifecycle_state(duplex);
     init_constructor(duplex, "Duplex");

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -6,6 +6,8 @@ use std::cell::RefCell;
 
 thread_local! {
     static WRITE_CAPTURED: RefCell<Vec<Vec<u8>>> = const { RefCell::new(Vec::new()) };
+    static WRITEV_CAPTURED: RefCell<Vec<Vec<u8>>> = const { RefCell::new(Vec::new()) };
+    static WRITEV_BUFFER_SHAPE: RefCell<Vec<bool>> = const { RefCell::new(Vec::new()) };
     static READABLE_DATA_CAPTURED: RefCell<Vec<Vec<u8>>> = const { RefCell::new(Vec::new()) };
     static READABLE_THIS_MATCHES: RefCell<Vec<bool>> = const { RefCell::new(Vec::new()) };
     static READABLE_END_COUNT: RefCell<usize> = const { RefCell::new(0) };
@@ -35,6 +37,33 @@ extern "C" fn write_capture(_closure: *const ClosureHeader, chunk: f64, _enc: f6
     let readable = js_node_stream_readable_from(chunk);
     let bytes = js_node_stream_collect_bytes(readable);
     WRITE_CAPTURED.with(|captured| captured.borrow_mut().push(bytes));
+    unsafe {
+        let _ = crate::closure::js_native_call_value(cb, std::ptr::null(), 0);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn writev_capture(_closure: *const ClosureHeader, chunks: f64, cb: f64) -> f64 {
+    let chunks = raw_ptr_from_value(chunks) as *const crate::array::ArrayHeader;
+    let len = crate::array::js_array_length(chunks);
+    for i in 0..len {
+        let record = crate::array::js_array_get_f64(chunks, i);
+        let record = raw_ptr_from_value(record) as *const ObjectHeader;
+        let chunk = js_object_get_field_by_name_f64(record, hidden_key(b"chunk"));
+        let encoding = js_object_get_field_by_name_f64(record, hidden_key(b"encoding"));
+        let raw = raw_ptr_from_value(chunk);
+        WRITEV_BUFFER_SHAPE.with(|shape| {
+            shape.borrow_mut().push(
+                crate::buffer::is_registered_buffer(raw) && string_value_eq(encoding, b"buffer"),
+            )
+        });
+        let readable = js_node_stream_readable_from(chunk);
+        WRITEV_CAPTURED.with(|captured| {
+            captured
+                .borrow_mut()
+                .push(js_node_stream_collect_bytes(readable))
+        });
+    }
     unsafe {
         let _ = crate::closure::js_native_call_value(cb, std::ptr::null(), 0);
     }
@@ -302,6 +331,47 @@ fn writable_cork_buffers_writes_until_uncorked() {
             &[b"a".to_vec(), b"b".to_vec()]
         );
     });
+}
+
+#[test]
+fn writable_cork_uses_writev_for_multi_chunk_flush() {
+    WRITE_CAPTURED.with(|captured| captured.borrow_mut().clear());
+    WRITEV_CAPTURED.with(|captured| captured.borrow_mut().clear());
+    WRITEV_BUFFER_SHAPE.with(|shape| shape.borrow_mut().clear());
+
+    let opts = crate::object::js_object_alloc(0, 2);
+    let write = js_closure_alloc(write_capture as *const u8, 0);
+    let writev = js_closure_alloc(writev_capture as *const u8, 0);
+    crate::closure::js_register_closure_arity(write_capture as *const u8, 3);
+    crate::closure::js_register_closure_arity(writev_capture as *const u8, 2);
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"write"),
+        f64::from_bits(JSValue::pointer(write as *const u8).bits()),
+    );
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"writev"),
+        f64::from_bits(JSValue::pointer(writev as *const u8).bits()),
+    );
+
+    let stream = js_node_stream_writable_new(box_pointer(opts as *const u8));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let undefined = f64::from_bits(TAG_UNDEFINED);
+
+    let _ = js_node_stream_method_cork(handle);
+    let _ = js_node_stream_method_write(handle, string_value("a"), undefined);
+    let _ = js_node_stream_method_write(handle, string_value("b"), undefined);
+    let _ = js_node_stream_method_uncork(handle);
+
+    WRITE_CAPTURED.with(|captured| assert!(captured.borrow().is_empty()));
+    WRITEV_CAPTURED.with(|captured| {
+        assert_eq!(
+            captured.borrow().as_slice(),
+            &[b"a".to_vec(), b"b".to_vec()]
+        );
+    });
+    WRITEV_BUFFER_SHAPE.with(|shape| assert_eq!(shape.borrow().as_slice(), &[true, true]));
 }
 
 #[test]

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -470,12 +470,6 @@
     "category": "bug-open",
     "reason": "node:stream: write(null) error path (ERR_STREAM_NULL_VALUES) doesn't emit error / throw. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/write/writev-batch": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: writev() constructor option not invoked when corked + multi-write. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/method-chain/setEncoding-returns-this": {
     "issue": "1531",
     "added": "2026-05-23",
@@ -1045,12 +1039,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: WritableStream sink.start() hook not awaited before first write. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/write/writev-chunk-shape": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: user writev(chunks, cb) — chunks not delivered as array of {chunk, encoding} objects. Flips to PASS when #1539 lands."
   },
   "node-suite/stream/readable/from-infinite-take": {
     "issue": "1558",
@@ -1651,12 +1639,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pause/resume on objectMode Readable — wrong count or first item value. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/writable/_writev-vs-write": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: cork+uncork dispatches to write() instead of writev() when writev is defined. Flips to PASS when #1539 lands."
   },
   "node-suite/stream/readable/unshift-while-flowing": {
     "issue": "1532",


### PR DESCRIPTION
## Summary

- stores Writable/Duplex constructor `writev(chunks, cb)` callbacks alongside `write`
- flushes multiple cork-buffered writes through a single `writev` call
- builds Node-shaped `_writev` chunk records with `{ chunk, encoding }`, converting default string writes to Buffer chunks with `encoding: "buffer"`
- removes the three now-passing writev known-failure entries

## DeepWiki

- Local reference only: `reference/deepwiki/nodejs-node-stream-writable-writev-batch-2026-05-27.md`
- Extracted invariant: when multiple chunks are buffered by `cork()` and a user `_writev`/`writev` implementation exists, flush should call `writev(chunks, cb)` once; otherwise flush through individual `write` calls. `chunks` entries expose `chunk` and `encoding`, with decoded string writes arriving as Buffer chunks.

## Verification

- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`
- `cargo test -p perry-runtime writable_cork_uses_writev_for_multi_chunk_flush --lib`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter writev` PASS 3/3 after rebase, report `test-parity/reports/parity_report_20260527_114217.json`

## Wider Guardrail

`CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/write/` still exits below threshold with pre-existing residual write semantics gaps (`after-end-emits-error`, `false-then-retry`, `three-arg-form`, `with-encoding`, `write-null`). The writev targets in that wider run stayed green.

## Non-goals

- no `write(null)` validation
- no write-after-end error path
- no high-watermark/backpressure return-value semantics
- no broader encoding/decodeStrings normalization
- no drain timing or full Writable state-machine rewrite
