### PR TITLE
fix(runtime): array [Symbol.iterator]()/.values() dynamic dispatch for effect Stream/Chunk (#321)

### DIFF
--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -128,6 +128,28 @@ pub extern "C" fn js_iterator_to_array(iter_f64: f64) -> *mut ArrayHeader {
     if iter_ptr == 0 {
         return arr;
     }
+
+    // #321: Perry materializes some JS iterators as plain arrays rather than
+    // standalone iterator objects. In particular `arr[Symbol.iterator]()`
+    // (and `arr.values()`) route to `js_array_values`, which returns an Array
+    // CLONE, not a `{ next }` object. effect's `Chunk[Symbol.iterator]`
+    // returns exactly this (`this.backing.array[Symbol.iterator]()`), and
+    // `js_get_iterator` hands the result straight here. Such a value has no
+    // `.next` method — pre-fix this returned an empty array (silent data loss)
+    // and downstream `.next()`/`.values()` calls on it then threw
+    // `values is not a function`. Detect an Array/lazy-array iterator value and
+    // return it directly; its elements ARE the iteration sequence.
+    {
+        use crate::gc::{GcHeader, GC_HEADER_SIZE, GC_TYPE_ARRAY, GC_TYPE_LAZY_ARRAY};
+        let ot = unsafe {
+            let gc_header = (iter_ptr as *const u8).sub(GC_HEADER_SIZE) as *const GcHeader;
+            (*gc_header).obj_type
+        };
+        if ot == GC_TYPE_ARRAY || ot == GC_TYPE_LAZY_ARRAY {
+            return iter_ptr as *mut ArrayHeader;
+        }
+    }
+
     let iter_obj = iter_ptr as *const ObjectHeader;
 
     // Look up the "next" method on the iterator object

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1281,6 +1281,38 @@ pub unsafe extern "C" fn js_native_call_method(
                         let s = crate::array::js_array_join(arr, sep_ptr);
                         return f64::from_bits(JSValue::string_ptr(s).bits());
                     }
+                    // #321 (effect Stream/Chunk): `arr.values()` / `arr.keys()` /
+                    // `arr.entries()` reaching the runtime dispatch tower (rather
+                    // than codegen's statically-typed array inline path). This
+                    // fires for `arr[Symbol.iterator]()`, which resolves to a
+                    // bound `values` method (see `symbol.rs::js_object_get_symbol_property`)
+                    // and lands here via `dispatch_bound_method`. Without these
+                    // arms the array tower fell through to the GC_TYPE_OBJECT-only
+                    // object-field scan (which an array skips entirely) and
+                    // ultimately returned the NULL_OBJECT_BYTES sentinel — a rodata
+                    // pointer that downstream `for...of` / `.next()` reads as an
+                    // empty/garbage value. effect's `Chunk[Symbol.iterator]` does
+                    // exactly `this.backing.array[Symbol.iterator]()`, so this gap
+                    // made every `for...of` over a Chunk yield nothing (and the
+                    // stream channel executor then SIGSEGV'd / produced a Die).
+                    // Perry materializes these iterators as plain arrays (matching
+                    // `js_array_values`); `js_iterator_to_array` returns such an
+                    // array verbatim.
+                    "values" => {
+                        let arr = raw_ptr as *const crate::array::ArrayHeader;
+                        let result = crate::array::js_array_values(arr);
+                        return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
+                    }
+                    "keys" => {
+                        let arr = raw_ptr as *const crate::array::ArrayHeader;
+                        let result = crate::array::js_array_keys(arr);
+                        return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
+                    }
+                    "entries" => {
+                        let arr = raw_ptr as *const crate::array::ArrayHeader;
+                        let result = crate::array::js_array_entries(arr);
+                        return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
+                    }
                     _ => {} // not a handled array method — fall through to object dispatch
                 }
             }

--- a/test-files/test_gap_array_symbol_iterator_dispatch.ts
+++ b/test-files/test_gap_array_symbol_iterator_dispatch.ts
@@ -1,0 +1,41 @@
+// #321 (effect Stream/Chunk): a dynamic `arr[Symbol.iterator]()` / `arr.values()`
+// dispatch must materialize the iteration sequence. effect's `Chunk[Symbol.iterator]`
+// does `this.backing.array[Symbol.iterator]()`, which resolves to the array's bound
+// `values` method at runtime. Before the fix that bound-method dispatch fell through
+// the array method tower and returned a sentinel, so every `for...of` over the result
+// yielded nothing (and downstream `.next()`/`.values()` threw "values is not a
+// function"). These cases exercise the runtime dispatch path (not codegen's static
+// array inline path).
+
+// 1) Direct symbol-keyed iterator call on a field-chain receiver (the Chunk shape).
+const obj = { backing: { array: [1, 2, 3] } };
+const it = obj.backing.array[Symbol.iterator]();
+const out: number[] = [];
+for (const x of it) {
+  out.push(x as number);
+}
+console.log("field-chain iter:", JSON.stringify(out));
+
+// 2) Spreading a symbol-keyed iterator result.
+const spread = [...obj.backing.array[Symbol.iterator]()];
+console.log("spread:", JSON.stringify(spread));
+
+// 3) Dynamic `.values()` dispatch on an array via an any-typed binding.
+const anyArr: any = [10, 20, 30];
+const valsOut: number[] = [];
+for (const v of anyArr.values()) {
+  valsOut.push(v as number);
+}
+console.log("values:", JSON.stringify(valsOut));
+
+// 4) Dynamic `.entries()` / `.keys()` dispatch on an array.
+const entriesOut: Array<[number, number]> = [];
+for (const e of anyArr.entries()) {
+  entriesOut.push(e as [number, number]);
+}
+console.log("entries:", JSON.stringify(entriesOut));
+const keysOut: number[] = [];
+for (const k of anyArr.keys()) {
+  keysOut.push(k as number);
+}
+console.log("keys:", JSON.stringify(keysOut));


### PR DESCRIPTION
## Summary

Fixes the first blocker in effect's **Stream** module (refs #321): basic `effect/Stream` usage SIGSEGV'd because a dynamic `arr[Symbol.iterator]()` / `arr.values()` dispatch on a native array returned a garbage sentinel instead of the iteration sequence.

## Root cause

effect's `Chunk[Symbol.iterator]` (`Chunk.ts`) does `this.backing.array[Symbol.iterator]()`. In Perry, `arr[Symbol.iterator]` resolves to the array's **bound `values` method** (`symbol.rs::js_object_get_symbol_property`). Invoking that bound method routes through `dispatch_bound_method` -> `js_native_call_method(arr, "values", ...)`.

But the array method dispatch tower in `js_native_call_method` had **no `values` / `keys` / `entries` arm** — those calls fell through the array tower to the `GC_TYPE_OBJECT`-only object-field scan (which an array skips entirely) and ultimately returned the `NULL_OBJECT_BYTES` sentinel: a rodata pointer that downstream `for...of` / `.next()` reads as an empty/garbage value.

Result: every `for...of` over a `Chunk` yielded nothing. The stream channel executor then produced a defect; effect tried to pretty-print the failing `Cause` via `makePrettyError` (`internal/cause.ts`), and `new Error(prettyErrorMessage(...))` was handed a corrupt `0x1` message pointer -> SIGSEGV in `alloc_error`.

(The codegen-static path for a provably-array receiver already inlined `arr.values()`; only the *runtime dynamic-dispatch* path — which the symbol-keyed bound method always takes — was missing.)

## Fix

Two small additive changes in `perry-runtime` (54 insertions, no deletions):

1. **`object/native_call_method.rs`** — add `"values"` / `"keys"` / `"entries"` arms to the array method dispatch tower, routing to the existing `js_array_values` / `js_array_keys` / `js_array_entries` helpers. Perry materializes these iterators as plain arrays (matching the long-standing `arr.values()` design).

2. **`array/iterator.rs`** — in `js_iterator_to_array`, detect when the iterator VALUE is itself a plain Array / lazy-array (which is what Perry's materialized `arr.values()` / `arr[Symbol.iterator]()` returns) and return it verbatim, rather than looking up a non-existent `.next` method and returning an empty array.

## Verification

- New gap test `test-files/test_gap_array_symbol_iterator_dispatch.ts` — byte-identical to `node --experimental-strip-types` (field-chain `arr[Symbol.iterator]()`, spread, dynamic `.values()`/`.keys()`/`.entries()`).
- Standalone `obj.backing.array[Symbol.iterator]()` for-of now yields `[1,2,3]` (was `[]`); iterating an `effect/Chunk` now yields `[1,2,3]` (was `[]`).
- No regression: existing `test_gap_array_symbol_iterator`, `test_compat_arrays_iterators`, `test_gap_array_methods`, `test_gap_array_splice_dispatch` all byte-identical; spread/for-of over arrays/Maps/Sets/generators/strings all byte-identical.
- effect survey no-regression: `21_schema_decode.ts` -> `Ada 36`, `nlay.ts` -> `provide: 42`, `05_gen.ts` -> `30`.
- `cargo test --release -p perry-runtime --lib -- --test-threads=1` -> 695 passed, 0 failed.
- `cargo fmt --all -- --check` clean.

## Next Stream blocker (not in this PR)

After this fix, `fr_stream.ts` / `fr_stream_run.ts` still SIGSEGV — but now on a **deeper** layer. `Effect.runSyncExit(Stream.runCollect(...))` produces a `Die` whose defect is a spurious `effect` exception. Root cause: effect's `makeException` factory (`internal/core.ts`) returns a distinct `class Base extends YieldableError` per call (`RuntimeException`, `TimeoutException`, `IllegalArgumentException`, ...). Perry collapses these class **expressions** to ONE shared class:

```
new Cause.RuntimeException("x")._tag        // Perry: undefined   Node: "RuntimeException"
new Cause.IllegalArgumentException("y")._tag // Perry: undefined   Node: "IllegalArgumentException"
(rt).constructor === (il).constructor        // Perry: true        Node: false
Cause.isRuntimeException(rt)                  // Perry: false       Node: true
```

All `makeException` results share one compiled class, losing their `_tag`/`name`/prototype, which makes effect's internal `isX(u)` guards misfire. This is the class-expression-as-heap-object family (#1772 / #1785), tracked separately.
