### PR TITLE
fix(node:stream): reject null writable chunks

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -319,7 +319,19 @@ fn invoke_writable_write(stream: f64, chunk: f64, enc: f64) {
     }
 }
 
+#[cold]
+fn throw_writable_null_chunk() -> ! {
+    let msg = b"May not write null values to stream";
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    crate::node_submodules::register_error_code_pub(s, "ERR_STREAM_NULL_VALUES");
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
 fn write_writable_chunk(stream: f64, chunk: f64, enc: f64) -> f64 {
+    if JSValue::from_bits(chunk.to_bits()).is_null() {
+        throw_writable_null_chunk();
+    }
     if writable_corked_count(stream) > 0.0 {
         buffer_writable_write(stream, chunk, enc);
         return f64::from_bits(TAG_TRUE);

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -464,12 +464,6 @@
     "category": "bug-open",
     "reason": "node:stream: final() constructor option not invoked before finish. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/write/write-null": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: write(null) error path (ERR_STREAM_NULL_VALUES) doesn't emit error / throw. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/write/writev-batch": {
     "issue": "1531",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary

- rejects `Writable.write(null)` before cork buffering or invoking the user `write` callback
- throws a Node-coded `TypeError [ERR_STREAM_NULL_VALUES]` with `May not write null values to stream`
- removes the now-passing `node-suite/stream/write/write-null` known-failure entry

## DeepWiki

- Local reference only: `reference/deepwiki/nodejs-node-stream-writable-write-null-2026-05-27.md`
- Extracted invariant: `Writable.write(null)` throws synchronously with `ERR_STREAM_NULL_VALUES`; user `_write`/`write` is not invoked and no boolean return value is produced.

## Verification

- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter write-null` PASS 1/1 after rebase, report `test-parity/reports/parity_report_20260527_115557.json`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/write/write-` PASS 2/2, report `test-parity/reports/parity_report_20260527_115108.json`

## Non-goals

- no write-after-end error path
- no high-watermark/backpressure return-value semantics
- no broader encoding/decodeStrings normalization
- no object-mode changes
- no full Writable state-machine rewrite
