### PR TITLE
fix(node:stream): emit write-after-end error

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -319,7 +319,20 @@ fn invoke_writable_write(stream: f64, chunk: f64, enc: f64) {
     }
 }
 
+fn writable_write_after_end_error() -> f64 {
+    let msg = b"write after end";
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    crate::node_submodules::register_error_code_pub(s, "ERR_STREAM_WRITE_AFTER_END");
+    let err = crate::error::js_error_new_with_message(s);
+    crate::value::js_nanbox_pointer(err as i64)
+}
+
 fn write_writable_chunk(stream: f64, chunk: f64, enc: f64) -> f64 {
+    if stream_hidden_ended(stream) {
+        let err = writable_write_after_end_error();
+        let _ = emit_stream_event(stream, string_value(b"error"), &[err]);
+        return f64::from_bits(TAG_FALSE);
+    }
     if writable_corked_count(stream) > 0.0 {
         buffer_writable_write(stream, chunk, enc);
         return f64::from_bits(TAG_TRUE);

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -9,6 +9,7 @@ thread_local! {
     static READABLE_DATA_CAPTURED: RefCell<Vec<Vec<u8>>> = const { RefCell::new(Vec::new()) };
     static READABLE_THIS_MATCHES: RefCell<Vec<bool>> = const { RefCell::new(Vec::new()) };
     static READABLE_END_COUNT: RefCell<usize> = const { RefCell::new(0) };
+    static ERROR_COUNT: RefCell<usize> = const { RefCell::new(0) };
     static WRITABLE_FINISH_COUNT: RefCell<usize> = const { RefCell::new(0) };
     static WRITABLE_CLOSE_COUNT: RefCell<usize> = const { RefCell::new(0) };
 }
@@ -71,6 +72,11 @@ extern "C" fn capture_end_listener(closure: *const ClosureHeader) -> f64 {
             .push(actual.to_bits() == expected.to_bits())
     });
     READABLE_END_COUNT.with(|count| *count.borrow_mut() += 1);
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn capture_error_listener(_closure: *const ClosureHeader, _err: f64) -> f64 {
+    ERROR_COUNT.with(|count| *count.borrow_mut() += 1);
     f64::from_bits(TAG_UNDEFINED)
 }
 
@@ -302,6 +308,39 @@ fn writable_cork_buffers_writes_until_uncorked() {
             &[b"a".to_vec(), b"b".to_vec()]
         );
     });
+}
+
+#[test]
+fn writable_write_after_end_emits_error_without_calling_write() {
+    WRITE_CAPTURED.with(|captured| captured.borrow_mut().clear());
+    ERROR_COUNT.with(|count| *count.borrow_mut() = 0);
+
+    let opts = crate::object::js_object_alloc(0, 1);
+    let write = js_closure_alloc(write_capture as *const u8, 0);
+    crate::closure::js_register_closure_arity(write_capture as *const u8, 3);
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"write"),
+        f64::from_bits(JSValue::pointer(write as *const u8).bits()),
+    );
+
+    let stream = js_node_stream_writable_new(box_pointer(opts as *const u8));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let error = js_closure_alloc(capture_error_listener as *const u8, 0);
+    crate::closure::js_register_closure_arity(capture_error_listener as *const u8, 1);
+    let _ = js_node_stream_method_on(
+        handle,
+        string_value("error"),
+        f64::from_bits(JSValue::pointer(error as *const u8).bits()),
+    );
+
+    let _ = js_node_stream_method_end(handle, string_value("a"));
+    let result =
+        js_node_stream_method_write(handle, string_value("b"), f64::from_bits(TAG_UNDEFINED));
+
+    assert_eq!(result.to_bits(), TAG_FALSE);
+    ERROR_COUNT.with(|count| assert_eq!(*count.borrow(), 1));
+    WRITE_CAPTURED.with(|captured| assert_eq!(captured.borrow().as_slice(), &[b"a".to_vec()]));
 }
 
 #[test]

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -548,12 +548,6 @@
     "category": "bug-open",
     "reason": "node:stream: setEncoding(hex) + data delivery doesn't fire. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/write/after-end-emits-error": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: write() after end() should emit ERR_STREAM_WRITE_AFTER_END. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/async-iter/break-cleanup": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- return false and emit ERR_STREAM_WRITE_AFTER_END for Writable.write() after end()
- skip user write invocation for the rejected post-end chunk
- add a runtime unit and remove the passing after-end known-failure entry

## Verification
- cargo fmt --check
- jq empty test-parity/known_failures.json
- git diff --check origin/main...HEAD
- cargo test -p perry-runtime writable_write_after_end_emits_error_without_calling_write --lib
- CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter after-end-emits-error (PASS 1/1, report test-parity/reports/parity_report_20260527_121040.json)
- Guardrail: after-end filter kept write/after-end-emits-error green but still has unrelated residuals in pipe/cleanup-state-after-end and readable/unshift-after-end