### PR TITLE
fix(node:stream): normalize writable write chunks

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -856,8 +856,8 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         has_receiver: true,
         method: "write",
         class_filter: None,
-        runtime: "js_node_stream_method_write",
-        args: &[NA_F64, NA_F64],
+        runtime: "js_node_stream_method_write3",
+        args: &[NA_F64, NA_F64, NA_F64],
         ret: NR_F64,
     },
     NativeModSig {

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -287,9 +287,9 @@ extern "C" fn writable_write_callback_noop(_closure: *const ClosureHeader) -> f6
     f64::from_bits(TAG_UNDEFINED)
 }
 
-extern "C" fn ns_write2(closure: *const ClosureHeader, chunk: f64, enc: f64) -> f64 {
+extern "C" fn ns_write3(closure: *const ClosureHeader, chunk: f64, enc: f64, cb: f64) -> f64 {
     let stream = this_value(closure);
-    write_writable_chunk(stream, chunk, enc)
+    write_writable_chunk(stream, chunk, enc, cb)
 }
 
 extern "C" fn ns_end3(closure: *const ClosureHeader, chunk: f64, encoding: f64, cb: f64) -> f64 {
@@ -306,10 +306,9 @@ extern "C" fn ns_uncork0(closure: *const ClosureHeader) -> f64 {
     uncork_stream(this_value(closure))
 }
 
-fn invoke_writable_write(stream: f64, chunk: f64, enc: f64) {
+fn invoke_writable_write(stream: f64, chunk: f64, enc: f64, callback: f64) {
     if let Some(write) = writable_hidden_write(stream) {
-        let cb = js_closure_alloc(writable_write_callback_noop as *const u8, 0);
-        let cb_value = f64::from_bits(JSValue::pointer(cb as *const u8).bits());
+        let cb_value = writable_write_callback_value(callback);
         let args = [chunk, enc, cb_value];
         let prev_this = crate::object::js_implicit_this_set(stream);
         unsafe {
@@ -328,15 +327,49 @@ fn throw_writable_null_chunk() -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
-fn write_writable_chunk(stream: f64, chunk: f64, enc: f64) -> f64 {
+fn writable_write_callback_value(callback: f64) -> f64 {
+    if is_callable_value(callback) {
+        callback
+    } else {
+        let cb = js_closure_alloc(writable_write_callback_noop as *const u8, 0);
+        f64::from_bits(JSValue::pointer(cb as *const u8).bits())
+    }
+}
+
+fn normalize_write_args(chunk: f64, enc: f64, cb: f64) -> (f64, f64, f64) {
+    let (encoding, callback) = if is_callable_value(enc) {
+        (f64::from_bits(TAG_UNDEFINED), enc)
+    } else {
+        (enc, cb)
+    };
+    let (chunk, encoding) = normalize_writable_write_chunk(chunk, encoding);
+    (chunk, encoding, callback)
+}
+
+fn normalize_writable_write_chunk(chunk: f64, encoding: f64) -> (f64, f64) {
+    let value = JSValue::from_bits(chunk.to_bits());
+    if value.is_any_string() {
+        let enc_tag = crate::buffer::js_encoding_tag_from_value(encoding);
+        let buf = crate::buffer::js_buffer_from_value(chunk.to_bits() as i64, enc_tag);
+        return (box_pointer(buf as *const u8), string_value(b"buffer"));
+    }
+    let raw = raw_ptr_from_value(chunk);
+    if raw >= 0x10000 && crate::buffer::is_registered_buffer(raw) {
+        return (chunk, string_value(b"buffer"));
+    }
+    (chunk, encoding)
+}
+
+fn write_writable_chunk(stream: f64, chunk: f64, enc: f64, cb: f64) -> f64 {
     if JSValue::from_bits(chunk.to_bits()).is_null() {
         throw_writable_null_chunk();
     }
+    let (chunk, enc, callback) = normalize_write_args(chunk, enc, cb);
     if writable_corked_count(stream) > 0.0 {
         buffer_writable_write(stream, chunk, enc);
         return f64::from_bits(TAG_TRUE);
     }
-    invoke_writable_write(stream, chunk, enc);
+    invoke_writable_write(stream, chunk, enc, callback);
     emit_writable_chunk(stream, chunk);
     f64::from_bits(TAG_TRUE)
 }
@@ -363,7 +396,7 @@ fn finish_stream(stream: f64, callback: Option<f64>) {
 fn finish_stream_with_args(stream: f64, chunk: f64, encoding: f64, cb: f64) {
     let (chunk, encoding, callback) = normalize_end_args(chunk, encoding, cb);
     if has_end_chunk(chunk) {
-        let _ = write_writable_chunk(stream, chunk, encoding);
+        let _ = write_writable_chunk(stream, chunk, encoding, f64::from_bits(TAG_UNDEFINED));
     }
     flush_writable_buffered(stream);
     finish_stream(stream, callback);
@@ -540,8 +573,18 @@ pub extern "C" fn js_node_stream_method_resume(stream_handle: i64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_write(stream_handle: i64, chunk: f64, enc: f64) -> f64 {
+    js_node_stream_method_write3(stream_handle, chunk, enc, f64::from_bits(TAG_UNDEFINED))
+}
+
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_write3(
+    stream_handle: i64,
+    chunk: f64,
+    enc: f64,
+    cb: f64,
+) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
-    write_writable_chunk(stream, chunk, enc)
+    write_writable_chunk(stream, chunk, enc, cb)
 }
 
 #[no_mangle]
@@ -1149,7 +1192,7 @@ fn register_stub_arities() {
     register(ns_read1 as *const u8, 1);
     register(ns_pipe1 as *const u8, 1);
     register(writable_write_callback_noop as *const u8, 0);
-    register(ns_write2 as *const u8, 2);
+    register(ns_write3 as *const u8, 3);
     register(ns_end3 as *const u8, 3);
     register(ns_cork0 as *const u8, 0);
     register(ns_uncork0 as *const u8, 0);
@@ -1554,7 +1597,7 @@ fn flush_writable_buffered(stream: f64) {
         } else {
             f64::from_bits(TAG_UNDEFINED)
         };
-        invoke_writable_write(stream, chunk, enc);
+        invoke_writable_write(stream, chunk, enc, f64::from_bits(TAG_UNDEFINED));
         emit_writable_chunk(stream, chunk);
         i += 2;
     }
@@ -1923,7 +1966,7 @@ fn writable_methods() -> [(&'static str, StubFn); 22] {
         ("listenerCount", cast1(ns_listener_count)),
         ("listeners", cast1(ns_listeners)),
         ("rawListeners", cast1(ns_raw_listeners)),
-        ("write", cast2(ns_write2)),
+        ("write", cast3(ns_write3)),
         ("end", cast3(ns_end3)),
         ("cork", cast0(ns_cork0)),
         ("uncork", cast0(ns_uncork0)),
@@ -1960,7 +2003,7 @@ fn duplex_methods() -> [(&'static str, StubFn); 28] {
         ("resume", cast0(ns_resume0)),
         ("setEncoding", cast1(ns_chain1)),
         ("isPaused", cast0(ns_undefined0)),
-        ("write", cast2(ns_write2)),
+        ("write", cast3(ns_write3)),
         ("end", cast3(ns_end3)),
         ("cork", cast0(ns_cork0)),
         ("uncork", cast0(ns_uncork0)),

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -6,6 +6,8 @@ use std::cell::RefCell;
 
 thread_local! {
     static WRITE_CAPTURED: RefCell<Vec<Vec<u8>>> = const { RefCell::new(Vec::new()) };
+    static WRITE_ENCODINGS: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+    static WRITE_CALLBACK_COUNT: RefCell<usize> = const { RefCell::new(0) };
     static READABLE_DATA_CAPTURED: RefCell<Vec<Vec<u8>>> = const { RefCell::new(Vec::new()) };
     static READABLE_THIS_MATCHES: RefCell<Vec<bool>> = const { RefCell::new(Vec::new()) };
     static READABLE_END_COUNT: RefCell<usize> = const { RefCell::new(0) };
@@ -31,6 +33,18 @@ fn buffer_value(bytes: &[u8]) -> f64 {
     box_pointer(buf as *const u8)
 }
 
+fn string_contents(value: f64) -> String {
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let Some((ptr, len)) = crate::string::str_bytes_from_jsvalue(value, &mut scratch) else {
+        return format!("0x{:x}", value.to_bits());
+    };
+    if ptr.is_null() {
+        return String::new();
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
 extern "C" fn write_capture(_closure: *const ClosureHeader, chunk: f64, _enc: f64, cb: f64) -> f64 {
     let readable = js_node_stream_readable_from(chunk);
     let bytes = js_node_stream_collect_bytes(readable);
@@ -38,6 +52,27 @@ extern "C" fn write_capture(_closure: *const ClosureHeader, chunk: f64, _enc: f6
     unsafe {
         let _ = crate::closure::js_native_call_value(cb, std::ptr::null(), 0);
     }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn write_capture_encoding(
+    _closure: *const ClosureHeader,
+    chunk: f64,
+    enc: f64,
+    cb: f64,
+) -> f64 {
+    let readable = js_node_stream_readable_from(chunk);
+    let bytes = js_node_stream_collect_bytes(readable);
+    WRITE_CAPTURED.with(|captured| captured.borrow_mut().push(bytes));
+    WRITE_ENCODINGS.with(|encodings| encodings.borrow_mut().push(string_contents(enc)));
+    unsafe {
+        let _ = crate::closure::js_native_call_value(cb, std::ptr::null(), 0);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn capture_write_callback(_closure: *const ClosureHeader) -> f64 {
+    WRITE_CALLBACK_COUNT.with(|count| *count.borrow_mut() += 1);
     f64::from_bits(TAG_UNDEFINED)
 }
 
@@ -302,6 +337,50 @@ fn writable_cork_buffers_writes_until_uncorked() {
             &[b"a".to_vec(), b"b".to_vec()]
         );
     });
+}
+
+#[test]
+fn writable_write_decodes_string_chunks_and_runs_callback() {
+    WRITE_CAPTURED.with(|captured| captured.borrow_mut().clear());
+    WRITE_ENCODINGS.with(|encodings| encodings.borrow_mut().clear());
+    WRITE_CALLBACK_COUNT.with(|count| *count.borrow_mut() = 0);
+
+    let opts = crate::object::js_object_alloc(0, 1);
+    let write = js_closure_alloc(write_capture_encoding as *const u8, 0);
+    crate::closure::js_register_closure_arity(write_capture_encoding as *const u8, 3);
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"write"),
+        f64::from_bits(JSValue::pointer(write as *const u8).bits()),
+    );
+
+    let stream = js_node_stream_writable_new(box_pointer(opts as *const u8));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let cb = js_closure_alloc(capture_write_callback as *const u8, 0);
+    crate::closure::js_register_closure_arity(capture_write_callback as *const u8, 0);
+    let cb_value = f64::from_bits(JSValue::pointer(cb as *const u8).bits());
+    let undefined = f64::from_bits(TAG_UNDEFINED);
+
+    let result =
+        js_node_stream_method_write3(handle, string_value("6869"), string_value("hex"), cb_value);
+    assert_eq!(result.to_bits(), TAG_TRUE);
+
+    let result = js_node_stream_method_write3(handle, string_value("ok"), cb_value, undefined);
+    assert_eq!(result.to_bits(), TAG_TRUE);
+
+    WRITE_CAPTURED.with(|captured| {
+        assert_eq!(
+            captured.borrow().as_slice(),
+            &[b"hi".to_vec(), b"ok".to_vec()]
+        );
+    });
+    WRITE_ENCODINGS.with(|encodings| {
+        assert_eq!(
+            encodings.borrow().as_slice(),
+            &["buffer".to_string(), "buffer".to_string()]
+        );
+    });
+    WRITE_CALLBACK_COUNT.with(|count| assert_eq!(*count.borrow(), 2));
 }
 
 #[test]
@@ -784,8 +863,8 @@ fn stream_stub_arities_are_registered_per_thread() {
             Some(0)
         );
         assert_eq!(
-            crate::closure::lookup_closure_arity(ns_write2 as *const u8),
-            Some(2)
+            crate::closure::lookup_closure_arity(ns_write3 as *const u8),
+            Some(3)
         );
     })
     .join()

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -488,18 +488,6 @@
     "category": "bug-open",
     "reason": "node:stream: class extends Readable with _read() doesn't deliver data via push. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/write/with-encoding": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: write(chunk, enc, cb) doesn't propagate encoding to _write. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/write/write-buffer": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: write(Buffer) doesn't invoke _write with Buffer / finish doesn't deliver. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/encoding/base64": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -1021,12 +1009,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Readable.from(infiniteGen).take(N) — take helper does not abort upstream early; iteration hangs or returns wrong items. Flips to PASS when #1558 lands."
-  },
-  "node-suite/stream/write/three-arg-form": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: write(chunk, encoding, callback) 3-arg form — encoding not propagated to user _write(chunk, enc, cb). Flips to PASS when #1539 lands."
   },
   "node-suite/stream/web/desired-size-backpressure": {
     "issue": "1545",


### PR DESCRIPTION
## Summary
- decode regular Writable string writes to Buffer chunks using the supplied encoding
- pass "buffer" to user write handlers for string/Buffer chunks and forward write callbacks
- remove the passing write encoding, 3-arg write, and Buffer-write known failures

## Verification
- cargo fmt --check
- jq empty test-parity/known_failures.json
- git diff --check origin/main...HEAD
- cargo test -p perry-runtime writable_write_decodes_string_chunks_and_runs_callback --lib
- cargo test -p perry-runtime stream_stub_arities_are_registered_per_thread --lib
- cargo test -p perry-codegen --lib native_table
- CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/write/with-encoding (PASS 1/1, report test-parity/reports/parity_report_20260527_122942.json)
- CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/write/three-arg-form (PASS 1/1, report test-parity/reports/parity_report_20260527_122942.json)
- CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/write/write-buffer (PASS 1/1, report test-parity/reports/parity_report_20260527_122942.json)
- Guardrail: stream/write/ keeps these targets green; remaining residuals are after-end-emits-error, false-then-retry, writev-batch, and writev-chunk-shape