### PR TITLE
fix(node:stream): return false at writable hwm

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -84,6 +84,7 @@ const WRITABLE_FINISH_SCHEDULED_KEY: &[u8] = b"__perryWritableFinishScheduled";
 const WRITABLE_FINISH_EMITTED_KEY: &[u8] = b"__perryWritableFinishEmitted";
 const WRITABLE_CORKED_KEY: &[u8] = b"__perryWritableCorked";
 const WRITABLE_BUFFERED_KEY: &[u8] = b"__perryWritableBuffered";
+const WRITABLE_LENGTH_KEY: &[u8] = b"__perryWritableLength";
 // #1534: direction + disturbed bits so the static introspection helpers
 // (`Readable.isReadable` / `isDisturbed` / `isErrored`) answer per-stream
 // instead of with a uniform stub. Set at construction / on first read.
@@ -332,13 +333,15 @@ fn write_writable_chunk(stream: f64, chunk: f64, enc: f64) -> f64 {
     if JSValue::from_bits(chunk.to_bits()).is_null() {
         throw_writable_null_chunk();
     }
+    let length = note_writable_write_length(stream, chunk);
+    let should_continue = length < writable_high_water_mark(stream) || length == 0.0;
     if writable_corked_count(stream) > 0.0 {
         buffer_writable_write(stream, chunk, enc);
-        return f64::from_bits(TAG_TRUE);
+        return f64::from_bits(if should_continue { TAG_TRUE } else { TAG_FALSE });
     }
     invoke_writable_write(stream, chunk, enc);
     emit_writable_chunk(stream, chunk);
-    f64::from_bits(TAG_TRUE)
+    f64::from_bits(if should_continue { TAG_TRUE } else { TAG_FALSE })
 }
 
 fn emit_writable_chunk(stream: f64, chunk: f64) {
@@ -1273,6 +1276,11 @@ fn hidden_writable_buffered_key() -> *mut crate::string::StringHeader {
 }
 
 #[inline]
+fn hidden_writable_length_key() -> *mut crate::string::StringHeader {
+    hidden_key(WRITABLE_LENGTH_KEY)
+}
+
+#[inline]
 fn hidden_readable_flag_key() -> *mut crate::string::StringHeader {
     hidden_key(READABLE_FLAG_KEY)
 }
@@ -1489,6 +1497,27 @@ fn writable_hidden_write(value: f64) -> Option<f64> {
 
 fn writable_corked_count(value: f64) -> f64 {
     get_hidden_value(value, hidden_writable_corked_key()).unwrap_or(0.0)
+}
+
+fn writable_buffered_length(value: f64) -> f64 {
+    get_hidden_value(value, hidden_writable_length_key()).unwrap_or(0.0)
+}
+
+fn set_writable_buffered_length(stream: f64, length: f64) {
+    if get_hidden_value(stream, hidden_writable_flag_key()).is_some() {
+        set_hidden_value(stream, hidden_writable_length_key(), length.max(0.0));
+    }
+}
+
+fn writable_high_water_mark(stream: f64) -> f64 {
+    get_hidden_value(stream, hidden_key(b"writableHighWaterMark"))
+        .unwrap_or_else(|| default_hwm(false))
+}
+
+fn note_writable_write_length(stream: f64, chunk: f64) -> f64 {
+    let length = writable_buffered_length(stream) + chunk_byte_len(chunk) as f64;
+    set_writable_buffered_length(stream, length);
+    length
 }
 
 fn set_writable_corked_count(stream: f64, count: f64) {
@@ -2161,6 +2190,7 @@ fn init_writable_state(stream: f64, opts: f64) {
     set_hidden_value(stream, hidden_key(b"destroyed"), f64::from_bits(TAG_FALSE));
     let w_hwm = resolve_hwm(opts, b"writableHighWaterMark", b"writableObjectMode");
     set_hidden_value(stream, hidden_key(b"writableHighWaterMark"), w_hwm);
+    set_writable_buffered_length(stream, 0.0);
     set_writable_corked_count(stream, 0.0);
     set_hidden_value(
         stream,

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -305,6 +305,37 @@ fn writable_cork_buffers_writes_until_uncorked() {
 }
 
 #[test]
+fn writable_write_returns_false_at_high_water_mark() {
+    WRITE_CAPTURED.with(|captured| captured.borrow_mut().clear());
+    let opts = crate::object::js_object_alloc(0, 2);
+    let closure = js_closure_alloc(write_capture as *const u8, 0);
+    crate::closure::js_register_closure_arity(write_capture as *const u8, 3);
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"write"),
+        f64::from_bits(JSValue::pointer(closure as *const u8).bits()),
+    );
+    js_object_set_field_by_name(opts, hidden_key(b"highWaterMark"), 2.0);
+
+    let stream = js_node_stream_writable_new(box_pointer(opts as *const u8));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let undefined = f64::from_bits(TAG_UNDEFINED);
+
+    let first = js_node_stream_method_write(handle, string_value("a"), undefined);
+    let second = js_node_stream_method_write(handle, string_value("b"), undefined);
+
+    assert_eq!(first.to_bits(), TAG_TRUE);
+    assert_eq!(second.to_bits(), TAG_FALSE);
+    assert_eq!(writable_buffered_length(stream), 2.0);
+    WRITE_CAPTURED.with(|captured| {
+        assert_eq!(
+            captured.borrow().as_slice(),
+            &[b"a".to_vec(), b"b".to_vec()]
+        );
+    });
+}
+
+#[test]
 fn stream_max_listeners_default_and_override_round_trip() {
     let stream = js_node_stream_passthrough_new(f64::from_bits(TAG_UNDEFINED));
     let obj = raw_ptr_from_value(stream) as *const ObjectHeader;

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -758,12 +758,6 @@
     "category": "bug-open",
     "reason": "node:stream: construct() callback receiving Error does not propagate via error event. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/write/false-then-retry": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: write() return value sequence under backpressure not honored. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/iter-helpers/flat-map-async": {
     "issue": "1572",
     "added": "2026-05-23",
@@ -1447,12 +1441,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: second getWriter() on locked WritableStream does not throw TypeError. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/writable/write-returns-false-at-hwm": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: write() does not return false when buffered bytes cross HWM. Flips to PASS when #1539 lands."
   },
   "node-suite/stream/iter-helpers/find-returns-promise": {
     "issue": "1558",


### PR DESCRIPTION
Refs #1531, #1539

## Summary
- add hidden byte-length accounting for classic Writable writes
- return `false` from `write()` once the admitted chunk brings writable length to or above `writableHighWaterMark`
- remove the two exact known-failure entries now covered by passing parity fixtures

## Verification
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD`
- `cargo test -p perry-runtime writable_write_returns_false_at_high_water_mark --lib`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/write/false-then-retry` PASS 1/1, report `test-parity/reports/parity_report_20260527_123928.json`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/writable/write-returns-false-at-hwm` PASS 1/1, report `test-parity/reports/parity_report_20260527_124009.json`
- Guardrail `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/write/` kept `false-then-retry` green and failed only on existing residuals: `after-end-emits-error`, `three-arg-form`, `with-encoding`, `writev-batch`, `writev-chunk-shape`; report `test-parity/reports/parity_report_20260527_124022.json`

## Reference
- DeepWiki: `reference/deepwiki/nodejs-node-stream-writable-write-hwm-return-2026-05-27.md` (local note only, not staged)

## Non-goals
- no drain event timing
- no visible `writableLength` property
- no callback-driven length decrement
- no write-after-end, encoding normalization, cork/writev, objectMode, or full Writable state-machine work
