### PR TITLE
fix(typedarray): gate index fast path to numeric keys so method access stops returning a number (#2063)

### DIFF
--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -409,6 +409,34 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 ));
             }
             if is_width_tracked_typed_array_receiver(ctx, object) {
+                // #2063: a key that isn't provably a number — a method-name
+                // string (`ta["copyWithin"]`, `ta[m]` where m iterates method
+                // names), a numeric string (`ta["2"]`), or any non-numeric /
+                // unknown-typed key — must NOT take the integer-indexed element
+                // fast path below. That path blindly `fptosi`s the key; a
+                // NaN-boxed string coerces to 0, so `ta["copyWithin"]`/`ta[m]`
+                // returned element 0 (`typeof` was "number") and `ta["2"]`
+                // returned element 0 instead of element 2. Route such keys
+                // through the runtime dispatcher, which reads an element only
+                // for a canonical numeric index and otherwise performs an
+                // ordinary [[Get]] (the same `js_object_get_field_by_name_f64`
+                // the dotted `ta.copyWithin` PropertyGet path uses — resolving
+                // the prototype method once reified, undefined until then,
+                // never a stray element value). `is_numeric_expr` stays true
+                // for literal/loop-counter indices, so every proven element
+                // fast path below is preserved.
+                if !is_numeric_expr(ctx, index) {
+                    let arr_box = lower_expr(ctx, object)?;
+                    let key_box = lower_expr(ctx, index)?;
+                    let blk = ctx.block();
+                    let arr_bits = blk.bitcast_double_to_i64(&arr_box);
+                    let arr_i64 = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+                    return Ok(blk.call(
+                        DOUBLE,
+                        "js_typed_array_index_get_dynamic",
+                        &[(I64, &arr_i64), (DOUBLE, &key_box)],
+                    ));
+                }
                 if let Some(value) = lower_typed_array_load(ctx, object, index)? {
                     return Ok(materialize_js_value(
                         ctx,

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1029,6 +1029,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_typed_array_new", I64, &[I32, DOUBLE]);
     module.declare_function("js_typed_array_length", I32, &[I64]);
     module.declare_function("js_typed_array_get", DOUBLE, &[I64, I32]);
+    // #2063: string / dynamic-key `ta[key]` [[Get]] dispatcher (canonical
+    // numeric index → element, else ordinary named-property [[Get]]).
+    module.declare_function("js_typed_array_index_get_dynamic", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_typed_array_at", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_typed_array_set", VOID, &[I64, I32, DOUBLE]);
     module.declare_function("js_uint8array_get", I32, &[I64, I32]);

--- a/crates/perry-runtime/src/typedarray.rs
+++ b/crates/perry-runtime/src/typedarray.rs
@@ -582,6 +582,85 @@ pub extern "C" fn js_typed_array_get(ta: *const TypedArrayHeader, index: i32) ->
     }
 }
 
+/// #2063 — dynamic / string-key `[[Get]]` on a TypedArray (`ta[key]`).
+///
+/// The codegen element-read fast path only fires for statically-proven
+/// numeric indices. A string key reaches here instead of being blindly
+/// coerced to an integer index (a NaN-boxed string `fptosi`'d to 0, so
+/// `ta["copyWithin"]` / `ta[m]` returned element 0 — `typeof` was "number" —
+/// and `ta["2"]` returned element 0 instead of element 2). This implements
+/// the ECMAScript IntegerIndexedExotic `[[Get]]` dispatch:
+///   * canonical numeric index string → integer-indexed element read
+///     (bounds-checked; out-of-range → undefined),
+///   * any other string → ordinary `[[Get]]` (named / prototype property) via
+///     the same `js_object_get_field_by_name_f64` the dotted `ta.copyWithin`
+///     PropertyGet path uses (resolves the reified method once #2059 lands;
+///     undefined until then — never a stray element value),
+///   * a numeric (non-string) key → integer-indexed element read.
+#[no_mangle]
+pub extern "C" fn js_typed_array_index_get_dynamic(ta: *const TypedArrayHeader, key: f64) -> f64 {
+    let jsval = crate::value::JSValue::from_bits(key.to_bits());
+    if jsval.is_string() || jsval.is_short_string() {
+        let key_ptr =
+            crate::value::js_get_string_pointer_unified(key) as *const crate::string::StringHeader;
+        if key_ptr.is_null() {
+            return f64::from_bits(crate::value::TAG_UNDEFINED);
+        }
+        if let Some(idx) = canonical_typed_array_index(key_ptr) {
+            return js_typed_array_get(ta, idx);
+        }
+        return crate::object::js_object_get_field_by_name_f64(
+            ta as *const crate::object::ObjectHeader,
+            key_ptr,
+        );
+    }
+    // Numeric key — INT32 tag or plain double (defensive: codegen only routes
+    // string-typed keys here, but type erasure can let a number flow in).
+    let num = if jsval.is_int32() {
+        jsval.as_int32() as f64
+    } else if !key.is_nan() {
+        key
+    } else {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    };
+    if !num.is_finite() || num < 0.0 || num.fract() != 0.0 || num > i32::MAX as f64 {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    js_typed_array_get(ta, num as i32)
+}
+
+/// Canonical numeric array-index parse for a TypedArray string key. Returns
+/// `Some(idx)` only when `key` is the canonical decimal form of a
+/// non-negative integer in `[0, i32::MAX]` (no leading zeros, sign, or
+/// fractional part) — a CanonicalNumericIndexString that is a valid integer
+/// index. Mirrors the array string-key dispatch in `js_array_set_string_key`.
+fn canonical_typed_array_index(key: *const crate::string::StringHeader) -> Option<i32> {
+    let key_str = unsafe {
+        let len = (*key).byte_len as usize;
+        if len == 0 {
+            return None;
+        }
+        let data = (key as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+        let bytes = std::slice::from_raw_parts(data, len);
+        std::str::from_utf8(bytes).ok()?
+    };
+    let idx = key_str.parse::<u32>().ok()?;
+    if idx.to_string() == key_str && idx <= i32::MAX as u32 {
+        Some(idx as i32)
+    } else {
+        None
+    }
+}
+
+// #2063: force-keep the dynamic-key getter under LTO / auto-optimize. Like
+// `js_dyn_index_get`, this export has zero internal Rust callers — it is only
+// invoked from generated LLVM IR (codegen emits the call in
+// `perry-codegen/src/expr/index_get.rs`), so a whole-program bitcode link is
+// free to internalize and dead-strip it. The `#[used]` anchor pins it.
+#[used]
+static KEEP_JS_TYPED_ARRAY_INDEX_GET_DYNAMIC: extern "C" fn(*const TypedArrayHeader, f64) -> f64 =
+    js_typed_array_index_get_dynamic;
+
 /// `ta.at(i)` with negative-index support.
 #[no_mangle]
 pub extern "C" fn js_typed_array_at(ta: *const TypedArrayHeader, index: f64) -> f64 {

--- a/test-files/test_issue_2063_typed_array_method_access.ts
+++ b/test-files/test_issue_2063_typed_array_method_access.ts
@@ -1,0 +1,42 @@
+// Issue #2063: TypedArray instance method access must NOT take the
+// integer-indexed element fast path. Pre-fix, `ta[m]` for any string key
+// `fptosi`'d the NaN-boxed string to index 0, so `typeof ta.copyWithin`
+// (and every other method name) was "number" and numeric strings like
+// `ta["2"]` returned element 0 instead of element 2.
+//
+// We assert `typeof ta[m] !== "number"` (rather than printing the typeof
+// directly) so the test is byte-identical to Node regardless of whether the
+// method is reified to a function value — reification is tracked separately
+// in #2059. The point of THIS test is that the index fast path no longer
+// shadows the property with a stray element value.
+
+const a = new Int8Array([10, 20, 30, 40]);
+
+// 1) Method-name keys (computed) no longer read a number.
+const methods = [
+  "copyWithin", "fill", "subarray", "slice", "set",
+  "indexOf", "map", "filter", "reduce", "join",
+];
+for (const m of methods) {
+  console.log(m, typeof a[m] !== "number");
+}
+
+// 2) Canonical numeric-index string keys read the correct element.
+console.log('a["0"]:', a["0"]);
+console.log('a["2"]:', a["2"]);
+const k2 = "2";
+console.log("a[k2]:", a[k2]);
+const k0 = "0";
+console.log("a[k0]:", a[k0]);
+
+// 3) Out-of-range numeric string → undefined (not element 0).
+const k9 = "9";
+console.log("a[k9]:", a[k9]);
+
+// 4) Plain numeric indices and .length are unaffected by the fix.
+console.log("a[0]:", a[0], "a[3]:", a[3], "len:", a.length);
+
+// 5) Float64Array behaves the same.
+const f = new Float64Array([1.5, 2.5, 3.5]);
+console.log('f["1"]:', f["1"]);
+console.log("f.fill not number:", typeof f["fill"] !== "number");


### PR DESCRIPTION
## Summary

Fixes #2063. Member access for a non-index (method-name) key on a TypedArray instance returned a *number* because the integer-indexed element fast path swallowed **every** member read, not just numeric-index keys.

`ta[key]` unconditionally took the element fast path, which `fptosi`s the key. A NaN-boxed string coerces to `0`, so:

- a method-name key (`ta["copyWithin"]`, or `ta[m]` iterating method names) read **element 0** — `typeof ta[m]` was `"number"`, and `ta.copyWithin(...)` threw "is not a function";
- a numeric string like `ta["2"]` read **element 0** instead of element 2.

## Fix

Gate the element fast path on `is_numeric_expr`: only provably-numeric keys (literals, loop counters, numeric expressions) take it — every existing numeric fast path is preserved. Any non-numeric / unknown-typed key now routes through a new runtime dispatcher `js_typed_array_index_get_dynamic`, implementing the ECMAScript IntegerIndexedExotic `[[Get]]` dispatch:

- canonical numeric-index string → integer-indexed element read (bounds-checked; out-of-range → `undefined`)
- any other string → ordinary `[[Get]]` via the same `js_object_get_field_by_name_f64` the dotted `ta.copyWithin` PropertyGet path uses (resolves the reified method once #2059 lands; `undefined` until then — never a stray element value)
- a numeric (non-string) key → integer-indexed element read

## Scope

This is the gating half the issue describes. The full `typeof ta.copyWithin === "function"` result additionally needs built-in prototype method reification, which the issue explicitly scopes to the sibling **#2059** ("built-in prototype methods undefined as property values"). After this fix, method-name access resolves against the prototype path (→ `undefined` until #2059), never a stray number.

## Validation

- New parity test `test-files/test_issue_2063_typed_array_method_access.ts` — **byte-identical to `node --experimental-strip-types`**. It asserts `typeof ta[m] !== "number"` (true in both Node and Perry) so it stays green independently of #2059 reification, plus the now-correct numeric-string element reads.
- Original `typeof` repro: Perry went from `number ×10` → `undefined ×10` (Node: `function ×10`); the bogus-number bug is gone.
- Numeric-string keys now correct: `ta["2"]` → 30, `ta[k]` (k="2") → 30, OOB `ta["9"]` → `undefined`.
- Existing typed-array gap tests (`test_gap_typed_arrays`, `test_gap_typed_array_numeric_length`, `test_json_typed_array`) remain byte-identical; a 20-pattern indexing stress test (loop/literal/var/expr/OOB/writes/all kinds/for-of) is byte-identical.
- 47 runtime typed-array unit tests pass; `cargo fmt --all -- --check` and the file-size gate pass.

(`test_issue_654_typed_array_dispatch` shows pre-existing **runtime** nondeterminism in `.at()` — the same fixed binary flips between runs, which a codegen change cannot cause; it is already listed in `known_failures.json`.)

Surfaced by the #799 Test262 radar (built-ins/TypedArray). Part of #793.
