### PR TITLE
fix(node:stream): expose writable closed flag

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2514,6 +2514,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("stream", "readableEnded", true, None),
     method("stream", "writableHighWaterMark", true, None),
     method("stream", "readableAborted", true, None),
+    method("stream", "closed", true, None),
     method("stream", "writableCorked", true, None),
     method("stream", "writable", true, None),
     method("stream", "writableEnded", true, None),

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -791,6 +791,15 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "stream",
         has_receiver: true,
+        method: "closed",
+        class_filter: None,
+        runtime: "js_node_stream_method_closed",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
         method: "writable",
         class_filter: None,
         runtime: "js_node_stream_method_writable",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -871,6 +871,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_to_web", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_from_web", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_method_readable_aborted", DOUBLE, &[I64]);
+    module.declare_function("js_node_stream_method_closed", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroyed", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroy", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_node_stream_method_readable", DOUBLE, &[I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -177,6 +177,7 @@ extern "C" fn ns_writable_finish_microtask(closure: *const ClosureHeader) -> f64
         );
         mark_writable_finished(stream);
         let _ = emit_stream_event(stream, string_value(b"finish"), &[]);
+        mark_stream_closed(stream);
         let _ = emit_stream_event(stream, string_value(b"close"), &[]);
     }
     if is_callable_value(callback) {
@@ -473,6 +474,16 @@ pub extern "C" fn js_node_stream_method_writable_hwm(stream_handle: i64) -> f64 
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_readable_aborted(stream_handle: i64) -> f64 {
     readable_aborted_value(stream_value_from_handle(stream_handle))
+}
+
+/// `stream.closed` property getter on typed stream instances.
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_closed(stream_handle: i64) -> f64 {
+    get_hidden_value(
+        stream_value_from_handle(stream_handle),
+        hidden_key(b"closed"),
+    )
+    .unwrap_or(f64::from_bits(TAG_FALSE))
 }
 
 /// `stream.writableCorked` property getter on a typed writable-side instance.
@@ -2073,6 +2084,7 @@ fn resolve_hwm(opts: f64, specific: &[u8], specific_object_mode: &[u8]) -> f64 {
 /// Initialize visible lifecycle flags shared by all stream sides.
 fn init_lifecycle_state(stream: f64) {
     set_hidden_value(stream, hidden_key(b"destroyed"), f64::from_bits(TAG_FALSE));
+    set_visible_closed(stream, false);
 }
 
 fn init_constructor(stream: f64, name: &str) {
@@ -2134,6 +2146,15 @@ fn mark_writable_ended(stream: f64) {
 fn mark_writable_finished(stream: f64) {
     set_visible_writable(stream, false);
     set_visible_writable_finished(stream, true);
+}
+
+fn set_visible_closed(stream: f64, closed: bool) {
+    let value = if closed { TAG_TRUE } else { TAG_FALSE };
+    set_hidden_value(stream, hidden_key(b"closed"), f64::from_bits(value));
+}
+
+pub(super) fn mark_stream_closed(stream: f64) {
+    set_visible_closed(stream, true);
 }
 
 /// Initialize the readable side of a stream: direction flag, buffered byte

--- a/crates/perry-runtime/src/node_stream_destroy_state.rs
+++ b/crates/perry-runtime/src/node_stream_destroy_state.rs
@@ -22,6 +22,7 @@ pub(super) extern "C" fn ns_destroy_error_microtask(closure: *const ClosureHeade
             let _ = super::event_emitter::emit_stream_event(stream, error, &[err]);
         }
     }
+    super::mark_stream_closed(stream);
     let _ = super::event_emitter::emit_stream_event(stream, super::string_value(b"close"), &[]);
     f64::from_bits(TAG_UNDEFINED)
 }

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -31,6 +31,8 @@ static KEEP_NS_WRITABLE_HWM: extern "C" fn(i64) -> f64 = super::js_node_stream_m
 static KEEP_NS_READABLE_ABORTED: extern "C" fn(i64) -> f64 =
     super::js_node_stream_method_readable_aborted;
 #[used]
+static KEEP_NS_METHOD_CLOSED: extern "C" fn(i64) -> f64 = super::js_node_stream_method_closed;
+#[used]
 static KEEP_NS_WRITABLE_CORKED: extern "C" fn(i64) -> f64 =
     super::js_node_stream_method_writable_corked;
 #[used]

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -630,6 +630,10 @@ fn writable_lifecycle_flags_reflect_end_and_finish() {
         TAG_TRUE
     );
     assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"closed")).to_bits(),
+        TAG_FALSE
+    );
+    assert_eq!(
         js_node_stream_method_writable_ended(handle).to_bits(),
         TAG_FALSE
     );
@@ -662,6 +666,10 @@ fn writable_lifecycle_flags_reflect_end_and_finish() {
     );
     assert_eq!(
         js_object_get_field_by_name_f64(obj, hidden_key(b"writableFinished")).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"closed")).to_bits(),
         TAG_TRUE
     );
     WRITABLE_FINISH_COUNT.with(|count| assert_eq!(*count.borrow(), 1));

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -350,12 +350,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.closed flag + close event don't deliver. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/writable/closed-flag": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Writable.closed flag + close event don't deliver. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/transform/flush-callback": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
Refs #1531

## Summary
- initialize classic stream `closed` state to `false`
- mark `closed` before Perry's existing `close` emissions
- expose typed classic `stream.closed` reads through manifest/codegen/native-table/runtime support
- remove the exact `node-suite/stream/writable/closed-flag` known-failure entry

## Verification
- Baseline before fix: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/writable/closed-flag` failed with Perry `closed: 0`, report `test-parity/reports/parity_report_20260527_124639.json`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD`
- `cargo test -p perry-runtime writable_lifecycle_flags_reflect_end_and_finish --lib`
- `cargo test -p perry-codegen --lib native_table` PASS compile, 0 matching tests
- `cargo test -p perry-api-manifest`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/writable/closed-flag` PASS 1/1, report `test-parity/reports/parity_report_20260527_125642.json`
- Guardrail `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter closed-flag` kept writable closed green and failed only the existing readable closed residual, report `test-parity/reports/parity_report_20260527_125723.json`

## Reference
- DeepWiki: `reference/deepwiki/nodejs-node-stream-writable-closed-flag-2026-05-27.md` (local note only, not staged)

## Non-goals
- no readable-side close emission fix
- no `emitClose:false`
- no destroy/error lifecycle expansion beyond marking `closed` before existing close emission
- no broader finished/destroyed lifecycle rewrite
