### PR TITLE
fix(node:stream): expose errored getter

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2514,6 +2514,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("stream", "readableEnded", true, None),
     method("stream", "writableHighWaterMark", true, None),
     method("stream", "readableAborted", true, None),
+    method("stream", "errored", true, None),
     method("stream", "writableCorked", true, None),
     method("stream", "writable", true, None),
     method("stream", "writableEnded", true, None),

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -791,6 +791,15 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "stream",
         has_receiver: true,
+        method: "errored",
+        class_filter: None,
+        runtime: "js_node_stream_method_errored",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
         method: "writable",
         class_filter: None,
         runtime: "js_node_stream_method_writable",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -871,6 +871,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_to_web", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_from_web", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_method_readable_aborted", DOUBLE, &[I64]);
+    module.declare_function("js_node_stream_method_errored", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroyed", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroy", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_node_stream_method_readable", DOUBLE, &[I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -475,6 +475,13 @@ pub extern "C" fn js_node_stream_method_readable_aborted(stream_handle: i64) -> 
     readable_aborted_value(stream_value_from_handle(stream_handle))
 }
 
+/// `stream.errored` property getter on typed stream instances.
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_errored(stream_handle: i64) -> f64 {
+    readable_hidden_error(stream_value_from_handle(stream_handle))
+        .unwrap_or(f64::from_bits(TAG_NULL))
+}
+
 /// `stream.writableCorked` property getter on a typed writable-side instance.
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_writable_corked(stream_handle: i64) -> f64 {

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -31,6 +31,8 @@ static KEEP_NS_WRITABLE_HWM: extern "C" fn(i64) -> f64 = super::js_node_stream_m
 static KEEP_NS_READABLE_ABORTED: extern "C" fn(i64) -> f64 =
     super::js_node_stream_method_readable_aborted;
 #[used]
+static KEEP_NS_METHOD_ERRORED: extern "C" fn(i64) -> f64 = super::js_node_stream_method_errored;
+#[used]
 static KEEP_NS_WRITABLE_CORKED: extern "C" fn(i64) -> f64 =
     super::js_node_stream_method_writable_corked;
 #[used]

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -677,12 +677,20 @@ fn stream_destroy_with_error_marks_errored_state() {
     );
     let err = string_value("boom");
 
+    assert_eq!(
+        js_node_stream_method_errored(raw_ptr_from_value(stream) as i64).to_bits(),
+        TAG_NULL
+    );
     let ret = unsafe { crate::closure::js_native_call_value(destroy, &err, 1) };
 
     assert_eq!(ret.to_bits(), stream.to_bits());
     assert_eq!(js_node_stream_is_errored(stream).to_bits(), TAG_FALSE);
     let _ = crate::promise::js_promise_run_microtasks();
     assert_eq!(js_node_stream_is_errored(stream).to_bits(), TAG_TRUE);
+    assert_eq!(
+        js_node_stream_method_errored(raw_ptr_from_value(stream) as i64).to_bits(),
+        err.to_bits()
+    );
 }
 
 #[test]

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -902,18 +902,6 @@
     "category": "bug-open",
     "reason": "node:stream: readable.unshift(chunk, encoding) — second-arg encoding form not honored. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/flags/readable-errored": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: readable.errored getter — stored Error after destroy(err) not exposed. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/flags/writable-errored": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: writable.errored getter — stored Error after destroy(err) not exposed. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/iter-helpers/map-returns-readable": {
     "issue": "1558",
     "added": "2026-05-24",


### PR DESCRIPTION
Refs #1531

## Summary
- add typed classic `stream.errored` getter support through manifest, codegen native table, runtime declaration, and runtime symbol retention
- return the stored stream error after `destroy(err)` and `null` before an error exists
- remove the exact readable/writable errored known-failure entries now covered by parity

## Verification
- Baseline before fix: exact `stream/flags/readable-errored` and `stream/flags/writable-errored` failed with Perry `errored before: 0`, report `test-parity/reports/parity_report_20260527_130249.json`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD`
- `cargo test -p perry-runtime stream_destroy_with_error_marks_errored_state --lib`
- `cargo test -p perry-codegen --lib native_table` PASS compile, 0 matching tests
- `cargo test -p perry-api-manifest`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/flags/readable-errored` PASS 1/1, report `test-parity/reports/parity_report_20260527_130841.json`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/flags/writable-errored` PASS 1/1, report `test-parity/reports/parity_report_20260527_130922.json`
- Guardrail `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter errored` PASS 7/7, report `test-parity/reports/parity_report_20260527_130929.json`

## Reference
- DeepWiki: `reference/deepwiki/nodejs-node-stream-errored-getter-2026-05-27.md` (local note only, not staged)

## Non-goals
- no write-after-error behavior changes
- no callback-error propagation changes
- no destroyed/closed flag work
- no pipeline behavior or broader error lifecycle rewrite
