### PR TITLE
fix(typed-array): reflect %TypedArray%.prototype accessor descriptors (#2060)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1087,7 +1087,26 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
         {
             if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
                 if obj_ident.sym.as_ref() == property.as_str() {
-                    object_expr = Expr::GlobalGet(0);
+                    // #2060: `<TypedArrayCtor>.prototype` must keep reading the
+                    // constructor closure's *real* prototype object — the per-kind
+                    // proto carries the reflectable `length`/`byteLength`/
+                    // `byteOffset`/`buffer` accessor descriptors installed by
+                    // `populate_builtin_prototype_methods`. Collapsing to
+                    // `PropertyGet { GlobalGet(0), "prototype" }` would instead hit
+                    // codegen's `0.0` no-value placeholder (a number), so
+                    // `Object.getPrototypeOf(Int8Array.prototype)` returned null and
+                    // the descriptor lookup found nothing. Leave the inner
+                    // `PropertyGet { GlobalGet(0), <ctor> }` in place so the outer
+                    // `.prototype` reads through the closure's dynamic-prop table.
+                    let outer_is_prototype = matches!(
+                        &member.prop,
+                        ast::MemberProp::Ident(p) if p.sym.as_ref() == "prototype"
+                    );
+                    let is_typed_array_ctor =
+                        crate::ir::typed_array_kind_for_name(property).is_some();
+                    if !(outer_is_prototype && is_typed_array_ctor) {
+                        object_expr = Expr::GlobalGet(0);
+                    }
                 }
             }
         }

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -306,6 +306,116 @@ extern "C" fn array_prototype_slice_thunk(
     f64::from_bits(crate::value::js_nanbox_pointer(result as i64).to_bits())
 }
 
+/// Resolve the `IMPLICIT_THIS` receiver to a `(typed-array ptr, kind)` if it
+/// is a typed array, else `None`. Backs the `%TypedArray%.prototype` accessor
+/// getters installed for reflection (#2060) — these fire when user code does
+/// `desc.get.call(int8arr)` after pulling the descriptor out via
+/// `Object.getOwnPropertyDescriptor`. Mirrors the receiver-extraction the
+/// `Array.prototype.slice` thunk uses (NaN-boxed pointer or raw-i64 form).
+fn typed_array_receiver() -> Option<(*const crate::typedarray::TypedArrayHeader, u8)> {
+    use crate::value::JSValue;
+    let this_bits = IMPLICIT_THIS.with(|c| c.get());
+    let this_jsv = JSValue::from_bits(this_bits);
+    let raw = if this_jsv.is_pointer() {
+        (this_bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else if this_bits >> 48 == 0 && this_bits > 0x10000 {
+        this_bits as usize
+    } else {
+        return None;
+    };
+    let kind = crate::typedarray::lookup_typed_array_kind(raw)?;
+    Some((raw as *const crate::typedarray::TypedArrayHeader, kind))
+}
+
+/// `%TypedArray%.prototype.length` getter — element count of the receiver.
+extern "C" fn typed_array_length_getter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    match typed_array_receiver() {
+        Some((ta, _)) => {
+            let len = crate::typedarray::js_typed_array_length(ta);
+            f64::from_bits(crate::value::JSValue::number(len as f64).bits())
+        }
+        None => f64::from_bits(crate::value::TAG_UNDEFINED),
+    }
+}
+
+/// `%TypedArray%.prototype.byteLength` getter — `length * BYTES_PER_ELEMENT`.
+extern "C" fn typed_array_byte_length_getter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    match typed_array_receiver() {
+        Some((ta, kind)) => {
+            let len = crate::typedarray::js_typed_array_length(ta) as usize;
+            let elem_size = crate::typedarray::elem_size_for_kind(kind);
+            f64::from_bits(crate::value::JSValue::number((len * elem_size) as f64).bits())
+        }
+        None => f64::from_bits(crate::value::TAG_UNDEFINED),
+    }
+}
+
+/// `%TypedArray%.prototype.byteOffset` getter — always 0 (Perry views are not
+/// backed by an offset into a shared `ArrayBuffer`).
+extern "C" fn typed_array_byte_offset_getter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    match typed_array_receiver() {
+        Some(_) => f64::from_bits(crate::value::JSValue::number(0.0).bits()),
+        None => f64::from_bits(crate::value::TAG_UNDEFINED),
+    }
+}
+
+/// `%TypedArray%.prototype.buffer` getter. Perry does not yet model a
+/// first-class `ArrayBuffer` behind a view, so this returns `undefined` for
+/// now (matching the existing `int8arr.buffer` data-path behavior). The
+/// accessor still exists so reflection sees a real getter — closing the
+/// `getOwnPropertyDescriptor(...).get` cascade in #2060.
+extern "C" fn typed_array_buffer_getter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// Install the four `%TypedArray%.prototype` accessor descriptors
+/// (`length`, `byteLength`, `byteOffset`, `buffer`) on a typed-array
+/// constructor's prototype object so `Object.getOwnPropertyDescriptor`
+/// reflects them as `{ get, set: undefined, enumerable: false,
+/// configurable: true }`. #2060.
+fn install_typed_array_proto_accessors(proto_obj: *mut ObjectHeader) {
+    unsafe {
+        // 0-arg getters: `.call(this)` forwards 0 user args.
+        let mk = |f: *const u8| -> u64 {
+            crate::closure::js_register_closure_arity(f, 0);
+            let c = crate::closure::js_closure_alloc(f, 0);
+            if c.is_null() {
+                0
+            } else {
+                crate::value::js_nanbox_pointer(c as i64).to_bits()
+            }
+        };
+        install_builtin_getter(
+            proto_obj,
+            "length",
+            mk(typed_array_length_getter_thunk as *const u8),
+        );
+        install_builtin_getter(
+            proto_obj,
+            "byteLength",
+            mk(typed_array_byte_length_getter_thunk as *const u8),
+        );
+        install_builtin_getter(
+            proto_obj,
+            "byteOffset",
+            mk(typed_array_byte_offset_getter_thunk as *const u8),
+        );
+        install_builtin_getter(
+            proto_obj,
+            "buffer",
+            mk(typed_array_buffer_getter_thunk as *const u8),
+        );
+    }
+}
+
 /// Populate the freshly-allocated globalThis singleton with built-in
 /// constructor / namespace properties. Called exactly once from the CAS
 /// winner in `js_get_global_this`. Constructors get a ClosureHeader-
@@ -442,6 +552,18 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
                 let value = crate::value::js_nanbox_pointer(to_string_closure as i64);
                 js_object_set_field_by_name(proto_obj, key, value);
             }
+        }
+        // Typed-array constructors: install the `%TypedArray%.prototype`
+        // accessor descriptors (`length`/`byteLength`/`byteOffset`/`buffer`)
+        // on the per-kind prototype object. Perry's `getPrototypeOf(heapObj)`
+        // returns the object itself, so `Object.getOwnPropertyDescriptor(
+        // Object.getPrototypeOf(Int8Array.prototype), "length")` resolves to
+        // this same object and finds the accessor — closing the
+        // `Cannot read properties of undefined (reading 'get')` cascade. #2060.
+        "Int8Array" | "Uint8Array" | "Uint8ClampedArray" | "Int16Array" | "Uint16Array"
+        | "Int32Array" | "Uint32Array" | "Float32Array" | "Float64Array" | "BigInt64Array"
+        | "BigUint64Array" => {
+            install_typed_array_proto_accessors(proto_obj);
         }
         _ => {}
     }

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -496,6 +496,34 @@ pub(crate) fn set_accessor_descriptor(obj: usize, key: String, acc: AccessorDesc
     });
 }
 
+/// Install a built-in *reflection-only* accessor descriptor for (obj, key)
+/// WITHOUT flipping the process-wide `GLOBAL_DESCRIPTORS_IN_USE` /
+/// `ACCESSORS_IN_USE` / `PROPERTY_ATTRS_IN_USE` hot-path gates.
+///
+/// `Object.getOwnPropertyDescriptor` reads `ACCESSOR_DESCRIPTORS` and
+/// `PROPERTY_DESCRIPTORS` *unconditionally*, so the descriptor is fully
+/// reflectable — but the hot object get/set paths (which only consult the
+/// side tables once a gate has flipped) keep skipping the HashMap lookup.
+/// This matters because built-in prototype accessors such as
+/// `%TypedArray%.prototype.length` are installed lazily at globalThis
+/// init for *every* program that merely touches a builtin global; flipping
+/// the gate there would slow the property-write fast path process-wide for
+/// no behavioral gain (these accessors have no setter and are never written
+/// in real workloads — they exist purely so reflection sees them). See #2060.
+pub(crate) fn set_builtin_accessor_descriptor(
+    obj: usize,
+    key: String,
+    acc: AccessorDescriptor,
+    attrs: PropertyAttrs,
+) {
+    ACCESSOR_DESCRIPTORS.with(|m| {
+        m.borrow_mut().insert((obj, key.clone()), acc);
+    });
+    PROPERTY_DESCRIPTORS.with(|m| {
+        m.borrow_mut().insert((obj, key), attrs);
+    });
+}
+
 /// Walk the keys array of `obj` and apply the given attribute mask AND filter to every existing key.
 /// Used by `Object.freeze` (drops `writable` + `configurable`) and `Object.seal` (drops `configurable`).
 unsafe fn mark_all_keys(

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -559,6 +559,37 @@ unsafe fn ensure_key_in_keys_array(obj: *mut ObjectHeader, key: *const crate::St
     }
 }
 
+/// Install a built-in *getter-only* accessor on a prototype object so that
+/// `Object.getOwnPropertyDescriptor(proto, key)` reflects it as a real
+/// accessor descriptor `{ get, set: undefined, enumerable, configurable }`.
+///
+/// `getter_bits` is the NaN-boxed `f64` bits of the getter closure (0 = none).
+/// The descriptor is non-enumerable and configurable, matching the ECMA-262
+/// shape for `%TypedArray%.prototype` accessors like `length` / `byteLength` /
+/// `byteOffset` / `buffer`. Reflection-only: this does NOT flip the hot-path
+/// descriptor gate (see `set_builtin_accessor_descriptor`). #2060.
+pub(crate) unsafe fn install_builtin_getter(proto: *mut ObjectHeader, key: &str, getter_bits: u64) {
+    if proto.is_null() || (proto as usize) < 0x10000 {
+        return;
+    }
+    let key_str = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+    if key_str.is_null() {
+        return;
+    }
+    // Make the key discoverable by `own_key_present` / `getOwnPropertyNames`.
+    ensure_key_in_keys_array(proto, key_str);
+    set_builtin_accessor_descriptor(
+        proto as usize,
+        key.to_string(),
+        AccessorDescriptor {
+            get: getter_bits,
+            set: 0,
+        },
+        // writable is N/A for an accessor; enumerable=false, configurable=true.
+        PropertyAttrs::new(true, false, true),
+    );
+}
+
 /// Object.getOwnPropertyDescriptor(obj, key) — returns a data descriptor
 /// `{ value, writable, enumerable, configurable }` for data properties, or an
 /// accessor descriptor `{ get, set, enumerable, configurable }` for properties

--- a/test-files/test_issue_2060_typed_array_accessor_descriptors.ts
+++ b/test-files/test_issue_2060_typed_array_accessor_descriptors.ts
@@ -1,0 +1,46 @@
+// Issue #2060: accessor (getter) properties on built-in prototypes must be
+// reflectable. `Object.getOwnPropertyDescriptor(%TypedArray%.prototype, "length")`
+// (reached via `Object.getPrototypeOf(Int8Array.prototype)`) returns a real
+// accessor descriptor `{ get, set, enumerable, configurable }` in Node, where
+// Perry previously returned `undefined` (the `Cannot read properties of
+// undefined (reading 'get')` cascade in the Test262 built-ins/TypedArray sample).
+
+// Exact repro from the issue.
+const TAp = Object.getPrototypeOf(Int8Array.prototype);
+const d = Object.getOwnPropertyDescriptor(TAp, "length");
+console.log(d ? Object.keys(d).sort().join(",") : "(undefined desc)", "| get:", d && typeof d.get);
+
+// Control: a user-defined accessor must keep round-tripping.
+const o: any = {};
+Object.defineProperty(o, "p", { get() { return 42; }, configurable: true, enumerable: true });
+console.log(o.p, Object.getOwnPropertyDescriptor(o, "p").get && "has-get");
+
+// Full descriptor shape for `length`: non-enumerable, configurable, no setter.
+console.log("len enumerable:", d!.enumerable, "configurable:", d!.configurable, "set:", d!.set);
+
+// byteLength / byteOffset / buffer are accessor properties too.
+for (const k of ["byteLength", "byteOffset", "buffer"]) {
+  const dd = Object.getOwnPropertyDescriptor(TAp, k);
+  console.log(k, "=>", dd ? ("get:" + typeof dd.get + " enum:" + dd.enumerable + " cfg:" + dd.configurable) : "(undef)");
+}
+
+// The getters compute the right value when invoked on a real instance.
+const a = new Int8Array(5);
+console.log("length.get.call(a):", (d!.get as any).call(a));
+const bld = Object.getOwnPropertyDescriptor(TAp, "byteLength");
+console.log("byteLength.get.call(a):", (bld!.get as any).call(a));
+const i32 = new Int32Array(4);
+const bl32 = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(Int32Array.prototype), "byteLength");
+console.log("Int32 byteLength.get.call(i32):", (bl32!.get as any).call(i32));
+
+// Instance property fast-path is unchanged.
+console.log("a.length:", a.length, "a.byteLength:", a.byteLength, "a.byteOffset:", a.byteOffset, "a.BYTES_PER_ELEMENT:", a.BYTES_PER_ELEMENT);
+
+// Reflection works across multiple kinds.
+const labels = ["Uint8", "Float64", "Uint16"];
+const ctors = [Uint8Array, Float64Array, Uint16Array];
+for (let i = 0; i < ctors.length; i++) {
+  const p = Object.getPrototypeOf((ctors[i] as any).prototype);
+  const dl = Object.getOwnPropertyDescriptor(p, "length");
+  console.log(labels[i], "length get:", dl && typeof dl.get);
+}


### PR DESCRIPTION
## Summary

Closes #2060. Accessor (getter) properties on built-in typed-array prototypes are now reflectable: `Object.getOwnPropertyDescriptor(Object.getPrototypeOf(Int8Array.prototype), "length")` returns a real accessor descriptor `{ get, set, enumerable, configurable }` instead of `undefined`.

**Before:** `Int8Array.prototype` evaluated to a **number** (the `0.0` placeholder), so `Object.getPrototypeOf(Int8Array.prototype)` was `null` and the descriptor lookup found nothing → `Cannot read properties of undefined (reading 'get')` (16× in the Test262 `built-ins/TypedArray` sample; part of #793, surfaced by #799).

## What changed

1. **Runtime install (reflection-only).** `length`/`byteLength`/`byteOffset`/`buffer` are installed as getter-only accessor descriptors (`enumerable: false`, `configurable: true`) on each typed-array constructor's prototype object during `populate_global_this_builtins`. A new `set_builtin_accessor_descriptor` inserts into `ACCESSOR_DESCRIPTORS` + `PROPERTY_DESCRIPTORS` **without** flipping the process-wide `GLOBAL_DESCRIPTORS_IN_USE` hot-path gate — `getOwnPropertyDescriptor` reads those tables unconditionally, so reflection works while the property-write fast path stays untouched for the many programs that merely touch a builtin global.
2. **Getter thunks** read the receiver from `IMPLICIT_THIS`, so `desc.get.call(typedArray)` returns the right `length`/`byteLength`. `.buffer` returns `undefined` for now (Perry has no first-class `ArrayBuffer` behind a view yet — separate gap; the getter still exists so reflection sees a function).
3. **HIR routing.** `<TypedArrayCtor>.prototype` no longer collapses to the `GlobalGet(0)` `0.0` placeholder; it reads the constructor closure's real prototype object. Perry's `getPrototypeOf(heapObj)` returns the object itself, so the descriptor is found on the returned object — no `%TypedArray%.prototype` intermediate or pointer-keyed proto side-table needed (GC-safe). Scoped to typed-array constructor names, so `Number.parseFloat === parseFloat` and other static-surface identities are unaffected.

## Validation

- Issue repro + new `test-files/test_issue_2060_typed_array_accessor_descriptors.ts` are **byte-identical to Node** (`node --experimental-strip-types`).
- Reflection survives `PERRY_GC_FORCE_EVACUATE=1`.
- Descriptor/object gap suite green (`getOwnPropertyDescriptor`, `defineProperty`, `Object.create`, proxy/reflect, symbols, `getPrototypeOf` class).
- `cargo test -p perry-hir -p perry-runtime` passes (0 failed); `cargo fmt --all -- --check` clean.

## Out of scope / follow-ups

- `%TypedArray%.prototype` is not modeled as a shared intermediate (Perry's `getPrototypeOf` returns the object itself), so cross-kind identity (`getPrototypeOf(Int8Array.prototype) === getPrototypeOf(Uint8Array.prototype)`) is not asserted.
- `.buffer` returns `undefined` pending real ArrayBuffer-behind-view modeling.
- The separate issue *title* (`function foo(){}; foo.name === undefined`) is a distinct gap and is not addressed here.
