### PR TITLE
fix(node:stream): expose readableDidRead flag

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2514,6 +2514,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("stream", "readableEnded", true, None),
     method("stream", "writableHighWaterMark", true, None),
     method("stream", "readableAborted", true, None),
+    method("stream", "readableDidRead", true, None),
     method("stream", "writableCorked", true, None),
     method("stream", "writable", true, None),
     method("stream", "writableEnded", true, None),

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -791,6 +791,15 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "stream",
         has_receiver: true,
+        method: "readableDidRead",
+        class_filter: None,
+        runtime: "js_node_stream_method_readable_did_read",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
         method: "writable",
         class_filter: None,
         runtime: "js_node_stream_method_writable",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -871,6 +871,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_to_web", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_from_web", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_method_readable_aborted", DOUBLE, &[I64]);
+    module.declare_function("js_node_stream_method_readable_did_read", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroyed", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroy", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_node_stream_method_readable", DOUBLE, &[I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -475,6 +475,17 @@ pub extern "C" fn js_node_stream_method_readable_aborted(stream_handle: i64) -> 
     readable_aborted_value(stream_value_from_handle(stream_handle))
 }
 
+/// `stream.readableDidRead` property getter on typed readable-side instances.
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_readable_did_read(stream_handle: i64) -> f64 {
+    let stream = stream_value_from_handle(stream_handle);
+    f64::from_bits(if has_truthy_hidden(stream, hidden_disturbed_key()) {
+        TAG_TRUE
+    } else {
+        TAG_FALSE
+    })
+}
+
 /// `stream.writableCorked` property getter on a typed writable-side instance.
 #[no_mangle]
 pub extern "C" fn js_node_stream_method_writable_corked(stream_handle: i64) -> f64 {
@@ -1301,6 +1312,7 @@ fn hidden_hwm_key() -> *mut crate::string::StringHeader {
 /// `Readable.isDisturbed(s)` (#1534).
 fn mark_disturbed(stream: f64) {
     set_hidden_value(stream, hidden_disturbed_key(), f64::from_bits(TAG_TRUE));
+    set_visible_readable_did_read(stream, true);
 }
 
 fn hidden_key(bytes: &[u8]) -> *mut crate::string::StringHeader {
@@ -1427,6 +1439,9 @@ fn drain_readable_from_events(stream: f64) {
     if let Some(chunks) = readable_hidden_chunks(stream) {
         let mut values = Vec::new();
         push_chunk_values(chunks, &mut values, 0);
+        if !values.is_empty() {
+            mark_disturbed(stream);
+        }
         for chunk in values {
             let _ = emit_stream_event(stream, data_event, &[chunk]);
         }
@@ -2094,6 +2109,17 @@ fn set_visible_readable_ended(stream: f64, ended: bool) {
     }
 }
 
+fn set_visible_readable_did_read(stream: f64, did_read: bool) {
+    if get_hidden_value(stream, hidden_readable_flag_key()).is_some() {
+        let value = if did_read { TAG_TRUE } else { TAG_FALSE };
+        set_hidden_value(
+            stream,
+            hidden_key(b"readableDidRead"),
+            f64::from_bits(value),
+        );
+    }
+}
+
 fn mark_stream_ended(stream: f64) {
     set_hidden_value(stream, hidden_ended_key(), f64::from_bits(TAG_TRUE));
     set_visible_readable(stream, false);
@@ -2153,6 +2179,7 @@ fn init_readable_state(stream: f64, opts: f64) {
     set_hidden_value(stream, hidden_key(b"readableHighWaterMark"), r_hwm);
     set_visible_readable(stream, true);
     set_visible_readable_ended(stream, false);
+    set_visible_readable_did_read(stream, false);
 }
 
 /// Initialize the writable side: direction flag and visible stream flags.

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -31,6 +31,9 @@ static KEEP_NS_WRITABLE_HWM: extern "C" fn(i64) -> f64 = super::js_node_stream_m
 static KEEP_NS_READABLE_ABORTED: extern "C" fn(i64) -> f64 =
     super::js_node_stream_method_readable_aborted;
 #[used]
+static KEEP_NS_READABLE_DID_READ: extern "C" fn(i64) -> f64 =
+    super::js_node_stream_method_readable_did_read;
+#[used]
 static KEEP_NS_WRITABLE_CORKED: extern "C" fn(i64) -> f64 =
     super::js_node_stream_method_writable_corked;
 #[used]

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -555,6 +555,24 @@ fn readable_lifecycle_flags_reflect_ended_state() {
         js_object_get_field_by_name_f64(obj, hidden_key(b"readableEnded")).to_bits(),
         TAG_FALSE
     );
+    assert_eq!(
+        js_node_stream_method_readable_did_read(handle).to_bits(),
+        TAG_FALSE
+    );
+    assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"readableDidRead")).to_bits(),
+        TAG_FALSE
+    );
+
+    let _ = js_node_stream_method_read(handle, f64::from_bits(TAG_UNDEFINED));
+    assert_eq!(
+        js_node_stream_method_readable_did_read(handle).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"readableDidRead")).to_bits(),
+        TAG_TRUE
+    );
 
     let _ = js_node_stream_method_push(handle, f64::from_bits(TAG_NULL));
     assert_eq!(js_node_stream_method_readable(handle).to_bits(), TAG_FALSE);

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -884,12 +884,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.prototype.compose(stream) instance method — not yet exposed (only free compose() works). Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/flags/readable-did-read": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: readable.readableDidRead getter (Node 16.7+) — not exposed. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/readable/read-size-passed-to-_read": {
     "issue": "1531",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- seed classic readable streams with visible `readableDidRead: false`
- flip `readableDidRead` through the existing disturbed/read path, including `Readable.from(...)` data emission
- add the manifest/codegen/runtime typed getter path and remove the flipped exact known-failure entry

## Verification
- Baseline exact `stream/flags/readable-did-read` failed before the fix with Perry `didRead before consume: undefined`, report `test-parity/reports/parity_report_20260527_131415.json`
- `cargo test -p perry-runtime readable_lifecycle_flags_reflect_ended_state --lib`
- `cargo test -p perry-codegen --lib native_table`
- `cargo test -p perry-api-manifest`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/flags/readable-did-read` PASS 1/1, report `test-parity/reports/parity_report_20260527_132438.json`
- Guardrail `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/flags/readable-` kept `readable-did-read` green and exited below threshold with existing residuals in `readable-encoding`, `readable-errored`, and `readable-flowing`, report `test-parity/reports/parity_report_20260527_132529.json`

## DeepWiki
- `reference/deepwiki/nodejs-node-stream-readable-did-read-2026-05-27.md` (local reference only, not staged)

## Non-goals
- no readableEncoding default/null work
- no readableFlowing state work
- no inclusion of open `errored` PR behavior
- no broader disturbed/read state-machine rewrite