### PR TITLE
fix(hir,codegen,runtime): run instance-field initializers when constructing from a class-expression value (#1787)

### DIFF
--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -306,6 +306,13 @@ pub(super) fn emit_string_pool(
     // static methods (`class Sub extends make(...) {}; Sub.greet()`); has_rest
     // tells the dispatcher to bundle trailing args for a `...rest` param.
     let mut static_method_triples: Vec<(u32, String, String, u32, bool)> = Vec::new();
+    // #1787: (cid, standalone-constructor symbol, total_param_count).
+    // Registered into CLASS_CONSTRUCTORS so `new <classObjectValue>()` (a
+    // class-expression value constructed dynamically) can replay the class's
+    // constructor + field initializers on the new instance. Only consulted by
+    // the heap-class-object arm of `js_new_function_construct`, so it's
+    // behavior-neutral for top-level class declarations (INT32 ref `new`).
+    let mut ctor_triples: Vec<(u32, String, u32)> = Vec::new();
     for (class_name, class) in classes.iter() {
         // Refs #486: skip alias keys (class_table now contains both the
         // canonical name and self-binding aliases like `_X` from
@@ -362,6 +369,23 @@ pub(super) fn emit_string_pool(
                 has_rest,
             ));
         }
+        // #1787: the standalone constructor `<prefix>__<class>_constructor`
+        // (emitted unconditionally in `artifacts.rs`). Its arity is the
+        // constructor's full param list — user params plus the synthesized
+        // `__perry_cap_<id>` capture params (`synthesize_class_captures`).
+        // Class-expression templates with no own/synthesized constructor (no
+        // captures) have arity 0 — the standalone ctor then just runs the
+        // literal field initializers.
+        let ctor_params = class
+            .constructor
+            .as_ref()
+            .map(|c| c.params.len() as u32)
+            .unwrap_or(0);
+        ctor_triples.push((
+            cid,
+            format!("{}__{}_constructor", module_prefix, class_name),
+            ctor_params,
+        ));
     }
     method_triples.sort_unstable();
     for (cid, method_name, llvm_name, param_count) in method_triples {
@@ -416,6 +440,22 @@ pub(super) fn emit_string_pool(
                 (I64, &func_i64),
                 (I64, &param_count.to_string()),
                 (I64, has_rest_str),
+            ],
+        );
+    }
+    // #1787: register each class's standalone constructor into
+    // CLASS_CONSTRUCTORS. ptrtoint @symbol both stores the function pointer
+    // and keeps the constructor alive past dead-code elimination.
+    ctor_triples.sort_unstable();
+    for (cid, ctor_symbol, ctor_params) in ctor_triples {
+        let func_ref = format!("@{}", ctor_symbol);
+        let func_i64 = blk.ptrtoint(&func_ref, I64);
+        blk.call_void(
+            "js_register_class_constructor",
+            &[
+                (I64, &cid.to_string()),
+                (I64, &func_i64),
+                (I64, &ctor_params.to_string()),
             ],
         );
     }

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -777,6 +777,7 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         Expr::ClassExprFresh {
             named_statics,
             symbol_statics,
+            captured_args,
             ..
         } => {
             for (_, v) in named_statics {
@@ -785,6 +786,9 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
             for (k, v) in symbol_statics {
                 walk(k, out);
                 walk(v, out);
+            }
+            for a in captured_args {
+                walk(a, out);
             }
         }
         Expr::RegisterClassParentDynamic { parent_expr, .. } => {

--- a/crates/perry-codegen/src/expr/static_field_meta.rs
+++ b/crates/perry-codegen/src/expr/static_field_meta.rs
@@ -165,6 +165,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             template,
             named_statics,
             symbol_statics,
+            captured_args,
         } => {
             let template_cid = ctx.class_ids.get(template).copied().unwrap_or(0);
             let tcid_str = template_cid.to_string();
@@ -190,6 +191,35 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 blk.call_void(
                     "js_object_set_field_by_name",
                     &[(I64, &obj), (I64, &key_raw), (DOUBLE, &v)],
+                );
+            }
+            // #1787: snapshot the captured outer-scope values onto the class
+            // object as the `__perry_ctor_caps` own array (in the constructor's
+            // capture-param order). `new <thisClassObjectValue>()` reads it back
+            // in `js_new_function_construct` and replays the constructor with the
+            // right captured environment — which the static `new ClassName()`
+            // inlining can't do once the class escapes its defining scope.
+            if !captured_args.is_empty() {
+                let cap_len = captured_args.len().to_string();
+                let mut caps_arr = ctx.block().call(I64, "js_array_alloc", &[(I32, &cap_len)]);
+                for arg in captured_args {
+                    let v = lower_expr(ctx, arg)?;
+                    caps_arr = ctx.block().call(
+                        I64,
+                        "js_array_push_f64",
+                        &[(I64, &caps_arr), (DOUBLE, &v)],
+                    );
+                }
+                let caps_box = nanbox_pointer_inline(ctx.block(), &caps_arr);
+                let key_idx = ctx.strings.intern("__perry_ctor_caps");
+                let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                let blk = ctx.block();
+                let key_box = blk.load(DOUBLE, &key_handle_global);
+                let key_bits = blk.bitcast_double_to_i64(&key_box);
+                let key_raw = blk.and(I64, &key_bits, crate::nanbox::POINTER_MASK_I64);
+                blk.call_void(
+                    "js_object_set_field_by_name",
+                    &[(I64, &obj), (I64, &key_raw), (DOUBLE, &caps_box)],
                 );
             }
             let obj_box = nanbox_pointer_inline(ctx.block(), &obj);

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1213,6 +1213,9 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // Refs #486: per-class setter dispatch — see object.rs::js_register_class_setter.
     module.declare_function("js_register_class_setter", VOID, &[I64, I64, I64, I64]);
     module.declare_function("js_register_class_method", VOID, &[I64, I64, I64, I64, I64]);
+    // #1787: register a class's standalone constructor so `new
+    // <classObjectValue>()` can replay it on a dynamically-allocated instance.
+    module.declare_function("js_register_class_constructor", VOID, &[I64, I64, I64]);
     // #1788: register a class STATIC method + dispatch an inherited static
     // method on a class value (subclass extends a class-expression value).
     module.declare_function(

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -322,6 +322,17 @@ pub enum Expr {
         template: String,
         named_statics: Vec<(String, Expr)>,
         symbol_statics: Vec<(Expr, Expr)>,
+        /// #1787: the captured outer-scope values this class expression
+        /// closes over, in the synthesized constructor's capture-param
+        /// order (see `synthesize_class_captures`). Each entry is a
+        /// `LocalGet(outer_id)` evaluated at the class-expression
+        /// evaluation site (where the captures are still live). Codegen
+        /// snapshots them onto the heap class object so a later
+        /// `new <classObjectValue>()` can replay the instance-field
+        /// initializers / constructor body with the right captured
+        /// environment — which the static `new ClassName()` inlining
+        /// can't do once the class escapes its defining scope.
+        captured_args: Vec<Expr>,
     },
 
     // Issue #711 part 2: `<func_expr>.prototype = <obj_expr>` pattern,

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -1391,10 +1391,23 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
             if parent_expr.is_none()
                 && (!named_statics.is_empty() || !static_symbol_registrations.is_empty())
             {
+                // #1787: snapshot the class's captured outer-scope values so a
+                // later `new <classObjectValue>()` can run the instance-field
+                // initializers / constructor body with the right environment.
+                // `synthesize_class_captures` (run during `lower_class_from_ast`
+                // above) appended one `__perry_cap_<id>` constructor param per
+                // captured outer id, in `captures_vec` order — read them back in
+                // that same order as `LocalGet(outer_id)`, evaluated here where
+                // the captures are still live.
+                let captured_args: Vec<Expr> = ctx
+                    .lookup_class_captures(&synthetic_name)
+                    .map(|ids| ids.iter().map(|id| Expr::LocalGet(*id)).collect())
+                    .unwrap_or_default();
                 return Ok(Expr::ClassExprFresh {
                     template: synthetic_name,
                     named_statics,
                     symbol_statics: static_symbol_registrations,
+                    captured_args,
                 });
             }
             let mut seq: Vec<Expr> = Vec::new();

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -548,7 +548,7 @@ impl SH for Expr {
             Expr::TemplateRaw(e) => { tag(h, 446); e.as_ref().hash(h); }
             Expr::RegisterClassParentDynamic { class_name, parent_expr, } => { tag(h, 447); class_name.hash(h); parent_expr.as_ref().hash(h); }
             Expr::RegisterClassStaticSymbol { class_name, key_expr, value_expr, } => { tag(h, 465); class_name.hash(h); key_expr.as_ref().hash(h); value_expr.as_ref().hash(h); }
-            Expr::ClassExprFresh { template, named_statics, symbol_statics, } => { tag(h, 466); template.hash(h); for (n, v) in named_statics { n.hash(h); v.hash(h); } for (k, v) in symbol_statics { k.hash(h); v.hash(h); } }
+            Expr::ClassExprFresh { template, named_statics, symbol_statics, captured_args, } => { tag(h, 466); template.hash(h); for (n, v) in named_statics { n.hash(h); v.hash(h); } for (k, v) in symbol_statics { k.hash(h); v.hash(h); } for a in captured_args { a.hash(h); } }
             Expr::SetFunctionPrototype { func, proto } => { tag(h, 448); func.as_ref().hash(h); proto.as_ref().hash(h); }
             Expr::RegisterPrototypeMethod { class_name, method_name, value, } => { tag(h, 463); class_name.hash(h); method_name.hash(h); value.as_ref().hash(h); }
             Expr::RegisterFunctionPrototypeMethod { func, method_name, value, } => { tag(h, 464); func.as_ref().hash(h); method_name.hash(h); value.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -511,6 +511,7 @@ where
         Expr::ClassExprFresh {
             named_statics,
             symbol_statics,
+            captured_args,
             ..
         } => {
             for (_, v) in named_statics.iter_mut() {
@@ -519,6 +520,9 @@ where
             for (k, v) in symbol_statics.iter_mut() {
                 f(k);
                 f(v);
+            }
+            for a in captured_args.iter_mut() {
+                f(a);
             }
         }
         Expr::SetFunctionPrototype { func, proto } => {

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -512,6 +512,7 @@ where
         Expr::ClassExprFresh {
             named_statics,
             symbol_statics,
+            captured_args,
             ..
         } => {
             for (_, v) in named_statics {
@@ -520,6 +521,9 @@ where
             for (k, v) in symbol_statics {
                 f(k);
                 f(v);
+            }
+            for a in captured_args {
+                f(a);
             }
         }
         Expr::SetFunctionPrototype { func, proto } => {

--- a/crates/perry-runtime/src/object/class_constructors.rs
+++ b/crates/perry-runtime/src/object/class_constructors.rs
@@ -1,0 +1,128 @@
+//! Per-template constructor replay for class EXPRESSIONS used as values
+//! (issue #1787, epic #1785 / design #1772).
+//!
+//! Split out of `object/class_registry.rs` to keep that file under the 2,000-
+//! line CI gate. Holds the `CLASS_CONSTRUCTORS` registry, its registration
+//! entry point, and the replay helper invoked by the heap-class-object arm of
+//! `js_new_function_construct`.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use super::class_registry::call_vtable_method;
+use super::ObjectHeader;
+
+/// #1787: per-template constructor function pointers, keyed by the
+/// compile-time class_id. The value is `(fn_ptr, total_param_count)`:
+/// `fn_ptr` is the standalone `<prefix>__<class>_constructor` LLVM symbol
+/// (signature `double(double this, double arg0, ...)` — the same shape as a
+/// vtable method, so `call_vtable_method` invokes it), and `total_param_count`
+/// is the constructor's full arity (user params plus the synthesized
+/// `__perry_cap_<id>` capture params appended by `synthesize_class_captures`).
+///
+/// Consulted only by the heap-class-object (`OBJECT_TYPE_CLASS`) arm of
+/// `js_new_function_construct`: a class EXPRESSION evaluated as a value
+/// (`const A = mk(...); new A()`) can't have its constructor inlined at the
+/// `new` site (the callee is a runtime value, and the captured environment
+/// lived at the evaluation site, not the construction site). So the
+/// per-evaluation captures are snapshotted onto the class object (as the
+/// `__perry_ctor_caps` own array) and the constructor is replayed here.
+/// Top-level class DECLARATIONS keep the INT32 class-ref `new` path and do not
+/// consult this table, so registering every class's constructor is
+/// behavior-neutral for them.
+pub static CLASS_CONSTRUCTORS: RwLock<Option<HashMap<u32, (usize, u32)>>> = RwLock::new(None);
+
+/// #1787: register a class's standalone constructor in `CLASS_CONSTRUCTORS`,
+/// keyed by the (template) class_id, so `new <classObjectValue>()` can replay
+/// the constructor / field initializers on a dynamically-allocated instance.
+/// Emitted by codegen at module init alongside the vtable registration.
+#[no_mangle]
+pub unsafe extern "C" fn js_register_class_constructor(
+    class_id: i64,
+    func_ptr: i64,
+    param_count: i64,
+) {
+    if class_id == 0 || func_ptr == 0 {
+        return;
+    }
+    let mut guard = CLASS_CONSTRUCTORS.write().unwrap();
+    if guard.is_none() {
+        *guard = Some(HashMap::new());
+    }
+    guard
+        .as_mut()
+        .unwrap()
+        .insert(class_id as u32, (func_ptr as usize, param_count as u32));
+}
+
+/// Look up a class's registered constructor `(fn_ptr, total_param_count)`.
+fn lookup_class_constructor(class_id: u32) -> Option<(usize, u32)> {
+    CLASS_CONSTRUCTORS
+        .read()
+        .ok()?
+        .as_ref()?
+        .get(&class_id)
+        .copied()
+}
+
+/// #1787: replay a class expression's constructor on a freshly-allocated
+/// instance. `classobj_value` is the NaN-boxed heap class object the `new`
+/// callee resolved to; `class_cid` is its (template) class_id; `inst` is the
+/// already-allocated instance; `args_ptr`/`args_len` are the `new`-call args.
+///
+/// The constructor's parameters are `[user params..., capture params...]`. The
+/// `new`-call args fill the user slots; the per-evaluation captures
+/// snapshotted onto the class object (`__perry_ctor_caps`, an own array in
+/// capture-param order) fill the trailing slots. No-op when the class has no
+/// registered constructor.
+pub(crate) unsafe fn replay_class_object_constructor(
+    classobj_value: f64,
+    class_cid: u32,
+    inst: *mut ObjectHeader,
+    args_ptr: *const f64,
+    args_len: usize,
+) {
+    let Some((ctor_ptr, total_params)) = lookup_class_constructor(class_cid) else {
+        return;
+    };
+
+    // Read the snapshotted captures (an own array, in capture-param order).
+    // Absent → no captures.
+    let caps_val = crate::object::js_object_get_own_field_or_undef(
+        classobj_value,
+        b"__perry_ctor_caps".as_ptr(),
+        17,
+    );
+    let caps_jv = crate::value::JSValue::from_bits(caps_val.to_bits());
+    let (caps_arr, n_caps): (*const crate::array::ArrayHeader, u32) = if caps_jv.is_pointer() {
+        let arr = caps_jv.as_pointer::<crate::array::ArrayHeader>();
+        if arr.is_null() {
+            (std::ptr::null(), 0)
+        } else {
+            (arr, crate::array::js_array_length(arr))
+        }
+    } else {
+        (std::ptr::null(), 0)
+    };
+
+    let user_params = (total_params as usize).saturating_sub(n_caps as usize);
+    let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let mut final_args: Vec<f64> = Vec::with_capacity(total_params as usize);
+    for i in 0..user_params {
+        if !args_ptr.is_null() && i < args_len {
+            final_args.push(*args_ptr.add(i));
+        } else {
+            final_args.push(undef);
+        }
+    }
+    for j in 0..n_caps {
+        final_args.push(crate::array::js_array_get_f64(caps_arr, j));
+    }
+    let _ = call_vtable_method(
+        ctor_ptr,
+        inst as i64,
+        final_args.as_ptr(),
+        final_args.len(),
+        total_params,
+    );
+}

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -831,21 +831,37 @@ pub unsafe extern "C" fn js_new_function_construct(
             _ => {}
         }
     }
-    // #1789: `new (classObjectValue)(args)` — the callee is a heap class
-    // object (the value a class EXPRESSION evaluates to, e.g.
-    // `const C = make(x); new C()`). Read its class_id (the compile-time
-    // template) and allocate an instance of it, so instance methods
-    // dispatch and `x instanceof C` matches. The template's constructor
-    // body / field initializers are emitted on the static `new ClassName()`
-    // path, not this dynamic helper, so a dynamically-constructed instance
-    // starts with no own props (constructor-run on dynamic new is a
-    // refinement); fields written afterward and prototype methods work.
+    // #1789/#1787: `new (classObjectValue)(args)` — the callee is a heap
+    // class object (the value a class EXPRESSION evaluates to, e.g.
+    // `const C = mk(x); new C()`). Read its class_id (the compile-time
+    // template) and allocate an instance stamped with it, so instance
+    // methods dispatch and `x instanceof C` matches.
+    //
+    // #1787: then REPLAY the class's constructor on the instance. The
+    // constructor can't be inlined at the `new` site — the callee is a
+    // runtime value, and the class's captured environment lived where the
+    // class EXPRESSION was evaluated (e.g. inside the `mk(tag)` factory),
+    // not at the (possibly far-away) construction site. So the codegen
+    // ClassExprFresh lowering snapshots those captures onto this class
+    // object as the `__perry_ctor_caps` own array, and registers the
+    // standalone `<prefix>__<class>_constructor` symbol in
+    // `CLASS_CONSTRUCTORS`. Replaying it here runs the instance-field
+    // initializers (literal AND captured) and the constructor body —
+    // matching what the static `new ClassName()` path does inline.
     if is_class_object_value(func_value) {
         let obj =
             crate::value::JSValue::from_bits(func_value.to_bits()).as_pointer::<ObjectHeader>();
         let class_cid = js_object_get_class_id(obj);
         if class_cid != 0 {
             let inst = js_object_alloc(class_cid, 0);
+            // Replay the class's registered constructor (instance-field
+            // initializers + body) on the fresh instance, filling the
+            // capture params from the snapshotted `__perry_ctor_caps`. The
+            // mechanism lives in `class_constructors` to keep this file under
+            // the 2,000-line CI gate.
+            super::class_constructors::replay_class_object_constructor(
+                func_value, class_cid, inst, args_ptr, args_len,
+            );
             return crate::value::js_nanbox_pointer(inst as i64);
         }
     }

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -26,6 +26,7 @@ mod alloc;
 mod assert;
 mod bigint_dispatch;
 mod buffer_dispatch;
+mod class_constructors;
 mod class_gc_roots;
 mod class_registry;
 mod delete_rest;
@@ -43,6 +44,7 @@ pub use alloc::*;
 pub use assert::*;
 pub(crate) use bigint_dispatch::*;
 pub use buffer_dispatch::*;
+pub use class_constructors::*;
 pub use class_gc_roots::scan_class_inheritance_roots_mut;
 #[cfg(test)]
 pub(crate) use class_gc_roots::{

--- a/test-files/test_gap_class_expr_instance_fields.ts
+++ b/test-files/test_gap_class_expr_instance_fields.ts
@@ -1,0 +1,78 @@
+// Issue #1787: `new <class-expression-value>()` must run the class
+// expression's INSTANCE-field initializers — both literal fields and fields
+// that capture the defining (factory) scope — and the constructor body.
+//
+// A class EXPRESSION with static fields lowers to a heap "class object"
+// (#1786) carrying per-evaluation identity. Constructing an instance from
+// such a value (`const A = mk(...); new A()`) can't inline the constructor at
+// the `new` site: the callee is a runtime value, and the captured environment
+// lived where the class expression was evaluated (inside `mk`), not at the
+// construction site. Pre-fix the dynamic `new` allocated a bare instance with
+// no own props, so every instance field read back `undefined`. Now the
+// captures are snapshotted onto the class object and the constructor is
+// replayed on the new instance.
+//
+// Scope note: per-evaluation class objects still share the compile-time
+// template's class_id, so cross-evaluation `.constructor` / `instanceof`
+// discrimination (telling a `mk("a")` instance apart from a `mk("b")` one) is
+// the deeper shared-class_id limitation tracked separately (see the scope
+// note in test_gap_class_expr_new_instanceof.ts) and is not asserted here.
+//
+// Expected output:
+// tags: LIT LIT
+// captured: a b
+// computed: A-1 B-2
+// static: a b
+// method reads instance field: a b
+// ctor arg + capture: pre:post
+// no-capture literal: 7
+
+// Captured + literal instance fields, a per-evaluation static, and an
+// instance method that reads a captured instance field through `this`.
+function mk(tag: string, n: number) {
+  return class {
+    _tag = "LIT"; // literal instance field
+    cap = tag; // instance field capturing the factory arg
+    computed = tag.toUpperCase() + "-" + n; // captured + computed
+    static S = tag; // per-evaluation static (already worked)
+    getCap() {
+      return this.cap;
+    }
+  };
+}
+const A = mk("a", 1);
+const B = mk("b", 2);
+const xa: any = new A();
+const xb: any = new B();
+console.log("tags:", xa._tag, xb._tag);
+console.log("captured:", xa.cap, xb.cap);
+console.log("computed:", xa.computed, xb.computed);
+console.log("static:", (A as any).S, (B as any).S);
+console.log("method reads instance field:", xa.getCap(), xb.getCap());
+
+// A user constructor whose body mixes a `new`-call argument with a captured
+// outer value — exercises the [user params..., capture params...] ordering.
+function mkWithArg(prefix: string) {
+  return class {
+    label = "";
+    static P = prefix;
+    constructor(suffix: string) {
+      this.label = prefix + ":" + suffix;
+    }
+  };
+}
+const C = mkWithArg("pre");
+const c: any = new C("post");
+console.log("ctor arg + capture:", c.label);
+
+// A class expression with only a literal instance field (no captures) — the
+// constructor still has to run to initialize it.
+function mkLiteral() {
+  return class {
+    v = 7;
+    static kind = "lit";
+  };
+}
+const D = mkLiteral();
+const d: any = new D();
+console.log("no-capture literal:", d.v);


### PR DESCRIPTION
## Summary

Completes the **instance side** of class-expression-as-value support (#1787): `new <classExpressionValue>()` now runs the class's instance-field initializers and constructor body.

`#1786` made a class **expression** evaluate to a heap "class object" with per-evaluation identity + own static fields, and `#2017` let a class-ref value be `new`'d. But constructing from a class-object value still allocated a **bare instance with no own properties** — every instance-field initializer read back `undefined`:

```ts
function mk(tag: string) { return class { _tag = "LIT"; cap = tag; static S = tag; }; }
const A = mk("a"), B = mk("b");
const xa = new A(), xb = new B();
```

| line | node | perry before | perry after |
|---|---|---|---|
| `xa._tag` (literal field) | `LIT` | `undefined` ✗ | `LIT` ✅ |
| `xa.cap`, `xb.cap` (captured field) | `a` `b` | `undefined undefined` ✗ | `a` `b` ✅ |
| `A.S`, `B.S` (per-eval static) | `a` `b` | `a` `b` ✅ | `a` `b` ✅ |
| `A === B` (identity) | `false` | `false` ✅ | `false` ✅ |

## Why the constructor can't just be inlined

A static `new ClassName()` inlines the constructor at the call site and reads any captured outer locals there (#740). A class expression returned from a factory is `new`'d **elsewhere** — the callee is a runtime value, and the captured environment (`tag`) lived where the class expression was *evaluated* (inside `mk`), not at the construction site. So the captures must be snapshotted at evaluation time and replayed at construction time.

## How

- **HIR** — `Expr::ClassExprFresh` gains `captured_args`: the outer values the class closes over, in `synthesize_class_captures`' capture-param order, read (`LocalGet`) at the evaluation site where they're still live.
- **Codegen** — the `ClassExprFresh` lowering stores those captures onto the class object as a `__perry_ctor_caps` own array; module init registers each class's standalone `<prefix>__<class>_constructor` symbol into a new runtime `CLASS_CONSTRUCTORS` table (`js_register_class_constructor`).
- **Runtime** — the heap-class-object (`OBJECT_TYPE_CLASS`) arm of `js_new_function_construct` looks up that constructor, fills the *user* parameters from the `new`-call args and the *trailing* capture parameters from `__perry_ctor_caps`, then invokes it via `call_vtable_method` — running the instance-field initializers + constructor body exactly as the static path does inline.

Only the heap-class-object `new` path consults the table, so the INT32 class-ref `new` path (top-level class declarations) is unchanged → behavior-neutral for them.

## Test

New gap test `test-files/test_gap_class_expr_instance_fields.ts`, **byte-identical** to `node --experimental-strip-types`: literal + captured + computed instance fields, a method reading a captured field through `this`, user-ctor-arg + capture ordering, and a no-capture literal field.

## Validation

- New gap test: byte-identical to node ✅
- `cargo test --release -p perry-runtime --lib -- --test-threads=1` → **700 passed, 0 failed** ✅
- `cargo test --release -p perry-hir -p perry-codegen` → all suites **0 failed** ✅
- `cargo fmt --all -- --check` → clean ✅
- No regression on the 12 existing `test_gap_class*` tests (the one diff — `test_gap_class_advanced` static-block — is pre-existing, identical on the pre-change binary).
- effect-dod survey regression guard: `survey/05_gen.ts`→`30`, `survey/nlay.ts`→`provide: 42`, `survey/21_schema_decode.ts`→`Ada 36` ✅

## Out of scope (deeper, reported precisely)

This PR lands the clean, well-scoped instance-field fix. Two related items are genuinely deeper and are **not** addressed here:

1. **Cross-evaluation `.constructor` / `instanceof` discrimination** (cx.ts lines `ctor xa===xb` and `instanceof xa B`). Per-evaluation class objects share the compile-time template's class_id, so the instance can't tell `mk("a")` apart from `mk("b")`. This is the inherent shared-class_id limitation already documented in `test_gap_class_expr_new_instanceof.ts`; discriminating would require modelling per-evaluation prototype/constructor identity.

2. **effect `Cause` (`new Cause.RuntimeException("x")._tag` / `isRuntimeException`)** — still `undefined` / `false`. effect's `makeException` is `class Base extends YieldableError { _tag = tag }`, which is blocked by a **chain of separate, mostly pre-existing** issues, none of which is the class-expression-value gap this PR closes:
   - It has `extends`, so it lowers to the INT32 class-ref path, **not** `ClassExprFresh` — there's no per-evaluation heap object to carry the captured `tag`.
   - The captured-instance-field-on-an-`extends`-class initializer is **broken even via static `new`** (verified: `function f(t){ class B extends Parent { _tag=t }; return new B() }; f("x")._tag` → `undefined` on both the pre-change and post-change binaries). The synthesized capture-constructor has no `super()` call, so the "self-fields applied at the SuperCall site" path never fires. This is an independent field-init/super bug.
   - `Cause.isRuntimeException(u)` is `hasProperty(u, RuntimeExceptionTypeId)` — a **prototype-chain symbol** set via `Object.assign(Base.prototype, { [sym]: sym })`, an orthogonal mechanism from instance-field init.

Closes the instance-field initialization part of #1787.
