### PR TITLE
fix(runtime): function `.name` own-property + getOwnPropertyDescriptor on functions (#2059)

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -342,6 +342,25 @@ pub fn register_function_name_if_absent(func_ptr: usize, name: &str) {
     }
 }
 
+/// Look up the codegen-registered JS name for a function pointer.
+///
+/// Returns the name registered by `js_register_function_name` (keyed on the
+/// `__perry_wrap_<name>` wrapper address that `js_closure_alloc_singleton`
+/// stamps into the `ClosureHeader`), or `None` when no non-empty name was
+/// registered. Used by the spec `fn.name` own-property read (#2059) and by
+/// `getOwnPropertyDescriptor(fn, "name")` — the same registry the
+/// `[Function: <name>]` console formatter already consults.
+pub fn function_name_for_ptr(func_ptr: usize) -> Option<String> {
+    if func_ptr == 0 {
+        return None;
+    }
+    function_name_registry()
+        .lock()
+        .ok()
+        .and_then(|map| map.get(&func_ptr).map(|n| n.to_string()))
+        .filter(|n| !n.is_empty())
+}
+
 /// Per-thread override for the `showHidden` inspect option. Defaults to
 /// `false` (Node default): `util.inspect` / `console.log` only show
 /// enumerable properties. `console.dir(value, { showHidden: true })`

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -70,8 +70,8 @@ pub use console::{
 };
 
 pub use formatting::{
-    js_array_print, js_register_function_name, js_util_format, js_util_inspect,
-    js_util_is_deep_strict_equal, js_util_strip_vt_control_characters,
+    function_name_for_ptr, js_array_print, js_register_function_name, js_util_format,
+    js_util_inspect, js_util_is_deep_strict_equal, js_util_strip_vt_control_characters,
     register_function_name_if_absent,
 };
 

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1000,6 +1000,20 @@ pub extern "C" fn js_object_get_field_by_name(
                             return vb;
                         }
                     }
+                    // #2059: the constructor's built-in `name` own property —
+                    // the class name. Checked last so an explicit static
+                    // `name` member (method/field, handled above) still wins.
+                    // This is what `assert.throws` reads via
+                    // `thrown.constructor.name` to label the thrown error.
+                    if name == "name" && class_id != 0 {
+                        if let Some(cname) = super::class_registry::class_name_for_id(class_id) {
+                            let s = crate::string::js_string_from_bytes(
+                                cname.as_ptr(),
+                                cname.len() as u32,
+                            );
+                            return JSValue::from_bits(crate::js_nanbox_string(s as i64).to_bits());
+                        }
+                    }
                 }
             }
             return JSValue::undefined();
@@ -1412,7 +1426,25 @@ pub extern "C" fn js_object_get_field_by_name(
                     return JSValue::number(arity.unwrap_or(0) as f64);
                 }
                 if let Ok(name_str) = std::str::from_utf8(name_bytes) {
+                    // User-attached own property (`fn.x = 1`) takes precedence.
                     let val = crate::closure::closure_get_dynamic_prop(obj as usize, name_str);
+                    if val.to_bits() != crate::value::TAG_UNDEFINED {
+                        return JSValue::from_bits(val.to_bits());
+                    }
+                    // #2059: `fn.name` — every function carries a built-in own
+                    // `name` data property. Resolve the codegen-registered name
+                    // (keyed by the wrapper func_ptr, the same registry the
+                    // `[Function: <name>]` formatter uses); anonymous functions
+                    // read back `""`, matching Node, not `undefined`.
+                    if name_str == "name" {
+                        let func_ptr =
+                            (*(obj as *const crate::closure::ClosureHeader)).func_ptr as usize;
+                        let fname =
+                            crate::builtins::function_name_for_ptr(func_ptr).unwrap_or_default();
+                        let s =
+                            crate::string::js_string_from_bytes(fname.as_ptr(), fname.len() as u32);
+                        return JSValue::from_bits(crate::js_nanbox_string(s as i64).to_bits());
+                    }
                     return JSValue::from_bits(val.to_bits());
                 }
             }

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -599,6 +599,90 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
             return f64::from_bits(crate::value::TAG_UNDEFINED);
         }
 
+        // #2059: function objects (closures) are not `ObjectHeader`s — routing
+        // them through `extract_obj_ptr`/`own_key_present` below reads an
+        // out-of-bounds "keys_array" slot (offset 16, past a 0-capture
+        // closure's payload) and segfaults. Resolve their descriptors here:
+        // the built-in `name`/`length` slots (non-writable, non-enumerable,
+        // configurable per spec) plus any user-attached own data property.
+        {
+            let jsv = crate::JSValue::from_bits(obj_value.to_bits());
+            if jsv.is_pointer() {
+                let ptr = jsv.as_pointer::<u8>() as usize;
+                if crate::closure::is_closure_ptr(ptr) {
+                    let key_str = crate::builtins::js_string_coerce(key_value);
+                    if key_str.is_null() {
+                        return f64::from_bits(crate::value::TAG_UNDEFINED);
+                    }
+                    let name_ptr =
+                        (key_str as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                    let name_len = (*key_str).byte_len as usize;
+                    let name = std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len))
+                        .unwrap_or("");
+
+                    // (value, writable, configurable). `name`/`length` are the
+                    // built-in own data slots; anything else falls back to the
+                    // user-attached dynamic-property side table.
+                    let resolved: Option<(f64, bool, bool)> = match name {
+                        "length" => {
+                            let arity = crate::closure::closure_arity(
+                                ptr as *const crate::closure::ClosureHeader,
+                            );
+                            // Numbers are NaN-boxed as their raw f64 bits.
+                            Some((arity.unwrap_or(0) as f64, false, true))
+                        }
+                        "name" => {
+                            let dynv = crate::closure::closure_get_dynamic_prop(ptr, "name");
+                            if dynv.to_bits() != crate::value::TAG_UNDEFINED {
+                                Some((dynv, true, true))
+                            } else {
+                                let func_ptr = (*(ptr as *const crate::closure::ClosureHeader))
+                                    .func_ptr
+                                    as usize;
+                                let fname = crate::builtins::function_name_for_ptr(func_ptr)
+                                    .unwrap_or_default();
+                                let s = crate::string::js_string_from_bytes(
+                                    fname.as_ptr(),
+                                    fname.len() as u32,
+                                );
+                                Some((crate::js_nanbox_string(s as i64), false, true))
+                            }
+                        }
+                        _ => {
+                            let dynv = crate::closure::closure_get_dynamic_prop(ptr, name);
+                            if dynv.to_bits() != crate::value::TAG_UNDEFINED {
+                                Some((dynv, true, true))
+                            } else {
+                                None
+                            }
+                        }
+                    };
+                    let Some((value, writable, configurable)) = resolved else {
+                        return f64::from_bits(crate::value::TAG_UNDEFINED);
+                    };
+                    // `name`/`length` are non-enumerable; user data props are.
+                    let enumerable = !matches!(name, "name" | "length");
+                    let packed = b"value\0writable\0enumerable\0configurable";
+                    let desc = js_object_alloc_with_shape(
+                        0x0D_E5_C0,
+                        4,
+                        packed.as_ptr(),
+                        packed.len() as u32,
+                    );
+                    let header_size = std::mem::size_of::<ObjectHeader>();
+                    let fields = (desc as *mut u8).add(header_size) as *mut f64;
+                    // GC_STORE_AUDIT(INIT): descriptor object is freshly allocated; layout is rebuilt before publication.
+                    *fields = value;
+                    *fields.add(1) = f64::from_bits(if writable { TAG_TRUE } else { TAG_FALSE });
+                    *fields.add(2) = f64::from_bits(if enumerable { TAG_TRUE } else { TAG_FALSE });
+                    *fields.add(3) =
+                        f64::from_bits(if configurable { TAG_TRUE } else { TAG_FALSE });
+                    super::rebuild_object_field_layout(desc, 4);
+                    return f64::from_bits((desc as u64) | 0x7FFD_0000_0000_0000);
+                }
+            }
+        }
+
         let obj = extract_obj_ptr(obj_value);
         if obj.is_null() {
             return f64::from_bits(crate::value::TAG_UNDEFINED);

--- a/test-parity/node-suite/object/function-name-descriptor.ts
+++ b/test-parity/node-suite/object/function-name-descriptor.ts
@@ -1,0 +1,27 @@
+// #2059: a function's built-in `name` own-property read back `undefined`
+// (and `getOwnPropertyDescriptor(fn, "name")` crashed). `name` is a
+// `{ writable:false, enumerable:false, configurable:true }` own data property.
+// Descriptor fields are logged individually so the byte-for-byte comparison
+// doesn't depend on console's multi-line object formatting.
+
+function foo(a: number, b: number) {}
+console.log("name:", foo.name);
+console.log("length:", foo.length);
+
+const d = Object.getOwnPropertyDescriptor(foo, "name");
+console.log(
+  "desc:",
+  d?.value,
+  d?.writable,
+  d?.enumerable,
+  d?.configurable,
+);
+
+const arrow = (x: number) => x;
+console.log("arrow:", arrow.name);
+
+class C {
+  m() {}
+}
+console.log("class:", C.name);
+console.log("method:", new C().m.name);


### PR DESCRIPTION
## Summary

Fixes #2059. A function's built-in `name` own-property read back `undefined`, and `Object.getOwnPropertyDescriptor(fn, "name")` **segfaulted**. Per spec, `name` is a `{ writable:false, enumerable:false, configurable:true }` own data property.

| | Node v25 | Perry (before) | Perry (after) |
|---|---|---|---|
| `foo.name` | `"foo"` | `undefined` | `"foo"` ✓ |
| `foo["name"]` / `foo[k]` | `"foo"` | `undefined` | `"foo"` ✓ |
| `getOwnPropertyDescriptor(foo,"name")` | data desc | **segfault** | `{value:"foo",writable:false,enumerable:false,configurable:true}` ✓ |
| `foo.length` | `2` | `2` ✓ | `2` ✓ |
| `C.name` (class) | `"C"` | `undefined` | `"C"` ✓ |

## Root cause

`name` was never resolved on closures — the `GC_TYPE_CLOSURE` arm of `js_object_get_field_by_name` only special-cased `length` (via `closure_arity`) and otherwise read the per-closure dynamic-property side table, which returns `undefined` for `name`. The runtime already keeps a func_ptr → name registry (what the `[Function: <name>]` formatter uses); the read path just never consulted it.

The descriptor crash was an out-of-bounds read: `getOwnPropertyDescriptor` ran the closure through `own_key_present`, which dereferences `(*obj).keys_array` at `ObjectHeader` offset 16 — past a 0-capture closure's 16-byte payload — and crashed when the adjacent heap word looked like a valid pointer.

## Changes (runtime-only)

- **`js_object_get_field_by_name`** (`GC_TYPE_CLOSURE` arm): resolve `name` from the function-name registry after the user-attached own-prop check. Anonymous functions read back `""` (matching Node), never `undefined`.
- **`js_object_get_own_property_descriptor`**: handle a closure receiver directly (before `extract_obj_ptr`/`own_key_present`), returning a proper data descriptor for `name`/`length` (`writable:false, enumerable:false, configurable:true`) and for user-attached own props. Fixes both the wrong result and the segfault.
- **`js_object_get_field_by_name`** (INT32 class-ref arm): resolve `C.name` to the class name (what `assert.throws` reads via `thrown.constructor.name`), checked last so an explicit static `name` member still wins.
- New `function_name_for_ptr` helper exposes the registry lookup.

`fn.length` already worked and is unchanged.

## Testing

- `test-parity/node-suite/object/function-name-descriptor.ts` (new) is byte-identical to `node --experimental-strip-types`.
- `perry-runtime`: 700/700 unit tests pass; `cargo fmt --all -- --check` clean.
- `console.log(fn)` formatting (`[Function: <name>]`) unchanged.

## Follow-up (not in this PR)

Two adjacent function-name *inference* gaps remain (distinct from the "reads back undefined" bug fixed here): named function expressions report the binding name rather than the function's own name (`const bar = function namedBar(){}` → `"bar"` vs Node's `"namedBar"`), and object-literal shorthand methods report `""` rather than the method name. Both live in codegen's name-registration (`user_fn_display_names`) and will be filed as a granular issue.

Surfaced by the #799 Test262 radar. Part of #793.
