### PR TITLE
fix(typedarray): resolve prototype methods + accessors on member reads (#2061)

### DIFF
--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -408,45 +408,86 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     &[(I64, &key_handle)],
                 ));
             }
+            // #2061: a non-index (method-name) key on a typed array must
+            // resolve against %TypedArray%.prototype, not be coerced to a
+            // numeric element index. The width-tracked element-load path below
+            // `fptosi`s the key — a NaN-boxed string coerces to 0, so
+            // `int8arr["copyWithin"]` returned element 0 (a number) and
+            // `typeof int8arr.copyWithin === "number"`.
+            //
+            // Three index shapes:
+            //   * provably string  → fall through to the generic
+            //     `js_object_get_field_by_name_f64` resolver below (binds
+            //     typed-array prototype methods + length/byteLength/etc.).
+            //   * provably numeric  → the existing element fast path.
+            //   * ambiguous (`any`, e.g. a `for..of` loop var whose element
+            //     type wasn't propagated) → runtime tag dispatch via
+            //     `js_typed_array_member_get`, which reads an element for a
+            //     numeric key and resolves a property for a string key.
             if is_width_tracked_typed_array_receiver(ctx, object) {
-                if let Some(value) = lower_typed_array_load(ctx, object, index)? {
-                    return Ok(materialize_js_value(
-                        ctx,
-                        value,
-                        MaterializationReason::RuntimeApi,
+                let index_is_string =
+                    matches!(index.as_ref(), Expr::String(_)) || is_string_expr(ctx, index);
+                if !index_is_string {
+                    let index_is_numeric =
+                        matches!(index.as_ref(), Expr::Integer(_) | Expr::Number(_))
+                            || is_numeric_expr(ctx, index);
+                    if index_is_numeric {
+                        // Provably-numeric index → the element fast path.
+                        if let Some(value) = lower_typed_array_load(ctx, object, index)? {
+                            return Ok(materialize_js_value(
+                                ctx,
+                                value,
+                                MaterializationReason::RuntimeApi,
+                            ));
+                        }
+
+                        // Width-aware typed-array native lowering is only sound
+                        // for tracked fresh views with proven/guarded element
+                        // bounds. All aliases, reassigned locals, and unknown
+                        // bounds stay on the runtime helper, with artifact
+                        // evidence for the fallback.
+                        let arr_box = lower_expr(ctx, object)?;
+                        let idx_double = lower_expr(ctx, index)?;
+                        let blk = ctx.block();
+                        let arr_bits = blk.bitcast_double_to_i64(&arr_box);
+                        let arr_i64 = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+                        let idx_i32 = blk.fptosi(DOUBLE, &idx_double, I32);
+                        let result = blk.call(
+                            DOUBLE,
+                            "js_typed_array_get",
+                            &[(I64, &arr_i64), (I32, &idx_i32)],
+                        );
+                        let slow = LoweredValue::js_value(result.clone());
+                        ctx.record_lowered_value_with_access_mode(
+                            "TypedArrayGet",
+                            None,
+                            "TypedArrayGet.slow_path",
+                            &slow,
+                            Some(BoundsState::Unknown),
+                            None,
+                            Some(BufferAccessMode::DynamicFallback),
+                            Some(buffer_access_materialization_reason(ctx, object)),
+                            false,
+                            false,
+                            vec!["typed_array_fallback=untracked_or_unproven".to_string()],
+                        );
+                        return Ok(result);
+                    }
+                    // Ambiguous (`any`) index → runtime tag dispatch: a numeric
+                    // key reads an element, a string key resolves a property /
+                    // prototype method.
+                    let obj_box = lower_expr(ctx, object)?;
+                    let idx_box = lower_expr(ctx, index)?;
+                    let blk = ctx.block();
+                    let obj_handle = unbox_to_i64(blk, &obj_box);
+                    return Ok(blk.call(
+                        DOUBLE,
+                        "js_typed_array_member_get",
+                        &[(I64, &obj_handle), (DOUBLE, &idx_box)],
                     ));
                 }
-
-                // Width-aware typed-array native lowering is only sound for
-                // tracked fresh views with proven/guarded element bounds. All
-                // aliases, reassigned locals, and unknown bounds stay on the
-                // runtime helper, with artifact evidence for the fallback.
-                let arr_box = lower_expr(ctx, object)?;
-                let idx_double = lower_expr(ctx, index)?;
-                let blk = ctx.block();
-                let arr_bits = blk.bitcast_double_to_i64(&arr_box);
-                let arr_i64 = blk.and(I64, &arr_bits, POINTER_MASK_I64);
-                let idx_i32 = blk.fptosi(DOUBLE, &idx_double, I32);
-                let result = blk.call(
-                    DOUBLE,
-                    "js_typed_array_get",
-                    &[(I64, &arr_i64), (I32, &idx_i32)],
-                );
-                let slow = LoweredValue::js_value(result.clone());
-                ctx.record_lowered_value_with_access_mode(
-                    "TypedArrayGet",
-                    None,
-                    "TypedArrayGet.slow_path",
-                    &slow,
-                    Some(BoundsState::Unknown),
-                    None,
-                    Some(BufferAccessMode::DynamicFallback),
-                    Some(buffer_access_materialization_reason(ctx, object)),
-                    false,
-                    false,
-                    vec!["typed_array_fallback=untracked_or_unproven".to_string()],
-                );
-                return Ok(result);
+                // Provably-string index → fall through to the generic
+                // property/method resolver below.
             }
             // Scalar-replaced array literal: `arr[k]` where arr was bound to
             // `[...]` and never escaped, and k is a compile-time index in

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1029,6 +1029,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_typed_array_new", I64, &[I32, DOUBLE]);
     module.declare_function("js_typed_array_length", I32, &[I64]);
     module.declare_function("js_typed_array_get", DOUBLE, &[I64, I32]);
+    // #2061: tag-aware `ta[key]` for ambiguous (`any`) keys — numeric reads an
+    // element, string resolves a prototype method/accessor.
+    module.declare_function("js_typed_array_member_get", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_typed_array_at", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_typed_array_set", VOID, &[I64, I32, DOUBLE]);
     module.declare_function("js_uint8array_get", I32, &[I64, I32]);

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1330,7 +1330,48 @@ pub extern "C" fn js_object_get_field_by_name(
                     }
                     b"byteOffset" => return JSValue::number(0.0),
                     b"BYTES_PER_ELEMENT" => return JSValue::number(elem_size as f64),
-                    _ => {}
+                    b"constructor" => {
+                        let name = crate::typedarray::name_for_kind(kind);
+                        let v = js_get_global_this_builtin_value(name.as_ptr(), name.len());
+                        return JSValue::from_bits(v.to_bits());
+                    }
+                    // #2061: a non-index (method-name) key must resolve against
+                    // %TypedArray%.prototype, not be swallowed as an element
+                    // index. Bind a callable closure so `typeof
+                    // int8arr.copyWithin === "function"` and the call routes
+                    // through `js_native_call_method`'s typed-array arm.
+                    _ => {
+                        if let Ok(name) = std::str::from_utf8(key_bytes) {
+                            if crate::typedarray::is_typed_array_method_name(name) {
+                                // Heap-copy the name so the bound closure's
+                                // capture outlives this StringHeader (mirrors
+                                // the Buffer method-bind path).
+                                let heap_name = {
+                                    let layout = std::alloc::Layout::from_size_align(
+                                        key_bytes.len().max(1),
+                                        1,
+                                    )
+                                    .unwrap();
+                                    let ptr = std::alloc::alloc(layout);
+                                    std::ptr::copy_nonoverlapping(
+                                        key_bytes.as_ptr(),
+                                        ptr,
+                                        key_bytes.len(),
+                                    );
+                                    ptr
+                                };
+                                // Bind with the RAW pointer (top16 == 0). The
+                                // bound-method dispatcher passes capture-0
+                                // unchanged to js_native_call_method, whose
+                                // typed-array arm matches on `top16 == 0` — a
+                                // POINTER_TAG box would miss it.
+                                let this_f64 = f64::from_bits(obj as u64);
+                                let result =
+                                    js_class_method_bind(this_f64, heap_name, key_bytes.len());
+                                return JSValue::from_bits(result.to_bits());
+                            }
+                        }
+                    }
                 }
             }
             return JSValue::undefined();

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -543,6 +543,20 @@ pub unsafe extern "C" fn js_native_call_method(
                         std::ptr::null()
                     }
                 };
+                let arg_n = |i: usize| -> Option<f64> {
+                    if i < args_len && !args_ptr.is_null() {
+                        Some(unsafe { *args_ptr.add(i) })
+                    } else {
+                        None
+                    }
+                };
+                let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+                let to_ta = |p: *mut crate::typedarray::TypedArrayHeader| -> f64 {
+                    f64::from_bits(p as u64)
+                };
+                let to_str = |p: *mut crate::string::StringHeader| -> f64 {
+                    f64::from_bits(crate::value::js_nanbox_string(p as i64).to_bits())
+                };
                 match method_name {
                     "length" => {
                         return crate::typedarray::js_typed_array_length(ta) as f64;
@@ -596,10 +610,117 @@ pub unsafe extern "C" fn js_native_call_method(
                         }
                         return crate::typedarray::js_typed_array_find_last_index(ta, cb);
                     }
+                    // #2061: the remaining common %TypedArray%.prototype
+                    // methods. Indexed/range args are pre-resolved here
+                    // (absent `start` → 0, absent `end` → length) so the
+                    // runtime helpers only normalize negatives + clamp.
+                    "fill" => {
+                        let len = crate::typedarray::js_typed_array_length(ta) as f64;
+                        let value = arg_n(0).unwrap_or(undef);
+                        let start = arg_n(1).unwrap_or(0.0);
+                        let end = arg_n(2).unwrap_or(len);
+                        return to_ta(crate::typedarray::js_typed_array_fill(
+                            ta, value, start, end,
+                        ));
+                    }
+                    "copyWithin" => {
+                        let len = crate::typedarray::js_typed_array_length(ta) as f64;
+                        let target = arg_n(0).unwrap_or(0.0);
+                        let start = arg_n(1).unwrap_or(0.0);
+                        let end = arg_n(2).unwrap_or(len);
+                        return to_ta(crate::typedarray::js_typed_array_copy_within(
+                            ta, target, start, end,
+                        ));
+                    }
+                    "slice" => {
+                        let len = crate::typedarray::js_typed_array_length(ta) as f64;
+                        let start = arg_n(0).unwrap_or(0.0);
+                        let end = arg_n(1).unwrap_or(len);
+                        return to_ta(crate::typedarray::js_typed_array_slice(ta, start, end));
+                    }
+                    "subarray" => {
+                        let len = crate::typedarray::js_typed_array_length(ta) as f64;
+                        let start = arg_n(0).unwrap_or(0.0);
+                        let end = arg_n(1).unwrap_or(len);
+                        return to_ta(crate::typedarray::js_typed_array_subarray(ta, start, end));
+                    }
+                    "indexOf" => {
+                        let value = arg_n(0).unwrap_or(undef);
+                        let from = arg_n(1).unwrap_or(0.0);
+                        return crate::typedarray::js_typed_array_index_of(ta, value, from);
+                    }
+                    "lastIndexOf" => {
+                        let value = arg_n(0).unwrap_or(undef);
+                        // Absent fromIndex → search from the last element.
+                        let from = arg_n(1).unwrap_or(f64::INFINITY);
+                        return crate::typedarray::js_typed_array_last_index_of(ta, value, from);
+                    }
+                    "includes" => {
+                        let value = arg_n(0).unwrap_or(undef);
+                        let from = arg_n(1).unwrap_or(0.0);
+                        return crate::typedarray::js_typed_array_includes(ta, value, from);
+                    }
+                    "join" => {
+                        let sep = arg_n(0).unwrap_or(undef);
+                        return to_str(crate::typedarray::js_typed_array_join(ta, sep));
+                    }
+                    "toString" | "toLocaleString" => {
+                        return to_str(crate::typedarray::js_typed_array_join(ta, undef));
+                    }
+                    "reverse" => {
+                        return to_ta(crate::typedarray::js_typed_array_reverse(ta));
+                    }
+                    "set" => {
+                        let source = arg_n(0).unwrap_or(undef);
+                        let offset = arg_n(1).unwrap_or(0.0);
+                        return crate::typedarray::js_typed_array_set_from(ta, source, offset);
+                    }
+                    "forEach" => {
+                        return crate::typedarray::js_typed_array_for_each(ta, arg_closure(0));
+                    }
+                    "map" => {
+                        return to_ta(crate::typedarray::js_typed_array_map(ta, arg_closure(0)));
+                    }
+                    "filter" => {
+                        return to_ta(crate::typedarray::js_typed_array_filter(ta, arg_closure(0)));
+                    }
+                    "some" => {
+                        return crate::typedarray::js_typed_array_some(ta, arg_closure(0));
+                    }
+                    "every" => {
+                        return crate::typedarray::js_typed_array_every(ta, arg_closure(0));
+                    }
+                    "find" => {
+                        return crate::typedarray::js_typed_array_find(ta, arg_closure(0));
+                    }
+                    "findIndex" => {
+                        return crate::typedarray::js_typed_array_find_index(ta, arg_closure(0));
+                    }
+                    "reduce" => {
+                        let has_init = if args_len >= 2 { 1 } else { 0 };
+                        let init = arg_n(1).unwrap_or(undef);
+                        return crate::typedarray::js_typed_array_reduce(
+                            ta,
+                            arg_closure(0),
+                            init,
+                            has_init,
+                        );
+                    }
+                    "reduceRight" => {
+                        let has_init = if args_len >= 2 { 1 } else { 0 };
+                        let init = arg_n(1).unwrap_or(undef);
+                        return crate::typedarray::js_typed_array_reduce_right(
+                            ta,
+                            arg_closure(0),
+                            init,
+                            has_init,
+                        );
+                    }
                     _ => {
-                        // Fall through. Other methods aren't handled here
-                        // yet; they hit the primitive-method catch-all
-                        // below — better than silent no-op.
+                        // Fall through. Remaining methods (keys/values/
+                        // entries iterators) aren't handled here yet; they
+                        // hit the primitive-method catch-all below — better
+                        // than silent no-op.
                     }
                 }
             }

--- a/crates/perry-runtime/src/typedarray.rs
+++ b/crates/perry-runtime/src/typedarray.rs
@@ -901,6 +901,687 @@ pub extern "C" fn js_typed_array_find_last_index(
     }
 }
 
+/// True for any name that is a method on `%TypedArray%.prototype`. The
+/// field-by-name resolver (#2061) uses this to bind a callable closure for
+/// `int8arr.copyWithin` (so `typeof int8arr.copyWithin === "function"` and
+/// the call routes through `js_native_call_method`) instead of coercing the
+/// key to an element index. Accessor properties (`length`, `byteLength`,
+/// `byteOffset`, `BYTES_PER_ELEMENT`, `buffer`, `constructor`) are handled
+/// separately by the caller and are intentionally NOT listed here.
+pub fn is_typed_array_method_name(name: &str) -> bool {
+    matches!(
+        name,
+        "at" | "copyWithin"
+            | "entries"
+            | "every"
+            | "fill"
+            | "filter"
+            | "find"
+            | "findIndex"
+            | "findLast"
+            | "findLastIndex"
+            | "forEach"
+            | "includes"
+            | "indexOf"
+            | "join"
+            | "keys"
+            | "lastIndexOf"
+            | "map"
+            | "reduce"
+            | "reduceRight"
+            | "reverse"
+            | "set"
+            | "slice"
+            | "some"
+            | "sort"
+            | "subarray"
+            | "toLocaleString"
+            | "toReversed"
+            | "toSorted"
+            | "toString"
+            | "values"
+    )
+}
+
+/// Normalize a relative index argument: `ToIntegerOrInfinity` then clamp to
+/// `[0, len]`. `NaN` → 0; negatives count back from the end. Saturating
+/// arithmetic keeps ±Infinity and out-of-range finite values in bounds.
+#[inline]
+fn norm_rel_index(idx: f64, len: usize) -> usize {
+    let len_i = len as i64;
+    let mut i = if idx.is_nan() {
+        0
+    } else if idx == f64::INFINITY {
+        len_i
+    } else if idx == f64::NEG_INFINITY {
+        0
+    } else {
+        idx as i64
+    };
+    if i < 0 {
+        i = i.saturating_add(len_i);
+    }
+    i.clamp(0, len_i) as usize
+}
+
+/// Interpret a search value (for `indexOf`/`lastIndexOf`/`includes`) as the
+/// JS number it represents, or `None` if it isn't a number — typed-array
+/// elements are always numbers, so a non-number target can never match under
+/// strict equality (`indexOf`) / SameValueZero (`includes`).
+#[inline]
+fn search_as_number(v: f64) -> Option<f64> {
+    let bits = v.to_bits();
+    let top16 = bits >> 48;
+    // INT32-tagged small integers are numbers.
+    if top16 == 0x7FFE {
+        return Some(((bits & 0xFFFF_FFFF) as i32) as f64);
+    }
+    // Any other NaN-box tag (undefined/null/bool/string/pointer/bigint and
+    // SSO short-strings) is a non-number.
+    if (0x7FFA..0x8000).contains(&top16) || top16 == 0x7FF9 {
+        return None;
+    }
+    // Plain double (incl. negatives and canonical NaN).
+    Some(v)
+}
+
+/// `ta.fill(value, start, end)` — in place, returns `ta`. `start`/`end` are
+/// pre-resolved by the caller (absent `start` → 0, absent `end` → length).
+#[no_mangle]
+pub extern "C" fn js_typed_array_fill(
+    ta: *mut TypedArrayHeader,
+    value: f64,
+    start: f64,
+    end: f64,
+) -> *mut TypedArrayHeader {
+    let ta = clean_ta_ptr(ta as *const TypedArrayHeader) as *mut TypedArrayHeader;
+    if ta.is_null() {
+        return ta;
+    }
+    unsafe {
+        let len = (*ta).length as usize;
+        let s = norm_rel_index(start, len);
+        let e = norm_rel_index(end, len);
+        let v = jsvalue_to_f64(value);
+        for i in s..e {
+            store_at(ta, i, v);
+        }
+        ta
+    }
+}
+
+/// `ta.copyWithin(target, start, end)` — in place, returns `ta`. Copies the
+/// sequence `[start, end)` to `target`, handling overlap via a temporary.
+#[no_mangle]
+pub extern "C" fn js_typed_array_copy_within(
+    ta: *mut TypedArrayHeader,
+    target: f64,
+    start: f64,
+    end: f64,
+) -> *mut TypedArrayHeader {
+    let ta = clean_ta_ptr(ta as *const TypedArrayHeader) as *mut TypedArrayHeader;
+    if ta.is_null() {
+        return ta;
+    }
+    unsafe {
+        let len = (*ta).length as usize;
+        let t = norm_rel_index(target, len);
+        let s = norm_rel_index(start, len);
+        let e = norm_rel_index(end, len);
+        let count = e.saturating_sub(s).min(len.saturating_sub(t));
+        if count > 0 {
+            let tmp: Vec<f64> = (0..count).map(|k| load_at(ta, s + k)).collect();
+            for (k, v) in tmp.into_iter().enumerate() {
+                store_at(ta, t + k, v);
+            }
+        }
+        ta
+    }
+}
+
+/// `ta.slice(start, end)` — new typed array of the same kind with the
+/// `[start, end)` elements copied out.
+#[no_mangle]
+pub extern "C" fn js_typed_array_slice(
+    ta: *const TypedArrayHeader,
+    start: f64,
+    end: f64,
+) -> *mut TypedArrayHeader {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return typed_array_alloc(KIND_FLOAT64, 0);
+    }
+    unsafe {
+        let kind = (*ta).kind;
+        let len = (*ta).length as usize;
+        let s = norm_rel_index(start, len);
+        let e = norm_rel_index(end, len);
+        let count = e.saturating_sub(s);
+        let out = typed_array_alloc(kind, count as u32);
+        for k in 0..count {
+            store_at(out, k, load_at(ta, s + k));
+        }
+        out
+    }
+}
+
+/// `ta.subarray(start, end)`. Node returns a *view* sharing the backing
+/// buffer; Perry typed arrays own their storage, so this returns an
+/// independent copy (mutations through the result do not write back to the
+/// source). Full shared-buffer view semantics are tracked by the
+/// %TypedArray%.prototype reification follow-up (#793).
+#[no_mangle]
+pub extern "C" fn js_typed_array_subarray(
+    ta: *const TypedArrayHeader,
+    start: f64,
+    end: f64,
+) -> *mut TypedArrayHeader {
+    js_typed_array_slice(ta, start, end)
+}
+
+/// `ta.indexOf(value, fromIndex)` — strict-equality forward search. `from`
+/// is pre-resolved (absent → 0). Returns the index or -1.
+#[no_mangle]
+pub extern "C" fn js_typed_array_index_of(
+    ta: *const TypedArrayHeader,
+    value: f64,
+    from: f64,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return -1.0;
+    }
+    let Some(target) = search_as_number(value) else {
+        return -1.0;
+    };
+    unsafe {
+        let len = (*ta).length as usize;
+        let start = norm_rel_index(from, len);
+        for i in start..len {
+            // `==` never matches NaN, matching indexOf semantics.
+            if load_at(ta, i) == target {
+                return i as f64;
+            }
+        }
+        -1.0
+    }
+}
+
+/// `ta.lastIndexOf(value, fromIndex)` — strict-equality backward search.
+/// `from` is pre-resolved (absent → +Infinity sentinel). Returns index or -1.
+#[no_mangle]
+pub extern "C" fn js_typed_array_last_index_of(
+    ta: *const TypedArrayHeader,
+    value: f64,
+    from: f64,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return -1.0;
+    }
+    let Some(target) = search_as_number(value) else {
+        return -1.0;
+    };
+    unsafe {
+        let len = (*ta).length as i64;
+        if len == 0 {
+            return -1.0;
+        }
+        let mut start = if from == f64::INFINITY {
+            len - 1
+        } else if from.is_nan() {
+            0
+        } else if from == f64::NEG_INFINITY {
+            return -1.0;
+        } else {
+            from as i64
+        };
+        if start < 0 {
+            start += len;
+        }
+        if start >= len {
+            start = len - 1;
+        }
+        let mut i = start;
+        while i >= 0 {
+            if load_at(ta, i as usize) == target {
+                return i as f64;
+            }
+            i -= 1;
+        }
+        -1.0
+    }
+}
+
+/// `ta.includes(value, fromIndex)` — SameValueZero search (NaN matches NaN).
+/// Returns a NaN-boxed JS boolean.
+#[no_mangle]
+pub extern "C" fn js_typed_array_includes(
+    ta: *const TypedArrayHeader,
+    value: f64,
+    from: f64,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    let mut found = false;
+    if !ta.is_null() {
+        let target = search_as_number(value);
+        unsafe {
+            let len = (*ta).length as usize;
+            let start = norm_rel_index(from, len);
+            for i in start..len {
+                let e = load_at(ta, i);
+                match target {
+                    Some(t) if t.is_nan() => {
+                        if e.is_nan() {
+                            found = true;
+                            break;
+                        }
+                    }
+                    Some(t) => {
+                        if e == t {
+                            found = true;
+                            break;
+                        }
+                    }
+                    None => {}
+                }
+            }
+        }
+    }
+    f64::from_bits(crate::value::JSValue::bool(found).bits())
+}
+
+/// `ta.reverse()` — reverse in place, returns `ta`.
+#[no_mangle]
+pub extern "C" fn js_typed_array_reverse(ta: *mut TypedArrayHeader) -> *mut TypedArrayHeader {
+    let ta = clean_ta_ptr(ta as *const TypedArrayHeader) as *mut TypedArrayHeader;
+    if ta.is_null() {
+        return ta;
+    }
+    unsafe {
+        let len = (*ta).length as usize;
+        for i in 0..len / 2 {
+            let a = load_at(ta, i);
+            let b = load_at(ta, len - 1 - i);
+            store_at(ta, i, b);
+            store_at(ta, len - 1 - i, a);
+        }
+        ta
+    }
+}
+
+/// `ta.join(separator)` — `separator` is the raw JS arg (TAG_UNDEFINED →
+/// default `","`). Each element is rendered like `String(number)`.
+#[no_mangle]
+pub extern "C" fn js_typed_array_join(
+    ta: *const TypedArrayHeader,
+    separator: f64,
+) -> *mut crate::string::StringHeader {
+    let ta = clean_ta_ptr(ta);
+    let sep = if separator.to_bits() == crate::value::TAG_UNDEFINED {
+        ",".to_string()
+    } else {
+        let s_ptr = crate::builtins::js_string_coerce(separator);
+        if s_ptr.is_null() {
+            String::new()
+        } else {
+            unsafe {
+                let bytes =
+                    (s_ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+                let len = (*s_ptr).byte_len as usize;
+                String::from_utf8_lossy(std::slice::from_raw_parts(bytes, len)).into_owned()
+            }
+        }
+    };
+    let mut out = String::new();
+    if !ta.is_null() {
+        unsafe {
+            let kind = (*ta).kind;
+            let len = (*ta).length as usize;
+            for i in 0..len {
+                if i > 0 {
+                    out.push_str(&sep);
+                }
+                out.push_str(&format_typed_value(kind, load_at(ta, i)));
+            }
+        }
+    }
+    crate::string::js_string_from_bytes(out.as_ptr(), out.len() as u32)
+}
+
+/// `ta.set(source, offset)` — copy elements from an Array or typed-array
+/// `source` into `ta` starting at `offset` (pre-resolved, absent → 0).
+/// Out-of-range writes are skipped. Returns undefined.
+#[no_mangle]
+pub extern "C" fn js_typed_array_set_from(
+    ta: *mut TypedArrayHeader,
+    source: f64,
+    offset: f64,
+) -> f64 {
+    let ta = clean_ta_ptr(ta as *const TypedArrayHeader) as *mut TypedArrayHeader;
+    if ta.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let off = if offset.is_nan() || offset < 0.0 {
+        0usize
+    } else {
+        offset as usize
+    };
+    let src_addr = strip_nanbox(source.to_bits());
+    if src_addr < 0x1000 {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    unsafe {
+        let dst_len = (*ta).length as usize;
+        if let Some(_k) = lookup_typed_array_kind(src_addr) {
+            let src = src_addr as *const TypedArrayHeader;
+            let slen = (*src).length as usize;
+            for i in 0..slen {
+                if off + i < dst_len {
+                    store_at(ta, off + i, load_at(src, i));
+                }
+            }
+        } else {
+            let arr = src_addr as *const ArrayHeader;
+            let slen = crate::array::js_array_length(arr) as usize;
+            for i in 0..slen {
+                if off + i < dst_len {
+                    let v = crate::array::js_array_get_f64(arr, i as u32);
+                    store_at(ta, off + i, jsvalue_to_f64(v));
+                }
+            }
+        }
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// NaN-boxed (POINTER_TAG-free) receiver for passing `ta` as the 3rd
+/// callback argument `(value, index, array)`. Typed arrays flow as raw
+/// f64-bitcast pointers, so this is just `from_bits`.
+#[inline]
+fn ta_as_callback_arg(ta: *const TypedArrayHeader) -> f64 {
+    f64::from_bits(ta as u64)
+}
+
+/// `ta.forEach(cb)` — returns undefined.
+#[no_mangle]
+pub extern "C" fn js_typed_array_for_each(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    if !ta.is_null() {
+        unsafe {
+            let len = (*ta).length as usize;
+            let arr = ta_as_callback_arg(ta);
+            for i in 0..len {
+                crate::closure::js_closure_call3(callback, load_at(ta, i), i as f64, arr);
+            }
+        }
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// `ta.map(cb)` — new typed array of the same kind.
+#[no_mangle]
+pub extern "C" fn js_typed_array_map(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+) -> *mut TypedArrayHeader {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return typed_array_alloc(KIND_FLOAT64, 0);
+    }
+    unsafe {
+        let kind = (*ta).kind;
+        let len = (*ta).length as usize;
+        let arr = ta_as_callback_arg(ta);
+        let out = typed_array_alloc(kind, len as u32);
+        for i in 0..len {
+            let r = crate::closure::js_closure_call3(callback, load_at(ta, i), i as f64, arr);
+            store_at(out, i, jsvalue_to_f64(r));
+        }
+        out
+    }
+}
+
+/// `ta.filter(cb)` — new typed array of the same kind holding the elements
+/// for which `cb` returned truthy.
+#[no_mangle]
+pub extern "C" fn js_typed_array_filter(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+) -> *mut TypedArrayHeader {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return typed_array_alloc(KIND_FLOAT64, 0);
+    }
+    unsafe {
+        let kind = (*ta).kind;
+        let len = (*ta).length as usize;
+        let arr = ta_as_callback_arg(ta);
+        let mut kept: Vec<f64> = Vec::new();
+        for i in 0..len {
+            let v = load_at(ta, i);
+            let r = crate::closure::js_closure_call3(callback, v, i as f64, arr);
+            if crate::value::js_is_truthy(r) != 0 {
+                kept.push(v);
+            }
+        }
+        let out = typed_array_alloc(kind, kept.len() as u32);
+        for (i, v) in kept.into_iter().enumerate() {
+            store_at(out, i, v);
+        }
+        out
+    }
+}
+
+/// `ta.some(cb)` — NaN-boxed boolean.
+#[no_mangle]
+pub extern "C" fn js_typed_array_some(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    let mut result = false;
+    if !ta.is_null() {
+        unsafe {
+            let len = (*ta).length as usize;
+            let arr = ta_as_callback_arg(ta);
+            for i in 0..len {
+                let r = crate::closure::js_closure_call3(callback, load_at(ta, i), i as f64, arr);
+                if crate::value::js_is_truthy(r) != 0 {
+                    result = true;
+                    break;
+                }
+            }
+        }
+    }
+    f64::from_bits(crate::value::JSValue::bool(result).bits())
+}
+
+/// `ta.every(cb)` — NaN-boxed boolean.
+#[no_mangle]
+pub extern "C" fn js_typed_array_every(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    let mut result = true;
+    if !ta.is_null() {
+        unsafe {
+            let len = (*ta).length as usize;
+            let arr = ta_as_callback_arg(ta);
+            for i in 0..len {
+                let r = crate::closure::js_closure_call3(callback, load_at(ta, i), i as f64, arr);
+                if crate::value::js_is_truthy(r) == 0 {
+                    result = false;
+                    break;
+                }
+            }
+        }
+    }
+    f64::from_bits(crate::value::JSValue::bool(result).bits())
+}
+
+/// `ta.find(cb)` — the matched element (plain f64) or undefined.
+#[no_mangle]
+pub extern "C" fn js_typed_array_find(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    if !ta.is_null() {
+        unsafe {
+            let len = (*ta).length as usize;
+            let arr = ta_as_callback_arg(ta);
+            for i in 0..len {
+                let v = load_at(ta, i);
+                let r = crate::closure::js_closure_call3(callback, v, i as f64, arr);
+                if crate::value::js_is_truthy(r) != 0 {
+                    return v;
+                }
+            }
+        }
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// `ta.findIndex(cb)` — matched index (plain f64) or -1.
+#[no_mangle]
+pub extern "C" fn js_typed_array_find_index(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    if !ta.is_null() {
+        unsafe {
+            let len = (*ta).length as usize;
+            let arr = ta_as_callback_arg(ta);
+            for i in 0..len {
+                let r = crate::closure::js_closure_call3(callback, load_at(ta, i), i as f64, arr);
+                if crate::value::js_is_truthy(r) != 0 {
+                    return i as f64;
+                }
+            }
+        }
+    }
+    -1.0
+}
+
+/// `ta.reduce(cb, initialValue?)`. `has_init` is 0 when no initial value was
+/// supplied. Empty array with no initial value returns undefined (Node
+/// throws a TypeError; this is the documented divergence).
+#[no_mangle]
+pub extern "C" fn js_typed_array_reduce(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+    init: f64,
+    has_init: i32,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    unsafe {
+        let len = (*ta).length as usize;
+        let arr = ta_as_callback_arg(ta);
+        let mut acc;
+        let mut start;
+        if has_init != 0 {
+            acc = init;
+            start = 0;
+        } else {
+            if len == 0 {
+                return f64::from_bits(crate::value::TAG_UNDEFINED);
+            }
+            acc = load_at(ta, 0);
+            start = 1;
+        }
+        while start < len {
+            acc = crate::closure::js_closure_call4(
+                callback,
+                acc,
+                load_at(ta, start),
+                start as f64,
+                arr,
+            );
+            start += 1;
+        }
+        acc
+    }
+}
+
+/// `ta.reduceRight(cb, initialValue?)`.
+#[no_mangle]
+pub extern "C" fn js_typed_array_reduce_right(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+    init: f64,
+    has_init: i32,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    unsafe {
+        let len = (*ta).length as usize;
+        let arr = ta_as_callback_arg(ta);
+        let mut acc;
+        let mut i: i64;
+        if has_init != 0 {
+            acc = init;
+            i = len as i64 - 1;
+        } else {
+            if len == 0 {
+                return f64::from_bits(crate::value::TAG_UNDEFINED);
+            }
+            acc = load_at(ta, len - 1);
+            i = len as i64 - 2;
+        }
+        while i >= 0 {
+            acc = crate::closure::js_closure_call4(
+                callback,
+                acc,
+                load_at(ta, i as usize),
+                i as f64,
+                arr,
+            );
+            i -= 1;
+        }
+        acc
+    }
+}
+
+/// `ta[key]` where `key` has an unknown static type (#2061). Codegen routes
+/// the ambiguous-index case here so a string method-name key resolves a
+/// prototype method/accessor (via `js_object_get_field_by_name_f64`) while a
+/// numeric key still reads an element. Without this, codegen `fptosi`'d the
+/// NaN-boxed string key to 0 and returned element 0 (a number), so
+/// `int8arr[m]` where `m` held `"copyWithin"` reported `typeof === "number"`.
+#[no_mangle]
+pub extern "C" fn js_typed_array_member_get(ta: *const TypedArrayHeader, index: f64) -> f64 {
+    let idx_bits = index.to_bits();
+    let top16 = idx_bits >> 48;
+    // STRING_TAG (0x7FFF) or SSO short-string (0x7FF9) → property/method.
+    if top16 == 0x7FFF || top16 == 0x7FF9 {
+        let key_ptr = crate::value::js_get_string_pointer_unified(index)
+            as *const crate::string::StringHeader;
+        if key_ptr.is_null() {
+            return f64::from_bits(crate::value::TAG_UNDEFINED);
+        }
+        return crate::object::js_object_get_field_by_name_f64(
+            ta as *const crate::object::ObjectHeader,
+            key_ptr,
+        );
+    }
+    // Numeric key → element read (per-kind; OOB → undefined).
+    if index.is_nan() || index.is_infinite() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    js_typed_array_get(ta, index as i32)
+}
+
 /// Format a typed array Node-style: `Int32Array(N) [ a, b, c ]`. Used by
 /// `format_jsvalue` in builtins.rs.
 pub fn format_typed_array(ta: *const TypedArrayHeader) -> String {

--- a/test-files/test_gap_typed_array_methods.ts
+++ b/test-files/test_gap_typed_array_methods.ts
@@ -1,0 +1,58 @@
+// Issue #2061: non-index (method-name) keys on a typed array must resolve
+// against %TypedArray%.prototype instead of being swallowed by the element
+// fast path (which returned a number, so calls threw "is not a function").
+//
+// This exercises the computed-key read + dynamic-dispatch call forms the
+// issue documents. NOTE: the *static* call form `arr.map(cb)` is lowered by
+// the HIR into dedicated Array* nodes (array layout) — that reification is a
+// separate gap (#793), so it's intentionally not asserted here.
+
+// --- the exact repro: every prototype method reads as a function ---
+const a = new Int8Array([1, 2, 3, 4]);
+for (const m of ["copyWithin", "fill", "subarray", "slice", "set", "indexOf", "map", "filter", "reduce", "join"]) {
+  console.log("typeof", m, typeof (a as any)[m]);
+}
+console.log("len/elem", a.length, a[0]);
+
+// --- static member-as-value form resolves too ---
+console.log("static typeof", typeof a.map, typeof a.fill, typeof a.reduce);
+
+// --- accessor properties ---
+const u16 = new Uint16Array([10, 20, 30]);
+console.log("byteLength", u16.byteLength, "BPE", u16.BYTES_PER_ELEMENT, "byteOffset", u16.byteOffset, "length", u16.length);
+
+// --- dynamic-key method calls dispatch to the prototype impl ---
+const f = new Float64Array([5, 3, 1, 4, 2]);
+for (const k of ["indexOf"]) console.log("indexOf", (f as any)[k](4), (f as any)[k](99));
+for (const k of ["lastIndexOf"]) console.log("lastIndexOf", (new Int8Array([1, 2, 1, 2]) as any)[k](1));
+for (const k of ["includes"]) console.log("includes", (f as any)[k](3), (f as any)[k](99));
+for (const k of ["join"]) console.log("join", (f as any)[k]("-"));
+for (const k of ["slice"]) console.log("slice", Array.from((f as any)[k](1, 3)));
+for (const k of ["subarray"]) console.log("subarray", Array.from((f as any)[k](2)));
+for (const k of ["map"]) console.log("map", Array.from((f as any)[k]((x: number) => x * 2)));
+for (const k of ["filter"]) console.log("filter", Array.from((f as any)[k]((x: number) => x > 2)));
+for (const k of ["reduce"]) console.log("reduce", (f as any)[k]((p: number, c: number) => p + c, 0));
+for (const k of ["reduceRight"]) console.log("reduceRight", (new Int32Array([1, 2, 3]) as any)[k]((p: number, c: number) => p - c));
+for (const k of ["some"]) console.log("some", (f as any)[k]((x: number) => x > 4));
+for (const k of ["every"]) console.log("every", (f as any)[k]((x: number) => x > 0));
+for (const k of ["find"]) console.log("find", (f as any)[k]((x: number) => x > 3));
+for (const k of ["findIndex"]) console.log("findIndex", (f as any)[k]((x: number) => x > 3));
+
+// --- in-place mutators via dynamic dispatch ---
+const fill = new Int16Array(4);
+for (const k of ["fill"]) (fill as any)[k](9, 1, 3);
+console.log("fill", Array.from(fill));
+
+const cw = new Int8Array([1, 2, 3, 4, 5]);
+for (const k of ["copyWithin"]) (cw as any)[k](0, 3);
+console.log("copyWithin", Array.from(cw));
+
+const rev = new Int8Array([1, 2, 3]);
+for (const k of ["reverse"]) (rev as any)[k]();
+console.log("reverse", Array.from(rev));
+
+// (Int16Array — not a Buffer-backed Uint8Array, which routes through the
+// separate Buffer dispatch path.)
+const dst = new Int16Array(5);
+for (const k of ["set"]) (dst as any)[k]([10, 20, 30], 1);
+console.log("set", Array.from(dst));


### PR DESCRIPTION
## Summary

Fixes #2061. Member access for a non-index (method-name) key on a TypedArray returned a **number** instead of resolving the prototype method, so `typeof int8arr.copyWithin === "number"` and every method call threw `is not a function`. The indexed-element fast path was swallowing all property reads, not just integer-index keys.

```js
var a = new Int8Array([1, 2, 3, 4]);
for (var m of ["copyWithin","fill","subarray","slice","set","indexOf","map","filter","reduce","join"])
  console.log(m, typeof a[m]);   // before: number ×10 — now: function ×10 (matches Node)
console.log(a.length, a[0]);     // 4 1
```

## What changed

- **codegen (`index_get.rs`)** — gate the width-tracked typed-array element fast path to *provably-numeric* keys. Provably-string keys fall through to the generic property resolver; ambiguous (`any`, e.g. a `for..of` loop var whose element type wasn't propagated) keys route to a new runtime tag dispatcher `js_typed_array_member_get` (numeric → element, string → property). Previously the path `fptosi`'d the NaN-boxed string key to `0` and read element 0.
- **runtime (`field_get_set.rs`)** — the existing typed-array branch in `js_object_get_field_by_name` now binds any `%TypedArray%.prototype` method name to a callable closure (so `typeof` is `"function"` and the call routes through `js_native_call_method`'s typed-array arm) and resolves `constructor`. `length`/`byteLength`/`byteOffset`/`BYTES_PER_ELEMENT` already resolved.
- **runtime (`typedarray.rs` + `native_call_method.rs`)** — implement the common prototype methods so the resolved methods are actually callable: `fill`, `copyWithin`, `slice`, `subarray`, `indexOf`, `lastIndexOf`, `includes`, `join`, `reverse`, `set`, `forEach`, `map`, `filter`, `reduce`, `reduceRight`, `some`, `every`, `find`, `findIndex` (alongside the existing `at`/`sort`/`toSorted`/`toReversed`/`with`/`findLast`/`findLastIndex`).

## Scope

The **static call form** `arr.map(cb)` is lowered by the HIR into dedicated `Array*` nodes (regular-array memory layout), so static method calls on a typed array still mis-read — that `%TypedArray%.prototype` reification is a separate, larger gap tracked under #793 and is intentionally **not** addressed here. This PR fixes the property/method **resolution** (the documented repro), which also makes the methods callable via the computed/dynamic-key and bound-method paths.

`Uint8Array` is registered as a Buffer in Perry, so its method-name reads route through the separate Buffer dispatch path — the new test uses non-buffer typed arrays.

## Testing

- `test-files/test_gap_typed_array_methods.ts` (new) is **byte-identical** to `node --experimental-strip-types` for the repro, the static member-as-value form, accessor reads, and dynamic-dispatch method calls — verified under both the default (auto-optimize) and `--no-auto-optimize` build paths.
- No regressions: 12/12 array/object/string/map collection gap tests still byte-match Node; `perry-runtime` unit tests pass; `cargo fmt --all --check` clean.
