### PR TITLE
fix(node:stream): return stream from setEncoding

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2502,6 +2502,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("stream", "read", true, None),
     method("stream", "resume", true, None),
     method("stream", "destroy", true, None),
+    method("stream", "setEncoding", true, None),
     method("stream", "write", true, None),
     method("stream", "end", true, None),
     method("stream", "cork", true, None),

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -845,6 +845,15 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "stream",
         has_receiver: true,
+        method: "setEncoding",
+        class_filter: None,
+        runtime: "js_node_stream_method_set_encoding",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
         method: "destroy",
         class_filter: None,
         runtime: "js_node_stream_method_destroy",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -881,6 +881,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_method_writable", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_writable_ended", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_writable_finished", DOUBLE, &[I64]);
+    module.declare_function("js_node_stream_method_set_encoding", DOUBLE, &[I64, DOUBLE]);
 
     // ========== Event emitter ==========
     module.declare_function("js_event_emitter_emit", DOUBLE, &[I64, I64, I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -530,6 +530,11 @@ pub extern "C" fn js_node_stream_method_read(stream_handle: i64, _n: f64) -> f64
 }
 
 #[no_mangle]
+pub extern "C" fn js_node_stream_method_set_encoding(stream_handle: i64, _encoding: f64) -> f64 {
+    stream_value_from_handle(stream_handle)
+}
+
+#[no_mangle]
 pub extern "C" fn js_node_stream_method_resume(stream_handle: i64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
     mark_stream_ended(stream);

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -44,6 +44,9 @@ static KEEP_NS_METHOD_WRITABLE_FINISHED: extern "C" fn(i64) -> f64 =
 #[used]
 static KEEP_NS_METHOD_RESUME: extern "C" fn(i64) -> f64 = super::js_node_stream_method_resume;
 #[used]
+static KEEP_NS_METHOD_SET_ENCODING: extern "C" fn(i64, f64) -> f64 =
+    super::js_node_stream_method_set_encoding;
+#[used]
 static KEEP_NS_METHOD_DESTROY: extern "C" fn(i64, f64) -> f64 =
     super::js_node_stream_method_destroy;
 #[used]

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -573,6 +573,17 @@ fn readable_lifecycle_flags_reflect_ended_state() {
 }
 
 #[test]
+fn readable_set_encoding_native_dispatch_returns_stream() {
+    let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let handle = raw_ptr_from_value(stream) as i64;
+
+    assert_eq!(
+        js_node_stream_method_set_encoding(handle, string_value("utf8")).to_bits(),
+        stream.to_bits()
+    );
+}
+
+#[test]
 fn writable_corked_counter_tracks_cork_balance() {
     let stream = js_node_stream_writable_new(f64::from_bits(TAG_UNDEFINED));
     let handle = raw_ptr_from_value(stream) as i64;

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -440,12 +440,6 @@
     "category": "bug-open",
     "reason": "node:stream: writev() constructor option not invoked when corked + multi-write. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/method-chain/setEncoding-returns-this": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: setEncoding() should return `this` for chaining; Perry returns something else. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/constructor/without-new": {
     "issue": "1531",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- add typed/native stream receiver dispatch for `setEncoding()` that returns the receiver stream
- wire `stream.setEncoding` through the API manifest, native table, runtime declaration, and keepalive list
- remove the now-passing `node-suite/stream/method-chain/setEncoding-returns-this` known failure

## Verification
- Baseline before fix: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/method-chain/setEncoding-returns-this` failed with Perry `returns self: false`, report `test-parity/reports/parity_report_20260527_135613.json`
- `cargo test -p perry-runtime readable_set_encoding_native_dispatch_returns_stream --lib`
- `cargo test -p perry-codegen --lib native_table`
- `cargo test -p perry-api-manifest`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD`
- Exact parity: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/method-chain/setEncoding-returns-this` PASS 1/1, report `test-parity/reports/parity_report_20260527_140052.json`
- Guardrail: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/method-chain/` PASS 2/2, report `test-parity/reports/parity_report_20260527_140135.json`

## DeepWiki
- Local-only note: `reference/deepwiki/nodejs-node-stream-readable-setencoding-chainable-2026-05-27.md`
- Invariant used: `Readable.prototype.setEncoding(enc)` returns `this`; decoded data delivery and StringDecoder behavior are separate surfaces.

## Non-goals
- no decoded data delivery changes
- no readableEncoding state tracking
- no StringDecoder validation or normalization
- no broader stream encoding pipeline work