### PR TITLE
fix(node:stream): return destination from pipe

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2500,6 +2500,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // Core stream instance stubs used by stream/promises and the
     // Readable/Writable/Duplex/Transform/PassThrough constructor surface.
     method("stream", "read", true, None),
+    method("stream", "pipe", true, None),
     method("stream", "resume", true, None),
     method("stream", "destroy", true, None),
     method("stream", "write", true, None),

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -845,6 +845,15 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "stream",
         has_receiver: true,
+        method: "pipe",
+        class_filter: None,
+        runtime: "js_node_stream_method_pipe",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
         method: "destroy",
         class_filter: None,
         runtime: "js_node_stream_method_destroy",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -873,6 +873,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_method_readable_aborted", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroyed", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroy", DOUBLE, &[I64, DOUBLE]);
+    module.declare_function("js_node_stream_method_pipe", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_node_stream_method_readable", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_readable_ended", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_cork", DOUBLE, &[I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -530,6 +530,11 @@ pub extern "C" fn js_node_stream_method_read(stream_handle: i64, _n: f64) -> f64
 }
 
 #[no_mangle]
+pub extern "C" fn js_node_stream_method_pipe(_stream_handle: i64, dest: f64) -> f64 {
+    dest
+}
+
+#[no_mangle]
 pub extern "C" fn js_node_stream_method_resume(stream_handle: i64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
     mark_stream_ended(stream);

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -44,6 +44,8 @@ static KEEP_NS_METHOD_WRITABLE_FINISHED: extern "C" fn(i64) -> f64 =
 #[used]
 static KEEP_NS_METHOD_RESUME: extern "C" fn(i64) -> f64 = super::js_node_stream_method_resume;
 #[used]
+static KEEP_NS_METHOD_PIPE: extern "C" fn(i64, f64) -> f64 = super::js_node_stream_method_pipe;
+#[used]
 static KEEP_NS_METHOD_DESTROY: extern "C" fn(i64, f64) -> f64 =
     super::js_node_stream_method_destroy;
 #[used]

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -573,6 +573,18 @@ fn readable_lifecycle_flags_reflect_ended_state() {
 }
 
 #[test]
+fn readable_pipe_native_dispatch_returns_destination() {
+    let source = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let dest = js_node_stream_writable_new(f64::from_bits(TAG_UNDEFINED));
+    let handle = raw_ptr_from_value(source) as i64;
+
+    assert_eq!(
+        js_node_stream_method_pipe(handle, dest).to_bits(),
+        dest.to_bits()
+    );
+}
+
+#[test]
 fn writable_corked_counter_tracks_cork_balance() {
     let stream = js_node_stream_writable_new(f64::from_bits(TAG_UNDEFINED));
     let handle = raw_ptr_from_value(stream) as i64;

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -380,12 +380,6 @@
     "category": "bug-open",
     "reason": "node:stream: read(n) doesn't return buffered chunk (push/read pipeline not wired). Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/pipe/returns-target": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: readable.pipe(writable) should return the writable (for chaining); Perry returns undefined. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/transform/with-encoding": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- add typed/native receiver dispatch for `stream.pipe(dest)` returning `dest`
- wire `stream.pipe` through the API manifest, native table, runtime declaration, and keepalive list
- remove the now-passing `node-suite/stream/pipe/returns-target` known failure

## Verification
- Baseline before fix: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/pipe/returns-target` failed with Perry `returns target: false`, report `test-parity/reports/parity_report_20260527_140745.json`
- `cargo test -p perry-runtime readable_pipe_native_dispatch_returns_destination --lib`
- `cargo test -p perry-codegen --lib native_table`
- `cargo test -p perry-api-manifest`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD`
- Exact parity: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/pipe/returns-target` PASS 1/1, report `test-parity/reports/parity_report_20260527_141247.json`
- Guardrail: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/pipe/returns` kept `returns-target` green and still failed separate `returns-destination` pipe/dataflow behavior, report `test-parity/reports/parity_report_20260527_141326.json`

## DeepWiki
- Local-only note: `reference/deepwiki/nodejs-node-stream-readable-pipe-return-destination-2026-05-27.md`
- Invariant used: classic `Readable.prototype.pipe(destination[, options])` returns the destination stream, enabling chainability.

## Non-goals
- no data transfer changes
- no end propagation changes
- no backpressure behavior
- no duplicate pipe handling
- no pipe option semantics
- no full pipe pipeline behavior