### PR TITLE
fix(transform): lift multiple yields in one expression to ordered temps (#321 Effect.gen)

### DIFF
--- a/crates/perry-transform/src/generator/hoist_yields.rs
+++ b/crates/perry-transform/src/generator/hoist_yields.rs
@@ -1,0 +1,380 @@
+//! #321: hoist `yield` / `yield*` out of compound expressions into ordered
+//! temps, so the linearizer only ever sees a yield at a position it already
+//! handles (bare `yield E;`, `let x = yield E;`, `return yield E;`).
+//!
+//! The linearizer (`linearize.rs`) special-cases yields at statement, let-init,
+//! and return positions. A yield buried inside a larger expression — e.g.
+//! `return (yield 1) + (yield 2)` — falls into the catch-all and is emitted as
+//! one unsplit statement; codegen then lowers each `Expr::Yield` via the
+//! "generators not implemented" arm (evaluate operand for side effects, return
+//! `0.0`), so the resumed values are dropped. The whole expression also never
+//! suspends, so the generator finishes on the first `.next()`.
+//!
+//! This pass walks every statement left-to-right and, for each `yield` /
+//! `yield*` sub-expression that is NOT already in a directly-handled position,
+//! emits `let __ygen_N = yield <E>;` immediately before the containing
+//! statement and replaces the occurrence with `LocalGet(__ygen_N)`. The
+//! existing let-init arms then split each into a suspend/resume state, binding
+//! the resumed value to the temp. The remaining (now yield-free) combining
+//! expression evaluates against the temps.
+//!
+//! Evaluation order is preserved: children are visited in evaluation order and
+//! each hoisted let is appended in that order, so `(yield a) + (yield b)`
+//! yields `a` then `b` and combines `t_a + t_b` left-to-right.
+//!
+//! Short-circuiting (`&&`, `||`, `??`) and the ternary `?:` are handled
+//! specially: a yield on a path that may not be taken must only run when that
+//! path is taken. Those forms are lifted into a temp + `if`-statement so the
+//! yield ends up inside the conditionally-executed branch (mirrors the
+//! conditional-await lift in `async_to_generator.rs`).
+//!
+//! Nested closures are not descended into — a yield inside a nested
+//! `function*` belongs to that generator, not this one.
+
+use super::*;
+
+/// Entry point: hoist non-top-level yields across a statement list, recursing
+/// into nested control-flow bodies.
+pub fn hoist_yields_in_stmts(stmts: &mut Vec<Stmt>, next_id: &mut LocalId) {
+    let mut out: Vec<Stmt> = Vec::with_capacity(stmts.len());
+    for stmt in std::mem::take(stmts) {
+        let mut hoisted: Vec<Stmt> = Vec::new();
+        let new_stmt = hoist_yields_in_stmt(stmt, next_id, &mut hoisted);
+        out.extend(hoisted);
+        out.push(new_stmt);
+    }
+    *stmts = out;
+}
+
+fn hoist_yields_in_stmt(mut stmt: Stmt, next_id: &mut LocalId, hoisted: &mut Vec<Stmt>) -> Stmt {
+    match &mut stmt {
+        // Top-level positions: keep the *outer* yield (the linearizer handles
+        // `let x = yield E`, `yield E;`, `return yield E`) but hoist any yields
+        // nested inside the operand `E`.
+        Stmt::Let { init: Some(e), .. } => {
+            hoist_yields_avoiding_top_level(e, next_id, hoisted);
+        }
+        Stmt::Expr(e) => {
+            hoist_yields_avoiding_top_level(e, next_id, hoisted);
+        }
+        Stmt::Return(Some(e)) => {
+            hoist_yields_avoiding_top_level(e, next_id, hoisted);
+        }
+        Stmt::Throw(e) => {
+            // `throw (yield x)` — hoist all yields fully (there is no
+            // throw-yield top-level arm in the linearizer, so a top-level
+            // yield here must be hoisted to a temp too).
+            hoist_yields_in_expr_full(e, next_id, hoisted);
+        }
+        Stmt::If {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            // Condition is evaluated before the branch is chosen — a yield in
+            // it always runs, so fully hoist it above the `if`.
+            hoist_yields_in_expr_full(condition, next_id, hoisted);
+            hoist_yields_in_stmts(then_branch, next_id);
+            if let Some(eb) = else_branch {
+                hoist_yields_in_stmts(eb, next_id);
+            }
+        }
+        Stmt::While { condition, body } => {
+            // A yield in the while-condition is re-evaluated each iteration;
+            // the linearizer's While arm rebuilds the condition into a per-
+            // iteration cond_state, so leave the condition's own yields in
+            // place (they would need re-running, not a one-shot hoist).
+            hoist_yields_in_stmts(body, next_id);
+            let _ = condition;
+        }
+        Stmt::DoWhile { body, condition } => {
+            hoist_yields_in_stmts(body, next_id);
+            let _ = condition;
+        }
+        Stmt::For {
+            init,
+            condition: _,
+            update: _,
+            body,
+        } => {
+            // For-loop init runs once before the loop; hoist its yields ahead
+            // of the loop. Condition/update are per-iteration — left in place
+            // for the linearizer's For arm (matching the await pass's
+            // single-hoist approximation for loop condition/update).
+            if let Some(i) = init {
+                let mut inner = Vec::new();
+                let replaced = hoist_yields_in_stmt((**i).clone(), next_id, &mut inner);
+                hoisted.extend(inner);
+                **i = replaced;
+            }
+            hoist_yields_in_stmts(body, next_id);
+        }
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            hoist_yields_in_stmts(body, next_id);
+            if let Some(c) = catch {
+                hoist_yields_in_stmts(&mut c.body, next_id);
+            }
+            if let Some(f) = finally {
+                hoist_yields_in_stmts(f, next_id);
+            }
+        }
+        Stmt::Switch {
+            discriminant,
+            cases,
+        } => {
+            hoist_yields_in_expr_full(discriminant, next_id, hoisted);
+            for case in cases.iter_mut() {
+                if let Some(t) = &mut case.test {
+                    hoist_yields_in_expr_full(t, next_id, hoisted);
+                }
+                hoist_yields_in_stmts(&mut case.body, next_id);
+            }
+        }
+        Stmt::Labeled { body, .. } => {
+            let mut inner = Vec::new();
+            let body_taken = std::mem::replace(body.as_mut(), Stmt::Break);
+            let new_body = hoist_yields_in_stmt(body_taken, next_id, &mut inner);
+            hoisted.extend(inner);
+            **body = new_body;
+        }
+        _ => {}
+    }
+    stmt
+}
+
+/// Hoist all yields in an expression INCLUDING one at the expression's own top
+/// level, into preceding `let __ygen_N = yield E;` statements. Used for
+/// positions that are not handled by a dedicated linearizer arm (if/while/for
+/// conditions, switch discriminant, call args once we recurse, etc.).
+fn hoist_yields_in_expr_full(expr: &mut Expr, next_id: &mut LocalId, hoisted: &mut Vec<Stmt>) {
+    if matches!(expr, Expr::Closure { .. }) {
+        // Yields inside a nested closure belong to that (generator) closure.
+        return;
+    }
+
+    // Short-circuiting forms: lift before the general walk so the yield ends
+    // up inside the conditionally-executed branch instead of running
+    // unconditionally above the statement.
+    if matches!(expr, Expr::Conditional { .. }) && conditional_branches_contain_yield(expr) {
+        lift_conditional_with_yield_branches(expr, next_id, hoisted);
+        return;
+    }
+    if matches!(expr, Expr::Logical { .. }) && logical_rhs_contains_yield(expr) {
+        lift_logical_with_yield_rhs(expr, next_id, hoisted);
+        return;
+    }
+
+    // Recurse into children first so inner yields are hoisted before the outer
+    // expression's own yield (innermost-first, left-to-right).
+    perry_hir::walker::walk_expr_children_mut(expr, &mut |child| {
+        hoist_yields_in_expr_full(child, next_id, hoisted);
+    });
+
+    if matches!(expr, Expr::Yield { .. }) {
+        let id = alloc_local(next_id);
+        let original = std::mem::replace(expr, Expr::LocalGet(id));
+        hoisted.push(Stmt::Let {
+            id,
+            name: format!("__ygen_{}", id),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(original),
+        });
+    }
+}
+
+/// Hoist nested yields but leave a top-level yield alone. Used for statement-
+/// positioned operands (Let init, Stmt::Expr operand, Return operand) where the
+/// linearizer already handles the outer yield.
+fn hoist_yields_avoiding_top_level(
+    expr: &mut Expr,
+    next_id: &mut LocalId,
+    hoisted: &mut Vec<Stmt>,
+) {
+    if let Expr::Yield { value, .. } = expr {
+        // Outer is a yield the linearizer handles — keep it, but fully hoist
+        // any yields nested inside its operand (`yield (yield x)`).
+        if let Some(inner) = value {
+            hoist_yields_in_expr_full(inner.as_mut(), next_id, hoisted);
+        }
+        return;
+    }
+    if matches!(expr, Expr::Closure { .. }) {
+        return;
+    }
+    // Short-circuiting forms at statement-operand top level: lift so the yield
+    // lands inside an if-branch rather than unconditionally above the stmt.
+    if matches!(expr, Expr::Conditional { .. }) && conditional_branches_contain_yield(expr) {
+        lift_conditional_with_yield_branches(expr, next_id, hoisted);
+        return;
+    }
+    if matches!(expr, Expr::Logical { .. }) && logical_rhs_contains_yield(expr) {
+        lift_logical_with_yield_rhs(expr, next_id, hoisted);
+        return;
+    }
+    // Outer is not a yield: children may hold yields, which are nested — fully
+    // hoist them.
+    perry_hir::walker::walk_expr_children_mut(expr, &mut |child| {
+        hoist_yields_in_expr_full(child, next_id, hoisted);
+    });
+}
+
+/// True if either branch of a `Conditional` contains a yield (outside nested
+/// closures).
+fn conditional_branches_contain_yield(expr: &Expr) -> bool {
+    if let Expr::Conditional {
+        then_expr,
+        else_expr,
+        ..
+    } = expr
+    {
+        return expr_contains_yield(then_expr) || expr_contains_yield(else_expr);
+    }
+    false
+}
+
+/// True if the RHS of a `Logical` (`&&`/`||`/`??`) contains a yield. Only the
+/// RHS is short-circuited — a yield in the LHS always runs, so it doesn't need
+/// the conditional lift (it is hoisted by the normal child walk).
+fn logical_rhs_contains_yield(expr: &Expr) -> bool {
+    if let Expr::Logical { right, .. } = expr {
+        return expr_contains_yield(right);
+    }
+    false
+}
+
+fn expr_contains_yield(expr: &Expr) -> bool {
+    if matches!(expr, Expr::Yield { .. }) {
+        return true;
+    }
+    if matches!(expr, Expr::Closure { .. }) {
+        return false;
+    }
+    let mut found = false;
+    perry_hir::walker::walk_expr_children(expr, &mut |child| {
+        if !found && expr_contains_yield(child) {
+            found = true;
+        }
+    });
+    found
+}
+
+/// Replace `cond ? then_e : else_e` (where a branch contains a yield) with
+/// `LocalGet(__ycond_N)` and emit before the containing statement:
+///
+///   let __ycond_N: any;
+///   if (cond) { __ycond_N = then_e; } else { __ycond_N = else_e; }
+///
+/// Yields inside each branch's assignment are then hoisted by the recursive
+/// `hoist_yields_in_stmts` so they land at the top of their own if-branch (the
+/// position the linearizer splits states at). The `cond` itself is fully
+/// hoisted because it always runs before either branch.
+fn lift_conditional_with_yield_branches(
+    expr: &mut Expr,
+    next_id: &mut LocalId,
+    hoisted: &mut Vec<Stmt>,
+) {
+    let temp_id = alloc_local(next_id);
+    let owned = std::mem::replace(expr, Expr::LocalGet(temp_id));
+    if let Expr::Conditional {
+        mut condition,
+        then_expr,
+        else_expr,
+    } = owned
+    {
+        // The condition always runs first; hoist any yields it holds above
+        // the lifted `if`.
+        hoist_yields_in_expr_full(condition.as_mut(), next_id, hoisted);
+
+        hoisted.push(Stmt::Let {
+            id: temp_id,
+            name: format!("__ycond_{}", temp_id),
+            ty: Type::Any,
+            mutable: true,
+            init: None,
+        });
+
+        let mut then_branch = vec![Stmt::Expr(Expr::LocalSet(temp_id, then_expr))];
+        hoist_yields_in_stmts(&mut then_branch, next_id);
+
+        let mut else_branch = vec![Stmt::Expr(Expr::LocalSet(temp_id, else_expr))];
+        hoist_yields_in_stmts(&mut else_branch, next_id);
+
+        hoisted.push(Stmt::If {
+            condition: *condition,
+            then_branch,
+            else_branch: Some(else_branch),
+        });
+    }
+}
+
+/// Replace `lhs && rhs` / `lhs || rhs` / `lhs ?? rhs` (where `rhs` contains a
+/// yield) with `LocalGet(__ylogic_N)` and emit before the containing statement
+/// an `if` that only evaluates `rhs` when the operator does not short-circuit:
+///
+///   &&:  let t = lhs; if (t) { t = rhs; }            // rhs only when lhs truthy
+///   ||:  let t = lhs; if (!t) { t = rhs; }           // rhs only when lhs falsy
+///   ??:  let t = lhs; if (t === null || t === undefined) { t = rhs; }
+///
+/// Yields inside `rhs`'s assignment are hoisted into the if-branch by the
+/// recursive `hoist_yields_in_stmts`. A yield in `lhs` always runs and is
+/// hoisted by the full walk of `lhs`. The temp `t` carries the operator's
+/// result value, preserving `&&`/`||`/`??` value semantics (returns the operand
+/// that determined the result, not a coerced boolean).
+fn lift_logical_with_yield_rhs(expr: &mut Expr, next_id: &mut LocalId, hoisted: &mut Vec<Stmt>) {
+    let temp_id = alloc_local(next_id);
+    let owned = std::mem::replace(expr, Expr::LocalGet(temp_id));
+    if let Expr::Logical {
+        op,
+        mut left,
+        right,
+    } = owned
+    {
+        // `left` always evaluates; hoist any yields it holds above the temp.
+        hoist_yields_in_expr_full(left.as_mut(), next_id, hoisted);
+
+        // let t = <left>;
+        hoisted.push(Stmt::Let {
+            id: temp_id,
+            name: format!("__ylogic_{}", temp_id),
+            ty: Type::Any,
+            mutable: true,
+            init: Some(*left),
+        });
+
+        // Build the guard that decides whether `right` is evaluated.
+        let guard = match op {
+            LogicalOp::And => Expr::LocalGet(temp_id),
+            LogicalOp::Or => Expr::Unary {
+                op: UnaryOp::Not,
+                operand: Box::new(Expr::LocalGet(temp_id)),
+            },
+            LogicalOp::Coalesce => Expr::Logical {
+                op: LogicalOp::Or,
+                left: Box::new(Expr::Compare {
+                    op: CompareOp::Eq,
+                    left: Box::new(Expr::LocalGet(temp_id)),
+                    right: Box::new(Expr::Null),
+                }),
+                right: Box::new(Expr::Compare {
+                    op: CompareOp::Eq,
+                    left: Box::new(Expr::LocalGet(temp_id)),
+                    right: Box::new(Expr::Undefined),
+                }),
+            },
+        };
+
+        let mut then_branch = vec![Stmt::Expr(Expr::LocalSet(temp_id, right))];
+        hoist_yields_in_stmts(&mut then_branch, next_id);
+
+        hoisted.push(Stmt::If {
+            condition: guard,
+            then_branch,
+            else_branch: None,
+        });
+    }
+}

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -60,6 +60,19 @@ pub fn transform_generator_function_with_extra_captures(
     let is_async_generator = func.is_async;
     func.is_async = false;
 
+    // #321: hoist `yield` / `yield*` that live inside a larger expression
+    // (`return (yield 1) + (yield 2)`, call args, array/object literals, etc.)
+    // into ordered `let __ygen_N = yield E;` temps so the linearizer below only
+    // ever encounters a yield at a position it already splits into states.
+    // Without this, a buried yield falls into the linearizer's catch-all and
+    // codegen lowers it via the "generators not implemented" arm (returns 0.0)
+    // — the resumed value is dropped and the generator never suspends at it.
+    // The temps land as `Stmt::Let` in the body, so `collect_hoisted_vars`
+    // below picks them up and boxes/preallocates them like any other hoisted
+    // local. Allocated before `local_id_before` so they are not double-counted
+    // in `extra_local_ids`.
+    hoist_yields_in_stmts(&mut func.body, next_local_id);
+
     let state_id = alloc_local(next_local_id);
     let done_id = alloc_local(next_local_id);
     let sent_id = alloc_local(next_local_id); // value passed by caller via next(val)

--- a/crates/perry-transform/src/generator/mod.rs
+++ b/crates/perry-transform/src/generator/mod.rs
@@ -13,6 +13,7 @@ use perry_types::{FuncId, LocalId, Type};
 
 mod break_continue;
 mod helpers;
+mod hoist_yields;
 mod id_scan;
 mod iter_result_rewrite;
 mod linearize;
@@ -32,6 +33,7 @@ pub(crate) use helpers::{
     alloc_local, make_iter_result, rewrite_hoisted_lets_in_stmt, rewrite_hoisted_lets_in_stmts,
     wrap_in_promise_resolve, wrap_returns_in_promise,
 };
+pub(crate) use hoist_yields::hoist_yields_in_stmts;
 pub(crate) use id_scan::{
     compute_max_func_id, compute_max_local_id, scan_expr_for_max_func, scan_expr_for_max_local,
     scan_stmt_for_max_func, scan_stmt_for_max_local, scan_stmts_for_max_func,

--- a/test-files/test_gap_generator_multi_yield_expr.ts
+++ b/test-files/test_gap_generator_multi_yield_expr.ts
@@ -1,0 +1,119 @@
+// Test: multiple `yield` / `yield*` inside a single (non-statement,
+// non-simple-binding) expression. Each yield must be hoisted to an ordered
+// temp, the generator suspended/resumed at each, and the resumed values
+// combined left-to-right (#321 Effect.gen general-case enabler). Previously a
+// yield buried in `a + b` / call args / array literals fell into the generator
+// linearizer's catch-all and lowered via the "generators not implemented"
+// codegen arm (returns 0.0) — the resumed value was dropped and the generator
+// never suspended at the buried yields.
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+// --- two yields in arithmetic, resumed values combined ---
+function* g(): any {
+  return (yield 1) + (yield 2);
+}
+const it: any = g();
+console.log(JSON.stringify(it.next())); // {"value":1,"done":false}
+console.log(JSON.stringify(it.next(10))); // {"value":2,"done":false}
+console.log(JSON.stringify(it.next(20))); // {"value":30,"done":true}
+
+// --- three yields ---
+function* h(): any {
+  return (yield 1) + (yield 2) + (yield 3);
+}
+const i2: any = h();
+i2.next();
+i2.next(10);
+i2.next(20);
+console.log("3yield:", i2.next(30).value); // 60
+
+// --- yields as array-literal elements (evaluation order) ---
+function* arr(): any {
+  return [yield 1, yield 2];
+}
+const a: any = arr();
+a.next();
+a.next(11);
+console.log("array:", JSON.stringify(a.next(22).value)); // [11,22]
+
+// --- yields as call arguments ---
+function add3(x: number, y: number, z: number): number {
+  return x + y + z;
+}
+function* call(): any {
+  return add3(yield 1, yield 2, yield 3);
+}
+const c: any = call();
+c.next();
+c.next(5);
+c.next(6);
+console.log("call:", c.next(7).value); // 18
+
+// --- && short-circuit: RHS yield must NOT run when LHS falsy ---
+function* andSc(): any {
+  return false && (yield 99);
+}
+const as1: any = andSc();
+const asr = as1.next();
+console.log("and-short:", asr.value, asr.done); // false true
+
+// --- && where LHS truthy: RHS yield runs and its resume value flows out ---
+function* andRun(): any {
+  return true && (yield 42);
+}
+const ar: any = andRun();
+const arA = ar.next();
+const arB = ar.next(100);
+console.log("and-run:", arA.value, arB.value); // 42 100
+
+// --- || short-circuit: RHS yield must NOT run when LHS truthy ---
+function* orSc(): any {
+  return 7 || (yield 99);
+}
+const os: any = orSc();
+const osr = os.next();
+console.log("or-short:", osr.value, osr.done); // 7 true
+
+// --- ?? : RHS runs only when LHS is null/undefined ---
+function* coalRun(): any {
+  return null ?? (yield 5);
+}
+const co: any = coalRun();
+const coA = co.next();
+const coB = co.next(123);
+console.log("coal-run:", coA.value, coB.value); // 5 123
+
+function* coalSc(): any {
+  return 8 ?? (yield 5);
+}
+const cs: any = coalSc();
+const csr = cs.next();
+console.log("coal-short:", csr.value, csr.done); // 8 true
+
+// --- ternary: only the taken branch's yield runs ---
+function* tern(cond: boolean): any {
+  return cond ? (yield 1) : (yield 2);
+}
+const tt: any = tern(true);
+const ttA = tt.next();
+const ttB = tt.next(50);
+console.log("tern-true:", ttA.value, ttB.value); // 1 50
+const tf: any = tern(false);
+const tfA = tf.next();
+const tfB = tf.next(60);
+console.log("tern-false:", tfA.value, tfB.value); // 2 60
+
+// --- yield* inside an expression (delegated completion values combined) ---
+function* inner(n: number): any {
+  const r = yield n;
+  return r + n;
+}
+function* deleg(): any {
+  return (yield* inner(1)) + (yield* inner(2));
+}
+const d: any = deleg();
+console.log(JSON.stringify(d.next())); // {"value":1,"done":false}
+console.log(JSON.stringify(d.next(10))); // {"value":2,"done":false}
+console.log(JSON.stringify(d.next(20))); // {"value":33,"done":true}
+
+console.log("ALL MULTI-YIELD-EXPR TESTS PASSED");


### PR DESCRIPTION
## Problem

Multiple `yield` / `yield*` inside a single expression produced the wrong
(undefined) result. The generator linearizer only special-cased a yield at
statement position (`yield E;`), simple-binding position (`let x = yield E;`),
and return-of-yield position (`return yield E;` / `return yield* E;`). A yield
buried inside a larger expression fell into the linearizer catch-all, so the
whole expression was emitted as one unsplit statement and each `Expr::Yield`
was lowered by the codegen "generators not implemented" arm (evaluate operand
for side effects, return `0.0`). The resumed value was dropped and the
generator never suspended at the buried yields, so it finished on the first
`.next()`.

Pure-generator repro (no Effect):

```ts
function* g(): any { return (yield 1) + (yield 2); }
const it = g();
it.next();              // {value:1, done:false}
it.next(10);            // resume 1st yield with 10
const r = it.next(20);  // resume 2nd yield with 20 -> 10+20
console.log(r.value);   // Node: 30   Perry (before): undefined
```

The bound form (`const a = yield 1; const b = yield 2; return a + b;`) already
worked — the gap was specifically multiple yields inside a single binary /
arith / call / array / short-circuit / ternary expression. This is a general
generator bug that broadly affects `Effect.gen` (#321), whose generators
combine multiple `yield*` results in one expression.

## Fix

New pre-pass `crates/perry-transform/src/generator/hoist_yields.rs`, run at the
top of `transform_generator_function_with_extra_captures` before
`linearize_body`. It walks each statement left-to-right and hoists every
`yield` / `yield*` that lives in a non-handled position into an ordered
`let __ygen_N = yield <E>;` temp, replacing the occurrence with a read of the
temp. The existing let-init arms then split each into a suspend/resume state
and bind the resumed value to the temp; the remaining (now yield-free)
combining expression evaluates against the temps. The temps land as
`Stmt::Let` in the body so `collect_hoisted_vars` boxes / preallocates them
like any other hoisted local (cross-state reads work via the captured box).

Evaluation order is preserved (children visited in evaluation order, each
hoisted let appended in order). Short-circuiting (`&&`, `||`, `??`) and the
ternary `?:` are handled by lifting into a temp + `if`-statement so a yield on
a not-taken path only runs when that path is taken — mirroring the existing
conditional-await lift in `async_to_generator.rs`. Nested closures are not
descended into. Covers both `yield` and `yield*`.

This is structurally the generator analogue of the established
`hoist_awaits_in_stmts` async pre-pass; it is a no-op on async-derived bodies
(await-hoisting already lifted those yields to top-level positions) and a no-op
on the bound form (no yield buried in the combining expression).

## Verification

All byte-identical to `node --experimental-strip-types`:

- `(yield 1) + (yield 2)` -> 30; three-yield -> 60
- array literal `[yield 1, yield 2]`, call args `add3(yield 1, yield 2, yield 3)`
- `&&` / `||` / `??` short-circuit (both the taken and short-circuited paths)
- ternary `cond ? (yield a) : (yield b)` (both branches)
- `yield*` in an expression: `(yield* inner(1)) + (yield* inner(2))`
- Effect: `Effect.runSync(Effect.gen(function*(){ return (yield* Effect.succeed(7)) + (yield* Effect.succeed(8)); }))` -> 15
- New gap test `test-files/test_gap_generator_multi_yield_expr.ts` is byte-identical
- No regression: all existing generator gap tests
  (`test_gap_generators`, `test_gap_generator_expressions`,
  `test_gap_yield_star_resume` / `_return` / `_iterable`,
  `test_gap_yieldstar_inherited_iterator_this`) still byte-identical
- `cargo test -p perry-transform -p perry-hir`, `cargo test -p perry-runtime --lib`: pass
- `cargo fmt --all -- --check`: clean
