### PR TITLE
fix(node:stream): reject nullish Readable.from input

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -328,6 +328,15 @@ fn throw_writable_null_chunk() -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
+#[cold]
+fn throw_readable_from_invalid_iterable() -> ! {
+    let msg = b"The \"iterable\" argument must be an instance of Iterable.";
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    crate::node_submodules::register_error_code_pub(s, "ERR_INVALID_ARG_TYPE");
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
 fn write_writable_chunk(stream: f64, chunk: f64, enc: f64) -> f64 {
     if JSValue::from_bits(chunk.to_bits()).is_null() {
         throw_writable_null_chunk();
@@ -2252,6 +2261,10 @@ pub extern "C" fn js_node_stream_passthrough_new(_opts: f64) -> f64 {
 /// `node:stream/consumers` can drain the current stub stream surface.
 #[no_mangle]
 pub extern "C" fn js_node_stream_readable_from(iterable: f64) -> f64 {
+    if matches!(iterable.to_bits(), TAG_NULL | TAG_UNDEFINED) {
+        throw_readable_from_invalid_iterable();
+    }
+
     let readable = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
     let raw = raw_ptr_from_value(readable);
     if raw >= 0x10000 {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -824,12 +824,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: pipeTo preventClose option not honored. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/readable/from-null-throws": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.from(null) / from(undefined) does not throw. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/finished/readable-false-option": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- throw a `TypeError` / `ERR_INVALID_ARG_TYPE` when `Readable.from()` receives `null` or `undefined` as the iterable argument
- keep the existing yielded-null chunk path and iterable/data delivery behavior out of scope
- remove the now-passing `node-suite/stream/readable/from-null-throws` known failure

## Verification
- Baseline before fix: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/readable/from-null-throws` failed with Perry `null threw: false`, report `test-parity/reports/parity_report_20260527_141738.json`
- `cargo test -p perry-runtime node_stream --lib`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD`
- Exact parity: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/readable/from-null-throws` PASS 1/1, report `test-parity/reports/parity_report_20260527_142131.json`
- Guardrail: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/readable/from-` kept `from-null-throws` green and still failed existing iterable/generator/non-iterable/options residuals, report `test-parity/reports/parity_report_20260527_142211.json`

## DeepWiki
- Local-only note: `reference/deepwiki/nodejs-node-stream-readable-from-nullish-throws-2026-05-27.md`
- Invariant used: `Readable.from(iterable)` throws synchronous `ERR_INVALID_ARG_TYPE` / `TypeError` when the iterable argument is `null` or `undefined`; a valid iterable yielding `null` is a separate `ERR_STREAM_NULL_VALUES` path.

## Non-goals
- no validation for arbitrary non-iterables
- no generator or async iterable consumption changes
- no yielded-null chunk error-path changes
- no objectMode/from options work
- no stream data-delivery changes