### PR TITLE
fix(node:stream): expose readable wrap method

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -1858,7 +1858,7 @@ pub(crate) fn js_node_stream_readable_chunks_result(stream: f64) -> Result<Optio
 // Writable, and Duplex method tables stay in distinct shape bands.
 // ─────────────────────────────────────────────────────────────────
 
-fn readable_methods() -> [(&'static str, StubFn); 37] {
+fn readable_methods() -> [(&'static str, StubFn); 38] {
     [
         ("on", cast2(ns_on2)),
         ("once", cast2(ns_once2)),
@@ -1878,6 +1878,7 @@ fn readable_methods() -> [(&'static str, StubFn); 37] {
         ("read", cast1(ns_read1)),
         ("pipe", cast1(ns_pipe1)),
         ("unpipe", cast1(ns_chain1)),
+        ("wrap", cast1(ns_chain1)),
         ("pause", cast0(ns_chain0)),
         ("resume", cast0(ns_resume0)),
         ("destroy", cast1(ns_destroy1)),
@@ -1933,7 +1934,7 @@ fn writable_methods() -> [(&'static str, StubFn); 22] {
     ]
 }
 
-fn duplex_methods() -> [(&'static str, StubFn); 28] {
+fn duplex_methods() -> [(&'static str, StubFn); 29] {
     // Union of readable + writable, deduped (`on/once/off/addListener/
     // removeListener/removeAllListeners/emit/listenerCount/listeners/
     // destroy` appear once each).
@@ -1956,6 +1957,7 @@ fn duplex_methods() -> [(&'static str, StubFn); 28] {
         ("read", cast1(ns_read1)),
         ("pipe", cast1(ns_pipe1)),
         ("unpipe", cast1(ns_chain1)),
+        ("wrap", cast1(ns_chain1)),
         ("pause", cast0(ns_chain0)),
         ("resume", cast0(ns_resume0)),
         ("setEncoding", cast1(ns_chain1)),

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -229,6 +229,19 @@ fn stream_methods_dispatch_through_dynamic_method_call() {
 }
 
 #[test]
+fn readable_wrap_method_is_present_and_chainable() {
+    let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let obj = raw_ptr_from_value(stream) as *const ObjectHeader;
+    let wrap = js_object_get_field_by_name_f64(obj, hidden_key(b"wrap"));
+    assert_ne!(wrap.to_bits(), TAG_UNDEFINED);
+
+    let wrapped = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let args = [wrapped];
+    let result = unsafe { crate::closure::js_native_call_value(wrap, args.as_ptr(), args.len()) };
+    assert_eq!(result.to_bits(), stream.to_bits());
+}
+
+#[test]
 fn writable_cork_and_uncork_update_counter_and_return_undefined() {
     let stream = js_node_stream_writable_new(f64::from_bits(TAG_UNDEFINED));
     let handle = raw_ptr_from_value(stream) as i64;

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1808,12 +1808,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: TS readable.cancel — writable.write does not reject after. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/readable/readable-property-shape": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: stream instance methods — some typeof not 'function' (or missing). Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/for-await-on-transform": {
     "issue": "1545",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- expose a chainable `wrap` method on readable-side stream stubs
- add `wrap` to Readable and Duplex method tables for classic stream surface parity
- remove the now-passing `node-suite/stream/readable/readable-property-shape` known failure

## Verification
- Baseline before fix: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/readable/readable-property-shape` failed because Perry printed `wrap: undefined`, report `test-parity/reports/parity_report_20260527_142710.json`
- `cargo test -p perry-runtime readable_wrap_method_is_present_and_chainable --lib`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD`
- Exact parity: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/readable/readable-property-shape` PASS 1/1, report `test-parity/reports/parity_report_20260527_143147.json`
- Guardrail: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/readable/readable-` kept `readable-property-shape` green and still failed existing readable event/dataflow/identity residuals, report `test-parity/reports/parity_report_20260527_143310.json`

## DeepWiki
- Local-only note: `reference/deepwiki/nodejs-node-stream-readable-wrap-method-shape-2026-05-27.md`
- Invariant used: classic `Readable` instances expose `wrap(oldStream)` as a method, and the basic return contract is `this`.

## Non-goals
- no old-style stream event forwarding
- no pause/resume proxying
- no pipe-through behavior
- no wrap data-delivery implementation
- no full legacy stream adapter