### PR TITLE
fix(node:stream): expose Duplex allowHalfOpen

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2518,6 +2518,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("stream", "writable", true, None),
     method("stream", "writableEnded", true, None),
     method("stream", "writableFinished", true, None),
+    method("stream", "allowHalfOpen", true, None),
     method("stream", "destroyed", true, None),
     // --- child_process (synchronous + async exec surface;
     //     spawn/fork are documented but not yet codegen'd) ---

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -827,6 +827,15 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "stream",
         has_receiver: true,
+        method: "allowHalfOpen",
+        class_filter: None,
+        runtime: "js_node_stream_method_allow_half_open",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
         method: "destroyed",
         class_filter: None,
         runtime: "js_node_stream_method_destroyed",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -881,6 +881,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_method_writable", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_writable_ended", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_writable_finished", DOUBLE, &[I64]);
+    module.declare_function("js_node_stream_method_allow_half_open", DOUBLE, &[I64]);
 
     // ========== Event emitter ==========
     module.declare_function("js_event_emitter_emit", DOUBLE, &[I64, I64, I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -521,6 +521,13 @@ pub extern "C" fn js_node_stream_method_writable_finished(stream_handle: i64) ->
 }
 
 #[no_mangle]
+pub extern "C" fn js_node_stream_method_allow_half_open(stream_handle: i64) -> f64 {
+    let stream = stream_value_from_handle(stream_handle);
+    get_hidden_value(stream, hidden_key(b"allowHalfOpen"))
+        .unwrap_or_else(|| f64::from_bits(TAG_UNDEFINED))
+}
+
+#[no_mangle]
 pub extern "C" fn js_node_stream_method_read(stream_handle: i64, _n: f64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
     mark_stream_ended(stream);
@@ -2172,6 +2179,21 @@ fn init_writable_state(stream: f64, opts: f64) {
     set_visible_writable_finished(stream, false);
 }
 
+fn init_duplex_state(stream: f64, opts: f64) {
+    let allow_half_open = if get_hidden_value(opts, hidden_key(b"allowHalfOpen"))
+        .is_some_and(|v| v.to_bits() == TAG_FALSE)
+    {
+        TAG_FALSE
+    } else {
+        TAG_TRUE
+    };
+    set_hidden_value(
+        stream,
+        hidden_key(b"allowHalfOpen"),
+        f64::from_bits(allow_half_open),
+    );
+}
+
 fn init_abort_signal_state(stream: f64, opts: f64) {
     if let Some(signal) = options_signal(opts) {
         attach_abort_signal(signal, stream);
@@ -2226,6 +2248,7 @@ pub extern "C" fn js_node_stream_duplex_new(opts: f64) -> f64 {
     init_constructor(duplex, "Duplex");
     init_readable_state(duplex, opts);
     init_writable_state(duplex, opts);
+    init_duplex_state(duplex, opts);
     init_abort_signal_state(duplex, opts);
     async_iterator::install_readable_async_iterator_symbol(duplex);
     duplex

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -42,6 +42,9 @@ static KEEP_NS_METHOD_WRITABLE_ENDED: extern "C" fn(i64) -> f64 =
 static KEEP_NS_METHOD_WRITABLE_FINISHED: extern "C" fn(i64) -> f64 =
     super::js_node_stream_method_writable_finished;
 #[used]
+static KEEP_NS_METHOD_ALLOW_HALF_OPEN: extern "C" fn(i64) -> f64 =
+    super::js_node_stream_method_allow_half_open;
+#[used]
 static KEEP_NS_METHOD_RESUME: extern "C" fn(i64) -> f64 = super::js_node_stream_method_resume;
 #[used]
 static KEEP_NS_METHOD_DESTROY: extern "C" fn(i64, f64) -> f64 =

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -573,6 +573,39 @@ fn readable_lifecycle_flags_reflect_ended_state() {
 }
 
 #[test]
+fn duplex_allow_half_open_defaults_true_and_honors_false_option() {
+    let stream = js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let obj = raw_ptr_from_value(stream) as *const ObjectHeader;
+    assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"allowHalfOpen")).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        js_node_stream_method_allow_half_open(handle).to_bits(),
+        TAG_TRUE
+    );
+
+    let opts = crate::object::js_object_alloc(0, 1);
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"allowHalfOpen"),
+        f64::from_bits(TAG_FALSE),
+    );
+    let stream = js_node_stream_duplex_new(box_pointer(opts as *const u8));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let obj = raw_ptr_from_value(stream) as *const ObjectHeader;
+    assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"allowHalfOpen")).to_bits(),
+        TAG_FALSE
+    );
+    assert_eq!(
+        js_node_stream_method_allow_half_open(handle).to_bits(),
+        TAG_FALSE
+    );
+}
+
+#[test]
 fn writable_corked_counter_tracks_cork_balance() {
     let stream = js_node_stream_writable_new(f64::from_bits(TAG_UNDEFINED));
     let handle = raw_ptr_from_value(stream) as i64;

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -452,12 +452,6 @@
     "category": "bug-open",
     "reason": "node:stream: calling PassThrough() without `new` should auto-instantiate; Perry behavior differs. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/duplex/allow-half-open": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Duplex.allowHalfOpen option not surfaced on instance. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/iterator/destroy-on-return-false": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -637,12 +631,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: class extends Writable + _write doesn't deliver finish. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/duplex/allow-half-open-default": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Duplex default allowHalfOpen not surfaced. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/backpressure/drain-after-overflow": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- initialize classic Duplex `allowHalfOpen` to `true` unless constructor options explicitly set it to `false`
- add typed/native getter wiring for compiled `stream.allowHalfOpen` reads
- remove the two now-passing stream Duplex allow-half-open known failures

## Verification
- DeepWiki note saved locally: `reference/deepwiki/nodejs-node-stream-duplex-allow-half-open-2026-05-27.md`
- Baseline exact failure: `test-parity/reports/parity_report_20260527_143811.json`
- Baseline combined failure: `test-parity/reports/parity_report_20260527_143907.json`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/duplex/allow-half-open` PASS 2/2, report `test-parity/reports/parity_report_20260527_144954.json`
- `cargo test -p perry-runtime duplex_allow_half_open_defaults_true_and_honors_false_option --lib`
- `cargo test -p perry-codegen --lib native_table`
- `cargo test -p perry-api-manifest`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD`

## Non-goals
- no half-open lifecycle behavior changes
- no readable/writable side end propagation changes
- no `net.Socket` / TLS socket `allowHalfOpen` semantics
- no broader stream close/end event rewrite
