### PR TITLE
fix(node:stream): throw when pipe destination is missing

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -280,9 +280,25 @@ fn chunk_byte_len(chunk: f64) -> usize {
     1
 }
 extern "C" fn ns_pipe1(_closure: *const ClosureHeader, dest: f64) -> f64 {
+    if pipe_destination_is_missing(dest) {
+        throw_readable_pipe_missing_destination();
+    }
     // Node's `Readable.pipe(dest)` returns `dest` to allow `r.pipe(a).pipe(b)`.
     dest
 }
+
+fn pipe_destination_is_missing(dest: f64) -> bool {
+    let value = JSValue::from_bits(dest.to_bits());
+    value.is_undefined() || value.is_null()
+}
+
+#[cold]
+fn throw_readable_pipe_missing_destination() -> ! {
+    crate::node_submodules::diagnostics::throw_type_error_no_code(
+        b"Cannot read properties of undefined (reading 'on')",
+    )
+}
+
 extern "C" fn writable_write_callback_noop(_closure: *const ClosureHeader) -> f64 {
     f64::from_bits(TAG_UNDEFINED)
 }

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -229,6 +229,16 @@ fn stream_methods_dispatch_through_dynamic_method_call() {
 }
 
 #[test]
+fn readable_pipe_stub_returns_destination_and_rejects_missing_destination() {
+    let dest = js_node_stream_writable_new(f64::from_bits(TAG_UNDEFINED));
+
+    assert_eq!(ns_pipe1(std::ptr::null(), dest).to_bits(), dest.to_bits());
+    assert!(pipe_destination_is_missing(f64::from_bits(TAG_UNDEFINED)));
+    assert!(pipe_destination_is_missing(f64::from_bits(TAG_NULL)));
+    assert!(!pipe_destination_is_missing(dest));
+}
+
+#[test]
 fn writable_cork_and_uncork_update_counter_and_return_undefined() {
     let stream = js_node_stream_writable_new(f64::from_bits(TAG_UNDEFINED));
     let handle = raw_ptr_from_value(stream) as i64;

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1760,12 +1760,6 @@
     "category": "bug-open",
     "reason": "node:stream: every(asyncFn) — fn rejection does not propagate as Promise reject. Flips to PASS when #1558 lands."
   },
-  "node-suite/stream/pipe/pipe-no-args-throws": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pipe() with no args — does not throw TypeError. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/iter-helpers/find-async-fn": {
     "issue": "1558",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- reject `Readable.pipe()` calls whose destination is `undefined` or `null`
- preserve the existing `pipe(dest) -> dest` return behavior for valid destinations
- remove the now-passing `pipe-no-args-throws` known failure

## Verification
- DeepWiki note saved locally: `reference/deepwiki/nodejs-node-stream-readable-pipe-no-destination-2026-05-27.md`
- Baseline exact failure: `test-parity/reports/parity_report_20260527_145516.json`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/pipe/pipe-no-args-throws` PASS 1/1, report `test-parity/reports/parity_report_20260527_145906.json`
- `cargo test -p perry-runtime readable_pipe_stub_returns_destination_and_rejects_missing_destination --lib`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD`

## Guardrail
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/pipe/pipe-` kept `pipe-no-args-throws` green and still failed existing pipe listener/dataflow/autodestroy residuals, report `test-parity/reports/parity_report_20260527_145954.json`

## Non-goals
- no pipe data transfer
- no destination listener setup
- no end propagation, pause/resume/backpressure, autodestroy, or duplicate-pipe behavior
- no full pipe state-machine implementation
