### PR TITLE
fix(node:stream): return stream from pause

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2500,6 +2500,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // Core stream instance stubs used by stream/promises and the
     // Readable/Writable/Duplex/Transform/PassThrough constructor surface.
     method("stream", "read", true, None),
+    method("stream", "pause", true, None),
     method("stream", "resume", true, None),
     method("stream", "destroy", true, None),
     method("stream", "write", true, None),

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -836,6 +836,15 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "stream",
         has_receiver: true,
+        method: "pause",
+        class_filter: None,
+        runtime: "js_node_stream_method_pause",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
         method: "resume",
         class_filter: None,
         runtime: "js_node_stream_method_resume",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -873,6 +873,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_method_readable_aborted", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroyed", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroy", DOUBLE, &[I64, DOUBLE]);
+    module.declare_function("js_node_stream_method_pause", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_readable", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_readable_ended", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_cork", DOUBLE, &[I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -539,6 +539,11 @@ pub extern "C" fn js_node_stream_method_resume(stream_handle: i64) -> f64 {
 }
 
 #[no_mangle]
+pub extern "C" fn js_node_stream_method_pause(stream_handle: i64) -> f64 {
+    stream_value_from_handle(stream_handle)
+}
+
+#[no_mangle]
 pub extern "C" fn js_node_stream_method_write(stream_handle: i64, chunk: f64, enc: f64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
     write_writable_chunk(stream, chunk, enc)

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -42,6 +42,8 @@ static KEEP_NS_METHOD_WRITABLE_ENDED: extern "C" fn(i64) -> f64 =
 static KEEP_NS_METHOD_WRITABLE_FINISHED: extern "C" fn(i64) -> f64 =
     super::js_node_stream_method_writable_finished;
 #[used]
+static KEEP_NS_METHOD_PAUSE: extern "C" fn(i64) -> f64 = super::js_node_stream_method_pause;
+#[used]
 static KEEP_NS_METHOD_RESUME: extern "C" fn(i64) -> f64 = super::js_node_stream_method_resume;
 #[used]
 static KEEP_NS_METHOD_DESTROY: extern "C" fn(i64, f64) -> f64 =

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -686,6 +686,17 @@ fn stream_destroy_with_error_marks_errored_state() {
 }
 
 #[test]
+fn readable_pause_native_dispatch_returns_stream() {
+    let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let handle = raw_ptr_from_value(stream) as i64;
+
+    assert_eq!(
+        js_node_stream_method_pause(handle).to_bits(),
+        stream.to_bits()
+    );
+}
+
+#[test]
 fn readable_aborted_reflects_destroy_before_end() {
     let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
     let handle = raw_ptr_from_value(stream) as i64;

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1046,12 +1046,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose() — error in middle transform does not propagate to composite 'error' event. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/chain/destroy-pause-resume-return-this": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pause()/resume()/destroy() don't all return `this` — chainability broken on one or more. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/tostring-tag-web-classes": {
     "issue": "1545",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- add typed/native receiver dispatch for classic stream `pause()`
- return the receiver stream from `pause()` to match Node chainability
- remove the now-passing `destroy-pause-resume-return-this` known failure

## Verification
- DeepWiki note saved locally: `reference/deepwiki/nodejs-node-stream-readable-chain-return-this-2026-05-27.md`
- Baseline exact failure: `test-parity/reports/parity_report_20260527_150306.json`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/chain/destroy-pause-resume-return-this` PASS 1/1, report `test-parity/reports/parity_report_20260527_150830.json`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/chain/` PASS 1/1, report `test-parity/reports/parity_report_20260527_150920.json`
- `cargo test -p perry-runtime readable_pause_native_dispatch_returns_stream --lib`
- `cargo test -p perry-codegen --lib native_table`
- `cargo test -p perry-api-manifest`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD`

## Non-goals
- no readableFlowing state changes
- no pause/resume event ordering changes
- no dataflow scheduling or `isPaused()` semantics
- no broader stream flow-state rewrite
