### PR TITLE
fix(node:stream): expose async dispose method

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -209,6 +209,12 @@ extern "C" fn ns_resume0(closure: *const ClosureHeader) -> f64 {
     stream
 }
 
+extern "C" fn ns_async_dispose(closure: *const ClosureHeader) -> f64 {
+    let stream = this_value(closure);
+    destroy_stream(stream, abort_error());
+    resolved_promise(f64::from_bits(TAG_UNDEFINED))
+}
+
 extern "C" fn ns_read1(closure: *const ClosureHeader, _n: f64) -> f64 {
     let stream = this_value(closure);
     mark_stream_ended(stream);
@@ -1146,6 +1152,7 @@ fn register_stub_arities() {
     register(ns_emit2 as *const u8, 2);
     crate::closure::js_register_closure_rest(ns_emit_rest as *const u8, 1);
     register(ns_resume0 as *const u8, 0);
+    register(ns_async_dispose as *const u8, 0);
     register(ns_read1 as *const u8, 1);
     register(ns_pipe1 as *const u8, 1);
     register(writable_write_callback_noop as *const u8, 0);
@@ -1167,6 +1174,22 @@ fn register_stub_arities() {
 #[inline]
 fn box_pointer(ptr: *const u8) -> f64 {
     f64::from_bits(JSValue::pointer(ptr).bits())
+}
+
+fn install_stream_async_dispose_symbol(stream: f64) {
+    let async_dispose = crate::symbol::well_known_symbol("asyncDispose");
+    if async_dispose.is_null() {
+        return;
+    }
+    let closure = js_closure_alloc(ns_async_dispose as *const u8, 1);
+    crate::closure::js_closure_set_capture_ptr(closure, 0, stream.to_bits() as i64);
+    unsafe {
+        crate::symbol::js_object_set_symbol_property(
+            stream,
+            box_pointer(async_dispose as *const u8),
+            box_pointer(closure as *const u8),
+        );
+    }
 }
 
 #[inline]
@@ -2192,6 +2215,7 @@ pub extern "C" fn js_node_stream_readable_new(opts: f64) -> f64 {
     init_readable_state(readable, opts);
     init_abort_signal_state(readable, opts);
     async_iterator::install_readable_async_iterator_symbol(readable);
+    install_stream_async_dispose_symbol(readable);
     readable
 }
 
@@ -2211,6 +2235,7 @@ pub extern "C" fn js_node_stream_writable_new(opts: f64) -> f64 {
     init_constructor(writable, "Writable");
     init_writable_state(writable, opts);
     init_abort_signal_state(writable, opts);
+    install_stream_async_dispose_symbol(writable);
     writable
 }
 
@@ -2228,6 +2253,7 @@ pub extern "C" fn js_node_stream_duplex_new(opts: f64) -> f64 {
     init_writable_state(duplex, opts);
     init_abort_signal_state(duplex, opts);
     async_iterator::install_readable_async_iterator_symbol(duplex);
+    install_stream_async_dispose_symbol(duplex);
     duplex
 }
 

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -686,6 +686,24 @@ fn stream_destroy_with_error_marks_errored_state() {
 }
 
 #[test]
+fn readable_exposes_async_dispose_symbol_method() {
+    let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let async_dispose = crate::symbol::well_known_symbol("asyncDispose");
+    let method = unsafe {
+        crate::symbol::js_object_get_symbol_property(
+            stream,
+            box_pointer(async_dispose as *const u8),
+        )
+    };
+
+    assert!(is_callable_value(method));
+    let result = unsafe { crate::closure::js_native_call_value(method, std::ptr::null(), 0) };
+    assert_ne!(result.to_bits(), TAG_UNDEFINED);
+    assert_eq!(js_node_stream_method_destroyed(handle).to_bits(), TAG_TRUE);
+}
+
+#[test]
 fn readable_aborted_reflects_destroy_before_end() {
     let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
     let handle = raw_ptr_from_value(stream) as i64;

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -782,12 +782,6 @@
     "category": "bug-open",
     "reason": "node:stream: stream.compose(single-transform) does not deliver data through. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/dispose/async-dispose": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Symbol.asyncDispose (Node 21+ explicit disposal protocol) not implemented on stream instances. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/ee/get-event-listeners": {
     "issue": "1531",
     "added": "2026-05-23",
@@ -835,12 +829,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: finished({readable:false}) does not fire callback on writable-only close. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/dispose/sync-dispose": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Symbol.dispose presence on stream instances (Node 21+) misreports. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/duplex-pair/wired-comms": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- install a `Symbol.asyncDispose` method on classic stream stubs
- have the method use the existing destroy-with-AbortError path and return a resolved Promise
- remove the now-passing async-dispose known failure plus the stale sync-dispose known failure

## Verification
- DeepWiki note saved locally: `reference/deepwiki/nodejs-node-stream-readable-async-dispose-shape-2026-05-27.md`
- Baseline exact failure: `test-parity/reports/parity_report_20260527_151302.json`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/dispose/async-dispose` PASS 1/1, report `test-parity/reports/parity_report_20260527_151816.json`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/dispose/sync-dispose` PASS 2/2, report `test-parity/reports/parity_report_20260527_152037.json`
- `cargo test -p perry-runtime readable_exposes_async_dispose_symbol_method --lib`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD`

## Guardrail
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/dispose/` kept `async-dispose`, `sync-dispose`, and `sync-dispose-call` green and still failed existing `await-using-disposes`, report `test-parity/reports/parity_report_20260527_151955.json`

## Non-goals
- no `await using` desugaring fix
- no end-of-stream Promise timing or rejection behavior
- no full AbortError/eos lifecycle fidelity
- no broader explicit resource management rewrite
