### PR TITLE
fix(node:events): return stream listeners

### DIFF
--- a/crates/perry-ext-events/src/lib.rs
+++ b/crates/perry-ext-events/src/lib.rs
@@ -68,6 +68,7 @@ extern "C" {
     ) -> *mut ArrayHeader;
     fn js_event_target_get_max_listeners(target: *mut u8) -> f64;
     fn js_event_target_set_max_listeners(target: *mut u8, n: f64) -> i32;
+    fn js_node_stream_method_listeners(stream_handle: i64, event: f64) -> i64;
     fn js_abort_signal_remove_listener(signal: *mut u8, event: f64, listener: f64);
     fn js_abort_signal_is_aborted(signal: *mut u8) -> i32;
     fn js_abort_error_value() -> f64;
@@ -213,6 +214,21 @@ unsafe fn event_target_ptr(handle: Handle) -> Option<*mut u8> {
     } else {
         None
     }
+}
+
+unsafe fn stream_listeners_for_heap_object(
+    handle: Handle,
+    event_name_ptr: *const StringHeader,
+) -> Option<*mut ArrayHeader> {
+    let addr = handle as u64;
+    if event_name_ptr.is_null()
+        || !(EVENT_TARGET_MIN_HEAP_POINTER..=MAX_HEAP_POINTER).contains(&addr)
+        || addr & 0x7 != 0
+    {
+        return None;
+    }
+    let event = f64::from_bits(nanbox_string_bits(event_name_ptr as *mut StringHeader));
+    Some(js_node_stream_method_listeners(handle, event) as *mut ArrayHeader)
 }
 
 fn handle_from_js_value_bits(bits: u64) -> Handle {
@@ -1047,6 +1063,9 @@ pub unsafe extern "C" fn js_events_get_event_listeners(
     }
     if let Some(target) = event_target_ptr(handle) {
         return js_event_target_get_event_listeners(target, event_name_ptr);
+    }
+    if let Some(listeners) = stream_listeners_for_heap_object(handle, event_name_ptr) {
+        return listeners;
     }
     js_array_alloc(0)
 }

--- a/crates/perry-stdlib/src/events.rs
+++ b/crates/perry-stdlib/src/events.rs
@@ -55,6 +55,24 @@ unsafe fn event_target_ptr(handle: Handle) -> Option<*mut ObjectHeader> {
     }
 }
 
+unsafe fn stream_listeners_for_heap_object(
+    handle: Handle,
+    event_name_ptr: *const StringHeader,
+) -> Option<*mut ArrayHeader> {
+    let addr = handle as u64;
+    if event_name_ptr.is_null()
+        || !(MIN_HEAP_POINTER..=MAX_HEAP_POINTER).contains(&addr)
+        || addr & 0x7 != 0
+    {
+        return None;
+    }
+    let event = js_nanbox_string(event_name_ptr as i64);
+    Some(
+        perry_runtime::node_stream::js_node_stream_method_listeners(handle, event)
+            as *mut ArrayHeader,
+    )
+}
+
 fn throw_max_listeners_out_of_range() -> ! {
     static REGISTER_RANGE_ERROR: std::sync::Once = std::sync::Once::new();
     REGISTER_RANGE_ERROR.call_once(|| {
@@ -1185,6 +1203,9 @@ pub unsafe extern "C" fn js_events_get_event_listeners(
             target,
             event_name_ptr,
         );
+    }
+    if let Some(listeners) = stream_listeners_for_heap_object(handle, event_name_ptr) {
+        return listeners;
     }
     js_event_emitter_listeners(handle, event_name_ptr)
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -788,12 +788,6 @@
     "category": "bug-open",
     "reason": "node:stream: Symbol.asyncDispose (Node 21+ explicit disposal protocol) not implemented on stream instances. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/ee/get-event-listeners": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:events.getEventListeners(stream, name) does not return the listener array. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/iterator/return-method": {
     "issue": "1531",
     "added": "2026-05-23",
@@ -1279,12 +1273,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: sequential read(N) drain — buffer order or chunk boundaries wrong. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/get-event-listeners-static": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: events.getEventListeners(emitter, event) — wrong listener array. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/async-iter-handler-rejection": {
     "issue": "1531",
@@ -2251,12 +2239,6 @@
     "added": "2026-05-25",
     "category": "bug-open",
     "reason": "node:stream: Readable.from(Set with duplicates) — count or order wrong (Set should dedup). Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/get-event-listeners-count": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: getEventListeners(emitter, event) — wrong count/array shape. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/from-bigint-throws": {
     "issue": "1545",


### PR DESCRIPTION
## Summary
- route events.getEventListeners(stream, event) through the existing classic stream listener table
- mirror the fallback in both stdlib and perry-ext-events event modules
- remove the three stream get-event-listeners known-failure entries that now pass

## Verification
- DeepWiki: reference/deepwiki/nodejs-node-events-geteventlisteners-stream-2026-05-27.md (local only)
- Baseline exact failure: test-parity/reports/parity_report_20260527_152513.json
- Exact pass: CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/ee/get-event-listeners -> test-parity/reports/parity_report_20260527_152837.json
- Guardrail pass before removal: CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter get-event-listeners -> test-parity/reports/parity_report_20260527_153009.json
- Guardrail pass after removal: CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter get-event-listeners -> test-parity/reports/parity_report_20260527_153116.json
- cargo test -p perry-stdlib --lib js_events_get_event_listeners
- cargo test -p perry-ext-events --lib js_events_get_event_listeners
- cargo fmt --check
- jq empty test-parity/known_failures.json
- git diff --check origin/main...HEAD -- crates/perry-stdlib/src/events.rs crates/perry-ext-events/src/lib.rs test-parity/known_failures.json

## Non-goals
- EventTarget listener mutation/copy semantics
- events.listenerCount / max-listener stream helper expansion
- stream listener storage rewrite or broader EventEmitter compatibility work