### PR TITLE
fix(node:stream): emit pause events

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2501,6 +2501,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // Readable/Writable/Duplex/Transform/PassThrough constructor surface.
     method("stream", "read", true, None),
     method("stream", "resume", true, None),
+    method("stream", "pause", true, None),
     method("stream", "destroy", true, None),
     method("stream", "write", true, None),
     method("stream", "end", true, None),

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -845,6 +845,15 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "stream",
         has_receiver: true,
+        method: "pause",
+        class_filter: None,
+        runtime: "js_node_stream_method_pause",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
         method: "destroy",
         class_filter: None,
         runtime: "js_node_stream_method_destroy",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -873,6 +873,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_method_readable_aborted", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroyed", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_destroy", DOUBLE, &[I64, DOUBLE]);
+    module.declare_function("js_node_stream_method_pause", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_readable", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_readable_ended", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_cork", DOUBLE, &[I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -120,6 +120,11 @@ fn this_value(closure: *const ClosureHeader) -> f64 {
 extern "C" fn ns_chain0(closure: *const ClosureHeader) -> f64 {
     this_value(closure)
 }
+extern "C" fn ns_pause0(closure: *const ClosureHeader) -> f64 {
+    let stream = this_value(closure);
+    let _ = emit_stream_event(stream, string_value(b"pause"), &[]);
+    stream
+}
 extern "C" fn ns_chain1(closure: *const ClosureHeader, _a: f64) -> f64 {
     this_value(closure)
 }
@@ -535,6 +540,13 @@ pub extern "C" fn js_node_stream_method_resume(stream_handle: i64) -> f64 {
     mark_stream_ended(stream);
     refresh_readable_aborted_flag(stream);
     mark_disturbed(stream);
+    stream
+}
+
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_pause(stream_handle: i64) -> f64 {
+    let stream = stream_value_from_handle(stream_handle);
+    let _ = emit_stream_event(stream, string_value(b"pause"), &[]);
     stream
 }
 
@@ -1127,6 +1139,7 @@ fn register_stub_arities() {
         crate::closure::js_register_closure_arity(func, arity);
     };
     register(ns_chain0 as *const u8, 0);
+    register(ns_pause0 as *const u8, 0);
     register(ns_chain1 as *const u8, 1);
     register(ns_destroy_error_microtask as *const u8, 0);
     register(ns_stream_abort_listener as *const u8, 0);
@@ -1878,7 +1891,7 @@ fn readable_methods() -> [(&'static str, StubFn); 37] {
         ("read", cast1(ns_read1)),
         ("pipe", cast1(ns_pipe1)),
         ("unpipe", cast1(ns_chain1)),
-        ("pause", cast0(ns_chain0)),
+        ("pause", cast0(ns_pause0)),
         ("resume", cast0(ns_resume0)),
         ("destroy", cast1(ns_destroy1)),
         ("setEncoding", cast1(ns_chain1)),
@@ -1956,7 +1969,7 @@ fn duplex_methods() -> [(&'static str, StubFn); 28] {
         ("read", cast1(ns_read1)),
         ("pipe", cast1(ns_pipe1)),
         ("unpipe", cast1(ns_chain1)),
-        ("pause", cast0(ns_chain0)),
+        ("pause", cast0(ns_pause0)),
         ("resume", cast0(ns_resume0)),
         ("setEncoding", cast1(ns_chain1)),
         ("isPaused", cast0(ns_undefined0)),

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -44,6 +44,8 @@ static KEEP_NS_METHOD_WRITABLE_FINISHED: extern "C" fn(i64) -> f64 =
 #[used]
 static KEEP_NS_METHOD_RESUME: extern "C" fn(i64) -> f64 = super::js_node_stream_method_resume;
 #[used]
+static KEEP_NS_METHOD_PAUSE: extern "C" fn(i64) -> f64 = super::js_node_stream_method_pause;
+#[used]
 static KEEP_NS_METHOD_DESTROY: extern "C" fn(i64, f64) -> f64 =
     super::js_node_stream_method_destroy;
 #[used]

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -11,6 +11,7 @@ thread_local! {
     static READABLE_END_COUNT: RefCell<usize> = const { RefCell::new(0) };
     static WRITABLE_FINISH_COUNT: RefCell<usize> = const { RefCell::new(0) };
     static WRITABLE_CLOSE_COUNT: RefCell<usize> = const { RefCell::new(0) };
+    static PAUSE_EVENT_MATCHES: RefCell<Vec<bool>> = const { RefCell::new(Vec::new()) };
 }
 
 fn string_value(s: &str) -> f64 {
@@ -81,6 +82,17 @@ extern "C" fn capture_finish_listener(_closure: *const ClosureHeader) -> f64 {
 
 extern "C" fn capture_close_listener(_closure: *const ClosureHeader) -> f64 {
     WRITABLE_CLOSE_COUNT.with(|count| *count.borrow_mut() += 1);
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn capture_pause_listener(closure: *const ClosureHeader) -> f64 {
+    let expected = crate::closure::js_closure_get_capture_f64(closure, 0);
+    let actual = crate::object::js_implicit_this_get();
+    PAUSE_EVENT_MATCHES.with(|matches| {
+        matches
+            .borrow_mut()
+            .push(actual.to_bits() == expected.to_bits())
+    });
     f64::from_bits(TAG_UNDEFINED)
 }
 
@@ -210,6 +222,37 @@ fn stream_method_closure_capture_wins_over_stale_implicit_this() {
 
     assert!(js_node_stream_is_stub_ended_after_read(stream));
     assert!(!stream_hidden_ended(other));
+}
+
+#[test]
+fn pause_emits_event_and_returns_stream() {
+    PAUSE_EVENT_MATCHES.with(|matches| matches.borrow_mut().clear());
+
+    let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let listener = js_closure_alloc(capture_pause_listener as *const u8, 1);
+    crate::closure::js_register_closure_arity(capture_pause_listener as *const u8, 0);
+    crate::closure::js_closure_set_capture_f64(listener, 0, stream);
+    let _ = js_node_stream_method_on(
+        handle,
+        string_value("pause"),
+        box_pointer(listener as *const u8),
+    );
+
+    let obj = raw_ptr_from_value(stream) as *const ObjectHeader;
+    let pause = js_object_get_field_by_name_f64(obj, hidden_key(b"pause"));
+    let dynamic_return =
+        unsafe { crate::closure::js_native_call_value(pause, std::ptr::null(), 0) };
+    assert_eq!(dynamic_return.to_bits(), stream.to_bits());
+
+    assert_eq!(
+        js_node_stream_method_pause(handle).to_bits(),
+        stream.to_bits()
+    );
+
+    PAUSE_EVENT_MATCHES.with(|matches| {
+        assert_eq!(matches.borrow().as_slice(), &[true, true]);
+    });
 }
 
 #[test]

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -608,12 +608,6 @@
     "category": "bug-open",
     "reason": "node:stream: read() with no arg should return the entire buffered chunk. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/pause-resume-events": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: pause/resume events don't fire. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/finished/options-config": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -1045,12 +1039,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: compose() — error in middle transform does not propagate to composite 'error' event. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/chain/destroy-pause-resume-return-this": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pause()/resume()/destroy() don't all return `this` — chainability broken on one or more. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/tostring-tag-web-classes": {
     "issue": "1545",
@@ -1657,12 +1645,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: events.once(stream, 'end') Promise — args shape wrong. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/pause-resume-event-order": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: multiple pause/resume cycles — event order wrong. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipeline/async-fn-rejection-propagates": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- emit the classic stream `pause` event from both dynamic object-method calls and typed receiver dispatch
- keep `pause()` chainable by returning the receiver stream
- remove the now-passing pause/resume event and pause chainability known-failure entries

## Verification
- DeepWiki: `reference/deepwiki/nodejs-node-stream-readable-pause-resume-events-2026-05-27.md`
- Baseline failures: `parity_report_20260527_155623.json`, `parity_report_20260527_155624.json`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/events/pause-resume-events` PASS, reports `parity_report_20260527_160309.json` and post-removal `parity_report_20260527_160411.json`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/events/pause-resume-event-order` PASS, reports `parity_report_20260527_160347.json` and post-removal `parity_report_20260527_160417.json`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/chain/destroy-pause-resume-return-this` PASS, reports `parity_report_20260527_160353.json` and post-removal `parity_report_20260527_160423.json`
- `cargo test -p perry-runtime pause_emits_event_and_returns_stream --lib`
- `cargo test -p perry-codegen --lib native_table`
- `cargo test -p perry-api-manifest`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check -- crates/perry-runtime/src/node_stream.rs crates/perry-runtime/src/node_stream_keepalive.rs crates/perry-runtime/src/node_stream_tests.rs crates/perry-codegen/src/lower_call/native_table/net_events.rs crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs crates/perry-api-manifest/src/entries.rs test-parity/known_failures.json`

## Non-goals
- no async `resume` event scheduling
- no readableFlowing state modeling or `isPaused` implementation
- no dataflow gating, pause/resume backpressure, or full stream flow-state rewrite

Fixes part of #1532.