### PR TITLE
fix(hir,codegen): array-typed class fields named stack/name + param-prop field types — effect SortedSet/RedBlackTree iteration (#321)

### DIFF
--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -1005,6 +1005,49 @@ pub(crate) fn is_definitely_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     }
 }
 
+/// Resolve the declared type of `<object>.<field>` when `object` is a
+/// known user class or interface that declares (or inherits) a field
+/// named `field`. Returns `None` when the receiver isn't a tracked
+/// class/interface, or when no such field is declared on it.
+///
+/// Used to keep name-only field heuristics (the Error `.message` /
+/// `.stack` / `.name` string assumption) from hijacking a user class
+/// whose own field happens to share that name with a non-string type
+/// (e.g. `effect`'s `RedBlackTreeIterator.stack: Array<...>` — #321).
+pub(crate) fn declared_field_type(ctx: &FnCtx<'_>, object: &Expr, field: &str) -> Option<HirType> {
+    let receiver_class = receiver_class_name(ctx, object)?;
+    if let Some(class) = ctx.classes.get(&receiver_class) {
+        if let Some(f) = class.fields.iter().find(|f| f.name == field) {
+            return Some(f.ty.clone());
+        }
+        // Walk the inheritance chain.
+        let mut parent = class.extends_name.as_deref();
+        while let Some(p) = parent {
+            let Some(pc) = ctx.classes.get(p) else { break };
+            if let Some(f) = pc.fields.iter().find(|f| f.name == field) {
+                return Some(f.ty.clone());
+            }
+            parent = pc.extends_name.as_deref();
+        }
+        return None;
+    }
+    if let Some(iface) = ctx.interfaces.get(&receiver_class) {
+        if let Some(p) = iface.properties.iter().find(|p| p.name == field) {
+            return Some(p.ty.clone());
+        }
+        for ext in &iface.extends {
+            if let HirType::Named(parent_name) = ext {
+                if let Some(parent_iface) = ctx.interfaces.get(parent_name) {
+                    if let Some(p) = parent_iface.properties.iter().find(|p| p.name == field) {
+                        return Some(p.ty.clone());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 pub(crate) fn is_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     match e {
         Expr::String(_) | Expr::WtfString(_) => true,
@@ -1148,9 +1191,28 @@ pub(crate) fn is_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         // all route through the runtime's GC_TYPE_ERROR dispatch and
         // return string pointers. Recognize them so chained calls like
         // `e.stack!.includes("...")` hit the string method fast path.
-        Expr::PropertyGet { property, .. }
+        //
+        // BUT this name-only heuristic must NOT hijack a user class /
+        // interface whose own field happens to be called `stack` /
+        // `name` / `message` with a non-string declared type. The
+        // RedBlackTreeIterator in `effect` has `readonly stack:
+        // Array<Node<K,V>>`; without this guard `this.stack[i]` was
+        // mis-lowered as a string `char_at` (garbage element reads →
+        // null SortedSet iteration, #321). When the receiver resolves
+        // to a concrete declared field type, defer to it; only fall
+        // back to the Error-string assumption when the receiver's type
+        // is genuinely unknown (a real caught `Error`/`unknown`/`any`).
+        Expr::PropertyGet { object, property }
             if matches!(property.as_str(), "message" | "stack" | "name") =>
         {
+            // If the receiver is a known user class / interface that
+            // *declares* a field with this name, that field's declared
+            // type wins over the name-only Error heuristic.
+            if let Some(declared) = declared_field_type(ctx, object, property) {
+                return matches!(declared, HirType::String);
+            }
+            // Otherwise it's an Error-shaped property (caught `e`,
+            // `unknown`/`any`, or an untracked receiver) → string.
             true
         }
         // Namespace `node:process` exports share the same runtime process

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -232,6 +232,48 @@ pub fn lower_class_decl(
             early_field_types.push((field_name, ty));
         }
     }
+    // TypeScript constructor parameter properties (`constructor(readonly
+    // stack: Node[])`) are class fields too, but they live on the
+    // constructor's param list rather than as `ClassProp` members — so the
+    // ClassProp loop above misses them. Without registering their declared
+    // types here, `const s = this.stack` inside a method infers `Any` (the
+    // `this.<field>` arm of `infer_type_from_expr` consults this registry),
+    // which knocks the subsequent `s[i]` element read off the array fast
+    // path. That mis-lowered `effect`'s `RedBlackTreeIterator` (whose
+    // `readonly stack: Array<Node<K,V>>` is a param-prop): a local alias
+    // `const stack = this.stack; stack[len-1]` returned garbage nodes, so
+    // in-order traversal lost the last node and SortedSet iteration came
+    // back short (#321). Mirror the param-prop field detection that runs
+    // later (when `fields` is built) so the early registry agrees.
+    for member in &class_decl.class.body {
+        if let ast::ClassMember::Constructor(ctor) = member {
+            for param in &ctor.params {
+                if let ast::ParamOrTsParamProp::TsParamProp(ts_prop) = param {
+                    let (param_name, param_type) = match &ts_prop.param {
+                        ast::TsParamPropParam::Ident(ident) => {
+                            let pname = ident.id.sym.to_string();
+                            let ty = ident
+                                .type_ann
+                                .as_ref()
+                                .map(|ann| extract_ts_type_with_ctx(&ann.type_ann, Some(ctx)))
+                                .unwrap_or(Type::Any);
+                            (pname, ty)
+                        }
+                        ast::TsParamPropParam::Assign(assign) => {
+                            let pname = get_pat_name(&assign.left).unwrap_or_default();
+                            let ty = extract_param_type_with_ctx(&assign.left, Some(ctx));
+                            (pname, ty)
+                        }
+                    };
+                    if !param_name.is_empty()
+                        && !early_field_types.iter().any(|(n, _)| *n == param_name)
+                    {
+                        early_field_types.push((param_name, param_type));
+                    }
+                }
+            }
+        }
+    }
     ctx.register_class_field_types(name.clone(), early_field_types);
 
     let mut fields = Vec::new();

--- a/test-files/test_gap_class_field_named_stack_index.ts
+++ b/test-files/test_gap_class_field_named_stack_index.ts
@@ -1,0 +1,117 @@
+// #321 (effect `SortedSet` / `RedBlackTree` iteration): indexing into a
+// class instance array field named `stack` / `name` / `message` must read a
+// real array element, NOT a string character.
+//
+// Perry has a name-only heuristic that classifies `<x>.message` / `<x>.stack`
+// / `<x>.name` as a string (for caught-Error `.stack.includes(...)` chains).
+// That heuristic wrongly hijacked a USER class whose own field happened to be
+// named `stack` with a non-string declared type: `this.stack[i]` lowered as a
+// string `char_at` and returned garbage. effect's `RedBlackTreeIterator` has
+// `readonly stack: Array<Node<K,V>>`, so `this.stack[this.stack.length - 1]`
+// read bogus nodes — SortedSet iteration came back as `[null, null]`.
+//
+// The fix: when the receiver is a known class/interface that declares a field
+// with that name, the field's declared type wins over the Error heuristic.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+interface TreeNode {
+  key: number;
+  left: TreeNode | undefined;
+  right: TreeNode | undefined;
+}
+
+// A class with array/object fields named exactly `stack`, `name`, `message`.
+class Walker {
+  stack: TreeNode[];
+  name: number[];
+  message: { v: number }[];
+  constructor(stack: TreeNode[], name: number[], message: { v: number }[]) {
+    this.stack = stack;
+    this.name = name;
+    this.message = message;
+  }
+  // (1) direct `this.stack[i]` index — must read a node, not a char.
+  topKey(): number {
+    return this.stack[this.stack.length - 1].key;
+  }
+  // (2) `this.name[i]` numeric-array index.
+  firstName(): number {
+    return this.name[0];
+  }
+  // (3) `this.message[i].v` index-then-member.
+  firstMessageV(): number {
+    return this.message[0].v;
+  }
+  // (4) local alias of the array field, then element index — the moveNext
+  //     shape (`const stack = this.stack; stack[stack.length - 1]`).
+  topKeyViaAlias(): number {
+    const stack = this.stack;
+    const n = stack[stack.length - 1];
+    return n.key;
+  }
+}
+
+const n1: TreeNode = { key: 1, left: undefined, right: undefined };
+const n3: TreeNode = { key: 3, left: undefined, right: undefined };
+const n2: TreeNode = { key: 2, left: n1, right: n3 };
+
+const w = new Walker([n2, n1], [10, 20], [{ v: 7 }, { v: 8 }]);
+console.log("topKey:", w.topKey());
+console.log("firstName:", w.firstName());
+console.log("firstMessageV:", w.firstMessageV());
+console.log("topKeyViaAlias:", w.topKeyViaAlias());
+
+// (5) The genuine Error `.message` / `.stack` string path must STILL work —
+//     the heuristic only yields to *declared* class fields.
+try {
+  throw new Error("boom");
+} catch (e) {
+  const err = e as Error;
+  console.log("err.message len:", err.message.length);
+  console.log("err.message upper:", err.message.toUpperCase());
+}
+
+// (6) An in-order stack walk that pushes/pops the array field via a local
+//     alias and reads `node.right` identity — the RedBlackTree moveNext.
+class InOrder {
+  stack: TreeNode[];
+  out: number[];
+  constructor(root: TreeNode) {
+    this.stack = [];
+    this.out = [];
+    let n: TreeNode | undefined = root;
+    while (n != null) {
+      this.stack.push(n);
+      n = n.left;
+    }
+  }
+  run(): number[] {
+    while (this.stack.length > 0) {
+      const top = this.stack[this.stack.length - 1];
+      this.out.push(top.key);
+      this.moveNext();
+    }
+    return this.out;
+  }
+  moveNext(): void {
+    const stack = this.stack;
+    if (stack.length === 0) return;
+    let n: TreeNode | undefined = stack[stack.length - 1];
+    if (n.right != null) {
+      n = n.right;
+      while (n != null) {
+        stack.push(n);
+        n = n.left;
+      }
+    } else {
+      stack.pop();
+      while (stack.length > 0 && stack[stack.length - 1].right === n) {
+        n = stack[stack.length - 1];
+        stack.pop();
+      }
+    }
+  }
+}
+
+console.log("inorder:", JSON.stringify(new InOrder(n2).run()));

--- a/test-files/test_gap_param_prop_array_index.ts
+++ b/test-files/test_gap_param_prop_array_index.ts
@@ -1,0 +1,141 @@
+// Issue #321 (effect `SortedSet` / `RedBlackTree` iteration): a TypeScript
+// constructor parameter property whose declared type is an array
+// (`constructor(readonly stack: Node[])`) must propagate that declared type
+// to a local alias so element indexing takes the array fast path.
+//
+// Perry registered param-prop fields in the class `fields` list, but NOT in
+// the early `class_field_types` registry that `infer_type_from_expr` consults
+// for `this.<field>`. So `const stack = this.stack` inferred the alias as
+// `Any`, and `stack[stack.length - 1]` read garbage objects (key/right came
+// back undefined/null). effect's `RedBlackTreeIterator` has `readonly stack:
+// Array<Node<K,V>>` and `moveNext()` does exactly `const stack = this.stack;
+// ...; stack[stack.length - 1]` — so its in-order walk lost the last node and
+// `Array.from(sortedSet)` returned a short/[null,null] array.
+//
+// Node's --experimental-strip-types can't run parameter properties, so this
+// is a perry-only expected-output test (compared against the stored
+// test-parity/expected/test_gap_param_prop_array_index.txt).
+//
+// Expected output:
+// alias top key: 3
+// alias right: 5
+// after push len: 3 top: 9
+// after pop  len: 2 top: 3
+// inorder: [1,2,3]
+
+interface Node {
+  key: number;
+  left: Node | undefined;
+  right: Node | undefined;
+}
+
+class Walker {
+  count = 0;
+  constructor(
+    readonly self: unknown,
+    readonly stack: Node[],
+    readonly dir: number,
+  ) {}
+
+  // local alias of the param-prop array field, then element index — the
+  // exact RedBlackTree moveNext shape.
+  topKey(): number {
+    const stack = this.stack;
+    const n = stack[stack.length - 1];
+    return n.key;
+  }
+
+  topRight(): number {
+    const stack = this.stack;
+    const n = stack[stack.length - 1];
+    return n.right != null ? n.right.key : -1;
+  }
+
+  push(n: Node): void {
+    this.count++;
+    const stack = this.stack;
+    stack.push(n);
+  }
+
+  pop(): void {
+    const stack = this.stack;
+    stack.pop();
+  }
+
+  len(): number {
+    return this.stack.length;
+  }
+}
+
+const n1: Node = { key: 1, left: undefined, right: undefined };
+const n5: Node = { key: 5, left: undefined, right: undefined };
+const n3: Node = { key: 3, left: undefined, right: n5 };
+
+const w = new Walker(null, [n1, n3], 0);
+console.log("alias top key:", w.topKey());
+console.log("alias right:", w.topRight());
+
+const n9: Node = { key: 9, left: undefined, right: undefined };
+w.push(n9);
+console.log("after push len:", w.len(), "top:", w.topKey());
+w.pop();
+console.log("after pop  len:", w.len(), "top:", w.topKey());
+
+// Full in-order traversal driven by a param-prop iterator (the RBTree shape).
+class InOrderIter {
+  count = 0;
+  constructor(
+    readonly self: unknown,
+    readonly stack: Node[],
+    readonly dir: number,
+  ) {}
+
+  next(): { done: boolean; value: number } {
+    let value = -1;
+    let done = true;
+    if (this.stack.length > 0) {
+      value = this.stack[this.stack.length - 1].key;
+      done = false;
+    }
+    this.count++;
+    this.moveNext();
+    return { done, value };
+  }
+
+  moveNext(): void {
+    const stack = this.stack;
+    if (stack.length === 0) return;
+    let n: Node | undefined = stack[stack.length - 1];
+    if (n.right != null) {
+      n = n.right;
+      while (n != null) {
+        stack.push(n);
+        n = n.left;
+      }
+    } else {
+      stack.pop();
+      while (stack.length > 0 && stack[stack.length - 1].right === n) {
+        n = stack[stack.length - 1];
+        stack.pop();
+      }
+    }
+  }
+}
+
+const a1: Node = { key: 1, left: undefined, right: undefined };
+const a3: Node = { key: 3, left: undefined, right: undefined };
+const a2: Node = { key: 2, left: a1, right: a3 };
+const initial: Node[] = [];
+let cur: Node | undefined = a2;
+while (cur != null) {
+  initial.push(cur);
+  cur = cur.left;
+}
+const it = new InOrderIter(null, initial, 0);
+const out: number[] = [];
+for (let i = 0; i < 10; i++) {
+  const r = it.next();
+  if (r.done) break;
+  out.push(r.value);
+}
+console.log("inorder:", JSON.stringify(out));

--- a/test-parity/expected/test_gap_param_prop_array_index.txt
+++ b/test-parity/expected/test_gap_param_prop_array_index.txt
@@ -1,0 +1,5 @@
+alias top key: 3
+alias right: 5
+after push len: 3 top: 9
+after pop  len: 2 top: 3
+inorder: [1,2,3]


### PR DESCRIPTION
## Summary

Fixes effect's `SortedSet` / `RedBlackTree` iteration (#321 frontier). `Array.from(sortedSet)` returned `[null, null]` (wrong values) **and** lost the last node (wrong count). Two distinct, bounded bugs in how a class instance's array-typed field is type-inferred:

### Bug 1 — codegen: Error-name string heuristic hijacks user fields

`is_string_expr` had a name-only arm classifying **any** `<x>.message` / `<x>.stack` / `<x>.name` as a string (so caught-error `e.stack.includes(...)` chains hit the string fast path). It wrongly fired for effect's `RedBlackTreeIterator.stack: Array<Node<K,V>>`, so `this.stack[i]` lowered to `js_string_char_at` and returned a bogus char instead of a node.

Fix: when the receiver resolves to a known class/interface that **declares** a field with that name, the field's declared type wins over the Error heuristic (new `declared_field_type` helper). The genuine caught-`Error` path (untracked receiver → unknown type) still takes the string assumption.

### Bug 2 — hir: param-prop field types missing from the early registry

TS constructor parameter properties (`constructor(readonly stack: Node[])`) were registered in the class `fields` list but **not** in the early `class_field_types` registry that `infer_type_from_expr` consults for `this.<field>`. So `const stack = this.stack` inside `moveNext()` inferred `Any`, and `stack[stack.length - 1]` element reads returned garbage nodes — the in-order walk read `n.right == null` every time and never pushed the right subtree, losing the last node.

Fix: register param-prop field types into the early registry alongside `ClassProp` fields (mirrors the later param-prop field detection that builds the full `fields` Vec).

## Diagnosis path

Narrowed from the full effect chain down to minimal standalone repros:
- `this.stack[0]` where field is named `stack`/`name`/`message` → garbage (Bug 1); renaming to `data` worked.
- `const s = this.paramPropArray; s[i]` → `undefined`; explicit-field or `s: Node[]`-annotated alias worked (Bug 2). HIR trace confirmed the alias inferred `Any` for param-props but `Array(Named("Node"))` for explicit fields.

Classification: **(A) bounded / distinct** — not the #1787 class-expression instance-field family. The RBTree `Node` is a plain object literal; `RedBlackTreeIterator` is a regular `class` declaration with param-properties.

## Verification

- `survey/fr_ss_narrow.ts` → `arr: [1,2,3] len: 3` (was `[null,null] len 2`)
- `survey/fr_sortedset.ts` → `sortedset: [1,1,2,3]`
- No regression: `fr_equal` → `equal: true false`; `fr_order` → `order: true false`; `21_schema_decode` → `Ada 36`
- All node-runnable gap tests: 80 pass; the 2 failures (`test_gap_class_advanced` #1635, `test_gap_console_methods` #1278) are pre-existing known failures
- `cargo test -p perry-runtime --lib` → 700 passed, 0 failed; `perry-hir` 81 / `perry-codegen` 111 passed
- `cargo fmt --all -- --check` clean

## Tests added

- `test_gap_class_field_named_stack_index.ts` — byte-identical vs node (Bug 1 + array-field-alias indexing).
- `test_gap_param_prop_array_index.ts` + stored expected output — param-prop array indexing / in-order walk (perry-only, since `node --experimental-strip-types` rejects parameter properties).
