### PR TITLE
fix(node:stream): mark data listeners flowing

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2512,6 +2512,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("stream", "readableHighWaterMark", true, None),
     method("stream", "readable", true, None),
     method("stream", "readableEnded", true, None),
+    method("stream", "readableFlowing", true, None),
     method("stream", "writableHighWaterMark", true, None),
     method("stream", "readableAborted", true, None),
     method("stream", "writableCorked", true, None),

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -773,6 +773,15 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "stream",
         has_receiver: true,
+        method: "readableFlowing",
+        class_filter: None,
+        runtime: "js_node_stream_method_readable_flowing",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: true,
         method: "writableHighWaterMark",
         class_filter: None,
         runtime: "js_node_stream_method_writable_hwm",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -875,6 +875,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_method_destroy", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_node_stream_method_readable", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_readable_ended", DOUBLE, &[I64]);
+    module.declare_function("js_node_stream_method_readable_flowing", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_cork", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_uncork", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_writable_corked", DOUBLE, &[I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -461,6 +461,17 @@ pub extern "C" fn js_node_stream_method_readable_ended(stream_handle: i64) -> f6
     }
 }
 
+/// `stream.readableFlowing` property getter on a typed readable-side instance.
+#[no_mangle]
+pub extern "C" fn js_node_stream_method_readable_flowing(stream_handle: i64) -> f64 {
+    let stream = stream_value_from_handle(stream_handle);
+    if get_hidden_value(stream, hidden_readable_flag_key()).is_none() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    get_hidden_value(stream, hidden_readable_flowing_key())
+        .unwrap_or_else(|| f64::from_bits(TAG_NULL))
+}
+
 /// `stream.writableHighWaterMark` property getter on a typed instance
 /// (#1539).
 #[no_mangle]
@@ -1275,6 +1286,11 @@ fn hidden_writable_buffered_key() -> *mut crate::string::StringHeader {
 #[inline]
 fn hidden_readable_flag_key() -> *mut crate::string::StringHeader {
     hidden_key(READABLE_FLAG_KEY)
+}
+
+#[inline]
+fn hidden_readable_flowing_key() -> *mut crate::string::StringHeader {
+    hidden_key(b"readableFlowing")
 }
 
 #[inline]
@@ -2094,6 +2110,18 @@ fn set_visible_readable_ended(stream: f64, ended: bool) {
     }
 }
 
+fn set_visible_readable_flowing(stream: f64, value: f64) {
+    if get_hidden_value(stream, hidden_readable_flag_key()).is_some() {
+        set_hidden_value(stream, hidden_readable_flowing_key(), value);
+    }
+}
+
+pub(super) fn mark_readable_flowing_on_data_listener(stream: f64, event: f64) {
+    if string_value_eq(event, b"data") {
+        set_visible_readable_flowing(stream, f64::from_bits(TAG_TRUE));
+    }
+}
+
 fn mark_stream_ended(stream: f64) {
     set_hidden_value(stream, hidden_ended_key(), f64::from_bits(TAG_TRUE));
     set_visible_readable(stream, false);
@@ -2153,6 +2181,7 @@ fn init_readable_state(stream: f64, opts: f64) {
     set_hidden_value(stream, hidden_key(b"readableHighWaterMark"), r_hwm);
     set_visible_readable(stream, true);
     set_visible_readable_ended(stream, false);
+    set_visible_readable_flowing(stream, f64::from_bits(TAG_NULL));
 }
 
 /// Initialize the writable side: direction flag and visible stream flags.

--- a/crates/perry-runtime/src/node_stream_event_emitter.rs
+++ b/crates/perry-runtime/src/node_stream_event_emitter.rs
@@ -219,6 +219,7 @@ fn add_stream_listener_for_event_with_options(
     }
     add_stream_listener(stream, event, cb, once, prepend);
     if super::string_value_eq(event, b"data") {
+        super::mark_readable_flowing_on_data_listener(stream, event);
         super::schedule_readable_from_drain(stream);
     }
 }

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -26,6 +26,9 @@ static KEEP_NS_METHOD_READABLE: extern "C" fn(i64) -> f64 = super::js_node_strea
 static KEEP_NS_METHOD_READABLE_ENDED: extern "C" fn(i64) -> f64 =
     super::js_node_stream_method_readable_ended;
 #[used]
+static KEEP_NS_READABLE_FLOWING: extern "C" fn(i64) -> f64 =
+    super::js_node_stream_method_readable_flowing;
+#[used]
 static KEEP_NS_WRITABLE_HWM: extern "C" fn(i64) -> f64 = super::js_node_stream_method_writable_hwm;
 #[used]
 static KEEP_NS_READABLE_ABORTED: extern "C" fn(i64) -> f64 =

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -213,6 +213,35 @@ fn stream_method_closure_capture_wins_over_stale_implicit_this() {
 }
 
 #[test]
+fn data_listener_marks_readable_flowing() {
+    let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let handle = raw_ptr_from_value(stream) as i64;
+
+    assert_eq!(
+        js_node_stream_method_readable_flowing(handle).to_bits(),
+        TAG_NULL
+    );
+
+    let listener = js_closure_alloc(noop_listener as *const u8, 0);
+    crate::closure::js_register_closure_arity(noop_listener as *const u8, 0);
+    let _ = js_node_stream_method_on(
+        handle,
+        string_value("data"),
+        box_pointer(listener as *const u8),
+    );
+
+    assert_eq!(
+        js_node_stream_method_readable_flowing(handle).to_bits(),
+        TAG_TRUE
+    );
+    let obj = raw_ptr_from_value(stream) as *const ObjectHeader;
+    assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"readableFlowing")).to_bits(),
+        TAG_TRUE
+    );
+}
+
+#[test]
 fn stream_methods_dispatch_through_dynamic_method_call() {
     let stream = js_node_stream_passthrough_new(f64::from_bits(TAG_UNDEFINED));
     unsafe {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1124,12 +1124,6 @@
     "category": "bug-open",
     "reason": "node:stream: readable.map(asyncFn) — rejection in fn does not abort iteration / propagate as throw. Flips to PASS when #1558 lands."
   },
-  "node-suite/stream/events/data-listener-auto-resume": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: adding 'data' listener does not flip readableFlowing to true. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/async-iter/iterator-next-direct": {
     "issue": "1531",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- initialize classic readable streams with public `readableFlowing: null`
- add typed receiver getter plumbing for `stream.readableFlowing`
- flip `readableFlowing` to `true` when a `data` listener is registered
- remove the now-passing `stream/events/data-listener-auto-resume` known-failure entry

## Verification
- DeepWiki: `reference/deepwiki/nodejs-node-stream-readable-flowing-ispaused-2026-05-27.md`
- Baseline failures: `parity_report_20260527_161027.json`, `parity_report_20260527_161036.json`, `parity_report_20260527_161048.json`, `parity_report_20260527_161055.json`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/events/data-listener-auto-resume` PASS, reports `parity_report_20260527_161822.json` and post-removal `parity_report_20260527_161930.json`
- Adjacent residual check: `stream/flags/readable-flowing` now matches `initial: null` and `after data listener: true`, but still fails at `after pause` (`parity_report_20260527_161943.json`)
- `cargo test -p perry-runtime data_listener_marks_readable_flowing --lib`
- `cargo test -p perry-codegen --lib native_table`
- `cargo test -p perry-api-manifest`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check -- crates/perry-runtime/src/node_stream.rs crates/perry-runtime/src/node_stream_event_emitter.rs crates/perry-runtime/src/node_stream_keepalive.rs crates/perry-runtime/src/node_stream_tests.rs crates/perry-codegen/src/lower_call/native_table/net_events.rs crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs crates/perry-api-manifest/src/entries.rs test-parity/known_failures.json`

## Non-goals
- no `pause()` transition to `false`
- no `resume()` transition or `isPaused()` implementation
- no paused dataflow gating, pipe backpressure interaction, or full stream state-machine rewrite

Fixes part of #1532.