### PR TITLE
test(node:stream): unskip empty string write

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -704,12 +704,6 @@
     "category": "bug-open",
     "reason": "node:stream: read() on a destroyed Readable should return null. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/writable/write-empty-string": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: write empty string does not reach _write with empty Buffer. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/writable/write-on-errored": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- revalidate `node-suite/stream/writable/write-empty-string` on current `main`
- remove the stale known-failure entry now that the fixture passes

## Verification
- DeepWiki: `reference/deepwiki/nodejs-node-stream-writable-write-empty-string-2026-05-27.md`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/writable/write-empty-string` PASS before removal, report `parity_report_20260527_162352.json`
- Same exact filter PASS after removal, report `parity_report_20260527_162429.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check -- test-parity/known_failures.json`

## Non-goals
- no stream runtime or compiler changes
- no broader writable write normalization, write-after-error behavior, writableLength tracking, or finish timing changes

Fixes part of #1532.