### PR TITLE
test(node:stream): unskip empty map readable

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1958,12 +1958,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline with multiple async-gen stages — fails to deliver final collected output. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/from-empty-map": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.from(empty Map) — does not yield immediate end. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/transform/objectmode-passes-objects": {
     "issue": "1539",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- revalidate `node-suite/stream/readable/from-empty-map` on current `main`
- remove the stale known-failure entry now that the fixture passes

## Verification
- DeepWiki: `reference/deepwiki/nodejs-node-stream-readable-from-empty-map-2026-05-27.md`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/readable/from-empty-map` PASS before removal, report `parity_report_20260527_163528.json`
- Same exact filter PASS after removal, report `parity_report_20260527_163604.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check -- test-parity/known_failures.json`

## Non-goals
- no stream runtime or compiler changes
- no Map/Set entry iteration semantics beyond this stale revalidation
- no non-empty iterable handling, objectMode dataflow changes, or full Readable.from rewrite

Fixes part of #1532.