### PR TITLE
fix(node:stream): decode string writes

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -319,6 +319,16 @@ fn invoke_writable_write(stream: f64, chunk: f64, enc: f64) {
     }
 }
 
+fn normalize_writable_string_chunk(chunk: f64, enc: f64) -> (f64, f64) {
+    if JSValue::from_bits(chunk.to_bits()).is_any_string() {
+        let encoding = crate::buffer::js_encoding_tag_from_value(enc);
+        let buffer = crate::buffer::js_buffer_from_value(chunk.to_bits() as i64, encoding);
+        (box_pointer(buffer as *const u8), string_value(b"buffer"))
+    } else {
+        (chunk, enc)
+    }
+}
+
 #[cold]
 fn throw_writable_null_chunk() -> ! {
     let msg = b"May not write null values to stream";
@@ -332,6 +342,7 @@ fn write_writable_chunk(stream: f64, chunk: f64, enc: f64) -> f64 {
     if JSValue::from_bits(chunk.to_bits()).is_null() {
         throw_writable_null_chunk();
     }
+    let (chunk, enc) = normalize_writable_string_chunk(chunk, enc);
     if writable_corked_count(stream) > 0.0 {
         buffer_writable_write(stream, chunk, enc);
         return f64::from_bits(TAG_TRUE);

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 
 thread_local! {
     static WRITE_CAPTURED: RefCell<Vec<Vec<u8>>> = const { RefCell::new(Vec::new()) };
+    static WRITE_ENCODING_IS_BUFFER: RefCell<Vec<bool>> = const { RefCell::new(Vec::new()) };
     static READABLE_DATA_CAPTURED: RefCell<Vec<Vec<u8>>> = const { RefCell::new(Vec::new()) };
     static READABLE_THIS_MATCHES: RefCell<Vec<bool>> = const { RefCell::new(Vec::new()) };
     static READABLE_END_COUNT: RefCell<usize> = const { RefCell::new(0) };
@@ -35,6 +36,24 @@ extern "C" fn write_capture(_closure: *const ClosureHeader, chunk: f64, _enc: f6
     let readable = js_node_stream_readable_from(chunk);
     let bytes = js_node_stream_collect_bytes(readable);
     WRITE_CAPTURED.with(|captured| captured.borrow_mut().push(bytes));
+    unsafe {
+        let _ = crate::closure::js_native_call_value(cb, std::ptr::null(), 0);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn write_capture_encoding(
+    _closure: *const ClosureHeader,
+    chunk: f64,
+    enc: f64,
+    cb: f64,
+) -> f64 {
+    let readable = js_node_stream_readable_from(chunk);
+    let bytes = js_node_stream_collect_bytes(readable);
+    WRITE_CAPTURED.with(|captured| captured.borrow_mut().push(bytes));
+    WRITE_ENCODING_IS_BUFFER.with(|encodings| {
+        encodings.borrow_mut().push(string_value_eq(enc, b"buffer"));
+    });
     unsafe {
         let _ = crate::closure::js_native_call_value(cb, std::ptr::null(), 0);
     }
@@ -153,6 +172,31 @@ fn writable_options_write_callback_is_invoked_by_stub_write() {
 
     WRITE_CAPTURED.with(|captured| {
         assert_eq!(captured.borrow().as_slice(), &[b"chunk".to_vec()]);
+    });
+}
+
+#[test]
+fn writable_string_write_decodes_with_encoding() {
+    WRITE_CAPTURED.with(|captured| captured.borrow_mut().clear());
+    WRITE_ENCODING_IS_BUFFER.with(|encodings| encodings.borrow_mut().clear());
+    let opts = crate::object::js_object_alloc(0, 1);
+    let closure = js_closure_alloc(write_capture_encoding as *const u8, 0);
+    crate::closure::js_register_closure_arity(write_capture_encoding as *const u8, 3);
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"write"),
+        f64::from_bits(JSValue::pointer(closure as *const u8).bits()),
+    );
+
+    let writable = js_node_stream_writable_new(box_pointer(opts as *const u8));
+    let handle = raw_ptr_from_value(writable) as i64;
+    let _ = js_node_stream_method_write(handle, string_value("6869"), string_value("hex"));
+
+    WRITE_CAPTURED.with(|captured| {
+        assert_eq!(captured.borrow().as_slice(), &[b"hi".to_vec()]);
+    });
+    WRITE_ENCODING_IS_BUFFER.with(|encodings| {
+        assert_eq!(encodings.borrow().as_slice(), &[true]);
     });
 }
 

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -488,12 +488,6 @@
     "category": "bug-open",
     "reason": "node:stream: class extends Readable with _read() doesn't deliver data via push. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/write/with-encoding": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: write(chunk, enc, cb) doesn't propagate encoding to _write. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/write/write-buffer": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- decode classic Writable string chunks through Buffer using the supplied encoding
- pass encoding `"buffer"` to user `write` callbacks after decoding
- remove the now-passing `stream/write/with-encoding` known-failure entry

## Verification
- DeepWiki: `reference/deepwiki/nodejs-node-stream-writable-write-string-decode-2026-05-27.md`
- Baseline failure: `stream/write/with-encoding`, report `parity_report_20260527_164025.json`
- `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/write/with-encoding` PASS before removal, report `parity_report_20260527_164427.json`, and post-removal `parity_report_20260527_164530.json`
- Adjacent residual: `stream/write/three-arg-form` now matches decoded chunk/encoding but still fails callback forwarding (`parity_report_20260527_164508.json`)
- `cargo test -p perry-runtime writable_string_write_decodes_with_encoding --lib`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check -- crates/perry-runtime/src/node_stream.rs crates/perry-runtime/src/node_stream_tests.rs test-parity/known_failures.json`

## Non-goals
- no `write(chunk, callback)` normalization or public write callback forwarding
- no Buffer-only encoding normalization in this branch
- no write-after-end/error behavior, writableLength tracking, or broader Writable state-machine rewrite

Fixes part of #1532.