### PR TITLE
test(node:stream): unskip write on errored writable

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -710,12 +710,6 @@
     "category": "bug-open",
     "reason": "node:stream: write empty string does not reach _write with empty Buffer. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/writable/write-on-errored": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: write after destroy(err) should emit additional error. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipe/repipe-after-unpipe": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- Remove stale known-failure metadata for `node-suite/stream/writable/write-on-errored` after revalidating it against current `origin/main`.
- No runtime/compiler changes; this is a parity metadata cleanup only.

## Verification
- Baseline before removal: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/writable/write-on-errored` PASS 1/1, report `test-parity/reports/parity_report_20260527_164938.json`.
- Post-removal rerun: same command PASS 1/1, report `test-parity/reports/parity_report_20260527_165039.json`.
- `jq empty test-parity/known_failures.json`
- `git diff --check -- test-parity/known_failures.json`

## DeepWiki
- Local reference only: `reference/deepwiki/nodejs-node-stream-writable-write-on-errored-2026-05-27.md`

## Non-goals
- No destroyed write callback error behavior changes.
- No write-after-end behavior changes.
- No error-code shape changes.
- No broader Writable state-machine rewrite.