### PR TITLE
fix(runtime): honor custom toString() in object→string coercion (#321)

### DIFF
--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -1,7 +1,147 @@
 //! NaN-boxed value to-string conversion helpers.
 
 use super::*;
+use std::cell::Cell;
 use std::sync::atomic::Ordering;
+
+thread_local! {
+    /// Re-entrancy guard for `OrdinaryToPrimitive(string)`. A user
+    /// `toString`/`valueOf` whose body coerces `this` back to a string
+    /// (e.g. `toString() { return "" + this; }`) would recurse forever;
+    /// Node throws `RangeError: Maximum call stack size exceeded`. We cap
+    /// the depth and fall back to `[object Object]` instead of overflowing
+    /// the Rust stack (which would SIGSEGV the whole process).
+    static TO_PRIMITIVE_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+/// `OrdinaryToPrimitive(O, "string")` (ES2024 §7.1.1.1) — the fallback
+/// `ToPrimitive` step used by `String(obj)` / template literals / `obj + ""`
+/// when the object has no `[Symbol.toPrimitive]`. For hint "string" the
+/// method order is `toString` then `valueOf`; each is invoked with
+/// `this = obj` and the first call returning a *primitive* (non-object)
+/// value wins.
+///
+/// Returns `Some(primitive_f64)` when a callable `toString`/`valueOf` was
+/// found on the object (own property or anywhere on its prototype chain,
+/// reusing the same `js_object_get_field_by_name` resolution +
+/// `clone_closure_rebind_this` receiver-binding the method-dispatch tower
+/// uses — see #1969/#1982) and produced a primitive. Returns `None` when
+/// neither method exists / is callable / yields a primitive, so the caller
+/// falls back to `"[object Object]"`.
+///
+/// `value` MUST be a NaN-boxed `POINTER_TAG` object whose pointer is a real
+/// heap address (`>= 0x10000`); the caller has already excluded symbols,
+/// buffers, arrays, and JSX nodes (those carry their own coercion rules).
+unsafe fn ordinary_to_primitive_string(value: f64) -> Option<f64> {
+    // Bound recursion: a `toString` that itself string-coerces `this`.
+    let depth = TO_PRIMITIVE_DEPTH.with(|c| c.get());
+    if depth >= 200 {
+        return None;
+    }
+    TO_PRIMITIVE_DEPTH.with(|c| c.set(depth + 1));
+    let result = ordinary_to_primitive_string_inner(value);
+    TO_PRIMITIVE_DEPTH.with(|c| c.set(depth));
+    result
+}
+
+unsafe fn ordinary_to_primitive_string_inner(value: f64) -> Option<f64> {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value_handle = scope.root_nanbox_f64(value);
+
+    // Hint "string": method order is `toString` then `valueOf` (ES2024
+    // §7.1.1.1). CRITICAL: in the real spec EVERY ordinary object inherits
+    // `Object.prototype.toString` (callable, returns `"[object Object]"`),
+    // so for the string hint `toString` is *always present* — `valueOf` is
+    // reached ONLY when a custom `toString` returns a non-primitive. Perry's
+    // object model has no discoverable `Object.prototype.toString` field, so
+    // `js_object_get_field_by_name(obj, "toString")` returning undefined
+    // STANDS IN FOR that default `"[object Object]"`. We must therefore stop
+    // and fall back to `"[object Object]"` (return None) rather than
+    // proceeding to `valueOf` — otherwise `String({ valueOf() {…} })`
+    // (string hint) would wrongly use `valueOf` where Node uses the default
+    // `toString`.
+    let to_string_result = call_method_for_primitive(&scope, &value_handle, b"toString");
+    match to_string_result {
+        MethodOutcome::Primitive(p) => return Some(p),
+        // Custom toString returned a non-primitive (object): per spec, fall
+        // through to `valueOf`.
+        MethodOutcome::NonPrimitive => {}
+        // No callable custom toString — this is the default
+        // `Object.prototype.toString` → `"[object Object]"`. Stop here.
+        MethodOutcome::Absent => return None,
+    }
+
+    match call_method_for_primitive(&scope, &value_handle, b"valueOf") {
+        MethodOutcome::Primitive(p) => Some(p),
+        // Both toString and valueOf failed to produce a primitive — Node
+        // throws `TypeError: Cannot convert object to primitive value`. We
+        // approximate by falling back to the default `"[object Object]"`.
+        MethodOutcome::NonPrimitive | MethodOutcome::Absent => None,
+    }
+}
+
+enum MethodOutcome {
+    /// Method was callable and returned a primitive.
+    Primitive(f64),
+    /// Method was callable but returned a non-primitive (object/array).
+    NonPrimitive,
+    /// No own/inherited callable method with that name was found.
+    Absent,
+}
+
+/// Resolve `obj[method_name]` (own + prototype chain) and, if it is a
+/// callable closure, invoke it with `this = obj` (no args). Returns whether
+/// the result was a primitive, a non-primitive, or whether the method was
+/// absent / non-callable.
+unsafe fn call_method_for_primitive(
+    scope: &crate::gc::RuntimeHandleScope,
+    value_handle: &crate::gc::RuntimeHandle<'_>,
+    method_name: &[u8],
+) -> MethodOutcome {
+    let recv = value_handle.get_nanbox_f64();
+    let obj_ptr = (recv.to_bits() & POINTER_MASK) as *const crate::object::ObjectHeader;
+    if obj_ptr.is_null() || (obj_ptr as usize) < 0x10000 {
+        return MethodOutcome::Absent;
+    }
+    let key = crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
+    let key_handle = scope.root_string_ptr(key);
+    let method = crate::object::js_object_get_field_by_name(
+        obj_ptr,
+        key_handle.get_raw_const_ptr::<crate::string::StringHeader>(),
+    );
+    // Must be a callable closure value (POINTER_TAG + CLOSURE_MAGIC).
+    let method_bits = method.bits();
+    if (method_bits & 0xFFFF_0000_0000_0000) != POINTER_TAG {
+        return MethodOutcome::Absent;
+    }
+    let method_ptr = (method_bits & POINTER_MASK) as usize;
+    if !crate::closure::is_closure_ptr(method_ptr) {
+        return MethodOutcome::Absent;
+    }
+    // Rebind `this` to the receiver: an INHERITED object-literal method
+    // (`Object.create(proto)`) bakes its reserved `this` slot to the
+    // prototype at construction time, and a bound-method closure carries the
+    // wrong `this` until rebound. For OWN methods the slot already is the
+    // receiver, so rebinding is a correct no-op. Mirrors #1982.
+    let recv = value_handle.get_nanbox_f64();
+    let bound = crate::closure::clone_closure_rebind_this(method_bits, recv);
+    let prev_this = crate::object::js_implicit_this_set(recv);
+    let ret = crate::closure::js_native_call_value(f64::from_bits(bound), std::ptr::null(), 0);
+    crate::object::js_implicit_this_set(prev_this);
+    let ret_jsv = JSValue::from_bits(ret.to_bits());
+    let is_primitive = ret_jsv.is_any_string()
+        || ret_jsv.is_number()
+        || ret_jsv.is_int32()
+        || ret_jsv.is_bool()
+        || ret_jsv.is_null()
+        || ret_jsv.is_undefined()
+        || ret_jsv.is_bigint();
+    if is_primitive {
+        MethodOutcome::Primitive(ret)
+    } else {
+        MethodOutcome::NonPrimitive
+    }
+}
 
 /// Convert a NaN-boxed f64 value to a string pointer.
 /// Handles all value types: strings (extract pointer), numbers (convert), JS handles, etc.
@@ -97,6 +237,23 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
                 if (*obj).class_id == crate::jsx::JSX_NODE_CLASS_ID {
                     let html = crate::object::js_object_get_field(obj, 0);
                     return js_jsvalue_to_string(f64::from_bits(html.bits()));
+                }
+            }
+            // OrdinaryToPrimitive(obj, "string"): the object has no
+            // `[Symbol.toPrimitive]` (checked above) and is not an
+            // array/buffer/JSX/symbol with its own coercion. Per spec, call
+            // the object's own/inherited `toString` (then `valueOf`) with
+            // `this = obj`. A custom `toString` on a plain object, an
+            // `Object.create(proto)` result, or a class instance resolves
+            // here; a primitive result is re-coerced (strings pass through,
+            // numbers via `js_number_to_string`). A plain `{}` (no callable
+            // toString/valueOf) returns None and falls through to the default
+            // `"[object Object]"`. (Built-in Error/Date prototype `toString`s
+            // are not discoverable as object fields in Perry's model, so they
+            // still hit the fallback — a separate, pre-existing gap.)
+            if let Some(primitive) = unsafe { ordinary_to_primitive_string(value) } {
+                if primitive.to_bits() != value.to_bits() {
+                    return js_jsvalue_to_string(primitive);
                 }
             }
         }

--- a/test-files/test_gap_string_coercion_tostring.ts
+++ b/test-files/test_gap_string_coercion_tostring.ts
@@ -1,0 +1,111 @@
+// #321 (effect Redacted): object→string coercion must honor a custom
+// `toString()` method (own OR inherited), per `ToPrimitive` /
+// `OrdinaryToPrimitive`. `String(obj)`, template literals, and `"" + obj`
+// all coerce with hint "string": try `toString` first, then `valueOf`.
+//
+// Pre-fix, Perry's coercion only consulted `[Symbol.toPrimitive]` and then
+// fell straight back to the default `Object.prototype.toString`
+// (`"[object Object]"`), so a user-defined `toString` was ignored. This
+// affects ANY object with a custom `toString`, surfaced via effect's
+// `Redacted` (`String(secret)` → `"<redacted>"`).
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+// (1) OWN custom toString — String(), template literal, and `+` all honor it.
+const a: any = {
+  toString() {
+    return "CUSTOM-A";
+  },
+};
+console.log("own:", String(a), `${a}`, "" + a); // CUSTOM-A CUSTOM-A CUSTOM-A
+
+// (2) INHERITED custom toString via Object.create — resolved off the
+//     prototype chain with `this` bound to the receiver.
+const Proto: any = {
+  toString() {
+    return "CUSTOM-P";
+  },
+};
+const b = Object.create(Proto);
+console.log("proto:", String(b), `${b}`); // CUSTOM-P CUSTOM-P
+
+// (3) Symbol.toPrimitive still takes priority over toString (already worked).
+const c: any = {
+  [Symbol.toPrimitive](hint: string) {
+    return "PRIM-" + hint;
+  },
+};
+console.log("toPrimitive:", String(c), `${c}`); // PRIM-string PRIM-string
+
+// (4) toString reads `this` — own and inherited.
+const t: any = {
+  name: "Bob",
+  toString() {
+    return "Name=" + this.name;
+  },
+};
+console.log("this-own:", String(t)); // Name=Bob
+const GP: any = {
+  greeting: "hi",
+  toString() {
+    return this.greeting + "!";
+  },
+};
+const g = Object.create(GP);
+g.greeting = "yo";
+console.log("this-inherited:", String(g)); // yo!
+
+// (5) class instance with a toString method.
+class K {
+  toString() {
+    return "K-INST";
+  }
+}
+console.log("class:", String(new K()), `${new K()}`, "" + new K()); // K-INST x3
+
+// (6) toString that returns a NUMBER primitive — coerced to its string form.
+const num: any = {
+  toString() {
+    return 42;
+  },
+};
+console.log("num-toString:", String(num), `${num}`); // 42 42
+
+// (7) toString returns a NON-primitive (object) → spec falls through to
+//     valueOf.
+const fallback: any = {
+  toString() {
+    return {};
+  },
+  valueOf() {
+    return "VALUEOF";
+  },
+};
+console.log("toString-nonprimitive:", String(fallback)); // VALUEOF
+
+// (8) hint "string" with ONLY valueOf (no custom toString): the default
+//     Object.prototype.toString wins, so `valueOf` is NOT consulted.
+const VP: any = {
+  valueOf() {
+    return 99;
+  },
+};
+const vo = Object.create(VP);
+console.log("valueOf-only-string-hint:", String(vo), `${vo}`); // [object Object] x2
+
+// (9) REGRESSION GUARDS — must keep matching Node exactly.
+console.log("plain:", String({}), `${{}}`, "" + {}); // [object Object] x3
+console.log("array:", String([1, 2, 3])); // 1,2,3
+class L {
+  x = 5;
+}
+console.log("class-no-tostring:", String(new L())); // [object Object]
+console.log(
+  "primitives:",
+  String(42),
+  String(null),
+  String(undefined),
+  String(true),
+  String(false),
+  String(3.14),
+); // 42 null undefined true false 3.14


### PR DESCRIPTION
## Summary

Object→string coercion now honors a custom `toString()` method (own OR inherited). Previously `String(obj)`, template literals, and `obj + ""` only consulted `[Symbol.toPrimitive]` and then fell straight back to the default `Object.prototype.toString` (`[object Object]`), ignoring any user-defined `toString`. Found on the #321 (Effect) frontier via `effect/Redacted`, where `String(secret)` must produce `<redacted>`. Broadly useful — affects ANY object with a custom `toString`.

## Root cause

`js_jsvalue_to_string` (in `crates/perry-runtime/src/value/to_string.rs`) implements `ToPrimitive(obj, "string")` but only did the `Symbol.toPrimitive` step. It skipped the spec's **OrdinaryToPrimitive** fallback that calls the object's `toString` (then `valueOf`), so after the `Symbol.toPrimitive` miss it returned `[object Object]`.

## Fix

Added `ordinary_to_primitive_string`, invoked right before the `[object Object]` fallback in `js_jsvalue_to_string` — the single chokepoint all three coercion forms route through (`String()` via `js_string_coerce`; template/`+` via `js_string_concat_value` / `js_value_concat_string`, both of which delegate non-numeric values to `js_jsvalue_to_string`). It:

- resolves `toString` (own + prototype chain) via `js_object_get_field_by_name`,
- rebinds the closure's `this` slot to the receiver with `clone_closure_rebind_this` so an inherited `Object.create(proto)` method reads the right `this` (mirrors the inherited-method `this` fixes in #1969 / #1982),
- calls it with `this = obj` and re-coerces a primitive result (strings pass through, numbers via `js_number_to_string`).

### Spec correctness for hint "string"

Every ordinary object inherits a callable `Object.prototype.toString`, so for the string hint `valueOf` is reached ONLY when a custom `toString` returns a non-primitive. Perry's object model has no discoverable `Object.prototype.toString` field, so a `toString` lookup miss STANDS IN FOR that default and falls back to `[object Object]` — it does NOT proceed to `valueOf`. This keeps `String({ valueOf() {…} })` equal to `[object Object]`, matching Node.

A thread-local depth guard caps recursion (a `toString` that string-coerces `this`) so the process degrades to `[object Object]` instead of overflowing the Rust stack / SIGSEGV. (Node throws `RangeError` there; we degrade safely rather than crash.)

## Verification (byte-identical to node --experimental-strip-types)

Repro (the 3 task lines):

```
own-toString:   CUSTOM-A CUSTOM-A CUSTOM-A
proto-toString: CUSTOM-P CUSTOM-P
toPrimitive:    PRIM-string PRIM-string
```

- `effect/Redacted`: `String(r)` produces `redacted: secret <redacted>` (matches Node).
- New gap test `test-files/test_gap_string_coercion_tostring.ts` — byte-identical to Node. Covers: own / inherited / class-instance custom `toString`; `Symbol.toPrimitive` priority; `this`-reading `toString` (own + inherited); `toString` returning a number; `toString` returning a non-primitive then `valueOf` fallback; `valueOf`-only string-hint giving `[object Object]`.
- No regression — byte-identical to Node for: plain `{}` giving `[object Object]`; `String([1,2,3])` giving `1,2,3`; class instance without `toString` giving `[object Object]`; `String(42)`/`null`/`undefined`/`true`/`false`/`3.14`.
- `cargo test --release -p perry-runtime --lib -- --test-threads=1` gives 700 passed, 0 failed.
- `cargo fmt --all -- --check` clean.

## Out of scope (pre-existing, unchanged)

Built-in `Error`/`Date` prototype `toString` remain `[object Object]` / `0` respectively. Their prototype `toString`s are not discoverable as object fields in Perry's model, so this change does not reach them — they were already broken before this PR and are unchanged here. Tracking them is a separate built-in-prototype-toString gap (distinct from the custom-`toString` fix). `test_issue_510_primitive_method_typeerror` SIGSEGVs (exit 139) on a number property read on both the clean main runtime and this branch — also pre-existing and unrelated.

Touches runtime only (`crates/perry-runtime/src/value/to_string.rs`); no codegen / `+` / template lowering changed.
