### PR TITLE
fix(node:stream): reject non-iterable readable inputs

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -1599,6 +1599,20 @@ fn is_single_chunk_value(value: f64) -> bool {
     raw >= 0x10000 && crate::buffer::is_registered_buffer(raw)
 }
 
+fn is_non_iterable_primitive_for_readable_from(value: f64) -> bool {
+    let jsval = JSValue::from_bits(value.to_bits());
+    (jsval.is_number() || jsval.is_int32() || jsval.is_bool()) && !jsval.is_any_string()
+}
+
+#[cold]
+fn throw_readable_from_invalid_iterable() -> ! {
+    let msg = b"The \"iterable\" argument must be an instance of Iterable";
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    crate::node_submodules::register_error_code_pub(s, "ERR_INVALID_ARG_TYPE");
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
 fn uint8array_byte_chunks(raw: usize) -> f64 {
     let arr = crate::array::js_array_alloc(0);
     if raw < 0x10000 || !crate::buffer::is_registered_buffer(raw) {
@@ -2252,6 +2266,9 @@ pub extern "C" fn js_node_stream_passthrough_new(_opts: f64) -> f64 {
 /// `node:stream/consumers` can drain the current stub stream surface.
 #[no_mangle]
 pub extern "C" fn js_node_stream_readable_from(iterable: f64) -> f64 {
+    if is_non_iterable_primitive_for_readable_from(iterable) {
+        throw_readable_from_invalid_iterable();
+    }
     let readable = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
     let raw = raw_ptr_from_value(readable);
     if raw >= 0x10000 {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1976,12 +1976,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline cb on success — err arg not null/undefined or wrong type. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/from-non-iterable-throws": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.from(non-iterable) — does not throw TypeError. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/destroy/_destroy-user-impl": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- Add a synchronous `TypeError` / `ERR_INVALID_ARG_TYPE` path for primitive non-iterable inputs to `Readable.from(...)`, before Perry allocates a readable stub.
- Remove the now-passing known-failure entry for `node-suite/stream/readable/from-non-iterable-throws`.

## Verification
- Baseline before fix: `CARGO_BUILD_JOBS=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream --filter stream/readable/from-non-iterable-throws` failed, report `test-parity/reports/parity_report_20260527_171819.json` (Node `threw: true`, Perry `threw: false`).
- Same command PASS before known-failure removal, report `test-parity/reports/parity_report_20260527_172427.json`.
- Same command PASS after known-failure removal, report `test-parity/reports/parity_report_20260527_172518.json`.
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check -- crates/perry-runtime/src/node_stream.rs test-parity/known_failures.json`

## DeepWiki
- Local reference only: `reference/deepwiki/nodejs-node-stream-readable-from-non-iterable-2026-05-27.md`

## Non-goals
- No nullish `Readable.from(null | undefined)` cleanup in this branch.
- No generic object iterator protocol support.
- No `Readable.from(iter, opts)` support.
- No async iterable/generator dataflow.
- No broader stream state-machine rewrite.