### PR TITLE
fix(node:stream): tag web stream handles

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1023,11 +1023,12 @@ pub type HandlePropertySetDispatchFn = unsafe extern "C" fn(
 /// fall through to the normal `(number).x is not a function` TypeError.
 pub type StreamHandleProbeFn = unsafe extern "C" fn(id: usize) -> bool;
 
-/// #1545: classify a numeric Web Streams handle for `instanceof`.
+/// #1545: classify a numeric Web Streams handle for `instanceof` and tags.
 /// Returns 0 = not a stream, 1 = ReadableStream, 2 = WritableStream,
-/// 3 = reader, 4 = writer. Lets `x instanceof ReadableStream` /
-/// `instanceof WritableStream` resolve for numeric stream handles
-/// (`ts.readable`, `rs.pipeThrough(ts)`, …).
+/// 3 = reader, 4 = writer, 5 = TransformStream. Lets `x instanceof
+/// ReadableStream` / `instanceof WritableStream` resolve for numeric stream
+/// handles (`ts.readable`, `rs.pipeThrough(ts)`, …), and lets
+/// `Object.prototype.toString.call(handle)` recover Web stream tags.
 pub type StreamHandleKindProbeFn = unsafe extern "C" fn(id: usize) -> u8;
 
 // Dispatch tables are written once at startup (by `js_register_handle_*_dispatch`)

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -196,6 +196,12 @@ extern "C" fn object_prototype_to_string_thunk(
 ) -> f64 {
     use crate::value::JSValue;
     let this_bits = IMPLICIT_THIS.with(|c| c.get());
+    if let Some(tag) = crate::object::web_stream_to_string_tag(f64::from_bits(this_bits)) {
+        let formatted = format!("[object {}]", tag);
+        let bytes = formatted.as_bytes();
+        let s = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+        return f64::from_bits(crate::js_nanbox_string(s as i64).to_bits());
+    }
     let this_jsv = JSValue::from_bits(this_bits);
     let tag: &[u8] = if this_jsv.is_undefined() {
         b"[object Undefined]"

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1405,6 +1405,19 @@ fn lookup_to_string_tag_hook(class_id: u32) -> Option<usize> {
     reg.as_ref().and_then(|m| m.get(&class_id).copied())
 }
 
+pub(crate) fn web_stream_to_string_tag(value: f64) -> Option<&'static str> {
+    if !value.is_finite() || value <= 0.0 || value.fract() != 0.0 {
+        return None;
+    }
+    let kind_probe = stream_handle_kind_probe()?;
+    match unsafe { kind_probe(value as usize) } {
+        1 => Some("ReadableStream"),
+        2 => Some("WritableStream"),
+        5 => Some("TransformStream"),
+        _ => None,
+    }
+}
+
 /// `Object.prototype.toString.call(x)` — returns `[object <tag>]` where
 /// `<tag>` is read from the value's class-level `Symbol.toStringTag` getter
 /// if registered, otherwise `Object` (matching Node for plain objects).
@@ -1437,6 +1450,12 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
     }
     if jsv.is_any_string() {
         let bytes = b"[object String]";
+        let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+        return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
+    }
+    if let Some(tag) = web_stream_to_string_tag(value) {
+        let formatted = format!("[object {}]", tag);
+        let bytes = formatted.as_bytes();
         let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
         return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
     }

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -1645,9 +1645,10 @@ pub extern "C" fn js_stream_handle_is_registered(id: usize) -> bool {
     js_stream_handle_kind(id) != 0
 }
 
-/// #1545: classify a numeric Web Streams handle for `instanceof` and dispatch.
+/// #1545: classify a numeric Web Streams handle for `instanceof`, dispatch,
+/// and `Object.prototype.toString` tags.
 /// 0 = not a stream, 1 = ReadableStream, 2 = WritableStream, 3 = reader,
-/// 4 = writer.
+/// 4 = writer, 5 = TransformStream.
 #[no_mangle]
 pub extern "C" fn js_stream_handle_kind(id: usize) -> u8 {
     if !(0x40000..0x100000).contains(&id) {
@@ -1672,6 +1673,13 @@ pub extern "C" fn js_stream_handle_kind(id: usize) -> u8 {
     }
     if WRITERS.lock().map(|m| m.contains_key(&id)).unwrap_or(false) {
         return 4;
+    }
+    if TRANSFORM_STREAMS
+        .lock()
+        .map(|m| m.contains_key(&id))
+        .unwrap_or(false)
+    {
+        return 5;
     }
     0
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1052,12 +1052,6 @@
     "category": "bug-open",
     "reason": "node:stream: pause()/resume()/destroy() don't all return `this` — chainability broken on one or more. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/web/tostring-tag-web-classes": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: ReadableStream/WritableStream/TransformStream lack Symbol.toStringTag — Object.prototype.toString.call() returns '[object Object]'. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/iter-helpers/to-array-erroring": {
     "issue": "1558",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- classify numeric `stream/web` handles as `TransformStream` in addition to readable/writable handles
- teach `Object.prototype.toString` paths to recover Web Stream tags from registered handles
- remove `node-suite/stream/web/tostring-tag-web-classes` from known failures

## DeepWiki
- `reference/deepwiki/nodejs-node-stream-web-tostringtag-2026-05-27.md`

## Verification
- Baseline exact parity fail: `test-parity/reports/parity_report_20260527_175446.json`
- Post-fix exact parity pass: `test-parity/reports/parity_report_20260527_180845.json`
- `cargo test -p perry-runtime --lib web_stream_to_string_tag`
- `cargo test -p perry-stdlib --no-default-features --features "bundled-streams crypto http-client" --lib js_stream_handle_kind`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`
