### PR TITLE
test(node:stream): unskip stream promises namespace

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1100,12 +1100,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory — `node:stream/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
-  "node-suite/stream/imports/promises-ns": {
-    "issue": "1533",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: stream.promises namespace is undefined (used for `await pipeline()` / `await finished()`). Flips to PASS when #1533 lands."
-  },
   "node-suite/stream/pipe/returns-destination": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- revalidated `stream.promises` namespace shape on current `main`
- removed stale known-failure entry for `node-suite/stream/imports/promises-ns`

## DeepWiki
- `reference/deepwiki/nodejs-node-stream-promises-namespace-2026-05-27.md`

## Verification
- Baseline exact parity pass before metadata removal: `test-parity/reports/parity_report_20260527_181419.json`
- Post-removal exact parity pass: `test-parity/reports/parity_report_20260527_181615.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check -- test-parity/known_failures.json`
