### PR TITLE
test(node:stream): unskip stream promises inventory

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1094,12 +1094,6 @@
     "category": "bug-open",
     "reason": "Regression test from #911 (express map undefined / http.METHODS). The METHODS property is now in the manifest (PR adding it alongside this entry); the test may still diverge from Node in the exact METHODS list shape. Re-evaluate once express compiles cleanly."
   },
-  "test_parity_stream_promises": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:stream/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "node-suite/stream/imports/promises-ns": {
     "issue": "1533",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- revalidated generated `node:stream/promises` inventory on current `main`
- removed stale known-failure entry for `test_parity_stream_promises`

## DeepWiki
- `reference/deepwiki/nodejs-node-stream-promises-module-inventory-2026-05-27.md`

## Verification
- Baseline generated parity pass before metadata removal: `test-parity/reports/parity_report_20260527_182101.json`
- Post-removal generated parity pass: `test-parity/reports/parity_report_20260527_182412.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check -- test-parity/known_failures.json`
