### PR TITLE
fix(node:stream): reject null writable stream sink

### DIFF
--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -767,6 +767,15 @@ pub(super) fn lower_builtin_new(
         }
 
         "WritableStream" => {
+            if matches!(args.first(), Some(Expr::Null)) {
+                for arg in args {
+                    let _ = lower_expr(ctx, arg)?;
+                }
+                let h = ctx
+                    .block()
+                    .call(DOUBLE, "js_writable_stream_throw_invalid_sink", &[]);
+                return Ok(Some(h));
+            }
             let mut start = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
             let mut write = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
             let mut close = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1747,6 +1747,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE],
     );
+    module.declare_function("js_writable_stream_throw_invalid_sink", DOUBLE, &[]);
     module.declare_function("js_writable_stream_get_writer", DOUBLE, &[DOUBLE]);
     module.declare_function("js_writable_stream_locked", DOUBLE, &[DOUBLE]);
     module.declare_function("js_writable_stream_close", I64, &[DOUBLE]);

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -297,6 +297,13 @@ unsafe fn make_error_with_message(msg: &str) -> u64 {
     JSValue::pointer(err as *const u8).bits()
 }
 
+unsafe fn throw_invalid_arg_type(message: &str) -> ! {
+    let s = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = perry_runtime::error::js_typeerror_new(s);
+    perry_runtime::node_submodules::register_error_code_pub(s, "ERR_INVALID_ARG_TYPE");
+    perry_runtime::exception::js_throw(perry_runtime::value::js_nanbox_pointer(err as i64))
+}
+
 fn alloc_readable(start_cb: i64, pull_cb: i64, cancel_cb: i64, hwm: f64) -> usize {
     let id = next_id(&NEXT_STREAM_ID);
     READABLE_STREAMS.lock().unwrap().insert(
@@ -1153,6 +1160,11 @@ pub unsafe extern "C" fn js_writable_stream_new(
         js_closure_call1(start_cb as *const ClosureHeader, id as f64);
     }
     id as f64
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_writable_stream_throw_invalid_sink() -> f64 {
+    throw_invalid_arg_type("The \"sink\" argument must be of type object")
 }
 
 #[no_mangle]

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1298,12 +1298,6 @@
     "category": "bug-open",
     "reason": "node:stream: Transform default objectMode — readableObjectMode/writableObjectMode wrong default. Flips to PASS when #1539 lands."
   },
-  "node-suite/stream/web/writable-stream-null-sink": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: new WritableStream(null) — null sink construction differs from Node. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/readable/read-with-undefined-size": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- reject `new WritableStream(null)` with a TypeError instead of constructing a default sink
- keep `WritableStream` object-literal sinks and strategy handling unchanged
- remove the now-passing `node-suite/stream/web/writable-stream-null-sink` known failure

## DeepWiki
- `reference/deepwiki/nodejs-node-stream-web-writable-null-sink-2026-05-27.md`

## Verification
- Baseline exact parity fail: `test-parity/reports/parity_report_20260527_183843.json`
- Post-fix exact parity pass before metadata removal: `test-parity/reports/parity_report_20260527_184403.json`
- Post-removal exact parity pass: `test-parity/reports/parity_report_20260527_185904.json`
- `cargo test -p perry-codegen --lib native_table`
- `cargo test -p perry-stdlib --no-default-features --features "bundled-streams crypto http-client" --lib js_writable_stream_throw_invalid_sink`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`
