### PR TITLE
fix(runtime): JSON.stringify serializes Map/Set as {} instead of SIGSEGV (#321)

### DIFF
--- a/test-files/test_gap_json_map_set.ts
+++ b/test-files/test_gap_json_map_set.ts
@@ -1,0 +1,52 @@
+// JSON.stringify of Map/Set values (#321).
+//
+// Per spec, Map and Set have no own enumerable string-keyed properties and no
+// toJSON, so JSON.stringify serializes them as "{}" (empty object) — at the
+// root, as an object field, as an array element, and through the indent,
+// function-replacer, and array (key-whitelist) replacer paths. Previously
+// Perry mis-read the Map/Set header as a plain object and dereferenced its
+// internals as a keys_array pointer, segfaulting the process.
+
+// Root value
+console.log(JSON.stringify(new Map([["a", 1], ["b", 2]])));
+console.log(JSON.stringify(new Set([1, 2, 3])));
+
+// As an object field (mixed with serializable siblings)
+console.log(JSON.stringify({ m: new Map([["x", 1]]), n: 5 }));
+console.log(JSON.stringify({ s: new Set([1, 2]), n: 5 }));
+
+// As an array element
+console.log(JSON.stringify([new Map(), 7]));
+console.log(JSON.stringify([new Set([1]), 8]));
+
+// Indent / pretty-print path
+console.log(JSON.stringify({ m: new Map([["x", 1]]) }, null, 2));
+console.log(JSON.stringify(new Map([["a", 1]]), null, 2));
+
+// Function-replacer path (identity replacer)
+console.log(JSON.stringify({ m: new Map([["x", 1]]), keep: 9 }, (k, v) => v));
+console.log(JSON.stringify(new Map([["x", 1]]), (k, v) => v));
+
+// Array (key-whitelist) replacer path
+console.log(JSON.stringify({ m: new Map([["x", 1]]), keep: 9 }, ["m", "keep"]));
+console.log(JSON.stringify(new Map([["x", 1]]), ["m"]));
+
+// Deeply nested Map/Set
+console.log(JSON.stringify({ outer: { inner: new Map([["k", new Set([1, 2])]]) } }));
+
+// Expected output:
+// {}
+// {}
+// {"m":{},"n":5}
+// {"s":{},"n":5}
+// [{},7]
+// [{},8]
+// {
+//   "m": {}
+// }
+// {}
+// {"m":{},"keep":9}
+// {}
+// {"m":{},"keep":9}
+// {}
+// {"outer":{"inner":{}}}


### PR DESCRIPTION
## Summary

`JSON.stringify(new Map(...))` (and `new Set(...)`) segfaulted Perry. Per spec, `Map`/`Set` have no own enumerable string-keyed properties and no `toJSON`, so Node serializes them as `"{}"` — Perry instead mis-read the `MapHeader`/`SetHeader` as a plain `ObjectHeader`, dereferenced its internals as a `keys_array` pointer, and crashed.

## Root cause

The JSON serializer's pointer dispatch (`stringify.rs` + `replacer.rs`) handles GC pointers in two ways:

1. Match on `gc_obj_type(ptr)` — the robust GC-header tag introduced by #2106 / #2112 — for `GC_TYPE_OBJECT`, `GC_TYPE_ARRAY`, `GC_TYPE_STRING`, and `GC_TYPE_ERROR`.
2. A structural `_` fallthrough that calls `is_object_pointer(ptr)`, which reads `ObjectHeader.keys_array` and then `(*keys_arr).length`.

`GC_TYPE_MAP` (8) and `GC_TYPE_SET` (12) had no explicit arms anywhere and fell into the `_` fallthrough, where the `keys_array` field offset inside `MapHeader` / `SetHeader` actually contains bucket-pointer / capacity bytes — values that frequently look "valid enough" to pass the heuristic, after which `(*keys_arr).length` deref's garbage and segfaults the process.

Same shape of bug as #928 fixed for `Error` (dedicated `ErrorHeader` layout); this PR extends the cure to `Map`/`Set`.

## Fix

Add `GC_TYPE_MAP | GC_TYPE_SET => buf.push_str("{}")` to every `match gc_obj_type(ptr)` site, mirroring the existing `GC_TYPE_ERROR` arm; and for the two dispatch sites that don't have a `gc_obj_type` match at all (the indent-only `stringify_value_pretty` and the top-level array-replacer entry), add an explicit `GC_TYPE_MAP | GC_TYPE_SET | GC_TYPE_ERROR` guard before the structural `is_object_pointer` deref. Six edits total across two files.

## Coverage

- `stringify.rs::stringify_value` — root, no-replacer, no-indent
- `stringify.rs::stringify_value_depth` — nested object field
- `stringify.rs::stringify_array_depth` — per-element dispatch
- `replacer.rs::dispatch_pointer_with_replacer` — function-replacer path (every position)
- `replacer.rs::stringify_value_pretty` — indent (no fn-replacer) path
- `replacer.rs::js_json_stringify_full` array-replacer arm — top-level whitelist path

The shape-template fast paths (`build_shape_prefix_template`, `try_emit_shape_element`) already bail to the per-element slow path on `!= GC_TYPE_OBJECT`, so they're correct as-is.

## Verification (byte-identical to `node --experimental-strip-types`)

`test-files/test_gap_json_map_set.ts` covers every dispatch site — root, object field, array element, indent, function-replacer, array-replacer, deeply nested — and matches Node byte-for-byte. Output:

```
{}
{}
{"m":{},"n":5}
{"s":{},"n":5}
[{},7]
[{},8]
{
  "m": {}
}
{}
{"m":{},"keep":9}
{}
{"m":{},"keep":9}
{}
{"outer":{"inner":{}}}
```

No regressions:

- `cargo test --release -p perry-runtime --lib -- --test-threads=1` — 700 passed, 0 failed.
- Existing JSON tests (`test_gap_json_advanced.ts`, `test_json.ts`, `test_issue_639_json_stringify_buffer.ts`, `test_issue_307_json_stringify_overflow_fields.ts`) all still byte-identical to Node.
- Hand-written regression sweep across plain objects/arrays/nested, own + prototype `toJSON` (#2112 — class with `toJSON`, Effect-`Option.some`-shape), function replacer, array replacer, pretty-print, Date, Error, primitives, empty `{}` / `[]` — all byte-identical.
- `cargo fmt --all -- --check` clean.

## Spec note

`Map` / `Set` aren't special-cased by `JSON.stringify` — they simply have no own enumerable string-keyed properties (their entries live in internal slots) and no `toJSON`. The empty-object output falls naturally out of the spec; the fix just stops Perry from walking a struct that doesn't have the assumed layout. The PR doesn't attempt to serialize entries — that would diverge from Node.

Related: #2106 (replacer + toJSON, the introduction of `gc_obj_type` dispatch in JSON), #2112 (toJSON via prototype chain), #928 (the equivalent `Error → "{}"` fix this mirrors).
