### PR TITLE
Remove stale stream emit-after-destroy failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1868,12 +1868,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: WritableStream({type:'bytes'}) — handling differs from Node (accept-and-ignore or throw). Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/events/emit-after-destroy-still-works": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: custom emit() on destroyed stream — listener does not fire or fires multiple times. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/pause-sets-flowing-false": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- revalidate `stream/events/emit-after-destroy-still-works` on current `main`
- remove the stale known-failure entry now that manual EventEmitter `emit()` after destroy passes

DeepWiki note saved locally: `reference/deepwiki/nodejs-node-stream-emit-after-destroy-2026-05-27.md`.

## Verification
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/events/emit-after-destroy-still-works` PASS before metadata removal (`test-parity/reports/parity_report_20260527_200422.json`)
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/events/emit-after-destroy-still-works` PASS after metadata removal (`test-parity/reports/parity_report_20260527_200521.json`)
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS