### PR TITLE
Remove stale stream sync-dispose failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -836,12 +836,6 @@
     "category": "bug-open",
     "reason": "node:stream: finished({readable:false}) does not fire callback on writable-only close. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/dispose/sync-dispose": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Symbol.dispose presence on stream instances (Node 21+) misreports. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/duplex-pair/wired-comms": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- revalidate the `stream/dispose/sync-dispose` filter on current `main`
- remove the stale known-failure entry for `node-suite/stream/dispose/sync-dispose`

DeepWiki note saved locally: `reference/deepwiki/nodejs-node-stream-symbol-dispose-2026-05-27.md`.

## Verification
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/dispose/sync-dispose` PASS before metadata removal (`test-parity/reports/parity_report_20260527_200733.json`)
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/dispose/sync-dispose` PASS after metadata removal (`test-parity/reports/parity_report_20260527_200757.json`)
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS