### PR TITLE
Remove stale stream sync-iterator failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1496,12 +1496,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: rs.cancel() during pipeTo — should reject (locked stream); resolves or wrong err name. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/iterator/for-of-not-async": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: sync for-of on Readable — Perry does not throw (TypeError expected since Symbol.iterator absent). Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/iter-helpers/take-zero": {
     "issue": "1558",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- revalidate `stream/iterator/for-of-not-async` on current `main`
- remove the stale known-failure entry now that sync `for...of` on classic Readable throws like Node

DeepWiki note saved locally: `reference/deepwiki/nodejs-node-stream-no-sync-iterator-2026-05-27.md`.

## Verification
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/iterator/for-of-not-async` PASS before metadata removal (`test-parity/reports/parity_report_20260527_200945.json`)
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/iterator/for-of-not-async` PASS after metadata removal (`test-parity/reports/parity_report_20260527_201016.json`)
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS