### PR TITLE
Remove stale stream iterator return failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -794,12 +794,6 @@
     "category": "bug-open",
     "reason": "node:events.getEventListeners(stream, name) does not return the listener array. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/iterator/return-method": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: async iterator's return() does not resolve { value: undefined, done: true }. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/web/writable-multiple-writers-fails": {
     "issue": "1545",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- revalidate `stream/iterator/return-method` on current `main`
- remove the stale known-failure entry now that async iterator `.return()` matches Node

DeepWiki note saved locally: `reference/deepwiki/nodejs-node-stream-async-iterator-return-2026-05-27.md`.

## Verification
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/iterator/return-method` PASS before metadata removal (`test-parity/reports/parity_report_20260527_201207.json`)
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/iterator/return-method` PASS after metadata removal (`test-parity/reports/parity_report_20260527_201237.json`)
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS