### PR TITLE
Remove stale stream iterator destroyOnReturn false failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -458,12 +458,6 @@
     "category": "bug-open",
     "reason": "node:stream: Duplex.allowHalfOpen option not surfaced on instance. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/iterator/destroy-on-return-false": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: readable.iterator({destroyOnReturn:false}) option not honored. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipe/pipe-chain": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- revalidate `stream/iterator/destroy-on-return-false` on current `main`
- remove the stale known-failure entry now that `readable.iterator({ destroyOnReturn:false })` keeps the stream readable

DeepWiki note saved locally: `reference/deepwiki/nodejs-node-stream-iterator-destroy-on-return-false-2026-05-27.md`.

## Verification
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/iterator/destroy-on-return-false` PASS before metadata removal (`test-parity/reports/parity_report_20260527_201401.json`)
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/iterator/destroy-on-return-false` PASS after metadata removal (`test-parity/reports/parity_report_20260527_201434.json`)
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS