### PR TITLE
fix(codegen): preserve string-tag when indexing into a <T extends string> param at call boundary (#321)

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -51,6 +51,7 @@ impl LoweringContext {
             builtin_module_aliases: Vec::new(),
             subns_path_aliases: HashMap::new(),
             type_param_scopes: Vec::new(),
+            type_param_constraints: Vec::new(),
             native_instances: Vec::new(),
             ui_widget_type_aliases: HashMap::new(),
             current_class: None,
@@ -126,11 +127,24 @@ impl LoweringContext {
     pub(crate) fn enter_type_param_scope(&mut self, type_params: &[TypeParam]) {
         let scope: HashSet<String> = type_params.iter().map(|p| p.name.clone()).collect();
         self.type_param_scopes.push(scope);
+        // Constraint table mirrors the same scope so `is_type_param(name)`
+        // and `resolve_type_param_constraint(name)` agree on visibility.
+        // Only params with a declared upper bound contribute an entry.
+        let constraints: HashMap<String, perry_types::Type> = type_params
+            .iter()
+            .filter_map(|p| {
+                p.constraint
+                    .as_ref()
+                    .map(|c| (p.name.clone(), (**c).clone()))
+            })
+            .collect();
+        self.type_param_constraints.push(constraints);
     }
 
     /// Exit the current type parameter scope
     pub(crate) fn exit_type_param_scope(&mut self) {
         self.type_param_scopes.pop();
+        self.type_param_constraints.pop();
     }
 
     /// Check if a name is a type parameter in the current scope
@@ -138,6 +152,45 @@ impl LoweringContext {
         self.type_param_scopes
             .iter()
             .any(|scope| scope.contains(name))
+    }
+
+    /// Resolve a type-parameter reference to its declared upper-bound
+    /// constraint, when that constraint is a runtime-meaningful type
+    /// (`String`, `Number`, `Boolean`, `BigInt`, `Array<T>`). Returns
+    /// `None` for parameters with no constraint or with constraints that
+    /// don't usefully narrow the runtime representation (`unknown`/`any`/
+    /// `object`/named-class/union — those keep `TypeVar(T)` so
+    /// monomorphization or downstream native-instance tagging still has
+    /// the chance to substitute a concrete type).
+    ///
+    /// Innermost scope wins (shadowing).
+    pub(crate) fn resolve_type_param_constraint(&self, name: &str) -> Option<perry_types::Type> {
+        for scope in self.type_param_constraints.iter().rev() {
+            if let Some(ty) = scope.get(name) {
+                // Only return constraints whose runtime shape is
+                // narrower than `Any`. `String`/`Number`/`Boolean`/
+                // `BigInt` are primitives; `Array<elem>` lets
+                // `<T extends string[]>` propagate to the array fast
+                // path. Anything else (e.g., `T extends SomeClass`,
+                // `T extends "literal"`, intersections) falls back to
+                // the `TypeVar`/`Named` path so existing native-
+                // instance tagging / class-id propagation still work.
+                let useful = matches!(
+                    ty,
+                    perry_types::Type::String
+                        | perry_types::Type::Number
+                        | perry_types::Type::Boolean
+                        | perry_types::Type::BigInt
+                        | perry_types::Type::Array(_)
+                );
+                if useful {
+                    return Some(ty.clone());
+                } else {
+                    return None;
+                }
+            }
+        }
+        None
     }
 
     /// Look up a type alias by name and return its resolved type (if found).

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -33,6 +33,23 @@ pub(super) fn lower_arrow(ctx: &mut LoweringContext, arrow: &ast::ArrowExpr) -> 
     let func_id = ctx.fresh_func();
     let scope_mark = ctx.enter_scope();
 
+    // Enter a type-parameter scope for arrow generics — `<T extends string>
+    // (self: T) => ...`. Without this scope the `T` reference in `self: T`
+    // never matches `is_type_param` and stays as `Type::Named("T")`, so
+    // the constraint-substitution path in `extract_ts_type_with_ctx` can't
+    // resolve it. Arrows and function expressions aren't monomorphized
+    // (only `FuncRef`-targeted calls go through that pass), so the
+    // un-narrowed param type would be the one codegen lowers — and the
+    // IndexGet fast path keys off the param's static type. Mirrors the
+    // existing `lower_fn_decl` scope-entry. (#321: effect's
+    // `Str.capitalize` / `Capitalize<T>` arrow utilities.)
+    let arrow_type_params = arrow
+        .type_params
+        .as_ref()
+        .map(|tp| crate::lower_types::extract_type_params(tp))
+        .unwrap_or_default();
+    ctx.enter_type_param_scope(&arrow_type_params);
+
     // Track which locals exist before entering the closure scope
     let outer_locals: Vec<(String, LocalId)> = ctx
         .locals
@@ -245,6 +262,11 @@ pub(super) fn lower_arrow(ctx: &mut LoweringContext, arrow: &ast::ArrowExpr) -> 
     }
 
     ctx.exit_scope(scope_mark);
+
+    // Exit the type-parameter scope opened at the top of `lower_arrow`.
+    // Paired with `enter_type_param_scope` above so nested generic
+    // arrows don't leak outer T/U bindings into sibling code.
+    ctx.exit_type_param_scope();
 
     let (captures, mutable_captures) = compute_closure_captures(ctx, &body, &outer_locals, &params);
 

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -114,6 +114,27 @@ pub struct LoweringContext {
     pub(crate) builtin_module_aliases: Vec<(String, String)>,
     /// Stack of type parameter scopes (for nested generics)
     pub(crate) type_param_scopes: Vec<HashSet<String>>,
+    /// Stack of type parameter CONSTRAINTS, paired with `type_param_scopes`.
+    /// `type_param_constraints[i]` maps type-parameter name → its declared
+    /// upper-bound constraint (`<T extends string>` → `String`). Used to
+    /// resolve a `Named(T)`/`TypeVar(T)` reference to the *runtime* type
+    /// the value must satisfy, so callers and the body see e.g.
+    /// `Type::String` instead of `Type::Named("T")`.
+    ///
+    /// Why this matters at lowering (not codegen): perry monomorphizes
+    /// `FuncRef`-targeted generic calls (issue #321 scaffolding) but does
+    /// NOT monomorphize closures/arrow functions and does NOT monomorphize
+    /// generic functions reached through a function-typed local. The
+    /// emitted body of such a function therefore lowers `self[0]` (for
+    /// `<T extends string>(self: T)`) with no string-typing on `self`,
+    /// and codegen falls through to `js_object_get_index_polymorphic`
+    /// which reads a `StringHeader*` as `ArrayHeader*` and returns the
+    /// header bytes as a subnormal f64 — surfacing as the `1.5E-323oo`
+    /// pattern in effect's `Str.capitalize`/`Capitalize<T>` utilities.
+    /// Resolving the constraint at the `TsTypeRef` site for `T` makes the
+    /// param type `String` everywhere downstream, so the IndexGet/Member
+    /// fast paths fire.
+    pub(crate) type_param_constraints: Vec<HashMap<String, Type>>,
     /// Native class instances: local_name -> (module_name, class_name)
     /// Tracks variables that hold instances of native module classes (e.g., EventEmitter)
     pub(crate) native_instances: Vec<(String, String, String)>,

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -863,9 +863,34 @@ pub(crate) fn extract_ts_type_with_ctx(
                 }
             };
 
-            // First check if this is a type parameter reference (like T, K, V)
+            // First check if this is a type parameter reference (like T, K, V).
+            //
+            // When the parameter has a runtime-meaningful upper-bound
+            // constraint (`<T extends string>`, `<T extends number>`,
+            // `<T extends string[]>` …) substitute the constraint type
+            // here, so the rest of the lowering + codegen sees the
+            // narrowed runtime type directly. Without this, perry's
+            // codegen `is_string_expr`/`is_array_expr`/`is_numeric_expr`
+            // fast paths don't fire on `<T extends string>(self: T)
+            // => self[0]` and the IndexGet falls through to the
+            // polymorphic-object runtime helper, which reads a
+            // `StringHeader*` as `ArrayHeader*` and returns header
+            // bytes as a subnormal f64 (#321: effect `Str.capitalize`
+            // surfaced as `1.5E-323oo`). Arrow functions and
+            // function-typed-local indirections in particular bypass
+            // generic-call monomorphization entirely, so the
+            // un-substituted body would be the one codegen emits.
+            //
+            // Constraints that don't usefully narrow the runtime
+            // representation (named class, literal type, intersection,
+            // `unknown`/`any`) fall through to `TypeVar(name)` as
+            // before — preserving the existing native-instance tagging
+            // / class-id propagation paths.
             if let Some(context) = ctx {
                 if context.is_type_param(&name) {
+                    if let Some(resolved) = context.resolve_type_param_constraint(&name) {
+                        return resolved;
+                    }
                     return Type::TypeVar(name);
                 }
             }

--- a/test-files/test_gap_generic_string_param_indexing.ts
+++ b/test-files/test_gap_generic_string_param_indexing.ts
@@ -1,0 +1,62 @@
+// #321 frontier: indexing into a generic-typed `<T extends string>` parameter
+// must produce a properly NaN-boxed string at the function-call boundary.
+//
+// Pre-fix, perry's codegen took the polymorphic-object IndexGet runtime
+// helper for `self[0]` because the param's static type was `Type::Named("T")`
+// (arrow type params weren't enter-scoped) or `Type::TypeVar("T")` (fn-decl
+// scope entered but no constraint substitution). That helper read a
+// `StringHeader*` as `ArrayHeader*` and returned the header's leading bytes
+// as a subnormal `f64`, surfacing in effect's `Str.capitalize` /
+// `Capitalize<T>` utilities as `1.5E-323oo` instead of `Foo`.
+//
+// Fix: in HIR lowering, when a type-parameter reference resolves to a
+// runtime-narrowing upper bound (`<T extends string>`, `<T extends number>`,
+// `<T extends boolean>`, `<T extends bigint>`, `<T extends U[]>`) substitute
+// the constraint type at the `TsTypeRef` site so the param's static type is
+// `String`/`Number`/etc. everywhere downstream, and the codegen IndexGet
+// fast path fires.
+
+// Arrow-form (the original repro shape).
+const innerG = <T extends string>(s: T): string => s.toUpperCase();
+const innerN = (s: string): string => s.toUpperCase();
+const outerGtoInnerG = <T extends string>(self: T): string => innerG(self[0]) + self.slice(1);
+const outerGtoInnerN = <T extends string>(self: T): string => innerN(self[0]) + self.slice(1);
+const outerNtoInnerG = (self: string): string => innerG(self[0]) + self.slice(1);
+console.log("ARROW G->G:", outerGtoInnerG("foo"));
+console.log("ARROW G->N:", outerGtoInnerN("foo"));
+console.log("ARROW N->G:", outerNtoInnerG("foo"));
+
+// Effect-shape Capitalize<T>: charAt(0).toUpperCase() + slice(1).
+const cap = <T extends string>(s: T): string => s.charAt(0).toUpperCase() + s.slice(1);
+console.log("CAP:", cap("foo"));
+console.log("CAP:", cap("a"));
+console.log("CAP:", cap(""));
+
+// Nested generic arrows — inner T captures outer's substituted type.
+const outer = <T extends string>(s: T): string => {
+  const inner = <U extends string>(u: U): string => u[0] + s;
+  return inner("Q");
+};
+console.log("NESTED:", outer("abc"));
+
+// Indirect call through a function-typed local — bypasses generic-call
+// monomorphization, so the function body needs the constraint baked in
+// at lowering time. Pre-fix this surfaced the same `1.5E-323oo` pattern.
+function genFn<T extends string>(self: T): string { return self[0].toUpperCase() + self.slice(1); }
+const fn: (s: string) => string = genFn;
+console.log("FNPTR:", fn("foo"));
+
+// Generic typed-array param.
+const firstStr = <T extends string[]>(a: T): string => a[0];
+console.log("ARR:", firstStr(["alpha", "beta"]));
+
+// `<T extends number>` keeps numeric-typed fast paths.
+const numAdd = <T extends number>(x: T): number => x + 1;
+console.log("NUM:", numAdd(41));
+
+// Unconstrained generics (`T extends unknown` / no constraint) are NOT
+// substituted — they keep their `TypeVar(T)` shape so existing
+// native-instance tagging / class-id propagation still apply.
+const idAny = <T>(x: T): T => x;
+console.log("ID:", idAny(42));
+console.log("ID:", idAny("z"));


### PR DESCRIPTION
## Problem

Indexing into a generic-typed `<T extends string>` parameter produced a value that lost its string tag at the function-call boundary. Surfaces in effect's `Str.capitalize` / `Capitalize<T>` / `Uppercase<T>` shape:

```ts
const innerG = <T extends string>(s: T): string => s.toUpperCase();
const outerGtoInnerG = <T extends string>(self: T): string =>
  innerG(self[0]) + self.slice(1);
console.log(outerGtoInnerG("foo"));
// Node:   Foo
// Perry:  1.5E-323oo   (pre-fix)
```

In effect this surfaces as `Str.capitalize("foo")` returning `1.5E-323oo`.

## Root cause

Perry's codegen IndexGet fast path keys off the receiver's static type. Two paths through HIR lowering dropped the constraint:

1. `lower_arrow` never entered a type-parameter scope (only `lower_fn_decl` / class / type-alias did), so the `T` in `(self: T)` resolved to `Type::Named("T")` — neither `is_string_expr` nor any other primitive predicate matched.

2. `lower_fn_decl` entered the scope but `extract_ts_type_with_ctx` just returned `Type::TypeVar("T")`, which also fell out of every primitive predicate. Generic-call monomorphization rescued direct `FuncRef` call sites, but indirect calls through a function-typed local (and arrows, which are never monomorphized) lowered the un-substituted body — IndexGet dispatched to `js_object_get_index_polymorphic`, which read a `StringHeader*` as `ArrayHeader*` and returned the header's leading bytes as a subnormal f64.

The pre-fix LLVM for `outerGtoInnerG` makes this concrete — instead of the `outerNtoInnerG` fast path:

```
%r7 = call i64 @js_string_char_at(i64 %r5, i32 %r6)
%r8 = or i64 %r7, 9223090561878065152          ; STRING_TAG
%r9 = bitcast i64 %r8 to double                 ; passed to innerG
```

it goes through the generic IndexGet dispatcher and ends up calling `js_object_get_index_polymorphic(StringHeader*, 0.0)`, whose result `%r20` flows straight into `js_closure_call1(..., %r20)` with no STRING_TAG re-wrap.

## Fix

In `extract_ts_type_with_ctx`, when `T` is an in-scope type parameter with a runtime-narrowing upper bound (`<T extends string|number|boolean|bigint|U[]>`), return the constraint type instead of `TypeVar(T)`. The narrow list keeps existing native-instance-tagging / class-id-propagation paths intact for `T extends SomeClass` / literal / intersection constraints — those still produce `TypeVar(T)` so monomorphization or downstream tagging can substitute a concrete type as before.

Also opens a type-parameter scope inside `lower_arrow` so the `is_type_param("T")` check fires for arrows the same way it already does for function declarations, classes, and type aliases.

Mechanics:
- `LoweringContext` grows a parallel `type_param_constraints: Vec<HashMap<String, Type>>` stack mirroring the existing `type_param_scopes`.
- `enter_type_param_scope` / `exit_type_param_scope` push/pop both stacks.
- `resolve_type_param_constraint(name)` consults the innermost scope first, returns the constraint only when it usefully narrows runtime shape.
- `extract_ts_type_with_ctx` calls it from the `TsTypeRef` branch.
- `lower_arrow` now extracts `arrow.type_params` and enters the scope at the top, exits at the bottom (mirroring `lower_fn_decl`).

## Verification

Repro file (`/tmp/comp.ts`):
```ts
const innerG = <T extends string>(s: T): string => s.toUpperCase();
const innerN = (s: string): string => s.toUpperCase();
const outerGtoInnerG = <T extends string>(self: T): string => innerG(self[0]) + self.slice(1);
const outerGtoInnerN = <T extends string>(self: T): string => innerN(self[0]) + self.slice(1);
const outerNtoInnerG = (self: string): string => innerG(self[0]) + self.slice(1);
console.log("G->G:", outerGtoInnerG("foo"));
console.log("G->N:", outerGtoInnerN("foo"));
console.log("N->G:", outerNtoInnerG("foo"));
```

Pre-fix:
```
G->G: 1.5E-323oo
G->N: 1.5E-323oo
N->G: Foo
```

Post-fix (byte-identical to `node --experimental-strip-types`):
```
G->G: Foo
G->N: Foo
N->G: Foo
```

Effect `/private/tmp/effect-dod/survey/fr_effstring.ts`:
```
effstring: camel_case snakeCase Foo
```
matches Node.

New gap test `test-files/test_gap_generic_string_param_indexing.ts` covers:
- arrow `<T extends string>` G->G / G->N / N->G matrix
- effect-shape `Capitalize<T>` (`charAt(0).toUpperCase() + slice(1)`)
- nested generics (inner `<U extends string>` inside outer `<T extends string>`)
- fn-decl invoked through a function-typed local (indirect call, no monomorphization)
- `<T extends string[]>` indexing
- `<T extends number>` keeps numeric fast paths
- unconstrained `<T>` falls back to TypeVar (unchanged behavior)

All byte-identical with Node.

Regression sweep:
- 87/87 gap tests (`test-files/test_gap_*.ts`) pass except 2 pre-existing failures (`test_gap_derived_param_props`, `test_gap_param_prop_array_index`) where Node's `--experimental-strip-types` rejects TS parameter-property syntax — those are NODE_FAIL in the parity runner.
- `cargo test --release -p perry-hir / perry-runtime / perry-codegen` green.
- `cargo fmt --all -- --check` clean.
- Effect smoke tests `01_succeed.ts`, `02_map.ts` byte-identical.

## Files changed

- `crates/perry-hir/src/lower/lowering_context.rs` — new `type_param_constraints` field
- `crates/perry-hir/src/lower/context.rs` — initialize / push / pop constraint stack, `resolve_type_param_constraint` helper
- `crates/perry-hir/src/lower_types.rs` — substitute constraint at `TsTypeRef` site
- `crates/perry-hir/src/lower/expr_function.rs` — enter/exit type-param scope in `lower_arrow`
- `test-files/test_gap_generic_string_param_indexing.ts` — new gap test

Closes a #321 frontier blocker. Doesn't depend on / unlock anything else, but removes a class of subtle string-tag-loss bugs in any generic utility that uses `<T extends string>` + indexing.
