### PR TITLE
Remove stale stream async iterator explicit return failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1544,12 +1544,6 @@
     "category": "bug-open",
     "reason": "node:stream: wrap(EE) + pipe(dst) — piped output empty or wrong. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/async-iter/return-method-explicit": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: asyncIterator.return() — does not destroy/end properly or returns wrong shape. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/destroy/destroy-during-read": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove the stale known-failure entry for node-suite/stream/async-iter/return-method-explicit
- keep the DeepWiki reference and experiment notes local/untracked

## Verification
- ./run_parity_tests.sh --suite node-suite --module stream --filter async-iter/return-method-explicit (before removal): PASS, report test-parity/reports/parity_report_20260527_201845.json
- ./run_parity_tests.sh --suite node-suite --module stream --filter async-iter/return-method-explicit (after removal): PASS, report test-parity/reports/parity_report_20260527_201907.json
- jq empty test-parity/known_failures.json
- git diff --check