### PR TITLE
Destroy readable iterators on default early return

### DIFF
--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -115,6 +115,55 @@ fn is_node_readable_for_await_target(ctx: &LoweringContext, expr: &ast::Expr) ->
     )
 }
 
+fn iterator_return_call(iter_id: LocalId, needs_await: bool) -> Expr {
+    let call = Expr::Call {
+        callee: Box::new(Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(iter_id)),
+            property: "return".to_string(),
+        }),
+        args: vec![],
+        type_args: vec![],
+    };
+    if needs_await {
+        Expr::Await(Box::new(call))
+    } else {
+        call
+    }
+}
+
+fn insert_iterator_return_before_breaks(
+    stmts: &mut Vec<Stmt>,
+    iter_id: LocalId,
+    needs_await: bool,
+) {
+    let mut rewritten = Vec::with_capacity(stmts.len());
+    for stmt in stmts.drain(..) {
+        match stmt {
+            Stmt::Break => {
+                rewritten.push(Stmt::Expr(iterator_return_call(iter_id, needs_await)));
+                rewritten.push(Stmt::Break);
+            }
+            Stmt::If {
+                condition,
+                mut then_branch,
+                mut else_branch,
+            } => {
+                insert_iterator_return_before_breaks(&mut then_branch, iter_id, needs_await);
+                if let Some(else_stmts) = else_branch.as_mut() {
+                    insert_iterator_return_before_breaks(else_stmts, iter_id, needs_await);
+                }
+                rewritten.push(Stmt::If {
+                    condition,
+                    then_branch,
+                    else_branch,
+                });
+            }
+            other => rewritten.push(other),
+        }
+    }
+    *stmts = rewritten;
+}
+
 pub(crate) fn lower_stmt_for_of(
     ctx: &mut LoweringContext,
     module: &mut Module,
@@ -327,6 +376,9 @@ pub(crate) fn lower_stmt_for_of(
             lower_stmt(ctx, module, &for_of_stmt.body)?;
         }
         let mut user_body: Vec<Stmt> = module.init.drain(init_before..).collect();
+        if is_node_readable_for_await {
+            insert_iterator_return_before_breaks(&mut user_body, iter_id, needs_await);
+        }
         body_stmts.append(&mut user_body);
         // __result = __iter.next()
         body_stmts.push(Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))));

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -111,6 +111,55 @@ fn is_node_readable_for_await_target(ctx: &LoweringContext, expr: &ast::Expr) ->
     )
 }
 
+fn iterator_return_call(iter_id: LocalId, needs_await: bool) -> Expr {
+    let call = Expr::Call {
+        callee: Box::new(Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(iter_id)),
+            property: "return".to_string(),
+        }),
+        args: vec![],
+        type_args: vec![],
+    };
+    if needs_await {
+        Expr::Await(Box::new(call))
+    } else {
+        call
+    }
+}
+
+fn insert_iterator_return_before_breaks(
+    stmts: &mut Vec<Stmt>,
+    iter_id: LocalId,
+    needs_await: bool,
+) {
+    let mut rewritten = Vec::with_capacity(stmts.len());
+    for stmt in stmts.drain(..) {
+        match stmt {
+            Stmt::Break => {
+                rewritten.push(Stmt::Expr(iterator_return_call(iter_id, needs_await)));
+                rewritten.push(Stmt::Break);
+            }
+            Stmt::If {
+                condition,
+                mut then_branch,
+                mut else_branch,
+            } => {
+                insert_iterator_return_before_breaks(&mut then_branch, iter_id, needs_await);
+                if let Some(else_stmts) = else_branch.as_mut() {
+                    insert_iterator_return_before_breaks(else_stmts, iter_id, needs_await);
+                }
+                rewritten.push(Stmt::If {
+                    condition,
+                    then_branch,
+                    else_branch,
+                });
+            }
+            other => rewritten.push(other),
+        }
+    }
+    *stmts = rewritten;
+}
+
 pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Vec<Stmt>> {
     let mut result = Vec::new();
 
@@ -1113,7 +1162,10 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                         property: "value".to_string(),
                     }),
                 });
-                let user_body = lower_body_stmt(ctx, &for_of_stmt.body)?;
+                let mut user_body = lower_body_stmt(ctx, &for_of_stmt.body)?;
+                if is_node_readable_for_await {
+                    insert_iterator_return_before_breaks(&mut user_body, iter_id, needs_await);
+                }
                 body_stmts.extend(user_body);
                 body_stmts.push(Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))));
 

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -1162,6 +1162,7 @@ fn register_stub_arities() {
     register(ns_undefined0 as *const u8, 0);
     register(ns_push1 as *const u8, 1);
     register(ns_compose1 as *const u8, 1);
+    async_iterator::register_arities();
 }
 
 #[inline]
@@ -1899,7 +1900,7 @@ fn readable_methods() -> [(&'static str, StubFn); 37] {
         ("flatMap", cast2(ns_iter_flat_map)),
         ("take", cast1(ns_iter_take)),
         ("drop", cast1(ns_iter_drop)),
-        ("iterator", cast0(async_iterator::ns_async_iterator)),
+        ("iterator", cast1(async_iterator::ns_iterator1)),
         // #1539 — push() backpressure return + readable.compose() instance form.
         ("push", cast1(ns_push1)),
         ("compose", cast1(ns_compose1)),

--- a/crates/perry-runtime/src/node_stream/async_iterator.rs
+++ b/crates/perry-runtime/src/node_stream/async_iterator.rs
@@ -4,6 +4,7 @@ const READABLE_ITERATOR_SHAPE_ID: u32 = 0x7FFF_FF60;
 const READABLE_ITERATOR_STREAM_KEY: &[u8] = b"__perryReadableIteratorStream";
 const READABLE_ITERATOR_INDEX_KEY: &[u8] = b"__perryReadableIteratorIndex";
 const READABLE_ITERATOR_DONE_KEY: &[u8] = b"__perryReadableIteratorDone";
+const READABLE_ITERATOR_DESTROY_ON_RETURN_KEY: &[u8] = b"__perryReadableIteratorDestroyOnReturn";
 
 fn iterator_result(value: f64, done: bool) -> f64 {
     let obj = crate::object::js_object_alloc(0, 2);
@@ -18,6 +19,27 @@ fn iterator_result(value: f64, done: bool) -> f64 {
 
 fn readable_iterator_done() -> f64 {
     resolved_promise(iterator_result(f64::from_bits(TAG_UNDEFINED), true))
+}
+
+fn destroy_on_return_from_options(opts: f64) -> bool {
+    !matches!(
+        get_hidden_value(opts, hidden_key(b"destroyOnReturn")),
+        Some(value) if value.to_bits() == TAG_FALSE
+    )
+}
+
+fn iterator_destroys_on_return(iterator: f64) -> bool {
+    get_hidden_value(
+        iterator,
+        hidden_key(READABLE_ITERATOR_DESTROY_ON_RETURN_KEY),
+    )
+    .is_none_or(|value| crate::value::js_is_truthy(value) != 0)
+}
+
+fn iterator_has_yielded(iterator: f64) -> bool {
+    get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_INDEX_KEY))
+        .and_then(jsvalue_as_f64)
+        .is_some_and(|index| index > 0.0)
 }
 
 extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
@@ -63,11 +85,19 @@ extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
 }
 
 extern "C" fn ns_readable_iterator_return(closure: *const ClosureHeader) -> f64 {
+    let iterator = this_value(closure);
+    let already_done = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_DONE_KEY))
+        .is_some_and(|v| crate::value::js_is_truthy(v) != 0);
     set_hidden_value(
-        this_value(closure),
+        iterator,
         hidden_key(READABLE_ITERATOR_DONE_KEY),
         f64::from_bits(TAG_TRUE),
     );
+    if !already_done && iterator_has_yielded(iterator) && iterator_destroys_on_return(iterator) {
+        if let Some(stream) = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_STREAM_KEY)) {
+            destroy_stream(stream, f64::from_bits(TAG_UNDEFINED));
+        }
+    }
     readable_iterator_done()
 }
 
@@ -76,7 +106,11 @@ extern "C" fn ns_readable_iterator_self(closure: *const ClosureHeader) -> f64 {
 }
 
 pub(super) extern "C" fn ns_async_iterator(closure: *const ClosureHeader) -> f64 {
-    build_readable_async_iterator(this_value(closure))
+    build_readable_async_iterator(this_value(closure), true)
+}
+
+pub(super) extern "C" fn ns_iterator1(closure: *const ClosureHeader, opts: f64) -> f64 {
+    build_readable_async_iterator(this_value(closure), destroy_on_return_from_options(opts))
 }
 
 fn install_async_iterator_symbol(target: f64, func: extern "C" fn(*const ClosureHeader) -> f64) {
@@ -93,7 +127,7 @@ fn install_async_iterator_symbol(target: f64, func: extern "C" fn(*const Closure
     }
 }
 
-fn build_readable_async_iterator(stream: f64) -> f64 {
+fn build_readable_async_iterator(stream: f64, destroy_on_return: bool) -> f64 {
     let methods = [
         ("next", cast0(ns_readable_iterator_next)),
         ("return", cast0(ns_readable_iterator_return)),
@@ -107,10 +141,27 @@ fn build_readable_async_iterator(stream: f64) -> f64 {
         hidden_key(READABLE_ITERATOR_DONE_KEY),
         f64::from_bits(TAG_FALSE),
     );
+    set_hidden_value(
+        iterator,
+        hidden_key(READABLE_ITERATOR_DESTROY_ON_RETURN_KEY),
+        f64::from_bits(if destroy_on_return {
+            TAG_TRUE
+        } else {
+            TAG_FALSE
+        }),
+    );
     install_async_iterator_symbol(iterator, ns_readable_iterator_self);
     iterator
 }
 
 pub(super) fn install_readable_async_iterator_symbol(stream: f64) {
     install_async_iterator_symbol(stream, ns_async_iterator);
+}
+
+pub(super) fn register_arities() {
+    crate::closure::js_register_closure_arity(ns_async_iterator as *const u8, 0);
+    crate::closure::js_register_closure_arity(ns_iterator1 as *const u8, 1);
+    crate::closure::js_register_closure_arity(ns_readable_iterator_next as *const u8, 0);
+    crate::closure::js_register_closure_arity(ns_readable_iterator_return as *const u8, 0);
+    crate::closure::js_register_closure_arity(ns_readable_iterator_self as *const u8, 0);
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1142,12 +1142,6 @@
     "category": "bug-open",
     "reason": "node:stream: reduce(fn) without initial — first item not used as accumulator. Flips to PASS when #1558 lands."
   },
-  "node-suite/stream/iterator/destroy-on-return-true-default": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: default destroyOnReturn:true — early break does not destroy stream. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/readable/read-zero-probe": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- track destroyOnReturn on classic Readable async iterators and preserve destroyOnReturn:false
- destroy the source only after the iterator has yielded, matching the before-next return guardrail
- insert iterator.return() before conditional Node-readable for-await breaks and remove the now-passing default-destroy known failure

## Verification
- ./run_parity_tests.sh --suite node-suite --module stream --filter iterator/destroy-on-return-true-default (baseline on main): FAIL, report test-parity/reports/parity_report_20260527_202052.json
- ./run_parity_tests.sh --suite node-suite --module stream --filter iterator/destroy-on-return-true-default (before removal): PASS, report test-parity/reports/parity_report_20260527_203515.json
- ./run_parity_tests.sh --suite node-suite --module stream --filter iterator/destroy-on-return-true-default (after removal): PASS, report test-parity/reports/parity_report_20260527_203602.json
- ./run_parity_tests.sh --suite node-suite --module stream --filter iterator/destroy-on-return-false: PASS, report test-parity/reports/parity_report_20260527_203524.json
- ./run_parity_tests.sh --suite node-suite --module stream --filter async-iter/return-method-explicit: PASS, report test-parity/reports/parity_report_20260527_203535.json
- cargo test -p perry-runtime --lib node_stream -- --nocapture
- cargo fmt --check
- jq empty test-parity/known_failures.json
- git diff --check

Residual: node-suite/stream/async-iter/break-cleanup still fails separately because Perry continues past an unconditional break in that lowering path; left listed.