### PR TITLE
Remove stale stream async iterator next failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1130,12 +1130,6 @@
     "category": "bug-open",
     "reason": "node:stream: adding 'data' listener does not flip readableFlowing to true. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/async-iter/iterator-next-direct": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: r[Symbol.asyncIterator]().next() — direct call doesn't yield correct {value, done} shape. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/iter-helpers/reduce-no-initial": {
     "issue": "1558",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove the stale known-failure entry for node-suite/stream/async-iter/iterator-next-direct
- keep the DeepWiki reference and experiment notes local/untracked

## Verification
- ./run_parity_tests.sh --suite node-suite --module stream --filter async-iter/iterator-next-direct (before removal): PASS, report test-parity/reports/parity_report_20260527_204159.json
- ./run_parity_tests.sh --suite node-suite --module stream --filter async-iter/iterator-next-direct (after removal): PASS, report test-parity/reports/parity_report_20260527_204228.json
- jq empty test-parity/known_failures.json
- git diff --check