### PR TITLE
Remove stale stream empty string write failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -704,12 +704,6 @@
     "category": "bug-open",
     "reason": "node:stream: read() on a destroyed Readable should return null. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/writable/write-empty-string": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: write empty string does not reach _write with empty Buffer. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/writable/write-on-errored": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- remove the stale known-failure entry for node-suite/stream/writable/write-empty-string
- keep the DeepWiki reference and experiment notes local/untracked

## Verification
- ./run_parity_tests.sh --suite node-suite --module stream --filter writable/write-empty-string (before removal): PASS, report test-parity/reports/parity_report_20260527_205516.json
- ./run_parity_tests.sh --suite node-suite --module stream --filter writable/write-empty-string (after removal): PASS, report test-parity/reports/parity_report_20260527_205544.json
- jq empty test-parity/known_failures.json
- git diff --check