### PR TITLE
Remove stale Readable.from arguments known failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2186,12 +2186,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: TransformStream instance — fails instanceof checks vs RS/WS for readable/writable sides. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/readable/from-arguments-object": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.from(arguments) — Array-like iteration fails. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/iter-helpers/reduce-with-initial": {
     "issue": "1558",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove stale known-failure entry for `node-suite/stream/readable/from-arguments-object`
- keep neighboring `Readable.from` iterator-normalization gaps listed

## Verification
- Baseline before removal: `./run_parity_tests.sh --suite node-suite --module stream/readable --filter from-arguments-object` PASS, report `test-parity/reports/parity_report_20260527_210057.json`
- Post-removal: `./run_parity_tests.sh --suite node-suite --module stream/readable --filter from-arguments-object` PASS, report `test-parity/reports/parity_report_20260527_210239.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check -- test-parity/known_failures.json`

## DeepWiki
- `reference/deepwiki/nodejs-node-stream-readable-from-arguments-object-2026-05-27.md` (local-only reference, not staged)

## Non-goals
- no stream runtime/compiler changes
- no generic object iterator protocol support
- no Set/Map `Readable.from` behavior
- no broader `Readable.from(...)` normalization

Closes #1532