### PR TITLE
fix(gc): scope inline-arena resync to the Eden arena (#1824)

### DIFF
--- a/crates/perry-runtime/src/arena/block.rs
+++ b/crates/perry-runtime/src/arena/block.rs
@@ -194,6 +194,22 @@ impl Arena {
 
     #[inline]
     fn resync_inline_to_current(&self) {
+        // `INLINE_STATE` mirrors ONLY the general nursery-Eden arena — the
+        // one the codegen inline bump-allocator (`js_inline_arena_state`)
+        // targets. The old-gen, survivor, and longlived arenas reuse this
+        // same `Arena::alloc` body, whose block-reuse forward-scan
+        // (`self.current = i`) calls back here. Without this guard, an
+        // old-gen/survivor allocation that forward-scans to reuse a block
+        // would repoint `INLINE_STATE` at a non-Eden block; the next Eden
+        // `arena_alloc` then writes that foreign block's offset into the
+        // real current Eden block, rewinding it and allocating fresh objects
+        // over still-live ones (#1824: a large-JSON `await` allocation that
+        // landed in old-gen clobbered a suspended async-step closure, whose
+        // bytes were then read as a garbage function pointer → SIGSEGV on
+        // resume; reproduced with `full_gc=0`, so no collection involved).
+        if self.space != HeapSpace::NurseryEden {
+            return;
+        }
         INLINE_STATE.with(|s| unsafe {
             let inline = &mut *s.get();
             if !inline.data.is_null() {

--- a/crates/perry-runtime/src/arena/tests.rs
+++ b/crates/perry-runtime/src/arena/tests.rs
@@ -904,3 +904,59 @@ fn reset_never_clears_old_gen_blocks() {
         "old-gen alloc not located in any old-gen block"
     );
 }
+
+#[test]
+fn old_arena_block_reuse_does_not_repoint_eden_inline_state() {
+    // #1824 regression. `Arena::alloc`'s block-reuse forward-scan calls
+    // `resync_inline_to_current`, which mirrors the codegen inline
+    // bump-allocator's `INLINE_STATE`. `INLINE_STATE` must track ONLY the
+    // general nursery-Eden arena. A non-Eden (old-gen / survivor) allocation
+    // that forward-scans to reuse an earlier block must NOT repoint
+    // `INLINE_STATE`: doing so pointed it at a foreign block, and the next
+    // Eden `arena_alloc` then wrote that block's offset into the live Eden
+    // block — rewinding the bump pointer so a fresh string allocation
+    // overwrote a still-live suspended async-step closure (read back later as
+    // a garbage function pointer → SIGSEGV during the await continuation).
+    run_with_fresh_arenas(|| {
+        // Initialize INLINE_STATE from the Eden arena and capture it.
+        let _ = js_inline_arena_state();
+        let _ = arena_alloc(64, 8); // make sure inline.data is live
+        let (eden_data, eden_size) = INLINE_STATE.with(|s| {
+            let st = unsafe { &*s.get() };
+            (st.data, st.size)
+        });
+        assert!(
+            !eden_data.is_null(),
+            "Eden INLINE_STATE should be initialized"
+        );
+
+        // Drive the OLD_ARENA into a forward-scan-reuse state: a reusable
+        // earlier block (offset 0) plus a full current block.
+        OLD_ARENA.with(|a| unsafe {
+            let arena = &mut *a.get();
+            arena.install_fresh_block(BLOCK_SIZE); // >=2 blocks, current = newest
+            let cur = arena.current;
+            assert!(cur > 0, "fresh block should advance current past block 0");
+            arena.blocks[cur].offset = arena.blocks[cur].size; // current is full
+            arena.blocks[0].offset = 0; // block 0 reusable
+                                        // Current full → forward-scan reuses block 0 → current = 0 →
+                                        // resync_inline_to_current(OLD_ARENA).
+            let _ = arena.alloc(64, 8);
+            assert_eq!(arena.current, 0, "forward-scan should have reused block 0");
+        });
+
+        // The OLD_ARENA block reuse must have left Eden's INLINE_STATE intact.
+        let (after_data, after_size) = INLINE_STATE.with(|s| {
+            let st = unsafe { &*s.get() };
+            (st.data, st.size)
+        });
+        assert_eq!(
+            after_data, eden_data,
+            "old-gen block reuse must not repoint Eden INLINE_STATE.data (#1824)"
+        );
+        assert_eq!(
+            after_size, eden_size,
+            "Eden INLINE_STATE.size must be intact"
+        );
+    });
+}


### PR DESCRIPTION
Fixes #1824.

## Root cause — allocator-state corruption, not GC

The reporter's symptom — a garbage "function pointer" in the resumed async-step continuation, reproducible with **no GC cycle** and surviving every GC escape hatch (`PERRY_GEN_GC=0`, `PERRY_GEN_GC_EVACUATE=0`, `PERRY_WRITE_BARRIERS=0`) — is **not** a GC/rooting bug and **not** codegen spill/restore. It is corruption of the codegen inline bump-allocator's `INLINE_STATE` by a non-Eden allocation:

1. `Arena::alloc`'s block-reuse forward-scan calls `resync_inline_to_current`, which mirrors the thread-global `INLINE_STATE`.
2. `INLINE_STATE` is only meaningful for the **general nursery-Eden** arena, but the same `Arena::alloc` body backs `OLD_ARENA` / survivors / longlived.
3. A large `await` result (e.g. `await response.json()` of a big payload) is born in the **old-gen** via `arena_alloc_gc`'s large-object path. When that old-gen allocation forward-scans to reuse an earlier old-gen block, `resync_inline_to_current` repoints `INLINE_STATE` at a non-Eden block.
4. The next general-Eden `arena_alloc` then writes that foreign block's offset into the live Eden block, **rewinding the Eden bump pointer**.
5. A fresh string allocation lands on top of a still-live, *suspended* async-step closure. When the microtask runner later resumes the continuation, its overwritten `func_ptr` (now string bytes) is jumped to → SIGSEGV.

This exactly reproduces the report: `full_gc=0/minor_gc=0` (no collection), ASCII-bytes-as-pointer in `lldb` (e.g. `0x343030302f303036` = `"600/0004"` from the JSON URL strings), and the crash surviving every GC mode.

## Fix

`resync_inline_to_current` no-ops unless `self.space == HeapSpace::NurseryEden`. The Eden forward-scan path is unchanged; only the non-Eden arenas stop clobbering `INLINE_STATE`. 16 lines including the explanatory comment.

## Validation

- Built a self-contained repro (local HTTP server + `fetch`/`json` in a loop feeding a long-lived accumulator + a retained `BIG`) that SIGSEGV'd deterministically with the reported signature.
- After the fix, full mark-sweep (`PERRY_GEN_GC=0` — the mode the reporter tested where the crash persisted) runs the repro 3/3 clean to "ALL DONE".
- Existing `arena::` (31) and `gc::` (289) unit tests still green.
- New regression test `old_arena_block_reuse_does_not_repoint_eden_inline_state` exercises an `OLD_ARENA` block-reuse forward-scan and asserts the Eden `INLINE_STATE` is left intact. Fails before the fix, passes after.
- `cargo fmt --all -- --check` clean.

## Follow-up I noticed while verifying (not this PR's scope)

The *aggressive* repro (8000-element retained allocation + 5000-element JSON payloads) still SIGSEGVs **under default generational GC only** after this fix — a garbage promise pointer `0x65` ('e' string byte) in `js_promise_reject` from the microtask runner, requiring ≥2 copying-GC cycles. It does **not** reproduce under `PERRY_GEN_GC=0` and **not** with a smaller payload. So that is a separate copying-GC promise-chain rooting issue under heavy large-object pressure (#1597 family), distinct from the reported crash. I can file it as its own issue if useful.
