### PR TITLE
Fix noninteractive tty stream constructors

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -771,6 +771,9 @@ pub unsafe extern "C" fn js_new_function_construct(
             if !fd.is_finite() || fd < 0.0 || fd.fract() != 0.0 {
                 crate::tty::throw_invalid_fd(fd);
             }
+            if !crate::tty::is_tty_fd(fd as i32) {
+                crate::tty::throw_tty_init_failed();
+            }
             return crate::value::js_nanbox_pointer(js_object_alloc(0, 0) as i64);
         }
     }

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -46,6 +46,10 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
     let true_val = f64::from_bits(TAG_TRUE);
     let false_val = f64::from_bits(TAG_FALSE);
 
+    if class_id == 0 {
+        return false_val;
+    }
+
     // User-defined `Symbol.hasInstance` takes precedence over the built-in
     // prototype-chain walk. The HIR lifts `static [Symbol.hasInstance](v)`
     // to a top-level function `__perry_wk_hasinstance_<class>` and the

--- a/crates/perry-runtime/src/tty.rs
+++ b/crates/perry-runtime/src/tty.rs
@@ -76,6 +76,10 @@ fn winsize_impl(_fd: i32) -> Option<(i32, i32)> {
     None
 }
 
+pub(crate) fn is_tty_fd(fd: i32) -> bool {
+    isatty_impl(fd)
+}
+
 // ---------------------------------------------------------------------------
 // SIGWINCH handler (Unix only)
 // ---------------------------------------------------------------------------
@@ -165,6 +169,14 @@ pub fn throw_invalid_fd(fd: f64) -> ! {
         );
     }
     crate::exception::js_throw(crate::value::js_nanbox_pointer(obj as i64))
+}
+
+pub fn throw_tty_init_failed() -> ! {
+    let message = "TTY initialization failed";
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    crate::node_submodules::register_error_code_pub(msg, "ERR_TTY_INIT_FAILED");
+    let err = crate::error::js_error_new_with_name_message(b"SystemError", msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
 /// `process.stdin.isTTY` / `process.stdout.isTTY` / `process.stderr.isTTY`.


### PR DESCRIPTION
## Summary
- reject valid-but-non-TTY `tty.ReadStream` / `tty.WriteStream` constructor calls with `SystemError` / `ERR_TTY_INIT_FAILED`
- stop fallback class id `0` from making anonymous objects satisfy `instanceof` checks such as `process.stdout instanceof tty.WriteStream`

## Verification
- Baseline focused `node-suite/tty`: 29 pass / 2 fail, report `test-parity/reports/parity_report_20260527_210503.json`
- `./run_parity_tests.sh --suite node-suite --module tty/classes --filter color-depth-env` PASS, report `test-parity/reports/parity_report_20260527_211100.json`
- `./run_parity_tests.sh --suite node-suite --module tty/classes --filter readstream-constructor-errors` PASS, report `test-parity/reports/parity_report_20260527_211101.json`
- `./run_parity_tests.sh --suite node-suite --module tty` PASS 31/31, report `test-parity/reports/parity_report_20260527_211231.json`
- `cargo test -p perry-runtime --lib tty -- --nocapture` PASS (existing warnings only)
- `cargo test -p perry-runtime --lib instanceof -- --nocapture` PASS, 0 matching tests (existing warnings only)
- `cargo fmt --check`
- `git diff --check`

## DeepWiki
- `reference/deepwiki/nodejs-node-tty-noninteractive-stream-constructors-2026-05-27.md` (local-only reference, not staged)

## Non-goals
- no real TTY-backed `net.Socket` stream implementation
- no process stdio stream rewrite
- no full terminal color-depth support
- no broad `instanceof` refactor beyond guarding class id `0`

Closes #793