### PR TITLE
Render enumerable symbol labels like Node inspect

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -973,10 +973,10 @@ unsafe fn format_object_as_json(
     }
 
     // Append symbol-keyed properties last (matches Node's enumeration order:
-    // string keys first, then symbol keys). Each entry renders as
-    // `[Symbol(<desc>)]: <value>`. By default Node prints enumerable symbol
-    // properties even without `showHidden` (they're own enumerable props).
-    // Refs #1201.
+    // string keys first, then symbol keys). Perry's symbol side table only
+    // stores enumerable own symbol props today, and Node renders those labels
+    // without brackets: `Symbol(<desc>): <value>`. Brackets are reserved for
+    // non-enumerable symbol props when `showHidden` is enabled. Refs #1201.
     let sym_entries = crate::symbol::clone_symbol_entries_for_obj_ptr(obj_addr);
     for (sym_ptr_usize, val_bits) in sym_entries {
         let sym_f64 = f64::from_bits(
@@ -995,7 +995,7 @@ unsafe fn format_object_as_json(
         };
         let value = f64::from_bits(val_bits);
         let value_str = format_jsvalue_for_json(value, depth + 1);
-        parts.push(format!("[{}]: {}", sym_label, value_str));
+        parts.push(format!("{}: {}", sym_label, value_str));
     }
 
     if parts.is_empty() {


### PR DESCRIPTION
## Summary
- render enumerable symbol-keyed properties as Symbol(desc): value in util.inspect / console.dir output
- keep bracketed labels reserved for non-enumerable symbol properties once that metadata exists

## Verification
- ./run_parity_tests.sh --suite node-suite --module console --filter symbol-keyed-multiple (PASS, report test-parity/reports/parity_report_20260527_214526.json)
- ./run_parity_tests.sh --suite node-suite --module console --filter custom-inspect-string-value (PASS, report test-parity/reports/parity_report_20260527_214527.json)
- ./run_parity_tests.sh --suite node-suite --module console (109 pass / 9 fail, report test-parity/reports/parity_report_20260527_214616.json)
- cargo fmt --check
- git diff --check -- crates/perry-runtime/src/builtins/formatting.rs