### PR TITLE
fix(runtime): guard generic field-get against primitive-number receivers (#2128)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -907,6 +907,27 @@ pub extern "C" fn js_object_get_field_by_name(
     obj: *const ObjectHeader,
     key: *const crate::StringHeader,
 ) -> JSValue {
+    // #2128: a plain JS number value (a finite double or canonical NaN —
+    // anything `JSValue::is_number` returns true for *minus* the raw-I64
+    // pointer convention where top16 == 0) reaches this generic property-get
+    // when codegen lacks static type info — e.g. drizzle's
+    // `buildQueryFromSourceParams` mapping a chunk that happens to be a
+    // bound-param number (`1` row-id, `31` age). Without this guard the
+    // receiver's f64 bits get bit-cast to a pointer and the first downstream
+    // helper that reads a GC header (`is_registered_set` here, `(*obj).field_*`
+    // elsewhere) derefs unmapped memory and SIGSEGVs. Spec: property access
+    // on a primitive number returns undefined for unknown keys (we don't
+    // auto-box to Number.prototype here; that's handled by the method-dispatch
+    // path, not this property-getter slow path). Heap pointers stored as raw
+    // I64 (module-level objects) have top16 == 0 and are preserved by this
+    // check.
+    {
+        let bits = obj as u64;
+        let top16 = bits >> 48;
+        if top16 != 0 && !(0x7FF9..=0x7FFF).contains(&top16) {
+            return JSValue::undefined();
+        }
+    }
     // Issue #818 (Effect class-instance pattern): a V8 handle (JS_HANDLE_TAG
     // = 0x7FFB) reaches here when codegen routes a generic `PropertyGet`
     // through this slow path — e.g. `Effect.succeed(42).value` where the

--- a/test-files/test_issue_2128_property_on_number.ts
+++ b/test-files/test_issue_2128_property_on_number.ts
@@ -1,0 +1,37 @@
+// Refs #2128: property access on a primitive number value via the generic
+// runtime field-getter must return `undefined`, not SIGSEGV.
+//
+// Pre-fix, `js_object_get_field_by_name` had no guard for a finite-double
+// receiver (top16 not in 0x7FF9..=0x7FFF, top16 != 0) — codegen would
+// bit-cast the f64 to a pointer and the first downstream helper that read
+// a GC header (`is_registered_set`, `(*obj).field_count`, etc.) derefed
+// unmapped memory. drizzle-orm's `buildQueryFromSourceParams` surfaces this
+// when it maps over SQL chunks that include bound-param numbers (an `id`,
+// an `age` etc.); UPDATE / DELETE / leftJoin all crashed with rc=139.
+//
+// JS spec: property access on a primitive number returns `undefined` for
+// unknown keys (auto-boxing to `Number.prototype` is a separate path for
+// known methods). The runtime field-getter slow path now returns undefined
+// instead of dereferencing.
+
+// Lose static type info so codegen can't inline a number-aware fast path.
+function asAny(v: number): any { return v; }
+
+const n = asAny(1);
+console.log("number .foo:", n.foo);
+
+const z = asAny(0);
+console.log("zero .anything:", z.anything);
+
+// Negative + float — different f64 bit patterns, same guard.
+console.log("negative .x:", asAny(-3.14).x);
+console.log("float .y:", asAny(2.5).y);
+
+// Property access on the result of an `any` array index.
+const arr: any[] = [42];
+console.log("arr[0].x:", arr[0].x);
+
+// JSON.parse("1") returns a number typed as any — load-bearing for the
+// drizzle-style chunk-mapping pattern.
+const j: any = JSON.parse("1");
+console.log("json-number .y:", j.y);


### PR DESCRIPTION
## What

Fixes the SIGSEGV that hit drizzle-orm's UPDATE / DELETE / leftJoin on sqlite (#2128) — the next #489 blocker after #2050. Post-fix the full CRUD + leftJoin program is byte-identical to Node.

## Root cause

drizzle's `buildQueryFromSourceParams` (in `sql/sql.js`) maps over SQL chunks and reads properties off each one. For an UPDATE / DELETE / leftJoin path, some of those chunks are bound-param **numbers** (a row id like `1`, an age like `31`) — the receiver flows into the generic runtime property-get slow path as an `any`-typed value.

`js_object_get_field_by_name` had guards for V8 handles (`0x7FFB`) and INT32 class refs (`0x7FFE`), but **none for a plain JS number value** — a finite double like `1.0` has bits `0x3FF0000000000000`, top16 `0x3FF0` (not in any tag band), and slipped through unguarded. Codegen bit-casts the f64 to a `*const ObjectHeader`, and the first downstream helper that reads the GC header byte (`is_registered_set` here, `(*obj).field_count` in `js_object_get_field`, etc.) dereferenced unmapped memory at `0x3FEFFFFFFFFFFFF8` and SIGSEGV'd.

## Fix

Single top-level guard in `js_object_get_field_by_name`: if the receiver bits have `top16 != 0` and `top16 not in 0x7FF9..=0x7FFF` (the perry-owned tag band that `JSValue::is_number` documents), the value is a primitive number (or canonical NaN). Return `JSValue::undefined()` per JS spec for unknown properties on a number primitive. The `top16 == 0` raw-I64-pointer convention (module-level objects) is preserved, and all NaN-tagged values (POINTER / INT32 / STRING / V8 handle / SHORT_STRING / etc.) continue past the guard untouched.

## Verification

On `tests/release/packages/drizzle-sqlite/` (drizzle-orm 0.45.2 + better-sqlite3):
- UPDATE repro: prints `UPDATE ok`, rc 0
- DELETE repro: prints `remaining=1`, rc 0
- leftJoin repro: prints `join rows=2`, rc 0
- Full CRUD + leftJoin program: **byte-identical to `node --experimental-strip-types`**
- Original `drizzle-sqlite` fixture: still PASS

Plus all 8 existing `getPrototypeOf` gap tests still match Node, and `cargo fmt` clean.

Adds `test-files/test_issue_2128_property_on_number.ts` exercising the guard via `asAny(...)` so codegen can't inline a number-aware fast path.

## Out of scope

The new guard returns `undefined` for `.constructor` on a primitive number, where Node returns `Number`. That's strictly better than the pre-fix SIGSEGV but doesn't match Node's auto-box-to-`Number.prototype` semantics. Filed as #2138 for a follow-up that intercepts `.constructor` / known `Number.prototype` methods on primitives. Not a drizzle blocker (drizzle doesn't access `.constructor` on its chunk numbers).

## #489 status after this lands

With #2050 (the getPrototypeOf self-cycle fix) plus this PR, drizzle's full CRUD + leftJoin surface compiles and runs byte-identically to Node on sqlite. What's left for #489 (the MySQL e2e demo) is the *integration* work: wiring `@perry/mysql` as drizzle's mysql driver + a real-MySQL fixture (`docker run mysql` on 127.0.0.1:3306). The compiler/runtime path should be clear.
