### PR TITLE
Remove stale assert inventory known failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -122,12 +122,6 @@
     "category": "ci-env",
     "reason": "Tracked in #1634 (parity CI environment fixtures). Net test needs a TLS-capable echo server fixture; not available on CI. Environmental — needs a CI-side fixture."
   },
-  "test_parity_assert": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:assert` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "test_parity_buffer": {
     "issue": "793",
     "added": "2026-05-15",


### PR DESCRIPTION
## Summary
- remove the stale `test_parity_assert` known-failure tracker now that the generated node:assert inventory parity test passes
- keep the remaining module-inventory trackers intact

## Verification
- `./run_parity_tests.sh --filter test_parity_assert` before removal: PASS, report `test-parity/reports/parity_report_20260527_224622.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check -- test-parity/known_failures.json`
- `./run_parity_tests.sh --filter test_parity_assert` after removal: PASS, report `test-parity/reports/parity_report_20260527_224713.json`

DeepWiki note saved locally at `reference/deepwiki/nodejs-node-assert-module-inventory-2026-05-27.md`.