### PR TITLE
Inspect Proxy targets by default

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -533,6 +533,9 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                 // would read garbage one word before the BufferHeader).
                 let buf_ptr = ptr as *const crate::buffer::BufferHeader;
                 format_buffer_value(buf_ptr)
+            } else if crate::proxy::js_proxy_is_proxy(value) != 0 {
+                let target = crate::proxy::js_proxy_target(value);
+                format_jsvalue(target, depth)
             } else if (ptr as usize) < 0x100000 {
                 // Refs #421: Web Fetch (and other) handles are NaN-boxed
                 // POINTER_TAG values whose unboxed payload is a small
@@ -1177,7 +1180,10 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
                 // A small registry-id handle (`< 0x100000`, e.g. a Web Fetch
                 // Request) carries no GC header, so reading `ptr - 8` would
                 // deref unmapped memory — print a placeholder instead.
-                if (ptr as usize) < 0x100000 {
+                if crate::proxy::js_proxy_is_proxy(value) != 0 {
+                    let target = crate::proxy::js_proxy_target(value);
+                    format_jsvalue_for_json(target, depth)
+                } else if (ptr as usize) < 0x100000 {
                     "[object Object]".to_string()
                 } else {
                     let gc_header = (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE)


### PR DESCRIPTION
## Summary
- detect Perry Proxy handles before the generic small-handle formatter fallback
- format default proxy inspection through the proxy target, matching Node's default util.inspect/console output
- leave `showProxy: true` and WeakMap display out of scope

## Verification
- `./run_parity_tests.sh --suite=node-suite --module=console --filter proxy-getters` PASS, report `test-parity/reports/parity_report_20260527_231822.json`
- `./run_parity_tests.sh --suite=node-suite --module=console --filter objects-and-arrays` PASS, report `test-parity/reports/parity_report_20260527_231927.json`
- `./run_parity_tests.sh --suite=node-suite --module=console` PASS 115 / FAIL 3 with `output/proxy-getters` green, report `test-parity/reports/parity_report_20260527_231934.json`
- `cargo fmt --check`
- `git diff --check -- crates/perry-runtime/src/builtins/formatting.rs`

Known residual checked: `node-suite/util/inspect/proxy-getters-weak` still fails on `showProxy: true` and WeakMap formatting after the default proxy line goes green, report `test-parity/reports/parity_report_20260527_231901.json`.

DeepWiki note saved locally at `reference/deepwiki/nodejs-node-util-inspect-proxy-default-target-2026-05-27.md`.