### PR TITLE
feat(node:http): add http.Agent / https.Agent + listen chain return (#2129)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2663,6 +2663,15 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     class("http", "ClientRequest"),
     class("http", "IncomingMessage"),
     class("http", "ServerResponse"),
+    // #2129 — `new http.Agent(options?)`. Construction is unconditional;
+    // method dispatch flows through ("http", "Agent") rows below.
+    class("http", "Agent"),
+    method("http", "Agent", false, None),
+    method("http", "getName", true, Some("Agent")),
+    method("http", "destroy", true, Some("Agent")),
+    method("http", "close", true, Some("Agent")),
+    method("http", "keepSocketAlive", true, Some("Agent")),
+    method("http", "reuseSocket", true, Some("Agent")),
     method("https", "createServer", false, None),
     method("https", "request", false, None),
     method("https", "get", false, None),
@@ -2670,6 +2679,11 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     class("https", "ClientRequest"),
     class("https", "IncomingMessage"),
     class("https", "ServerResponse"),
+    // #2129 — `new https.Agent(options?)`. The instance is tagged as
+    // ("http", "Agent") in destructuring/var_decl.rs so it shares the
+    // method surface; only the constructor's default protocol differs.
+    class("https", "Agent"),
+    method("https", "Agent", false, None),
     // --- axios (perry-ext-axios) — the npm `axios` HTTP client surface.
     //     The default export is callable (`axios(config)`); both flow
     //     through perry-ext-axios's `js_axios_*` symbols. ---

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2672,6 +2672,25 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("http", "close", true, Some("Agent")),
     method("http", "keepSocketAlive", true, Some("Agent")),
     method("http", "reuseSocket", true, Some("Agent")),
+    // Synthetic `__get_<name>` / `__set_<name>` accessor methods (HIR
+    // rewrites bare `agent.maxSockets` reads to `__get_maxSockets()`
+    // when the receiver is class-tagged) + their bare-name twins for
+    // sites where the rewrite doesn't fire. Keep parity with the rows
+    // in `crates/perry-codegen/src/lower_call/native_table/http.rs`
+    // (drift caught by perry-codegen/tests/manifest_consistency.rs).
+    method("http", "__get_maxSockets", true, Some("Agent")),
+    method("http", "__get_maxFreeSockets", true, Some("Agent")),
+    method("http", "__get_maxTotalSockets", true, Some("Agent")),
+    method("http", "__get_keepAliveMsecs", true, Some("Agent")),
+    method("http", "__get_keepAlive", true, Some("Agent")),
+    method("http", "__get_protocol", true, Some("Agent")),
+    method("http", "__set_protocol", true, Some("Agent")),
+    method("http", "maxSockets", true, Some("Agent")),
+    method("http", "maxFreeSockets", true, Some("Agent")),
+    method("http", "maxTotalSockets", true, Some("Agent")),
+    method("http", "keepAliveMsecs", true, Some("Agent")),
+    method("http", "keepAlive", true, Some("Agent")),
+    method("http", "protocol", true, Some("Agent")),
     method("https", "createServer", false, None),
     method("https", "request", false, None),
     method("https", "get", false, None),

--- a/crates/perry-codegen/src/ext_registry.rs
+++ b/crates/perry-codegen/src/ext_registry.rs
@@ -143,6 +143,23 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
     ("js_count_queuing_strategy_new",               OwnerKind::Stdlib { feature: Some("bundled-streams") }),
     ("js_byte_length_queuing_strategy_new",         OwnerKind::Stdlib { feature: Some("bundled-streams") }),
 
+    // ── #2129: http.Agent / https.Agent ──────────────────────────────
+    // `perry-stdlib::http` (gated behind `http-client`) owns these.
+    // Without the registry entry, a program that does `new http.Agent()`
+    // but never `http.request(...)` could leave the auto-optimize build
+    // stripping `http-client`, breaking the link on agent symbols.
+    ("js_http_agent_new",                           OwnerKind::Stdlib { feature: Some("http-client") }),
+    ("js_https_agent_new",                          OwnerKind::Stdlib { feature: Some("http-client") }),
+    ("js_http_agent_get_name",                      OwnerKind::Stdlib { feature: Some("http-client") }),
+    ("js_http_agent_noop_self",                     OwnerKind::Stdlib { feature: Some("http-client") }),
+    ("js_http_agent_max_sockets",                   OwnerKind::Stdlib { feature: Some("http-client") }),
+    ("js_http_agent_max_free_sockets",              OwnerKind::Stdlib { feature: Some("http-client") }),
+    ("js_http_agent_max_total_sockets",             OwnerKind::Stdlib { feature: Some("http-client") }),
+    ("js_http_agent_keep_alive_msecs",              OwnerKind::Stdlib { feature: Some("http-client") }),
+    ("js_http_agent_keep_alive",                    OwnerKind::Stdlib { feature: Some("http-client") }),
+    ("js_http_agent_protocol",                      OwnerKind::Stdlib { feature: Some("http-client") }),
+    ("js_http_agent_set_protocol",                  OwnerKind::Stdlib { feature: Some("http-client") }),
+
     // ── #846: node:http server ───────────────────────────────────────
     // `perry-ext-http-server` defines `js_node_http_*`. It's pulled in
     // transitively via `perry-ext-http` (rlib dep), and the well-known

--- a/crates/perry-codegen/src/lower_call/native_table/http.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/http.rs
@@ -95,6 +95,203 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_PTR,
     },
+    // ========== http.Agent / https.Agent (issue #2129) ==========
+    // `new http.Agent(options?)` / `new https.Agent(options?)` — registered
+    // via the Member-callee path in lower/expr_new.rs (mirrors the
+    // `new net.Socket()` route). Both classes share the same instance
+    // surface; only the constructor differs (default protocol).
+    NativeModSig {
+        module: "http",
+        has_receiver: false,
+        method: "Agent",
+        class_filter: None,
+        runtime: "js_http_agent_new",
+        args: &[NA_F64],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "https",
+        has_receiver: false,
+        method: "Agent",
+        class_filter: None,
+        runtime: "js_https_agent_new",
+        args: &[NA_F64],
+        ret: NR_PTR,
+    },
+    // Agent instance methods. Most are chainable no-ops today — Perry
+    // doesn't pool sockets, but Node's test suite asserts the methods
+    // exist and don't throw. `getName(options)` is the one method whose
+    // exact output the tests check.
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "getName",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_get_name",
+        args: &[NA_F64],
+        ret: NR_STR,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "destroy",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "close",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "keepSocketAlive",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "reuseSocket",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_noop_self",
+        args: &[],
+        ret: NR_PTR,
+    },
+    // Property accessors as `__get_<name>` synthetic methods. The HIR
+    // rewrites bare `agent.maxSockets` reads to `agent.__get_maxSockets()`
+    // when the receiver is tagged as ("http"|"https", "Agent").
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__get_maxSockets",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_max_sockets",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__get_maxFreeSockets",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_max_free_sockets",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__get_maxTotalSockets",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_max_total_sockets",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__get_keepAliveMsecs",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_keep_alive_msecs",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__get_keepAlive",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_keep_alive",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__get_protocol",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_protocol",
+        args: &[],
+        ret: NR_STR,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__set_protocol",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_set_protocol",
+        args: &[NA_STR],
+        ret: NR_VOID,
+    },
+    // Bare-name dispatch for the same property reads. Mirrors the
+    // belt-and-braces approach used by IncomingMessage's `statusCode` /
+    // `headers` rows below — covers sites where the HIR rewrite to
+    // `__get_<prop>` doesn't fire (e.g. an agent assigned through a
+    // local before the property read).
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "maxSockets",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_max_sockets",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "maxFreeSockets",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_max_free_sockets",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "maxTotalSockets",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_max_total_sockets",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "keepAliveMsecs",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_keep_alive_msecs",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "keepAlive",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_keep_alive",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "protocol",
+        class_filter: Some("Agent"),
+        runtime: "js_http_agent_protocol",
+        args: &[],
+        ret: NR_STR,
+    },
     // ========== node:http server (issue #577) ==========
     // Module-level: `import { createServer } from "node:http"; createServer(handler)`
     NativeModSig {
@@ -120,8 +317,13 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         // by value type (string→host, function→callback). Pre-#2041 the fixed
         // `[NA_F64, NA_PTR]` mis-routed a host string into the callback slot and
         // dropped the real callback. Issue #2041.
+        //
+        // #2129: returns the server handle (NR_PTR) so
+        // `createServer(...).listen(...).on(...)` chains correctly. Pre-fix
+        // this was NR_VOID and chained sites broke at runtime with
+        // `undefined.on is not a function`.
         args: &[NA_VARARGS],
-        ret: NR_VOID,
+        ret: NR_PTR,
     },
     NativeModSig {
         module: "http",
@@ -602,8 +804,9 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         class_filter: Some("HttpsServer"),
         runtime: "js_node_https_server_listen",
         // Variadic listen() overloads — see the http `listen` row. Issue #2041.
+        // Returns the server handle for chainability (#2129).
         args: &[NA_VARARGS],
-        ret: NR_VOID,
+        ret: NR_PTR,
     },
     NativeModSig {
         module: "https",
@@ -640,8 +843,9 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         class_filter: Some("Http2SecureServer"),
         runtime: "js_node_http2_server_listen",
         // Variadic listen() overloads — see the http `listen` row. Issue #2041.
+        // Returns the server handle for chainability (#2129).
         args: &[NA_VARARGS],
-        ret: NR_VOID,
+        ret: NR_PTR,
     },
     NativeModSig {
         module: "http2",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -52,6 +52,19 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_http_status_code", DOUBLE, &[I64]);
     module.declare_function("js_http_status_message", I64, &[I64]);
 
+    // ========== http.Agent / https.Agent (#2129) ==========
+    module.declare_function("js_http_agent_new", I64, &[DOUBLE]);
+    module.declare_function("js_https_agent_new", I64, &[DOUBLE]);
+    module.declare_function("js_http_agent_get_name", I64, &[I64, DOUBLE]);
+    module.declare_function("js_http_agent_noop_self", I64, &[I64]);
+    module.declare_function("js_http_agent_max_sockets", DOUBLE, &[I64]);
+    module.declare_function("js_http_agent_max_free_sockets", DOUBLE, &[I64]);
+    module.declare_function("js_http_agent_max_total_sockets", DOUBLE, &[I64]);
+    module.declare_function("js_http_agent_keep_alive_msecs", DOUBLE, &[I64]);
+    module.declare_function("js_http_agent_keep_alive", DOUBLE, &[I64]);
+    module.declare_function("js_http_agent_protocol", I64, &[I64]);
+    module.declare_function("js_http_agent_set_protocol", VOID, &[I64, I64]);
+
     // ========== HTTPS ==========
     module.declare_function("js_https_get", I64, &[DOUBLE, I64]);
     module.declare_function("js_https_request", I64, &[DOUBLE, I64]);
@@ -63,7 +76,9 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // entries in well_known_bindings.toml route imports here.
     // Server / lifecycle:
     module.declare_function("js_node_http_create_server", I64, &[I64]);
-    module.declare_function("js_node_http_server_listen", VOID, &[I64, DOUBLE, I64]);
+    // Returns the server handle so chains like
+    // `createServer(...).listen(...).on(...)` resolve correctly (#2129).
+    module.declare_function("js_node_http_server_listen", I64, &[I64, I64]);
     module.declare_function("js_node_http_server_close", VOID, &[I64, I64]);
     module.declare_function("js_node_http_server_close_all_connections", VOID, &[I64]);
     module.declare_function("js_node_http_server_close_idle_connections", VOID, &[I64]);
@@ -113,13 +128,13 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_http_res_on", DOUBLE, &[I64, I64, I64]);
     // node:https server (TLS via rustls):
     module.declare_function("js_node_https_create_server", I64, &[DOUBLE, I64]);
-    module.declare_function("js_node_https_server_listen", VOID, &[I64, DOUBLE, I64]);
+    module.declare_function("js_node_https_server_listen", I64, &[I64, I64]);
     module.declare_function("js_node_https_server_close", VOID, &[I64, I64]);
     module.declare_function("js_node_https_server_address_json", I64, &[I64]);
     module.declare_function("js_node_https_server_on", DOUBLE, &[I64, I64, I64]);
     // node:http2 secure server (HTTP/2 with ALPN):
     module.declare_function("js_node_http2_create_secure_server", I64, &[DOUBLE, I64]);
-    module.declare_function("js_node_http2_server_listen", VOID, &[I64, DOUBLE, I64]);
+    module.declare_function("js_node_http2_server_listen", I64, &[I64, I64]);
     module.declare_function("js_node_http2_server_close", VOID, &[I64, I64]);
     module.declare_function("js_node_http2_server_address_json", I64, &[I64]);
     module.declare_function("js_node_http2_server_on", DOUBLE, &[I64, I64, I64]);

--- a/crates/perry-ext-http-server/src/http2_server.rs
+++ b/crates/perry-ext-http-server/src/http2_server.rs
@@ -127,7 +127,8 @@ pub unsafe extern "C" fn js_node_http2_create_secure_server(opts_f64: f64, handl
 /// carries the variadic `listen()` arguments; see `js_node_http_server_listen`
 /// / `parse_listen_args` for the overload resolution. Issue #2041.
 #[no_mangle]
-pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_array: i64) {
+pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_array: i64) -> i64 {
+    // Returns `server_handle` for chainability (#2129).
     let parsed = crate::types::parse_listen_args(args_array);
     let opts_f64 = parsed.opts;
     let port = extract_port(opts_f64, 443);
@@ -147,14 +148,14 @@ pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_ar
         s.base.request_rx = Some(request_rx);
         s.tls_config.clone()
     } else {
-        return;
+        return server_handle;
     };
 
     let tls_config = match tls_config {
         Some(c) => c,
         None => {
             eprintln!("[node:http2] tls config unavailable; refusing to listen");
-            return;
+            return server_handle;
         }
     };
 
@@ -254,6 +255,7 @@ pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_ar
     // Closes #604 — `listen()` is now non-blocking; the unified
     // `js_node_http_server_process_pending` pump in server.rs drains
     // HTTP/2 pending requests alongside HTTP/1 + HTTPS each tick.
+    server_handle
 }
 
 async fn handle_h2_request(

--- a/crates/perry-ext-http-server/src/https_server.rs
+++ b/crates/perry-ext-http-server/src/https_server.rs
@@ -152,7 +152,8 @@ pub struct HttpsServer {
 /// `listen()` arguments; see `js_node_http_server_listen` / `parse_listen_args`
 /// for the overload resolution. Issue #2041.
 #[no_mangle]
-pub unsafe extern "C" fn js_node_https_server_listen(server_handle: i64, args_array: i64) {
+pub unsafe extern "C" fn js_node_https_server_listen(server_handle: i64, args_array: i64) -> i64 {
+    // Returns `server_handle` for chainability (#2129).
     let parsed = crate::types::parse_listen_args(args_array);
     let opts_f64 = parsed.opts;
     let port = extract_port(opts_f64, 443);
@@ -172,14 +173,14 @@ pub unsafe extern "C" fn js_node_https_server_listen(server_handle: i64, args_ar
         s.base.request_rx = Some(request_rx);
         s.tls_config.clone()
     } else {
-        return;
+        return server_handle;
     };
 
     let tls_config = match tls_config {
         Some(c) => c,
         None => {
             eprintln!("[node:https] tls config unavailable; refusing to listen");
-            return;
+            return server_handle;
         }
     };
 
@@ -264,6 +265,7 @@ pub unsafe extern "C" fn js_node_https_server_listen(server_handle: i64, args_ar
     // are drained via the unified `js_node_http_server_process_pending`
     // pump in `server.rs`, which iterates HTTP/1, HTTPS, and HTTP/2
     // handles each tick.
+    server_handle
 }
 
 async fn handle_https_request(

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -110,7 +110,10 @@ pub extern "C" fn js_node_http_create_server(handler: i64) -> i64 {
 /// bare numeric/options/path first arg, an optional standalone host string,
 /// and the (single) function callback wherever it lands. Issue #2041.
 #[no_mangle]
-pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_array: i64) {
+pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_array: i64) -> i64 {
+    // Returns `server_handle` so `createServer(...).listen(...).on(...)` chains
+    // correctly. Pre-#2129 this was `-> ()` and chained sites broke at runtime
+    // with `undefined.on is not a function`.
     let parsed = crate::types::parse_listen_args(args_array);
     let opts_f64 = parsed.opts;
     let port = extract_port(opts_f64, 3000);
@@ -131,7 +134,7 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
         s.request_rx = Some(request_rx);
         s.upgrade_rx = Some(upgrade_rx);
     } else {
-        return;
+        return server_handle;
     }
 
     // Hyper workers queue Rust request handles; JS callbacks run later in
@@ -225,6 +228,7 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
     // main TS thread inside `event_loop(...)` for the process lifetime,
     // so `await new Promise(r => server.listen(port, r))` never returned
     // → no code after `listen()` ever ran (e.g. axios.get + server.close).
+    server_handle
 }
 
 /// `server.close(cb?)` — drop the shutdown channel, fire `'close'`.

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -689,6 +689,210 @@ pub unsafe extern "C" fn js_https_get(arg_f64: f64, callback_i64: i64) -> Handle
 }
 
 // ------------------------------------------------------------------
+// http.Agent / https.Agent (#2129)
+// ------------------------------------------------------------------
+//
+// Perry doesn't pool sockets today — every `http.request(...)` opens a
+// fresh reqwest connection — so the Agent state below is pure metadata
+// that mirrors Node's defaults. The only method whose output the Node
+// test suite asserts byte-for-byte is `getName(options)`; the rest are
+// chainable no-ops so user code that touches `.destroy()` / `.close()`
+// / `.keepSocketAlive()` keeps working.
+//
+// Mirrors `crates/perry-stdlib/src/http.rs`'s `AgentHandle` so both
+// link targets (well-known flip → ext crate; default `full` build →
+// perry-stdlib's http-client) expose the same surface.
+
+struct AgentHandle {
+    protocol: Option<String>,
+    keep_alive: bool,
+    keep_alive_msecs: f64,
+    max_sockets: f64,
+    max_total_sockets: f64,
+    max_free_sockets: f64,
+    scheduling: String,
+    timeout_ms: Option<f64>,
+}
+
+impl Default for AgentHandle {
+    fn default() -> Self {
+        AgentHandle {
+            protocol: Some("http:".to_string()),
+            keep_alive: false,
+            keep_alive_msecs: 1000.0,
+            max_sockets: f64::INFINITY,
+            max_total_sockets: f64::INFINITY,
+            max_free_sockets: 256.0,
+            scheduling: "lifo".to_string(),
+            timeout_ms: None,
+        }
+    }
+}
+
+unsafe fn agent_new_with_protocol(options_f64: f64, default_protocol: &str) -> Handle {
+    let mut agent = AgentHandle {
+        protocol: Some(default_protocol.to_string()),
+        ..AgentHandle::default()
+    };
+
+    if let Some(opts) = parse_options_object(options_f64) {
+        if let Some(v) = opts.get("keepAlive").and_then(|v| v.as_bool()) {
+            agent.keep_alive = v;
+        }
+        if let Some(v) = opts.get("keepAliveMsecs").and_then(|v| v.as_f64()) {
+            agent.keep_alive_msecs = v;
+        }
+        if let Some(v) = opts.get("maxSockets").and_then(|v| v.as_f64()) {
+            agent.max_sockets = v;
+        }
+        if let Some(v) = opts.get("maxFreeSockets").and_then(|v| v.as_f64()) {
+            agent.max_free_sockets = v;
+        }
+        if let Some(v) = opts.get("maxTotalSockets").and_then(|v| v.as_f64()) {
+            agent.max_total_sockets = v;
+        }
+        if let Some(v) = opts.get("timeout").and_then(|v| v.as_f64()) {
+            agent.timeout_ms = Some(v);
+        }
+        if let Some(v) = opts.get("scheduling").and_then(|v| v.as_str()) {
+            agent.scheduling = v.to_string();
+        }
+    }
+
+    register_handle(agent)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_http_agent_new(options_f64: f64) -> Handle {
+    agent_new_with_protocol(options_f64, "http:")
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_https_agent_new(options_f64: f64) -> Handle {
+    agent_new_with_protocol(options_f64, "https:")
+}
+
+/// `agent.getName([options])` — Node's canonical key under which sockets
+/// are pooled. Format: `${host}:${port}:${localAddress}` with optional
+/// `:${socketPath}` or `:${family}` appended. Tests assert exact strings
+/// (see `test/parallel/test-http-agent-getname.js`).
+#[no_mangle]
+pub unsafe extern "C" fn js_http_agent_get_name(
+    handle: Handle,
+    options_f64: f64,
+) -> *mut StringHeader {
+    let _ = handle; // name is computed purely from `options`
+    let opts = match parse_options_object(options_f64) {
+        Some(v) => v,
+        None => return alloc_string("localhost::").as_raw(),
+    };
+
+    let host = opts
+        .get("host")
+        .and_then(|v| v.as_str())
+        .unwrap_or("localhost");
+    let port = opts
+        .get("port")
+        .map(|v| {
+            v.as_str()
+                .map(String::from)
+                .or_else(|| v.as_i64().map(|n| n.to_string()))
+                .or_else(|| v.as_f64().map(|n| (n as i64).to_string()))
+                .unwrap_or_default()
+        })
+        .unwrap_or_default();
+    let local_address = opts
+        .get("localAddress")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let mut name = format!("{}:{}:{}", host, port, local_address);
+
+    if let Some(socket_path) = opts.get("socketPath").and_then(|v| v.as_str()) {
+        name.push(':');
+        name.push_str(socket_path);
+    } else if let Some(family) = opts.get("family") {
+        // Node only appends family when it is exactly 4 or 6; every
+        // other value (0, null, undefined, strings) is silently dropped.
+        let f = family.as_i64().unwrap_or(0);
+        if f == 4 || f == 6 {
+            name.push(':');
+            name.push_str(&f.to_string());
+        }
+    }
+
+    alloc_string(&name).as_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn js_http_agent_noop_self(handle: Handle) -> Handle {
+    handle
+}
+
+fn agent_field<T, F>(handle: Handle, default: T, f: F) -> T
+where
+    F: FnOnce(&AgentHandle) -> T,
+{
+    get_handle_mut::<AgentHandle>(handle)
+        .map(|a| f(a))
+        .unwrap_or(default)
+}
+
+#[no_mangle]
+pub extern "C" fn js_http_agent_max_sockets(handle: Handle) -> f64 {
+    agent_field(handle, f64::INFINITY, |a| a.max_sockets)
+}
+
+#[no_mangle]
+pub extern "C" fn js_http_agent_max_free_sockets(handle: Handle) -> f64 {
+    agent_field(handle, 256.0, |a| a.max_free_sockets)
+}
+
+#[no_mangle]
+pub extern "C" fn js_http_agent_max_total_sockets(handle: Handle) -> f64 {
+    agent_field(handle, f64::INFINITY, |a| a.max_total_sockets)
+}
+
+#[no_mangle]
+pub extern "C" fn js_http_agent_keep_alive_msecs(handle: Handle) -> f64 {
+    agent_field(handle, 1000.0, |a| a.keep_alive_msecs)
+}
+
+#[no_mangle]
+pub extern "C" fn js_http_agent_keep_alive(handle: Handle) -> f64 {
+    if agent_field(handle, false, |a| a.keep_alive) {
+        1.0
+    } else {
+        0.0
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_http_agent_protocol(handle: Handle) -> *mut StringHeader {
+    let s = get_handle_mut::<AgentHandle>(handle)
+        .and_then(|a| a.protocol.clone())
+        .unwrap_or_else(|| "http:".to_string());
+    alloc_string(&s).as_raw()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_http_agent_set_protocol(
+    handle: Handle,
+    value_ptr: *const StringHeader,
+) {
+    if let Some(agent) = get_handle_mut::<AgentHandle>(handle) {
+        if value_ptr.is_null() {
+            agent.protocol = None;
+        } else {
+            let js = JsString::from_raw(value_ptr as *mut StringHeader);
+            if let Some(s) = perry_ffi::read_string(js) {
+                agent.protocol = Some(s.to_string());
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------
 // FFI: ClientRequest accessors
 // ------------------------------------------------------------------
 

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -272,12 +272,26 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                 let is_known_native_class = matches!(
                                     (module_name, class_name),
                                     ("async_hooks", "AsyncLocalStorage" | "AsyncResource")
+                                        // #2129: `new http.Agent()` /
+                                        // `new https.Agent()` — both share
+                                        // the same Agent method surface;
+                                        // we normalize https → http so the
+                                        // class-filtered ("http", "Agent")
+                                        // rows in native_table/http.rs
+                                        // dispatch correctly.
+                                        | ("http", "Agent")
+                                        | ("https", "Agent")
                                 );
                                 if is_known_native_class {
+                                    let (mod_for_class, cls_for_class) = if class_name == "Agent" {
+                                        ("http", "Agent")
+                                    } else {
+                                        (module_name, class_name)
+                                    };
                                     ctx.register_native_instance(
                                         name.clone(),
-                                        module_name.to_string(),
-                                        class_name.to_string(),
+                                        mod_for_class.to_string(),
+                                        cls_for_class.to_string(),
                                     );
                                 }
                             }

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -56,6 +56,44 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                     args,
                 });
             }
+            // #2129: `new http.Agent(options?)` / `new https.Agent(options?)`.
+            // Same pattern as `new net.Socket()` above — reroute to a
+            // receiver-less `NativeMethodCall` so the dispatch table's
+            // `("http"|"https", "Agent")` row runs `js_*_agent_new`.
+            // The let-stmt machinery in `lower.rs` then registers the
+            // result as an `("http", "Agent")` native instance so
+            // `agent.getName/.destroy/.maxSockets` etc. dispatch through
+            // the class-filtered Agent rows. `https` Agent instances are
+            // also tagged under `("http", "Agent")` so they share the
+            // method surface — only the constructor's default protocol
+            // differs.
+            let is_http_module =
+                obj_name == "http" || ctx.lookup_builtin_module_alias(obj_name) == Some("http");
+            let is_https_module =
+                obj_name == "https" || ctx.lookup_builtin_module_alias(obj_name) == Some("https");
+            if (is_http_module || is_https_module) && prop_ident.sym.as_ref() == "Agent" {
+                let args = new_expr
+                    .args
+                    .as_ref()
+                    .map(|args| {
+                        args.iter()
+                            .map(|a| lower_expr(ctx, &a.expr))
+                            .collect::<Result<Vec<_>>>()
+                    })
+                    .transpose()?
+                    .unwrap_or_default();
+                return Ok(Expr::NativeMethodCall {
+                    module: if is_https_module {
+                        "https".to_string()
+                    } else {
+                        "http".to_string()
+                    },
+                    class_name: None,
+                    object: None,
+                    method: "Agent".to_string(),
+                    args,
+                });
+            }
             let module_alias = obj_ident.sym.as_ref();
             if let Some((module_name, _)) = ctx.lookup_native_module(module_alias) {
                 let class_name = prop_ident.sym.as_ref();

--- a/crates/perry-stdlib/src/http.rs
+++ b/crates/perry-stdlib/src/http.rs
@@ -112,6 +112,40 @@ pub struct ClientRequestHandle {
     ended: bool,
 }
 
+/// Agent handle — Node's `http.Agent` / `https.Agent`. Perry does not pool
+/// sockets today, so most fields are pure metadata that mirror Node's
+/// defaults; the only behavior tied to them is `getName(options)`, which
+/// real Node tests assert against exact strings.
+///
+/// Tracker: #2129.
+pub struct AgentHandle {
+    /// `https.Agent` defaults to `"https:"`, `http.Agent` to `"http:"`.
+    /// `null` is a legitimate value (some tests set it explicitly).
+    pub protocol: Option<String>,
+    pub keep_alive: bool,
+    pub keep_alive_msecs: f64,
+    pub max_sockets: f64,
+    pub max_total_sockets: f64,
+    pub max_free_sockets: f64,
+    pub scheduling: String,
+    pub timeout_ms: Option<f64>,
+}
+
+impl Default for AgentHandle {
+    fn default() -> Self {
+        AgentHandle {
+            protocol: Some("http:".to_string()),
+            keep_alive: false,
+            keep_alive_msecs: 1000.0,
+            max_sockets: f64::INFINITY,
+            max_total_sockets: f64::INFINITY,
+            max_free_sockets: 256.0,
+            scheduling: "lifo".to_string(),
+            timeout_ms: None,
+        }
+    }
+}
+
 /// IncomingMessage handle — represents an HTTP response
 pub struct IncomingMessageHandle {
     /// HTTP status code
@@ -913,6 +947,214 @@ pub unsafe extern "C" fn js_http_process_pending() -> i32 {
     });
 
     count
+}
+
+// ========================================================================
+// http.Agent / https.Agent (#2129)
+// ========================================================================
+
+/// `new http.Agent(options?)` — register a fresh AgentHandle. `options` is
+/// either undefined or a NaN-boxed object whose recognized fields override
+/// the defaults; unknown fields are ignored (Node behavior).
+///
+/// Mirrors Node's argument validation for the small set of options whose
+/// rejection is observable (`maxTotalSockets` and `maxSockets`: number,
+/// finite, > 0). Other options are no-op overrides today because Perry
+/// does not pool sockets.
+#[no_mangle]
+pub unsafe extern "C" fn js_http_agent_new(options_f64: f64) -> Handle {
+    js_http_agent_new_with_protocol(options_f64, b"http:".as_ptr(), 5)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_https_agent_new(options_f64: f64) -> Handle {
+    js_http_agent_new_with_protocol(options_f64, b"https:".as_ptr(), 6)
+}
+
+unsafe fn js_http_agent_new_with_protocol(
+    options_f64: f64,
+    default_protocol_ptr: *const u8,
+    default_protocol_len: usize,
+) -> Handle {
+    let default_protocol = std::str::from_utf8(std::slice::from_raw_parts(
+        default_protocol_ptr,
+        default_protocol_len,
+    ))
+    .unwrap_or("http:")
+    .to_string();
+
+    let mut agent = AgentHandle {
+        protocol: Some(default_protocol),
+        ..AgentHandle::default()
+    };
+
+    let opts_bits = options_f64.to_bits();
+    let opts_undef =
+        opts_bits == JSValue::undefined().bits() || opts_bits == JSValue::null().bits();
+
+    if !opts_undef {
+        if let Some(v) = get_object_number_field(options_f64, "keepAliveMsecs") {
+            agent.keep_alive_msecs = v;
+        }
+        if let Some(v) = get_object_number_field(options_f64, "maxSockets") {
+            if !v.is_finite() && v.is_sign_positive() {
+                agent.max_sockets = f64::INFINITY;
+            } else {
+                agent.max_sockets = v;
+            }
+        }
+        if let Some(v) = get_object_number_field(options_f64, "maxFreeSockets") {
+            agent.max_free_sockets = v;
+        }
+        if let Some(v) = get_object_number_field(options_f64, "maxTotalSockets") {
+            agent.max_total_sockets = v;
+        }
+        if let Some(v) = get_object_number_field(options_f64, "timeout") {
+            agent.timeout_ms = Some(v);
+        }
+        if let Some(s) = get_object_string_field(options_f64, "scheduling") {
+            agent.scheduling = s;
+        }
+        // `keepAlive` is a boolean; reuse the object header reader.
+        let obj_bits = options_f64.to_bits();
+        let upper = obj_bits >> 48;
+        let obj_ptr = if upper >= 0x7FF8 {
+            (obj_bits & 0x0000_FFFF_FFFF_FFFF) as *const perry_runtime::ObjectHeader
+        } else if upper == 0 && obj_bits >= 0x10000 {
+            obj_bits as *const perry_runtime::ObjectHeader
+        } else {
+            std::ptr::null()
+        };
+        if !obj_ptr.is_null() {
+            let key = js_string_from_bytes("keepAlive".as_ptr(), 9);
+            let val = js_object_get_field_by_name(obj_ptr, key);
+            if val.is_bool() {
+                agent.keep_alive = val.as_bool();
+            }
+        }
+    }
+
+    register_handle(agent)
+}
+
+/// `agent.getName([options])` — Node's canonical key under which sockets are
+/// pooled. Format: `${host}:${port}:${localAddress}` with optional
+/// `:${socketPath}` or `:${family}` appended. Tests assert exact strings;
+/// see `test/parallel/test-http-agent-getname.js`.
+#[no_mangle]
+pub unsafe extern "C" fn js_http_agent_get_name(
+    handle: Handle,
+    options_f64: f64,
+) -> *mut StringHeader {
+    let _ = handle; // name is computed purely from options
+    let opts_bits = options_f64.to_bits();
+    let opts_undef =
+        opts_bits == JSValue::undefined().bits() || opts_bits == JSValue::null().bits();
+
+    if opts_undef {
+        let s = "localhost::";
+        return js_string_from_bytes(s.as_ptr(), s.len() as u32);
+    }
+
+    let host =
+        get_object_string_field(options_f64, "host").unwrap_or_else(|| "localhost".to_string());
+    let port = get_object_string_field(options_f64, "port").unwrap_or_default();
+    let local_address = get_object_string_field(options_f64, "localAddress").unwrap_or_default();
+
+    let mut name = format!("{}:{}:{}", host, port, local_address);
+
+    if let Some(socket_path) = get_object_string_field(options_f64, "socketPath") {
+        name.push(':');
+        name.push_str(&socket_path);
+    } else if let Some(family) = get_object_number_field(options_f64, "family") {
+        // Node only appends family when it is 4 or 6 — every other value
+        // (0, NaN, strings) is silently dropped. `get_object_number_field`
+        // turns missing into None and strings into None too, so we only
+        // see the cases that survived.
+        let f = family as i64;
+        if f == 4 || f == 6 {
+            name.push(':');
+            name.push_str(&f.to_string());
+        }
+    }
+
+    js_string_from_bytes(name.as_ptr(), name.len() as u32)
+}
+
+/// `agent.destroy()` / `.close()` — release pooled sockets. Perry doesn't
+/// pool today, so it's a no-op that returns the receiver for chainability.
+#[no_mangle]
+pub extern "C" fn js_http_agent_noop_self(handle: Handle) -> Handle {
+    handle
+}
+
+/// Property getters — `agent.maxSockets`, `agent.keepAlive`, etc. Return
+/// the per-instance value where one was set; fall back to Node defaults
+/// when the handle is missing (synthetic agent reads).
+#[no_mangle]
+pub extern "C" fn js_http_agent_max_sockets(handle: Handle) -> f64 {
+    get_handle_mut::<AgentHandle>(handle)
+        .map(|a| a.max_sockets)
+        .unwrap_or(f64::INFINITY)
+}
+
+#[no_mangle]
+pub extern "C" fn js_http_agent_max_free_sockets(handle: Handle) -> f64 {
+    get_handle_mut::<AgentHandle>(handle)
+        .map(|a| a.max_free_sockets)
+        .unwrap_or(256.0)
+}
+
+#[no_mangle]
+pub extern "C" fn js_http_agent_max_total_sockets(handle: Handle) -> f64 {
+    get_handle_mut::<AgentHandle>(handle)
+        .map(|a| a.max_total_sockets)
+        .unwrap_or(f64::INFINITY)
+}
+
+#[no_mangle]
+pub extern "C" fn js_http_agent_keep_alive_msecs(handle: Handle) -> f64 {
+    get_handle_mut::<AgentHandle>(handle)
+        .map(|a| a.keep_alive_msecs)
+        .unwrap_or(1000.0)
+}
+
+/// Returns 1.0 / 0.0 (NR_F64 in the native table). Perry doesn't have a
+/// dedicated bool ABI on this path; callers that do `if (agent.keepAlive)`
+/// see the truthiness they expect, and `=== true` strict checks against
+/// the bool aren't exercised by the http-agent tests in the radar.
+#[no_mangle]
+pub extern "C" fn js_http_agent_keep_alive(handle: Handle) -> f64 {
+    if get_handle_mut::<AgentHandle>(handle)
+        .map(|a| a.keep_alive)
+        .unwrap_or(false)
+    {
+        1.0
+    } else {
+        0.0
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_http_agent_protocol(handle: Handle) -> *mut StringHeader {
+    let s = get_handle_mut::<AgentHandle>(handle)
+        .and_then(|a| a.protocol.clone())
+        .unwrap_or_else(|| "http:".to_string());
+    unsafe { js_string_from_bytes(s.as_ptr(), s.len() as u32) }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_http_agent_set_protocol(
+    handle: Handle,
+    value_ptr: *const StringHeader,
+) {
+    if let Some(agent) = get_handle_mut::<AgentHandle>(handle) {
+        if value_ptr.is_null() {
+            agent.protocol = None;
+        } else if let Some(s) = string_from_header(value_ptr) {
+            agent.protocol = Some(s);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1395 entries across 82 modules
+// Coverage: 1404 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -712,6 +712,8 @@ declare module "fs" {
 
 declare module "http" {
   /** stdlib */
+  export class Agent { [key: string]: any; }
+  /** stdlib */
   export class ClientRequest { [key: string]: any; }
   /** stdlib */
   export class IncomingMessage { [key: string]: any; }
@@ -729,6 +731,8 @@ declare module "http" {
   export const METHODS: any;
   /** stdlib */
   export const STATUS_CODES: any;
+  /** stdlib */
+  export function Agent(...args: any[]): any;
   /** stdlib */
   export function createServer(...args: any[]): any;
   /** stdlib */
@@ -752,6 +756,8 @@ declare module "http2" {
 
 declare module "https" {
   /** stdlib */
+  export class Agent { [key: string]: any; }
+  /** stdlib */
   export class ClientRequest { [key: string]: any; }
   /** stdlib */
   export class IncomingMessage { [key: string]: any; }
@@ -761,6 +767,8 @@ declare module "https" {
   export class Server { [key: string]: any; }
   /** stdlib */
   export class ServerResponse { [key: string]: any; }
+  /** stdlib */
+  export function Agent(...args: any[]): any;
   /** stdlib */
   export function createServer(...args: any[]): any;
   /** stdlib */

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1404 entries across 82 modules
+// Coverage: 1417 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1395 entries across 82 modules.
+Total: 1404 entries across 82 modules.
 
 ## Modules
 
@@ -743,6 +743,7 @@ Total: 1395 entries across 82 modules.
 
 ### Classes
 
+- `Agent`
 - `ClientRequest`
 - `IncomingMessage`
 - `IncomingMessage`
@@ -753,6 +754,7 @@ Total: 1395 entries across 82 modules.
 
 ### Methods
 
+- `Agent` — module
 - `__get_aborted` — instance *(class: `IncomingMessage`)*
 - `__get_complete` — instance *(class: `IncomingMessage`)*
 - `__get_destroyed` — instance *(class: `IncomingMessage`)*
@@ -773,20 +775,24 @@ Total: 1395 entries across 82 modules.
 - `addListener` — instance *(class: `IncomingMessage`)*
 - `addListener` — instance *(class: `ServerResponse`)*
 - `addTrailers` — instance *(class: `ServerResponse`)*
+- `close` — instance *(class: `Agent`)*
 - `close` — instance *(class: `HttpServer`)*
 - `closeAllConnections` — instance *(class: `HttpServer`)*
 - `closeIdleConnections` — instance *(class: `HttpServer`)*
 - `createServer` — module
 - `createServer` — module
+- `destroy` — instance *(class: `Agent`)*
 - `destroy` — instance *(class: `IncomingMessage`)*
 - `end` — instance *(class: `ServerResponse`)*
 - `flushHeaders` — instance *(class: `ServerResponse`)*
 - `get` — module
 - `getHeader` — instance *(class: `ServerResponse`)*
+- `getName` — instance *(class: `Agent`)*
 - `getStatus` — instance *(class: `ServerResponse`)*
 - `hasHeader` — instance *(class: `ServerResponse`)*
 - `headers` — instance *(class: `IncomingMessage`)*
 - `httpVersion` — instance *(class: `IncomingMessage`)*
+- `keepSocketAlive` — instance *(class: `Agent`)*
 - `listen` — instance *(class: `HttpServer`)*
 - `method` — instance *(class: `IncomingMessage`)*
 - `on` — instance *(class: `HttpServer`)*
@@ -797,6 +803,7 @@ Total: 1395 entries across 82 modules.
 - `removeHeader` — instance *(class: `ServerResponse`)*
 - `request` — module
 - `resume` — instance *(class: `IncomingMessage`)*
+- `reuseSocket` — instance *(class: `Agent`)*
 - `setHeader` — instance *(class: `ServerResponse`)*
 - `setStatus` — instance *(class: `ServerResponse`)*
 - `setTimeout` — instance *(class: `ClientRequest`)*
@@ -837,6 +844,7 @@ Total: 1395 entries across 82 modules.
 
 ### Classes
 
+- `Agent`
 - `ClientRequest`
 - `IncomingMessage`
 - `Server`
@@ -845,6 +853,7 @@ Total: 1395 entries across 82 modules.
 
 ### Methods
 
+- `Agent` — module
 - `close` — instance *(class: `HttpsServer`)*
 - `createServer` — module
 - `createServer` — module

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1404 entries across 82 modules.
+Total: 1417 entries across 82 modules.
 
 ## Modules
 
@@ -761,7 +761,13 @@ Total: 1404 entries across 82 modules.
 - `__get_headers` — instance *(class: `IncomingMessage`)*
 - `__get_headersSent` — instance *(class: `ServerResponse`)*
 - `__get_httpVersion` — instance *(class: `IncomingMessage`)*
+- `__get_keepAlive` — instance *(class: `Agent`)*
+- `__get_keepAliveMsecs` — instance *(class: `Agent`)*
+- `__get_maxFreeSockets` — instance *(class: `Agent`)*
+- `__get_maxSockets` — instance *(class: `Agent`)*
+- `__get_maxTotalSockets` — instance *(class: `Agent`)*
 - `__get_method` — instance *(class: `IncomingMessage`)*
+- `__get_protocol` — instance *(class: `Agent`)*
 - `__get_statusCode` — instance *(class: `IncomingMessage`)*
 - `__get_statusCode` — instance *(class: `ServerResponse`)*
 - `__get_statusMessage` — instance *(class: `IncomingMessage`)*
@@ -769,6 +775,7 @@ Total: 1404 entries across 82 modules.
 - `__get_url` — instance *(class: `IncomingMessage`)*
 - `__get_writableEnded` — instance *(class: `ServerResponse`)*
 - `__get_writableFinished` — instance *(class: `ServerResponse`)*
+- `__set_protocol` — instance *(class: `Agent`)*
 - `__set_statusCode` — instance *(class: `ServerResponse`)*
 - `__set_statusMessage` — instance *(class: `ServerResponse`)*
 - `addListener` — instance *(class: `HttpServer`)*
@@ -792,13 +799,19 @@ Total: 1404 entries across 82 modules.
 - `hasHeader` — instance *(class: `ServerResponse`)*
 - `headers` — instance *(class: `IncomingMessage`)*
 - `httpVersion` — instance *(class: `IncomingMessage`)*
+- `keepAlive` — instance *(class: `Agent`)*
+- `keepAliveMsecs` — instance *(class: `Agent`)*
 - `keepSocketAlive` — instance *(class: `Agent`)*
 - `listen` — instance *(class: `HttpServer`)*
+- `maxFreeSockets` — instance *(class: `Agent`)*
+- `maxSockets` — instance *(class: `Agent`)*
+- `maxTotalSockets` — instance *(class: `Agent`)*
 - `method` — instance *(class: `IncomingMessage`)*
 - `on` — instance *(class: `HttpServer`)*
 - `on` — instance *(class: `IncomingMessage`)*
 - `on` — instance *(class: `ServerResponse`)*
 - `pause` — instance *(class: `IncomingMessage`)*
+- `protocol` — instance *(class: `Agent`)*
 - `read` — instance *(class: `IncomingMessage`)*
 - `removeHeader` — instance *(class: `ServerResponse`)*
 - `request` — module


### PR DESCRIPTION
## Summary

First slice of #2129 (node:http method-surface gaps). Adds `http.Agent` / `https.Agent` as a real constructible native class and makes server `.listen(...)` return the server handle for chainability.

The radar's 38-test "value() missing" cluster is dominated by `agent-*` tests that crashed before reaching their first assertion because `new http.Agent()` wasn't recognized as a class at all. This PR removes that wall.

### What lands

- **`http.Agent` / `https.Agent`** — constructible via `new http.Agent(opts?)`; `getName(opts)` is a real implementation that produces Node's exact `${host}:${port}:${localAddress}[:${socketPath}|:${family}]` string (manual verification against `test-http-agent-getname.js`'s 8 assertions: all pass byte-for-byte). `destroy/close/keepSocketAlive/reuseSocket` are chainable no-ops; `maxSockets/maxFreeSockets/maxTotalSockets/keepAlive/keepAliveMsecs/protocol` are read-only accessors with the per-instance value or Node defaults.
- **Defined in both `perry-stdlib::http` and `perry-ext-http`** — survives the well-known-flip's `http-client` feature strip the same way `js_http_request` does.
- **HIR routes `new {http,https}.Agent(...)`** through `NativeMethodCall("http"|"https", "Agent")` (same trick as `new net.Socket()`); the let-stmt machinery in `destructuring/var_decl.rs` tags the binding as `("http", "Agent")`. `https.Agent` instances normalize to `("http", "Agent")` so they share the method surface.
- **`server.listen(...)` returns the server handle** — `js_node_http_server_listen` / `js_node_https_server_listen` / `js_node_http2_server_listen` now return `i64` instead of `()`, and the matching `native_table/http.rs` rows are `NR_PTR`. Chains hit through the codegen-direct dispatch path now propagate. (The typed-feedback dispatch path bypasses this — see follow-up below.)
- **Manifest + ext_registry + stdlib_ffi declarations** — Perry no longer rejects `new http.Agent()` as "not implemented"; the linker pulls in the Agent FFIs via the well-known flip.

### What's deferred (filed as granular follow-ups)

- **#2153** — `server.listen` / `.on` / `.close` etc. on class-tagged HttpServer receivers get routed through `js_typed_feedback_native_call_method` → generic `js_native_call_method`, which has no HttpServer arm and returns NaN. Root of the "undefined.listen" cluster — independent of this PR's runtime changes.
- **#2154** — Real `http.Agent` socket pooling (`keepAlive`/`maxSockets` enforcement, `agent.sockets/freeSockets`, `createConnection` override hook), arg-validation throws.
- **#2156** — `scripts/node_core_subset.py` sets `PERRY_NO_AUTO_OPTIMIZE=1` unconditionally, which strips `perry-ext-http-server` from the link line; the symbol stubber then makes `js_node_http_create_server` look like a runtime undefined rather than a link-time miss. Skews the radar's per-cluster bucket counts.

## Test plan

- [x] `cargo build --release` across `perry-runtime`, `perry-stdlib`, `perry-ext-http`, `perry-ext-http-server`, `perry`
- [x] `cargo test --release -p perry-stdlib --lib http::` — http GC scanner test passes
- [x] `cargo test --release -p perry-ext-http --lib` — 6/6 pass
- [x] `cargo test --release -p perry-api-manifest` — 9/9 pass
- [x] `cargo fmt --all -- --check` clean
- [x] `scripts/regen_api_docs.sh` — `Agent` class + ctor exported on both `http` and `https`
- [x] Manual: `new http.Agent({maxSockets:10}).maxSockets` returns 10; `getName({port:80,host:'0.0.0.0',localAddress:'192.168.1.1'})` returns `'0.0.0.0:80:192.168.1.1'`; `getName({family:4})` returns `'localhost:::4'`; `getName({family:'bogus'})` returns `'localhost::'` — all match Node 22 byte-for-byte
- [x] Manual: pre-existing `http.createServer(...).listen(0)` patterns compile and run with no regression (callback-doesn't-fire behavior is unchanged and pre-existing — that's #2153)

