### PR TITLE
test(release): drizzle-mysql end-to-end against real MySQL via @perryts/mysql (#489)

### DIFF
--- a/tests/release/packages/drizzle-mysql/entry.ts
+++ b/tests/release/packages/drizzle-mysql/entry.ts
@@ -1,0 +1,83 @@
+// #489 acceptance: 50-line drizzle program against a real MySQL via
+// `@perryts/mysql` (pure-TS wire-protocol driver compiled natively
+// through perry's compilePackages). Uses `drizzle-orm/mysql-proxy`
+// (drizzle's callback-based entry) so we never pull in npm `mysql2`.
+
+import { drizzle } from "drizzle-orm/mysql-proxy";
+import { mysqlTable, int, varchar } from "drizzle-orm/mysql-core";
+import { eq } from "drizzle-orm";
+import { connect } from "@perryts/mysql";
+
+const conn = await connect({
+    host: "127.0.0.1",
+    port: 3306,
+    user: "root",
+    password: "",
+    database: "perry_drizzle_test",
+});
+
+// Adapter: @perryts/mysql → drizzle/mysql-proxy callback. `method` is
+// "all" for SELECT (returns object rows that drizzle maps via field
+// order — convert to row-arrays here) and "execute" for everything
+// else (returns `[{ insertId, affectedRows }]` per drizzle's contract).
+async function exec(sql: string, params: any[], method: string): Promise<{ rows: any[] }> {
+    const result = await conn.query(sql, params);
+    if (method === "execute" && result.fields.length === 0) {
+        return { rows: [{
+            insertId: typeof result.lastInsertId === "bigint" ? Number(result.lastInsertId) : result.lastInsertId,
+            affectedRows: result.rowCount,
+        }] };
+    }
+    const fieldNames = result.fields.map((f: any) => f.name);
+    const rows = result.rows.map((r: any) => fieldNames.map((n: string) => r[n]));
+    return { rows };
+}
+
+const db = drizzle(exec);
+
+// Note: idiomatic drizzle would `await db.select().from(users)` (the builder
+// is thenable via QueryPromise.then). Under Perry that inherited .then
+// currently resolves to undefined (#2159), so we use explicit .execute()
+// throughout. Once #2159 lands, the .execute() calls can be dropped.
+
+
+const users = mysqlTable("users", {
+    id: int("id").primaryKey().autoincrement(),
+    name: varchar("name", { length: 64 }).notNull(),
+    age: int("age").notNull(),
+});
+const posts = mysqlTable("posts", {
+    id: int("id").primaryKey().autoincrement(),
+    userId: int("user_id").notNull(),
+    title: varchar("title", { length: 128 }).notNull(),
+});
+
+// Fresh schema each run so we're deterministic.
+await exec("DROP TABLE IF EXISTS posts", [], "execute");
+await exec("DROP TABLE IF EXISTS users", [], "execute");
+await exec("CREATE TABLE users (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(64) NOT NULL, age INT NOT NULL)", [], "execute");
+await exec("CREATE TABLE posts (id INT PRIMARY KEY AUTO_INCREMENT, user_id INT NOT NULL, title VARCHAR(128) NOT NULL)", [], "execute");
+
+await db.insert(users).values([
+    { id: 1, name: "alice", age: 30 },
+    { id: 2, name: "bob",   age: 25 },
+]).execute();
+await db.insert(posts).values([
+    { id: 1, userId: 1, title: "hello" },
+    { id: 2, userId: 1, title: "world" },
+]).execute();
+
+const all = await db.select().from(users).execute();
+console.log(`count=${all.length}`);
+
+await db.update(users).set({ age: 31 }).where(eq(users.id, 1)).execute();
+const a = await db.select().from(users).where(eq(users.id, 1)).execute();
+console.log(`alice.age=${a[0].age}`);
+
+await db.delete(users).where(eq(users.id, 2)).execute();
+console.log(`after_delete=${(await db.select().from(users).execute()).length}`);
+
+const joined = await db.select().from(users).leftJoin(posts, eq(users.id, posts.userId)).execute();
+console.log(`join_rows=${joined.length}`);
+
+await conn.close();

--- a/tests/release/packages/drizzle-mysql/expected.txt
+++ b/tests/release/packages/drizzle-mysql/expected.txt
@@ -1,0 +1,4 @@
+count=2
+alice.age=31
+after_delete=1
+join_rows=2

--- a/tests/release/packages/drizzle-mysql/fixture.sh
+++ b/tests/release/packages/drizzle-mysql/fixture.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(dirname "$0")"
+. "$(dirname "$0")/../_fixture_lib.sh"
+
+# Real-MySQL fixture: needs a running mysqld on 127.0.0.1:3306 reachable
+# as root without a password, with a `perry_drizzle_test` database. Skip
+# (rather than fail) if MySQL isn't available — CI wiring is tracked in
+# #804.
+if ! command -v mysql >/dev/null 2>&1 || ! mysql -h 127.0.0.1 -u root -e "SELECT 1" >/dev/null 2>&1; then
+    fixture_skip "drizzle-mysql" "no MySQL on 127.0.0.1:3306 (see #804 for CI wiring)"
+fi
+mysql -h 127.0.0.1 -u root -e "CREATE DATABASE IF NOT EXISTS perry_drizzle_test" >/dev/null 2>&1 || \
+    fixture_skip "drizzle-mysql" "cannot create perry_drizzle_test database"
+
+fixture_setup "drizzle-mysql" || exit 1
+fixture_compile_run_diff "drizzle-mysql"

--- a/tests/release/packages/drizzle-mysql/package-lock.json
+++ b/tests/release/packages/drizzle-mysql/package-lock.json
@@ -1,0 +1,149 @@
+{
+  "name": "perry-release-fixture-drizzle-mysql",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "perry-release-fixture-drizzle-mysql",
+      "version": "0.0.0",
+      "dependencies": {
+        "@perryts/mysql": "github:PerryTS/mysql",
+        "drizzle-orm": "^0.45.2"
+      }
+    },
+    "node_modules/@perryts/mysql": {
+      "version": "0.1.4",
+      "resolved": "git+ssh://git@github.com/PerryTS/mysql.git#aa1095187332f897cb388a3f257f761a67032da0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/tests/release/packages/drizzle-mysql/package.json
+++ b/tests/release/packages/drizzle-mysql/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "perry-release-fixture-drizzle-mysql",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Tier-3 fixture: drizzle-orm via @perryts/mysql against a real MySQL on 127.0.0.1:3306. Exercises schema + insert/select/update/delete + leftJoin end-to-end (the #489 acceptance).",
+  "dependencies": {
+    "drizzle-orm": "^0.45.2",
+    "@perryts/mysql": "github:PerryTS/mysql"
+  },
+  "perry": {
+    "compilePackages": ["drizzle-orm", "@perryts/mysql"],
+    "allow": {
+      "compilePackages": ["drizzle-orm", "@perryts/mysql"]
+    }
+  }
+}


### PR DESCRIPTION
## What

Closes the #489 acceptance: a 50-line drizzle-orm program runs end-to-end against a real MySQL on `127.0.0.1:3306` via the pure-TS `@perryts/mysql` driver compiled natively through perry's `compilePackages`. Output is byte-identical between Perry and Bun-with-the-`perry`-export-condition (the canonical baseline).

## Shape

```
tests/release/packages/drizzle-mysql/
├── entry.ts          # 50-line program + 12-line @perryts/mysql ↔ drizzle adapter
├── expected.txt      # baseline captured from `bun --conditions=perry run entry.ts`
├── fixture.sh        # skip if no mysqld on 127.0.0.1:3306; else compile + run + diff
├── package.json      # drizzle-orm + @perryts/mysql (github), compilePackages: both
└── package-lock.json # pins @perryts/mysql to commit aa10951873…
```

The fixture exercises schema + insert + select + update + select + delete + select + **leftJoin** — full CRUD plus a relational join, all going through perry's compilePackages → @perryts/mysql wire protocol → real `mysqld`.

Driver glue uses **`drizzle-orm/mysql-proxy`** (drizzle's callback-based entry) so we never pull in npm `mysql2`. The fixture-local adapter is the only "integration" code — ~12 lines that map `@perryts/mysql`'s `QueryResult` into the shape drizzle expects (`[{insertId, affectedRows}]` for execute, row-arrays for `all`).

## What landed before this

- #2050 — `Object.getPrototypeOf` self-cycle fix (terminated drizzle's `is()` walk on array chunks).
- #2141 — primitive-number field-get safety guard (stopped UPDATE/DELETE/leftJoin SIGSEGV via drizzle's bound-param numbers).

Without both, the program hangs or SIGSEGVs early. With both, the entire drizzle + @perryts/mysql + real-MySQL path compiles and runs through perry.

## Known limitation (worked around in this fixture)

The entry uses explicit **`.execute()`** at every drizzle call site instead of relying on the idiomatic `await db.select().from(users)` thenable form. Under perry, `MySqlSelectBase.then` (inherited 4+ levels deep from drizzle's `QueryPromise`) currently resolves to `undefined`, so `await` doesn't see a thenable and unwraps to the builder itself. `.execute()` returns a real Promise and works. Filed as #2159; once it lands the `.execute()` calls can be dropped (entry already documents the link).

## Acceptance vs #489

| #489 deliverable | status |
|---|---|
| Wire `@perryts/mysql` as drizzle's mysql driver | ✓ (via `drizzle-orm/mysql-proxy` + 12-line adapter) |
| 50-line program: schema + insert/select/update/delete + leftJoin | ✓ |
| Run against a real MySQL on `127.0.0.1:3306` | ✓ |
| Diff output against Node-equivalent (`bun --conditions=perry`) | ✓ byte-identical |

## What's still left

- **#804** (CI version): Phase 2 — promote this fixture to the release-packages sweep and add a GH Actions `services:` block for MySQL (first real-DB service container in this repo).
- **#2159** (the await-thenable workaround): drop the `.execute()` workarounds once fixed.
- **`@perryts/mysql` on npm**: currently pulled from GitHub; if you publish it, the `package.json` dep can switch to a normal version.

## Local verification

```sh
# Requires a mysqld on 127.0.0.1:3306 reachable as root (no password).
mysql -h 127.0.0.1 -u root -e "CREATE DATABASE IF NOT EXISTS perry_drizzle_test"
cd tests/release/packages/drizzle-mysql
PERRY_BIN=…/target/release/perry bash fixture.sh
# → PASS drizzle-mysql
```
