### PR TITLE
Make WeakRef inspect output opaque

### DIFF
--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -341,10 +341,10 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
 
             // Handle instanceof specially - needs to extract class name
             if matches!(bin.op, ast::BinaryOp::InstanceOf) {
-                // WeakRef / FinalizationRegistry: Perry doesn't register a runtime class id,
-                // so generic InstanceOf would always return false. Pre-scan tracks bindings
-                // explicitly, so `local instanceof WeakRef|FinalizationRegistry` can be folded
-                // at lowering time when we recognise the receiver.
+                // WeakRef / FinalizationRegistry: pre-scan tracks local
+                // constructor results explicitly, so common `local instanceof
+                // WeakRef|FinalizationRegistry` checks can be folded at
+                // lowering time when we recognise the receiver.
                 if let ast::Expr::Ident(class_ident) = bin.right.as_ref() {
                     let class_name = class_ident.sym.as_ref();
                     if class_name == "WeakRef" || class_name == "FinalizationRegistry" {

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -781,13 +781,16 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                     // self-referencing case wins over the depth-2 collapse to
                     // `[Object]` (#1204). The depth cap is overridable via
                     // INSPECT_DEPTH_LIMIT for `%o` / `console.dir(v, { depth })`.
+                    let obj_ptr = ptr as *const crate::object::ObjectHeader;
+                    if let Some(label) = crate::weakref::weak_wrapper_inspect_label(obj_ptr) {
+                        return format!("{label} {{}}");
+                    }
                     if let Err(id) = inspect_enter_circular(ptr as usize) {
                         return format!("[Circular *{}]", id);
                     }
                     if depth > inspect_depth_limit() {
                         return inspect_finish_circular(ptr as usize, "[Object]".to_string());
                     }
-                    let obj_ptr = ptr as *const crate::object::ObjectHeader;
                     let keys_array = (*obj_ptr).keys_array;
 
                     // Always route through `format_object_as_json` so the
@@ -1326,13 +1329,16 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
                         // depth-limit collapse to `[Object]` (#1204). The
                         // depth cap is overridable via INSPECT_DEPTH_LIMIT
                         // for `%o` / `console.dir(v, { depth })`.
+                        let obj_ptr = ptr as *const crate::object::ObjectHeader;
+                        if let Some(label) = crate::weakref::weak_wrapper_inspect_label(obj_ptr) {
+                            return format!("{label} {{}}");
+                        }
                         if let Err(id) = inspect_enter_circular(ptr as usize) {
                             return format!("[Circular *{}]", id);
                         }
                         if depth > inspect_depth_limit() {
                             return inspect_finish_circular(ptr as usize, "[Object]".to_string());
                         }
-                        let obj_ptr = ptr as *const crate::object::ObjectHeader;
                         let keys_array = (*obj_ptr).keys_array;
                         let body_str = if !keys_array.is_null()
                             && (keys_array as usize) > 0x10000

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -25,6 +25,19 @@ const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
 
 const WEAKREF_SHAPE_ID: u32 = 0x7FFF_FE10;
 const FINREG_SHAPE_ID: u32 = 0x7FFF_FE11;
+pub const CLASS_ID_WEAKREF: u32 = 0xFFFF_0029;
+pub const CLASS_ID_FINALIZATION_REGISTRY: u32 = 0xFFFF_002A;
+
+pub(crate) fn weak_wrapper_inspect_label(obj: *const ObjectHeader) -> Option<&'static str> {
+    if obj.is_null() {
+        return None;
+    }
+    match unsafe { (*obj).class_id } {
+        CLASS_ID_WEAKREF => Some("WeakRef"),
+        CLASS_ID_FINALIZATION_REGISTRY => Some("FinalizationRegistry"),
+        _ => None,
+    }
+}
 
 /// Allocate a `WeakRef` wrapper object that strongly holds the target value
 /// in a single field named `target`.
@@ -33,6 +46,9 @@ pub extern "C" fn js_weakref_new(target: f64) -> *mut ObjectHeader {
     let packed = b"target\0";
     let obj = js_object_alloc_with_shape(WEAKREF_SHAPE_ID, 1, packed.as_ptr(), packed.len() as u32);
     js_object_set_field(obj, 0, JSValue::from_bits(target.to_bits()));
+    unsafe {
+        (*obj).class_id = CLASS_ID_WEAKREF;
+    }
     obj
 }
 
@@ -65,6 +81,9 @@ pub extern "C" fn js_finreg_new(callback: f64) -> *mut ObjectHeader {
     js_object_set_field(obj, 0, JSValue::from_bits(callback.to_bits()));
     let entries_arr = js_array_alloc(0);
     js_object_set_field(obj, 1, JSValue::array_ptr(entries_arr));
+    unsafe {
+        (*obj).class_id = CLASS_ID_FINALIZATION_REGISTRY;
+    }
     obj
 }
 


### PR DESCRIPTION
## Summary
- Tag Perry WeakRef and FinalizationRegistry wrapper objects with internal class IDs.
- Short-circuit util.inspect/console formatting for those wrappers to Node-style opaque output: `WeakRef {}` and `FinalizationRegistry {}`.
- Refresh the stale HIR comment around folded WeakRef/FinalizationRegistry instanceof checks.

## Verification
- `./run_parity_tests.sh --suite=node-suite --module=util --filter promise-weakrefs` PASS, report `test-parity/reports/parity_report_20260528_002654.json`
- `./run_parity_tests.sh --suite=node-suite --module=process --filter finalization` PASS, report `test-parity/reports/parity_report_20260528_002824.json`
- `target/release/perry test-files/test_gap_weakref_finalization.ts -o /tmp/perry-weakref-finalization && /tmp/perry-weakref-finalization` PASS
- `cargo test -p perry-runtime --lib weakref -- --nocapture` PASS (0 matching tests)
- `cargo fmt --check` PASS
- `git diff --check` PASS

## Non-goals
- No real weak-reference GC semantics or FinalizationRegistry callback scheduling.
- No WeakMap/WeakSet inspect formatting or showProxy formatting.
- No assert/deepStrictEqual changes; `node-suite/assert/deep/promise-and-weak-collections` remains an existing Promise/WeakMap identity gap.
