### PR TITLE
fix(hir): bind legacy 'arguments' object inside object-literal shorthand methods (#321)

### DIFF
--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -21,7 +21,7 @@ use crate::analysis::{
     closure_uses_this, collect_assigned_locals_stmt, collect_local_refs_stmt, uses_this_stmt,
 };
 use crate::ir::{EnumValue, Expr, Function, Param, Stmt};
-use crate::lower_decl::lower_block_stmt;
+use crate::lower_decl::{append_synthetic_arguments_param, body_uses_arguments, lower_block_stmt};
 use crate::lower_patterns::{get_param_default, get_pat_name, is_rest_param};
 use crate::lower_types::{extract_param_type_with_ctx, extract_ts_type_with_ctx};
 
@@ -170,6 +170,32 @@ fn lower_method_prop(
         .as_ref()
         .map(|rt| extract_ts_type_with_ctx(&rt.type_ann, Some(ctx)))
         .unwrap_or(Type::Any);
+
+    // #321 / #64 / #65: synthesize legacy `arguments` for object-literal methods
+    // whose body references it. Without this, effect's Pipeable prototype
+    // methods (`pipe() { return pipeArguments(this, arguments) }` on
+    // `TypeMatcherProto`/`ValueMatcherProto` and friends) see an unbound
+    // `arguments` identifier, and `.pipe(...)` quietly drops all of its
+    // operands. Mirrors the synthesis in `class_members.rs` / `fn_decl.rs` /
+    // `expr_function.rs` — the only call site that was missing this hook.
+    let user_has_arguments_param = method
+        .function
+        .params
+        .iter()
+        .any(|p| get_pat_name(&p.pat).ok().as_deref() == Some("arguments"));
+    let user_has_rest = method.function.params.iter().any(|p| is_rest_param(&p.pat));
+    let needs_arguments_synth = !user_has_arguments_param
+        && !user_has_rest
+        && method
+            .function
+            .body
+            .as_ref()
+            .map(|b| body_uses_arguments(&b.stmts))
+            .unwrap_or(false);
+    if needs_arguments_synth {
+        append_synthetic_arguments_param(ctx, &mut params);
+    }
+
     let body = if let Some(ref block) = method.function.body {
         lower_block_stmt(ctx, block)?
     } else {

--- a/test-files/test_gap_arguments_in_object_literal_method.ts
+++ b/test-files/test_gap_arguments_in_object_literal_method.ts
@@ -1,0 +1,68 @@
+// #321 / #64 / #65: legacy `arguments` inside an object-literal shorthand
+// method body (`{ pipe() { return f(this, arguments) } }`).
+//
+// This is the EXACT shape effect's Pipeable trait uses on its
+// `TypeMatcherProto` / `ValueMatcherProto` (and on every other Pipeable
+// instance — Effect, Match, Console, Logger, Either, Option, Cause, Exit,
+// …). Without synthesis, `arguments` inside the object-literal method body
+// was unbound, so `pipeArguments(this, arguments)` saw nothing → `.pipe(fn)`
+// silently returned `this`, dropping every operand.
+//
+// `class_members.rs` / `fn_decl.rs` / `expr_function.rs` already synthesize a
+// trailing `...arguments` rest param when the body references the identifier
+// (#677, #1069, #1816). `expr_object.rs::lower_method_prop` was the missing
+// site — added in the same shape so the synthetic param is in scope before
+// the body lowers.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+// (1) capture-free object-literal method using `arguments`.
+const a = {
+  fn() {
+    return arguments.length;
+  },
+};
+console.log("(1) a.fn():", a.fn());
+console.log("(1) a.fn(1,2,3):", (a as any).fn(1, 2, 3));
+
+// (2) `this`-using object-literal method with `arguments` — the Pipeable
+// shape. Falls through the Closure path (captures_this=true).
+const proto = {
+  pipe() {
+    const args = arguments;
+    return args.length > 0 ? args[0](this) : this;
+  },
+};
+const o = Object.create(proto);
+(o as any).x = 10;
+const bump = (self: any) => ({ ...self, x: self.x + 1 });
+const o2 = (o as any).pipe(bump);
+console.log("(2) o2.x:", o2.x);
+
+// (3) named params + `arguments` together. `arguments` reflects ALL passed
+// values, not just the trailing ones.
+const m = {
+  go(first: number) {
+    return `first=${first} count=${arguments.length}`;
+  },
+};
+console.log("(3) m.go(7):", m.go(7));
+console.log("(3) m.go(7,8,9):", (m as any).go(7, 8, 9));
+
+// (4) the actual Pipeable.pipe shape that effect ships — variadic
+// transformations chained off arguments.
+function applyAll(self: any, args: IArguments): any {
+  let acc = self;
+  for (let i = 0; i < args.length; i++) acc = args[i](acc);
+  return acc;
+}
+const pipeable = {
+  v: 1,
+  pipe() {
+    return applyAll(this, arguments);
+  },
+};
+const inc = (s: any) => ({ ...s, v: s.v + 1 });
+const dbl = (s: any) => ({ ...s, v: s.v * 2 });
+const result = (pipeable as any).pipe(inc, dbl, inc);
+console.log("(4) result.v:", result.v); // ((1+1)*2)+1 = 5


### PR DESCRIPTION
## Summary

Bind legacy `arguments` inside **object-literal shorthand method** bodies. This is the missing case in Perry's `arguments`-synthesis pipeline — the other call sites (`class_members.rs`, `fn_decl.rs`, `expr_function.rs`) all do this; `lower_method_prop` in `expr_object.rs` was the one site that was missed.

This is the exact shape effect's Pipeable trait uses on `TypeMatcherProto` / `ValueMatcherProto` (and every other Pipeable instance — `Effect`, `Match`, `Either`, `Option`, `Cause`, `Exit`, `Logger`, `Console`, …):

```ts
const TypeMatcherProto = {
  pipe() {
    return pipeArguments(this, arguments)   // <-- arguments was unbound
  }
}
```

Without synthesis, `arguments` inside the method body resolved to nothing, `pipeArguments(this, arguments)` saw zero operands, and `.pipe(...)` silently returned `this` — dropping every operand. `Match.type<>().pipe(Match.when(...))` produced a matcher with no cases.

## Root cause

`expr_object.rs::lower_method_prop` lowers object-literal shorthand methods (`{ m() {} }`). It walked the user-written params, registered them as locals, and lowered the body. It never called `body_uses_arguments` / `append_synthetic_arguments_param`, so a body referencing `arguments` had nothing to bind to. The other three call sites in the HIR pipeline all do this synthesis (added under #677 / #1069 / #1816) — `lower_method_prop` was overlooked.

## Fix

Pre-scan the user-written method body with `body_uses_arguments`. If it references `arguments`, and the user has not already bound the name (explicit param or own rest), append a synthetic `...arguments` rest param via `append_synthetic_arguments_param` **before** body lowering, so `Expr::Ident("arguments")` resolves to the new `LocalId`. Same shape as the class/function-decl/function-expr sites.

## Verification

### Direct repro (object-literal method) — Node vs Perry, byte-identical

```ts
const proto = {
  pipe() {
    const args = arguments;
    return args.length > 0 ? args[0](this) : this;
  },
};
const o = Object.create(proto);
(o as any).x = 10;
const bump = (self: any) => ({ ...self, x: self.x + 1 });
const o2 = (o as any).pipe(bump);
console.log("o2.x:", o2.x);
```

- BASE (no fix): `args.length: undefined` -> `o2.x: 10` (pipe dropped operand)
- FIXED: `o2.x: 11` (byte-identical to Node)

### Effect framework (the real-world unlock)

`survey/fr_match.ts` — `Match.type<>().pipe(Match.when(...), Match.when(...), Match.exhaustive)`:

- BASE: `TypeError: value is not a function`
- FIXED: byte-identical to Node (`A:1`, `B:x`)

`survey/fr_match_dbg2.ts` (the dissected probe):

- BASE: `m1.cases: []`, `typeof m2: object`
- FIXED: `m1.cases: [{_tag: 'When', guard, evaluate}]`, `typeof m2: function`

### Gap suite

```
Parity Pass:   88
Parity Fail:   2
Compile Fail:  0
```

The 2 fails (`test_gap_class_advanced`, `test_gap_json_map_set`) are pre-existing on main, listed in `test-parity/known_failures.json`. Arguments-specific tests:

```
test_gap_arguments_in_object_literal_method     PASS  (new)
test_gap_cross_module_arguments                 PASS
test_issue_1069_arguments_coverage              PASS
test_issue_effect_arguments_length_returned_fn  PASS
```

### Cargo tests

`cargo test --release -p perry-hir --lib` — 111 passed
`cargo test --release -p perry-runtime --lib` — 722 passed
`cargo test --release -p perry-codegen --lib` — 81 passed

### Formatting

`cargo fmt --all -- --check` clean.

## New gap test

`test-files/test_gap_arguments_in_object_literal_method.ts` covers four shapes: capture-free body, `this`-using body (the Pipeable shape), named-params + arguments, and variadic-pipe-over-arguments. All byte-identical to `node --experimental-strip-types`.

## Out of scope (follow-ups, not new regressions)

- `Effect.runSync(Effect.succeed(42))` via barrel import (`import { Effect } from "effect"`) still fails with `TypeError: value is not a function` — same failure on main; this is the known #1758 barrel-import issue. Deep-import (`import * as Effect from "effect/Effect"`) works on main and continues to work after this fix.
- `survey/fr_console.ts` / `fr_logger.ts` rely on the same barrel-import path and still fail — pre-existing, unrelated to the `arguments` fix.

Refs #321, #64, #65, #63.
