### PR TITLE
Honor formatWithOptions inspect options

### DIFF
--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -1606,18 +1606,21 @@ pub(crate) fn lower_native_method_call(
     // failed the parity gate on every PR.
     //
     // Bundle the substitution args into a heap array (same shape
-    // `js_console_log_spread` uses) and call `js_util_format`. For
-    // `formatWithOptions(opts, fmt, ...args)`, drop arg[0] (the
-    // `util.inspect` options bag) — the runtime stub ignores it; full
-    // options-passthrough (real `%o` / `%O` styling) is a follow-up.
+    // `js_console_log_spread` uses). For `formatWithOptions(opts, fmt,
+    // ...args)`, pass arg[0] separately so the runtime can apply the
+    // inspect options around `%O` / `%o`.
     if module == "util" && object.is_none() && (method == "format" || method == "formatWithOptions")
     {
-        let skip = if method == "formatWithOptions" { 1 } else { 0 };
-        // Lower any dropped args (just the options bag for now) for
-        // side effects so closures inside them still register.
-        for a in args.iter().take(skip) {
-            let _ = lower_expr(ctx, a)?;
-        }
+        let options_value = if method == "formatWithOptions" {
+            if let Some(options_arg) = args.first() {
+                Some(lower_expr(ctx, options_arg)?)
+            } else {
+                Some(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
+            }
+        } else {
+            None
+        };
+        let skip = usize::from(method == "formatWithOptions");
         let payload: Vec<&Expr> = args.iter().skip(skip).collect();
         let cap = (payload.len() as u32).to_string();
         let mut current_arr = ctx.block().call(I64, "js_array_alloc", &[(I32, &cap)]);
@@ -1631,7 +1634,15 @@ pub(crate) fn lower_native_method_call(
             );
         }
         let blk = ctx.block();
-        let result = blk.call(DOUBLE, "js_util_format", &[(I64, &current_arr)]);
+        let result = if let Some(options_value) = options_value {
+            blk.call(
+                DOUBLE,
+                "js_util_format_with_options",
+                &[(DOUBLE, &options_value), (I64, &current_arr)],
+            )
+        } else {
+            blk.call(DOUBLE, "js_util_format", &[(I64, &current_arr)])
+        };
         return Ok(result);
     }
 

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -487,6 +487,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // bundles the call args into a heap array (same shape as
     // js_console_log_spread) and gets a NaN-boxed string back.
     module.declare_function("js_util_format", DOUBLE, &[I64]);
+    module.declare_function("js_util_format_with_options", DOUBLE, &[DOUBLE, I64]);
     module.declare_function("js_util_inspect", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_util_is_deep_strict_equal", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_util_strip_vt_control_characters", DOUBLE, &[DOUBLE]);

--- a/crates/perry-runtime/src/builtins/console.rs
+++ b/crates/perry-runtime/src/builtins/console.rs
@@ -897,7 +897,7 @@ pub extern "C" fn js_console_clear() {
 /// # Safety
 ///
 /// `options_value` must be a valid NaN-boxed JSValue.
-unsafe fn decode_dir_depth_option(options_value: f64) -> Option<usize> {
+pub(crate) unsafe fn decode_dir_depth_option(options_value: f64) -> Option<usize> {
     let jsval = JSValue::from_bits(options_value.to_bits());
     if !jsval.is_pointer() {
         return None;
@@ -1047,11 +1047,13 @@ pub unsafe extern "C" fn js_console_dir_with_options(value: f64, options_value: 
     let custom_inspect = decode_dir_bool_option(options_value, "customInspect").unwrap_or(false);
     let getters = decode_dir_bool_option(options_value, "getters").unwrap_or(false);
     let sorted = decode_dir_bool_option(options_value, "sorted").unwrap_or(false);
+    let compact = decode_dir_bool_option(options_value, "compact").unwrap_or(true);
     let _depth_guard = InspectDepthLimitGuard::new(max_depth);
     let _hidden_guard = InspectShowHiddenGuard::new(show_hidden);
     let _custom_guard = InspectCustomInspectGuard::new(custom_inspect);
     let _getters_guard = InspectGettersGuard::new(getters);
     let _sorted_guard = InspectSortedGuard::new(sorted);
+    let _compact_guard = InspectCompactGuard::new(compact);
     println!("{}", format_jsvalue(value, 0));
 }
 

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -9,6 +9,8 @@
 use super::println;
 use super::*;
 
+mod boxed_primitives;
+
 /// Returns true if the f64 value is negative zero (-0.0).
 /// Uses bit pattern comparison so +0.0 and -0.0 are distinguished
 /// (they compare equal with normal `==`).
@@ -1840,76 +1842,12 @@ fn looks_like_raw_heap_pointer(value: f64) -> bool {
     (0x1000..0x8000_0000_0000usize).contains(&addr) && addr >= crate::gc::GC_HEADER_SIZE + 0x1000
 }
 
-const CLASS_ID_BOXED_NUMBER: u32 = 0xFFFF_0060;
-const CLASS_ID_BOXED_STRING: u32 = 0xFFFF_0061;
-const CLASS_ID_BOXED_BOOLEAN: u32 = 0xFFFF_0062;
-
-#[inline]
-fn boxed_primitive_payload(value: f64) -> Option<(u32, f64)> {
-    let jv = crate::value::JSValue::from_bits(value.to_bits());
-    if !jv.is_pointer() {
-        return None;
-    }
-    let ptr = jv.as_pointer::<crate::object::ObjectHeader>() as *mut crate::object::ObjectHeader;
-    if ptr.is_null() || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
-        return None;
-    }
-    unsafe {
-        let class_id = (*ptr).class_id;
-        if !matches!(
-            class_id,
-            CLASS_ID_BOXED_NUMBER | CLASS_ID_BOXED_STRING | CLASS_ID_BOXED_BOOLEAN
-        ) {
-            return None;
-        }
-        let payload = crate::object::js_object_get_field_f64(ptr, 0);
-        Some((class_id, payload))
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn js_boxed_number_new(value: f64) -> f64 {
-    let obj = crate::object::js_object_alloc(CLASS_ID_BOXED_NUMBER, 1);
-    // `new Number()` (no args) is spec'd to box +0, not NaN. js_number_coerce
-    // would map undefined → NaN, so detect the missing-arg sentinel first.
-    let payload = if crate::value::JSValue::from_bits(value.to_bits()).is_undefined() {
-        0.0
-    } else {
-        js_number_coerce(value)
-    };
-    crate::object::js_object_set_field_f64(obj, 0, payload);
-    crate::value::js_nanbox_pointer(obj as i64)
-}
-
-#[no_mangle]
-pub extern "C" fn js_boxed_string_new(value: f64) -> f64 {
-    let obj = crate::object::js_object_alloc(CLASS_ID_BOXED_STRING, 1);
-    // `new String()` (no args) is spec'd to box "", not "undefined".
-    let ptr = if crate::value::JSValue::from_bits(value.to_bits()).is_undefined() {
-        crate::string::js_string_from_bytes(std::ptr::null(), 0)
-    } else {
-        js_string_coerce(value)
-    };
-    let boxed = f64::from_bits(crate::value::JSValue::string_ptr(ptr).bits());
-    crate::object::js_object_set_field_f64(obj, 0, boxed);
-    crate::value::js_nanbox_pointer(obj as i64)
-}
-
-#[no_mangle]
-pub extern "C" fn js_boxed_boolean_new(value: f64) -> f64 {
-    let obj = crate::object::js_object_alloc(CLASS_ID_BOXED_BOOLEAN, 1);
-    let boxed =
-        f64::from_bits(crate::value::JSValue::bool(crate::value::js_is_truthy(value) != 0).bits());
-    crate::object::js_object_set_field_f64(obj, 0, boxed);
-    crate::value::js_nanbox_pointer(obj as i64)
-}
-
 #[no_mangle]
 pub extern "C" fn js_util_is_deep_strict_equal(left: f64, right: f64) -> f64 {
     let left_value = crate::value::JSValue::from_bits(left.to_bits());
     let right_value = crate::value::JSValue::from_bits(right.to_bits());
-    let left_boxed = boxed_primitive_payload(left);
-    let right_boxed = boxed_primitive_payload(right);
+    let left_boxed = boxed_primitives::boxed_primitive_payload(left);
+    let right_boxed = boxed_primitives::boxed_primitive_payload(right);
     if left_boxed.is_some() || right_boxed.is_some() {
         let equal = match (left_boxed, right_boxed) {
             (Some((left_class, left_payload)), Some((right_class, right_payload)))

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -170,10 +170,9 @@ pub(crate) fn format_bigint_literal(val: f64) -> String {
 
 /// Per-thread override for the depth at which nested objects/arrays
 /// collapse to `[Object]` / `[Array]`. Defaults to Node's `util.inspect`
-/// default of 2. The `%o` format specifier raises this temporarily so
-/// `console.log("%o", deep)` renders deeper than `%O` / a bare arg
-/// (Node distinguishes them: `%o` is effectively unbounded, `%O` uses
-/// the default cap of 2).
+/// default of 2. The `%o` format specifier raises this temporarily to
+/// Node's object-format depth of 4, while `%O` uses the current inspect
+/// options unchanged.
 thread_local! {
     static INSPECT_DEPTH_LIMIT: std::cell::Cell<usize> = const { std::cell::Cell::new(2) };
 }
@@ -423,6 +422,7 @@ impl Drop for InspectCustomInspectGuard {
 thread_local! {
     static INSPECT_GETTERS: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     static INSPECT_SORTED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static INSPECT_COMPACT: std::cell::Cell<bool> = const { std::cell::Cell::new(true) };
 }
 
 fn inspect_getters_enabled() -> bool {
@@ -431,6 +431,10 @@ fn inspect_getters_enabled() -> bool {
 
 fn inspect_sorted_enabled() -> bool {
     INSPECT_SORTED.with(|c| c.get())
+}
+
+fn inspect_compact_enabled() -> bool {
+    INSPECT_COMPACT.with(|c| c.get())
 }
 
 pub(crate) struct InspectGettersGuard(bool);
@@ -460,6 +464,21 @@ impl InspectSortedGuard {
 impl Drop for InspectSortedGuard {
     fn drop(&mut self) {
         INSPECT_SORTED.with(|c| c.set(self.0));
+    }
+}
+
+pub(crate) struct InspectCompactGuard(bool);
+
+impl InspectCompactGuard {
+    pub(crate) fn new(enabled: bool) -> Self {
+        let prev = INSPECT_COMPACT.with(|c| c.replace(enabled));
+        Self(prev)
+    }
+}
+
+impl Drop for InspectCompactGuard {
+    fn drop(&mut self) {
+        INSPECT_COMPACT.with(|c| c.set(self.0));
     }
 }
 
@@ -723,7 +742,8 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                     }
                     let inner = parts.join(", ");
                     // Node uses multi-line when length > 6 or single-line exceeds breakLength (76)
-                    let use_multiline = length > 6 || inner.len() + 4 > 76;
+                    let use_multiline =
+                        !inspect_compact_enabled() || length > 6 || inner.len() + 4 > 76;
                     let body_str = if !use_multiline {
                         format!("[ {} ]", inner)
                     } else if all_numeric {
@@ -1154,7 +1174,7 @@ unsafe fn format_object_as_json(
     // indent prefix, producing a left-aligned inner body inside an indented
     // outer body.
     let any_child_multiline = parts.iter().any(|p| p.contains('\n'));
-    if !any_child_multiline && single_line.len() <= 72 {
+    if inspect_compact_enabled() && !any_child_multiline && single_line.len() <= 72 {
         return single_line;
     }
     let indent = "  ";
@@ -1704,11 +1724,12 @@ pub extern "C" fn js_util_format(arr_ptr: *const crate::array::ArrayHeader) -> f
                     }
                 }
                 b'o' => {
-                    // Node's `%o` uses an effectively unbounded inspect
-                    // depth (showHidden + showProxy with no depth cap on
-                    // the typical fixtures used in the parity suite), so
-                    // raise the per-thread depth limit just for this call.
-                    let _guard = InspectDepthLimitGuard::new(usize::MAX);
+                    // Node's `%o` overlays util.inspect options with
+                    // showHidden/showProxy and depth: 4. Perry does not expose
+                    // showProxy yet, but showHidden and the depth budget are
+                    // observable in current parity fixtures.
+                    let _depth_guard = InspectDepthLimitGuard::new(4);
+                    let _hidden_guard = InspectShowHiddenGuard::new(true);
                     out.push_str(&format_jsvalue(val, 0));
                 }
                 b'O' => {
@@ -1752,7 +1773,35 @@ pub extern "C" fn js_util_format(arr_ptr: *const crate::array::ArrayHeader) -> f
 }
 
 #[no_mangle]
+pub extern "C" fn js_util_format_with_options(
+    options: f64,
+    arr_ptr: *const crate::array::ArrayHeader,
+) -> f64 {
+    let max_depth = unsafe { super::console::decode_dir_depth_option(options) }.unwrap_or(2);
+    let show_hidden =
+        unsafe { super::console::decode_dir_bool_option(options, "showHidden") }.unwrap_or(false);
+    let custom_inspect =
+        unsafe { super::console::decode_dir_bool_option(options, "customInspect") }.unwrap_or(true);
+    let getters =
+        unsafe { super::console::decode_dir_bool_option(options, "getters") }.unwrap_or(false);
+    let sorted =
+        unsafe { super::console::decode_dir_bool_option(options, "sorted") }.unwrap_or(false);
+    let compact =
+        unsafe { super::console::decode_dir_bool_option(options, "compact") }.unwrap_or(true);
+    let _depth_guard = InspectDepthLimitGuard::new(max_depth);
+    let _hidden_guard = InspectShowHiddenGuard::new(show_hidden);
+    let _custom_guard = InspectCustomInspectGuard::new(custom_inspect);
+    let _getters_guard = InspectGettersGuard::new(getters);
+    let _sorted_guard = InspectSortedGuard::new(sorted);
+    let _compact_guard = InspectCompactGuard::new(compact);
+    js_util_format(arr_ptr)
+}
+
+#[no_mangle]
 pub extern "C" fn js_util_inspect(value: f64, options: f64) -> f64 {
+    let max_depth = unsafe { super::console::decode_dir_depth_option(options) }.unwrap_or(2);
+    let show_hidden =
+        unsafe { super::console::decode_dir_bool_option(options, "showHidden") }.unwrap_or(false);
     // `util.inspect` defaults to `customInspect: true`; an explicit
     // `{ customInspect: false }` opts out and surfaces the hook as a
     // symbol property. Refs #1201.
@@ -1762,9 +1811,14 @@ pub extern "C" fn js_util_inspect(value: f64, options: f64) -> f64 {
         unsafe { super::console::decode_dir_bool_option(options, "getters") }.unwrap_or(false);
     let sorted =
         unsafe { super::console::decode_dir_bool_option(options, "sorted") }.unwrap_or(false);
+    let compact =
+        unsafe { super::console::decode_dir_bool_option(options, "compact") }.unwrap_or(true);
+    let _depth_guard = InspectDepthLimitGuard::new(max_depth);
+    let _hidden_guard = InspectShowHiddenGuard::new(show_hidden);
     let _custom_guard = InspectCustomInspectGuard::new(custom_inspect);
     let _getters_guard = InspectGettersGuard::new(getters);
     let _sorted_guard = InspectSortedGuard::new(sorted);
+    let _compact_guard = InspectCompactGuard::new(compact);
     let jv = crate::value::JSValue::from_bits(value.to_bits());
     let out = if jv.is_any_string() {
         let s = jsvalue_string_content(value).unwrap_or_default();

--- a/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
+++ b/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+const CLASS_ID_BOXED_NUMBER: u32 = 0xFFFF_0060;
+const CLASS_ID_BOXED_STRING: u32 = 0xFFFF_0061;
+const CLASS_ID_BOXED_BOOLEAN: u32 = 0xFFFF_0062;
+
+#[inline]
+pub(super) fn boxed_primitive_payload(value: f64) -> Option<(u32, f64)> {
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return None;
+    }
+    let ptr = jv.as_pointer::<crate::object::ObjectHeader>() as *mut crate::object::ObjectHeader;
+    if ptr.is_null() || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return None;
+    }
+    unsafe {
+        let class_id = (*ptr).class_id;
+        if !matches!(
+            class_id,
+            CLASS_ID_BOXED_NUMBER | CLASS_ID_BOXED_STRING | CLASS_ID_BOXED_BOOLEAN
+        ) {
+            return None;
+        }
+        let payload = crate::object::js_object_get_field_f64(ptr, 0);
+        Some((class_id, payload))
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_boxed_number_new(value: f64) -> f64 {
+    let obj = crate::object::js_object_alloc(CLASS_ID_BOXED_NUMBER, 1);
+    // `new Number()` (no args) is spec'd to box +0, not NaN. js_number_coerce
+    // would map undefined to NaN, so detect the missing-arg sentinel first.
+    let payload = if crate::value::JSValue::from_bits(value.to_bits()).is_undefined() {
+        0.0
+    } else {
+        js_number_coerce(value)
+    };
+    crate::object::js_object_set_field_f64(obj, 0, payload);
+    crate::value::js_nanbox_pointer(obj as i64)
+}
+
+#[no_mangle]
+pub extern "C" fn js_boxed_string_new(value: f64) -> f64 {
+    let obj = crate::object::js_object_alloc(CLASS_ID_BOXED_STRING, 1);
+    // `new String()` (no args) is spec'd to box "", not "undefined".
+    let ptr = if crate::value::JSValue::from_bits(value.to_bits()).is_undefined() {
+        crate::string::js_string_from_bytes(std::ptr::null(), 0)
+    } else {
+        js_string_coerce(value)
+    };
+    let boxed = f64::from_bits(crate::value::JSValue::string_ptr(ptr).bits());
+    crate::object::js_object_set_field_f64(obj, 0, boxed);
+    crate::value::js_nanbox_pointer(obj as i64)
+}
+
+#[no_mangle]
+pub extern "C" fn js_boxed_boolean_new(value: f64) -> f64 {
+    let obj = crate::object::js_object_alloc(CLASS_ID_BOXED_BOOLEAN, 1);
+    let boxed =
+        f64::from_bits(crate::value::JSValue::bool(crate::value::js_is_truthy(value) != 0).bits());
+    crate::object::js_object_set_field_f64(obj, 0, boxed);
+    crate::value::js_nanbox_pointer(obj as i64)
+}

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -71,14 +71,14 @@ pub use console::{
 
 pub use formatting::{
     function_name_for_ptr, js_array_print, js_register_function_name, js_util_format,
-    js_util_inspect, js_util_is_deep_strict_equal, js_util_strip_vt_control_characters,
-    register_function_name_if_absent,
+    js_util_format_with_options, js_util_inspect, js_util_is_deep_strict_equal,
+    js_util_strip_vt_control_characters, register_function_name_if_absent,
 };
 
 pub(crate) use formatting::{
     format_finite_number_js, format_jsvalue, is_negative_zero, jsvalue_string_content,
-    InspectCustomInspectGuard, InspectDepthLimitGuard, InspectGettersGuard, InspectShowHiddenGuard,
-    InspectSortedGuard,
+    InspectCompactGuard, InspectCustomInspectGuard, InspectDepthLimitGuard, InspectGettersGuard,
+    InspectShowHiddenGuard, InspectSortedGuard,
 };
 
 pub use globals::{

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -866,7 +866,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
             for i in 1..args_len {
                 arr = crate::array::js_array_push_f64(arr, arg(i));
             }
-            crate::builtins::js_util_format(arr)
+            crate::builtins::js_util_format_with_options(arg(0), arr)
         }
         ("util", "inspect") => crate::builtins::js_util_inspect(arg(0), arg(1)),
         ("util", "isDeepStrictEqual") => {


### PR DESCRIPTION
## Summary
- Pass `formatWithOptions()` inspect options through both codegen-lowered and dynamic native-module call paths.
- Add scoped inspect support for `compact: false`, and apply depth/showHidden/customInspect/getters/sorted/compact guards around formatted output.
- Align `%o` with Node's inspect overlay by forcing showHidden and depth 4 while leaving `%O` to honor the current inspect options.

## Verification
- `./run_parity_tests.sh --suite=node-suite --module=util --filter inspect-options-interaction` PASS, report `test-parity/reports/parity_report_20260528_004527.json`
- `./run_parity_tests.sh --suite=node-suite --module=util --filter colors-depth` PASS, report `test-parity/reports/parity_report_20260528_004535.json`
- `./run_parity_tests.sh --suite=node-suite --module=util --filter format-with-options` PASS, report `test-parity/reports/parity_report_20260528_004544.json`
- `./run_parity_tests.sh --suite=node-suite --module=util --filter specifier-edge-cases` PASS, report `test-parity/reports/parity_report_20260528_004551.json`
- `./run_parity_tests.sh --suite=node-suite --module=console --filter uppercase-object-format` PASS, report `test-parity/reports/parity_report_20260528_004601.json`
- `cargo fmt --check` PASS
- `git diff --check` PASS
- `cargo test -p perry-codegen --lib nanbox -- --nocapture` PASS (3 tests)

## Residual
- `./run_parity_tests.sh --suite=node-suite --module=util --filter formatWithOptions` still fails `formatWithOptions/getters-and-custominspect` on an existing symbol-keyed `inspect.custom` function-label mismatch, report `test-parity/reports/parity_report_20260528_004611.json`.

## Non-goals
- No ANSI color styling for `colors: true`.
- No `showProxy` formatting.
- No `inspect.custom` symbol function-name inference change.
- No full numeric `compact` mode or `breakLength` rewrite.
