### PR TITLE
ci: drizzle-mysql-smoke job — run #489 fixture against real MySQL (#804)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -822,6 +822,84 @@ jobs:
             -- --nocapture
 
   # ---------------------------------------------------------------------------
+  # drizzle-mysql smoke: runs the tier-3 release fixture
+  # `tests/release/packages/drizzle-mysql/` against a real MySQL — the CI
+  # counterpart of #489's local acceptance, closing #804.
+  #
+  # The fixture itself stays Docker-free (per the tier-3 "no Docker"
+  # preference in scripts/release_sweep_tiers/tier03_real_packages.sh —
+  # locally it skips when no mysqld is reachable on 127.0.0.1:3306). The
+  # `services: mysql:8` block below is runner-side setup, transparent to
+  # the fixture. `MYSQL_ALLOW_EMPTY_PASSWORD` matches the fixture's
+  # root-no-password convention; `MYSQL_DATABASE` auto-creates the test
+  # DB on init so the fixture's CREATE-IF-NOT-EXISTS is a no-op.
+  #
+  # Gated to tag pushes + opt-in (parity with compile-smoke / doc-tests
+  # / parity). Real-DB setup + perry release build + drizzle +
+  # @perryts/mysql compile is ~15 min wall — PRs shouldn't pay it by
+  # default. Opt-in via the `run-extended-tests` label.
+  # ---------------------------------------------------------------------------
+  drizzle-mysql-smoke:
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_extended_tests) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-extended-tests'))
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_DATABASE: perry_drizzle_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -P 3306 --silent"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "${{ runner.os }}-perry"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install mysql client (for fixture health probe)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq mysql-client
+
+      - name: Wait for MySQL service to accept connections
+        run: |
+          set -e
+          for i in $(seq 1 30); do
+            if mysql -h 127.0.0.1 -P 3306 -u root -e "SELECT 1" >/dev/null 2>&1; then
+              echo "mysql ready after $i attempts"
+              break
+            fi
+            sleep 1
+          done
+          mysql -h 127.0.0.1 -P 3306 -u root -e "SELECT VERSION();"
+
+      - name: Build perry compiler
+        run: cargo build --release -p perry-runtime -p perry-stdlib -p perry
+
+      - name: Run drizzle-mysql fixture
+        run: |
+          cd tests/release/packages/drizzle-mysql
+          PERRY_BIN="$GITHUB_WORKSPACE/target/release/perry" bash fixture.sh
+
+  # ---------------------------------------------------------------------------
   # Doc-example tests: compile + run every .ts under docs/examples/.
   # UI examples launch with PERRY_UI_TEST_MODE=1 so they auto-exit after one
   # frame. Gallery screenshots are diffed against per-OS baselines (advisory


### PR DESCRIPTION
## What

Closes #804 — wires the `tests/release/packages/drizzle-mysql/` fixture (added in #2160) into CI against a real MySQL.

Adds a new `drizzle-mysql-smoke` job to `.github/workflows/test.yml` with a `services: mysql:8` block. `MYSQL_ALLOW_EMPTY_PASSWORD=yes` and `MYSQL_DATABASE=perry_drizzle_test` match the fixture's expectations (root with no password, database pre-created). The job builds perry, waits for MySQL to accept connections, then invokes `bash tests/release/packages/drizzle-mysql/fixture.sh`.

## Why services-block (and not Docker in the fixture)

`scripts/release_sweep_tiers/tier03_real_packages.sh` documents the project preference: fixtures themselves use mock/embedded backends — **no Docker in fixture.sh**. That's about the local sweep on macOS. CI is a separate context: GH Actions runs `ubuntu-latest`, the standard idiom for getting MySQL reachable on the runner is a `services:` block (Docker behind the scenes, but transparent to the fixture). The fixture remains unchanged — it still skips gracefully when no `mysqld` is reachable, which is what happens on a macOS dev box without docker.

## Gating

Mirrors `compile-smoke` / `doc-tests` / `parity`:

- runs on tag push (`github.event_name == 'push'`),
- runs on `workflow_dispatch` with `run_extended_tests=true`,
- opt-in on a PR via the `run-extended-tests` label.

Real-DB setup + perry release build + drizzle + `@perryts/mysql` compile is ~15 min wall — PRs shouldn't pay it by default. Release tags still get the gate before publish.

## Verification

- YAML parses (`python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` → 10 jobs, `drizzle-mysql-smoke` present with 8 steps + 1 service).
- Fixture re-run locally: `PASS drizzle-mysql` (the local mysqld on 127.0.0.1:3306 path the fixture already handled).
- The CI run for this PR (with the `run-extended-tests` label) is the actual end-to-end check — it's the first time real MySQL has run in this repo's CI.

## #489 status after this lands

Together with #2160, both #489 (local e2e) and #804 (CI version) close. The compiler/runtime path through drizzle + `@perryts/mysql` + real MySQL is verifiable both locally and in CI.

Workaround note carried forward: the fixture entry uses explicit `.execute()` to dodge #2159 (inherited `.then` on drizzle's `MySqlSelectBase` returns `undefined` under perry). Drop the `.execute()` calls when #2159 lands.
