### PR TITLE
fix(node:stream): wire Transform callbacks to readable output

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -114,6 +114,19 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // regress; thread a real id through here instead.
                 "Object" => 0xFFFF0050u32,
                 _ => ctx.class_ids.get(ty).copied().unwrap_or_else(|| {
+                    // Keep in sync with perry-runtime/src/object/instanceof.rs.
+                    let classic_stream_cid = match ty.as_str() {
+                        "Stream" => Some(0xFFFF0070u32),
+                        "Readable" => Some(0xFFFF0071u32),
+                        "Writable" => Some(0xFFFF0072u32),
+                        "Duplex" => Some(0xFFFF0073u32),
+                        "Transform" => Some(0xFFFF0074u32),
+                        "PassThrough" => Some(0xFFFF0075u32),
+                        _ => None,
+                    };
+                    if let Some(cid) = classic_stream_cid {
+                        return cid;
+                    }
                     // Issue #574: `b instanceof Lib.A` where Lib is a
                     // namespace import. The HIR captures the receiver
                     // as a dotted `ty` ("Lib.A") which `class_ids`

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -881,6 +881,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_method_readable_length", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_readable_flowing", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_readable_ended", DOUBLE, &[I64]);
+    module.declare_function("js_node_stream_method_readable_object_mode", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_pipe", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_node_stream_method_unpipe", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_node_stream_method_pause", DOUBLE, &[I64]);
@@ -897,6 +898,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_method_writable_finished", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_allow_half_open", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_method_set_encoding", DOUBLE, &[I64, DOUBLE]);
+    module.declare_function("js_node_stream_method_writable_object_mode", DOUBLE, &[I64]);
 
     // ========== Event emitter ==========
     module.declare_function("js_event_emitter_emit", DOUBLE, &[I64, I64, I64]);

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -707,6 +707,7 @@ pub(super) fn try_array_only_methods(
                         // (e.g. Stack<T>.push()), or an object type literal (e.g.
                         // { push: (v) => void, ... }), so its method dispatches correctly.
                         let is_user_class_receiver = match member.obj.as_ref() {
+                            ast::Expr::This(_) => true,
                             ast::Expr::Ident(ident) => {
                                 ctx.lookup_local_type(ident.sym.as_ref())
                                     .map(|ty| {

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -91,6 +91,10 @@ const WRITABLE_NEED_DRAIN_KEY: &[u8] = b"__perryWritableNeedDrain";
 const WRITABLE_OBJECT_MODE_KEY: &[u8] = b"__perryWritableObjectMode";
 const WRITABLE_PENDING_FINISH_CALLBACK_KEY: &[u8] = b"__perryWritablePendingFinishCallback";
 const WRITABLE_WRITEV_KEY: &[u8] = b"__perryWritableWritev";
+const TRANSFORM_CALLBACK_KEY: &[u8] = b"__perryTransformCallback";
+const TRANSFORM_FLUSH_KEY: &[u8] = b"__perryTransformFlush";
+const TRANSFORM_PASSTHROUGH_KEY: &[u8] = b"__perryTransformPassThrough";
+const TRANSFORM_FINISHING_KEY: &[u8] = b"__perryTransformFinishing";
 // #1534: direction + disturbed bits so the static introspection helpers
 // (`Readable.isReadable` / `isDisturbed` / `isErrored`) answer per-stream
 // instead of with a uniform stub. Set at construction / on first read.
@@ -394,6 +398,53 @@ fn throw_readable_pipe_missing_destination() -> ! {
     )
 }
 
+extern "C" fn transform_write_callback(closure: *const ClosureHeader, err: f64, value: f64) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let stream = js_closure_get_capture_f64(closure, 0);
+    let len = js_closure_get_capture_f64(closure, 1);
+    let callback = js_closure_get_capture_f64(closure, 2);
+    if err.to_bits() != TAG_UNDEFINED && err.to_bits() != TAG_NULL {
+        complete_writable_write(stream, len, callback, err);
+        destroy_stream(stream, err);
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    push_callback_value(stream, value);
+    complete_writable_write(stream, len, callback, f64::from_bits(TAG_UNDEFINED));
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn transform_flush_callback(closure: *const ClosureHeader, err: f64, value: f64) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let stream = js_closure_get_capture_f64(closure, 0);
+    let callback = js_closure_get_capture_f64(closure, 1);
+    set_hidden_value(
+        stream,
+        hidden_transform_finishing_key(),
+        f64::from_bits(TAG_FALSE),
+    );
+    if err.to_bits() != TAG_UNDEFINED && err.to_bits() != TAG_NULL {
+        destroy_stream(stream, err);
+        if is_callable_value(callback) {
+            call_listener_args(stream, callback, &[err]);
+        }
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    push_callback_value(stream, value);
+    finish_stream(
+        stream,
+        if is_callable_value(callback) {
+            Some(callback)
+        } else {
+            None
+        },
+    );
+    f64::from_bits(TAG_UNDEFINED)
+}
+
 extern "C" fn ns_write3(closure: *const ClosureHeader, chunk: f64, enc: f64, cb: f64) -> f64 {
     let stream = this_value(closure);
     write_writable_chunk(stream, chunk, enc, cb)
@@ -456,6 +507,37 @@ fn writable_write_after_end_error() -> f64 {
     crate::value::js_nanbox_pointer(err as i64)
 }
 
+fn push_callback_value(stream: f64, value: f64) {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if !jsval.is_null() && !jsval.is_undefined() {
+        let _ = push_chunk(stream, value);
+    }
+}
+
+fn invoke_transform_write(stream: f64, chunk: f64, enc: f64, len: f64, callback: f64) {
+    if has_truthy_hidden(stream, hidden_transform_passthrough_key()) {
+        let _ = push_chunk(stream, chunk);
+        complete_writable_write(stream, len, callback, f64::from_bits(TAG_UNDEFINED));
+        return;
+    }
+    if let Some(transform) = transform_hidden_callback(stream) {
+        let cb = js_closure_alloc(transform_write_callback as *const u8, 3);
+        js_closure_set_capture_f64(cb, 0, stream);
+        js_closure_set_capture_f64(cb, 1, len);
+        js_closure_set_capture_f64(cb, 2, callback);
+        let cb_value = f64::from_bits(JSValue::pointer(cb as *const u8).bits());
+        let args = [chunk, enc, cb_value];
+        let prev_this = crate::object::js_implicit_this_set(stream);
+        unsafe {
+            let _ = crate::closure::js_native_call_value(transform, args.as_ptr(), args.len());
+        }
+        crate::object::js_implicit_this_set(prev_this);
+        return;
+    }
+    emit_writable_chunk(stream, chunk);
+    complete_writable_write(stream, len, callback, f64::from_bits(TAG_UNDEFINED));
+}
+
 #[cold]
 fn throw_writable_null_chunk() -> ! {
     let msg = b"May not write null values to stream";
@@ -513,6 +595,8 @@ fn write_writable_chunk(stream: f64, chunk: f64, enc: f64, cb: f64) -> f64 {
     let ret = writable_backpressure_return(stream);
     if writable_corked_count(stream) > 0.0 {
         buffer_writable_write(stream, chunk, enc, len, callback);
+    } else if is_transform_stream(stream) {
+        invoke_transform_write(stream, chunk, enc, len, callback);
     } else {
         invoke_writable_write(stream, chunk, enc, len, callback);
         emit_writable_chunk(stream, chunk);
@@ -594,6 +678,9 @@ fn finish_stream_with_args(stream: f64, chunk: f64, encoding: f64, cb: f64) {
         let _ = write_writable_chunk(stream, chunk, encoding, f64::from_bits(TAG_UNDEFINED));
     }
     flush_writable_buffered(stream);
+    if finish_transform_stream(stream, callback) {
+        return;
+    }
     finish_stream(stream, callback);
 }
 
@@ -1527,6 +1614,8 @@ fn register_stub_arities() {
     register(ns_pipe1 as *const u8, 1);
     register(ns_writable_write_done as *const u8, 1);
     register(writable_write_callback_noop as *const u8, 0);
+    register(transform_write_callback as *const u8, 2);
+    register(transform_flush_callback as *const u8, 2);
     register(ns_write3 as *const u8, 3);
     register(ns_end3 as *const u8, 3);
     register(ns_cork0 as *const u8, 0);
@@ -1699,6 +1788,26 @@ fn hidden_writable_pending_finish_callback_key() -> *mut crate::string::StringHe
 #[inline]
 fn hidden_writev_key() -> *mut crate::string::StringHeader {
     hidden_key(WRITABLE_WRITEV_KEY)
+}
+
+#[inline]
+fn hidden_transform_callback_key() -> *mut crate::string::StringHeader {
+    hidden_key(TRANSFORM_CALLBACK_KEY)
+}
+
+#[inline]
+fn hidden_transform_flush_key() -> *mut crate::string::StringHeader {
+    hidden_key(TRANSFORM_FLUSH_KEY)
+}
+
+#[inline]
+fn hidden_transform_passthrough_key() -> *mut crate::string::StringHeader {
+    hidden_key(TRANSFORM_PASSTHROUGH_KEY)
+}
+
+#[inline]
+fn hidden_transform_finishing_key() -> *mut crate::string::StringHeader {
+    hidden_key(TRANSFORM_FINISHING_KEY)
 }
 
 #[inline]
@@ -1886,6 +1995,37 @@ pub(crate) fn is_classic_stream_instance_value(value: f64) -> bool {
     unsafe {
         own_field_by_key_bytes(obj, READABLE_FLAG_KEY).is_some()
             || own_field_by_key_bytes(obj, WRITABLE_FLAG_KEY).is_some()
+    }
+}
+
+pub(crate) fn is_classic_stream_instance_of(value: f64, constructor_name: &str) -> bool {
+    if constructor_name == "Stream" {
+        return is_classic_stream_instance_value(value);
+    }
+
+    let Some(obj) = object_ptr_from_value(value) else {
+        return false;
+    };
+    let Some(constructor) = (unsafe { own_field_by_key_bytes(obj, b"constructor") }) else {
+        return false;
+    };
+    let Some((module, actual)) =
+        (unsafe { crate::object::bound_native_callable_module_and_method(constructor) })
+    else {
+        return false;
+    };
+    if module != "stream" {
+        return false;
+    }
+    let actual = actual.as_str();
+
+    match constructor_name {
+        "Readable" => matches!(actual, "Readable" | "Duplex" | "Transform" | "PassThrough"),
+        "Writable" => matches!(actual, "Writable" | "Duplex" | "Transform" | "PassThrough"),
+        "Duplex" => matches!(actual, "Duplex" | "Transform" | "PassThrough"),
+        "Transform" => matches!(actual, "Transform" | "PassThrough"),
+        "PassThrough" => actual == "PassThrough",
+        _ => false,
     }
 }
 
@@ -2404,6 +2544,48 @@ fn writable_hidden_writev(value: f64) -> Option<f64> {
     get_hidden_value(value, hidden_writev_key())
 }
 
+fn transform_hidden_callback(value: f64) -> Option<f64> {
+    get_hidden_value(value, hidden_transform_callback_key())
+}
+
+fn transform_hidden_flush(value: f64) -> Option<f64> {
+    get_hidden_value(value, hidden_transform_flush_key())
+}
+
+fn is_transform_stream(stream: f64) -> bool {
+    transform_hidden_callback(stream).is_some()
+        || transform_hidden_flush(stream).is_some()
+        || has_truthy_hidden(stream, hidden_transform_passthrough_key())
+}
+
+fn finish_transform_stream(stream: f64, callback: Option<f64>) -> bool {
+    let Some(flush) = transform_hidden_flush(stream) else {
+        return false;
+    };
+    if has_truthy_hidden(stream, hidden_transform_finishing_key()) {
+        return true;
+    }
+    set_hidden_value(
+        stream,
+        hidden_transform_finishing_key(),
+        f64::from_bits(TAG_TRUE),
+    );
+    let cb = js_closure_alloc(transform_flush_callback as *const u8, 2);
+    js_closure_set_capture_f64(cb, 0, stream);
+    js_closure_set_capture_f64(
+        cb,
+        1,
+        callback.unwrap_or_else(|| f64::from_bits(TAG_UNDEFINED)),
+    );
+    let cb_value = f64::from_bits(JSValue::pointer(cb as *const u8).bits());
+    let prev_this = crate::object::js_implicit_this_set(stream);
+    unsafe {
+        let _ = crate::closure::js_native_call_value(flush, [cb_value].as_ptr(), 1);
+    }
+    crate::object::js_implicit_this_set(prev_this);
+    true
+}
+
 fn writable_corked_count(value: f64) -> f64 {
     get_hidden_value(value, hidden_writable_corked_key()).unwrap_or(0.0)
 }
@@ -2612,6 +2794,14 @@ fn write_callback_from_options(opts: f64) -> Option<f64> {
 
 fn writev_callback_from_options(opts: f64) -> Option<f64> {
     get_hidden_value(opts, hidden_key(b"writev"))
+}
+
+fn transform_callback_from_options(opts: f64) -> Option<f64> {
+    get_hidden_value(opts, hidden_key(b"transform"))
+}
+
+fn transform_flush_from_options(opts: f64) -> Option<f64> {
+    get_hidden_value(opts, hidden_key(b"flush"))
 }
 
 fn invoke_read_once(stream: f64) {
@@ -2996,7 +3186,7 @@ fn writable_methods() -> [(&'static str, StubFn); 22] {
     ]
 }
 
-fn duplex_methods() -> [(&'static str, StubFn); 29] {
+fn duplex_methods() -> [(&'static str, StubFn); 31] {
     // Union of readable + writable, deduped (`on/once/off/addListener/
     // removeListener/removeAllListeners/emit/listenerCount/listeners/
     // destroy` appear once each).
@@ -3024,6 +3214,8 @@ fn duplex_methods() -> [(&'static str, StubFn); 29] {
         ("resume", cast0(ns_resume0)),
         ("setEncoding", cast1(ns_set_encoding1)),
         ("isPaused", cast0(ns_is_paused0)),
+        ("push", cast1(ns_push1)),
+        ("compose", cast1(ns_compose1)),
         ("write", cast3(ns_write3)),
         ("end", cast3(ns_end3)),
         ("cork", cast0(ns_cork0)),
@@ -3313,8 +3505,6 @@ fn init_writable_state(stream: f64, opts: f64) {
     );
     let w_hwm = resolve_hwm(opts, b"writableHighWaterMark", b"writableObjectMode");
     set_hidden_value(stream, hidden_key(b"writableHighWaterMark"), w_hwm);
-    let writable_object_mode =
-        opt_bool(opts, b"writableObjectMode") || opt_bool(opts, b"objectMode");
     set_hidden_value(
         stream,
         hidden_writable_object_mode_key(),
@@ -3430,18 +3620,35 @@ pub extern "C" fn js_node_stream_duplex_new(opts: f64) -> f64 {
     duplex
 }
 
-/// Transform / PassThrough share Duplex's surface for the stub — the
-/// `transform`/`flush` callbacks aren't wired through.
 #[no_mangle]
-pub extern "C" fn js_node_stream_transform_new(_opts: f64) -> f64 {
-    let transform = js_node_stream_duplex_new(_opts);
+pub extern "C" fn js_node_stream_transform_new(opts: f64) -> f64 {
+    let transform = js_node_stream_duplex_new(opts);
+    if let Some(callback) = transform_callback_from_options(opts) {
+        set_hidden_value(
+            transform,
+            hidden_transform_callback_key(),
+            rebind_callback_this(callback, transform),
+        );
+    }
+    if let Some(flush) = transform_flush_from_options(opts) {
+        set_hidden_value(
+            transform,
+            hidden_transform_flush_key(),
+            rebind_callback_this(flush, transform),
+        );
+    }
     init_constructor(transform, "Transform");
     transform
 }
 
 #[no_mangle]
-pub extern "C" fn js_node_stream_passthrough_new(_opts: f64) -> f64 {
-    let passthrough = js_node_stream_duplex_new(_opts);
+pub extern "C" fn js_node_stream_passthrough_new(opts: f64) -> f64 {
+    let passthrough = js_node_stream_duplex_new(opts);
+    set_hidden_value(
+        passthrough,
+        hidden_transform_passthrough_key(),
+        f64::from_bits(TAG_TRUE),
+    );
     init_constructor(passthrough, "PassThrough");
     passthrough
 }
@@ -3677,3 +3884,7 @@ mod destroy_state;
 #[cfg(test)]
 #[path = "node_stream_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "node_stream_state_tests.rs"]
+mod state_tests;

--- a/crates/perry-runtime/src/node_stream_state_tests.rs
+++ b/crates/perry-runtime/src/node_stream_state_tests.rs
@@ -1,0 +1,167 @@
+//! State/introspection tests for [`super`] (`node_stream.rs`). Kept separate
+//! from the helper-heavy stream tests so each file stays under the CI size gate.
+
+use super::*;
+
+#[test]
+fn fresh_streams_expose_destroyed_false() {
+    let streams = [
+        js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED)),
+        js_node_stream_writable_new(f64::from_bits(TAG_UNDEFINED)),
+        js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED)),
+        js_node_stream_transform_new(f64::from_bits(TAG_UNDEFINED)),
+    ];
+
+    for stream in streams {
+        let destroyed = js_object_get_field_by_name_f64(
+            raw_ptr_from_value(stream) as *const ObjectHeader,
+            hidden_key(b"destroyed"),
+        );
+        assert_eq!(destroyed.to_bits(), TAG_FALSE);
+        assert_eq!(
+            js_node_stream_method_destroyed(raw_ptr_from_value(stream) as i64).to_bits(),
+            TAG_FALSE
+        );
+    }
+}
+
+#[test]
+fn readable_lifecycle_flags_reflect_ended_state() {
+    let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let obj = raw_ptr_from_value(stream) as *const ObjectHeader;
+
+    assert_eq!(js_node_stream_method_readable(handle).to_bits(), TAG_TRUE);
+    assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"readable")).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        js_node_stream_method_readable_ended(handle).to_bits(),
+        TAG_FALSE
+    );
+    assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"readableEnded")).to_bits(),
+        TAG_FALSE
+    );
+    assert_eq!(
+        js_node_stream_method_readable_did_read(handle).to_bits(),
+        TAG_FALSE
+    );
+    assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"readableDidRead")).to_bits(),
+        TAG_FALSE
+    );
+
+    let _ = js_node_stream_method_read(handle, f64::from_bits(TAG_UNDEFINED));
+    assert_eq!(
+        js_node_stream_method_readable_did_read(handle).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"readableDidRead")).to_bits(),
+        TAG_TRUE
+    );
+
+    let _ = js_node_stream_method_push(handle, f64::from_bits(TAG_NULL));
+    assert_eq!(js_node_stream_method_readable(handle).to_bits(), TAG_FALSE);
+    assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"readable")).to_bits(),
+        TAG_FALSE
+    );
+    assert_eq!(
+        js_node_stream_method_readable_ended(handle).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        js_object_get_field_by_name_f64(obj, hidden_key(b"readableEnded")).to_bits(),
+        TAG_TRUE
+    );
+}
+
+#[test]
+fn stream_object_mode_flags_default_false_and_follow_options() {
+    let default_transform = js_node_stream_transform_new(f64::from_bits(TAG_UNDEFINED));
+    let default_obj = raw_ptr_from_value(default_transform) as *const ObjectHeader;
+    assert_eq!(
+        js_object_get_field_by_name_f64(default_obj, hidden_key(b"readableObjectMode")).to_bits(),
+        TAG_FALSE
+    );
+    assert_eq!(
+        js_object_get_field_by_name_f64(default_obj, hidden_key(b"writableObjectMode")).to_bits(),
+        TAG_FALSE
+    );
+
+    let opts = crate::object::js_object_alloc(0, 2);
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"readableObjectMode"),
+        f64::from_bits(TAG_TRUE),
+    );
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"writableObjectMode"),
+        f64::from_bits(TAG_FALSE),
+    );
+    let duplex = js_node_stream_duplex_new(box_pointer(opts as *const u8));
+    let duplex_obj = raw_ptr_from_value(duplex) as *const ObjectHeader;
+    assert_eq!(
+        js_object_get_field_by_name_f64(duplex_obj, hidden_key(b"readableObjectMode")).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        js_object_get_field_by_name_f64(duplex_obj, hidden_key(b"writableObjectMode")).to_bits(),
+        TAG_FALSE
+    );
+}
+
+#[test]
+fn stream_dynamic_instanceof_follows_node_stream_inheritance() {
+    let readable = crate::object::bound_native_callable_export_value("stream", "Readable");
+    let writable = crate::object::bound_native_callable_export_value("stream", "Writable");
+    let duplex = crate::object::bound_native_callable_export_value("stream", "Duplex");
+    let transform_ctor = crate::object::bound_native_callable_export_value("stream", "Transform");
+    let passthrough_ctor =
+        crate::object::bound_native_callable_export_value("stream", "PassThrough");
+    let stream_ctor = crate::object::bound_native_callable_export_value("stream", "Stream");
+
+    let transform = js_node_stream_transform_new(f64::from_bits(TAG_UNDEFINED));
+    assert_eq!(
+        crate::object::js_instanceof_dynamic(transform, transform_ctor).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        crate::object::js_instanceof(transform, 0xFFFF0074).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        crate::object::js_instanceof_dynamic(transform, duplex).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        crate::object::js_instanceof_dynamic(transform, readable).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        crate::object::js_instanceof_dynamic(transform, writable).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        crate::object::js_instanceof_dynamic(transform, stream_ctor).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        crate::object::js_instanceof_dynamic(transform, passthrough_ctor).to_bits(),
+        TAG_FALSE
+    );
+
+    let passthrough = js_node_stream_passthrough_new(f64::from_bits(TAG_UNDEFINED));
+    assert_eq!(
+        crate::object::js_instanceof_dynamic(passthrough, passthrough_ctor).to_bits(),
+        TAG_TRUE
+    );
+    assert_eq!(
+        crate::object::js_instanceof_dynamic(passthrough, transform_ctor).to_bits(),
+        TAG_TRUE
+    );
+}

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -21,6 +21,8 @@ thread_local! {
     static WRITABLE_CLOSE_COUNT: RefCell<usize> = const { RefCell::new(0) };
     static WRITABLE_DRAIN_COUNT: RefCell<usize> = const { RefCell::new(0) };
     static PENDING_WRITE_CALLBACK: RefCell<Option<f64>> = const { RefCell::new(None) };
+    static TRANSFORM_THIS_HAS_STREAM_STATE: RefCell<Vec<bool>> = const { RefCell::new(Vec::new()) };
+    static TRANSFORM_FLUSH_COUNT: RefCell<usize> = const { RefCell::new(0) };
 }
 
 fn string_value(s: &str) -> f64 {
@@ -217,6 +219,78 @@ extern "C" fn read_records_this(closure: *const ClosureHeader) -> f64 {
     f64::from_bits(TAG_UNDEFINED)
 }
 
+extern "C" fn transform_upper_callback(
+    _closure: *const ClosureHeader,
+    chunk: f64,
+    _enc: f64,
+    cb: f64,
+) -> f64 {
+    let this = crate::object::js_implicit_this_get();
+    TRANSFORM_THIS_HAS_STREAM_STATE.with(|matches| {
+        matches.borrow_mut().push(
+            get_hidden_value(this, hidden_readable_flag_key()).is_some()
+                && get_hidden_value(this, hidden_writable_flag_key()).is_some(),
+        )
+    });
+    let readable = js_node_stream_readable_from(chunk);
+    let bytes = js_node_stream_collect_bytes(readable);
+    let upper = String::from_utf8(bytes).unwrap().to_uppercase();
+    let args = [f64::from_bits(TAG_UNDEFINED), string_value(&upper)];
+    unsafe {
+        let _ = crate::closure::js_native_call_value(cb, args.as_ptr(), args.len());
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn transform_identity_callback(
+    _closure: *const ClosureHeader,
+    chunk: f64,
+    _enc: f64,
+    cb: f64,
+) -> f64 {
+    let args = [f64::from_bits(TAG_UNDEFINED), chunk];
+    unsafe {
+        let _ = crate::closure::js_native_call_value(cb, args.as_ptr(), args.len());
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn transform_push_pair_callback(
+    _closure: *const ClosureHeader,
+    _chunk: f64,
+    _enc: f64,
+    cb: f64,
+) -> f64 {
+    let this = crate::object::js_implicit_this_get();
+    let push = js_object_get_field_by_name_f64(
+        raw_ptr_from_value(this) as *const ObjectHeader,
+        hidden_key(b"push"),
+    );
+    unsafe {
+        let _ = crate::closure::js_native_call_value(push, [string_value("a")].as_ptr(), 1);
+        let _ = crate::closure::js_native_call_value(push, [string_value("b")].as_ptr(), 1);
+        let _ =
+            crate::closure::js_native_call_value(cb, [f64::from_bits(TAG_UNDEFINED)].as_ptr(), 1);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn transform_flush_tail_callback(_closure: *const ClosureHeader, cb: f64) -> f64 {
+    let this = crate::object::js_implicit_this_get();
+    TRANSFORM_THIS_HAS_STREAM_STATE.with(|matches| {
+        matches.borrow_mut().push(
+            get_hidden_value(this, hidden_readable_flag_key()).is_some()
+                && get_hidden_value(this, hidden_writable_flag_key()).is_some(),
+        )
+    });
+    TRANSFORM_FLUSH_COUNT.with(|count| *count.borrow_mut() += 1);
+    let args = [f64::from_bits(TAG_UNDEFINED), string_value("!")];
+    unsafe {
+        let _ = crate::closure::js_native_call_value(cb, args.as_ptr(), args.len());
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
 #[test]
 fn readable_from_retains_string_chunks_for_consumers() {
     let mut arr = crate::array::js_array_alloc(2);
@@ -335,6 +409,190 @@ fn writable_options_write_callback_is_invoked_by_stub_write() {
     });
 }
 
+#[test]
+fn transform_option_callback_transforms_written_chunks() {
+    READABLE_DATA_CAPTURED.with(|captured| captured.borrow_mut().clear());
+    READABLE_THIS_MATCHES.with(|matches| matches.borrow_mut().clear());
+    TRANSFORM_THIS_HAS_STREAM_STATE.with(|matches| matches.borrow_mut().clear());
+
+    let opts = crate::object::js_object_alloc(0, 1);
+    let transform_cb = js_closure_alloc(transform_upper_callback as *const u8, 0);
+    crate::closure::js_register_closure_arity(transform_upper_callback as *const u8, 3);
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"transform"),
+        box_pointer(transform_cb as *const u8),
+    );
+
+    let stream = js_node_stream_transform_new(box_pointer(opts as *const u8));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let data_closure = js_closure_alloc(capture_data_listener as *const u8, 1);
+    crate::closure::js_register_closure_arity(capture_data_listener as *const u8, 1);
+    crate::closure::js_closure_set_capture_f64(data_closure, 0, stream);
+    let _ = js_node_stream_method_on(
+        handle,
+        string_value("data"),
+        box_pointer(data_closure as *const u8),
+    );
+
+    let _ = js_node_stream_method_write(
+        handle,
+        string_value("hello"),
+        f64::from_bits(TAG_UNDEFINED),
+        f64::from_bits(TAG_UNDEFINED),
+    );
+
+    READABLE_DATA_CAPTURED.with(|captured| {
+        assert_eq!(captured.borrow().as_slice(), &[b"HELLO".to_vec()]);
+    });
+    READABLE_THIS_MATCHES.with(|matches| assert_eq!(matches.borrow().as_slice(), &[true]));
+    TRANSFORM_THIS_HAS_STREAM_STATE
+        .with(|matches| assert_eq!(matches.borrow().as_slice(), &[true]));
+}
+
+#[test]
+fn transform_pipe_chain_applies_callback_output() {
+    READABLE_DATA_CAPTURED.with(|captured| captured.borrow_mut().clear());
+    READABLE_THIS_MATCHES.with(|matches| matches.borrow_mut().clear());
+    TRANSFORM_THIS_HAS_STREAM_STATE.with(|matches| matches.borrow_mut().clear());
+
+    let mut chunks = crate::array::js_array_alloc(1);
+    chunks = crate::array::js_array_push_f64(chunks, string_value("ab"));
+    let src = js_node_stream_readable_from(box_pointer(chunks as *const u8));
+
+    let opts = crate::object::js_object_alloc(0, 1);
+    let transform_cb = js_closure_alloc(transform_upper_callback as *const u8, 0);
+    crate::closure::js_register_closure_arity(transform_upper_callback as *const u8, 3);
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"transform"),
+        box_pointer(transform_cb as *const u8),
+    );
+    let upper = js_node_stream_transform_new(box_pointer(opts as *const u8));
+    let sink = js_node_stream_passthrough_new(f64::from_bits(TAG_UNDEFINED));
+
+    let sink_data = js_closure_alloc(capture_data_listener as *const u8, 1);
+    crate::closure::js_register_closure_arity(capture_data_listener as *const u8, 1);
+    crate::closure::js_closure_set_capture_f64(sink_data, 0, sink);
+    let _ = js_node_stream_method_on(
+        raw_ptr_from_value(sink) as i64,
+        string_value("data"),
+        box_pointer(sink_data as *const u8),
+    );
+
+    let src_pipe = js_object_get_field_by_name_f64(
+        raw_ptr_from_value(src) as *const ObjectHeader,
+        hidden_key(b"pipe"),
+    );
+    let upper_pipe = js_object_get_field_by_name_f64(
+        raw_ptr_from_value(upper) as *const ObjectHeader,
+        hidden_key(b"pipe"),
+    );
+    let _ = unsafe { crate::closure::js_native_call_value(src_pipe, [upper].as_ptr(), 1) };
+    let _ = unsafe { crate::closure::js_native_call_value(upper_pipe, [sink].as_ptr(), 1) };
+    let _ = crate::promise::js_promise_run_microtasks();
+
+    READABLE_DATA_CAPTURED.with(|captured| {
+        assert_eq!(captured.borrow().as_slice(), &[b"AB".to_vec()]);
+    });
+    READABLE_THIS_MATCHES.with(|matches| assert_eq!(matches.borrow().as_slice(), &[true]));
+    TRANSFORM_THIS_HAS_STREAM_STATE
+        .with(|matches| assert_eq!(matches.borrow().as_slice(), &[true]));
+}
+
+#[test]
+fn transform_flush_callback_pushes_tail_before_finish() {
+    READABLE_DATA_CAPTURED.with(|captured| captured.borrow_mut().clear());
+    TRANSFORM_THIS_HAS_STREAM_STATE.with(|matches| matches.borrow_mut().clear());
+    TRANSFORM_FLUSH_COUNT.with(|count| *count.borrow_mut() = 0);
+
+    let opts = crate::object::js_object_alloc(0, 2);
+    let transform_cb = js_closure_alloc(transform_identity_callback as *const u8, 0);
+    let flush_cb = js_closure_alloc(transform_flush_tail_callback as *const u8, 0);
+    crate::closure::js_register_closure_arity(transform_identity_callback as *const u8, 3);
+    crate::closure::js_register_closure_arity(transform_flush_tail_callback as *const u8, 1);
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"transform"),
+        box_pointer(transform_cb as *const u8),
+    );
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"flush"),
+        box_pointer(flush_cb as *const u8),
+    );
+
+    let stream = js_node_stream_transform_new(box_pointer(opts as *const u8));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let data_closure = js_closure_alloc(capture_data_listener as *const u8, 1);
+    crate::closure::js_register_closure_arity(capture_data_listener as *const u8, 1);
+    crate::closure::js_closure_set_capture_f64(data_closure, 0, stream);
+    let _ = js_node_stream_method_on(
+        handle,
+        string_value("data"),
+        box_pointer(data_closure as *const u8),
+    );
+
+    let _ = js_node_stream_method_write(
+        handle,
+        string_value("a"),
+        f64::from_bits(TAG_UNDEFINED),
+        f64::from_bits(TAG_UNDEFINED),
+    );
+    let _ = js_node_stream_method_end(handle, f64::from_bits(TAG_UNDEFINED));
+
+    READABLE_DATA_CAPTURED.with(|captured| {
+        assert_eq!(
+            captured.borrow().as_slice(),
+            &[b"a".to_vec(), b"!".to_vec()]
+        );
+    });
+    TRANSFORM_FLUSH_COUNT.with(|count| assert_eq!(*count.borrow(), 1));
+    TRANSFORM_THIS_HAS_STREAM_STATE.with(|matches| {
+        assert_eq!(matches.borrow().as_slice(), &[true]);
+    });
+}
+
+#[test]
+fn transform_callback_can_push_multiple_outputs_per_input() {
+    READABLE_DATA_CAPTURED.with(|captured| captured.borrow_mut().clear());
+
+    let opts = crate::object::js_object_alloc(0, 1);
+    let transform_cb = js_closure_alloc(transform_push_pair_callback as *const u8, 0);
+    crate::closure::js_register_closure_arity(transform_push_pair_callback as *const u8, 3);
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"transform"),
+        box_pointer(transform_cb as *const u8),
+    );
+
+    let stream = js_node_stream_transform_new(box_pointer(opts as *const u8));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let data_closure = js_closure_alloc(capture_data_listener as *const u8, 1);
+    crate::closure::js_register_closure_arity(capture_data_listener as *const u8, 1);
+    crate::closure::js_closure_set_capture_f64(data_closure, 0, stream);
+    let _ = js_node_stream_method_on(
+        handle,
+        string_value("data"),
+        box_pointer(data_closure as *const u8),
+    );
+
+    let _ = js_node_stream_method_write(
+        handle,
+        string_value("x"),
+        f64::from_bits(TAG_UNDEFINED),
+        f64::from_bits(TAG_UNDEFINED),
+    );
+
+    READABLE_DATA_CAPTURED.with(|captured| {
+        assert_eq!(
+            captured.borrow().as_slice(),
+            &[b"a".to_vec(), b"b".to_vec()]
+        );
+    });
+}
+
+#[test]
 fn readable_options_read_callback_this_is_rebound_to_stream() {
     let opts = crate::object::js_object_alloc(0, 1);
     let closure = js_closure_alloc(
@@ -1188,82 +1446,6 @@ fn destroyed_readable_drops_late_push_data() {
     );
 
     READABLE_DATA_CAPTURED.with(|captured| assert!(captured.borrow().is_empty()));
-}
-
-#[test]
-fn fresh_streams_expose_destroyed_false() {
-    let streams = [
-        js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED)),
-        js_node_stream_writable_new(f64::from_bits(TAG_UNDEFINED)),
-        js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED)),
-        js_node_stream_transform_new(f64::from_bits(TAG_UNDEFINED)),
-    ];
-
-    for stream in streams {
-        let destroyed = js_object_get_field_by_name_f64(
-            raw_ptr_from_value(stream) as *const ObjectHeader,
-            hidden_key(b"destroyed"),
-        );
-        assert_eq!(destroyed.to_bits(), TAG_FALSE);
-        assert_eq!(
-            js_node_stream_method_destroyed(raw_ptr_from_value(stream) as i64).to_bits(),
-            TAG_FALSE
-        );
-    }
-}
-
-#[test]
-fn readable_lifecycle_flags_reflect_ended_state() {
-    let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
-    let handle = raw_ptr_from_value(stream) as i64;
-    let obj = raw_ptr_from_value(stream) as *const ObjectHeader;
-
-    assert_eq!(js_node_stream_method_readable(handle).to_bits(), TAG_TRUE);
-    assert_eq!(
-        js_object_get_field_by_name_f64(obj, hidden_key(b"readable")).to_bits(),
-        TAG_TRUE
-    );
-    assert_eq!(
-        js_node_stream_method_readable_ended(handle).to_bits(),
-        TAG_FALSE
-    );
-    assert_eq!(
-        js_object_get_field_by_name_f64(obj, hidden_key(b"readableEnded")).to_bits(),
-        TAG_FALSE
-    );
-    assert_eq!(
-        js_node_stream_method_readable_did_read(handle).to_bits(),
-        TAG_FALSE
-    );
-    assert_eq!(
-        js_object_get_field_by_name_f64(obj, hidden_key(b"readableDidRead")).to_bits(),
-        TAG_FALSE
-    );
-
-    let _ = js_node_stream_method_read(handle, f64::from_bits(TAG_UNDEFINED));
-    assert_eq!(
-        js_node_stream_method_readable_did_read(handle).to_bits(),
-        TAG_TRUE
-    );
-    assert_eq!(
-        js_object_get_field_by_name_f64(obj, hidden_key(b"readableDidRead")).to_bits(),
-        TAG_TRUE
-    );
-
-    let _ = js_node_stream_method_push(handle, f64::from_bits(TAG_NULL));
-    assert_eq!(js_node_stream_method_readable(handle).to_bits(), TAG_FALSE);
-    assert_eq!(
-        js_object_get_field_by_name_f64(obj, hidden_key(b"readable")).to_bits(),
-        TAG_FALSE
-    );
-    assert_eq!(
-        js_node_stream_method_readable_ended(handle).to_bits(),
-        TAG_TRUE
-    );
-    assert_eq!(
-        js_object_get_field_by_name_f64(obj, hidden_key(b"readableEnded")).to_bits(),
-        TAG_TRUE
-    );
 }
 
 fn duplex_allow_half_open_defaults_true_and_honors_false_option() {

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -34,6 +34,15 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
         }
     }
     if let Some((module, method)) = unsafe { bound_native_callable_module_and_method(type_ref) } {
+        if module == "stream"
+            && matches!(
+                method.as_str(),
+                "Readable" | "Writable" | "Duplex" | "Transform" | "PassThrough" | "Stream"
+            )
+            && crate::node_stream::is_classic_stream_instance_of(value, method.as_str())
+        {
+            return f64::from_bits(crate::value::TAG_TRUE);
+        }
         if module == "events"
             && method == "EventEmitter"
             && (crate::node_stream::is_classic_stream_instance_value(value)
@@ -57,6 +66,24 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
 
     if class_id == 0 {
         return false_val;
+    }
+
+    // Keep in sync with perry-codegen/src/expr/instance_misc1.rs.
+    let classic_stream_name = match class_id {
+        0xFFFF0070 => Some("Stream"),
+        0xFFFF0071 => Some("Readable"),
+        0xFFFF0072 => Some("Writable"),
+        0xFFFF0073 => Some("Duplex"),
+        0xFFFF0074 => Some("Transform"),
+        0xFFFF0075 => Some("PassThrough"),
+        _ => None,
+    };
+    if let Some(name) = classic_stream_name {
+        return if crate::node_stream::is_classic_stream_instance_of(value, name) {
+            true_val
+        } else {
+            false_val
+        };
     }
 
     // User-defined `Symbol.hasInstance` takes precedence over the built-in

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -272,12 +272,6 @@
     "category": "bug-open",
     "reason": "node:stream: `for await (chunk of readable)` iterates to empty — async iterator does not yield chunks. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/transform/uppercase": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Transform.write → transform() → data event chain does not deliver. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/object-mode": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -349,12 +343,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: read(n) doesn't return buffered chunk (push/read pipeline not wired). Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/transform/with-encoding": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Transform with explicit encoding doesn't deliver transformed chunks. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/finished/with-options-signal": {
     "issue": "1532",
@@ -445,12 +433,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: read(n) larger than buffer doesn't return remaining bytes after end. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/transform/cb-with-error": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: transform() callback with Error doesn't propagate as `error` event. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/wrap-old-stream": {
     "issue": "1532",
@@ -728,12 +710,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipe() called twice with same destination duplicates writes (should be no-op for second call). Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/transform/transform-callback-error": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Transform's transform() cb(err) does not propagate as 'error' event. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/from-with-options": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -932,12 +908,6 @@
     "category": "bug-open",
     "reason": "node:stream: read() inside 'readable' listener — while-loop drain pattern produces wrong output. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/transform/multi-output-per-input": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Transform pushing multiple outputs per single input — only first push consumed. Flips to PASS when #1539 lands."
-  },
   "node-suite/stream/readable/read-before-push": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1064,12 +1034,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: writer.desiredSize does not restore to HWM after write resolves. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/transform/this-binding-in-transform": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: `this` inside transform() — not bound to Transform instance, or this.push() does not enqueue. Flips to PASS when #1539 lands."
-  },
   "node-suite/stream/readable/highwater-mark-buffer": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1177,12 +1141,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: destroy() inside _read() — readCalls count or close-event behavior wrong. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/transform/flush-called-once": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Transform._flush — not called exactly once after end. Flips to PASS when #1539 lands."
   },
   "node-suite/stream/promises/finished-rejects-on-error": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- wire Transform transform/flush callbacks into readable output and write completion
- preserve Transform callback `this` binding, including static and dynamic stream `instanceof` checks
- add focused stream tests and remove now-passing Transform parity known failures

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `jq empty test-parity/known_failures.json`
- `cargo check -p perry-codegen`
- `cargo check -p perry-runtime`
- `cargo test -p perry-runtime node_stream:: -- --nocapture`
- `./scripts/check_file_size.sh`
- `CARGO_BUILD_JOBS=1 ./run_parity_tests.sh --suite=node-suite --module=stream --filter=<each removed transform case>`