### PR TITLE
fix(child_process): reify spawn/spawnSync/execSync/fork/execFileSync as values (#2130)

### DIFF
--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -365,11 +365,20 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("tty", "WriteStream")
             // #1856: `child_process.ChildProcess` reads as `[Function: ChildProcess]`.
             | ("child_process", "ChildProcess")
-            // #1857: exec/execFile read as functions so `typeof child_process.exec
-            // === "function"` and `util.promisify(child_process.exec)` can detect
-            // and wrap them (see the `("util","promisify")` dispatch arm).
+            // #1857 / #2130: every exported function reads as a bound-method
+            // closure so `const spawn = cp.spawn; spawn(...)` (Node's canonical
+            // test idiom — `const spawn = require('child_process').spawn`) and
+            // `util.promisify(cp.exec)` both detect/wrap them. Method-call form
+            // (`cp.spawn(...)`) already lowers through a dedicated codegen path;
+            // this just keeps the value-read form coherent so it dispatches
+            // through dispatch_native_module_method.
             | ("child_process", "exec")
             | ("child_process", "execFile")
+            | ("child_process", "execSync")
+            | ("child_process", "execFileSync")
+            | ("child_process", "spawn")
+            | ("child_process", "spawnSync")
+            | ("child_process", "fork")
             | ("events", "EventEmitter")
             | ("events", "on")
             | ("stream", "Readable")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1097,6 +1097,54 @@ pub(crate) unsafe fn dispatch_native_module_method(
             f64::from_bits(JSValue::undefined().bits())
         }
 
+        // #2130: captured-then-called child_process methods (`const spawn =
+        // require('child_process').spawn; spawn(...)`, Node's canonical test
+        // idiom). The bound-method closure produced by `cp.spawn` (and the
+        // other entries allowlisted in `is_native_module_callable_export`)
+        // funnels back here when invoked. The method-call form
+        // (`cp.spawn(...)`) is lowered to the same FFIs through dedicated
+        // codegen arms (`expr/child_proc.rs`); this arm mirrors them for the
+        // value-call form. `cmd` / `file` / `module` strings come in NaN-boxed
+        // (SSO-safe via `js_string_materialize_to_heap`); `args` is the array
+        // pointer (or null); `opts` is the options-object pointer (or 0 →
+        // undefined inside the impls).
+        ("child_process", "spawn") => {
+            let cmd = crate::string::js_string_materialize_to_heap(arg(0)) as i64;
+            let args_p = ptr_addr(arg(1)) as i64;
+            let opts_p = ptr_addr(arg(2)) as i64;
+            crate::child_process::reactor::js_child_process_spawn_streams(cmd, args_p, opts_p)
+        }
+        ("child_process", "spawnSync") => {
+            let cmd = crate::string::js_string_materialize_to_heap(arg(0));
+            let args_p = ptr_addr(arg(1)) as *const crate::array::ArrayHeader;
+            let opts_p = ptr_addr(arg(2)) as *const ObjectHeader;
+            let result = crate::child_process::js_child_process_spawn_sync(cmd, args_p, opts_p);
+            ptr_to_f64(result as *const u8)
+        }
+        ("child_process", "execSync") => {
+            let cmd = crate::string::js_string_materialize_to_heap(arg(0));
+            let opts_p = ptr_addr(arg(1)) as *const ObjectHeader;
+            crate::child_process::js_child_process_exec_sync(cmd, opts_p)
+        }
+        ("child_process", "exec") => {
+            let cmd = crate::string::js_string_materialize_to_heap(arg(0));
+            crate::child_process::js_child_process_exec(cmd, arg(1), arg(2))
+        }
+        ("child_process", "execFile") => {
+            let file = crate::string::js_string_materialize_to_heap(arg(0)) as i64;
+            crate::child_process::js_child_process_exec_file(file, arg(1), arg(2), arg(3))
+        }
+        ("child_process", "execFileSync") => {
+            let file = crate::string::js_string_materialize_to_heap(arg(0)) as i64;
+            crate::child_process::js_child_process_exec_file_sync(file, arg(1), arg(2))
+        }
+        ("child_process", "fork") => {
+            let module = crate::string::js_string_materialize_to_heap(arg(0)) as i64;
+            let args_p = ptr_addr(arg(1)) as i64;
+            let opts_p = ptr_addr(arg(2)) as i64;
+            crate::child_process::fork::js_child_process_fork(module, args_p, opts_p)
+        }
+
         // #1577: captured-then-called crypto methods (`const f =
         // crypto.createHash; f(...)`). The impls live in perry-stdlib (which
         // depends on this crate), so route through the dispatcher stdlib


### PR DESCRIPTION
## Summary

Closes part of #2130 — Node's canonical test idiom `const spawn = require('child_process').spawn` was returning `undefined`, and even the already-allowlisted `exec`/`execFile` silently no-op'd when invoked via a captured reference (`const f = cp.exec; f(...)`). The reified bound-method closure funnels through `dispatch_native_module_method`, which had **no `child_process` arm** — so the captured-value call dispatched to the catch-all undefined.

Two coupled fixes:

- **Allowlist** in `is_native_module_callable_export` (`crates/perry-runtime/src/object/native_module.rs`): add `spawn`, `spawnSync`, `execSync`, `fork`, `execFileSync` (the existing `exec`/`execFile`/`ChildProcess` entries from #1856/#1857 were the only ones reifying).
- **Dispatch arm** in `dispatch_native_module_method` (`crates/perry-runtime/src/object/native_module_dispatch.rs`): route each method through `js_string_materialize_to_heap` (SSO-safe — child_process tests pass short strings like `"echo"`) + `ptr_addr` for the array/options pointers, then into the same FFIs the codegen lowers the method-call form to.

The inline method-call form (`cp.spawn(...)`) already lowered through dedicated codegen arms (`expr/child_proc.rs`); this just closes the value-call path so both shapes dispatch coherently.

## Radar impact

`scripts/node_core_subset.py --root vendor/nodejs --api child_process`:

| Bucket | Before | After |
|---|---:|---:|
| pass | 4 | **11** |
| diff | 0 | 1 |
| runtime-fail | 64 | 56 |
| compile-fail | 9 | 9 |
| parity | 5.2% | **14.3%** |

The `TypeError: value is not a function` bucket dropped from 46 → 6. Remaining "value is not a function" / "(reading 'stdout')" cases are distinct gaps: `exec()` with a callback returns `undefined` rather than a ChildProcess (with `.pid`/`.stdout`/etc.), and there's a `(no output)` cluster of 39 spawn-self tests where `process.argv[0]` is the Perry binary rather than Node (environmental, not a stub).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry`
- [x] `cargo test --release -p perry-runtime` — only failure is the pre-existing TUI handle-counter flake (passes when run in isolation)
- [x] Manual smoke: `const spawn = cp.spawn; spawn('/bin/echo', ['hi']).stdout.on('data', d => process.stdout.write(d))` now works
- [x] Node-core radar (`--api child_process`): 4 → 11 passing
