### PR TITLE
fix(hir): typeof + .bind/.call/.apply on namespace statics (#2143)

### DIFF
--- a/crates/perry-hir/src/lower/array_fold.rs
+++ b/crates/perry-hir/src/lower/array_fold.rs
@@ -208,3 +208,93 @@ pub(crate) fn is_known_array_prototype_method(name: &str) -> bool {
         | "toSpliced"
     )
 }
+
+/// Names of `Promise.<name>` static methods recognised by Perry's codegen
+/// (`crates/perry-codegen/src/lower_call/console_promise.rs`).
+pub(crate) fn is_known_promise_static_method(name: &str) -> bool {
+    matches!(
+        name,
+        "resolve" | "reject" | "all" | "race" | "allSettled" | "any" | "withResolvers" | "try"
+    )
+}
+
+/// Names of `Math.<name>` static functions Perry's runtime implements.
+pub(crate) fn is_known_math_static_method(name: &str) -> bool {
+    matches!(
+        name,
+        "abs"
+            | "acos"
+            | "acosh"
+            | "asin"
+            | "asinh"
+            | "atan"
+            | "atan2"
+            | "atanh"
+            | "cbrt"
+            | "ceil"
+            | "clz32"
+            | "cos"
+            | "cosh"
+            | "exp"
+            | "expm1"
+            | "floor"
+            | "fround"
+            | "hypot"
+            | "imul"
+            | "log"
+            | "log10"
+            | "log1p"
+            | "log2"
+            | "max"
+            | "min"
+            | "pow"
+            | "random"
+            | "round"
+            | "sign"
+            | "sin"
+            | "sinh"
+            | "sqrt"
+            | "tan"
+            | "tanh"
+            | "trunc"
+    )
+}
+
+/// Names of `JSON.<name>` static functions Perry's runtime implements.
+pub(crate) fn is_known_json_static_method(name: &str) -> bool {
+    matches!(name, "parse" | "stringify")
+}
+
+/// Names of `Number.<name>` static functions Perry's runtime implements.
+pub(crate) fn is_known_number_static_method(name: &str) -> bool {
+    matches!(
+        name,
+        "isFinite" | "isInteger" | "isNaN" | "isSafeInteger" | "parseFloat" | "parseInt"
+    )
+}
+
+/// Names of `String.<name>` static functions Perry's runtime implements.
+pub(crate) fn is_known_string_static_method(name: &str) -> bool {
+    matches!(name, "fromCharCode" | "fromCodePoint" | "raw")
+}
+
+/// True when `<obj_name>.<prop_name>` names a built-in function value
+/// (a static method on a known namespace). Used by the `typeof
+/// <NS>.<static>` and `typeof <NS>.<static>.<bind|call|apply>` AST folds
+/// (#2143). Direct calls to these statics (`Promise.resolve(x)`,
+/// `Math.min(1,2)`) are special-cased in codegen; this fold makes the
+/// value-read agree with Node's "function" typeof so feature-detection
+/// idioms (and Test262's `propertyHelper.js` family) see callable
+/// methods.
+pub(crate) fn is_known_namespace_static_function(obj_name: &str, prop_name: &str) -> bool {
+    match obj_name {
+        "Object" => is_known_object_static_method(prop_name),
+        "Array" => is_known_array_static_method(prop_name),
+        "Promise" => is_known_promise_static_method(prop_name),
+        "Math" => is_known_math_static_method(prop_name),
+        "JSON" => is_known_json_static_method(prop_name),
+        "Number" => is_known_number_static_method(prop_name),
+        "String" => is_known_string_static_method(prop_name),
+        _ => false,
+    }
+}

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -14,7 +14,7 @@ use swc_ecma_ast as ast;
 
 use crate::ir::*;
 
-use super::super::{lower_expr, LoweringContext};
+use super::super::{is_known_namespace_static_function, lower_expr, LoweringContext};
 
 /// Issue #668: AOT `require(stringLiteral)` from a user TypeScript file
 /// currently lowers to `Call { callee: GlobalGet(0), ... }` (the unknown-ident
@@ -723,6 +723,156 @@ fn is_builtin_prototype_receiver(ctx: &LoweringContext, recv: &ast::Expr) -> boo
         ast::Expr::Lit(ast::Lit::Str(_)) => true,
         _ => false,
     }
+}
+
+/// #2143 — namespace-static `.bind`/`.call`/`.apply` immediate-call rewrites.
+///
+/// Built-in function values like `Promise.resolve`, `Math.min`, `JSON.parse`
+/// do not inherit `Function.prototype` in Perry's representation (each direct
+/// call site is special-cased in codegen — there's no reified function value
+/// to hang `.call`/`.apply`/`.bind` off). The bare value-read lowers to a
+/// numeric fallback, so `Promise.resolve.bind(Promise)(x)` throws
+/// "value is not a function" at the outer call.
+///
+/// Rewrite at the AST level for the shapes whose intent is unambiguous and
+/// where the `thisArg` is irrelevant (namespace statics don't read `this`):
+///
+///   `<NS>.<static>.call(thisArg, a, b, …)`     → `<NS>.<static>(a, b, …)`
+///   `<NS>.<static>.apply(thisArg)`             → `<NS>.<static>()`
+///   `<NS>.<static>.apply(thisArg, [a, b, …])`  → `<NS>.<static>(a, b, …)`
+///   `<NS>.<static>.bind(thisArg, …pre)(…rest)` → `<NS>.<static>(…pre, …rest)`
+///
+/// The deferred-bind shape (`const f = Promise.resolve.bind(Promise);
+/// f(x);`) cannot be rewritten purely at the AST level — that needs a
+/// real reified function value and is tracked as follow-up.
+pub(super) fn try_namespace_static_method_apply_call_bind(
+    ctx: &mut LoweringContext,
+    call: &ast::CallExpr,
+    has_spread: bool,
+) -> Result<Option<Expr>> {
+    if has_spread {
+        return Ok(None);
+    }
+    let ast::Callee::Expr(callee_expr) = &call.callee else {
+        return Ok(None);
+    };
+
+    // Form A/B: `<NS>.<static>.call(…)` or `.apply(…)`.
+    if let ast::Expr::Member(outer) = callee_expr.as_ref() {
+        if let ast::MemberProp::Ident(outer_prop) = &outer.prop {
+            let mode = match outer_prop.sym.as_ref() {
+                "call" => Some(false),
+                "apply" => Some(true),
+                _ => None,
+            };
+            if let Some(is_apply) = mode {
+                if let Some(inner) = match_namespace_static_member(ctx, outer.obj.as_ref()) {
+                    return Ok(Some(rewrite_dropping_this(ctx, call, &inner, is_apply)?));
+                }
+            }
+        }
+    }
+
+    // Form C: `(<NS>.<static>.bind(thisArg, …pre))(…rest)` — the outer call's
+    // callee is itself a CallExpr to `.bind`.
+    if let ast::Expr::Call(bind_call) = callee_expr.as_ref() {
+        if let ast::Callee::Expr(bind_callee) = &bind_call.callee {
+            if let ast::Expr::Member(bind_member) = bind_callee.as_ref() {
+                if let ast::MemberProp::Ident(bind_prop) = &bind_member.prop {
+                    if bind_prop.sym.as_ref() == "bind" {
+                        // The bind call itself can't have spreads we don't
+                        // understand; require at least `thisArg`.
+                        let bind_spread = bind_call.args.iter().any(|a| a.spread.is_some());
+                        if !bind_spread && !bind_call.args.is_empty() {
+                            if let Some(inner_member) =
+                                match_namespace_static_member(ctx, bind_member.obj.as_ref())
+                            {
+                                // Build: <inner_member>(…preBound, …rest)
+                                let pre_bound: Vec<ast::ExprOrSpread> =
+                                    bind_call.args.iter().skip(1).cloned().collect();
+                                let mut synth = call.clone();
+                                synth.callee =
+                                    ast::Callee::Expr(Box::new(ast::Expr::Member(inner_member)));
+                                let mut combined = pre_bound;
+                                combined.extend(call.args.iter().cloned());
+                                synth.args = combined;
+                                return Ok(Some(super::lower_call(ctx, &synth)?));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// If `expr` is `<NS>.<static>` where `<NS>` is a known namespace-static
+/// holder (Promise/Math/JSON/Number/String/Object/Array) not shadowed by a
+/// local, and `<static>` is a known method on it, return a clone of that
+/// MemberExpr so it can be reused as the rewritten callee.
+fn match_namespace_static_member(
+    ctx: &LoweringContext,
+    expr: &ast::Expr,
+) -> Option<ast::MemberExpr> {
+    let ast::Expr::Member(m) = expr else {
+        return None;
+    };
+    let ast::MemberProp::Ident(prop) = &m.prop else {
+        return None;
+    };
+    let ast::Expr::Ident(base) = m.obj.as_ref() else {
+        return None;
+    };
+    let ns = base.sym.as_ref();
+    let name = prop.sym.as_ref();
+    if ctx.lookup_local(ns).is_some() || ctx.lookup_func(ns).is_some() {
+        return None;
+    }
+    if !is_known_namespace_static_function(ns, name) {
+        return None;
+    }
+    Some(m.clone())
+}
+
+/// Rewrite `<NS>.<static>.{call,apply}(thisArg, …)` to a direct call,
+/// dropping the `thisArg` (namespace statics don't use it). For `.apply`,
+/// the args array must be a clean literal.
+fn rewrite_dropping_this(
+    ctx: &mut LoweringContext,
+    call: &ast::CallExpr,
+    inner: &ast::MemberExpr,
+    is_apply: bool,
+) -> Result<Expr> {
+    let mut synth = call.clone();
+    synth.callee = ast::Callee::Expr(Box::new(ast::Expr::Member(inner.clone())));
+    if is_apply {
+        // `.apply(thisArg)` / `.apply(thisArg, [a, b, …])`.
+        synth.args = match call.args.get(1) {
+            None => Vec::new(),
+            Some(arr_arg) => match arr_arg.expr.as_ref() {
+                ast::Expr::Array(arr) => {
+                    let clean = arr
+                        .elems
+                        .iter()
+                        .all(|e| matches!(e, Some(eos) if eos.spread.is_none()));
+                    if !clean {
+                        // Bail to the unrewritten form; the inner `<NS>.<static>`
+                        // value-read will still TypeError, but we don't pretend
+                        // to expand a non-literal apply-args array.
+                        return Ok(super::lower_call(ctx, call)?);
+                    }
+                    arr.elems.iter().filter_map(|e| e.clone()).collect()
+                }
+                _ => return Ok(super::lower_call(ctx, call)?),
+            },
+        };
+    } else {
+        // `.call(thisArg, …args)` — drop thisArg, keep the rest.
+        synth.args = call.args.iter().skip(1).cloned().collect();
+    }
+    Ok(super::lower_call(ctx, &synth)?)
 }
 
 /// Followup to #957 / PR #959 — `Function('return this')()`.

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -58,7 +58,8 @@ use imported_array_methods::try_imported_array_methods;
 use inline_array_methods::try_inline_array_methods;
 use intrinsics::{
     check_eval_function_call, try_bare_regexp_call, try_builtin_prototype_method_apply_call,
-    try_embed_wasm, try_function_return_this, try_iife_call_rewrite, try_native_arena_intrinsics,
+    try_embed_wasm, try_function_return_this, try_iife_call_rewrite,
+    try_namespace_static_method_apply_call_bind, try_native_arena_intrinsics,
     try_native_module_method_apply_call, try_precompile, try_require_literal_bail,
 };
 use local_array_methods::try_local_array_methods;
@@ -170,6 +171,13 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
     // thisArg, …)` to `thisArg.method(…)` so the indirect prototype-borrow
     // dispatches (the bare method value otherwise reads `undefined`).
     if let Some(expr) = try_builtin_prototype_method_apply_call(ctx, call, has_spread)? {
+        return Ok(expr);
+    }
+    // #2143: `Promise.resolve.call(t, x)` / `Math.min.apply(t, [a,b])` /
+    // `(JSON.parse.bind(t, x))(y)` — drop the (unused) `thisArg` and call the
+    // namespace static directly. Built-in function values otherwise lower to a
+    // numeric fallback (no reified `Function.prototype`).
+    if let Some(expr) = try_namespace_static_method_apply_call_bind(ctx, call, has_spread)? {
         return Ok(expr);
     }
     if let Some(expr) = try_function_return_this(ctx, call, has_spread) {

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -643,8 +643,19 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                         if let ast::MemberProp::Ident(prop_ident) = &member.prop {
                             let obj_name = obj_ident.sym.as_ref();
                             let prop_name = prop_ident.sym.as_ref();
-                            if (obj_name == "Object" && is_known_object_static_method(prop_name))
-                                || (obj_name == "Array" && is_known_array_static_method(prop_name))
+                            // #2143: `typeof Promise.resolve`, `typeof Math.min`,
+                            // `typeof JSON.parse`, etc. — namespace static methods
+                            // that Perry implements as codegen direct-call
+                            // intrinsics. A bare value-read of these lowers to a
+                            // numeric fallback (typeof "number"), but Node treats
+                            // them as real functions. Folding to "function" here
+                            // unblocks feature-detection idioms and the
+                            // `.bind`/`.call`/`.apply` chain fold below. The
+                            // existing Object/Array static method lists are
+                            // subsumed by `is_known_namespace_static_function`.
+                            if ctx.lookup_local(obj_name).is_none()
+                                && ctx.lookup_func(obj_name).is_none()
+                                && is_known_namespace_static_function(obj_name, prop_name)
                             {
                                 return Ok(Expr::String("function".to_string()));
                             }
@@ -823,6 +834,37 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                             && is_known_array_prototype_method(prop_name)
                         {
                             return Ok(Expr::String("function".to_string()));
+                        }
+                        // #2143: `typeof Promise.resolve.bind` /
+                        // `typeof Math.min.call` / `typeof JSON.parse.apply`.
+                        // Built-in function values don't inherit
+                        // `Function.prototype` in Perry's representation, so the
+                        // chained `.bind`/`.call`/`.apply` read falls through to
+                        // a numeric fallback (typeof "number"). Node treats
+                        // these as real functions — fold here when the inner
+                        // member names a known namespace static so feature
+                        // detection (Test262 `propertyHelper.js`, the Promise
+                        // tests cited in #793) sees callable values.
+                        if matches!(prop_name, "bind" | "call" | "apply") {
+                            if let ast::Expr::Member(inner) = member.obj.as_ref() {
+                                if let (
+                                    ast::Expr::Ident(inner_obj),
+                                    ast::MemberProp::Ident(inner_prop),
+                                ) = (inner.obj.as_ref(), &inner.prop)
+                                {
+                                    let inner_obj_name = inner_obj.sym.as_ref();
+                                    let inner_prop_name = inner_prop.sym.as_ref();
+                                    if ctx.lookup_local(inner_obj_name).is_none()
+                                        && ctx.lookup_func(inner_obj_name).is_none()
+                                        && is_known_namespace_static_function(
+                                            inner_obj_name,
+                                            inner_prop_name,
+                                        )
+                                    {
+                                        return Ok(Expr::String("function".to_string()));
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -78,9 +78,11 @@ pub(crate) use typed_parse::{extract_typed_parse_source_order, resolve_typed_par
 
 mod array_fold;
 pub(crate) use array_fold::{
-    is_known_array_prototype_method, is_known_array_static_method,
+    is_known_array_prototype_method, is_known_array_static_method, is_known_json_static_method,
+    is_known_math_static_method, is_known_namespace_static_function, is_known_number_static_method,
     is_known_object_prototype_method, is_known_object_static_method,
-    is_known_string_prototype_method, try_fold_array_method_call,
+    is_known_promise_static_method, is_known_string_prototype_method,
+    is_known_string_static_method, try_fold_array_method_call,
 };
 
 mod lower_module_fn;

--- a/test-files/test_gap_2143_builtin_bind.ts
+++ b/test-files/test_gap_2143_builtin_bind.ts
@@ -1,0 +1,38 @@
+// #2143 — built-in function `.bind`/`.call`/`.apply` on namespace statics.
+//
+// Pre-fix, reading `.bind` (or `.call` / `.apply`) off a value like
+// `Promise.resolve` returned `number` rather than `function`, and calling
+// `Promise.resolve.bind(Promise)(x)` threw "value is not a function".
+//
+// Built-in function values don't inherit `Function.prototype` in Perry's
+// representation — each direct call site is special-cased in codegen, with
+// no reified function value to hang `.bind`/`.call`/`.apply` off. This test
+// pins the typeof folds + the immediate-call shape rewrites that landed
+// alongside the issue.
+
+// typeof of the namespace static itself — `function` now.
+console.log("typeof Promise.resolve:", typeof Promise.resolve);
+console.log("typeof Math.min:", typeof Math.min);
+console.log("typeof JSON.parse:", typeof JSON.parse);
+console.log("typeof Number.isFinite:", typeof Number.isFinite);
+console.log("typeof String.fromCharCode:", typeof String.fromCharCode);
+
+// typeof of the chained `.bind` / `.call` / `.apply` read — `function` now.
+console.log("typeof Promise.resolve.bind:", typeof Promise.resolve.bind);
+console.log("typeof Math.min.call:", typeof Math.min.call);
+console.log("typeof JSON.parse.apply:", typeof JSON.parse.apply);
+
+// `.call(thisArg, …)` — thisArg ignored, args forwarded.
+console.log("Math.min.call(null, 3, 1, 2):", Math.min.call(null, 3, 1, 2));
+console.log("Math.max.call(null, 3, 1, 2):", Math.max.call(null, 3, 1, 2));
+
+// `.apply(thisArg, [args])` — clean literal args expanded.
+console.log("Math.min.apply(null, [3, 1, 2]):", Math.min.apply(null, [3, 1, 2]));
+
+// `.bind(thisArg, …pre)(…rest)` — immediate-call form.
+console.log("Math.min.bind(null, 3, 1)(2):", Math.min.bind(null, 3, 1)(2));
+
+// Promise.resolve.bind(Promise)(x) — the issue's headline repro.
+Promise.resolve.bind(Promise)(42).then((v: any) => {
+    console.log("Promise.resolve.bind(Promise)(42) →", v);
+});


### PR DESCRIPTION
## Summary

Fixes #2143. Built-in function values like `Promise.resolve`, `Math.min`, `JSON.parse` do not inherit `Function.prototype` in Perry's representation — each direct call is special-cased in codegen, so a bare value-read lowers to a numeric fallback (`typeof "number"`) and a chained `.bind` / `.call` / `.apply` either reads as `undefined` or as a number, then throws "value is not a function" at the outer call.

Two AST-level folds in `perry-hir` cover the high-frequency shapes:

1. **`typeof` fold** (`lower_expr.rs`) — `typeof <NS>.<static>` and `typeof <NS>.<static>.<bind|call|apply>` evaluate to `"function"` when `<NS>` is one of `Promise` / `Math` / `JSON` / `Number` / `String` / `Object` / `Array` (not shadowed by a local) and `<static>` is a known method on it.

2. **Call-shape rewrite** (`expr_call/intrinsics.rs::try_namespace_static_method_apply_call_bind`) — drops the irrelevant `thisArg` (namespace statics don't read `this`) and forwards the args to the direct call:

   ```
   <NS>.<static>.call(t, a, b)       → <NS>.<static>(a, b)
   <NS>.<static>.apply(t, [a, b])    → <NS>.<static>(a, b)
   (<NS>.<static>.bind(t, …pre))(…r) → <NS>.<static>(…pre, …r)
   ```

### Deferred-bind follow-up

The deferred-bind shape (`const f = Promise.resolve.bind(Promise); f(x);`) cannot be rewritten purely at the AST level — it needs a reified function value with real `Function.prototype` inheritance. That's left as a follow-up; this PR covers the typeof reads + the immediate-call shapes that show up in Test262's `propertyHelper.js` family (cited in the issue) and in feature-detection idioms.

## Test plan

- [x] New `test-files/test_gap_2143_builtin_bind.ts` — byte-for-byte vs `node --experimental-strip-types`
- [x] `cargo fmt --all -- --check` clean
- [x] Existing `test_method_bind_any_receiver.ts` still passes (no regression on user-class method bind)
- [x] Shadowed namespace (`const Math = {min: 99}; typeof Math.min`) still reports `"number"`, not folded
