### PR TITLE
Add util.promisify custom hook support

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -473,30 +473,37 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
         }
     }
 
-    // `util.inspect.custom` / `inspect.custom` (named import from node:util)
-    // — Node exposes this as the registered symbol `Symbol.for("nodejs.util.inspect.custom")`,
-    // and object-literal keys / inspect output expect that exact description.
-    // See #1201.
+    // `util.inspect.custom` / `inspect.custom` and
+    // `util.promisify.custom` / `promisify.custom` (named imports from
+    // node:util) — Node exposes these as registered `Symbol.for(...)`
+    // values, and computed keys expect those exact descriptions.
+    // See #1201 and util.promisify.custom parity.
     if let ast::MemberProp::Ident(prop_ident) = &member.prop {
         if prop_ident.sym.as_ref() == "custom" {
             // Case A: `inspect.custom` where `inspect` is a named import from
-            // node:util.
+            // node:util, and the analogous `promisify.custom`.
             if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
                 if let Some((module_name, Some(method_name))) =
                     ctx.lookup_native_module(obj_ident.sym.as_ref())
                 {
-                    if (module_name == "util" || module_name == "node:util")
-                        && method_name == "inspect"
-                    {
-                        return Ok(Expr::SymbolFor(Box::new(Expr::String(
-                            "nodejs.util.inspect.custom".to_string(),
-                        ))));
+                    if module_name == "util" || module_name == "node:util" {
+                        if method_name == "inspect" {
+                            return Ok(Expr::SymbolFor(Box::new(Expr::String(
+                                "nodejs.util.inspect.custom".to_string(),
+                            ))));
+                        }
+                        if method_name == "promisify" {
+                            return Ok(Expr::SymbolFor(Box::new(Expr::String(
+                                "nodejs.util.promisify.custom".to_string(),
+                            ))));
+                        }
                     }
                 }
             }
             // Case B: `util.inspect.custom` where `util` is a whole-module
             // alias (`import * as util from "node:util"` or
-            // `import util from "node:util"`).
+            // `import util from "node:util"`), and the analogous
+            // `util.promisify.custom`.
             if let ast::Expr::Member(inner) = member.obj.as_ref() {
                 if let (ast::Expr::Ident(obj_ident), ast::MemberProp::Ident(inner_prop)) =
                     (inner.obj.as_ref(), &inner.prop)
@@ -504,10 +511,20 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     let obj_name = obj_ident.sym.to_string();
                     let is_util_module = obj_name == "util"
                         || ctx.lookup_builtin_module_alias(&obj_name) == Some("util");
-                    if is_util_module && inner_prop.sym.as_ref() == "inspect" {
-                        return Ok(Expr::SymbolFor(Box::new(Expr::String(
-                            "nodejs.util.inspect.custom".to_string(),
-                        ))));
+                    if is_util_module {
+                        match inner_prop.sym.as_ref() {
+                            "inspect" => {
+                                return Ok(Expr::SymbolFor(Box::new(Expr::String(
+                                    "nodejs.util.inspect.custom".to_string(),
+                                ))));
+                            }
+                            "promisify" => {
+                                return Ok(Expr::SymbolFor(Box::new(Expr::String(
+                                    "nodejs.util.promisify.custom".to_string(),
+                                ))));
+                            }
+                            _ => {}
+                        }
                     }
                 }
             }

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -203,6 +203,14 @@ pub(crate) fn bound_native_callable_export_value(module_name: &str, property_nam
         );
     }
 
+    if module_name == "util" && property_name == "promisify" {
+        crate::closure::closure_set_dynamic_prop(
+            (value.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize,
+            "custom",
+            crate::util_promisify::promisify_custom_symbol(),
+        );
+    }
+
     NATIVE_CALLABLE_EXPORTS.with(|c| {
         c.borrow_mut().insert(key, value.to_bits());
     });

--- a/crates/perry-runtime/src/util_promisify.rs
+++ b/crates/perry-runtime/src/util_promisify.rs
@@ -38,6 +38,7 @@ use crate::promise::{js_promise_new, js_promise_reject, js_promise_resolve, Prom
 use crate::value::{JSValue, POINTER_MASK, POINTER_TAG, TAG_MASK, TAG_NULL, TAG_UNDEFINED};
 
 const TAG_UNDEFINED_F64: f64 = unsafe { std::mem::transmute::<u64, f64>(TAG_UNDEFINED) };
+const PROMISIFY_CUSTOM_KEY: &[u8] = b"nodejs.util.promisify.custom";
 
 fn nanbox_pointer(ptr: *const u8) -> f64 {
     f64::from_bits(JSValue::pointer(ptr).bits())
@@ -50,6 +51,53 @@ fn nanbox_promise(p: *mut Promise) -> f64 {
 fn err_is_nullish(err: f64) -> bool {
     let bits = err.to_bits();
     bits == TAG_UNDEFINED || bits == TAG_NULL
+}
+
+pub(crate) fn promisify_custom_symbol() -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let key = crate::string::js_string_from_bytes(
+        PROMISIFY_CUSTOM_KEY.as_ptr(),
+        PROMISIFY_CUSTOM_KEY.len() as u32,
+    );
+    let key_handle = scope.root_string_ptr(key);
+    let key_value = f64::from_bits(
+        JSValue::string_ptr(key_handle.get_raw_const_ptr::<crate::StringHeader>() as *mut _).bits(),
+    );
+    unsafe { crate::symbol::js_symbol_for(key_value) }
+}
+
+fn is_callable_closure(value: f64) -> bool {
+    let bits = value.to_bits();
+    if (bits & TAG_MASK) != POINTER_TAG {
+        return false;
+    }
+    let ptr = (bits & POINTER_MASK) as usize;
+    crate::closure::is_closure_ptr(ptr)
+}
+
+fn custom_promisified_value(fn_value: f64) -> Option<f64> {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let fn_handle = scope.root_nanbox_f64(fn_value);
+    let custom_symbol = promisify_custom_symbol();
+    let symbol_handle = scope.root_nanbox_f64(custom_symbol);
+    let custom_value = unsafe {
+        crate::symbol::js_object_get_symbol_property(
+            fn_handle.get_nanbox_f64(),
+            symbol_handle.get_nanbox_f64(),
+        )
+    };
+    if !is_callable_closure(custom_value) {
+        return None;
+    }
+    let custom_handle = scope.root_nanbox_f64(custom_value);
+    unsafe {
+        crate::symbol::js_object_set_symbol_property(
+            custom_handle.get_nanbox_f64(),
+            symbol_handle.get_nanbox_f64(),
+            custom_handle.get_nanbox_f64(),
+        );
+    }
+    Some(custom_handle.get_nanbox_f64())
 }
 
 fn register_thunks_once() {
@@ -85,6 +133,10 @@ pub extern "C" fn js_util_promisify(fn_value: f64) -> f64 {
     let tag = bits & TAG_MASK;
     if tag != POINTER_TAG {
         return fn_value;
+    }
+
+    if let Some(custom) = custom_promisified_value(fn_value) {
+        return custom;
     }
 
     // #1857: `child_process.exec` / `execFile` carry a Node custom-promisify

--- a/test-parity/node-suite/util/promisify/custom-and-this.ts
+++ b/test-parity/node-suite/util/promisify/custom-and-this.ts
@@ -1,5 +1,6 @@
 import { promisify } from "node:util";
 
+console.log("custom symbol:", promisify.custom === Symbol.for("nodejs.util.promisify.custom"));
 const obj = {
   value: 5,
   add(x: number, cb: Function) { cb(null, this.value + x); },


### PR DESCRIPTION
## Summary
- expose util.promisify.custom as the registered Symbol.for('nodejs.util.promisify.custom') value
- make util.promisify return a callable symbol-keyed custom hook before falling back to the standard wrapper
- extend the util promisify parity fixture to verify the symbol identity and custom hook result while preserving existing this/first-value behavior

## DeepWiki
- reference/deepwiki/nodejs-node-util-promisify-custom-2026-05-28.md

## Verification
- ./run_parity_tests.sh --suite=node-suite --module=util --filter custom-and-this (PASS, report test-parity/reports/parity_report_20260528_020259.json)
- ./run_parity_tests.sh --suite=node-suite --module=util --filter promisify (PASS, report test-parity/reports/parity_report_20260528_020344.json)
- ./run_parity_tests.sh --suite=node-suite --module=util --filter custom-hook (PASS, report test-parity/reports/parity_report_20260528_020351.json)
- cargo test -p perry-runtime --lib util_promisify -- --nocapture (PASS, 0 matched tests)
- cargo fmt --check (PASS)
- git diff --check (PASS)
- ./scripts/check_file_size.sh (PASS)