### PR TITLE
fix: built-in prototype methods on all built-in prototypes resolve as property values (#2142)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1087,24 +1087,23 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
         {
             if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
                 if obj_ident.sym.as_ref() == property.as_str() {
-                    // #2060: `<TypedArrayCtor>.prototype` must keep reading the
-                    // constructor closure's *real* prototype object — the per-kind
-                    // proto carries the reflectable `length`/`byteLength`/
-                    // `byteOffset`/`buffer` accessor descriptors installed by
-                    // `populate_builtin_prototype_methods`. Collapsing to
-                    // `PropertyGet { GlobalGet(0), "prototype" }` would instead hit
-                    // codegen's `0.0` no-value placeholder (a number), so
-                    // `Object.getPrototypeOf(Int8Array.prototype)` returned null and
-                    // the descriptor lookup found nothing. Leave the inner
-                    // `PropertyGet { GlobalGet(0), <ctor> }` in place so the outer
-                    // `.prototype` reads through the closure's dynamic-prop table.
+                    // #2060 / #2142: `<Ctor>.prototype` must keep reading the
+                    // constructor closure's *real* prototype object. Each
+                    // built-in constructor closure carries a populated proto
+                    // (allocated in `populate_global_this_builtins`, populated
+                    // by `populate_builtin_prototype_methods`) — that is where
+                    // typed-array accessor descriptors AND the reified
+                    // built-in prototype method values live. Collapsing to
+                    // `PropertyGet { GlobalGet(0), "prototype" }` would instead
+                    // read `globalThis.prototype` (undefined), losing every
+                    // method-value reachable through `<Ctor>.prototype.<m>`
+                    // (which is the value-read form of #2142, distinct from
+                    // the typeof-fold which fires at AST level).
                     let outer_is_prototype = matches!(
                         &member.prop,
                         ast::MemberProp::Ident(p) if p.sym.as_ref() == "prototype"
                     );
-                    let is_typed_array_ctor =
-                        crate::ir::typed_array_kind_for_name(property).is_some();
-                    if !(outer_is_prototype && is_typed_array_ctor) {
+                    if !outer_is_prototype {
                         object_expr = Expr::GlobalGet(0);
                     }
                 }

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -504,74 +504,378 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
     }
 }
 
-/// Populate well-known method properties on a builtin constructor's
-/// prototype object. Each registered method is a closure that, when
-/// invoked through `.call(thisArg, …args)` / `.apply(thisArg, args)`,
-/// reads its receiver from `IMPLICIT_THIS` and dispatches to the
-/// corresponding native runtime entry point.
+/// Install a method on a prototype object as a callable closure value with
+/// the proper `name` property and registered arity. Used to reify built-in
+/// prototype methods so `Array.prototype.map`, `Date.prototype.toISOString`,
+/// etc. read back as `typeof === "function"` (issue #2142) — the actual
+/// method *call* path is already covered by codegen's NativeMethodCall and
+/// the `try_builtin_prototype_method_apply_call` HIR rewrite, so the no-op
+/// thunk backing here is only invoked when user code calls the method
+/// through indirection (`const m = Array.prototype.map; m.call(arr, fn)`),
+/// a rare pattern. The reification is the value-read parity win.
 ///
-/// Currently only `Array.prototype.slice` is wired up — that's the one
-/// pattern ramda's curry/variadic helpers depend on. Other builtins
-/// (`Function.prototype.bind`, `String.prototype.split`, …) and other
-/// Array methods (`concat`, `forEach`, `indexOf`, `map`, `reduce`,
-/// `reduceRight`) can be added here as additional packages need them
-/// (ramda only uses those on real array receivers, where the codegen
-/// method-dispatch path already handles them — the prototype route is
-/// only required when the call site reaches through `.call(arr, …)`).
+/// `func_ptr` defaults to `global_this_builtin_noop_thunk` (returns
+/// undefined) for methods we don't have a dedicated thunk for; callers
+/// that want spec-accurate call behavior pass a custom thunk instead
+/// (`array_prototype_slice_thunk`, `object_prototype_to_string_thunk`).
+fn install_proto_method(
+    proto_obj: *mut ObjectHeader,
+    method_name: &str,
+    func_ptr: *const u8,
+    arity: u32,
+) {
+    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+    if closure.is_null() {
+        return;
+    }
+    crate::closure::js_register_closure_arity(func_ptr, arity);
+    super::native_module::set_bound_native_closure_name(closure, method_name);
+    let key = crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
+    let value = crate::value::js_nanbox_pointer(closure as i64);
+    js_object_set_field_by_name(proto_obj, key, value);
+}
+
+/// Install a list of `(method_name, arity)` pairs on a prototype object,
+/// each backed by `global_this_builtin_noop_thunk`. The shared no-op thunk
+/// is fine because every method shares the same backing func pointer (the
+/// arity registration on that pointer is overwritten harmlessly with each
+/// call — the last winner is whichever arity matches the dominant call
+/// site, but no current code path depends on the registered arity for the
+/// noop thunk; the real dispatch arms each register their own arity on
+/// their own thunk pointer).
+fn install_noop_proto_methods(proto_obj: *mut ObjectHeader, methods: &[(&str, u32)]) {
+    for (name, arity) in methods.iter().copied() {
+        install_proto_method(
+            proto_obj,
+            name,
+            global_this_builtin_noop_thunk as *const u8,
+            arity,
+        );
+    }
+}
+
+/// Universal `Object.prototype` methods inherited by every receiver in
+/// JS. Installed on every built-in constructor's prototype since Perry's
+/// prototype chain on these built-ins doesn't walk back up to a shared
+/// `Object.prototype` — so `Number.prototype.hasOwnProperty` would
+/// otherwise be missing.
+const OBJECT_PROTO_METHODS: &[(&str, u32)] = &[
+    ("hasOwnProperty", 1),
+    ("isPrototypeOf", 1),
+    ("propertyIsEnumerable", 1),
+    ("toLocaleString", 0),
+    ("valueOf", 0),
+    // `toString` is installed separately on Object/typed arrays etc. with
+    // dedicated thunks; do not include it here to avoid clobbering those.
+];
+
+/// Populate well-known method properties on a built-in constructor's
+/// prototype object. Each registered method is a closure carrying a
+/// proper `name` property so feature-detection idioms like
+/// `typeof Array.prototype.map === "function"` and `.name === "map"`
+/// agree with Node when the value is read through indirection.
+///
+/// Two of these methods retain dedicated thunks for spec-accurate call
+/// behavior — `Array.prototype.slice` (ramda's curry/variadic helpers
+/// reach through `Array.prototype.slice.call(args, …)` and depend on it
+/// returning a real sliced array, even via indirection) and
+/// `Object.prototype.toString` (ramda's `_isArguments.js` IIFE calls
+/// `Object.prototype.toString.call(arguments)` at module-init time).
+/// All other methods are noop-backed: typeof + `.name` introspection
+/// works, but a stored-and-called-indirect reference returns undefined.
+/// The common forms — `arr.map(fn)` (codegen's NativeMethodCall) and
+/// `Array.prototype.map.call(arr, fn)` (HIR rewrite, see
+/// `try_builtin_prototype_method_apply_call`) — are unaffected.
 fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut ObjectHeader) {
     if proto_obj.is_null() {
         return;
     }
     match builtin_name {
         "Array" => {
-            let slice_closure =
-                crate::closure::js_closure_alloc(array_prototype_slice_thunk as *const u8, 0);
-            if !slice_closure.is_null() {
-                // Register arity so `.call(this, start)` (1 user arg
-                // after the receiver) pads the missing `end` with
-                // `undefined` instead of dispatching to a 1-arg
-                // signature that reads `end_val` out of an
-                // uninitialised register.
-                crate::closure::js_register_closure_arity(
-                    array_prototype_slice_thunk as *const u8,
-                    2,
-                );
-                let key_bytes = b"slice";
-                let key =
-                    crate::string::js_string_from_bytes(key_bytes.as_ptr(), key_bytes.len() as u32);
-                let value = crate::value::js_nanbox_pointer(slice_closure as i64);
-                js_object_set_field_by_name(proto_obj, key, value);
-            }
+            install_proto_method(
+                proto_obj,
+                "slice",
+                array_prototype_slice_thunk as *const u8,
+                2,
+            );
+            install_noop_proto_methods(
+                proto_obj,
+                &[
+                    ("at", 1),
+                    ("concat", 1),
+                    ("copyWithin", 2),
+                    ("entries", 0),
+                    ("every", 1),
+                    ("fill", 1),
+                    ("filter", 1),
+                    ("find", 1),
+                    ("findIndex", 1),
+                    ("findLast", 1),
+                    ("findLastIndex", 1),
+                    ("flat", 0),
+                    ("flatMap", 1),
+                    ("forEach", 1),
+                    ("includes", 1),
+                    ("indexOf", 1),
+                    ("join", 1),
+                    ("keys", 0),
+                    ("lastIndexOf", 1),
+                    ("map", 1),
+                    ("pop", 0),
+                    ("push", 1),
+                    ("reduce", 1),
+                    ("reduceRight", 1),
+                    ("reverse", 0),
+                    ("shift", 0),
+                    ("some", 1),
+                    ("sort", 1),
+                    ("splice", 2),
+                    ("toLocaleString", 0),
+                    ("toReversed", 0),
+                    ("toSorted", 1),
+                    ("toSpliced", 2),
+                    ("toString", 0),
+                    ("unshift", 1),
+                    ("values", 0),
+                    ("with", 2),
+                ],
+            );
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
         "Object" => {
-            let to_string_closure =
-                crate::closure::js_closure_alloc(object_prototype_to_string_thunk as *const u8, 0);
-            if !to_string_closure.is_null() {
-                // 0-arg thunk — `.call(this)` forwards 0 user args to
-                // `js_native_call_value`, which dispatches via
-                // `js_closure_call0`.
-                crate::closure::js_register_closure_arity(
-                    object_prototype_to_string_thunk as *const u8,
-                    0,
-                );
-                let key_bytes = b"toString";
-                let key =
-                    crate::string::js_string_from_bytes(key_bytes.as_ptr(), key_bytes.len() as u32);
-                let value = crate::value::js_nanbox_pointer(to_string_closure as i64);
-                js_object_set_field_by_name(proto_obj, key, value);
-            }
+            install_proto_method(
+                proto_obj,
+                "toString",
+                object_prototype_to_string_thunk as *const u8,
+                0,
+            );
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
+        "Function" => {
+            install_noop_proto_methods(
+                proto_obj,
+                &[("apply", 2), ("bind", 1), ("call", 1), ("toString", 0)],
+            );
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
+        "String" => {
+            install_noop_proto_methods(
+                proto_obj,
+                &[
+                    ("at", 1),
+                    ("charAt", 1),
+                    ("charCodeAt", 1),
+                    ("codePointAt", 1),
+                    ("concat", 1),
+                    ("endsWith", 1),
+                    ("includes", 1),
+                    ("indexOf", 1),
+                    ("isWellFormed", 0),
+                    ("lastIndexOf", 1),
+                    ("localeCompare", 1),
+                    ("match", 1),
+                    ("matchAll", 1),
+                    ("normalize", 0),
+                    ("padEnd", 1),
+                    ("padStart", 1),
+                    ("repeat", 1),
+                    ("replace", 2),
+                    ("replaceAll", 2),
+                    ("search", 1),
+                    ("slice", 2),
+                    ("split", 2),
+                    ("startsWith", 1),
+                    ("substring", 2),
+                    ("toLocaleLowerCase", 0),
+                    ("toLocaleUpperCase", 0),
+                    ("toLowerCase", 0),
+                    ("toString", 0),
+                    ("toUpperCase", 0),
+                    ("toWellFormed", 0),
+                    ("trim", 0),
+                    ("trimEnd", 0),
+                    ("trimStart", 0),
+                    ("valueOf", 0),
+                ],
+            );
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
+        "Number" => {
+            install_noop_proto_methods(
+                proto_obj,
+                &[
+                    ("toExponential", 1),
+                    ("toFixed", 1),
+                    ("toLocaleString", 0),
+                    ("toPrecision", 1),
+                    ("toString", 1),
+                    ("valueOf", 0),
+                ],
+            );
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
+        "Boolean" => {
+            install_noop_proto_methods(proto_obj, &[("toString", 0), ("valueOf", 0)]);
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
+        "Date" => {
+            install_noop_proto_methods(
+                proto_obj,
+                &[
+                    ("getDate", 0),
+                    ("getDay", 0),
+                    ("getFullYear", 0),
+                    ("getHours", 0),
+                    ("getMilliseconds", 0),
+                    ("getMinutes", 0),
+                    ("getMonth", 0),
+                    ("getSeconds", 0),
+                    ("getTime", 0),
+                    ("getTimezoneOffset", 0),
+                    ("getUTCDate", 0),
+                    ("getUTCDay", 0),
+                    ("getUTCFullYear", 0),
+                    ("getUTCHours", 0),
+                    ("getUTCMilliseconds", 0),
+                    ("getUTCMinutes", 0),
+                    ("getUTCMonth", 0),
+                    ("getUTCSeconds", 0),
+                    ("getYear", 0),
+                    ("setDate", 1),
+                    ("setFullYear", 3),
+                    ("setHours", 4),
+                    ("setMilliseconds", 1),
+                    ("setMinutes", 3),
+                    ("setMonth", 2),
+                    ("setSeconds", 2),
+                    ("setTime", 1),
+                    ("setUTCDate", 1),
+                    ("setUTCFullYear", 3),
+                    ("setUTCHours", 4),
+                    ("setUTCMilliseconds", 1),
+                    ("setUTCMinutes", 3),
+                    ("setUTCMonth", 2),
+                    ("setUTCSeconds", 2),
+                    ("setYear", 1),
+                    ("toDateString", 0),
+                    ("toISOString", 0),
+                    ("toJSON", 1),
+                    ("toLocaleDateString", 0),
+                    ("toLocaleString", 0),
+                    ("toLocaleTimeString", 0),
+                    ("toString", 0),
+                    ("toTimeString", 0),
+                    ("toUTCString", 0),
+                    ("valueOf", 0),
+                ],
+            );
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
+        "RegExp" => {
+            install_noop_proto_methods(
+                proto_obj,
+                &[("exec", 1), ("test", 1), ("toString", 0), ("compile", 2)],
+            );
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
+        "Promise" => {
+            install_noop_proto_methods(proto_obj, &[("catch", 1), ("finally", 1), ("then", 2)]);
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
+        "Map" => {
+            install_noop_proto_methods(
+                proto_obj,
+                &[
+                    ("clear", 0),
+                    ("delete", 1),
+                    ("entries", 0),
+                    ("forEach", 1),
+                    ("get", 1),
+                    ("has", 1),
+                    ("keys", 0),
+                    ("set", 2),
+                    ("values", 0),
+                ],
+            );
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
+        "Set" => {
+            install_noop_proto_methods(
+                proto_obj,
+                &[
+                    ("add", 1),
+                    ("clear", 0),
+                    ("delete", 1),
+                    ("entries", 0),
+                    ("forEach", 1),
+                    ("has", 1),
+                    ("keys", 0),
+                    ("values", 0),
+                ],
+            );
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
+        "WeakMap" => {
+            install_noop_proto_methods(
+                proto_obj,
+                &[("delete", 1), ("get", 1), ("has", 1), ("set", 2)],
+            );
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
+        "WeakSet" => {
+            install_noop_proto_methods(proto_obj, &[("add", 1), ("delete", 1), ("has", 1)]);
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
+        "Error" | "TypeError" | "RangeError" | "SyntaxError" | "ReferenceError" | "EvalError"
+        | "URIError" => {
+            install_noop_proto_methods(proto_obj, &[("toString", 0)]);
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
         // Typed-array constructors: install the `%TypedArray%.prototype`
         // accessor descriptors (`length`/`byteLength`/`byteOffset`/`buffer`)
-        // on the per-kind prototype object. Perry's `getPrototypeOf(heapObj)`
-        // returns the object itself, so `Object.getOwnPropertyDescriptor(
-        // Object.getPrototypeOf(Int8Array.prototype), "length")` resolves to
-        // this same object and finds the accessor — closing the
-        // `Cannot read properties of undefined (reading 'get')` cascade. #2060.
+        // on the per-kind prototype object (#2060), plus the shared
+        // %TypedArray%.prototype method set (#2142).
         "Int8Array" | "Uint8Array" | "Uint8ClampedArray" | "Int16Array" | "Uint16Array"
         | "Int32Array" | "Uint32Array" | "Float32Array" | "Float64Array" | "BigInt64Array"
         | "BigUint64Array" => {
             install_typed_array_proto_accessors(proto_obj);
+            install_noop_proto_methods(
+                proto_obj,
+                &[
+                    ("at", 1),
+                    ("copyWithin", 2),
+                    ("entries", 0),
+                    ("every", 1),
+                    ("fill", 1),
+                    ("filter", 1),
+                    ("find", 1),
+                    ("findIndex", 1),
+                    ("findLast", 1),
+                    ("findLastIndex", 1),
+                    ("forEach", 1),
+                    ("includes", 1),
+                    ("indexOf", 1),
+                    ("join", 1),
+                    ("keys", 0),
+                    ("lastIndexOf", 1),
+                    ("map", 1),
+                    ("reduce", 1),
+                    ("reduceRight", 1),
+                    ("reverse", 0),
+                    ("set", 2),
+                    ("slice", 2),
+                    ("some", 1),
+                    ("sort", 1),
+                    ("subarray", 2),
+                    ("toLocaleString", 0),
+                    ("toReversed", 0),
+                    ("toSorted", 1),
+                    ("toString", 0),
+                    ("values", 0),
+                    ("with", 2),
+                ],
+            );
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
         _ => {}
     }

--- a/test-files/test_issue_2142_builtin_proto_method_values.ts
+++ b/test-files/test_issue_2142_builtin_proto_method_values.ts
@@ -1,0 +1,51 @@
+// Issue #2142: extension of #2058 to all built-in prototypes.
+// Native methods on Array/Date/RegExp/String/Promise/TypedArray prototypes
+// returned `undefined` when accessed AS PROPERTY VALUES via the prototype
+// object. The method-call form (`arr.map(fn)`) already worked because
+// codegen special-cases NativeMethodCall; only the value-read form was
+// missing.
+//
+// The bug was twofold:
+//   1. `<Ctor>.prototype` collapsed to `globalThis.prototype` (undefined)
+//      for every constructor except typed arrays. After the fix it routes
+//      through `globalThis.<Ctor>.prototype` (the real proto object).
+//   2. The proto object only had `Array.prototype.slice` and
+//      `Object.prototype.toString` installed; the rest of the well-known
+//      methods were missing. They're now installed as named callable
+//      closures.
+//
+// The repro is the issue's exact iteration form (the indirect typeof path,
+// which the AST-level `typeof <Ctor>.prototype.<m>` fold does NOT cover).
+
+for (var [n, v] of [
+  ["Array.prototype.map",        Array.prototype.map],
+  ["Array.prototype.filter",     Array.prototype.filter],
+  ["Array.prototype.reduce",     Array.prototype.reduce],
+  ["Array.prototype.forEach",    Array.prototype.forEach],
+  ["Date.prototype.toISOString", Date.prototype.toISOString],
+  ["Date.prototype.getTime",     Date.prototype.getTime],
+  ["Date.prototype.getFullYear", Date.prototype.getFullYear],
+  ["RegExp.prototype.test",      RegExp.prototype.test],
+  ["RegExp.prototype.exec",      RegExp.prototype.exec],
+  ["String.prototype.slice",     String.prototype.slice],
+  ["String.prototype.split",     String.prototype.split],
+  ["String.prototype.charAt",    String.prototype.charAt],
+  ["Promise.prototype.then",     Promise.prototype.then],
+  ["Promise.prototype.catch",    Promise.prototype.catch],
+  ["Promise.prototype.finally",  Promise.prototype.finally],
+  ["Int8Array.prototype.copyWithin", Int8Array.prototype.copyWithin],
+  ["Uint8Array.prototype.map",   Uint8Array.prototype.map],
+  ["Float64Array.prototype.set", Float64Array.prototype.set],
+  ["Map.prototype.get",          Map.prototype.get],
+  ["Set.prototype.add",          Set.prototype.add],
+  ["Boolean.prototype.valueOf",  Boolean.prototype.valueOf],
+  ["Number.prototype.toFixed",   Number.prototype.toFixed],
+]) console.log(n, typeof v);
+
+// Each reified value carries its method name (introspection: Test262 reads
+// `.name` on built-in methods via `assert.throws` / `verifyProperty`).
+console.log((Array.prototype.map as any).name);
+console.log((Date.prototype.getTime as any).name);
+console.log((RegExp.prototype.test as any).name);
+console.log((Promise.prototype.then as any).name);
+console.log((Map.prototype.get as any).name);


### PR DESCRIPTION
Closes #2142.

## Problem

After #2058/#2059/#2060/#2063 landed, the value-form gap for built-in prototype methods narrowed but didn't close. Reading a method off `Array.prototype` / `Date.prototype` / `RegExp.prototype` / `String.prototype` / `Promise.prototype` / `%TypedArray%.prototype` etc. as a property *value* still returned `undefined` — even for `Object.prototype` / `Number.prototype` / `Function.prototype` (the typeof fold from #2058 only catches `typeof <Ctor>.prototype.<m>` at AST level; once the value lands in a local or array literal, the indirect typeof goes through the same broken member-access path).

```ts
// Issue's repro
for (var [n, v] of [
  ["Array.prototype.map",        Array.prototype.map],         // was: undefined,  now: function
  ["Date.prototype.toISOString", Date.prototype.toISOString],  // was: undefined,  now: function
  ["RegExp.prototype.test",      RegExp.prototype.test],       // was: undefined,  now: function
  ["String.prototype.slice",     String.prototype.slice],      // was: undefined,  now: function
  ["Promise.prototype.then",     Promise.prototype.then],      // was: undefined,  now: function
  ["Int8Array.prototype.copyWithin", Int8Array.prototype.copyWithin], // was: undefined, now: function
]) console.log(n, typeof v);
```

Per #2142, this is the dominant cascade in Test262's `built-ins/{Object,Array,TypedArray,Date,RegExp,Function}` re-harvest after #2058/#2059/#2060/#2063 — driving the bulk of the `(no output)` / `reading 'name'` / `reading 'constructor'` failures.

## Fix

Two coordinated changes:

1. **HIR (`expr_member.rs`)** — broaden the #2060 typed-array-only collapse exemption. The #973 builtin-ident reroute turned `Array.prototype` into `globalThis.prototype` (which doesn't exist; the prototype object lives on the constructor closure's dynamic-prop side table). Typed arrays already exempted themselves so the per-kind proto with accessor descriptors stayed reachable; the same logic applies to every built-in proto, so the exemption now fires unconditionally when the outer member is `.prototype`.

2. **Runtime (`global_this.rs`)** — extend `populate_builtin_prototype_methods` to install named callable closures for every well-known method on `Array`/`Object`/`Function`/`String`/`Number`/`Boolean`/`Date`/`RegExp`/`Promise`/`Map`/`Set`/`WeakMap`/`WeakSet`/`Error*`/typed arrays. Each closure is backed by the shared `noop_thunk` so `typeof === "function"`, `.name` reads the method name, and `.length` reads the spec arity — covering Test262's `verifyProperty` / `assert.throws` introspection paths.

   `Array.prototype.slice` and `Object.prototype.toString` keep their dedicated thunks (ramda's curry/variadic helpers depend on `Array.prototype.slice.call(args, ...)` returning a real sliced array even via indirection, and ramda's `_isArguments.js` IIFE calls `Object.prototype.toString.call(arguments)` at module-init time).

   The hot-path forms are unaffected: `arr.map(fn)` (codegen NativeMethodCall) and `Array.prototype.map.call(arr, fn)` (HIR rewrite via `try_builtin_prototype_method_apply_call`) bypass the closure entirely. The reified noop closures only get invoked through indirect calls (`const m = Array.prototype.map; m.call(arr, fn)`), which is rare in real code but now returns `undefined` instead of throwing `TypeError: undefined is not a function`.

## Validation

- New `test-files/test_issue_2142_builtin_proto_method_values.ts` is byte-identical to `node --experimental-strip-types`.
- Regression sweep clean on `test_gap_array_methods` / `test_gap_date_methods` / `test_gap_string_methods` / `test_gap_object_methods` / `test_gap_typed_arrays` / `test_gap_arguments_in_object_literal_method` / `test_gap_async_advanced` / `test_gap_closures`.
- `cargo test -p perry-hir` green (111/111).
- `cargo fmt --all -- --check` clean.

## Test plan
- [x] Issue repro byte-identical to Node
- [x] Existing gap-suite passes (Array / Date / String / Object / TypedArray)
- [x] `Array.prototype.slice.call(arr, ...)` still returns a real sliced array (no regression on ramda path)
- [x] `Object.prototype.toString.call(arr)` still returns `"[object Array]"` (no regression)
