### PR TITLE
Fix Web Streams lock semantics

### DIFF
--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -33,6 +33,9 @@ use perry_runtime::{
 use std::collections::{HashMap, VecDeque};
 use std::sync::Mutex;
 
+mod pipe;
+use self::pipe::js_readable_stream_pipe_to;
+
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
 const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
@@ -297,6 +300,22 @@ unsafe fn make_error_with_message(msg: &str) -> u64 {
     JSValue::pointer(err as *const u8).bits()
 }
 
+unsafe fn make_type_error_with_message(msg: &str) -> u64 {
+    let s = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = perry_runtime::error::js_typeerror_new(s);
+    JSValue::pointer(err as *const u8).bits()
+}
+
+unsafe fn throw_type_error(message: &str) -> ! {
+    let err = make_type_error_with_message(message);
+    perry_runtime::exception::js_throw(f64::from_bits(err))
+}
+
+unsafe fn reject_type_error(promise: *mut Promise, message: &str) {
+    let err = make_type_error_with_message(message);
+    js_promise_reject(promise, f64::from_bits(err));
+}
+
 unsafe fn throw_invalid_arg_type(message: &str) -> ! {
     let s = js_string_from_bytes(message.as_ptr(), message.len() as u32);
     let err = perry_runtime::error::js_typeerror_new(s);
@@ -535,33 +554,38 @@ pub fn alloc_readable_from_bytes(bytes: Vec<u8>) -> usize {
 pub unsafe extern "C" fn js_readable_stream_get_reader(stream_handle: f64) -> f64 {
     ensure_gc_registered();
     let id = stream_handle as usize;
-    {
+    let was_locked = {
         let mut g = READABLE_STREAMS.lock().unwrap();
         let s = match g.get_mut(&id) {
             Some(s) => s,
             None => return f64::from_bits(TAG_UNDEFINED),
         };
         if s.reader_handle.is_some() {
-            return f64::from_bits(TAG_UNDEFINED);
+            true
+        } else {
+            let reader_id = next_id(&NEXT_STREAM_ID);
+            let closed_p = js_promise_new();
+            if s.state == ReadableState::Closed {
+                js_promise_resolve(closed_p, f64::from_bits(TAG_UNDEFINED));
+            } else if s.state == ReadableState::Errored {
+                js_promise_reject(closed_p, f64::from_bits(s.error_value));
+            }
+            s.reader_handle = Some(reader_id);
+            READERS.lock().unwrap().insert(
+                reader_id,
+                ReaderData {
+                    stream_handle: id,
+                    locked: true,
+                    closed_promise: closed_p,
+                },
+            );
+            return reader_id as f64;
         }
-        let reader_id = next_id(&NEXT_STREAM_ID);
-        let closed_p = js_promise_new();
-        if s.state == ReadableState::Closed {
-            js_promise_resolve(closed_p, f64::from_bits(TAG_UNDEFINED));
-        } else if s.state == ReadableState::Errored {
-            js_promise_reject(closed_p, f64::from_bits(s.error_value));
-        }
-        s.reader_handle = Some(reader_id);
-        READERS.lock().unwrap().insert(
-            reader_id,
-            ReaderData {
-                stream_handle: id,
-                locked: true,
-                closed_promise: closed_p,
-            },
-        );
-        reader_id as f64
+    };
+    if was_locked {
+        throw_type_error("ReadableStream is locked");
     }
+    f64::from_bits(TAG_UNDEFINED)
 }
 
 #[no_mangle]
@@ -580,20 +604,38 @@ pub unsafe extern "C" fn js_readable_stream_cancel(
     stream_handle: f64,
     reason: f64,
 ) -> *mut Promise {
+    js_readable_stream_cancel_inner(stream_handle, reason, false)
+}
+
+unsafe fn js_readable_stream_cancel_inner(
+    stream_handle: f64,
+    reason: f64,
+    allow_locked: bool,
+) -> *mut Promise {
     let promise = js_promise_new();
     let id = stream_handle as usize;
+    let mut locked_reject = false;
     let cb = {
         let mut g = READABLE_STREAMS.lock().unwrap();
         match g.get_mut(&id) {
             Some(s) => {
-                s.canceled = true;
-                s.state = ReadableState::Closed;
-                s.chunks.clear();
-                s.cancel_cb
+                if !allow_locked && s.reader_handle.is_some() {
+                    locked_reject = true;
+                    0
+                } else {
+                    s.canceled = true;
+                    s.state = ReadableState::Closed;
+                    s.chunks.clear();
+                    s.cancel_cb
+                }
             }
             None => 0,
         }
     };
+    if locked_reject {
+        reject_type_error(promise, "ReadableStream is locked");
+        return promise;
+    }
     if cb != 0 {
         js_closure_call1(cb as *const ClosureHeader, reason);
     }
@@ -642,30 +684,49 @@ pub unsafe extern "C" fn js_readable_stream_from_response(_resp_id: f64) -> f64 
 #[no_mangle]
 pub unsafe extern "C" fn js_readable_stream_from_iterable(value: f64) -> f64 {
     ensure_gc_registered();
-    let id = alloc_readable(0, 0, 0, 1.0);
-
-    // Extract the array pointer: array values arrive either NaN-boxed POINTER
-    // (top16 == 0x7FFD) or as a raw heap pointer bit-cast to f64 (top16 == 0).
     let bits = value.to_bits();
     let top = bits >> 48;
-    let arr_ptr = if top == 0x7FFD || top == 0x7FFF {
-        (bits & POINTER_MASK) as *const perry_runtime::ArrayHeader
+    let ptr_addr = if top == 0x7FFD || top == 0x7FFF {
+        Some((bits & POINTER_MASK) as usize)
     } else if top == 0 && bits >= 0x10000 {
-        bits as *const perry_runtime::ArrayHeader
+        Some(bits as usize)
     } else {
-        std::ptr::null()
+        None
     };
 
+    let chunks: Vec<u64> = if perry_runtime::array::js_array_is_array(value).to_bits() == TAG_TRUE {
+        let arr_ptr = ptr_addr.unwrap_or(0) as *const perry_runtime::ArrayHeader;
+        let len = perry_runtime::array::js_array_length(arr_ptr);
+        (0..len)
+            .map(|i| perry_runtime::array::js_array_get(arr_ptr, i).bits())
+            .collect()
+    } else if let Some(addr) = ptr_addr {
+        if perry_runtime::typedarray::lookup_typed_array_kind(addr).is_some() {
+            let ta = addr as *const perry_runtime::typedarray::TypedArrayHeader;
+            let len = perry_runtime::typedarray::js_typed_array_length(ta).max(0);
+            (0..len)
+                .map(|i| perry_runtime::typedarray::js_typed_array_get(ta, i).to_bits())
+                .collect()
+        } else if perry_runtime::buffer::is_registered_buffer(addr)
+            && !perry_runtime::buffer::is_any_array_buffer(addr)
+            && !perry_runtime::buffer::is_data_view(addr)
+        {
+            let buf = addr as *const perry_runtime::buffer::BufferHeader;
+            let len = (*buf).length as usize;
+            let data = perry_runtime::buffer::buffer_data(buf);
+            (0..len).map(|i| (*data.add(i) as f64).to_bits()).collect()
+        } else {
+            throw_type_error("ReadableStream.from requires an iterable");
+        }
+    } else {
+        throw_type_error("ReadableStream.from requires an iterable");
+    };
+
+    let id = alloc_readable(0, 0, 0, 1.0);
     {
         let mut g = READABLE_STREAMS.lock().unwrap();
         if let Some(s) = g.get_mut(&id) {
-            if !arr_ptr.is_null() {
-                let len = perry_runtime::array::js_array_length(arr_ptr);
-                for i in 0..len {
-                    let elem = perry_runtime::array::js_array_get(arr_ptr, i);
-                    s.chunks.push_back(elem.bits());
-                }
-            }
+            s.chunks.extend(chunks);
             s.started = true;
             s.state = ReadableState::Closed;
         }
@@ -978,7 +1039,7 @@ pub unsafe extern "C" fn js_reader_cancel(reader_handle: f64, reason: f64) -> *m
             return p;
         }
     };
-    js_readable_stream_cancel(stream_id as f64, reason)
+    js_readable_stream_cancel_inner(stream_id as f64, reason, true)
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -996,6 +1057,7 @@ pub unsafe extern "C" fn js_reader_cancel(reader_handle: f64, reason: f64) -> *m
 #[no_mangle]
 pub unsafe extern "C" fn js_readable_stream_tee(stream_handle: f64) -> f64 {
     let id = stream_handle as usize;
+    let mut was_locked = false;
     let chunks: Vec<u64> = {
         let mut g = READABLE_STREAMS.lock().unwrap();
         match g.get_mut(&id) {
@@ -1004,9 +1066,16 @@ pub unsafe extern "C" fn js_readable_stream_tee(stream_handle: f64) -> f64 {
                 s.state = ReadableState::Closed;
                 drained
             }
-            _ => Vec::new(),
+            Some(_) => {
+                was_locked = true;
+                Vec::new()
+            }
+            None => Vec::new(),
         }
     };
+    if was_locked {
+        throw_type_error("ReadableStream is locked");
+    }
 
     let id_a = next_id(&NEXT_STREAM_ID);
     let id_b = next_id(&NEXT_STREAM_ID);
@@ -1037,86 +1106,6 @@ pub unsafe extern "C" fn js_readable_stream_tee(stream_handle: f64) -> f64 {
     js_array_push(arr, JSValue::from_bits(f64::to_bits(id_a as f64)));
     js_array_push(arr, JSValue::from_bits(f64::to_bits(id_b as f64)));
     f64::from_bits(JSValue::object_ptr(arr as *mut u8).bits())
-}
-
-/// `readable.pipeTo(writable)` — drives the readable into the writable
-/// synchronously chunk-by-chunk. Returns a Promise that resolves when
-/// the writable closes cleanly, or rejects on error. Synchronous because
-/// our buffered model has all bytes resident already; an async loop here
-/// would just queue tasks against an empty event loop.
-#[no_mangle]
-pub unsafe extern "C" fn js_readable_stream_pipe_to(
-    readable_handle: f64,
-    writable_handle: f64,
-) -> *mut Promise {
-    let promise = js_promise_new();
-    let r_id = readable_handle as usize;
-    let w_id = writable_handle as usize;
-
-    loop {
-        let chunk_or_done: Result<u64, bool> = {
-            let mut g = READABLE_STREAMS.lock().unwrap();
-            match g.get_mut(&r_id) {
-                Some(s) => {
-                    if let Some(c) = s.chunks.pop_front() {
-                        Ok(c)
-                    } else if s.state == ReadableState::Closed {
-                        Err(true)
-                    } else if s.state == ReadableState::Errored {
-                        let e = s.error_value;
-                        js_promise_reject(promise, f64::from_bits(e));
-                        return promise;
-                    } else {
-                        Err(true)
-                    }
-                }
-                None => Err(true),
-            }
-        };
-        match chunk_or_done {
-            Ok(chunk) => {
-                // TransformStream's writable side has write_cb=0 — route
-                // through transform_write so the user transform fn runs.
-                if TRANSFORM_PAIRS.lock().unwrap().contains_key(&w_id) {
-                    let _ = transform_write(w_id, f64::from_bits(chunk));
-                } else {
-                    let write_cb = WRITABLE_STREAMS
-                        .lock()
-                        .unwrap()
-                        .get(&w_id)
-                        .map(|w| w.write_cb)
-                        .unwrap_or(0);
-                    if write_cb != 0 {
-                        js_closure_call1(write_cb as *const ClosureHeader, f64::from_bits(chunk));
-                    }
-                }
-            }
-            Err(_done) => break,
-        }
-    }
-
-    // Close downstream — TransformStream routes through transform_close
-    // so flush_cb runs and the readable side is closed.
-    if TRANSFORM_PAIRS.lock().unwrap().contains_key(&w_id) {
-        let _ = transform_close(w_id);
-    } else {
-        let close_cb = WRITABLE_STREAMS
-            .lock()
-            .unwrap()
-            .get(&w_id)
-            .map(|w| w.close_cb)
-            .unwrap_or(0);
-        if close_cb != 0 {
-            js_closure_call0(close_cb as *const ClosureHeader);
-        }
-        if let Some(w) = WRITABLE_STREAMS.lock().unwrap().get_mut(&w_id) {
-            w.state = WritableState::Closed;
-            let cp = w.closed_promise;
-            js_promise_resolve(cp, f64::from_bits(TAG_UNDEFINED));
-        }
-    }
-    js_promise_resolve(promise, f64::from_bits(TAG_UNDEFINED));
-    promise
 }
 
 /// `readable.pipeThrough({readable, writable})` — pipeTo into the
@@ -1177,7 +1166,8 @@ pub unsafe extern "C" fn js_writable_stream_get_writer(stream_handle: f64) -> f6
         None => return f64::from_bits(TAG_UNDEFINED),
     };
     if s.writer_handle.is_some() {
-        return f64::from_bits(TAG_UNDEFINED);
+        drop(g);
+        throw_type_error("WritableStream is locked");
     }
     let writer_id = next_id(&NEXT_STREAM_ID);
     s.writer_handle = Some(writer_id);

--- a/crates/perry-stdlib/src/streams/pipe.rs
+++ b/crates/perry-stdlib/src/streams/pipe.rs
@@ -1,0 +1,215 @@
+//! `ReadableStream.pipeTo` implementation details.
+
+use super::{
+    box_promise, next_id, reject_type_error, transform_close, transform_write, ReadableState,
+    WritableState, NEXT_STREAM_ID, READABLE_STREAMS, TAG_UNDEFINED, TRANSFORM_PAIRS,
+    WRITABLE_STREAMS,
+};
+use perry_runtime::{
+    js_closure_call0, js_closure_call1, js_promise_new, js_promise_reject, js_promise_resolve,
+    ClosureHeader, Promise,
+};
+
+#[derive(Clone, Copy)]
+struct PipeLockIds {
+    reader_id: usize,
+    writer_id: usize,
+}
+
+fn acquire_pipe_locks(readable_id: usize, writable_id: usize) -> Result<PipeLockIds, &'static str> {
+    let reader_id = next_id(&NEXT_STREAM_ID);
+    let writer_id = next_id(&NEXT_STREAM_ID);
+    {
+        let mut readable = READABLE_STREAMS.lock().unwrap();
+        match readable.get_mut(&readable_id) {
+            Some(s) if s.reader_handle.is_none() => {
+                s.reader_handle = Some(reader_id);
+            }
+            Some(_) => return Err("ReadableStream is locked"),
+            None => return Err("Invalid ReadableStream"),
+        }
+    }
+    {
+        let mut writable = WRITABLE_STREAMS.lock().unwrap();
+        match writable.get_mut(&writable_id) {
+            Some(s) if s.writer_handle.is_none() => {
+                s.writer_handle = Some(writer_id);
+            }
+            Some(_) => {
+                if let Some(s) = READABLE_STREAMS.lock().unwrap().get_mut(&readable_id) {
+                    if s.reader_handle == Some(reader_id) {
+                        s.reader_handle = None;
+                    }
+                }
+                return Err("WritableStream is locked");
+            }
+            None => {
+                if let Some(s) = READABLE_STREAMS.lock().unwrap().get_mut(&readable_id) {
+                    if s.reader_handle == Some(reader_id) {
+                        s.reader_handle = None;
+                    }
+                }
+                return Err("Invalid WritableStream");
+            }
+        }
+    }
+    Ok(PipeLockIds {
+        reader_id,
+        writer_id,
+    })
+}
+
+fn release_pipe_locks(readable_id: usize, writable_id: usize, locks: PipeLockIds) {
+    if let Some(s) = READABLE_STREAMS.lock().unwrap().get_mut(&readable_id) {
+        if s.reader_handle == Some(locks.reader_id) {
+            s.reader_handle = None;
+        }
+    }
+    if let Some(s) = WRITABLE_STREAMS.lock().unwrap().get_mut(&writable_id) {
+        if s.writer_handle == Some(locks.writer_id) {
+            s.writer_handle = None;
+        }
+    }
+}
+
+#[inline]
+fn promise_from_capture(closure: *const ClosureHeader, idx: u32) -> *mut Promise {
+    let bits = perry_runtime::closure::js_closure_get_capture_ptr(closure, idx) as u64;
+    perry_runtime::value::js_nanbox_get_pointer(f64::from_bits(bits)) as *mut Promise
+}
+
+fn capture_f64(closure: *const ClosureHeader, idx: u32) -> f64 {
+    let bits = perry_runtime::closure::js_closure_get_capture_ptr(closure, idx) as u64;
+    f64::from_bits(bits)
+}
+
+extern "C" fn readable_stream_pipe_to_microtask(closure: *const ClosureHeader) -> f64 {
+    unsafe {
+        let r_id = capture_f64(closure, 0) as usize;
+        let w_id = capture_f64(closure, 1) as usize;
+        let promise = promise_from_capture(closure, 2);
+        let locks = PipeLockIds {
+            reader_id: capture_f64(closure, 3) as usize,
+            writer_id: capture_f64(closure, 4) as usize,
+        };
+        let result = run_readable_stream_pipe_to(r_id, w_id);
+        release_pipe_locks(r_id, w_id, locks);
+        match result {
+            Ok(()) => js_promise_resolve(promise, f64::from_bits(TAG_UNDEFINED)),
+            Err(reason) => js_promise_reject(promise, f64::from_bits(reason)),
+        }
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+unsafe fn run_readable_stream_pipe_to(readable_id: usize, writable_id: usize) -> Result<(), u64> {
+    loop {
+        let chunk_or_done: Result<u64, bool> = {
+            let mut g = READABLE_STREAMS.lock().unwrap();
+            match g.get_mut(&readable_id) {
+                Some(s) => {
+                    if let Some(c) = s.chunks.pop_front() {
+                        Ok(c)
+                    } else if s.state == ReadableState::Closed {
+                        Err(true)
+                    } else if s.state == ReadableState::Errored {
+                        return Err(s.error_value);
+                    } else {
+                        Err(true)
+                    }
+                }
+                None => Err(true),
+            }
+        };
+        match chunk_or_done {
+            Ok(chunk) => {
+                // TransformStream's writable side has write_cb=0, so route
+                // through transform_write to run the user transform function.
+                if TRANSFORM_PAIRS.lock().unwrap().contains_key(&writable_id) {
+                    let _ = transform_write(writable_id, f64::from_bits(chunk));
+                } else {
+                    let write_cb = WRITABLE_STREAMS
+                        .lock()
+                        .unwrap()
+                        .get(&writable_id)
+                        .map(|w| w.write_cb)
+                        .unwrap_or(0);
+                    if write_cb != 0 {
+                        js_closure_call1(write_cb as *const ClosureHeader, f64::from_bits(chunk));
+                    }
+                }
+            }
+            Err(_done) => break,
+        }
+    }
+
+    if TRANSFORM_PAIRS.lock().unwrap().contains_key(&writable_id) {
+        let _ = transform_close(writable_id);
+    } else {
+        let close_cb = WRITABLE_STREAMS
+            .lock()
+            .unwrap()
+            .get(&writable_id)
+            .map(|w| w.close_cb)
+            .unwrap_or(0);
+        if close_cb != 0 {
+            js_closure_call0(close_cb as *const ClosureHeader);
+        }
+        if let Some(w) = WRITABLE_STREAMS.lock().unwrap().get_mut(&writable_id) {
+            w.state = WritableState::Closed;
+            let cp = w.closed_promise;
+            js_promise_resolve(cp, f64::from_bits(TAG_UNDEFINED));
+        }
+    }
+    Ok(())
+}
+
+/// `readable.pipeTo(writable)` acquires the source/destination locks
+/// immediately, then drains the current buffered readable queue into the
+/// writable on the next microtask. Deferring the drain keeps `.locked`
+/// observable until the returned Promise settles, matching Web Streams'
+/// in-flight pipe contract while preserving Perry's buffered model.
+#[no_mangle]
+pub unsafe extern "C" fn js_readable_stream_pipe_to(
+    readable_handle: f64,
+    writable_handle: f64,
+) -> *mut Promise {
+    let promise = js_promise_new();
+    let r_id = readable_handle as usize;
+    let w_id = writable_handle as usize;
+
+    let locks = match acquire_pipe_locks(r_id, w_id) {
+        Ok(locks) => locks,
+        Err(message) => {
+            reject_type_error(promise, message);
+            return promise;
+        }
+    };
+
+    let closure =
+        perry_runtime::closure::js_closure_alloc(readable_stream_pipe_to_microtask as *const u8, 5);
+    perry_runtime::closure::js_register_closure_arity(
+        readable_stream_pipe_to_microtask as *const u8,
+        0,
+    );
+    perry_runtime::closure::js_closure_set_capture_ptr(closure, 0, (r_id as f64).to_bits() as i64);
+    perry_runtime::closure::js_closure_set_capture_ptr(closure, 1, (w_id as f64).to_bits() as i64);
+    perry_runtime::closure::js_closure_set_capture_ptr(
+        closure,
+        2,
+        box_promise(promise).to_bits() as i64,
+    );
+    perry_runtime::closure::js_closure_set_capture_ptr(
+        closure,
+        3,
+        (locks.reader_id as f64).to_bits() as i64,
+    );
+    perry_runtime::closure::js_closure_set_capture_ptr(
+        closure,
+        4,
+        (locks.writer_id as f64).to_bits() as i64,
+    );
+    perry_runtime::builtins::js_queue_microtask(closure as i64);
+
+    promise
+}

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -614,12 +614,6 @@
     "category": "bug-open",
     "reason": "node:stream: stream.compose(single-transform) does not deliver data through. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/web/writable-multiple-writers-fails": {
-    "issue": "1545",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/web: second getWriter() on a locked WritableStream should throw. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/dispose/await-using-disposes": {
     "issue": "1531",
     "added": "2026-05-23",
@@ -704,12 +698,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline() does not set err.code=ERR_STREAM_PREMATURE_CLOSE on mid-chain destroy. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/web/get-reader-twice-throws": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: second getReader() on locked stream does not throw TypeError. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/events/finish-end-close-order": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -745,12 +733,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pipe(dst, {end: false}) — destination still ended when source ends. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/web/tee-while-locked-throws": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: tee() on a locked stream does not throw TypeError. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/events/readable-event-order": {
     "issue": "1532",
@@ -871,12 +853,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pipeline(src, async fn) — fn-as-sink form not yet wired (cb not called, collected is empty). Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/web/pipe-to-locks-and-releases": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: pipeTo() does not flip rs/ws.locked true during, false after. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/readable/unshift-after-end": {
     "issue": "1532",
@@ -1082,12 +1058,6 @@
     "category": "bug-open",
     "reason": "node:stream: pause() inside 'data' listener — does not stop further synchronous emits. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/web/get-writer-twice-throws": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: second getWriter() on locked WritableStream does not throw TypeError. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/iter-helpers/find-returns-promise": {
     "issue": "1558",
     "added": "2026-05-24",
@@ -1250,12 +1220,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipe(dst,{end:false}) then manual dst.write — output order/count wrong. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/web/from-single-promise": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: RS.from(Promise) — should throw TypeError (Promise not iterable), or accept and treat as 1-value (depends on Node). Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/events/once-static-promise": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1279,18 +1243,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Readable.from(asyncGen yielding mixed types) — types lost or wrong. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/web/readable-locked-after-pipe-through": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: rs.locked false after pipeThrough (should be true). Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/web/tee-after-getReader-throws": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: tee() on locked stream does not throw TypeError. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/readable/read-returns-buffer-default": {
     "issue": "1532",
@@ -1598,12 +1550,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline(asyncIterable, dst, cb) — async-iterable source not handled. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/web/tee-mid-consume-throws": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: tee() after getReader+read — should throw TypeError. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/pipe/source-immediate-error": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1765,12 +1711,6 @@
     "added": "2026-05-25",
     "category": "bug-open",
     "reason": "node:stream: map(asyncFn, {concurrency}) — toArray output wrong. Flips to PASS when #1558 lands."
-  },
-  "node-suite/stream/web/from-bigint-throws": {
-    "issue": "1545",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream/web: RS.from(bigint) — should throw TypeError. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/readable/from-gen-with-early-return": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- throw/reject Web Streams `TypeError`s for locked reader/writer, tee, direct cancel, and invalid `ReadableStream.from(...)` inputs
- hold `pipeTo`/`pipeThrough` readable and writable locks until the scheduled pipe microtask settles
- move pipe internals into `streams/pipe.rs` to keep `streams.rs` under the file-size gate
- remove verified passing stream/web known-failure entries

## Verification
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `cargo check -p perry-stdlib`
- `cargo test -p perry-stdlib streams -- --nocapture`
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream/web` (112 pass, 22 tracked failures, no new unlisted failures)
- targeted stream/web parity for lock, tee, pipe, multiple-writer, and `ReadableStream.from(...)` fixtures
