### PR TITLE
Remove stale Transform flush known failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -326,12 +326,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.closed flag + close event don't deliver. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/transform/flush-callback": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Transform flush() callback never invoked + tail chunk not emitted. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipeline/three-stream-chain": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary

- Revalidated `node-suite/stream/transform/flush-callback` on current `origin/main` after #2167.
- Removed only that stale known-failure entry from `test-parity/known_failures.json`.

## Verification

- `./run_parity_tests.sh --suite=node-suite --module=stream --filter flush-callback` PASS, report `test-parity/reports/parity_report_20260528_032215.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Scope

No stream runtime changes and no adjacent stream known-failure cleanup. This only un-skips the verified Transform flush fixture.
