### PR TITLE
fix(runtime): extend fs::validate to fsync/fdatasync/fchown/lchown/lchmod/copyFile/write/writev (#2013)

### DIFF
--- a/crates/perry-runtime/src/fs/callbacks.rs
+++ b/crates/perry-runtime/src/fs/callbacks.rs
@@ -203,6 +203,10 @@ pub extern "C" fn js_fs_exists_callback(path_value: f64, callback: f64) -> f64 {
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
     const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
     const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
+    // Node throws `ERR_INVALID_ARG_TYPE` if the callback isn't a function
+    // (this is the *only* arg `fs.exists` validates — a bad path just
+    // makes the callback fire with `false`, see test-fs-exists.js).
+    crate::fs::validate::validate_function("cb", callback);
     let exists = js_fs_exists_sync(path_value) == 1;
     let cb = last_callback(&[callback]);
     if !cb.is_null() {
@@ -418,6 +422,10 @@ pub extern "C" fn js_fs_lchown_callback(
     callback: f64,
 ) -> f64 {
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+    crate::fs::validate::validate_path("path", path_value);
+    crate::fs::validate::validate_int32(uid_value, "uid", -1, u32::MAX as i64);
+    crate::fs::validate::validate_int32(gid_value, "gid", -1, u32::MAX as i64);
+    crate::fs::validate::validate_function("cb", callback);
     let cb = last_callback(&[callback]);
     unsafe {
         if let Some(err_val) = fs_callback_lstat_error(path_value, "lchown") {
@@ -434,6 +442,8 @@ pub extern "C" fn js_fs_lchown_callback(
 #[no_mangle]
 pub extern "C" fn js_fs_lchmod_callback(path_value: f64, mode_value: f64, callback: f64) -> f64 {
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+    crate::fs::validate::validate_path("path", path_value);
+    crate::fs::validate::validate_function("cb", callback);
     let cb = last_callback(&[callback]);
     unsafe {
         if let Some(err_val) = fs_callback_lstat_error(path_value, "lchmod") {
@@ -978,6 +988,15 @@ pub extern "C" fn js_fs_copy_file_callback(
     } else {
         f64::from_bits(TAG_UNDEFINED)
     };
+    crate::fs::validate::validate_path("src", from_value);
+    crate::fs::validate::validate_path("dest", to_value);
+    // `copyFile(src, dest, cb)` puts the cb in arg2 (arg3 is undefined);
+    // `copyFile(src, dest, mode, cb)` puts it in arg3. Either way, *some*
+    // arg must be a function — `copyFile(src, dest, 0, 0)` is the case
+    // Node rejects with `ERR_INVALID_ARG_TYPE`.
+    if extract_closure_ptr(arg2).is_null() && extract_closure_ptr(arg3).is_null() {
+        crate::fs::validate::validate_function("cb", arg3);
+    }
     let cb = last_callback(&[arg2, arg3]);
     unsafe {
         if let Some(err_val) = fs_callback_read_error(from_value, "copyfile") {

--- a/crates/perry-runtime/src/fs/fd_ops.rs
+++ b/crates/perry-runtime/src/fs/fd_ops.rs
@@ -225,7 +225,11 @@ pub extern "C" fn js_fs_write_string_sync_options(
     data_value: f64,
     position_value: f64,
 ) -> f64 {
-    let fd = fd_value as i32;
+    crate::fs::validate::validate_fd(fd_value);
+    write_string_sync_inner(fd_value as i32, data_value, position_value)
+}
+
+pub(crate) fn write_string_sync_inner(fd: i32, data_value: f64, position_value: f64) -> f64 {
     let bytes = bytes_from_value(data_value);
     let position = if position_value.is_finite() && position_value >= 0.0 {
         Some(position_value as u64)
@@ -261,7 +265,23 @@ pub extern "C" fn js_fs_write_buffer_sync(
     length_value: f64,
     position_value: f64,
 ) -> f64 {
-    let fd = fd_value as i32;
+    crate::fs::validate::validate_fd(fd_value);
+    write_buffer_sync_inner(
+        fd_value as i32,
+        buffer_value,
+        offset_value,
+        length_value,
+        position_value,
+    )
+}
+
+pub(crate) fn write_buffer_sync_inner(
+    fd: i32,
+    buffer_value: f64,
+    offset_value: f64,
+    length_value: f64,
+    position_value: f64,
+) -> f64 {
     let offset = offset_value.max(0.0) as usize;
     let length = length_value.max(0.0) as usize;
     let position = if position_value.is_finite() && position_value >= 0.0 {
@@ -400,7 +420,19 @@ pub extern "C" fn js_fs_readv_sync(fd_value: f64, buffers_value: f64, position_v
 /// `fs.writevSync(fd, buffers[, position])` — deterministic Buffer[] subset.
 #[no_mangle]
 pub extern "C" fn js_fs_writev_sync(fd_value: f64, buffers_value: f64, position_value: f64) -> f64 {
-    let fd = fd_value as i32;
+    // Match Node: skip fd validation when the buffers array is empty (Node's
+    // own writev returns 0 without touching the fd), validate only when
+    // there's something to write.
+    let buffers_for_check = array_ptr_from_value(buffers_value);
+    let buffers_nonempty = !buffers_for_check.is_null()
+        && unsafe { crate::array::js_array_length(buffers_for_check) } > 0;
+    if buffers_nonempty {
+        crate::fs::validate::validate_fd(fd_value);
+    }
+    writev_sync_inner(fd_value as i32, buffers_value, position_value)
+}
+
+pub(crate) fn writev_sync_inner(fd: i32, buffers_value: f64, position_value: f64) -> f64 {
     let position = if position_value.is_finite() && position_value >= 0.0 {
         Some(position_value as u64)
     } else {

--- a/crates/perry-runtime/src/fs/filehandle.rs
+++ b/crates/perry-runtime/src/fs/filehandle.rs
@@ -39,12 +39,15 @@ pub(crate) extern "C" fn filehandle_close_impl(closure: *const ClosureHeader) ->
 }
 
 pub(crate) extern "C" fn filehandle_sync_impl(closure: *const ClosureHeader) -> f64 {
-    let _ = js_fs_fsync_sync(filehandle_fd(closure) as f64);
+    // Bypass `js_fs_fsync_sync`'s arg-validation: FileHandle may legitimately
+    // hold a `-1` fd sentinel from a failed open, and Node's API surfaces that
+    // earlier (at `open`), not here.
+    let _ = crate::fs::fsync_sync_inner(filehandle_fd(closure));
     promise_undefined_fs()
 }
 
 pub(crate) extern "C" fn filehandle_datasync_impl(closure: *const ClosureHeader) -> f64 {
-    let _ = js_fs_fdatasync_sync(filehandle_fd(closure) as f64);
+    let _ = crate::fs::fdatasync_sync_inner(filehandle_fd(closure));
     promise_undefined_fs()
 }
 
@@ -79,7 +82,7 @@ pub(crate) extern "C" fn filehandle_chown_impl(
     uid: f64,
     gid: f64,
 ) -> f64 {
-    let _ = js_fs_fchown_sync(filehandle_fd(closure) as f64, uid, gid);
+    let _ = crate::fs::fchown_sync_inner(filehandle_fd(closure), uid, gid);
     promise_undefined_fs()
 }
 
@@ -226,9 +229,9 @@ pub(crate) extern "C" fn filehandle_write_impl(
         } else {
             (buffer_len - actual_offset).max(0.0)
         };
-        js_fs_write_buffer_sync(fd as f64, data, actual_offset, actual_length, position)
+        crate::fs::write_buffer_sync_inner(fd, data, actual_offset, actual_length, position)
     } else {
-        js_fs_write_string_sync_options(fd as f64, data, offset)
+        crate::fs::write_string_sync_inner(fd, data, offset)
     };
     unsafe {
         promise_value_fs(build_file_io_result(
@@ -263,7 +266,7 @@ pub(crate) extern "C" fn filehandle_writev_impl(
     position: f64,
 ) -> f64 {
     let fd = filehandle_fd(closure);
-    let bytes_written = js_fs_writev_sync(fd as f64, buffers, position);
+    let bytes_written = crate::fs::writev_sync_inner(fd, buffers, position);
     unsafe {
         promise_value_fs(build_file_io_result(
             "bytesWritten",

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -663,6 +663,9 @@ pub extern "C" fn js_fs_chown_sync(path_value: f64, uid_value: f64, gid_value: f
 /// `fs.lchownSync(path, uid, gid)`.
 #[no_mangle]
 pub extern "C" fn js_fs_lchown_sync(path_value: f64, uid_value: f64, gid_value: f64) -> i32 {
+    crate::fs::validate::validate_path("path", path_value);
+    crate::fs::validate::validate_int32(uid_value, "uid", -1, u32::MAX as i64);
+    crate::fs::validate::validate_int32(gid_value, "gid", -1, u32::MAX as i64);
     chown_path_value(path_value, uid_value, gid_value, false)
 }
 
@@ -672,6 +675,12 @@ pub extern "C" fn js_fs_lchown_sync(path_value: f64, uid_value: f64, gid_value: 
 /// ENOSYS-equivalent. No-op success on non-unix.
 #[no_mangle]
 pub extern "C" fn js_fs_lchmod_sync(path_value: f64, mode: f64) -> i32 {
+    // Mode range validation is deliberately not done here: Node opens the
+    // path first, so a bad-path call surfaces ENOENT before mode validation
+    // would fire. Validating mode here would deviate from Node ordering on
+    // paths that don't exist. The mode-validation gap on existing paths is
+    // a separate follow-up.
+    crate::fs::validate::validate_path("path", path_value);
     #[cfg(all(
         unix,
         any(
@@ -909,6 +918,12 @@ pub extern "C" fn js_fs_copy_file_sync_flags(
     to_value: f64,
     flags_value: f64,
 ) -> i32 {
+    crate::fs::validate::validate_path("src", from_value);
+    crate::fs::validate::validate_path("dest", to_value);
+    let flags_jv = crate::value::JSValue::from_bits(flags_value.to_bits());
+    if !flags_jv.is_undefined() {
+        crate::fs::validate::validate_int32(flags_value, "mode", 0, 7);
+    }
     unsafe {
         let from = match decode_path_value(from_value) {
             Some(s) => s,
@@ -1202,7 +1217,14 @@ pub extern "C" fn js_fs_ftruncate_sync(fd_value: f64, len_value: f64) -> i32 {
 /// `fs.fsyncSync(fd)` — flush an open registry fd.
 #[no_mangle]
 pub extern "C" fn js_fs_fsync_sync(fd_value: f64) -> i32 {
-    let fd = fd_value as i32;
+    crate::fs::validate::validate_fd(fd_value);
+    fsync_sync_inner(fd_value as i32)
+}
+
+/// Internal fsync without validation — for the FileHandle wrappers, which
+/// may legitimately hold a `-1` sentinel from a failed open and rely on
+/// the silent no-op behavior.
+pub(crate) fn fsync_sync_inner(fd: i32) -> i32 {
     FD_REGISTRY.with(|r| {
         let reg = r.borrow();
         let Some(file) = reg.get(&fd) else {
@@ -1220,7 +1242,11 @@ pub extern "C" fn js_fs_fsync_sync(fd_value: f64) -> i32 {
 /// Perry maps this to `sync_data`, falling back to fsync-like semantics.
 #[no_mangle]
 pub extern "C" fn js_fs_fdatasync_sync(fd_value: f64) -> i32 {
-    let fd = fd_value as i32;
+    crate::fs::validate::validate_fd(fd_value);
+    fdatasync_sync_inner(fd_value as i32)
+}
+
+pub(crate) fn fdatasync_sync_inner(fd: i32) -> i32 {
     FD_REGISTRY.with(|r| {
         let reg = r.borrow();
         let Some(file) = reg.get(&fd) else {
@@ -1263,7 +1289,13 @@ pub extern "C" fn js_fs_fchmod_sync(fd_value: f64, mode: f64) -> i32 {
 /// `fs.fchownSync(fd, uid, gid)`.
 #[no_mangle]
 pub extern "C" fn js_fs_fchown_sync(fd_value: f64, uid_value: f64, gid_value: f64) -> i32 {
-    let fd = fd_value as i32;
+    crate::fs::validate::validate_fd(fd_value);
+    crate::fs::validate::validate_int32(uid_value, "uid", -1, u32::MAX as i64);
+    crate::fs::validate::validate_int32(gid_value, "gid", -1, u32::MAX as i64);
+    fchown_sync_inner(fd_value as i32, uid_value, gid_value)
+}
+
+pub(crate) fn fchown_sync_inner(fd: i32, uid_value: f64, gid_value: f64) -> i32 {
     #[cfg(unix)]
     {
         FD_REGISTRY.with(|r| {

--- a/crates/perry-runtime/src/fs/validate.rs
+++ b/crates/perry-runtime/src/fs/validate.rs
@@ -155,3 +155,93 @@ pub(crate) fn validate_path_or_fd(arg_name: &str, value: f64, syscall: &'static 
     }
     throw_invalid_path_arg(arg_name, value);
 }
+
+/// Validate that `value` is a JS number suitable for a file descriptor —
+/// finite integer in `[0, 2^31-1]`. Matches Node's `validateInt32(fd, 'fd', 0)`.
+///
+/// Non-numbers raise `TypeError [ERR_INVALID_ARG_TYPE]`; `NaN`, `Infinity`,
+/// non-integers, and out-of-range integers raise `RangeError
+/// [ERR_OUT_OF_RANGE]`. The filehandle path (`filehandle_fd(closure) as f64`)
+/// always passes a real `i32`-ranged value, so the validators are no-ops there.
+pub(crate) fn validate_fd(value: f64) {
+    validate_int32(value, "fd", 0, i32::MAX as i64);
+}
+
+/// Validate that `value` is a finite integer in `[min, max]`. On type or
+/// range failure throws Node's `ERR_INVALID_ARG_TYPE` / `ERR_OUT_OF_RANGE`
+/// with the same `Received` clause shape Node uses.
+pub(crate) fn validate_int32(value: f64, arg_name: &str, min: i64, max: i64) {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !is_numeric(jv) {
+        let message = format!(
+            "The \"{}\" argument must be of type number. Received {}",
+            arg_name,
+            describe_received(value)
+        );
+        throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    let n = if jv.is_int32() {
+        jv.as_int32() as f64
+    } else {
+        jv.as_number()
+    };
+    if !n.is_finite() || n.fract() != 0.0 {
+        let received = if n.is_nan() {
+            "NaN".to_string()
+        } else if n.is_infinite() {
+            if n.is_sign_negative() {
+                "-Infinity".to_string()
+            } else {
+                "Infinity".to_string()
+            }
+        } else {
+            format_received_number(n)
+        };
+        let message = format!(
+            "The value of \"{}\" is out of range. It must be an integer. Received {}",
+            arg_name, received
+        );
+        throw_range_error_with_code(&message);
+    }
+    let i = n as i64;
+    if i < min || i > max {
+        let message = format!(
+            "The value of \"{}\" is out of range. It must be >= {} && <= {}. Received {}",
+            arg_name,
+            min,
+            max,
+            format_received_number(n)
+        );
+        throw_range_error_with_code(&message);
+    }
+}
+
+fn format_received_number(n: f64) -> String {
+    if n.fract() == 0.0 && n.is_finite() && n.abs() < 1e21 {
+        format!("{}", n as i64)
+    } else {
+        format!("{}", n)
+    }
+}
+
+/// Validate that `value` is a function (closure). On failure throws
+/// `TypeError [ERR_INVALID_ARG_TYPE]`. Mirrors Node's `validateFunction`
+/// helper — used to catch `fs.exists(path)` / `fs.copyFile(src, dest, 0, 0)`
+/// where the trailing callback is missing or the wrong type.
+pub(crate) fn validate_function(arg_name: &str, value: f64) {
+    if super::stream::extract_closure_ptr(value).is_null() {
+        let message = format!(
+            "The \"{}\" argument must be of type function. Received {}",
+            arg_name,
+            describe_received(value)
+        );
+        throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+}
+
+fn throw_range_error_with_code(message: &str) -> ! {
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    crate::node_submodules::register_error_code_pub(msg, "ERR_OUT_OF_RANGE");
+    let err = crate::error::js_rangeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}

--- a/test-parity/node-suite/fs/sync/arg-validation.ts
+++ b/test-parity/node-suite/fs/sync/arg-validation.ts
@@ -1,0 +1,68 @@
+// #2013 — Node argument-validation errors on fs sync APIs.
+//
+// Each block calls the API with bad arguments and prints the thrown error's
+// `.name` and `.code`. Perry and Node must produce the exact same lines.
+// `existsSync` is the lone exception: Node guarantees it *never* throws and
+// returns `false` on bad input (see test/parallel/test-fs-exists.js), so the
+// assertions there cover the no-throw contract.
+
+import * as fs from "node:fs";
+
+function probe(label: string, fn: () => any) {
+  try {
+    fn();
+    console.log(label, "no-throw");
+  } catch (e: any) {
+    console.log(label, e.name, e.code);
+  }
+}
+
+// fsyncSync / fdatasyncSync — fd type and range
+probe("fsyncSync(null)", () => fs.fsyncSync(null as any));
+probe("fsyncSync('')", () => fs.fsyncSync("" as any));
+probe("fsyncSync({})", () => fs.fsyncSync({} as any));
+probe("fsyncSync(NaN)", () => fs.fsyncSync(NaN));
+probe("fsyncSync(Infinity)", () => fs.fsyncSync(Infinity));
+probe("fsyncSync(-1)", () => fs.fsyncSync(-1));
+probe("fdatasyncSync(null)", () => fs.fdatasyncSync(null as any));
+probe("fdatasyncSync(2**32)", () => fs.fdatasyncSync(2 ** 32));
+
+// fchownSync — fd, uid, gid
+probe("fchownSync('',0,0)", () => fs.fchownSync("" as any, 0, 0));
+probe("fchownSync(1,'',0)", () => fs.fchownSync(1, "" as any, 0));
+probe("fchownSync(1,1,{})", () => fs.fchownSync(1, 1, {} as any));
+probe("fchownSync(1,1,Infinity)", () => fs.fchownSync(1, 1, Infinity));
+probe("fchownSync(1,-2,1)", () => fs.fchownSync(1, -2, 1));
+
+// lchownSync — path, uid, gid
+probe("lchownSync(false,1,1)", () => fs.lchownSync(false as any, 1, 1));
+probe("lchownSync(1,1,1)", () => fs.lchownSync(1 as any, 1, 1));
+probe("lchownSync('/x','',1)", () => fs.lchownSync("/x", "" as any, 1));
+probe("lchownSync('/x',1,null)", () => fs.lchownSync("/x", 1, null as any));
+
+// lchmodSync — path-type validation only. Node opens the path before
+// validating the mode, so a bad mode on a non-existent path surfaces
+// ENOENT, not ERR_OUT_OF_RANGE — match that ordering by deferring mode
+// validation entirely (covered separately by the mode-on-existing-path
+// follow-up).
+probe("lchmodSync(false,0)", () => fs.lchmodSync(false as any, 0));
+probe("lchmodSync(1,0)", () => fs.lchmodSync(1 as any, 0));
+
+// copyFileSync — src, dest, mode
+probe("copyFileSync(1,'/x')", () => fs.copyFileSync(1 as any, "/x"));
+probe("copyFileSync('/x',1)", () => fs.copyFileSync("/x", 1 as any));
+probe("copyFileSync('/x','/y','r')", () => fs.copyFileSync("/x", "/y", "r" as any));
+probe("copyFileSync('/x','/y',8)", () => fs.copyFileSync("/x", "/y", 8));
+
+// writeSync — fd
+probe("writeSync(null,'x')", () => fs.writeSync(null as any, "x"));
+probe("writeSync({},'x')", () => fs.writeSync({} as any, "x"));
+
+// writevSync — fd; Node skips fd validation on an empty buffers array
+// (returns 0 without touching the fd), so the empty case must NOT throw.
+probe("writevSync(null,[])", () => fs.writevSync(null as any, []));
+probe("writevSync(null,[Buffer.from('x')])", () => fs.writevSync(null as any, [Buffer.from("x")]));
+
+// `existsSync` never throws on bad input (Node 22+ instead prints DEP0187
+// to stderr, which the parity runner would capture into the diff). The
+// no-throw contract is exercised by other tests in this suite.


### PR DESCRIPTION
## Summary

Extends the `fs::validate` helpers from #2035 to the rest-of-`fs` slice
of #2013 — the 27 `assert.throws`-style tests the issue update flagged
as still falling through:

| API                           | Validation                                              |
| ----------------------------- | ------------------------------------------------------- |
| `fsyncSync` / `fdatasyncSync` | fd type / range                                         |
| `fchownSync`                  | fd, uid, gid (TypeError + RangeError per Node)          |
| `lchownSync`                  | path-type, uid, gid                                     |
| `lchmodSync`                  | path-type (mode validation deferred — see ordering note)|
| `copyFileSync` (+ async)      | src/dest path-type, mode (TypeError on string, RangeError on out-of-range int) |
| `writeSync` family            | fd                                                      |
| `writevSync`                  | fd, **only** when the buffers array is non-empty        |
| `exists` (callback)           | callback-must-be-function                               |
| `lchown` / `lchmod` async     | same as their sync siblings + callback                  |

## New validators in `fs::validate`

- `validate_fd(value)` — TypeError for non-number, RangeError for `NaN`/`Infinity`/non-integer/out-of-range. Matches Node's `validateInt32(fd, 'fd', 0)`.
- `validate_int32(value, name, min, max)` — reused for uid / gid / mode where Node validates a bounded integer.
- `validate_function(name, value)` — TypeError if the value isn't a Perry closure (via the existing `extract_closure_ptr` helper). Mirrors Node's `validateFunction`.

Range errors are surfaced through `js_rangeerror_new` and registered in the per-error side table from #2035 so `err.code === 'ERR_OUT_OF_RANGE'` round-trips correctly.

## Deliberate scope limits

- **`lchmodSync` mode range:** Node opens the path first, so a bad mode on a non-existent path surfaces `ENOENT` before mode validation fires. Validating mode here in Perry would diverge from Node's ordering. The mode-on-existing-path validation is a separate follow-up paired with proper `ENOENT` propagation.
- **`writevSync` empty buffers:** Node skips fd validation when the buffers array is empty (returns 0 without touching the fd). Perry now gates fd validation on `array.length > 0` to match.
- **`existsSync`** is unchanged — it never throws on bad input under Node and Perry already returns `false` via `decode_path_value`.
- **Callback-required cases** for `fsync`/`fdatasync`/`fchown`/`copyFile` aren't validated at the top of the callback wrapper — those already dispatch into the sync impl which now validates fd, so an `assert.throws(() => fs.fsync(input))` with bad input throws regardless. Required-callback-on-valid-input is left for the next slice.

## Verification

- Added `test-parity/node-suite/fs/sync/arg-validation.ts` — byte-identical to `node --experimental-strip-types` across 27 cases covering fd type/range, path-type, uid/gid type/range, copyFile src/dest/mode, write/writev fd, and the writev empty-array no-throw contract.
- No regressions in the rest of `node-suite/fs` (filehandle path still uses real fds; `lchmodSync` mode pass-through unchanged).
- `cargo fmt --all -- --check` clean.

## Follow-ups (still in #2013)

- `lchmodSync` / `lchownSync` mode + range validation on existing paths (paired with `ENOENT` propagation).
- Required-callback validation on `fsync`/`fdatasync`/`fchown` async wrappers.
- buffer (10), net (10), zlib (10), http (9), process (8), crypto (7), url (2), timers (1) — same pattern, applied per-crate.
