### PR TITLE
Remove stale Transform object-mode known failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -296,12 +296,6 @@
     "category": "bug-open",
     "reason": "node:stream: write() return + drain event semantics not delivered. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/object-mode/transform-object-mode": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Transform objectMode + data event chain doesn't deliver. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/error/error-event": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary

- Revalidated `node-suite/stream/object-mode/transform-object-mode` on current `origin/main` after #2167.
- Removed only that stale known-failure entry from `test-parity/known_failures.json`.

## Verification

- `./run_parity_tests.sh --suite=node-suite --module=stream --filter transform-object-mode` PASS, report `test-parity/reports/parity_report_20260528_032844.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Scope

No stream runtime changes and no adjacent stream known-failure cleanup. This only un-skips the verified object-mode Transform fixture.
