### PR TITLE
fix(node:stream): order writable end callback before finish

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -222,12 +222,12 @@ extern "C" fn ns_writable_finish_microtask(closure: *const ClosureHeader) -> f64
             f64::from_bits(TAG_TRUE),
         );
         mark_writable_finished(stream);
+        if is_callable_value(callback) {
+            call_listener_args(stream, callback, &[]);
+        }
         let _ = emit_stream_event(stream, string_value(b"finish"), &[]);
         mark_stream_closed(stream);
         let _ = emit_stream_event(stream, string_value(b"close"), &[]);
-    }
-    if is_callable_value(callback) {
-        call_listener_args(stream, callback, &[]);
     }
     f64::from_bits(TAG_UNDEFINED)
 }

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -19,6 +19,7 @@ thread_local! {
     static STREAM_EVENT_ORDER: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
     static WRITABLE_FINISH_COUNT: RefCell<usize> = const { RefCell::new(0) };
     static WRITABLE_CLOSE_COUNT: RefCell<usize> = const { RefCell::new(0) };
+    static WRITABLE_END_CALLBACK_SNAPSHOT: RefCell<Option<(usize, usize, bool, bool)>> = const { RefCell::new(None) };
     static WRITABLE_DRAIN_COUNT: RefCell<usize> = const { RefCell::new(0) };
     static PENDING_WRITE_CALLBACK: RefCell<Option<f64>> = const { RefCell::new(None) };
     static TRANSFORM_THIS_HAS_STREAM_STATE: RefCell<Vec<bool>> = const { RefCell::new(Vec::new()) };
@@ -205,6 +206,18 @@ extern "C" fn capture_finish_listener(_closure: *const ClosureHeader) -> f64 {
 
 extern "C" fn capture_close_listener(_closure: *const ClosureHeader) -> f64 {
     WRITABLE_CLOSE_COUNT.with(|count| *count.borrow_mut() += 1);
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn capture_end_callback_state(closure: *const ClosureHeader) -> f64 {
+    let stream = crate::closure::js_closure_get_capture_f64(closure, 0);
+    let handle = raw_ptr_from_value(stream) as i64;
+    let finish_count = WRITABLE_FINISH_COUNT.with(|count| *count.borrow());
+    let close_count = WRITABLE_CLOSE_COUNT.with(|count| *count.borrow());
+    let finished = js_node_stream_method_writable_finished(handle).to_bits() == TAG_TRUE;
+    let closed = js_node_stream_method_closed(handle).to_bits() == TAG_TRUE;
+    let snapshot = (finish_count, close_count, finished, closed);
+    WRITABLE_END_CALLBACK_SNAPSHOT.with(|value| *value.borrow_mut() = Some(snapshot));
     f64::from_bits(TAG_UNDEFINED)
 }
 
@@ -1714,6 +1727,52 @@ fn writable_end_waits_for_pending_write_before_finish() {
         let _ = crate::closure::js_native_call_value(cb, std::ptr::null(), 0);
     }
     let _ = crate::promise::js_promise_run_microtasks();
+    WRITABLE_FINISH_COUNT.with(|count| assert_eq!(*count.borrow(), 1));
+    WRITABLE_CLOSE_COUNT.with(|count| assert_eq!(*count.borrow(), 1));
+}
+
+#[test]
+fn writable_end_callback_runs_before_finish_and_close_events() {
+    WRITABLE_FINISH_COUNT.with(|count| *count.borrow_mut() = 0);
+    WRITABLE_CLOSE_COUNT.with(|count| *count.borrow_mut() = 0);
+    WRITABLE_END_CALLBACK_SNAPSHOT.with(|snapshot| *snapshot.borrow_mut() = None);
+    PENDING_WRITE_CALLBACK.with(|pending| *pending.borrow_mut() = None);
+
+    let opts = crate::object::js_object_alloc(0, 1);
+    let closure = js_closure_alloc(write_capture_pending as *const u8, 0);
+    crate::closure::js_register_closure_arity(write_capture_pending as *const u8, 3);
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"write"),
+        f64::from_bits(JSValue::pointer(closure as *const u8).bits()),
+    );
+
+    let stream = js_node_stream_writable_new(box_pointer(opts as *const u8));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let undefined = f64::from_bits(TAG_UNDEFINED);
+    let finish =
+        box_pointer(js_closure_alloc(capture_finish_listener as *const u8, 0) as *const u8);
+    let close = box_pointer(js_closure_alloc(capture_close_listener as *const u8, 0) as *const u8);
+    let end_cb = js_closure_alloc(capture_end_callback_state as *const u8, 1);
+    js_closure_set_capture_f64(end_cb, 0, stream);
+    let end_cb_value = box_pointer(end_cb as *const u8);
+    let _ = js_node_stream_method_on(handle, string_value("finish"), finish);
+    let _ = js_node_stream_method_on(handle, string_value("close"), close);
+
+    let _ = js_node_stream_method_write(handle, string_value("pending"), undefined, undefined);
+    let _ = js_node_stream_method_end3(handle, undefined, undefined, end_cb_value);
+    let _ = crate::promise::js_promise_run_microtasks();
+    WRITABLE_END_CALLBACK_SNAPSHOT.with(|snapshot| assert!(snapshot.borrow().is_none()));
+
+    let cb = PENDING_WRITE_CALLBACK.with(|pending| pending.borrow_mut().take().unwrap());
+    unsafe {
+        let _ = crate::closure::js_native_call_value(cb, std::ptr::null(), 0);
+    }
+    let _ = crate::promise::js_promise_run_microtasks();
+
+    WRITABLE_END_CALLBACK_SNAPSHOT.with(|snapshot| {
+        assert_eq!(*snapshot.borrow(), Some((0, 0, true, false)));
+    });
     WRITABLE_FINISH_COUNT.with(|count| assert_eq!(*count.borrow(), 1));
     WRITABLE_CLOSE_COUNT.with(|count| assert_eq!(*count.borrow(), 1));
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1574,12 +1574,6 @@
     "category": "bug-open",
     "reason": "node:stream: Writable destroyed false after 'finish' (autoDestroy default true). Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/writable/end-cb-fires-after-flush": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: end(cb) — cb fires before write callbacks or before finish. Flips to PASS when #1539 lands."
-  },
   "node-suite/stream/readable/encoding-via-constructor": {
     "issue": "1532",
     "added": "2026-05-24",

--- a/test-parity/node-suite/stream/writable/end-cb-fires-after-flush.ts
+++ b/test-parity/node-suite/stream/writable/end-cb-fires-after-flush.ts
@@ -1,5 +1,5 @@
 import { Writable } from "node:stream";
-// end(cb) — cb fires after all pending writes flush + finish event.
+// end(cb) — cb fires after pending writes flush, before 'finish' listeners.
 const order: string[] = [];
 const w = new Writable({
   write(_c, _e, cb) {


### PR DESCRIPTION
## Summary
- match Node's Writable.end(cb) success-path ordering after pending async writes flush
- mark writableFinished before the stored end callback, then emit finish and close afterward
- remove the now-green node-suite/stream/writable/end-cb-fires-after-flush known-failure entry

Refs #1539

## DeepWiki
- reference/deepwiki/nodejs-node-stream-writable-end-callback-order-2026-05-28.md

## Verification
- Baseline exact target failed on origin/main: test-parity/reports/parity_report_20260528_033028.json
- ./run_parity_tests.sh --suite=node-suite --module=stream --filter end-cb-fires-after-flush PASS, report test-parity/reports/parity_report_20260528_033729.json
- ./run_parity_tests.sh --suite=node-suite --module=stream --filter writable/end PASS 8/8 with one Node-side skip, report test-parity/reports/parity_report_20260528_033737.json
- ./run_parity_tests.sh --suite=node-suite --module=stream --filter finish-before-close PASS, report test-parity/reports/parity_report_20260528_033748.json
- cargo test -p perry-runtime node_stream --lib PASS
- cargo test -p perry-runtime writable_end_callback_runs_before_finish_and_close_events --lib PASS
- cargo fmt --check --all --message-format short PASS
- jq empty test-parity/known_failures.json PASS
- git diff --check PASS
- ./scripts/check_file_size.sh PASS

## Non-goals
- no _final() implementation
- no stream error/destroy callback ordering changes
- no repeated end(cb) after finished validation
- no readable-side close changes
- no broad stream lifecycle rewrite