### PR TITLE
fix(hir): built-in function .name own-property (#2144)

### DIFF
--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -9,7 +9,9 @@ use crate::ir::*;
 use crate::walker::{walk_expr_children, walk_expr_children_mut};
 
 mod builtins;
-pub(crate) use builtins::{is_builtin_function, is_builtin_global_value_name};
+pub(crate) use builtins::{
+    is_builtin_function, is_builtin_global_value_name, is_builtin_static_function_member,
+};
 
 /// Collect every `LocalId` referenced by `expr` (and its sub-expressions).
 ///

--- a/crates/perry-hir/src/analysis/builtins.rs
+++ b/crates/perry-hir/src/analysis/builtins.rs
@@ -71,3 +71,122 @@ pub(crate) fn is_builtin_global_value_name(name: &str) -> bool {
             | "process"
     )
 }
+
+/// Spec-defined static *function* members of built-in namespaces /
+/// constructors. Used by the `<Builtin>.<member>.name` HIR fold (#2144)
+/// to recognize cases where `.name` should resolve to the member ident
+/// string — `Math.min.name === "min"`, `Promise.race.name === "race"`,
+/// `Array.isArray.name === "isArray"`, and so on.
+///
+/// Only function-typed members are listed. Numeric constants (`Math.PI`,
+/// `Number.EPSILON`) and namespace-level objects are excluded so that
+/// reads like `Math.PI.name` continue to lower the normal way (which
+/// yields `undefined` on a number, matching Node).
+///
+/// The list is conservative — adding a new pair is a one-line change and
+/// the safe fallback (no fold → existing behavior) is the same shape as
+/// pre-fix. Mirrors well-known spec surfaces; the hot ones are the ones
+/// surfaced by `built-ins/Function` Test262 (38× `Cannot read … (reading
+/// 'name')` on the #799 radar).
+pub(crate) fn is_builtin_static_function_member(namespace: &str, member: &str) -> bool {
+    match namespace {
+        "Math" => matches!(
+            member,
+            "abs"
+                | "acos"
+                | "acosh"
+                | "asin"
+                | "asinh"
+                | "atan"
+                | "atan2"
+                | "atanh"
+                | "cbrt"
+                | "ceil"
+                | "clz32"
+                | "cos"
+                | "cosh"
+                | "exp"
+                | "expm1"
+                | "floor"
+                | "fround"
+                | "hypot"
+                | "imul"
+                | "log"
+                | "log10"
+                | "log1p"
+                | "log2"
+                | "max"
+                | "min"
+                | "pow"
+                | "random"
+                | "round"
+                | "sign"
+                | "sin"
+                | "sinh"
+                | "sqrt"
+                | "tan"
+                | "tanh"
+                | "trunc"
+        ),
+        "Promise" => matches!(
+            member,
+            "resolve" | "reject" | "all" | "race" | "allSettled" | "any" | "withResolvers" | "try"
+        ),
+        "Array" => matches!(member, "isArray" | "from" | "of" | "fromAsync"),
+        "Object" => matches!(
+            member,
+            "assign"
+                | "create"
+                | "defineProperties"
+                | "defineProperty"
+                | "entries"
+                | "freeze"
+                | "fromEntries"
+                | "getOwnPropertyDescriptor"
+                | "getOwnPropertyDescriptors"
+                | "getOwnPropertyNames"
+                | "getOwnPropertySymbols"
+                | "getPrototypeOf"
+                | "groupBy"
+                | "hasOwn"
+                | "is"
+                | "isExtensible"
+                | "isFrozen"
+                | "isSealed"
+                | "keys"
+                | "preventExtensions"
+                | "seal"
+                | "setPrototypeOf"
+                | "values"
+        ),
+        "Number" => matches!(
+            member,
+            "isFinite" | "isInteger" | "isNaN" | "isSafeInteger" | "parseFloat" | "parseInt"
+        ),
+        "String" => matches!(member, "fromCharCode" | "fromCodePoint" | "raw"),
+        "Symbol" => matches!(member, "for" | "keyFor"),
+        "JSON" => matches!(member, "parse" | "stringify"),
+        "Date" => matches!(member, "now" | "UTC" | "parse"),
+        "ArrayBuffer" => matches!(member, "isView"),
+        "Int8Array" | "Uint8Array" | "Uint8ClampedArray" | "Int16Array" | "Uint16Array"
+        | "Int32Array" | "Uint32Array" | "Float32Array" | "Float64Array" | "BigInt64Array"
+        | "BigUint64Array" => matches!(member, "from" | "of"),
+        "Reflect" => matches!(
+            member,
+            "apply"
+                | "construct"
+                | "defineProperty"
+                | "deleteProperty"
+                | "get"
+                | "getOwnPropertyDescriptor"
+                | "getPrototypeOf"
+                | "has"
+                | "isExtensible"
+                | "ownKeys"
+                | "preventExtensions"
+                | "set"
+                | "setPrototypeOf"
+        ),
+        _ => false,
+    }
+}

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -36,6 +36,7 @@ mod intrinsics;
 mod local_array_methods;
 mod module_class_static;
 mod module_static;
+mod name_fold;
 mod native_module;
 mod nested_namespace;
 mod object_static;

--- a/crates/perry-hir/src/lower/expr_call/name_fold.rs
+++ b/crates/perry-hir/src/lower/expr_call/name_fold.rs
@@ -1,0 +1,66 @@
+//! `<BuiltinFn>.name` / `Object.getOwnPropertyDescriptor(<BuiltinFn>, "name")`
+//! HIR-level folds (#2144).
+//!
+//! Built-in constructors (`TypeError`, `Promise`, …) and the static functions
+//! on built-in namespaces (`Math.min`, `Promise.race`, `Array.isArray`, …)
+//! are not represented as named closure values in Perry — bare reads of them
+//! return the 0 sentinel. The direct `.name` access is folded in
+//! `lower/expr_member.rs`; the descriptor-form access (the spec defines
+//! `name` as `{ value, writable:false, enumerable:false, configurable:true }`)
+//! is folded by callers in `expr_call/native_module.rs`. Both rely on the
+//! AST-shape recognizer here.
+
+use swc_ecma_ast as ast;
+
+use crate::analysis::{is_builtin_global_value_name, is_builtin_static_function_member};
+use crate::ir::Expr;
+
+/// If `arg` is an AST shape we recognize as a built-in function value —
+/// either `Ident<BuiltinCtor>` (`TypeError`, `Promise`, …) or
+/// `Member(Ident<Builtin>, Ident<staticFn>)` (`Math.min`, `Promise.race`,
+/// …) — return the spec `name` string for that function. Otherwise None.
+///
+/// Local shadowing is NOT checked here (the bare-AST recognizer can't see
+/// the scope), so call sites must verify the lowered receiver looks like
+/// the global intrinsic — same gating logic as the direct-`.name` fold.
+/// In practice both call sites operate on chains where the receiver
+/// already lowered to a `GlobalGet(0)`/`PropertyGet { GlobalGet(0), … }`
+/// shape, so the AST-only recognizer is a safe complement.
+pub(super) fn builtin_fn_name_for_arg(arg: &ast::Expr) -> Option<String> {
+    match arg {
+        ast::Expr::Ident(id) => {
+            let name = id.sym.as_ref();
+            if is_builtin_global_value_name(name) {
+                Some(name.to_string())
+            } else {
+                None
+            }
+        }
+        ast::Expr::Member(m) => {
+            if let (ast::Expr::Ident(ns_ident), ast::MemberProp::Ident(method_ident)) =
+                (m.obj.as_ref(), &m.prop)
+            {
+                let ns = ns_ident.sym.as_ref();
+                let method = method_ident.sym.as_ref();
+                if is_builtin_static_function_member(ns, method) {
+                    return Some(method.to_string());
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Build the spec-compliant data descriptor for a function `.name` property
+/// — `{ value, writable:false, enumerable:false, configurable:true }`.
+/// Mirrors `js_object_get_own_property_descriptor` in the runtime; the two
+/// must stay in sync.
+pub(super) fn name_data_descriptor(fname: String) -> Expr {
+    Expr::Object(vec![
+        ("value".to_string(), Expr::String(fname)),
+        ("writable".to_string(), Expr::Bool(false)),
+        ("enumerable".to_string(), Expr::Bool(false)),
+        ("configurable".to_string(), Expr::Bool(true)),
+    ])
+}

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -725,6 +725,46 @@ pub(super) fn try_native_module_methods(
                             )));
                         }
                         "getOwnPropertyDescriptor" => {
+                            // #2144: built-in function `.name` descriptor.
+                            //
+                            // `Object.getOwnPropertyDescriptor(<BuiltinCtor>,
+                            // "name")` and `…(<BuiltinNs>.<staticFn>, "name")`
+                            // — the runtime path returns `undefined` because
+                            // the bare ctor/static-fn lowers to a
+                            // `PropertyGet { GlobalGet(0), … }` whose value
+                            // is the 0 sentinel (no closure to read the
+                            // built-in `name` slot off of). Per spec the
+                            // descriptor is a non-writable, non-enumerable,
+                            // configurable data property whose value is the
+                            // function's name. Fold to an inline object
+                            // literal when we can statically recognize the
+                            // shape — same gating logic as the `.name` fold
+                            // in `expr_member.rs`.
+                            if call.args.len() >= 2 && args.len() >= 2 {
+                                let key_is_name = matches!(
+                                    call.args[1].expr.as_ref(),
+                                    ast::Expr::Lit(ast::Lit::Str(s)) if s.value.as_str() == Some("name")
+                                );
+                                if key_is_name {
+                                    let lowered_obj_is_global_intrinsic = match &args[0] {
+                                        Expr::GlobalGet(0) => true,
+                                        Expr::PropertyGet { object: inner, .. } => {
+                                            matches!(inner.as_ref(), Expr::GlobalGet(0))
+                                        }
+                                        _ => false,
+                                    };
+                                    if lowered_obj_is_global_intrinsic {
+                                        let folded = super::name_fold::builtin_fn_name_for_arg(
+                                            call.args[0].expr.as_ref(),
+                                        );
+                                        if let Some(fname) = folded {
+                                            return Ok(Ok(super::name_fold::name_data_descriptor(
+                                                fname,
+                                            )));
+                                        }
+                                    }
+                                }
+                            }
                             let mut iter = args.into_iter();
                             let obj = iter.next().unwrap_or(Expr::Undefined);
                             let key = iter.next().unwrap_or(Expr::Undefined);

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1111,6 +1111,63 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
             }
         }
     }
+
+    // #2144: spec `.name` own-property on built-in functions / constructors.
+    //
+    // Built-in constructors (`TypeError`, `Promise`, `Array`, …) and the
+    // static functions on built-in namespaces / constructors (`Math.min`,
+    // `Promise.race`, `Array.isArray`, …) are not represented as named
+    // closure values in Perry. Reading their `.name` therefore falls through
+    // to a globalThis lookup that returns 0/undefined instead of the spec
+    // name string. `assert.throws` reports `expectedErrorConstructor.name`
+    // and Test262 regularly inspects built-in `.name`, so fold these reads
+    // here at lowering time when the receiver shape is unambiguous.
+    //
+    // Detection is gated on the *lowered* receiver expression — bare
+    // `GlobalGet(0)` (after the reroute-undo above for `TypeError.name`) or
+    // `PropertyGet { GlobalGet(0), <method> }` (for `Math.min.name` /
+    // `Promise.race.name`). Local shadowing (`const Math = …`) lowers the
+    // receiver to a `LocalGet` instead, so the fold is correctly skipped.
+    if let ast::MemberProp::Ident(prop_ident) = &member.prop {
+        if prop_ident.sym.as_ref() == "name" {
+            match &object_expr {
+                Expr::GlobalGet(0) => {
+                    if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
+                        let name = obj_ident.sym.as_ref();
+                        if crate::analysis::is_builtin_global_value_name(name) {
+                            return Ok(Expr::String(name.to_string()));
+                        }
+                    }
+                }
+                Expr::PropertyGet {
+                    object: inner,
+                    property,
+                } => {
+                    if matches!(inner.as_ref(), Expr::GlobalGet(0)) {
+                        if let ast::Expr::Member(inner_member) = member.obj.as_ref() {
+                            if let (
+                                ast::Expr::Ident(ns_ident),
+                                ast::MemberProp::Ident(method_ident),
+                            ) = (inner_member.obj.as_ref(), &inner_member.prop)
+                            {
+                                let ns = ns_ident.sym.as_ref();
+                                let method = method_ident.sym.as_ref();
+                                if method == property.as_str()
+                                    && crate::analysis::is_builtin_static_function_member(
+                                        ns, method,
+                                    )
+                                {
+                                    return Ok(Expr::String(method.to_string()));
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
     let object = Box::new(object_expr);
 
     // Unimplemented-API gate (#463). When the receiver is a

--- a/test-parity/node-suite/object/builtin-function-name.ts
+++ b/test-parity/node-suite/object/builtin-function-name.ts
@@ -1,0 +1,79 @@
+// #2144: a built-in function's `name` own-property read back `undefined`
+// (and `getOwnPropertyDescriptor(Promise.race, "name")` returned undefined).
+// Per spec, `name` is a `{ writable:false, enumerable:false, configurable:true }`
+// own data property whose value is the function's name. Follow-up to #2075
+// (#2059), which only covered user-defined function declarations and
+// expressions.
+//
+// Descriptor fields are logged individually so the byte-for-byte comparison
+// doesn't depend on console's multi-line object formatting.
+
+// Built-in constructors.
+console.log("Promise:", Promise.name);
+console.log("Array:", Array.name);
+console.log("Object:", Object.name);
+console.log("Map:", Map.name);
+console.log("Set:", Set.name);
+
+// Built-in Error constructors — `assert.throws` reports
+// `expectedErrorConstructor.name` to label thrown errors.
+console.log("Error:", Error.name);
+console.log("TypeError:", TypeError.name);
+console.log("RangeError:", RangeError.name);
+console.log("SyntaxError:", SyntaxError.name);
+console.log("ReferenceError:", ReferenceError.name);
+
+// Static functions on built-in namespaces / constructors.
+console.log("Math.min:", Math.min.name);
+console.log("Math.max:", Math.max.name);
+console.log("Math.floor:", Math.floor.name);
+console.log("Math.abs:", Math.abs.name);
+console.log("Promise.race:", Promise.race.name);
+console.log("Promise.all:", Promise.all.name);
+console.log("Promise.resolve:", Promise.resolve.name);
+console.log("Array.isArray:", Array.isArray.name);
+console.log("Array.from:", Array.from.name);
+console.log("Object.keys:", Object.keys.name);
+console.log("Object.assign:", Object.assign.name);
+console.log("Number.isFinite:", Number.isFinite.name);
+console.log("Number.isInteger:", Number.isInteger.name);
+console.log("JSON.parse:", JSON.parse.name);
+console.log("JSON.stringify:", JSON.stringify.name);
+
+// Descriptor form — Test262 inspects the data descriptor directly.
+const d1 = Object.getOwnPropertyDescriptor(Promise.race, "name");
+console.log(
+  "Promise.race desc:",
+  d1?.value,
+  d1?.writable,
+  d1?.enumerable,
+  d1?.configurable,
+);
+const d2 = Object.getOwnPropertyDescriptor(TypeError, "name");
+console.log(
+  "TypeError desc:",
+  d2?.value,
+  d2?.writable,
+  d2?.enumerable,
+  d2?.configurable,
+);
+const d3 = Object.getOwnPropertyDescriptor(Math.min, "name");
+console.log(
+  "Math.min desc:",
+  d3?.value,
+  d3?.writable,
+  d3?.enumerable,
+  d3?.configurable,
+);
+
+// Non-function members must NOT fold (Math.PI is a number — `.name` is
+// undefined per spec, not the string "PI").
+console.log("Math.PI.name:", (Math.PI as any).name);
+
+// Local shadowing should bypass the fold and fall through to the lookup
+// on the user value. The arrow stored via object-literal property syntax
+// is left to the runtime — testing here only ensures we do NOT mis-fold.
+{
+  const Math: any = { custom: () => "shadowed" };
+  console.log("shadowed has-prop:", typeof Math.custom);
+}


### PR DESCRIPTION
## Summary

Built-in functions' `.name` own-property read back `undefined`. `Promise.race.name`, `Math.min.name`, `Array.isArray.name`, and built-in error constructors (`TypeError.name`, …) all returned `0` / `undefined` where the spec defines `name` as `{ value, writable:false, enumerable:false, configurable:true }`. Follow-up to #2075 (which covered user-defined functions only).

Built-in constructors and namespace static functions in Perry aren't represented as named closure values — bare reads of them produce the `globalThis` lookup's sentinel, so `.name` on the result follows suit. `assert.throws` consequently reported the expected error constructor as `undefined` instead of `TypeError`/`RangeError`/etc., and Test262's `built-ins/Function` sample is dominated by `Cannot read … (reading 'name')`.

## Fix

HIR-level constant fold in `lower/expr_member.rs` and `lower/expr_call/native_module.rs`:

- `<BuiltinCtor>.name` → `Expr::String("<Ctor>")`
- `<BuiltinNs>.<staticFn>.name` → `Expr::String("<fn>")` (gated on a known spec-defined function table — numeric constants like `Math.PI.name` stay unfolded)
- `Object.getOwnPropertyDescriptor(<BuiltinFn>, "name")` → the spec-compliant data descriptor object literal

Both fold sites gate on the *lowered* receiver matching `GlobalGet(0)` / `PropertyGet { GlobalGet(0), … }`, so a locally-shadowed `const Math = …` lowers to a `LocalGet` and correctly bypasses the fold.

## Test plan

- [x] `test-parity/node-suite/object/builtin-function-name.ts` byte-identical to `node --experimental-strip-types`
- [x] Existing `test-parity/node-suite/object/function-name-descriptor.ts` (#2075) still byte-identical (no regression)
- [x] `cargo test --release -p perry-hir --lib` — 111/111 pass
- [x] `cargo fmt --all -- --check` clean

Surfaced by the #799 Test262 radar re-harvest. Part of #793.
