### PR TITLE
fix(node:http): wire HttpServer for nested-scope createServer + add Server.address() (#2153)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -3088,6 +3088,10 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("http", "closeIdleConnections", true, Some("HttpServer")),
     method("http", "on", true, Some("HttpServer")),
     method("http", "addListener", true, Some("HttpServer")),
+    // #2153 — `.address()` was stubbed in the runtime
+    // (`js_node_http_server_address_json`) but missing from both
+    // `NATIVE_MODULE_TABLE` and the manifest.
+    method("http", "address", true, Some("HttpServer")),
     method("http", "on", true, Some("IncomingMessage")),
     method("http", "addListener", true, Some("IncomingMessage")),
     method("http", "pause", true, Some("IncomingMessage")),
@@ -3150,12 +3154,14 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("https", "listen", true, Some("HttpsServer")),
     method("https", "close", true, Some("HttpsServer")),
     method("https", "on", true, Some("HttpsServer")),
+    method("https", "address", true, Some("HttpsServer")),
     class("https", "Server"),
     // --- node:http2 server (issue #577 Phase 3) ---
     method("http2", "createSecureServer", false, None),
     method("http2", "listen", true, Some("Http2SecureServer")),
     method("http2", "close", true, Some("Http2SecureServer")),
     method("http2", "on", true, Some("Http2SecureServer")),
+    method("http2", "address", true, Some("Http2SecureServer")),
     class("http2", "Http2SecureServer"),
     class("http2", "Http2ServerRequest"),
     class("http2", "Http2ServerResponse"),

--- a/crates/perry-codegen/src/lower_call/native_table/http.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/http.rs
@@ -370,6 +370,20 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         args: &[NA_STR, NA_PTR],
         ret: NR_F64,
     },
+    // `server.address()` — returns `{ port, address, family }` (or `null`
+    // before listen completes). Runtime serializes to JSON; codegen
+    // parses via `NR_OBJ_FROM_JSON_STR`. Without this row, `server.address()`
+    // fell through to typed-feedback dispatch and returned NaN.
+    // (#2153 followup to #2129.)
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "address",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_address_json",
+        args: &[],
+        ret: NR_OBJ_FROM_JSON_STR,
+    },
     // IncomingMessage instance methods
     NativeModSig {
         module: "http",
@@ -826,6 +840,15 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         args: &[NA_STR, NA_PTR],
         ret: NR_F64,
     },
+    NativeModSig {
+        module: "https",
+        has_receiver: true,
+        method: "address",
+        class_filter: Some("HttpsServer"),
+        runtime: "js_node_https_server_address_json",
+        args: &[],
+        ret: NR_OBJ_FROM_JSON_STR,
+    },
     // ========== node:http2 server (issue #577 Phase 3) ==========
     NativeModSig {
         module: "http2",
@@ -864,6 +887,15 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         runtime: "js_node_http2_server_on",
         args: &[NA_STR, NA_PTR],
         ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http2",
+        has_receiver: true,
+        method: "address",
+        class_filter: Some("Http2SecureServer"),
+        runtime: "js_node_http2_server_address_json",
+        args: &[],
+        ret: NR_OBJ_FROM_JSON_STR,
     },
     // `@perryts/google-auth` is no longer bundled in perry-stdlib —
     // since v0.5.1015 the package is published as a standalone npm

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -410,6 +410,26 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                             ("http" | "https", "request" | "get") => {
                                                 Some("ClientRequest")
                                             }
+                                            // #2153 — `const server = http.createServer(...)`
+                                            // inside a function body (the CJS wrapper closure
+                                            // counts: a raw `.js` user file is wrapped in
+                                            // `(function(){ ... })()` before lowering). The
+                                            // module-level + named-import paths
+                                            // (`createServer(...)` after
+                                            // `import { createServer } from 'node:http'`) were
+                                            // already registering correctly; the member-call
+                                            // form `http.createServer(...)` slipped through
+                                            // this arm's match because the row didn't exist.
+                                            // Without the tag, `server.listen(...)` /
+                                            // `server.on(...)` / `server.close()` falls
+                                            // through to `js_typed_feedback_native_call_method`
+                                            // → generic `js_native_call_method`, which has no
+                                            // HttpServer arm → returns NaN.
+                                            ("http", "createServer") => Some("HttpServer"),
+                                            ("https", "createServer") => Some("HttpsServer"),
+                                            ("http2", "createSecureServer") => {
+                                                Some("Http2SecureServer")
+                                            }
                                             // node-cron's `cron.schedule(expr, cb)` returns a job
                                             // handle whose `start()`/`stop()`/`isRunning()` methods
                                             // dispatch via the ("node-cron", true, METHOD) entries

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1432 entries across 82 modules
+// Coverage: 1435 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1432 entries across 82 modules.
+Total: 1435 entries across 82 modules.
 
 ## Modules
 
@@ -782,6 +782,7 @@ Total: 1432 entries across 82 modules.
 - `addListener` — instance *(class: `IncomingMessage`)*
 - `addListener` — instance *(class: `ServerResponse`)*
 - `addTrailers` — instance *(class: `ServerResponse`)*
+- `address` — instance *(class: `HttpServer`)*
 - `close` — instance *(class: `Agent`)*
 - `close` — instance *(class: `HttpServer`)*
 - `closeAllConnections` — instance *(class: `HttpServer`)*
@@ -844,6 +845,7 @@ Total: 1432 entries across 82 modules.
 
 ### Methods
 
+- `address` — instance *(class: `Http2SecureServer`)*
 - `close` — instance *(class: `Http2SecureServer`)*
 - `createSecureServer` — module
 - `listen` — instance *(class: `Http2SecureServer`)*
@@ -867,6 +869,7 @@ Total: 1432 entries across 82 modules.
 ### Methods
 
 - `Agent` — module
+- `address` — instance *(class: `HttpsServer`)*
 - `close` — instance *(class: `HttpsServer`)*
 - `createServer` — module
 - `createServer` — module


### PR DESCRIPTION
## Summary

Second slice of #2129 (node:http method-surface gaps). Fixes the "undefined.listen" / NaN-listen-return cluster by registering the result of `http.createServer(...)` as an `HttpServer` native instance even when the decl lives inside a function body (which all CJS `.js` programs do — Perry wraps them in `(function(){ ... })()`).

### Root cause

The member-callee var_decl arm in `destructuring/var_decl.rs:401` had match rows for `mysql.createPool`, `pg.connect`, etc. but missed `http.createServer` / `https.createServer` / `http2.createSecureServer`. The module-level + named-import paths were already registering correctly (`const s = createServer(...)` after `import { createServer } from 'node:http'`), but `const s = http.createServer(...)` slipped through.

Without the tag, `server.listen(...)` fell through to `js_typed_feedback_native_call_method` → generic `js_native_call_method`, which has no HttpServer arm and returned NaN. Symptoms:

```
typeof server.listen(0)  // "number" instead of "object"
result === server        // false instead of true
listen callback          // never fired
```

After the fix, the HIR lowers `server.listen(0)` as `NativeMethodCall { module: "http", class_name: Some("HttpServer"), method: "listen" }` — the direct dispatch path that PR #2157 already wired through to a chain-returning runtime.

### Also includes

`address()` dispatch rows for HttpServer / HttpsServer / Http2SecureServer. The runtime fns (`js_node_http_*_server_address_json`) already existed and serialized the bind state as JSON, but no NativeModSig entry routed user calls to them — so `server.address()` was hitting the same typed-feedback NaN path. Now `server.address()` returns `{ address, family, port }`.

### Verification

End-to-end test now works:

```js
const http = require('http');
const server = http.createServer((req, res) => { res.end('hello\n'); });
server.listen(3456, () => {
  console.log(JSON.stringify(server.address()));
  // → {"address":"0.0.0.0","family":"IPv4","port":3456}
  http.get('http://127.0.0.1:3456/', (res) => {
    let data = '';
    res.on('data', (c) => data += c);
    res.on('end', () => { console.log(data.trim()); server.close(); });
  });
});
// listening, address: {"address":"0.0.0.0","family":"IPv4","port":3456}
// server received request
// response: hello
```

Pre-fix, the listen callback never fired and the program exited silently.

## Test plan

- [x] HIR `--print-hir` confirms `server.listen(0)` lowers as `NativeMethodCall { class_name: Some("HttpServer"), method: "listen" }` (was a plain Call+PropertyGet)
- [x] Manual end-to-end: createServer → listen(port, cb) → address() → http.get → res.on('data'/'end') → server.close — all dispatch correctly
- [x] `cargo test --release -p perry-codegen --test manifest_consistency` — 4/4 pass (drift gate covers the new manifest entries)
- [x] `cargo fmt --all -- --check` clean

## Remaining #2129 work

- #2154 — real Agent socket pooling (`keepAlive` / `maxSockets` enforcement, `agent.sockets`/`freeSockets`, validation throws)
- #2156 — radar `PERRY_NO_AUTO_OPTIMIZE=1` strips `perry-ext-http-server` from the link line

Companion to PR #2157 (#2129 Agent slice — merged).
