### PR TITLE
test(parity): remove stale transform objectMode failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1478,12 +1478,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline with multiple async-gen stages — fails to deliver final collected output. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/transform/objectmode-passes-objects": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: objectMode Transform — object data not preserved through transform. Flips to PASS when #1539 lands."
-  },
   "node-suite/stream/pipeline/null-cb-error-form": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- revalidated that stream/transform/objectmode-passes-objects now passes on current main after the Transform callback work
- remove only that stale known-failure entry

Refs #1539

## DeepWiki
- reference/deepwiki/nodejs-node-stream-transform-objectmode-passes-objects-2026-05-28.md

## Verification
- Baseline exact fixture on origin/main PASS: test-parity/reports/parity_report_20260528_034535.json
- ./run_parity_tests.sh --suite=node-suite --module=stream --filter transform/objectmode-passes-objects PASS, report test-parity/reports/parity_report_20260528_034712.json
- jq empty test-parity/known_failures.json PASS
- git diff --check PASS

## Non-goals
- no stream runtime changes
- no broader Transform callback/error/pipe cleanup
- no removal of adjacent still-failing stream known failures