### PR TITLE
test(parity): remove stale objectMode buffer failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -566,12 +566,6 @@
     "category": "bug-open",
     "reason": "node:stream: after error, end event should NOT fire. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/object-mode/preserve-buffer": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: objectMode does not preserve Buffer identity through data event. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/options/auto-destroy-false": {
     "issue": "1531",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- revalidated that stream/object-mode/preserve-buffer passes on current main
- remove only that stale known-failure entry

Refs #1532

## DeepWiki
- reference/deepwiki/nodejs-node-stream-readable-objectmode-buffer-identity-2026-05-28.md

## Verification
- Baseline exact fixture on origin/main PASS: test-parity/reports/parity_report_20260528_034959.json
- ./run_parity_tests.sh --suite=node-suite --module=stream --filter object-mode/preserve-buffer PASS, report test-parity/reports/parity_report_20260528_035056.json
- jq empty test-parity/known_failures.json PASS
- git diff --check PASS

## Non-goals
- no stream runtime changes
- no broader objectMode read/flow semantics
- no removal of adjacent still-failing stream known failures