### PR TITLE
Fix Node Readable async iterator cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,6 +166,14 @@ jobs:
         # - perry-ui-android: needs Android NDK.
         # - perry-ui-windows: needs win32 headers.
         run: |
+          (
+            while sleep 60; do
+              echo "cargo-test still running at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            done
+          ) &
+          cargo_test_heartbeat_pid=$!
+          trap 'kill "$cargo_test_heartbeat_pid" 2>/dev/null || true' EXIT
+
           # #1444: perry-runtime's tests share process-global state — the
           # per-thread arena/GC, the timer queues, and the `NOTIFIED` flag are
           # process singletons. Running them across the default test-harness

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -1019,6 +1019,22 @@ pub(crate) fn lower_stmt(
                 });
             }
         }
+        ast::Stmt::Break(break_stmt) => {
+            if let Some(ref label) = break_stmt.label {
+                module.init.push(Stmt::LabeledBreak(label.sym.to_string()));
+            } else {
+                module.init.push(Stmt::Break);
+            }
+        }
+        ast::Stmt::Continue(continue_stmt) => {
+            if let Some(ref label) = continue_stmt.label {
+                module
+                    .init
+                    .push(Stmt::LabeledContinue(label.sym.to_string()));
+            } else {
+                module.init.push(Stmt::Continue);
+            }
+        }
         ast::Stmt::For(for_stmt) => {
             // Push a lexical scope covering init/test/update/body, so
             // `for (let i = 0; ...)` bindings don't leak to the outer scope.

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -131,7 +131,7 @@ fn iterator_return_call(iter_id: LocalId, needs_await: bool) -> Expr {
     }
 }
 
-fn insert_iterator_return_before_breaks(
+fn insert_iterator_return_before_abrupts(
     stmts: &mut Vec<Stmt>,
     iter_id: LocalId,
     needs_await: bool,
@@ -143,14 +143,26 @@ fn insert_iterator_return_before_breaks(
                 rewritten.push(Stmt::Expr(iterator_return_call(iter_id, needs_await)));
                 rewritten.push(Stmt::Break);
             }
+            Stmt::LabeledBreak(label) => {
+                rewritten.push(Stmt::Expr(iterator_return_call(iter_id, needs_await)));
+                rewritten.push(Stmt::LabeledBreak(label));
+            }
+            Stmt::Return(value) => {
+                rewritten.push(Stmt::Expr(iterator_return_call(iter_id, needs_await)));
+                rewritten.push(Stmt::Return(value));
+            }
+            Stmt::Throw(expr) => {
+                rewritten.push(Stmt::Expr(iterator_return_call(iter_id, needs_await)));
+                rewritten.push(Stmt::Throw(expr));
+            }
             Stmt::If {
                 condition,
                 mut then_branch,
                 mut else_branch,
             } => {
-                insert_iterator_return_before_breaks(&mut then_branch, iter_id, needs_await);
+                insert_iterator_return_before_abrupts(&mut then_branch, iter_id, needs_await);
                 if let Some(else_stmts) = else_branch.as_mut() {
-                    insert_iterator_return_before_breaks(else_stmts, iter_id, needs_await);
+                    insert_iterator_return_before_abrupts(else_stmts, iter_id, needs_await);
                 }
                 rewritten.push(Stmt::If {
                     condition,
@@ -377,7 +389,7 @@ pub(crate) fn lower_stmt_for_of(
         }
         let mut user_body: Vec<Stmt> = module.init.drain(init_before..).collect();
         if is_node_readable_for_await {
-            insert_iterator_return_before_breaks(&mut user_body, iter_id, needs_await);
+            insert_iterator_return_before_abrupts(&mut user_body, iter_id, needs_await);
         }
         body_stmts.append(&mut user_body);
         // __result = __iter.next()

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -127,7 +127,7 @@ fn iterator_return_call(iter_id: LocalId, needs_await: bool) -> Expr {
     }
 }
 
-fn insert_iterator_return_before_breaks(
+fn insert_iterator_return_before_abrupts(
     stmts: &mut Vec<Stmt>,
     iter_id: LocalId,
     needs_await: bool,
@@ -139,14 +139,26 @@ fn insert_iterator_return_before_breaks(
                 rewritten.push(Stmt::Expr(iterator_return_call(iter_id, needs_await)));
                 rewritten.push(Stmt::Break);
             }
+            Stmt::LabeledBreak(label) => {
+                rewritten.push(Stmt::Expr(iterator_return_call(iter_id, needs_await)));
+                rewritten.push(Stmt::LabeledBreak(label));
+            }
+            Stmt::Return(value) => {
+                rewritten.push(Stmt::Expr(iterator_return_call(iter_id, needs_await)));
+                rewritten.push(Stmt::Return(value));
+            }
+            Stmt::Throw(expr) => {
+                rewritten.push(Stmt::Expr(iterator_return_call(iter_id, needs_await)));
+                rewritten.push(Stmt::Throw(expr));
+            }
             Stmt::If {
                 condition,
                 mut then_branch,
                 mut else_branch,
             } => {
-                insert_iterator_return_before_breaks(&mut then_branch, iter_id, needs_await);
+                insert_iterator_return_before_abrupts(&mut then_branch, iter_id, needs_await);
                 if let Some(else_stmts) = else_branch.as_mut() {
-                    insert_iterator_return_before_breaks(else_stmts, iter_id, needs_await);
+                    insert_iterator_return_before_abrupts(else_stmts, iter_id, needs_await);
                 }
                 rewritten.push(Stmt::If {
                     condition,
@@ -1164,7 +1176,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 });
                 let mut user_body = lower_body_stmt(ctx, &for_of_stmt.body)?;
                 if is_node_readable_for_await {
-                    insert_iterator_return_before_breaks(&mut user_body, iter_id, needs_await);
+                    insert_iterator_return_before_abrupts(&mut user_body, iter_id, needs_await);
                 }
                 body_stmts.extend(user_body);
                 body_stmts.push(Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))));

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -1315,6 +1315,9 @@ extern "C" fn ns_iter_to_array(closure: *const ClosureHeader, opts: f64) -> f64 
     if !arr.is_null() {
         out = extend_with_array(out, arr);
     }
+    mark_stream_ended(this);
+    clear_readable_buffer(this);
+    destroy_stream(this, f64::from_bits(TAG_UNDEFINED));
     settle_consuming(this, opts, box_pointer(out as *const u8))
 }
 

--- a/crates/perry-runtime/src/node_stream/async_iterator.rs
+++ b/crates/perry-runtime/src/node_stream/async_iterator.rs
@@ -5,6 +5,7 @@ const READABLE_ITERATOR_STREAM_KEY: &[u8] = b"__perryReadableIteratorStream";
 const READABLE_ITERATOR_INDEX_KEY: &[u8] = b"__perryReadableIteratorIndex";
 const READABLE_ITERATOR_DONE_KEY: &[u8] = b"__perryReadableIteratorDone";
 const READABLE_ITERATOR_DESTROY_ON_RETURN_KEY: &[u8] = b"__perryReadableIteratorDestroyOnReturn";
+const READABLE_ITERATOR_STREAM_INDEX_KEY: &[u8] = b"__perryReadableIteratorStreamIndex";
 
 fn iterator_result(value: f64, done: bool) -> f64 {
     let obj = crate::object::js_object_alloc(0, 2);
@@ -42,6 +43,28 @@ fn iterator_has_yielded(iterator: f64) -> bool {
         .is_some_and(|index| index > 0.0)
 }
 
+fn iterator_local_index(iterator: f64) -> u32 {
+    get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_INDEX_KEY))
+        .and_then(jsvalue_as_f64)
+        .unwrap_or(0.0)
+        .max(0.0) as u32
+}
+
+fn stream_consume_index(stream: f64) -> u32 {
+    get_hidden_value(stream, hidden_key(READABLE_ITERATOR_STREAM_INDEX_KEY))
+        .and_then(jsvalue_as_f64)
+        .unwrap_or(0.0)
+        .max(0.0) as u32
+}
+
+fn set_stream_consume_index(stream: f64, index: u32) {
+    set_hidden_value(
+        stream,
+        hidden_key(READABLE_ITERATOR_STREAM_INDEX_KEY),
+        index as f64,
+    );
+}
+
 extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
     let iterator = this_value(closure);
     if get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_DONE_KEY))
@@ -52,6 +75,15 @@ extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
     let Some(stream) = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_STREAM_KEY)) else {
         return readable_iterator_done();
     };
+    if stream_destroyed(stream) {
+        set_hidden_value(
+            iterator,
+            hidden_key(READABLE_ITERATOR_DONE_KEY),
+            f64::from_bits(TAG_TRUE),
+        );
+        return readable_iterator_done();
+    }
+    invoke_read_once(stream);
     if let Some(err) = readable_hidden_error(stream) {
         set_hidden_value(
             iterator,
@@ -61,24 +93,23 @@ extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
         return rejected_promise(err);
     }
     let arr = readable_chunks_array(stream);
-    let index = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_INDEX_KEY))
-        .and_then(jsvalue_as_f64)
-        .unwrap_or(0.0)
-        .max(0.0) as u32;
+    let index = stream_consume_index(stream);
     if arr.is_null() || index >= crate::array::js_array_length(arr) {
         set_hidden_value(
             iterator,
             hidden_key(READABLE_ITERATOR_DONE_KEY),
             f64::from_bits(TAG_TRUE),
         );
-        set_hidden_value(stream, hidden_ended_key(), f64::from_bits(TAG_TRUE));
+        mark_stream_ended(stream);
+        destroy_stream(stream, f64::from_bits(TAG_UNDEFINED));
         return readable_iterator_done();
     }
     let value = crate::array::js_array_get_f64(arr, index);
+    set_stream_consume_index(stream, index + 1);
     set_hidden_value(
         iterator,
         hidden_key(READABLE_ITERATOR_INDEX_KEY),
-        (index + 1) as f64,
+        (iterator_local_index(iterator) + 1) as f64,
     );
     mark_disturbed(stream);
     resolved_promise(iterator_result(value, false))

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -266,12 +266,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline() callback never fires (depends on stream event delivery). Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/from-iterable-iteration": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: `for await (chunk of readable)` iterates to empty — async iterator does not yield chunks. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/object-mode": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -410,12 +404,6 @@
     "category": "bug-open",
     "reason": "node:stream: setEncoding(hex) + data delivery doesn't fire. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/async-iter/break-cleanup": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: `for await` break + destroyOnReturn (default) doesn't destroy the stream. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/events/readable-event": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -457,12 +445,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: pipeline for already-ended source doesn't invoke callback. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/double-iterate-empty": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: re-iterating a consumed Readable doesn't behave correctly (event chain). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/read-no-arg": {
     "issue": "1532",
@@ -506,12 +488,6 @@
     "category": "bug-open",
     "reason": "node:stream: read + unshift + re-read sequence doesn't deliver chunks in the right order. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/async-iter/try-finally-cleanup": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: try/finally with for-await early bail-out + destroyed flag not honored. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/error/error-no-listener": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -523,12 +499,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: read() on objectMode stream should return one object per call. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/async-iter/two-iterators-error": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: two concurrent Symbol.asyncIterator on same Readable should error. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/with-async-fn": {
     "issue": "1539",
@@ -788,12 +758,6 @@
     "category": "bug-open",
     "reason": "node:stream: read() after end — does not consistently return null. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/iterate-after-toarray": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: iteration after toArray() yields wrong count (state not drained). Flips to PASS when #1558 lands."
-  },
   "node-suite/stream/web/transform-cancel-propagates": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -932,12 +896,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose() async-gen handler throw — composite does not emit 'error'. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/flow/pause-during-async-iter": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pause() inside for-await — affects iteration count incorrectly. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipe/dest-error-propagates": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1063,12 +1021,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: getReader({mode:'byob'}) on bytes-type stream fails or returns wrong shape. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/async-iter/single-iteration-only": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: second for-await on already-iterated Readable yields wrong count (state not drained). Flips to PASS when #1531 lands."
   },
   "node-suite/stream/pipe/source-error-no-propagation": {
     "issue": "1532",
@@ -1298,12 +1250,6 @@
     "category": "bug-open",
     "reason": "node:stream: simple R→T→W e2e pipe — received chunks wrong (transform/uppercase not applied). Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/iterator-prevent-cancel": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: readable.iterator({destroyOnReturn:false}) — early return still destroys. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/iter-helpers/every-async-rejection": {
     "issue": "1558",
     "added": "2026-05-24",
@@ -1448,12 +1394,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: ReadableStream.from(customIterable) — value or done wrong. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/readable/iterator-empty-after-consumed": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: second [Symbol.asyncIterator]() call — does not return immediately-done iterator. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/web/writer-write-resolves-after-sink": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -1465,12 +1405,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: compose(transform).toArray() — chain produces wrong result. Flips to PASS when #1558 lands."
-  },
-  "node-suite/stream/readable/iter-and-data-listener": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: for-await + 'data' listener — data event listener counts wrong, or iter empty. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipeline/three-async-fns": {
     "issue": "1532",

--- a/test-parity/node-suite/stream/async-iter/destroy-on-return-false-continues.ts
+++ b/test-parity/node-suite/stream/async-iter/destroy-on-return-false-continues.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+
+// Returning an iterator with destroyOnReturn:false leaves the stream open and
+// a later default async iterator resumes from the next unread chunk.
+const r = Readable.from(["a", "b", "c"]);
+const it = (r as any).iterator({ destroyOnReturn: false });
+const first = await it.next();
+await it.return?.();
+const rest: string[] = [];
+for await (const v of r) rest.push(String(v));
+console.log("first:", first.value);
+console.log("rest:", rest.join(","));
+console.log("destroyed:", r.destroyed);


### PR DESCRIPTION
Summary
- Destroy Node Readable streams on default async-iterator exhaustion and early abrupt exits.
- Track consumption at the stream level so later iterators do not replay drained chunks, while destroyOnReturn:false can resume from the next chunk.
- Drain/destroy after Readable.toArray() and remove the now-passing stream async-iterator known failures.

Tests
- cargo fmt --all -- --check
- ./scripts/check_file_size.sh
- git diff --check
- jq empty test-parity/known_failures.json
- cargo check -p perry-hir -p perry-runtime
- RUST_TEST_THREADS=1 cargo test -p perry-runtime
- cargo test -p perry-hir
- ./scripts/regen_api_docs.sh
- cargo build -p perry
- cargo test -p perry-codegen-arkts --release --lib
- cargo test -p perry-codegen-arkts --release --test phase2_full_app_smoke -- --nocapture
- PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream/async-iter
- PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream/iterator
- PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream/flow --filter pause-during-async-iter
- PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream/readable --filter double-iterate-empty
- PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream/readable --filter from-iterable-iteration
- PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream/readable --filter iterate-after-toarray
- PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream/readable --filter iterator-empty-after-consumed
- PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream/readable --filter iterator-prevent-cancel
- PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream/readable --filter iter-and-data-listener

Note
- python3 -m unittest tests.test_compiler_output_regression exits 0 locally after skipping because the local Python is older than 3.11.