### PR TITLE
test(node:stream): drop stale readable objectMode failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -248,12 +248,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline() callback never fires (depends on stream event delivery). Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/object-mode": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Readable objectMode push/data events don't deliver. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/set-encoding": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary

- Remove the stale `node-suite/stream/readable/object-mode` known-failure entry.
- Leave the adjacent still-failing `node-suite/stream/readable/object-mode-read-returns-object` entry intact.

## Evidence

- DeepWiki local reference: `reference/deepwiki/nodejs-node-stream-readable-objectmode-data-events-2026-05-28.md` (not staged)
- Probe: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/object-mode`
  - `node-suite/stream/readable/object-mode`: PASS
  - `node-suite/stream/readable/object-mode-read-returns-object`: still FAILS as expected
  - report: `test-parity/reports/parity_report_20260528_040240.json`
- Manual exact fixture check before and after removal: `test-parity/node-suite/stream/readable/object-mode.ts`
  - Node: `count + first: 2 {"a":1}`
  - Perry: `count + first: 2 {"a":1}`
- `jq empty test-parity/known_failures.json`: PASS
- `git diff --check`: PASS

## Non-goals

- No stream runtime changes.
- No `read()` / readable-event semantics cleanup.
- No removal of adjacent still-failing stream known failures.
