### PR TITLE
test(node:stream): drop stale writable drain failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -266,12 +266,6 @@
     "category": "bug-open",
     "reason": "node:stream: unshift+data chain doesn't deliver. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/writable/drain-event": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: write() return + drain event semantics not delivered. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/error/error-event": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary

- Remove the stale `node-suite/stream/writable/drain-event` known-failure entry.
- Keep adjacent stream known failures untouched.

## Evidence

- DeepWiki local reference: `reference/deepwiki/nodejs-node-stream-writable-drain-event-2026-05-28.md` (not staged)
- Baseline exact pass: `./run_parity_tests.sh --suite=node-suite --module=stream --filter writable/drain-event`
  - report: `test-parity/reports/parity_report_20260528_040700.json`
- Final exact pass after known-failure removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter writable/drain-event`
  - report: `test-parity/reports/parity_report_20260528_040712.json`
- `jq empty test-parity/known_failures.json`: PASS
- `git diff --check`: PASS

## Non-goals

- No stream runtime changes.
- No broader Writable lifecycle or backpressure rewrite.
- No removal of adjacent still-failing stream known failures.
