### PR TITLE
test(node:stream): drop stale error event failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -272,12 +272,6 @@
     "category": "bug-open",
     "reason": "node:stream: write() return + drain event semantics not delivered. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/error/error-event": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: destroy(err) → error event chain doesn't deliver. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/from-async-iterable": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary

- Remove the stale `node-suite/stream/error/error-event` known-failure entry.
- Keep adjacent stream known failures untouched.

## Evidence

- DeepWiki local reference: `reference/deepwiki/nodejs-node-stream-error-event-delivery-2026-05-28.md` (not staged)
- Baseline exact pass: `./run_parity_tests.sh --suite=node-suite --module=stream --filter error/error-event`
  - report: `test-parity/reports/parity_report_20260528_040919.json`
- Final exact pass after known-failure removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter error/error-event`
  - report: `test-parity/reports/parity_report_20260528_040931.json`
- `jq empty test-parity/known_failures.json`: PASS
- `git diff --check`: PASS

## Non-goals

- No stream runtime changes.
- No broader destroy/error ordering rewrite.
- No removal of adjacent still-failing stream known failures.
