### PR TITLE
test(node:stream): drop stale pipe chain failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -374,12 +374,6 @@
     "category": "bug-open",
     "reason": "node:stream: final() constructor option not invoked before finish. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/pipe/pipe-chain": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: r.pipe(t).pipe(sink) chain doesn't propagate data through transforms. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipeline/async-function": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary

- Remove the stale `node-suite/stream/pipe/pipe-chain` known-failure entry.
- Keep adjacent stream known failures untouched.

## Evidence

- DeepWiki local reference: `reference/deepwiki/nodejs-node-stream-pipe-chain-2026-05-28.md` (not staged)
- Baseline exact pass: `./run_parity_tests.sh --suite=node-suite --module=stream --filter pipe/pipe-chain`
  - report: `test-parity/reports/parity_report_20260528_041111.json`
- Final exact pass after known-failure removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter pipe/pipe-chain`
  - report: `test-parity/reports/parity_report_20260528_041130.json`
- `jq empty test-parity/known_failures.json`: PASS
- `git diff --check`: PASS

## Non-goals

- No stream runtime changes.
- No pipeline or compose cleanup.
- No removal of adjacent still-failing stream known failures.
