### PR TITLE
test(node:stream): drop stale read no-arg failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -398,12 +398,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline for already-ended source doesn't invoke callback. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/read-no-arg": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: read() with no arg should return the entire buffered chunk. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/finished/options-config": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary

- Remove the stale `node-suite/stream/readable/read-no-arg` known-failure entry.
- Keep adjacent stream known failures untouched.

## Evidence

- DeepWiki local reference: `reference/deepwiki/nodejs-node-stream-readable-read-no-arg-2026-05-28.md` (not staged)
- Baseline exact pass: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/read-no-arg`
  - report: `test-parity/reports/parity_report_20260528_041323.json`
- Final exact pass after known-failure removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/read-no-arg`
  - report: `test-parity/reports/parity_report_20260528_041336.json`
- `jq empty test-parity/known_failures.json`: PASS
- `git diff --check`: PASS

## Non-goals

- No stream runtime changes.
- No explicit `read(n)` behavior change.
- No removal of adjacent still-failing stream known failures.
