### PR TITLE
fix(runtime): wire %TypedArray% intrinsic chain (#2145)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1087,23 +1087,26 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
         {
             if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
                 if obj_ident.sym.as_ref() == property.as_str() {
-                    // #2060 / #2142: `<Ctor>.prototype` must keep reading the
-                    // constructor closure's *real* prototype object. Each
-                    // built-in constructor closure carries a populated proto
-                    // (allocated in `populate_global_this_builtins`, populated
-                    // by `populate_builtin_prototype_methods`) — that is where
+                    // #2060 / #2142 / #2145: `<Ctor>.prototype` and
+                    // `<Ctor>.__proto__` must keep reading the constructor
+                    // closure's real proto / static-prototype. Each built-in
+                    // constructor closure carries a populated proto (allocated
+                    // in `populate_global_this_builtins`, populated by
+                    // `populate_builtin_prototype_methods`) — that is where
                     // typed-array accessor descriptors AND the reified
-                    // built-in prototype method values live. Collapsing to
-                    // `PropertyGet { GlobalGet(0), "prototype" }` would instead
-                    // read `globalThis.prototype` (undefined), losing every
-                    // method-value reachable through `<Ctor>.prototype.<m>`
-                    // (which is the value-read form of #2142, distinct from
-                    // the typeof-fold which fires at AST level).
-                    let outer_is_prototype = matches!(
+                    // built-in prototype method values live. For
+                    // `__proto__`, typed-array constructors are linked to the
+                    // shared `%TypedArray%` intrinsic via
+                    // `closure_set_static_prototype` (#2145); collapsing here
+                    // would drop the receiver, and codegen lowers
+                    // `globalThis.__proto__` through the no-name path → literal
+                    // `0.0` (a number), which is the symptom reported in #2145.
+                    let outer_is_prototype_or_proto = matches!(
                         &member.prop,
                         ast::MemberProp::Ident(p) if p.sym.as_ref() == "prototype"
+                            || p.sym.as_ref() == "__proto__"
                     );
-                    if !outer_is_prototype {
+                    if !outer_is_prototype_or_proto {
                         object_expr = Expr::GlobalGet(0);
                     }
                 }

--- a/crates/perry-runtime/src/gc/types.rs
+++ b/crates/perry-runtime/src/gc/types.rs
@@ -723,6 +723,12 @@ pub const OBJ_FLAG_NO_EXTEND: u16 = 0x04;
 // (`GC_COPY_SURVIVAL_AGE_MASK = 0x0038`) and bits 14..15 the layout state,
 // so 0x08 would be clobbered on every minor GC. Bits 6..13 are free.
 pub const OBJ_FLAG_NULL_PROTO: u16 = 0x40;
+// #2145: this object is a per-kind `<TypedArrayCtor>.prototype` whose
+// `[[Prototype]]` is the shared `%TypedArray%.prototype` intrinsic.
+// `Object.getPrototypeOf(Int8Array.prototype)` returns the cached
+// `TYPED_ARRAY_INTRINSIC_PROTO_PTR` (a single object shared across all
+// 11 typed-array kinds) when this bit is set.
+pub const OBJ_FLAG_TYPED_ARRAY_PROTO: u16 = 0x100;
 /// Array payload is stored as canonical raw `f64` values, not NaN-boxed
 /// `JSValue` slots. This is only meaningful for `GC_TYPE_ARRAY`; object
 /// flags share the same `_reserved` word but never inspect this bit.

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1481,6 +1481,26 @@ pub extern "C" fn js_object_get_field_by_name(
                         crate::closure::closure_arity(obj as *const crate::closure::ClosureHeader);
                     return JSValue::number(arity.unwrap_or(0) as f64);
                 }
+                // #2145: `fn.__proto__` is the closure's [[Prototype]]
+                // — `Int8Array.__proto__ === %TypedArray%` after
+                // `populate_global_this_builtins` wired the static-proto
+                // side-table. Spec models `__proto__` as a
+                // `Object.prototype` accessor that returns
+                // `[[GetPrototypeOf]](this)`; for closures Perry resolves
+                // that off the same side-table `Object.setPrototypeOf`
+                // writes to. Walking `closure_get_dynamic_prop` would
+                // instead look for a `__proto__` own-prop on the parent,
+                // which is the wrong thing — the proto IS the answer.
+                // Returns undefined (not null) when no proto is recorded,
+                // matching the closure-receiver `getPrototypeOf` arm
+                // semantics for non-wired closures.
+                if name_bytes == b"__proto__" {
+                    if let Some(proto_bits) = crate::closure::closure_static_prototype(obj as usize)
+                    {
+                        return JSValue::from_bits(proto_bits);
+                    }
+                    return JSValue::undefined();
+                }
                 if let Ok(name_str) = std::str::from_utf8(name_bytes) {
                     // User-attached own property (`fn.x = 1`) takes precedence.
                     let val = crate::closure::closure_get_dynamic_prop(obj as usize, name_str);

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -424,6 +424,64 @@ fn install_typed_array_proto_accessors(proto_obj: *mut ObjectHeader) {
     }
 }
 
+/// Allocate the shared `%TypedArray%` intrinsic constructor (a closure) and
+/// its `.prototype` object, cache both in the GC-rooted atomics, and wire the
+/// closure's `prototype` dynamic-prop to point at the shared prototype.
+///
+/// Spec: `%TypedArray%` is the abstract parent constructor for `Int8Array`,
+/// `Uint8Array`, … — `Int8Array.__proto__ === %TypedArray%` and
+/// `Object.getPrototypeOf(Int8Array.prototype) === %TypedArray%.prototype`.
+/// Perry didn't model this before #2145, so test262's TypedArray-prototype
+/// walks read `null.prototype` and the constructor's `__proto__` returned the
+/// `0.0` no-value placeholder (`typeof Int8Array.__proto__ === "number"`).
+///
+/// Idempotent: subsequent calls return the cached pointer. Called from
+/// `populate_global_this_builtins` (single-threaded under the singleton CAS),
+/// so the AtomicI64 stores don't need to race-resolve.
+fn ensure_typed_array_intrinsic() -> (*mut crate::closure::ClosureHeader, *mut ObjectHeader) {
+    let existing_ctor = crate::object::TYPED_ARRAY_INTRINSIC_PTR.load(Ordering::Acquire);
+    let existing_proto = crate::object::TYPED_ARRAY_INTRINSIC_PROTO_PTR.load(Ordering::Acquire);
+    if existing_ctor != 0 && existing_proto != 0 {
+        return (
+            existing_ctor as *mut crate::closure::ClosureHeader,
+            existing_proto as *mut ObjectHeader,
+        );
+    }
+    let ctor = crate::closure::js_closure_alloc(global_this_builtin_noop_thunk as *const u8, 0);
+    let proto = js_object_alloc(0, 0);
+    if ctor.is_null() || proto.is_null() {
+        return (std::ptr::null_mut(), std::ptr::null_mut());
+    }
+    // Wire `%TypedArray%.prototype` so `getPrototypeOf(Int8Array).prototype`
+    // hits a real object instead of undefined.
+    let proto_key_bytes = b"prototype";
+    let proto_key =
+        crate::string::js_string_from_bytes(proto_key_bytes.as_ptr(), proto_key_bytes.len() as u32);
+    let proto_value = crate::value::js_nanbox_pointer(proto as i64);
+    js_object_set_field_by_name(ctor as *mut ObjectHeader, proto_key, proto_value);
+    // #2060: the four reflectable `length`/`byteLength`/`byteOffset`/`buffer`
+    // accessor descriptors are own properties of `%TypedArray%.prototype` per
+    // spec, NOT of the per-kind proto. Pre-#2145 they were installed on each
+    // per-kind proto because `getPrototypeOf(per_kind_proto)` returned the
+    // per-kind proto itself (identity), so the same lookup happened to land
+    // there. After #2145 wires the per-kind protos to share the intrinsic
+    // proto, the descriptors must live on the intrinsic itself for
+    // `Object.getOwnPropertyDescriptor(getPrototypeOf(Int8Array.prototype),
+    // "length")` to keep working.
+    install_typed_array_proto_accessors(proto);
+    crate::object::TYPED_ARRAY_INTRINSIC_PTR.store(ctor as i64, Ordering::Release);
+    crate::object::TYPED_ARRAY_INTRINSIC_PROTO_PTR.store(proto as i64, Ordering::Release);
+    (ctor, proto)
+}
+
+/// Public accessor for the `%TypedArray%.prototype` object. Returns the cached
+/// pointer if `populate_global_this_builtins` has run (so the intrinsic is
+/// initialised), else null. Used by `js_object_get_prototype_of` to resolve
+/// `Object.getPrototypeOf(Int8Array.prototype)` to the shared prototype.
+pub(crate) fn typed_array_intrinsic_proto_ptr() -> *mut ObjectHeader {
+    crate::object::TYPED_ARRAY_INTRINSIC_PROTO_PTR.load(Ordering::Acquire) as *mut ObjectHeader
+}
+
 /// Populate the freshly-allocated globalThis singleton with built-in
 /// constructor / namespace properties. Called exactly once from the CAS
 /// winner in `js_get_global_this`. Constructors get a ClosureHeader-
@@ -441,6 +499,11 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
     let proto_key_bytes = b"prototype";
     let proto_key =
         crate::string::js_string_from_bytes(proto_key_bytes.as_ptr(), proto_key_bytes.len() as u32);
+    // #2145: pre-allocate the shared `%TypedArray%` intrinsic so per-kind
+    // typed-array constructors can link their `__proto__` to it as they're
+    // built below, and the per-kind `.prototype` objects can be flagged with
+    // `OBJ_FLAG_TYPED_ARRAY_PROTO` for `Object.getPrototypeOf` resolution.
+    let (typed_array_intrinsic_ctor, _) = ensure_typed_array_intrinsic();
     // Constructors: ClosureHeader-backed so typeof is "function".
     for name in GLOBAL_THIS_BUILTIN_CONSTRUCTORS.iter().copied() {
         let func_ptr = if name == "String" {
@@ -470,6 +533,38 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             // entry point — works in tandem with `.call`/`.apply` since
             // those arms (#970) rebind IMPLICIT_THIS before forwarding.
             populate_builtin_prototype_methods(name, proto_obj);
+            // #2145: link per-kind typed-array constructors into the
+            // `%TypedArray%` chain. `Int8Array.__proto__ === %TypedArray%`
+            // and `Object.getPrototypeOf(Int8Array.prototype) ===
+            // %TypedArray%.prototype`. Both reads are resolved off this
+            // wiring (closure static-prototype side-table for the ctor;
+            // `OBJ_FLAG_TYPED_ARRAY_PROTO` + the cached
+            // `TYPED_ARRAY_INTRINSIC_PROTO_PTR` for the per-kind proto).
+            if !typed_array_intrinsic_ctor.is_null()
+                && matches!(
+                    name,
+                    "Int8Array"
+                        | "Uint8Array"
+                        | "Uint8ClampedArray"
+                        | "Int16Array"
+                        | "Uint16Array"
+                        | "Int32Array"
+                        | "Uint32Array"
+                        | "Float32Array"
+                        | "Float64Array"
+                        | "BigInt64Array"
+                        | "BigUint64Array"
+                )
+            {
+                let intrinsic_bits =
+                    crate::value::js_nanbox_pointer(typed_array_intrinsic_ctor as i64).to_bits();
+                crate::closure::closure_set_static_prototype(closure_ptr as usize, intrinsic_bits);
+                unsafe {
+                    let gc = (proto_obj as *mut u8).sub(crate::gc::GC_HEADER_SIZE)
+                        as *mut crate::gc::GcHeader;
+                    (*gc)._reserved |= crate::gc::OBJ_FLAG_TYPED_ARRAY_PROTO;
+                }
+            }
         }
         let name_bytes = name.as_bytes();
         let name_key =
@@ -831,14 +926,23 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
             install_noop_proto_methods(proto_obj, &[("toString", 0)]);
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
-        // Typed-array constructors: install the `%TypedArray%.prototype`
-        // accessor descriptors (`length`/`byteLength`/`byteOffset`/`buffer`)
-        // on the per-kind prototype object (#2060), plus the shared
-        // %TypedArray%.prototype method set (#2142).
+        // Typed-array constructors: keep the reified per-kind prototype
+        // method set (#2142) on each per-kind `.prototype` so direct
+        // reads like `Int8Array.prototype.at` continue to return a
+        // function. The accessor descriptors
+        // (`length`/`byteLength`/`byteOffset`/`buffer`) are installed
+        // *only* on the shared `%TypedArray%.prototype` (#2145, in
+        // `ensure_typed_array_intrinsic`) — reached via
+        // `Object.getPrototypeOf(Int8Array.prototype) ===
+        // %TypedArray%.prototype`. Pre-#2145 they were also stamped on
+        // each per-kind proto because `getPrototypeOf(per_kind)`
+        // returned identity; now that it walks to the intrinsic, they
+        // belong on the parent (matches Node's
+        // `getOwnPropertyDescriptor(Int8Array.prototype, "length")` =
+        // `undefined`).
         "Int8Array" | "Uint8Array" | "Uint8ClampedArray" | "Int16Array" | "Uint16Array"
         | "Int32Array" | "Uint32Array" | "Float32Array" | "Float64Array" | "BigInt64Array"
         | "BigUint64Array" => {
-            install_typed_array_proto_accessors(proto_obj);
             install_noop_proto_methods(
                 proto_obj,
                 &[

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -76,6 +76,15 @@ static OS_CONSTANTS_ERRNO_CACHE: AtomicU64 = AtomicU64::new(0);
 static OS_CONSTANTS_PRIORITY_CACHE: AtomicU64 = AtomicU64::new(0);
 static OS_CONSTANTS_DLOPEN_CACHE: AtomicU64 = AtomicU64::new(0);
 static GLOBAL_THIS_PTR: AtomicI64 = AtomicI64::new(0);
+// #2145: the `%TypedArray%` intrinsic constructor (a closure) and its
+// `.prototype` (an object). Lazily allocated by
+// `populate_global_this_builtins` so the per-kind typed-array constructors
+// (`Int8Array`, ...) can chain `__proto__` to `%TypedArray%`, and each per-kind
+// `.prototype` carries `OBJ_FLAG_TYPED_ARRAY_PROTO` whose
+// `js_object_get_prototype_of` returns the shared `%TypedArray%.prototype` here.
+// Both are mutable roots scanned by `scan_object_cache_roots_mut`.
+pub(crate) static TYPED_ARRAY_INTRINSIC_PTR: AtomicI64 = AtomicI64::new(0);
+pub(crate) static TYPED_ARRAY_INTRINSIC_PROTO_PTR: AtomicI64 = AtomicI64::new(0);
 
 // Overflow field storage for objects that exceed their pre-allocated inline slot count.
 // Keyed by (obj_ptr as usize) -> Vec<JSValue bits> indexed by absolute field_index
@@ -1178,6 +1187,16 @@ pub fn scan_object_cache_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
         Ordering::Relaxed,
     );
     visitor.visit_atomic_i64_slot(&GLOBAL_THIS_PTR, Ordering::Acquire, Ordering::Release);
+    visitor.visit_atomic_i64_slot(
+        &TYPED_ARRAY_INTRINSIC_PTR,
+        Ordering::Acquire,
+        Ordering::Release,
+    );
+    visitor.visit_atomic_i64_slot(
+        &TYPED_ARRAY_INTRINSIC_PROTO_PTR,
+        Ordering::Acquire,
+        Ordering::Release,
+    );
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1254,18 +1254,33 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                 if (*gc)._reserved & crate::gc::OBJ_FLAG_NULL_PROTO != 0 {
                     return f64::from_bits(TAG_NULL);
                 }
-                // #489: a function/constructor receiver has no walkable
-                // [[Prototype]] in Perry's model. This is reached when a
-                // prototype-chain walk hits a built-in constructor — e.g.
-                // drizzle's `is(value, type)` does
-                // `cls = Object.getPrototypeOf(arr).constructor` (the global
-                // `Array` closure) then loops `cls = Object.getPrototypeOf(cls)`
-                // until it hits null. Returning the closure itself here makes
-                // `getPrototypeOf(cls) === cls`, an infinite self-cycle that
-                // hangs the walk. JS terminates it at null (Function.prototype
-                // → Object.prototype → null); Perry doesn't model those, so
-                // return null directly to break the cycle.
+                // #2145: per-kind typed-array `.prototype` objects share a
+                // single `%TypedArray%.prototype` parent. Resolved off the
+                // cached intrinsic pointer (also a GC root) so the chain holds
+                // through copying GC.
+                if (*gc)._reserved & crate::gc::OBJ_FLAG_TYPED_ARRAY_PROTO != 0 {
+                    let p = crate::object::typed_array_intrinsic_proto_ptr();
+                    if !p.is_null() {
+                        return f64::from_bits(crate::value::js_nanbox_pointer(p as i64).to_bits());
+                    }
+                }
+                // #489 / #2145: a function/constructor receiver has no
+                // walkable [[Prototype]] in Perry's model UNLESS its
+                // closure-static-prototype side-table has been set
+                // (`Object.setPrototypeOf(closure, parent)` — effect's
+                // TagClass and Perry's `%TypedArray%`-chain typed-array
+                // constructors use this). Returning the recorded parent
+                // satisfies drizzle's `cls = getPrototypeOf(cls)` walk
+                // (which terminates when the parent has no further
+                // recorded proto) and the test262 `__proto__` chain. When
+                // no static prototype is recorded, return null to break
+                // the would-be `getPrototypeOf(cls) === cls` self-cycle.
                 if (*gc).obj_type == crate::gc::GC_TYPE_CLOSURE {
+                    if let Some(proto_bits) =
+                        crate::closure::closure_static_prototype(raw_addr as usize)
+                    {
+                        return f64::from_bits(proto_bits);
+                    }
                     return f64::from_bits(TAG_NULL);
                 }
             }
@@ -1280,9 +1295,22 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                 if (*gc)._reserved & crate::gc::OBJ_FLAG_NULL_PROTO != 0 {
                     return f64::from_bits(TAG_NULL);
                 }
-                // #489: function/constructor receiver — see the 0x7FFD branch
-                // above. Break the prototype-chain self-cycle with null.
+                if (*gc)._reserved & crate::gc::OBJ_FLAG_TYPED_ARRAY_PROTO != 0 {
+                    let p = crate::object::typed_array_intrinsic_proto_ptr();
+                    if !p.is_null() {
+                        return f64::from_bits(crate::value::js_nanbox_pointer(p as i64).to_bits());
+                    }
+                }
+                // #489 / #2145: function/constructor receiver — see the
+                // 0x7FFD branch above. Return the recorded static
+                // prototype if any, else null to break the chain-walk
+                // self-cycle.
                 if (*gc).obj_type == crate::gc::GC_TYPE_CLOSURE {
+                    if let Some(proto_bits) =
+                        crate::closure::closure_static_prototype(bits as usize)
+                    {
+                        return f64::from_bits(proto_bits);
+                    }
                     return f64::from_bits(TAG_NULL);
                 }
             }


### PR DESCRIPTION
## Summary

Fixes #2145 — the `%TypedArray%` intrinsic constructor chain was malformed:
`typeof Int8Array.__proto__` returned `"number"`, and
`Object.getPrototypeOf(Int8Array).prototype` was `null`. This drove the 25× `Cannot read properties of null (reading 'prototype')` cascade in the test262 TypedArray re-harvest.

Two layered bugs:

- **Codegen / HIR**: `Int8Array.__proto__` collapsed to `PropertyGet { GlobalGet(0), "__proto__" }` (receiver lost), and the GlobalGet-receiver codegen arm lowered unknown property names to a literal `0.0` — hence `typeof === "number"`. Extended the existing #2060 "preserve receiver for typed-array `.prototype`" case to also fire for `.__proto__`.
- **Runtime**: no `%TypedArray%` intrinsic existed. Now allocated once from `populate_global_this_builtins` (closure + prototype object, both as GC-rooted `AtomicI64` statics). Each per-kind constructor links to it via `closure_set_static_prototype`; each per-kind `.prototype` carries a new `OBJ_FLAG_TYPED_ARRAY_PROTO` so `js_object_get_prototype_of` resolves to the shared intrinsic proto. The #2060 `length` / `byteLength` / `byteOffset` / `buffer` accessor descriptors moved onto the shared proto (spec-correct location).

Byte-identical with Node on the issue's repro and the extended cross-kind sharing check. `closure_static_prototype` is now consulted by `getPrototypeOf` for closures, so drizzle's `cls = getPrototypeOf(cls)` walk still terminates (the `%TypedArray%` itself has no further parent recorded → null).

## Test plan
- [x] `repro_2145.ts` from the issue — 4/4 byte-identical with Node
- [x] Extended cross-kind sharing (`Int8Array..BigUint64Array` all share `%TypedArray%`) — byte-identical
- [x] #2060 reflection regression (`getOwnPropertyDescriptor(getPrototypeOf(Int8Array.prototype), "length").get.call(new Int8Array(5))` → `5`) — byte-identical
- [x] `test_gap_typed_arrays.ts`, `test_gap_typed_array_numeric_length.ts` — byte-identical
- [x] `cargo test --release -p perry-runtime --lib object::` — 8/8 pass
- [x] `cargo fmt --all -- --check` clean
