### PR TITLE
fix(node:http,https): Server() callable alias + sync bind for address().port (#2132)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2679,6 +2679,9 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // --- http (perry-ext-http surface + classes the framework spec
     //     exposes). Both http and https route through the same crate. ---
     method("http", "createServer", false, None),
+    // `http.Server(handler)` is Node's callable-constructor alias for
+    // `createServer` (works with or without `new`). #2132.
+    method("http", "Server", false, None),
     method("http", "request", false, None),
     method("http", "get", false, None),
     property("http", "METHODS"),
@@ -2716,6 +2719,9 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("http", "keepAlive", true, Some("Agent")),
     method("http", "protocol", true, Some("Agent")),
     method("https", "createServer", false, None),
+    // `https.Server(options, handler)` is Node's callable-constructor
+    // alias for `createServer` (works with or without `new`). #2132.
+    method("https", "Server", false, None),
     method("https", "request", false, None),
     method("https", "get", false, None),
     class("https", "Server"),

--- a/crates/perry-codegen/src/lower_call/native_table/http.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/http.rs
@@ -303,6 +303,17 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         args: &[NA_PTR],
         ret: NR_PTR,
     },
+    // `http.Server(handler)` is Node's callable-constructor alias for
+    // `http.createServer` (works with or without `new`). #2132.
+    NativeModSig {
+        module: "http",
+        has_receiver: false,
+        method: "Server",
+        class_filter: None,
+        runtime: "js_node_http_create_server",
+        args: &[NA_PTR],
+        ret: NR_PTR,
+    },
     // HttpServer instance methods (class_filter: HttpServer)
     NativeModSig {
         module: "http",
@@ -806,6 +817,17 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         module: "https",
         has_receiver: false,
         method: "createServer",
+        class_filter: None,
+        runtime: "js_node_https_create_server",
+        args: &[NA_F64, NA_PTR],
+        ret: NR_PTR,
+    },
+    // `https.Server(options, handler)` is Node's callable-constructor
+    // alias for `https.createServer` (works with or without `new`). #2132.
+    NativeModSig {
+        module: "https",
+        has_receiver: false,
+        method: "Server",
         class_filter: None,
         runtime: "js_node_https_create_server",
         args: &[NA_F64, NA_PTR],

--- a/crates/perry-ext-http-server/src/http2_server.rs
+++ b/crates/perry-ext-http-server/src/http2_server.rs
@@ -135,8 +135,29 @@ pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_ar
     let (request_tx, request_rx) = mpsc::channel::<HttpPendingRequest>(1024);
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
 
+    // #2132 — synchronous bind so `server.address().port` is correct
+    // before the `listen(port, cb)` callback fires. See
+    // `server::js_node_http_server_listen` for the rationale.
+    let bind_str = format!("{}:{}", host, port);
+    let addr: SocketAddr = match bind_str.parse() {
+        Ok(a) => a,
+        Err(_) => SocketAddr::from(([0, 0, 0, 0], port)),
+    };
+    let std_listener = match std::net::TcpListener::bind(addr) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("[node:http2] bind {}:{} failed: {}", host, port, e);
+            return server_handle;
+        }
+    };
+    let actual_port = std_listener.local_addr().map(|a| a.port()).unwrap_or(port);
+    if let Err(e) = std_listener.set_nonblocking(true) {
+        eprintln!("[node:http2] set_nonblocking failed: {}", e);
+        return server_handle;
+    }
+
     let tls_config = if let Some(s) = get_handle_mut::<Http2SecureServer>(server_handle) {
-        s.base.bound_port = port;
+        s.base.bound_port = actual_port;
         s.base.bound_host = host.clone();
         s.base.listening = true;
         s.base.shutdown_tx = Some(shutdown_tx);
@@ -159,7 +180,6 @@ pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_ar
 
     let request_tx = Arc::new(request_tx);
     let request_tx_for_spawn = request_tx.clone();
-    let host_for_spawn = host.clone();
     let acceptor = TlsAcceptor::from(tls_config);
 
     // Issue #577 Phase 3 — `tokio::spawn` from inside
@@ -181,18 +201,10 @@ pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_ar
             .build()
             .expect("Failed to create http2 accept-loop runtime");
         handle.block_on(async move {
-            let bind_str = format!("{}:{}", host_for_spawn, port);
-            let addr: SocketAddr = match bind_str.parse() {
-                Ok(a) => a,
-                Err(_) => SocketAddr::from(([0, 0, 0, 0], port)),
-            };
-            let listener = match TcpListener::bind(addr).await {
+            let listener = match TcpListener::from_std(std_listener) {
                 Ok(l) => l,
                 Err(e) => {
-                    eprintln!(
-                        "[node:http2] bind {}:{} failed: {}",
-                        host_for_spawn, port, e
-                    );
+                    eprintln!("[node:http2] tokio adopt failed: {}", e);
                     return;
                 }
             };

--- a/crates/perry-ext-http-server/src/https_server.rs
+++ b/crates/perry-ext-http-server/src/https_server.rs
@@ -161,8 +161,30 @@ pub unsafe extern "C" fn js_node_https_server_listen(server_handle: i64, args_ar
     let (request_tx, request_rx) = mpsc::channel::<HttpPendingRequest>(1024);
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
 
+    // #2132 — synchronous bind so `server.address().port` reflects the
+    // OS-assigned ephemeral port before the `listen(port, cb)` callback
+    // fires. See `server::js_node_http_server_listen` for the full
+    // rationale; same shape here, on top of the TLS-acceptor wrap.
+    let bind_str = format!("{}:{}", host, port);
+    let addr: SocketAddr = match bind_str.parse() {
+        Ok(a) => a,
+        Err(_) => SocketAddr::from(([0, 0, 0, 0], port)),
+    };
+    let std_listener = match std::net::TcpListener::bind(addr) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("[node:https] bind {}:{} failed: {}", host, port, e);
+            return server_handle;
+        }
+    };
+    let actual_port = std_listener.local_addr().map(|a| a.port()).unwrap_or(port);
+    if let Err(e) = std_listener.set_nonblocking(true) {
+        eprintln!("[node:https] set_nonblocking failed: {}", e);
+        return server_handle;
+    }
+
     let tls_config = if let Some(s) = get_handle_mut::<HttpsServer>(server_handle) {
-        s.base.bound_port = port;
+        s.base.bound_port = actual_port;
         s.base.bound_host = host.clone();
         s.base.listening = true;
         s.base.shutdown_tx = Some(shutdown_tx);
@@ -185,23 +207,14 @@ pub unsafe extern "C" fn js_node_https_server_listen(server_handle: i64, args_ar
 
     let request_tx = Arc::new(request_tx);
     let request_tx_for_spawn = request_tx.clone();
-    let host_for_spawn = host.clone();
     let acceptor = TlsAcceptor::from(tls_config);
 
     perry_ffi::spawn_blocking_with_reactor(move || {
         tokio::spawn(async move {
-            let bind_str = format!("{}:{}", host_for_spawn, port);
-            let addr: SocketAddr = match bind_str.parse() {
-                Ok(a) => a,
-                Err(_) => SocketAddr::from(([0, 0, 0, 0], port)),
-            };
-            let listener = match TcpListener::bind(addr).await {
+            let listener = match TcpListener::from_std(std_listener) {
                 Ok(l) => l,
                 Err(e) => {
-                    eprintln!(
-                        "[node:https] bind {}:{} failed: {}",
-                        host_for_spawn, port, e
-                    );
+                    eprintln!("[node:https] tokio adopt failed: {}", e);
                     return;
                 }
             };

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -126,8 +126,38 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
     let (upgrade_tx, upgrade_rx) = mpsc::channel::<HttpPendingUpgrade>(256);
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
 
+    // #2132 — bind synchronously here so `server.address().port` returns
+    // the OS-assigned ephemeral port when the user passed `port: 0`. The
+    // pre-#2132 path wrote the *requested* port (0) into `bound_port`,
+    // spawned an async task to do `TcpListener::bind(...).await`, and
+    // fired the `listen(port, cb)` callback before the bind had actually
+    // happened — so `server.address().port` inside the callback was 0
+    // and downstream `http.get({port: 0, ...})` calls couldn't connect.
+    //
+    // `std::net::TcpListener::bind` is synchronous; we then hand the
+    // standard listener to `tokio::net::TcpListener::from_std` for the
+    // async accept loop. `set_nonblocking(true)` is required for
+    // `from_std` to drive `.accept().await` correctly.
+    let bind_str = format!("{}:{}", host, port);
+    let addr: SocketAddr = match bind_str.parse() {
+        Ok(a) => a,
+        Err(_) => SocketAddr::from(([0, 0, 0, 0], port)),
+    };
+    let std_listener = match std::net::TcpListener::bind(addr) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("[node:http] bind {}:{} failed: {}", host, port, e);
+            return server_handle;
+        }
+    };
+    let actual_port = std_listener.local_addr().map(|a| a.port()).unwrap_or(port);
+    if let Err(e) = std_listener.set_nonblocking(true) {
+        eprintln!("[node:http] set_nonblocking failed: {}", e);
+        return server_handle;
+    }
+
     if let Some(s) = get_handle_mut::<HttpServer>(server_handle) {
-        s.bound_port = port;
+        s.bound_port = actual_port;
         s.bound_host = host.clone();
         s.listening = true;
         s.shutdown_tx = Some(shutdown_tx);
@@ -146,7 +176,6 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
     let upgrade_tx = Arc::new(upgrade_tx);
     let request_tx_for_spawn = request_tx.clone();
     let upgrade_tx_for_spawn = upgrade_tx.clone();
-    let host_for_spawn = host.clone();
 
     // The closure passed to `spawn_blocking_with_reactor` runs INSIDE
     // a tokio worker task (perry-stdlib's shim wraps it in
@@ -157,15 +186,10 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
     // and let the closure return immediately.
     perry_ffi::spawn_blocking_with_reactor(move || {
         tokio::spawn(async move {
-            let bind_str = format!("{}:{}", host_for_spawn, port);
-            let addr: SocketAddr = match bind_str.parse() {
-                Ok(a) => a,
-                Err(_) => SocketAddr::from(([0, 0, 0, 0], port)),
-            };
-            let listener = match TcpListener::bind(addr).await {
+            let listener = match TcpListener::from_std(std_listener) {
                 Ok(l) => l,
                 Err(e) => {
-                    eprintln!("[node:http] bind {}:{} failed: {}", host_for_spawn, port, e);
+                    eprintln!("[node:http] tokio adopt failed: {}", e);
                     return;
                 }
             };

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1435 entries across 82 modules
+// Coverage: 1437 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -734,6 +734,8 @@ declare module "http" {
   /** stdlib */
   export function Agent(...args: any[]): any;
   /** stdlib */
+  export function Server(...args: any[]): any;
+  /** stdlib */
   export function createServer(...args: any[]): any;
   /** stdlib */
   export function get(...args: any[]): any;
@@ -769,6 +771,8 @@ declare module "https" {
   export class ServerResponse { [key: string]: any; }
   /** stdlib */
   export function Agent(...args: any[]): any;
+  /** stdlib */
+  export function Server(...args: any[]): any;
   /** stdlib */
   export function createServer(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1435 entries across 82 modules.
+Total: 1437 entries across 82 modules.
 
 ## Modules
 
@@ -755,6 +755,7 @@ Total: 1435 entries across 82 modules.
 ### Methods
 
 - `Agent` — module
+- `Server` — module
 - `__get_aborted` — instance *(class: `IncomingMessage`)*
 - `__get_complete` — instance *(class: `IncomingMessage`)*
 - `__get_destroyed` — instance *(class: `IncomingMessage`)*
@@ -869,6 +870,7 @@ Total: 1435 entries across 82 modules.
 ### Methods
 
 - `Agent` — module
+- `Server` — module
 - `address` — instance *(class: `HttpsServer`)*
 - `close` — instance *(class: `HttpsServer`)*
 - `createServer` — module


### PR DESCRIPTION
## Summary

Two related fixes for the runtime-fail cluster in #2132 (stacked after PR #2184):

1. **`http.Server(handler)` / `https.Server(opts, handler)` are now callable.** Node treats `Server` and `createServer` as interchangeable — the same constructor backs both, with or without `new`. Many Node test fixtures use the callable form. Without a dispatch row, Perry returned undefined and the next `.listen(...)` crashed with `Cannot read properties of undefined (reading 'listen')`. Adds `Server` rows to the codegen native table aliased to `js_node_http_create_server` / `js_node_https_create_server`.

2. **`server.address().port` returned the *requested* port.** The listen() FFI wrote `bound_port = port` (e.g. 0) and then spawned an async task to actually `TcpListener::bind(...).await`. The `listen(port, cb)` callback fired *before* the async bind resolved, so `server.address().port` inside the callback was the pre-OS-assignment port — `0` for `listen(0, cb)`. Downstream `http.get({ port: 0, ... })` then couldn't reach the server. Bind synchronously with `std::net::TcpListener::bind`, capture `local_addr().port()`, write the *actual* port into `bound_port`, then hand the listener to `tokio::net::TcpListener::from_std` for the async accept loop.

Same fix mirrored across `http`, `https`, and `http2` server FFIs. The synchronous bind also matches Node's observable timing: the `listen()` callback runs after the socket is actually bound.

## Verified

- `cargo test --release -p perry-ext-http-server --lib`: 8 passed.
- `cargo fmt --all -- --check`: clean.
- Direct re-run of the 4 cited "Cannot read 'listen'" diff tests against local radar staging:
  - `test-https-agent.js`: was runtime-fail, now **pass**.
  - `test-https-agent-servername.js`: was runtime-fail, now **pass**.
  - `test-https-agent-additional-options.js`: was runtime-fail, now **pass**.
  - `test-http-abort-client.js`: moves past listen crash to surface a distinct downstream gap (`serverRes.on` undefined) — separate follow-up.

## Scope

Second cluster from #2132 after the PEM-Buffer cluster in #2184. Remaining buckets surfaced by the radar (`Agent.getName` / `addRequest` missing methods, `(no output)` silent exits, `UnsupportedCertVersion` cert-fixture incompat) will be follow-up PRs.

## Test plan

- [x] `cargo test --release -p perry-ext-http-server --lib`
- [x] `cargo fmt --all -- --check`
- [x] Local node-core radar comparison on the 4 cited diff tests
- [ ] CI green
