### PR TITLE
fix(node:stream): honor readable read size

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -270,9 +270,9 @@ extern "C" fn ns_async_dispose(closure: *const ClosureHeader) -> f64 {
     resolved_promise(f64::from_bits(TAG_UNDEFINED))
 }
 
-extern "C" fn ns_read1(closure: *const ClosureHeader, _n: f64) -> f64 {
+extern "C" fn ns_read1(closure: *const ClosureHeader, n: f64) -> f64 {
     let stream = this_value(closure);
-    read_stream_default_size(stream)
+    read_stream_with_size_arg(stream, n)
 }
 
 extern "C" fn ns_set_encoding1(closure: *const ClosureHeader, encoding: f64) -> f64 {
@@ -921,10 +921,10 @@ pub extern "C" fn js_node_stream_method_allow_half_open(stream_handle: i64) -> f
 }
 
 #[no_mangle]
-pub extern "C" fn js_node_stream_method_read(stream_handle: i64, _n: f64) -> f64 {
+pub extern "C" fn js_node_stream_method_read(stream_handle: i64, n: f64) -> f64 {
     let stream = stream_value_from_handle(stream_handle);
     mark_disturbed(stream);
-    read_stream_default_size(stream)
+    read_stream_with_size_arg(stream, n)
 }
 
 #[no_mangle]
@@ -2404,10 +2404,27 @@ fn clear_readable_buffer(stream: f64) {
         box_pointer(crate::array::js_array_alloc(0) as *const u8),
     );
     set_hidden_value(stream, hidden_buffered_key(), 0.0);
+    set_hidden_value(stream, hidden_key(b"readableLength"), 0.0);
+}
+
+fn read_stream_with_size_arg(stream: f64, size: f64) -> f64 {
+    let size_value = JSValue::from_bits(size.to_bits());
+    if size_value.is_undefined() || !size_value.is_number() {
+        return read_stream_default_size(stream);
+    }
+    let size = size_value.as_number();
+    if size.is_nan() {
+        return read_stream_default_size(stream);
+    }
+    read_stream_exact_size(stream, size.trunc())
 }
 
 fn read_stream_default_size(stream: f64) -> f64 {
     invoke_read_once(stream);
+    read_stream_available_default(stream)
+}
+
+fn read_stream_available_default(stream: f64) -> f64 {
     if get_hidden_value(stream, hidden_buffered_key()).unwrap_or(0.0) <= 0.0 {
         if stream_hidden_ended(stream) {
             refresh_readable_aborted_flag(stream);
@@ -2434,6 +2451,69 @@ fn read_stream_default_size(stream: f64) -> f64 {
     }
     let result = crate::string::js_string_concat_chain(values.as_ptr(), values.len() as i32);
     box_pointer(crate::buffer::js_buffer_from_string(result, 0) as *const u8)
+}
+
+fn read_stream_exact_size(stream: f64, size: f64) -> f64 {
+    invoke_read_once(stream);
+    if size <= 0.0 {
+        return f64::from_bits(TAG_NULL);
+    }
+    let requested = size as usize;
+    let available = get_hidden_value(stream, hidden_buffered_key())
+        .unwrap_or(0.0)
+        .max(0.0) as usize;
+    if available == 0 {
+        if stream_hidden_ended(stream) {
+            refresh_readable_aborted_flag(stream);
+        }
+        return f64::from_bits(TAG_NULL);
+    }
+    if requested > available && !stream_hidden_ended(stream) {
+        return f64::from_bits(TAG_NULL);
+    }
+    if requested >= available {
+        return read_stream_available_default(stream);
+    }
+
+    let mut bytes = Vec::new();
+    if let Some(chunks) = readable_hidden_chunks(stream) {
+        append_chunk_bytes(chunks, &mut bytes, 0);
+    }
+    if bytes.len() <= requested {
+        return read_stream_available_default(stream);
+    }
+    let result = buffer_value_from_bytes(&bytes[..requested]);
+    set_readable_buffer_bytes(stream, &bytes[requested..]);
+    mark_disturbed(stream);
+    result
+}
+
+fn set_readable_buffer_bytes(stream: f64, bytes: &[u8]) {
+    if bytes.is_empty() {
+        clear_readable_buffer(stream);
+        return;
+    }
+    let chunk = buffer_value_from_bytes(bytes);
+    let mut arr = crate::array::js_array_alloc(0);
+    arr = crate::array::js_array_push_f64(arr, chunk);
+    set_hidden_value(stream, hidden_chunks_key(), box_pointer(arr as *const u8));
+    let remaining = bytes.len() as f64;
+    set_hidden_value(stream, hidden_buffered_key(), remaining);
+    set_hidden_value(stream, hidden_key(b"readableLength"), remaining);
+}
+
+fn buffer_value_from_bytes(bytes: &[u8]) -> f64 {
+    let buf = crate::buffer::js_buffer_alloc(bytes.len() as i32, 0);
+    if !bytes.is_empty() {
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                crate::buffer::buffer_data_mut(buf),
+                bytes.len(),
+            );
+        }
+    }
+    box_pointer(buf as *const u8)
 }
 
 fn string_chunk_to_buffer(value: f64) -> Option<f64> {

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -1427,6 +1427,45 @@ fn readable_read_default_size_drains_buffer_as_buffer_then_null() {
     });
 }
 
+fn stream_test_buffer_bytes(value: f64) -> Vec<u8> {
+    let len = crate::buffer::js_native_buffer_byte_len(value);
+    let data = crate::buffer::js_native_buffer_data_ptr(value);
+    if data.is_null() || len == 0 {
+        return Vec::new();
+    }
+    unsafe { std::slice::from_raw_parts(data, len).to_vec() }
+}
+
+#[test]
+fn readable_read_with_size_splits_buffer_and_keeps_remainder() {
+    let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let handle = raw_ptr_from_value(stream) as i64;
+
+    let _ = js_node_stream_method_push(handle, string_value("abcdef"));
+    let _ = js_node_stream_method_push(handle, f64::from_bits(TAG_NULL));
+    assert_eq!(js_node_stream_method_readable_length(handle), 6.0);
+
+    let first = js_node_stream_method_read(handle, 3.0);
+    assert_eq!(stream_test_buffer_bytes(first), b"abc");
+    assert_eq!(js_node_stream_method_readable_length(handle), 3.0);
+
+    let second = js_node_stream_method_read(handle, f64::from_bits(TAG_UNDEFINED));
+    assert_eq!(stream_test_buffer_bytes(second), b"def");
+    assert_eq!(js_node_stream_method_readable_length(handle), 0.0);
+    assert_eq!(
+        js_node_stream_method_read(handle, f64::from_bits(TAG_UNDEFINED)).to_bits(),
+        TAG_NULL
+    );
+
+    let ended = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let ended_handle = raw_ptr_from_value(ended) as i64;
+    let _ = js_node_stream_method_push(ended_handle, string_value("ab"));
+    let _ = js_node_stream_method_push(ended_handle, f64::from_bits(TAG_NULL));
+    let larger_than_remaining = js_node_stream_method_read(ended_handle, 100.0);
+    assert_eq!(stream_test_buffer_bytes(larger_than_remaining), b"ab");
+    assert_eq!(js_node_stream_method_readable_length(ended_handle), 0.0);
+}
+
 #[test]
 fn destroyed_readable_drops_late_push_data() {
     READABLE_DATA_CAPTURED.with(|captured| captured.borrow_mut().clear());

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -338,12 +338,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline with intermediate transform doesn't propagate data → end. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/read-with-size": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: read(n) doesn't return buffered chunk (push/read pipeline not wired). Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/finished/with-options-signal": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -427,12 +421,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: decodeStrings:false option not honored (writes still arrive as Buffer). Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/read-larger-than-buffer": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: read(n) larger than buffer doesn't return remaining bytes after end. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/wrap-old-stream": {
     "issue": "1532",
@@ -553,12 +541,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: re-piping after unpipe does not flow / sink does not end. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/read-zero": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: read(0) special case not handled. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/error/error-then-end-order": {
     "issue": "1532",
@@ -829,18 +811,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: reduce(fn) without initial — first item not used as accumulator. Flips to PASS when #1558 lands."
-  },
-  "node-suite/stream/readable/read-zero-probe": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: read(0) probe — does not return null/trigger 'readable' without consuming. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/read-larger-than-buffered": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: read(N>buffered) — does not return remaining buffered bytes at EOF. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipeline/async-fn-sink": {
     "issue": "1532",


### PR DESCRIPTION
## Summary

- Route both classic `Readable.read(n)` entry points through size-aware byte-mode reads.
- Return exactly `n` bytes when enough data is buffered and keep the remainder buffered for later reads.
- Preserve default no-size drain behavior, return remaining bytes after EOF for oversized reads, and keep `read(0)` non-consuming.
- Remove the now-green `read(n)` known-failure entries: `read-with-size`, `read-larger-than-buffer`, `read-zero`, `read-zero-probe`, and `read-larger-than-buffered`.

## Evidence

- DeepWiki local reference: `reference/deepwiki/nodejs-node-stream-readable-read-sized-2026-05-28.md` (not staged)
- Baseline exact failure: `test-parity/reports/parity_report_20260528_041557.json`
- Final exact pass: `test-parity/reports/parity_report_20260528_042144.json`
- Guardrail `node-suite/stream/readable/read-larger-than-buffer*`: PASS 2/2, report `test-parity/reports/parity_report_20260528_042154.json`
- Guardrail `node-suite/stream/readable/read-zero*`: PASS 2/2, report `test-parity/reports/parity_report_20260528_042204.json`
- Focused runtime unit `readable_read_with_size_splits_buffer_and_keeps_remainder`: PASS
- `cargo test -p perry-runtime node_stream --lib`: PASS
- `cargo fmt --check --all --message-format short`: PASS
- `jq empty test-parity/known_failures.json`: PASS
- `git diff --check`: PASS
- `./scripts/check_file_size.sh`: PASS

## Non-goals

- No objectMode `read()` semantics; that is handled separately.
- No `setEncoding()` string return behavior.
- No readable-event ordering rewrite or broader stream pump refactor.
