### PR TITLE
fix(codegen): dispatch tower must forward un-bundled args (#321 regression from #2162)

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -1382,13 +1382,20 @@ pub fn try_lower_property_get_method_call(
             // `this` is captured/bound, so we don't pass the receiver
             // as an extra arg — matches the static-class fast path's
             // contract.
+            //
+            // Use `static_user_args` (the raw user args captured before
+            // rest-bundling / issue-#235 padding mutated `lowered_args`).
+            // The override target runs its own rest-bundling at call time
+            // (via `js_native_call_value` → closure-call dispatch), so it
+            // must receive the un-bundled args — the same fix as the
+            // default branch below for #321 / regression from #2162.
             ctx.current_block = probe_override_idx;
-            let user_arg_count_probe = lowered_args.len().saturating_sub(1);
+            let user_arg_count_probe = static_user_args.len();
             let (probe_args_ptr, probe_args_len_str) = if user_arg_count_probe == 0 {
                 ("null".to_string(), "0".to_string())
             } else {
                 let buf_reg = ctx.func.alloca_entry_array(DOUBLE, user_arg_count_probe);
-                for (i, a_val) in lowered_args.iter().skip(1).enumerate() {
+                for (i, a_val) in static_user_args.iter().enumerate() {
                     let slot = ctx
                         .block()
                         .gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", i))]);
@@ -1529,18 +1536,30 @@ pub fn try_lower_property_get_method_call(
             let entry = ctx.strings.entry(key_idx);
             let bytes_global = format!("@{}", entry.bytes_global);
             let name_len_str = entry.byte_len.to_string();
-            let (fb_args_ptr, fb_args_len) = if args.is_empty() {
+            let (fb_args_ptr, fb_args_len) = if static_user_args.is_empty() {
                 ("null".to_string(), "0".to_string())
             } else {
                 // Hoist the args-array alloca to the function entry
                 // block — see issue #167 and `alloca_entry_array` doc.
-                let n = args.len();
+                //
+                // Use `static_user_args` (the raw user-provided args captured
+                // before rest-bundling / issue-#235 padding mutated
+                // `lowered_args`). The `js_native_call_method` fallback path
+                // performs its own rest-bundling at runtime, so it must
+                // receive the un-bundled args. Pre-fix this read from the
+                // post-bundling `lowered_args`, which on a rest-bearing
+                // dispatch (e.g. `obj.pipe(c1, c2, c3)` post-#2162 where
+                // `pipe()` now has a synthesized `...arguments` rest) had
+                // already been truncated+rest_box'd to `[recv, rest_arr]`.
+                // The old code then alloca'd `[args.len() x double]`, stored
+                // only the rest_arr into slot 0, and told the runtime to
+                // read `args.len()` doubles — slots 1..N-1 were uninit
+                // garbage that landed in pipeArguments's `arguments[i]`,
+                // tripping `value is not a function` (#321 regression from
+                // #2162; effect-barrel-init crash).
+                let n = static_user_args.len();
                 let buf_reg = ctx.func.alloca_entry_array(DOUBLE, n);
-                // skip(1) the receiver, take(n) so the issue-#235 default-arg
-                // padding entries appended to lowered_args don't overflow the
-                // n-sized buffer (and aren't needed for the ncm fallback path,
-                // which forwards user-provided args only).
-                for (i, a_val) in lowered_args.iter().skip(1).take(n).enumerate() {
+                for (i, a_val) in static_user_args.iter().enumerate() {
                     let slot = ctx
                         .block()
                         .gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", i))]);

--- a/test-files/test_gap_arguments_dispatch_tower_default.ts
+++ b/test-files/test_gap_arguments_dispatch_tower_default.ts
@@ -1,0 +1,68 @@
+// Regression test for #321 follow-up to #2162: the dynamic method-dispatch
+// tower's default branch (`property_get.rs`'s `idispatch.default` block)
+// was filling the `js_native_call_method` args buffer from the
+// POST-rest-bundling `lowered_args`. When the dispatched method has a
+// rest-bundled signature (e.g. effect's `pipe()` once it gained the
+// synthesized `...arguments` rest from #2162), `lowered_args` had already
+// been truncated+bundled to `[recv, rest_array]`; the default branch then
+// alloca'd `[args.len() x double]`, stored only one value (the rest_array)
+// into slot 0, and told `js_native_call_method` to read `args.len()`
+// doubles — slots 1..N-1 were uninit garbage that landed in
+// `pipeArguments`'s `arguments[i]`, tripping `value is not a function` at
+// module-init time on a barrel `import { Effect } from "effect"`.
+//
+// Shape needed to trigger the fix path:
+//   1. ≥1 user class with a `pipe()` method that uses `arguments` (so the
+//      method has `method_has_rest` registered and rest-bundling kicks in).
+//   2. The call-site receiver is NOT one of those user classes (so the
+//      dispatch tower's class-id switch misses and falls into the default
+//      branch).
+//   3. The call has ≥2 args so the codegen alloca's a multi-slot buffer.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+// (1) A user class with a Pipeable-shape pipe() method. This is enough to
+// flip on the dispatch tower's class-id switch and the `method_has_rest`
+// rest-bundling path for the call-site dispatch of `.pipe(...)`.
+class Pipeable1 {
+  v = 0;
+  pipe() {
+    let acc: any = this;
+    for (let i = 0; i < arguments.length; i++) acc = arguments[i](acc);
+    return acc;
+  }
+}
+const _keep = new Pipeable1(); // keep the class alive
+
+// (2) Plain object literal with a same-shape pipe() method. Its class_id
+// (an anon-shape class id) is NOT Pipeable1's, so a method dispatch on it
+// falls through to `idispatch.default` — the fix path.
+const proto: any = {
+  v: 100,
+  pipe() {
+    let acc: any = this;
+    for (let i = 0; i < arguments.length; i++) acc = arguments[i](acc);
+    return acc;
+  },
+};
+
+const inc = (s: any) => ({ ...s, v: s.v + 1 });
+const dbl = (s: any) => ({ ...s, v: s.v * 2 });
+const sub = (s: any) => ({ ...s, v: s.v - 3 });
+
+// (3) Three transforms = exactly the shape that triggered the
+// SchemaAST_ts__282 crash inside effect:
+// `getTitleAnnotation(ast).pipe(orElse, orElse, map)`. The receiver type was
+// inferred wide enough that the static-call fast paths missed and the call
+// landed in `idispatch.default`.
+const r3 = proto.pipe(inc, dbl, sub);
+console.log("r3.v:", r3.v); // ((100+1)*2)-3 = 199
+
+const r2 = proto.pipe(inc, dbl);
+console.log("r2.v:", r2.v); // (100+1)*2 = 202
+
+const r1 = proto.pipe(inc);
+console.log("r1.v:", r1.v); // 101
+
+const r0 = proto.pipe();
+console.log("r0.v:", r0.v); // 100


### PR DESCRIPTION
## Summary

PR #2162 (the 28-line additive HIR fix that bound legacy `arguments` for object-literal shorthand methods) is correct — effect's Pipeable trait writes `pipe() { return pipeArguments(this, arguments) }` on every Pipeable instance, and without that binding `.pipe(...)` silently dropped every operand.

But the synthesis exposed a latent **codegen** bug. The dynamic method-call dispatch tower (`property_get.rs`'s `try_lower_property_get_method_call`, both the override and default branches) was filling the runtime args buffer from the POST-rest-bundling `lowered_args` vector. When the dispatched method has a rest-bundled signature (e.g. effect's `pipe()` once it gained the synthesized `...arguments`), the upstream bundling at lines 1318–1338 had already TRUNCATED `lowered_args` to `[recv, rest_array]`. The override and default branches then `alloca`'d `[args.len() x double]`, stored only the rest_array into slot 0, and told the runtime to read `args.len()` doubles — slots 1..N-1 were uninitialized garbage that landed in `pipeArguments`'s `arguments[i]`, tripping `value is not a function` at module-init time on a barrel `import { Effect } from "effect"` (effect's `SchemaAST.ts:3013` `getTitleAnnotation(ast).pipe(orElse, orElse, map)` chain reached the default branch with uninit slots and crashed).

Pre-#2162, the bug was invisible because effect's `pipe()` saw an UNBOUND `arguments` identifier, `pipeArguments(this, arguments)` saw nothing, and `.pipe(...)` silently returned `this` — operands were dropped without crashing.

## Fix

In both the override branch (`js_native_call_value` path, around line 1392) and the default branch (`js_native_call_method` path, around line 1539), source the args buffer from `static_user_args` (a `Vec<String>` captured at line 1263 BEFORE the rest-bundling / issue-#235 padding mutated `lowered_args`). The override target and the runtime method dispatcher both run their own rest-bundling at call time, so they must receive un-bundled user args.

The case branches (which call STATIC `perry_method_*__pipe` symbols whose signatures match the post-bundling shape) keep using `arg_slices` and are unchanged.

## Verification

- `/private/tmp/effect-dod/survey/fr_barrel_init.ts` — the regression repro from the task spec. Prints `hello` cleanly in both `PERRY_NO_AUTO_OPTIMIZE=1` and default-optimize modes.
- `survey/fr_match.ts` — the positive case (`Match.type<...>().pipe(Match.when(...), Match.when(...), Match.exhaustive)`). Byte-identical to `node --experimental-strip-types`.
- Existing #2162 gap test `test_gap_arguments_in_object_literal_method.ts`: still byte-identical to node.
- New gap test `test_gap_arguments_dispatch_tower_default.ts` covers the specific dispatch-tower shape: a user class declares `pipe()` that reads `arguments` (so the method has the `method_has_rest` registration and the rest-bundling path engages), plus an object literal with a same-shape `pipe()` method whose class_id ≠ the user class's, so `.pipe(c1, c2, c3)` calls on the object literal fall through to the dispatch tower's default branch with three stores into the 3-double buffer.
- Gap suite: 90 PASS / 2 FAIL — pre-existing `test_gap_class_advanced` and `test_gap_json_map_set` are the only failures; no regressions.
- `cargo test --release -p perry-hir --lib` clean (111 tests).
- `cargo test --release -p perry-codegen --lib` clean (81 tests).
- `cargo fmt --all -- --check` clean.

## Why not revert #2162

The HIR fix in #2162 is correct and necessary — effect-as-a-package needs the synthesized `arguments` binding. The bug is purely codegen-side and was already latent on `main` (any rest-bearing dispatched method called through the override or default branch would have hit it; pre-#2162 only the `pipe()` shape didn't trigger it because `arguments` was unbound and `pipeArguments` quietly returned `this`).

Refs #321.
