### PR TITLE
test(node:stream): drop stale readable from iterable failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -266,12 +266,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline() callback never fires (depends on stream event delivery). Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/from-iterable-iteration": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: `for await (chunk of readable)` iterates to empty — async iterator does not yield chunks. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/object-mode": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary

- Remove the stale `node-suite/stream/readable/from-iterable-iteration` known-failure entry.
- Keep adjacent stream known failures untouched.

## Evidence

- DeepWiki local reference: `reference/deepwiki/nodejs-node-stream-readable-from-iterable-iteration-2026-05-28.md` (not staged)
- Baseline exact pass: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/from-iterable-iteration`
  - report: `test-parity/reports/parity_report_20260528_042804.json`
- Final exact pass after known-failure removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/from-iterable-iteration`
  - report: `test-parity/reports/parity_report_20260528_042821.json`
- `jq empty test-parity/known_failures.json`: PASS
- `git diff --check`: PASS

## Non-goals

- No stream runtime changes.
- No async-iterable or generator cleanup.
- No removal of adjacent still-failing stream known failures.
