### PR TITLE
test(node:stream): drop stale destroyed readable failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -542,12 +542,6 @@
     "category": "bug-open",
     "reason": "node:stream: four-stage pipe chain does not propagate through. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/read-on-destroyed": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: read() on a destroyed Readable should return null. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipe/repipe-after-unpipe": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary

- Remove the stale `node-suite/stream/readable/read-on-destroyed` known-failure entry.
- Keep adjacent stream known failures untouched.

## Evidence

- DeepWiki local reference: `reference/deepwiki/nodejs-node-stream-readable-read-on-destroyed-2026-05-28.md` (not staged)
- Baseline exact pass: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/read-on-destroyed`
  - report: `test-parity/reports/parity_report_20260528_043038.json`
- Final exact pass after known-failure removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/read-on-destroyed`
  - report: `test-parity/reports/parity_report_20260528_043056.json`
- `jq empty test-parity/known_failures.json`: PASS
- `git diff --check`: PASS

## Non-goals

- No stream runtime changes.
- No destroy/error ordering changes.
- No removal of adjacent still-failing stream known failures.
