### PR TITLE
test(node:stream): drop stale autoDestroy false failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -476,12 +476,6 @@
     "category": "bug-open",
     "reason": "node:stream: after error, end event should NOT fire. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/options/auto-destroy-false": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: autoDestroy:false option not honored. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/options/construct-cb-error": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- remove the stale known-failure entry for `node-suite/stream/options/auto-destroy-false`
- keep adjacent autoDestroy option failures listed because they still need separate fixes
- no stream runtime behavior changes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-autodestroy-false-2026-05-28.md` (local only, not staged)
- Baseline exact parity PASS: `./run_parity_tests.sh --suite=node-suite --module=stream --filter options/auto-destroy-false`, report `test-parity/reports/parity_report_20260528_043344.json`
- Final exact parity PASS after removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter options/auto-destroy-false`, report `test-parity/reports/parity_report_20260528_043556.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no `autoDestroy:true` or default autoDestroy cleanup
- no broader stream lifecycle changes
- no removal of adjacent still-failing stream known failures