### PR TITLE
test(node:stream): drop stale defaultEncoding failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -884,12 +884,6 @@
     "category": "bug-open",
     "reason": "node:stream: iter-helper closure capture — outer-var reference in arrow fn yields wrong values. Flips to PASS when #1558 lands."
   },
-  "node-suite/stream/options/default-encoding": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Writable defaultEncoding option — encoding arg seen by _write differs from 'hex'. Flips to PASS when #1539 lands."
-  },
   "node-suite/stream/readable/unshift-increases-length": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove the stale known-failure entry for `node-suite/stream/options/default-encoding`
- keep construct/destroy/final stream option failures listed because they still fail independently
- no stream runtime behavior changes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-writable-default-encoding-2026-05-28.md` (local only, not staged)
- Baseline exact parity PASS: `./run_parity_tests.sh --suite=node-suite --module=stream --filter options/default-encoding`, report `test-parity/reports/parity_report_20260528_043859.json`
- Final exact parity PASS after removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter options/default-encoding`, report `test-parity/reports/parity_report_20260528_043955.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no construct/destroy/final callback option cleanup
- no broader stream lifecycle changes
- no removal of adjacent still-failing stream known failures