### PR TITLE
test(node:stream): drop stale read undefined failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -992,12 +992,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose() — Buffer chunks not preserved through pipeline (typed as string?). Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/readable/read-with-undefined-size": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: read(undefined) — not equivalent to read() no-arg form. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/iter-yields-buffer-no-encoding": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove the stale known-failure entry for `node-suite/stream/readable/read-with-undefined-size`
- keep neighboring stream known failures listed because they still need separate fixes or are covered by already-open PRs
- no stream runtime behavior changes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-readable-read-undefined-size-2026-05-28.md` (local only, not staged)
- Baseline exact parity PASS: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/read-with-undefined-size`, report `test-parity/reports/parity_report_20260528_044232.json`
- Final exact parity PASS after removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/read-with-undefined-size`, report `test-parity/reports/parity_report_20260528_044418.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no byte-mode `read(n)` cleanup already covered by open PRs
- no broader Readable buffering or event-order changes
- no removal of adjacent still-failing stream known failures