### PR TITLE
test(node:stream): drop stale read buffer failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1028,12 +1028,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.from(asyncGen yielding mixed types) — types lost or wrong. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/read-returns-buffer-default": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: read() in non-encoded mode — does not return Buffer instance. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipe/pipe-autodestroy-default": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove the stale known-failure entry for `node-suite/stream/readable/read-returns-buffer-default`
- keep `readable/iter-yields-buffer-no-encoding` listed because it still fails independently
- no stream runtime behavior changes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-readable-read-buffer-default-2026-05-28.md` (local only, not staged)
- Baseline exact parity PASS: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/read-returns-buffer-default`, report `test-parity/reports/parity_report_20260528_044731.json`
- Sibling guardrail still FAILS: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/iter-yields-buffer-no-encoding`, report `test-parity/reports/parity_report_20260528_044743.json`
- Final exact parity PASS after removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/read-returns-buffer-default`, report `test-parity/reports/parity_report_20260528_044834.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no async-iterator Buffer cleanup
- no broader Readable buffering or encoding changes
- no removal of adjacent still-failing stream known failures