### PR TITLE
test(node:stream): drop stale read-before-push failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -908,12 +908,6 @@
     "category": "bug-open",
     "reason": "node:stream: read() inside 'readable' listener — while-loop drain pattern produces wrong output. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/read-before-push": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: read() before any push — should return null, returns wrong value. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/read-n-consumes-exactly-n": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove the stale known-failure entry for `node-suite/stream/readable/read-before-push`
- keep `readable/read-after-end` listed because it still fails independently
- no stream runtime behavior changes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-readable-read-before-push-2026-05-28.md` (local only, not staged)
- Baseline exact parity PASS: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/read-before-push`, report `test-parity/reports/parity_report_20260528_045004.json`
- Sibling guardrail still FAILS: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/read-after-end`, report `test-parity/reports/parity_report_20260528_045010.json`
- Final exact parity PASS after removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/read-before-push`, report `test-parity/reports/parity_report_20260528_045054.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no read-after-end cleanup
- no broader Readable buffering or lifecycle changes
- no removal of adjacent still-failing stream known failures