### PR TITLE
test(node:stream): drop stale readableLength failures

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1034,12 +1034,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: writer.desiredSize does not restore to HWM after write resolves. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/readable/highwater-mark-buffer": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: readableLength after multiple push() — does not equal sum of chunk lengths. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/flow/sync-pause-in-data-listener": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1105,12 +1099,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: TransformStream(t, writableStrategy, readableStrategy) — 3-arg constructor form not honored. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/readable/length-byte-exact": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: readableLength after push('é') — does not count 2 UTF-8 bytes. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/compose-multi-async-fn": {
     "issue": "1531",
@@ -1501,12 +1489,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: objectMode 'readable' event — read() returns wrong object values. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/many-pushes-accumulate": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: many push() — readableLength does not match total bytes. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/iter-helpers/drop-zero-yields-all": {
     "issue": "1558",


### PR DESCRIPTION
## Summary
- remove stale known-failure entries for three green Readable buffered-length fixtures
- keep nearby readable event/flowing-mode failures listed because they still need separate fixes
- no stream runtime behavior changes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-readable-buffered-length-2026-05-28.md` (local only, not staged)
- Baseline exact parity PASS: `readable/length-byte-exact`, report `test-parity/reports/parity_report_20260528_045232.json`
- Baseline exact parity PASS: `readable/highwater-mark-buffer`, report `test-parity/reports/parity_report_20260528_045247.json`
- Baseline exact parity PASS: `readable/many-pushes-accumulate`, report `test-parity/reports/parity_report_20260528_045241.json`
- Final exact parity PASS after removal: `readable/length-byte-exact`, report `test-parity/reports/parity_report_20260528_045412.json`
- Final exact parity PASS after removal: `readable/highwater-mark-buffer`, report `test-parity/reports/parity_report_20260528_045430.json`
- Final exact parity PASS after removal: `readable/many-pushes-accumulate`, report `test-parity/reports/parity_report_20260528_045435.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no readable event or flowing-mode cleanup
- no broader stream buffering changes
- no removal of adjacent still-failing stream known failures