### PR TITLE
test(node:stream): drop stale flow-mode failures

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -866,12 +866,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose(src, asyncGenWithAwait) — async-await handler not iterated correctly. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/flow/multi-data-event-no-concat": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: flowing-mode push() yields concatenated chunk instead of separate 'data' events. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/byob-reader-getReader": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -1153,12 +1147,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: read(1) on multibyte UTF-8 chunk — fails to compile (Buffer-length access). Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/flow/data-after-pause-resume": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pause→resume cycle — does not deliver all data events. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/writable/sink-write-rejection-becomes-error": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- remove stale known-failure entries for two green Readable flowing-mode fixtures
- keep sequential readable-mode/manual-read failures listed because they still fail independently
- no stream runtime behavior changes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-readable-flowing-data-events-2026-05-28.md` (local only, not staged)
- Baseline exact parity PASS: `flow/multi-data-event-no-concat`, report `test-parity/reports/parity_report_20260528_045715.json`
- Baseline exact parity PASS: `flow/data-after-pause-resume`, report `test-parity/reports/parity_report_20260528_045725.json`
- Sibling guardrail still FAILS: `flow/sequential-reads`, report `test-parity/reports/parity_report_20260528_045737.json`
- Final exact parity PASS after removal: `flow/multi-data-event-no-concat`, report `test-parity/reports/parity_report_20260528_045842.json`
- Final exact parity PASS after removal: `flow/data-after-pause-resume`, report `test-parity/reports/parity_report_20260528_045850.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no sequential readable-mode cleanup
- no broader stream flow/readable-event changes
- no removal of adjacent still-failing stream known failures