### PR TITLE
test(node:stream): drop stale duplex getter failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1694,12 +1694,6 @@
     "category": "bug-open",
     "reason": "node:stream: distinct Readable instances — same identity or wrong prototype shared. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/writable-side-getters": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Duplex writable-side getters — wrong types or undefined. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/transform-piped-twice": {
     "issue": "1545",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove the stale known-failure entry for `node-suite/stream/readable/writable-side-getters`
- keep adjacent identity/prototype and decodeStrings failures listed because they still fail independently
- no stream runtime behavior changes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-duplex-writable-side-getters-2026-05-28.md` (local only, not staged)
- Baseline exact parity PASS: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/writable-side-getters`, report `test-parity/reports/parity_report_20260528_050057.json`
- Adjacent guardrail still FAILS: `readable/readable-stream-id-properties`, report `test-parity/reports/parity_report_20260528_050050.json`
- Adjacent guardrail still FAILS: `options/decode-strings-false`, report `test-parity/reports/parity_report_20260528_050106.json`
- Final exact parity PASS after removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/writable-side-getters`, report `test-parity/reports/parity_report_20260528_050210.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no distinct-instance/prototype cleanup
- no decodeStrings cleanup
- no broader Duplex runtime changes