### PR TITLE
fix(hir): bare `console` Ident resolves like other globals (#321)

### DIFF
--- a/crates/perry-hir/src/analysis/builtins.rs
+++ b/crates/perry-hir/src/analysis/builtins.rs
@@ -69,6 +69,7 @@ pub(crate) fn is_builtin_global_value_name(name: &str) -> bool {
             | "TextEncoderStream"
             | "TextDecoderStream"
             | "process"
+            | "console"
     )
 }
 

--- a/test-files/test_gap_console_bare_global.ts
+++ b/test-files/test_gap_console_bare_global.ts
@@ -1,0 +1,22 @@
+// #321 / #64 / Console-bare-global: `console` referenced as a bare identifier
+// (not a method receiver) at module-top-level resolved to 0 (typeof "number")
+// instead of an object handle whose `.log`/`.error`/etc. accessors work.
+// effect's `defaultConsole.unsafe = console` (line 99 of
+// node_modules/effect/src/internal/defaultServices/console.ts) crashed downstream
+// inside `Effect.runSync(Console.log("x"))` with "(number).log is not a function"
+// because the stored value was the bare-fallthrough 0 sentinel.
+//
+// The fix adds "console" to `is_builtin_global_value_name` so the bare Ident
+// lowers to PropertyGet{GlobalGet(0), "console"} like other builtins (`Date`,
+// `Array`, `process`, etc.), which codegen routes through the native-module
+// helper and downstream method-dispatch works.
+
+const c = console;
+const obj = { unsafe: console };
+
+console.log("typeof c:", typeof c);
+console.log("typeof obj.unsafe:", typeof obj.unsafe);
+console.log("typeof obj.unsafe.log:", typeof obj.unsafe.log);
+
+obj.unsafe.log("via_alias");
+c.log("via_direct_alias");


### PR DESCRIPTION
## Summary

Adds `"console"` to `is_builtin_global_value_name` so a bare `console` reference at module-top-level lowers like other globals (`Date`, `Array`, `process`, `Map`, `Symbol`, …) instead of falling through to the `Expr::GlobalGet(0)` sentinel.

## Root cause

Effect's `node_modules/effect/src/internal/defaultServices/console.ts:99` does:

```ts
defaultConsole: Console.Console = {
  // ... methods that wrap console.log/error/etc. via core.sync(() => console.x(...))
  unsafe: console      // <-- bare global ref at module-init
}
```

Inside a compile-as-package module, the bare `console` ident hits the fallthrough branch of `crates/perry-hir/src/lower/lower_expr.rs:243-322`. That branch consults `is_builtin_global_value_name` to decide between a `PropertyGet { GlobalGet, "<name>" }` (which codegen routes through `js_native_module_property_by_name`) and a bare `Expr::GlobalGet(0)` sentinel which codegen lowers to `0.0`.

`console` wasn't in the matcher, so `obj.unsafe = console` stored the literal number `0`. Then any downstream property access on it — e.g. `Context.get(services, consoleTag).unsafe.log(…)` in `fiberRuntime.ts:1451` (the canonical Console.log / Effect.log / Logger code path) — threw `(number).log is not a function`.

## Fix

```diff
             | "TextEncoderStream"
             | "TextDecoderStream"
             | "process"
+            | "console"
```

One line. Mirrors what `process` (and every other listed global) already does.

## Verification

- New gap test `test_gap_console_bare_global.ts` covers bare-alias (`const c = console`), object-literal-field (`{unsafe: console}`), and method dispatch from both shapes — **byte-identical to Node**.
- `/private/tmp/effect-dod/survey/fr_logger.ts` (Effect.gen + Effect.log + Effect.runSync) — **byte-identical to Node** (was: `(number).log is not a function`).
- `/private/tmp/effect-dod/survey/fr_console.ts` (Console.log via barrel + Effect.runSync) — **runs without crashing** (was: `(number).log is not a function`); output formatting differs from Node because of a separate Console.log → Logger routing bug downstream that this PR doesn't touch.
- `cargo test --release -p perry-hir --lib` — 111/111 PASS.
- `cargo fmt --all -- --check` — clean.

## Related

Frontier sweep of effect (#321). Builds on the recent #2122 (generic-T-extends-string indexing), #2162 (object-literal-method `arguments` synthesis), and #2199 (codegen dispatch-tower args buffer). With those + this PR, effect's `Console`, `Logger`, and `Effect.log` paths no longer init-crash via the `(number).log is not a function` path.
