### PR TITLE
test(node:stream): drop stale writableLength failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1412,12 +1412,6 @@
     "category": "bug-open",
     "reason": "node:stream: post-pipe-end destroyed flags wrong on source or destination. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/writable/writable-length-tracker": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: writableLength does not track buffered bytes in the writable queue. Flips to PASS when #1539 lands."
-  },
   "node-suite/stream/readable/options-autoDestroy-explicit": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove the stale known-failure entry for `node-suite/stream/writable/writable-length-tracker`
- keep sink write callback error propagation listed because it still fails independently
- no stream runtime behavior changes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-writable-length-2026-05-28.md` (local only, not staged)
- Baseline exact parity PASS: `./run_parity_tests.sh --suite=node-suite --module=stream --filter writable/writable-length-tracker`, report `test-parity/reports/parity_report_20260528_050422.json`
- Adjacent guardrail still FAILS: `writable/sink-write-rejection-becomes-error`, report `test-parity/reports/parity_report_20260528_050429.json`
- Final exact parity PASS after removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter writable/writable-length-tracker`, report `test-parity/reports/parity_report_20260528_050530.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no write-callback error cleanup
- no broader Writable lifecycle changes
- no removal of adjacent still-failing stream known failures