### PR TITLE
test(node:stream): drop stale basic pipe failures

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -458,12 +458,6 @@
     "category": "bug-open",
     "reason": "node:stream: stream.compose(asyncGenerator) doesn't run the async stage / forward data. Reopened #1539 for pipeline execution."
   },
-  "node-suite/stream/pipe/four-stage-chain": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: four-stage pipe chain does not propagate through. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipe/repipe-after-unpipe": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -974,12 +968,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: ReadableStream.from(asyncGen()) — iteration wrong or fails. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/pipe/objectmode-pipe": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: objectMode pipe — raw object data not preserved through pipe. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/unshift-while-flowing": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1069,12 +1057,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Readable.from(array with one Promise.reject) — error not emitted at the right point. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/pipe/r-t-w-end-to-end": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: simple R→T→W e2e pipe — received chunks wrong (transform/uppercase not applied). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/iter-helpers/every-async-rejection": {
     "issue": "1558",
@@ -1310,12 +1292,6 @@
     "category": "bug-open",
     "reason": "node:stream: encoding option in ctor — readableEncoding wrong or data not string. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/pipe/pipe-to-plain-writable": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pipe() to plain Writable — collected wrong / empty. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/byob-reader-method-shape": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -1441,18 +1417,6 @@
     "added": "2026-05-25",
     "category": "bug-open",
     "reason": "node:stream: generator with explicit return — values yielded after return statement aren't reached. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/pipe/four-stage-chain-v2": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: 4-stage pipe — wrong output. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/pipe/many-listeners-on-dst": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: multi 'data' listeners on dst — count or values wrong. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/from-gen-return-value-ignored": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- remove stale known-failure entries for green basic pipe fixtures
- cover objectMode pipe, plain Writable pipe, Readable→Transform→Writable, four-stage chains, multiple destination data listeners, and explicit `end: true`
- keep listener-count internals and `end: false` pipe behavior listed because they still need separate fixes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-basic-pipe-behavior-2026-05-28.md` (local only, not staged)
- Baseline PASS: `pipe/objectmode-pipe`, report `test-parity/reports/parity_report_20260528_050747.json`
- Baseline PASS: `pipe/r-t-w-end-to-end`, report `test-parity/reports/parity_report_20260528_050753.json`
- Baseline PASS: `pipe/end-true-explicit*` 2/2, report `test-parity/reports/parity_report_20260528_050809.json`
- Baseline PASS: `pipe/pipe-to-plain-writable`, report `test-parity/reports/parity_report_20260528_050828.json`
- Baseline PASS: `pipe/many-listeners-on-dst`, report `test-parity/reports/parity_report_20260528_050835.json`
- Baseline PASS: `pipe/four-stage-chain*` 2/2, report `test-parity/reports/parity_report_20260528_050844.json`
- Guardrail still FAILS: `pipe/pipe-adds-listener-on-dst`, report `test-parity/reports/parity_report_20260528_050802.json`
- Final PASS after removal: `pipe/objectmode-pipe`, report `test-parity/reports/parity_report_20260528_051022.json`
- Final PASS after removal: `pipe/r-t-w-end-to-end`, report `test-parity/reports/parity_report_20260528_051032.json`
- Final PASS after removal: `pipe/pipe-to-plain-writable`, report `test-parity/reports/parity_report_20260528_051039.json`
- Final PASS after removal: `pipe/end-true-explicit*` 2/2, report `test-parity/reports/parity_report_20260528_051048.json`
- Final PASS after removal: `pipe/four-stage-chain*` 2/2, report `test-parity/reports/parity_report_20260528_051056.json`
- Final PASS after removal: `pipe/many-listeners-on-dst`, report `test-parity/reports/parity_report_20260528_051103.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no stream runtime changes
- no listener-count pipe internals
- no `end: false` cleanup
- no removal of adjacent still-failing stream known failures