### PR TITLE
test(node:stream): drop stale pipe manual-end failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1358,12 +1358,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: for-await directly on TransformStream.readable — empty or wrong output. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/pipe/end-false-then-explicit-end": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pipe(dst,{end:false}) followed by manual dst.end() — dst not ending. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/iter-helpers/for-each-await-each": {
     "issue": "1558",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove the stale known-failure entry for `node-suite/stream/pipe/end-false-then-explicit-end`
- keep `end-false-then-write` listed because it still fails independently
- no stream runtime behavior changes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-pipe-end-false-manual-end-2026-05-28.md` (local only, not staged)
- Baseline exact parity PASS: `./run_parity_tests.sh --suite=node-suite --module=stream --filter pipe/end-false-then-explicit-end`, report `test-parity/reports/parity_report_20260528_051334.json`
- Adjacent guardrail still FAILS: `pipe/end-false-then-write`, report `test-parity/reports/parity_report_20260528_051345.json`
- Final exact parity PASS after removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter pipe/end-false-then-explicit-end`, report `test-parity/reports/parity_report_20260528_051444.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no `end:false` write-continuation cleanup
- no broader pipe lifecycle changes
- no removal of adjacent still-failing stream known failures