### PR TITLE
test(node:stream): drop stale duplex readable failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -644,12 +644,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose(readable, asyncGenFn) — fails to compile (single-fn compose form not yet wired). Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/duplex/from-readable": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Duplex.from(readable) — wrapping a Readable as a Duplex returns a different shape than Node. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/duplex/from-async-iterable": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- remove the stale known-failure entry for `node-suite/stream/duplex/from-readable`
- keep Duplex.from object-form and async-iterable entries listed because they still fail independently
- no stream runtime behavior changes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-duplex-from-readable-2026-05-28.md` (local only, not staged)
- Baseline exact parity PASS: `./run_parity_tests.sh --suite=node-suite --module=stream --filter duplex/from-readable`, report `test-parity/reports/parity_report_20260528_052101.json`
- Adjacent guardrail still FAILS: `duplex/from-object-form`, report `test-parity/reports/parity_report_20260528_052113.json`
- Adjacent guardrail still FAILS: `duplex/from-async-iterable`, report `test-parity/reports/parity_report_20260528_052122.json`
- Final exact parity PASS after removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter duplex/from-readable`, report `test-parity/reports/parity_report_20260528_052228.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no Duplex.from object-form cleanup
- no Duplex.from async-iterable cleanup
- no broader stream runtime changes