### PR TITLE
test(node:stream): drop stale pipe source-error failures

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -878,12 +878,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: getReader({mode:'byob'}) on bytes-type stream fails or returns wrong shape. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/pipe/source-error-no-propagation": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pipe(src,dst) source-error handling — wrong error count on src or dst. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/error-event-arg-shape": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1274,12 +1268,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable({captureRejections}) — async listener throws not caught as 'error'. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/pipe/pipe-error-handler-on-source": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: src.on('error') during pipe — handler receives wrong error / not called. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/iter-helpers/some-finds-match": {
     "issue": "1558",
     "added": "2026-05-24",
@@ -1291,12 +1279,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pipeline(asyncIterable, dst, cb) — async-iterable source not handled. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/pipe/source-immediate-error": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pipe() src immediate error — error not fired on src listener. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/destroyed-after-finish": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- remove stale known-failure entries for green pipe source-error fixtures
- keep destination write-error propagation listed because it still fails independently
- no stream runtime behavior changes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-pipe-source-errors-2026-05-28.md` (local only, not staged)
- Baseline PASS: `pipe/pipe-error-handler-on-source`, report `test-parity/reports/parity_report_20260528_053006.json`
- Baseline PASS: `pipe/source-immediate-error`, report `test-parity/reports/parity_report_20260528_053014.json`
- Baseline PASS: `pipe/source-error-no-propagation`, report `test-parity/reports/parity_report_20260528_053029.json`
- Final PASS after removal: `pipe/pipe-error-handler-on-source`, report `test-parity/reports/parity_report_20260528_053204.json`
- Final PASS after removal: `pipe/source-immediate-error`, report `test-parity/reports/parity_report_20260528_053219.json`
- Final PASS after removal: `pipe/source-error-no-propagation`, report `test-parity/reports/parity_report_20260528_053238.json`
- Guardrail still FAILS: `pipe/dest-error-propagates`, report `test-parity/reports/parity_report_20260528_053303.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no destination write-error propagation cleanup
- no pipeline error handling cleanup
- no broader pipe lifecycle changes