### PR TITLE
fix(hir,codegen): class extending runtime-value function dispatches super() through the closure (#321 / #66 / #1787 follow-up)

### DIFF
--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -96,6 +96,131 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let parent_class = match ctx.classes.get(&parent_name).copied() {
                 Some(c) => c,
                 None => {
+                    // #321 / #66 (#1787 follow-up): `class Sub extends <runtimeValueFn>`
+                    // — the parent is a runtime-value function/closure (the IIFE-
+                    // returned constructor function `Base` in Effect's `Data.Class`).
+                    // HIR's `lower_decl/class_decl.rs` already captures
+                    // `class.extends_expr` for this shape (unknown Ident super-class)
+                    // and codegen wires the class_id parent edge at module init via
+                    // `js_register_class_parent_dynamic`. The MISSING piece this arm
+                    // adds is the `super(args)` call itself: evaluate the extends
+                    // expression here, bind IMPLICIT_THIS to the current `this`, and
+                    // dispatch via `js_native_call_value` so the parent function's
+                    // body runs with `this` bound to the new instance (any
+                    // `Object.assign(this, args)` / `this.x = args.x` writes land on
+                    // the subclass instance). Falls through to the existing
+                    // stream/Error-like/no-op chain when no extends_expr is captured
+                    // (which is exactly the prior baseline).
+                    //
+                    // Gate: skip well-known built-in parent NAMES (Error/Stream
+                    // family) — HIR captures `extends_expr` for any unknown Ident,
+                    // INCLUDING the built-ins, so we'd otherwise eat the more-correct
+                    // Error-init path below. The built-in arms handle their own
+                    // semantics (Error sets this.message + this.name; streams allocate
+                    // a registry handle). Anything else with an extends_expr is a
+                    // real runtime-value parent and routes through this dispatch.
+                    let is_builtin_parent_name = matches!(
+                        parent_name.as_str(),
+                        "Error"
+                            | "TypeError"
+                            | "RangeError"
+                            | "ReferenceError"
+                            | "SyntaxError"
+                            | "URIError"
+                            | "EvalError"
+                            | "AggregateError"
+                            | "ReadableStream"
+                            | "WritableStream"
+                            | "TransformStream"
+                    );
+                    if !is_builtin_parent_name {
+                        if let Some(extends_expr) = current_class.extends_expr.as_deref() {
+                            // Lower the super-call args first so they get fresh slots
+                            // and are spilled into a flat f64 buffer for the variadic
+                            // dispatch.
+                            let mut lowered_args: Vec<String> =
+                                Vec::with_capacity(super_args.len());
+                            for a in super_args {
+                                lowered_args.push(lower_expr(ctx, a)?);
+                            }
+
+                            // Evaluate the parent expression (the runtime function
+                            // value). The HIR layer already lowered it as part of
+                            // class.extends_expr.
+                            let parent_val = lower_expr(ctx, extends_expr)?;
+
+                            // Spill args into a contiguous double[] for the
+                            // js_native_call_value(ptr, len) ABI. Mirrors the
+                            // method_override.rs override-path spilling.
+                            let user_arg_count = lowered_args.len();
+                            let (args_ptr, args_len) = if user_arg_count == 0 {
+                                ("null".to_string(), "0".to_string())
+                            } else {
+                                let buf_reg = ctx.func.alloca_entry_array(DOUBLE, user_arg_count);
+                                for (i, a_val) in lowered_args.iter().enumerate() {
+                                    let slot = ctx.block().gep(
+                                        DOUBLE,
+                                        &buf_reg,
+                                        &[(I64, &format!("{}", i))],
+                                    );
+                                    ctx.block().store(DOUBLE, a_val, &slot);
+                                }
+                                let ptr_reg = ctx.block().next_reg();
+                                ctx.block().emit_raw(format!(
+                                    "{} = getelementptr [{} x double], ptr {}, i64 0, i64 0",
+                                    ptr_reg, user_arg_count, buf_reg
+                                ));
+                                (ptr_reg, user_arg_count.to_string())
+                            };
+
+                            // Bind IMPLICIT_THIS to the current `this` so the parent
+                            // function body's `this.x = ...` writes land on the
+                            // subclass instance (non-arrow functions read `this` via
+                            // `js_implicit_this_get` when their this_stack is empty).
+                            // Save the prior IMPLICIT_THIS and restore it after — see
+                            // the #519 pattern in console_promise.rs / method_override.rs.
+                            let this_box = match ctx.this_stack.last().cloned() {
+                                Some(slot) => ctx.block().load(DOUBLE, &slot),
+                                None => {
+                                    double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                                }
+                            };
+                            let prev_this = ctx.block().call(
+                                DOUBLE,
+                                "js_implicit_this_set",
+                                &[(DOUBLE, &this_box)],
+                            );
+                            let _ = ctx.block().call(
+                                DOUBLE,
+                                "js_native_call_value",
+                                &[
+                                    (DOUBLE, &parent_val),
+                                    (crate::types::PTR, &args_ptr),
+                                    (I64, &args_len),
+                                ],
+                            );
+                            ctx.block().call(
+                                DOUBLE,
+                                "js_implicit_this_set",
+                                &[(DOUBLE, &prev_this)],
+                            );
+
+                            // Per JS spec: subclass field initializers run AFTER
+                            // super() returns. Same call the user-class branch makes
+                            // (line ~434 below) and the stream subclass branch makes
+                            // above. Without this, `this.foo = []` on the subclass
+                            // would never run.
+                            crate::lower_call::apply_field_initializers_recursive(
+                                ctx,
+                                &current_class_name,
+                                crate::lower_call::FieldInitMode::SelfOnly,
+                            )?;
+
+                            return Ok(double_literal(f64::from_bits(
+                                crate::nanbox::TAG_UNDEFINED,
+                            )));
+                        }
+                    }
                     // Issue #562: `class X extends WritableStream/ReadableStream/TransformStream`
                     // — `super({ ... })` allocates an underlying stream registry handle and
                     // stashes it on `this` under `__perry_stream_handle__`. Inherited methods

--- a/test-files/test_gap_class_extends_runtime_value_super.ts
+++ b/test-files/test_gap_class_extends_runtime_value_super.ts
@@ -1,0 +1,61 @@
+// #321 / #66 (#1787 follow-up): `class Sub extends Base` where `Base` is a
+// runtime-value FUNCTION (not a class declaration). Effect's `Data.Class`
+// uses this exact pattern — an IIFE returns the constructor function and
+// `class Point extends Data.Class<{x,y}>` instances need `super(args)` to
+// actually invoke the parent function with `this` bound to the instance, so
+// any `Object.assign(this, args)` writes the subclass's fields.
+//
+// Without the fix, perry's `super(args)` dispatched to no-op for non-static
+// parents — `Base`'s body never ran, `this` stayed null inside `Sub`'s
+// constructor body, and `s.x` came back `undefined`.
+
+// Repro 1: simplest IIFE-returned constructor function (Effect's Data.Class shape).
+const Base: any = (function () {
+  function Base(this: any, args: any) {
+    if (args) Object.assign(this, args);
+  }
+  return Base;
+})();
+
+class Sub extends Base {
+  constructor(args: any) {
+    super(args);
+  }
+}
+
+const s = new Sub({ x: 7, y: 9 });
+console.log("s.x:", (s as any).x);
+console.log("s.y:", (s as any).y);
+
+// Repro 2: parent function reads `this` and writes a constant default.
+const WithDefault: any = (function () {
+  function WithDefault(this: any) {
+    this.flag = "default-from-parent";
+  }
+  return WithDefault;
+})();
+
+class Child extends WithDefault {
+  constructor() {
+    super();
+  }
+}
+
+const c = new Child();
+console.log("c.flag:", (c as any).flag);
+
+// Repro 3: subclass field initializers run AFTER super() returns (JS spec).
+const Empty: any = (function () {
+  function Empty(this: any) {}
+  return Empty;
+})();
+
+class WithFields extends Empty {
+  ownField: string = "subclass-init";
+  constructor() {
+    super();
+  }
+}
+
+const w = new WithFields();
+console.log("w.ownField:", w.ownField);


### PR DESCRIPTION
## Summary

Make `class Sub extends Base` work when `Base` is a runtime-value FUNCTION/closure (not a class declaration), by dispatching `super(args)` through that function with `this` bound to the new instance.

This is the missing super-call dispatch piece for Effect's `Data.Class` pattern (issue #66 / #321) and the natural follow-up to the #1787 / #2074 class-expr-as-value epic.

## Repro

```ts
const Base: any = (function () {
  function Base(this: any, args: any) {
    if (args) Object.assign(this, args);
  }
  return Base;
})();

class Sub extends Base {
  constructor(args: any) {
    super(args);
  }
}

const s = new Sub({ x: 7 });
console.log((s as any).x); // node: 7, perry pre-fix: undefined
```

Node prints `7`. Perry pre-fix printed `undefined` — `Base`'s ctor body never ran, `this` stayed null inside `Sub`'s constructor.

## Root cause

When `class Sub extends Base` is lowered, HIR's `lower_decl/class_decl.rs` recognises `Base` as an unknown Ident (no class declared by that name in scope) and captures the lowered identifier in `class.extends_expr` (the #711 mechanism). Module init then calls `js_register_class_parent_dynamic(child_cid, eval(extends_expr))`, which (for a closure with `.prototype` set) wires a synthetic-class-id parent edge plus a `CLASS_PARENT_CLOSURES` entry — that part already works on main.

The MISSING piece was `super(args)` itself. The codegen lowering at `expr/this_super_call.rs:96` does `ctx.classes.get(&parent_name)` and, when the parent isn't a registered class, falls through to:

1. Stream subclass arm (matches `ReadableStream`/`WritableStream`/`TransformStream`), or
2. Error-like arm (matches `Error`/`TypeError`/...), or
3. Imported cross-module ctor stub arm, or
4. `return undefined` (the no-op terminal).

Anything else — including the IIFE-returned function-value parents Effect's `Data.Class` produces — hit case 4 and silently dropped the super-call.

## Fix

`crates/perry-codegen/src/expr/this_super_call.rs` gains a new arm placed BEFORE the stream/Error-like fall-throughs: when the current class has a captured `extends_expr` and the parent name isn't a well-known built-in (Error-family or Stream-family — those have dedicated arms below that set `this.message`/`this.name` or allocate stream handles, and HIR also captures `extends_expr` for them as the unknown-Ident fallback, so the gate is load-bearing), evaluate the extends expression, save IMPLICIT_THIS, set it to the current `this`, dispatch via `js_native_call_value(parent, argsPtr, argsLen)`, restore IMPLICIT_THIS, then run subclass field initializers (`apply_field_initializers_recursive` — JS spec: subclass fields run after super() returns). Mirrors the existing #519 / #2074 IMPLICIT_THIS save/set/restore pattern used by `method_override.rs` and `console_promise.rs`.

No new HIR variant, no new runtime helper — the fix reuses the already-existing `js_native_call_value`, `js_implicit_this_set`, and `apply_field_initializers_recursive` infrastructure.

## Verification

- `/tmp/repro.ts` — byte-identical to node (parent ctor body runs, `s.x = 7`).
- `test-files/test_gap_class_extends_runtime_value_super.ts` (new) — 3 sub-reprors (Object.assign super-call, constant default writes via `this`, subclass field initializers running after super()) all match node byte-for-byte.
- Effect `survey/fr_data_class.ts` — `eq: true` flips from false to true (instance fields now populate on Point instances). `Equal.equals: true` requires symbol-keyed prototype-method dispatch through the closure parent's `.prototype` object, which is a separate downstream gap not in scope here.
- Gap suite: 37 PASS / 2 FAIL — the two pre-existing failures (`test_gap_class_advanced` static-block timing, `test_gap_console_methods` timer precision). Unchanged from main.
- All class-related gap tests still pass — checked `test_gap_async_advanced`, `test_gap_class_advanced` (same diff as main), `test_gap_closures`, `test_gap_error_extensions` (verified does NOT regress — the built-in-parent gate is load-bearing), `test_gap_generators`, `test_gap_object_methods`, `test_gap_proxy_reflect`, `test_gap_symbols`, `test_gap_typeof_instanceof`.
- `cargo test --release -p perry-codegen -p perry-hir --lib` — clean.
- `cargo fmt --all -- --check` — clean.

## Refs

- #321 (Effect framework end-to-end) — frontier sub-issue #66.
- #1787 (class-expr-as-value foundation, shipped via PR #2074) — same `CLASS_CONSTRUCTORS` / `js_register_class_parent_dynamic` infrastructure family.
- #711 (`class X extends fn(...)` dynamic parent-class registration) — the existing mechanism this fix extends.
