### PR TITLE
test(node:stream): drop stale error delivery failures

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -440,12 +440,6 @@
     "category": "bug-open",
     "reason": "node:stream: read + unshift + re-read sequence doesn't deliver chunks in the right order. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/error/error-no-listener": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: destroy(err) + error listener doesn't deliver the message to handler. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/object-mode/read-single-object": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -469,12 +463,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: re-piping after unpipe does not flow / sink does not end. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/error/error-then-end-order": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: after error, end event should NOT fire. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/options/auto-destroy-false": {
     "issue": "1531",
@@ -883,12 +871,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pipe(src,dst) source-error handling — wrong error count on src or dst. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/error-event-arg-shape": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: 'error' event arg — identity / instanceof Error / message wrong. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/pipethrough-preventclose-flag": {
     "issue": "1545",


### PR DESCRIPTION
## Summary
- remove stale known-failure entries for green stream error-delivery/order fixtures
- keep default `_read` error behavior and autoDestroy-after-finish listed because they still fail independently
- no stream runtime behavior changes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-readable-error-delivery-2026-05-28.md` (local only, not staged)
- Baseline PASS: `readable/error-event-arg-shape`, report `test-parity/reports/parity_report_20260528_053613.json`
- Baseline PASS: `error/error-no-listener`, report `test-parity/reports/parity_report_20260528_053648.json`
- Baseline PASS: `error/error-then-end-order`, report `test-parity/reports/parity_report_20260528_053729.json`
- Guardrail still FAILS: `error/no-read-impl`, report `test-parity/reports/parity_report_20260528_053701.json`
- Guardrail still FAILS: `readable/destroyed-after-finish`, report `test-parity/reports/parity_report_20260528_053622.json`
- Final PASS after removal: `readable/error-event-arg-shape`, report `test-parity/reports/parity_report_20260528_053927.json`
- Final PASS after removal: `error/error-no-listener`, report `test-parity/reports/parity_report_20260528_053938.json`
- Final PASS after removal: `error/error-then-end-order`, report `test-parity/reports/parity_report_20260528_053954.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no default `_read` error implementation
- no autoDestroy-after-finish cleanup
- no broader stream lifecycle changes