### PR TITLE
test(node:stream): drop stale duplex writable failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1616,12 +1616,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose(src,t1,t2) — output transformation order wrong. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/readable/duplex-acts-as-writable": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Duplex write side — received array empty / wrong order. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipeline/async-source-throws-mid": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove the stale known-failure entry for `node-suite/stream/readable/duplex-acts-as-writable`
- keep `duplexPair()` listed because it still fails independently
- no stream runtime behavior changes

## Evidence
- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-duplex-writable-side-2026-05-28.md` (local only, not staged)
- Baseline exact parity PASS: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/duplex-acts-as-writable`, report `test-parity/reports/parity_report_20260528_054255.json`
- Adjacent guardrail still FAILS: `duplex-pair/wired-comms`, report `test-parity/reports/parity_report_20260528_054318.json`
- Final exact parity PASS after removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/duplex-acts-as-writable`, report `test-parity/reports/parity_report_20260528_054458.json`
- `jq empty test-parity/known_failures.json` PASS
- `git diff --check` PASS

## Non-goals
- no `duplexPair()` cleanup
- no broader Duplex runtime changes
- no removal of adjacent still-failing stream known failures