### PR TITLE
test(node:stream): drop stale readable autoDestroy failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1178,12 +1178,6 @@
     "category": "bug-open",
     "reason": "node:stream: post-pipe-end destroyed flags wrong on source or destination. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/options-autoDestroy-explicit": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: autoDestroy: false — stream still destroyed after 'end' or 'close' fires when it shouldn't. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/sink-all-four-methods": {
     "issue": "1545",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- revalidated `node-suite/stream/readable/options-autoDestroy-explicit` now passes on current `origin/main`
- removed only the stale known-failure entry for that passing fixture
- kept adjacent still-failing stream cases listed, including `Readable.from(..., options)` objectMode behavior

## Verification
- Baseline exact: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/options-autoDestroy-explicit` PASS, report `test-parity/reports/parity_report_20260528_054905.json`
- Final exact after removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter readable/options-autoDestroy-explicit` PASS, report `test-parity/reports/parity_report_20260528_055046.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Reference
- DeepWiki local note, not staged: `reference/deepwiki/nodejs-node-stream-readable-autodestroy-false-2026-05-28.md`

## Non-goals
- no stream runtime changes
- no autoDestroy default/true behavior cleanup
- no `Readable.from(..., options)` objectMode cleanup (`node-suite/stream/readable/static-from-with-options` still fails, report `test-parity/reports/parity_report_20260528_054847.json`)
- no removal of adjacent still-failing stream known failures
