### PR TITLE
test(node:stream): drop stale readable event-order failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -608,12 +608,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipe(dst, {end: false}) — destination still ended when source ends. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/readable-event-order": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: 'readable' event ordering relative to 'end' — extra readable before end missing or out-of-order. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/finished/with-cleanup-option": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- revalidated `node-suite/stream/events/readable-event-order` now passes on current `origin/main`
- removed only the stale known-failure entry for that passing fixture
- kept adjacent still-failing stream event cases listed, including `node-suite/stream/events/readable-event`

## Verification
- Baseline exact: `./run_parity_tests.sh --suite=node-suite --module=stream --filter events/readable-event-order` PASS, report `test-parity/reports/parity_report_20260528_055623.json`
- Final exact after removal: `./run_parity_tests.sh --suite=node-suite --module=stream --filter events/readable-event-order` PASS, report `test-parity/reports/parity_report_20260528_055719.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Reference
- DeepWiki local note, not staged: `reference/deepwiki/nodejs-node-stream-readable-event-order-2026-05-28.md`

## Non-goals
- no stream runtime changes
- no `readable-event` output cleanup (`node-suite/stream/events/readable-event` still fails in the broader filter, report `test-parity/reports/parity_report_20260528_055601.json`)
- no event-order runtime rewrite
- no removal of adjacent still-failing stream known failures
