### PR TITLE
test: drop stale primitive TypeError failures

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -62,18 +62,6 @@
     "category": "ci-env",
     "reason": "Tracked in #1634 (parity CI environment fixtures). #422 closed (net.Socket connect/error events + factory). The test passes locally with an echo server running but fails on Linux CI because no echo fixture server runs. Environmental — needs a CI-side fixture, not a Perry fix."
   },
-  "test_issue_462_nullish_property_access": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "bug-stale",
-    "reason": "Behavior is correct (TypeError thrown, UNREACHABLE never prints). Only stack-trace format diverges from Node — #616 closed with framing improvements but byte-for-byte parity requires source-text retention through the runtime. Track under the parity roadmap; file a dedicated stack-format issue if/when it becomes a real blocker."
-  },
-  "test_issue_510_primitive_method_typeerror": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "bug-stale",
-    "reason": "Same root cause as test_issue_462 — see #616 (closed). Behavior correct; framing differs. Regression vector: v0.5.702 (#596) routed throw helpers through js_throw which exposed the format gap. Track under the parity roadmap until a stack-format issue is filed."
-  },
   "test_issue_561_sigv4_chain": {
     "issue": "793",
     "added": "2026-05-15",


### PR DESCRIPTION
## Summary
- revalidated `test_issue_462_nullish_property_access` and `test_issue_510_primitive_method_typeerror` now pass via their expected-output path
- removed only those stale TypeError known-failure entries
- left adjacent top-level/class known failures untouched

## Verification
- Baseline exact: `./run_parity_tests.sh --filter test_issue_510_primitive_method_typeerror` PASS, report `test-parity/reports/parity_report_20260528_060431.json`
- Baseline exact: `./run_parity_tests.sh --filter test_issue_462_nullish_property_access` PASS, report `test-parity/reports/parity_report_20260528_060519.json`
- Final exact after removal: `./run_parity_tests.sh --filter test_issue_462_nullish_property_access` PASS, report `test-parity/reports/parity_report_20260528_060540.json`
- Final exact after removal: `./run_parity_tests.sh --filter test_issue_510_primitive_method_typeerror` PASS, report `test-parity/reports/parity_report_20260528_060547.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Reference
- DeepWiki local note, not staged: `reference/deepwiki/nodejs-node-primitive-method-typeerror-2026-05-28.md`

## Non-goals
- no runtime changes
- no stack-format implementation
- no adjacent class/top-level cleanup
- no broad expected-output cleanup
