### PR TITLE
test: drop stale async array-param failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -50,12 +50,6 @@
     "category": "bug-stale",
     "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #806 is closed. Deliberate failing repro/harness — kept as a regression canary. #806 harness for `class X extends Fn(...)<...>` patterns. Two sub-cases surface real Perry gaps today: (1) bare-factory subclass loses the base's field initializer (`bare.kind: undefined` vs Node's `bare.kind: bare`); (2) chained mixin `WithA(WithB(WithC(Base)))` throws `TypeError: value is not a function` at construction. Captured-factory + Effect double-call shapes pass post-#740 — the harness verifies that survives. Linked to #321 umbrella; will flip to PASS as each sub-case lands."
   },
-  "test_issue_233_async_array_param_push": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "bug-stale",
-    "reason": "#233 (16-element cap on async array-param push) closed on macOS. Linux CI still surfaces a divergence — bisect needed to pin the Linux-only sub-case before filing a new tracking issue. Rolled under the parity roadmap (#793) in the meantime."
-  },
   "test_issue_422_socket_connect": {
     "issue": "1634",
     "added": "2026-05-15",


### PR DESCRIPTION
## Summary
- revalidated `test_issue_233_async_array_param_push` now passes on current `origin/main`
- removed only that stale known-failure entry
- left adjacent top-level and CI-env known failures untouched

## Verification
- Baseline exact: `./run_parity_tests.sh --filter test_issue_233_async_array_param_push` PASS, report `test-parity/reports/parity_report_20260528_060801.json`
- Final exact after removal: `./run_parity_tests.sh --filter test_issue_233_async_array_param_push` PASS, report `test-parity/reports/parity_report_20260528_060859.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Reference
- DeepWiki local note, not staged: `reference/deepwiki/nodejs-node-async-array-param-push-2026-05-28.md`

## Non-goals
- no runtime changes
- no async/array implementation changes
- no adjacent top-level known-failure cleanup
- no CI-env cleanup
