### PR TITLE
test: drop stale Express methods failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -806,12 +806,6 @@
     "category": "gap-categorical",
     "reason": "#1278: console.trace / Error.stack frame format diverges from Node (Perry prints native frame addresses like `0: __mh_execute_header` instead of `at <fn> (file:///…:line:col)`). Requires source-position retention through HIR/transform + native-frame → TS-source mapping. The other two divergences in this fixture (#1276 spurious `Values` column on array-of-arrays, #1277 timer ms numbers) are not gating: #1276 was fixed in v0.5.1019+; #1277 is a misdiagnosis — Perry's `Instant::now()` is correct and the apparent 1000× gap is just AOT-vs-interpreted speedup on the trivial loop workload. Flips to PASS when #1278 lands."
   },
-  "test_issue_express_map_undefined": {
-    "issue": "912",
-    "added": "2026-05-17",
-    "category": "bug-open",
-    "reason": "Regression test from #911 (express map undefined / http.METHODS). The METHODS property is now in the manifest (PR adding it alongside this entry); the test may still diverge from Node in the exact METHODS list shape. Re-evaluate once express compiles cleanly."
-  },
   "node-suite/stream/readable/object-mode-read-returns-object": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- revalidated `test_issue_express_map_undefined` now passes on current `origin/main`
- removed only that stale Express/http.METHODS known-failure entry
- left adjacent top-level and stream known failures untouched

## Verification
- Baseline exact: `./run_parity_tests.sh --filter test_issue_express_map_undefined` PASS, report `test-parity/reports/parity_report_20260528_061318.json`
- Final exact after removal: `./run_parity_tests.sh --filter test_issue_express_map_undefined` PASS, report `test-parity/reports/parity_report_20260528_061524.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

## Reference
- DeepWiki local note, not staged: `reference/deepwiki/nodejs-node-http-methods-express-map-2026-05-28.md`

## Non-goals
- no runtime changes
- no HTTP manifest changes
- no Express/package fixture changes
- no adjacent known-failure cleanup
