### PR TITLE
fix(runtime): tighten dyn_index_get pointer-heuristic to avoid SIGBUS on denormal f64 (#63 / #321)

### DIFF
--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -43,6 +43,23 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
     if raw_ptr < 0x10000 {
         return f64::from_bits(TAG_UNDEFINED);
     }
+    // Issue #63 / #321 (Effect.runSync→fork SIGBUS): the raw-I64 fallback
+    // above accepts arbitrary in-range bits — including denormal f64
+    // payloads from non-pointer dataflow (e.g. effect's fiberRefs.ts loop
+    // produced `bits ≈ 0x8_0000_0000` which passed every gate but is just
+    // a number value, not a real I64 pointer). The unchecked
+    // `(*gc_hdr).obj_type` read at the bottom of this fn then crossed
+    // the macOS user/kernel boundary at `[raw_ptr - 8]` → SIGBUS.
+    //
+    // The platform-aware heap range used by `crate::object::is_valid_obj_ptr`
+    // covers exactly the address space mimalloc / system malloc actually
+    // hand out (macOS host: `[0x200_0000_0000, 0x8000_0000_0000)`; Linux /
+    // iOS / Android: `[0x1000, 0x8000_0000_0000)`). Any value with
+    // POINTER_TAG that codegen put there is trusted (it asked for a
+    // pointer), so this gate only applies to the heuristic fallback.
+    if !jsval.is_pointer() && !crate::object::is_valid_obj_ptr(raw_ptr as *const u8) {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
     // Issue #957: if the index itself is a string, route through the
     // by-name object getter. Pre-fix, `obj["foo"]` lowered through
     // `IndexUpdate` re-entered this helper with a NaN-boxed string index
@@ -159,6 +176,11 @@ pub extern "C" fn js_dyn_index_set(obj: f64, index: f64, value: f64) -> f64 {
         return value;
     };
     if raw_ptr < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return value;
+    }
+    // Mirror the #63/#321 guard on the get side: heuristic-derived
+    // pseudo-pointers from non-pointer dataflow must not be dereferenced.
+    if !jsval.is_pointer() && !crate::object::is_valid_obj_ptr(raw_ptr as *const u8) {
         return value;
     }
     let is_array = unsafe {

--- a/test-files/test_gap_dyn_index_get_denormal_safe.ts
+++ b/test-files/test_gap_dyn_index_get_denormal_safe.ts
@@ -1,0 +1,62 @@
+// Issue #63 / #321: `js_dyn_index_get` MUST NOT SIGBUS when its receiver
+// is a number whose f64 bit pattern happens to satisfy the
+// "looks-like-a-raw-I64-pointer" heuristic the helper falls back on for
+// module-level objects stored as raw I64 (where LLVM ABI passes them as
+// DOUBLE).
+//
+// Before the fix, effect's fiberRefs.ts loop produced a value whose
+// f64 bits were a small denormal (~0x8_0000_0000, value ~1.7e-314).
+// That value: not-NaN, non-zero, < 2^48, low-2 bits zero, >= 0x10000 —
+// so the heuristic accepted it as a "raw pointer", read
+// `(*gc_hdr).obj_type` at `[bits - 8]`, and SIGBUSed crossing the
+// macOS user/kernel boundary.
+//
+// This test exercises the same dataflow shape (a denormal-bits number
+// reaching `obj[idx]` with both operands typed Any/Unknown so codegen
+// picks the runtime `js_dyn_index_get` dispatcher). The receiver is
+// a *number* — so `[idx]` must return `undefined` (Node semantics:
+// `(1.7e-314)[0]` is undefined), and Perry must NOT crash.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+// Build a denormal-bits f64 the same way effect's fiber loop happens to.
+// 0x8_0000_0000 raw bits ⇒ subnormal ~1.7e-314. Type as `any` so the
+// codegen sees Any/Unknown and routes through `js_dyn_index_get`.
+const buf = new ArrayBuffer(8);
+const u = new BigUint64Array(buf);
+u[0] = BigInt("0x800000000");
+const f = new Float64Array(buf);
+const denormal: any = f[0];
+
+// 1. typeof is number for any f64 bit pattern, including denormals.
+console.log("denorm-is-number:", typeof denormal === "number");
+
+// 2. The hot path: `obj[idx]` where the receiver is the denormal number
+//    (typed Any so this routes through `js_dyn_index_get`). Indexing a
+//    number returns undefined in JS — Perry must match, NOT SIGBUS.
+const idx: any = 0;
+const result0 = denormal[idx];
+const result1 = denormal[1 as any];
+const result2 = denormal[7 as any];
+console.log("idx0:", result0);
+console.log("idx1:", result1);
+console.log("idx7:", result2);
+
+// 3. Many adjacent bit patterns that ALSO pass the heuristic's range
+//    check (non-zero, < 2^48, > 0x10000, low-2 bits zero) — none should
+//    crash, all should produce `undefined`.
+for (const raw of [
+  "0x10000",
+  "0x20000",
+  "0x100000000",
+  "0x800000000",
+  "0xFFFFFFFFFFF8",
+]) {
+  u[0] = BigInt(raw);
+  const v: any = f[0];
+  const r = v[0 as any];
+  console.log("probe", raw, "→", r);
+}
+
+// 4. Final sentinel — we got here without crashing.
+console.log("done");


### PR DESCRIPTION
## Summary

`Effect.runSync`, `Effect.race`, `Effect.timeout`, `Effect.repeat`, `Effect.retry`, `Effect.fork`, and `Stream.runCollect` all silently exited with code 138 (SIGBUS) the moment the fiber loop entered effect's `fiberRefs.ts`. The crash root-caused to `js_dyn_index_get` accepting a denormal-bits f64 as a "raw I64 pointer" and dereferencing the synthetic `[raw_ptr - 8]` GcHeader, which on macOS host falls in `0x7fff_fff8` (the kernel boundary) and traps with `EXC_BAD_ACCESS` instead of a JS error.

Closes the SIGBUS half of #63. The remaining `(number).patch is not a function` is an upstream effect-fiberRefs miscompile, surfaced now that the runtime no longer crashes underneath it.

## Root cause

`crates/perry-runtime/src/value/dyn_index.rs` had a fallback branch for "module-level objects stored as raw I64 (LLVM ABI passes them as DOUBLE)":

```rust
} else if !value.is_nan()
    && bits != 0
    && bits < 0x0001_0000_0000_0000
    && (bits & 0x3) == 0
    && bits >= 0x10000
{
    bits as usize
}
```

Effect's fiberRefs loop produced a non-pointer value whose f64 bits were `~ 0x8_0000_0000` (a subnormal ~ 1.7e-314). That passed every gate. The function then unconditionally read `(*gc_hdr).obj_type` at `[raw_ptr - 8] = 0x7_fffffff8`, crossing the macOS user/kernel boundary -> SIGBUS, exit 138.

Debug build + lldb confirms:

```
EXC_BAD_ACCESS (code=2, address=0x7fffffff8)
frame #0: js_dyn_index_get + 540
frame #1-9: perry_closure_node_modules_effect_src_internal_fiberRefs_ts__7/8/9
frame #10+: FiberRuntime.runLoop / evaluateEffect / start
```

## Fix

Gate the heuristic-derived `raw_ptr` with `crate::object::is_valid_obj_ptr` before any deref. That predicate is already the canonical platform-aware heap-range check used by the typed-feedback / class-registry hot paths (`macOS host [0x200_0000_0000, 0x8000_0000_0000)`, `Linux / iOS / Android / Windows [0x1000, 0x8000_0000_0000)`). Pointer-tagged values (`is_pointer()`) skip the gate -- codegen explicitly asked for a pointer, the tag is authoritative. Heuristic-derived values now bail to `TAG_UNDEFINED` (get) / no-op (set) when out of the heap range. Buffer-registry fast path is unchanged (its `is_registered_buffer` lookup is a set membership test, safe for any input).

Same gate added to `js_dyn_index_set` for symmetry.

Net touchpoint: 2 added blocks in `crates/perry-runtime/src/value/dyn_index.rs`. No tag layout / NaN-box semantics change.

## Verification

`cargo build --release -p perry-runtime -p perry-stdlib -p perry` then with `PERRY_NO_AUTO_OPTIMIZE=1`:

| Probe (effect-dod survey/) | Before | After |
|---|---|---|
| `fr_fork_min.ts` | stops at step4, exit 138 | all 6 steps print, catchable error on `runSync` |
| `fr_race_dbg.ts` | SIGBUS | "before / after-build", catchable error on `runSync` |
| `fr_race.ts` | SIGBUS | catchable error on `runSync` |
| `fr_timeout.ts` | SIGBUS | catchable error on `runSync` |
| `fr_fork.ts` | SIGBUS | catchable error on `runSync` |
| `fr_repeat.ts` | SIGBUS | exit 0 |
| `fr_retry.ts` | SIGBUS | exit 0 |
| `fr_stream_run.ts` | SIGBUS | exit 0, `stream-foreach: 0` |
| `fr_stream_basic.ts` | SIGBUS | runs, prints stream shape (wrong, separate upstream bug) |

The residual `TypeError: (number).patch is not a function` is the upstream effect-fiberRefs miscompile that the SIGBUS was masking; it is now a catchable JS error and tracked separately. The runtime-side guard is the in-scope fix.

New gap test `test-files/test_gap_dyn_index_get_denormal_safe.ts` constructs a denormal-bits f64 via `Float64Array(BigUint64Array)`, types it `any`, and indexes it through the dyn dispatcher with a handful of bit patterns that all pass the old heuristic (`0x10000`, `0x20000`, `0x100000000`, `0x800000000`, `0xFFFFFFFFFFF8`). Expected behavior: every index is `undefined`, no SIGBUS, `done` prints. Byte-identical against `node --experimental-strip-types` (verified).

Other checks:

- `cargo test --release -p perry-runtime --lib`: 733/733 pass.
- `cargo fmt --all -- --check`: clean.
- Mini gap-suite sweep over `test-files/test_gap_*.ts` (95 tests): 90 pass, 5 pre-existing fails (`test_gap_class_advanced`, `test_gap_console_methods`, `test_gap_json_map_set`, `test_gap_derived_param_props`, `test_gap_param_prop_array_index` -- all unrelated to dyn_index_get; the latter two compare against node which errors on TS-only param-property syntax).

## Files

- `crates/perry-runtime/src/value/dyn_index.rs` -- two `is_valid_obj_ptr` gates, one per fn.
- `test-files/test_gap_dyn_index_get_denormal_safe.ts` -- new gap test.
