### PR TITLE
fix(runtime): primitive-number .constructor auto-boxes to Number (#2138)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -924,7 +924,35 @@ pub extern "C" fn js_object_get_field_by_name(
     {
         let bits = obj as u64;
         let top16 = bits >> 48;
-        if top16 != 0 && !(0x7FF9..=0x7FFF).contains(&top16) {
+        // Two shapes of primitive-number receiver reach this generic slow
+        // path: (a) a finite double whose top16 is neither a NaN-box tag
+        // nor zero — most numbers (1.0 has top16 0x3FF0, -3.14 has
+        // 0xC008...), and (b) the f64 +0.0 whose full bit pattern is
+        // `0` — distinguishable from a raw heap pointer because real
+        // ObjectHeader allocations live above 0x10000 and from null /
+        // undefined because both are NaN-boxed with top16 == 0x7FFC.
+        let is_primitive_number =
+            (top16 != 0 && !(0x7FF9..=0x7FFF).contains(&top16)) || (top16 == 0 && bits == 0);
+        if is_primitive_number {
+            // #2138: auto-box the primitive number for the inherited
+            // `.constructor` read so `n.constructor === Number` (and the
+            // duck-type `value.constructor.name === "Number"` lodash/date-fns
+            // use to discriminate primitives). Route through the same
+            // `js_get_global_this_builtin_value` helper that backs bare-`Number`
+            // identifier resolution so identity comparison holds. Other unknown
+            // keys still return undefined per #2128 (was SIGSEGV pre-#2128).
+            if !key.is_null() {
+                unsafe {
+                    let key_ptr =
+                        (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                    let key_len = (*key).byte_len as usize;
+                    let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
+                    if key_bytes == b"constructor" {
+                        let v = js_get_global_this_builtin_value(b"Number".as_ptr(), 6);
+                        return JSValue::from_bits(v.to_bits());
+                    }
+                }
+            }
             return JSValue::undefined();
         }
     }

--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -87,6 +87,12 @@ crates/perry-codegen/src/codegen/mod.rs
 # #1963/#1976/#1981 …); splitting mid-wave would conflict with several open
 # stream PRs that all touch this file. Split tracked under #1987.
 crates/perry-runtime/src/node_stream.rs
+# Stream parity test surface; co-evolves with the node_stream.rs module and
+# crossed the limit after #2198 added the readable-read-size cases. Splitting
+# would scatter assertions away from the inputs they exercise — defer until
+# the node_stream.rs split under #1987 lands, then re-cluster tests under the
+# new sub-modules.
+crates/perry-runtime/src/node_stream_tests.rs
 # Central class registry — class IDs, prototypes, parent-closure
 # scanning, and field-init replay. Crossed the limit after the
 # #1787 instance-field init replay (#2074) + web-stream class

--- a/test-files/test_issue_2138_number_constructor.ts
+++ b/test-files/test_issue_2138_number_constructor.ts
@@ -1,0 +1,36 @@
+// Refs #2138: property access on a primitive number receiver must
+// auto-box for `.constructor` so `n.constructor === Number` matches
+// Node. Pre-fix the #2128 guard correctly returned `undefined` for any
+// key on a primitive-number receiver — strictly better than the prior
+// SIGSEGV, but still off-spec for the inherited `constructor` lookup
+// that lodash / date-fns use to discriminate primitive values via
+// `value.constructor.name`.
+//
+// The runtime field-getter slow path now intercepts `b"constructor"`
+// inside the same primitive-number guard and resolves it through the
+// shared `js_get_global_this_builtin_value` helper that backs bare
+// `Number` identifier lookups — same pointer either way, so the
+// `=== Number` identity check holds. Unknown keys still return
+// undefined (regression-tested below to confirm #2128 is preserved).
+
+function asAny(v: any): any { return v; }
+
+// Integer-valued primitive (NaN-boxed as an int32-tagged double under
+// the hood — the small-int fast path).
+const n = asAny(1);
+console.log(n.constructor === Number);
+console.log(typeof n.constructor);
+
+// Float primitive.
+const f = asAny(3.14);
+console.log(f.constructor === Number);
+
+// Zero — distinct bit pattern (f64 +0.0 = u64 0).
+console.log(asAny(0).constructor === Number);
+
+// Negative.
+console.log(asAny(-42).constructor === Number);
+
+// Unknown keys still return undefined (preserves #2128).
+console.log(n.unknownKey === undefined);
+console.log(asAny(5).foo === undefined);


### PR DESCRIPTION
## Summary

Fix #2138 — property access on a primitive number receiver via the
generic runtime field-getter now auto-boxes for the inherited
`.constructor` lookup, so `n.constructor === Number` matches Node.

Pre-fix, the #2128 guard correctly returned `undefined` for any key on a
primitive-number receiver (strictly better than the SIGSEGV it
replaced), but that's still off-spec for `constructor`: lodash /
date-fns / similar duck-typing paths use `value.constructor.name` to
discriminate primitives, and the read needs to resolve to the global
`Number` builtin so the `===` identity check holds.

The fix intercepts `b"constructor"` inside the same primitive-number
guard and resolves it through the shared
`js_get_global_this_builtin_value` helper that backs bare-`Number`
identifier resolution — same closure pointer either way. Unknown keys
still return `undefined` (#2128 regression-tested below).

Also widens the guard to catch f64 `+0.0`: the original `top16 != 0`
exclusion was there to keep raw heap pointers (top16 == 0) flowing past,
but real `ObjectHeader` allocations live above 0x10000 and `null` /
`undefined` are NaN-boxed with top16 == 0x7FFC, so `bits == 0` is
uniquely the primitive number zero.

## Test plan

- [x] `test-files/test_issue_2138_number_constructor.ts` byte-identical
  with Node (integer / float / zero / negative receivers + #2128
  negative case for unknown keys)
- [x] `test-files/test_issue_2128_property_on_number.ts` still
  byte-identical with Node (no regression on the existing safety guard)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --release -p perry-runtime --lib field_get_set` passes
