### PR TITLE
test(parity): pin #2048 prototype-walk + multi-stringify case

### DIFF
--- a/test-files/test_issue_2048_json_stringify_inline_array.ts
+++ b/test-files/test_issue_2048_json_stringify_inline_array.ts
@@ -1,0 +1,39 @@
+// Issue #2048: a program that walks a prototype chain into a function-local
+// array and then calls `JSON.stringify(walk(...))` inline twice (once on a
+// class instance, once on a plain Array) used to SIGSEGV (or hang in a
+// `.join()` variant) under `PERRY_NO_AUTO_OPTIMIZE=1`. The crash was the
+// severe form of #2047: deforest's local `walk_expr_children` treated
+// `JsonStringifyFull` (and other less-common `Expr` variants) as a leaf,
+// so the producer call `walk(...)` hidden inside an inline
+// `JSON.stringify(...)` slipped past the unsafe-call-site scan. The
+// candidate got rewritten to take a trailing accumulator argument and
+// `return out` became `return undefined`, but the inline expression-
+// position caller still passed a single argument — heap corruption
+// followed. The #2047 fix (delegate to perry-hir's exhaustive walker)
+// also resolves this case; this gap test pins it in place.
+
+const kind = Symbol.for("k");
+class Base { static [kind] = "Base"; }
+class Leaf extends Base { static [kind] = "Leaf"; }
+
+function walk(value: any): string[] {
+    const seen: string[] = [];
+    let cls = Object.getPrototypeOf(value).constructor;
+    while (cls) {
+        if (kind in cls) seen.push(cls[kind]);
+        cls = Object.getPrototypeOf(cls);
+    }
+    return seen;
+}
+
+// Two inline JSON.stringify calls — the second one used to crash before
+// the deforest walker fix.
+console.log("leaf:", JSON.stringify(walk(new Leaf())));
+console.log("array:", JSON.stringify(walk([1, 2, 3])));
+
+// The `.join()` variant the issue called out as hanging instead of
+// crashing — keep it here so we catch a regression in either direction.
+const a = walk(new Leaf());
+console.log("leaf join:", a.join(","));
+const b = walk([1, 2, 3]);
+console.log("array join:", b.join(","));


### PR DESCRIPTION
## Summary

Closes #2048. Adds a gap test for the prototype-walk + multi-`JSON.stringify` shape from the issue. No code change — the underlying deforest fix landed in #2233 (already merged to main); #2048's repros (segfault, hang, default-compile link failure) are all resolved by that same fix, as the issue itself hypothesized ("almost certainly the severe form of #2047").

## Test plan

- [x] Both inline-`JSON.stringify(walk(...))` repros from the issue: `leaf: ["Leaf","Base"]` / `array: []` — byte-identical to `node --experimental-strip-types`.
- [x] The `.join()` hang variant: `leaf join: Leaf,Base` / `array join:` — byte-identical to Node.
- [x] Deterministic under `PERRY_NO_AUTO_OPTIMIZE=1`: 5/5 runs rc=0.
- [x] Default-compile (no env): same output, rc=0.
- [x] `cargo fmt --all -- --check` clean.
- [x] `./run_parity_tests.sh --filter test_issue_204` — 2/2 pass (2047 + 2048).
