### PR TITLE
fix(runtime): Object.defineProperty on Class.prototype (drizzle applyMixins) — #2159

### DIFF
--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -311,6 +311,93 @@ unsafe fn gc_header_for(obj: *const ObjectHeader) -> *mut crate::gc::GcHeader {
     (obj as *mut u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader
 }
 
+/// #2159 helper: install a `target_cid.method` entry from an
+/// `Object.defineProperty(C.prototype, name, descriptor)` call.
+///
+/// The descriptor's `value` came in two main shapes in practice:
+///
+/// 1. A `BOUND_METHOD_FUNC_PTR` closure returned by `getOwnPropertyDescriptor`
+///    on a sibling class (drizzle's `applyMixins(Base, [Mixin])`: the
+///    `getOwnPropertyDescriptor(Mixin.prototype, name)` value reads as
+///    `js_class_method_bind(Mixin_class_ref, name)`). Dispatching that bound
+///    closure would re-enter `js_native_call_method` against the class-ref —
+///    a class object reaches the *static* dispatch arm, not the instance
+///    method, so calling it would return the wrong thing. Instead we look up
+///    the raw vtable entry on the source class and copy it onto the target
+///    class's vtable directly, so future `inst.method(args)` dispatches via
+///    the regular chain walk with `this = inst`.
+///
+/// 2. A user-supplied closure (e.g. `Object.defineProperty(C.prototype, "m",
+///    { value: function () { … } })`). Route through the same per-class
+///    prototype-method side table that `js_register_prototype_method` (#838)
+///    uses, so the `inst.m` / `inst.m()` lookup paths in
+///    `field_get_set.rs` / `native_call_method.rs` find it after the regular
+///    vtable miss.
+unsafe fn define_class_prototype_method(target_cid: u32, name: &str, value_bits: u64) {
+    use crate::closure::{ClosureHeader, BOUND_METHOD_FUNC_PTR, CLOSURE_MAGIC};
+    use crate::object::class_registry::{ClassVTable, VTableMethodEntry, CLASS_VTABLE_REGISTRY};
+
+    // Reject undefined / null / numeric values up front — those aren't
+    // methods and shouldn't make it onto the prototype side tables.
+    let value = f64::from_bits(value_bits);
+    let jsv = crate::JSValue::from_bits(value_bits);
+    if !jsv.is_pointer() {
+        return;
+    }
+    let ptr = jsv.as_pointer::<u8>() as usize;
+    if ptr < 0x1000 {
+        return;
+    }
+
+    // Shape (1): BOUND_METHOD closure. Extract source class-ref + method
+    // name from the captures (see `js_class_method_bind`), then copy the
+    // source class's vtable entry (or any inherited entry up the parent
+    // chain) onto `target_cid`.
+    if crate::closure::is_closure_ptr(ptr) {
+        let closure = ptr as *const ClosureHeader;
+        if (*closure).type_tag == CLOSURE_MAGIC && (*closure).func_ptr == BOUND_METHOD_FUNC_PTR {
+            let recv = crate::closure::js_closure_get_capture_f64(closure, 0);
+            if let Some(source_cid) = super::class_ref_id(recv) {
+                if let Some((func_ptr, param_count)) =
+                    super::lookup_class_method_in_chain(source_cid, name)
+                {
+                    let mut guard = CLASS_VTABLE_REGISTRY.write().unwrap();
+                    if guard.is_none() {
+                        *guard = Some(std::collections::HashMap::new());
+                    }
+                    let reg = guard.as_mut().unwrap();
+                    let vtable = reg.entry(target_cid).or_insert_with(|| ClassVTable {
+                        methods: std::collections::HashMap::new(),
+                        getters: std::collections::HashMap::new(),
+                        setters: std::collections::HashMap::new(),
+                    });
+                    vtable.methods.insert(
+                        name.to_string(),
+                        VTableMethodEntry {
+                            func_ptr,
+                            param_count,
+                        },
+                    );
+                    drop(guard);
+                    super::class_registry::js_register_class_id(target_cid);
+                    crate::typed_feedback::invalidate_method_change(target_cid);
+                    return;
+                }
+            }
+        }
+    }
+
+    // Shape (2): any other callable value (user closure, regular function).
+    // Mirror the `Class.prototype.method = fn` direct-assignment path so the
+    // existing `lookup_prototype_method` walks find it.
+    super::class_registry::js_register_prototype_method(
+        target_cid,
+        name.as_ptr(),
+        name.len(),
+        value,
+    );
+}
+
 /// Object.defineProperty(obj, key, descriptor) — set the value AND record the
 /// `writable` / `enumerable` / `configurable` attribute flags in the side table.
 /// Returns the object (NaN-boxed pointer).
@@ -325,6 +412,33 @@ pub extern "C" fn js_object_define_property(
     descriptor_value: f64,
 ) -> f64 {
     unsafe {
+        // #2159: when the receiver is a class-ref (`Class.prototype` evaluates
+        // back to the class itself in Perry — see `class_ref_id` /
+        // `js_object_get_own_property_descriptor`'s class-ref arm), route the
+        // descriptor through the class-vtable / prototype-method side tables
+        // so instance lookups (`new C().method`) see the new entry. Drizzle's
+        // `applyMixins(Base, [Mixin])` copies methods between class
+        // prototypes via `Object.defineProperty(Base.prototype, name,
+        // Object.getOwnPropertyDescriptor(Mixin.prototype, name))` — pre-fix
+        // the call hit `extract_obj_ptr → null` (a class-ref isn't a pointer)
+        // and silently dropped the descriptor, so `await
+        // db.select().from(x)` saw `instance.then === undefined` and `await`
+        // unwrapped the builder unchanged.
+        if let Some(target_cid) = super::class_ref_id(obj_value) {
+            if let Some(name) = super::metadata_key_to_string(key_value) {
+                let desc_ptr = extract_obj_ptr(descriptor_value);
+                if !desc_ptr.is_null() {
+                    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+                    let value_field =
+                        js_object_get_field_by_name(desc_ptr as *const ObjectHeader, value_key);
+                    if !value_field.is_undefined() {
+                        define_class_prototype_method(target_cid, &name, value_field.bits());
+                    }
+                }
+            }
+            return obj_value;
+        }
+
         let obj = extract_obj_ptr(obj_value);
         if obj.is_null() {
             return obj_value;

--- a/test-files/test_gap_2159_defineproperty_class_prototype.ts
+++ b/test-files/test_gap_2159_defineproperty_class_prototype.ts
@@ -1,0 +1,59 @@
+// #2159 — Object.defineProperty(Class.prototype, name, descriptor) and the
+// `applyMixins(Target, [Source])` pattern that copies methods between class
+// prototypes (drizzle-orm's `MySqlSelectBase` borrows `then`/`catch`/`finally`
+// from `QueryPromise` this way).
+//
+// Pre-fix, `Class.prototype` evaluated to the class-ref itself in Perry
+// (not a separate prototype object), so `Object.defineProperty(C.prototype,
+// name, desc)` hit `extract_obj_ptr → null` in the runtime and silently
+// dropped the descriptor. Instance lookups (`(new C()).method`) never saw
+// the new property, so `await db.select().from(x)` returned the builder
+// itself instead of resolving the query.
+
+// 1. Single-method install via a plain function value.
+class A { x() { return "x-original"; } }
+Object.defineProperty(
+  (A as any).prototype,
+  "y",
+  { value: function (this: any) { return "y-installed"; }, writable: true, configurable: true },
+);
+const a = new A();
+console.log("typeof a.x:", typeof a.x);
+console.log("typeof a.y:", typeof (a as any).y);
+console.log("a.x():", a.x());
+console.log("a.y():", (a as any).y());
+
+// 2. Mixin pattern: copy descriptors from one class's prototype onto another.
+//    Receiver-binding check: the copied method's `this` is the receiver, so
+//    `this.execute()` finds the target class's own `execute`.
+class QueryPromise {
+  catch(this: any, onR?: any) { return this.then(undefined, onR); }
+  then(this: any, onF?: any, onR?: any) { return this.execute().then(onF, onR); }
+}
+class Builder {
+  execute = async () => ["row1", "row2", "row3"];
+}
+function applyMixins(baseClass: any, extendedClasses: any[]) {
+  for (const ext of extendedClasses) {
+    for (const name of Object.getOwnPropertyNames(ext.prototype)) {
+      if (name === "constructor") continue;
+      Object.defineProperty(
+        baseClass.prototype,
+        name,
+        Object.getOwnPropertyDescriptor(ext.prototype, name)!,
+      );
+    }
+  }
+}
+applyMixins(Builder, [QueryPromise]);
+
+const b = new Builder();
+console.log("typeof b.then:", typeof (b as any).then);
+console.log("typeof b.catch:", typeof (b as any).catch);
+
+// 3. `await <thenable>` assimilation — the inherited `then` must be
+//    callable so the await loop sees a real thenable and routes through
+//    `js_assimilate_thenable`.
+const rows = await (b as any);
+console.log("await b len:", rows.length);
+console.log("await b[0]:", rows[0]);

--- a/tests/release/packages/drizzle-mysql/entry.ts
+++ b/tests/release/packages/drizzle-mysql/entry.ts
@@ -35,10 +35,9 @@ async function exec(sql: string, params: any[], method: string): Promise<{ rows:
 
 const db = drizzle(exec);
 
-// Note: idiomatic drizzle would `await db.select().from(users)` (the builder
-// is thenable via QueryPromise.then). Under Perry that inherited .then
-// currently resolves to undefined (#2159), so we use explicit .execute()
-// throughout. Once #2159 lands, the .execute() calls can be dropped.
+// Idiomatic drizzle: `await db.select().from(users)` resolves via the
+// QueryPromise.then thenable that `applyMixins(MySqlSelectBase,
+// [QueryPromise])` copies onto MySqlSelectBase.prototype. Closed by #2159.
 
 
 const users = mysqlTable("users", {
@@ -61,23 +60,23 @@ await exec("CREATE TABLE posts (id INT PRIMARY KEY AUTO_INCREMENT, user_id INT N
 await db.insert(users).values([
     { id: 1, name: "alice", age: 30 },
     { id: 2, name: "bob",   age: 25 },
-]).execute();
+]);
 await db.insert(posts).values([
     { id: 1, userId: 1, title: "hello" },
     { id: 2, userId: 1, title: "world" },
-]).execute();
+]);
 
-const all = await db.select().from(users).execute();
+const all = await db.select().from(users);
 console.log(`count=${all.length}`);
 
-await db.update(users).set({ age: 31 }).where(eq(users.id, 1)).execute();
-const a = await db.select().from(users).where(eq(users.id, 1)).execute();
+await db.update(users).set({ age: 31 }).where(eq(users.id, 1));
+const a = await db.select().from(users).where(eq(users.id, 1));
 console.log(`alice.age=${a[0].age}`);
 
-await db.delete(users).where(eq(users.id, 2)).execute();
-console.log(`after_delete=${(await db.select().from(users).execute()).length}`);
+await db.delete(users).where(eq(users.id, 2));
+console.log(`after_delete=${(await db.select().from(users)).length}`);
 
-const joined = await db.select().from(users).leftJoin(posts, eq(users.id, posts.userId)).execute();
+const joined = await db.select().from(users).leftJoin(posts, eq(users.id, posts.userId));
 console.log(`join_rows=${joined.length}`);
 
 await conn.close();


### PR DESCRIPTION
## Summary

Closes #2159 — `Object.defineProperty(C.prototype, name, descriptor)` is now
honored on a class-ref receiver, so the `applyMixins(Target, [Source])`
pattern works and drizzle-orm's `await db.select().from(users)` resolves
through the inherited `QueryPromise.then` thenable.

`Class.prototype` evaluates to the class-ref itself in Perry (not a
separate prototype object — see the existing `class_ref_id` arm in
`js_object_get_own_property_descriptor`). Pre-fix the defineProperty
runtime helper hit `extract_obj_ptr → null` on that class-ref and silently
dropped the descriptor, so `(new C()).method` came back `undefined`.

The fix detects the class-ref receiver up front and installs the
descriptor's value where instance lookup will find it:

- **`BOUND_METHOD_FUNC_PTR` closures** (what `getOwnPropertyDescriptor`
  returns for class methods, hot path for `applyMixins`): extract the
  source class-ref + method name from the closure's captures, look the
  method up in the source class's vtable chain via the existing
  `lookup_class_method_in_chain`, and copy the raw `(func_ptr,
  param_count)` entry onto the target class's `CLASS_VTABLE_REGISTRY`.
  Dispatching the bound closure directly would route through
  `js_native_call_method` on the source class-ref (static-dispatch arm)
  and never reach the inherited instance method.
- **Other callables** (user-supplied `{ value: function (…) { … } }`):
  route through `js_register_prototype_method` — the same
  `Class.prototype.m = fn` direct-assignment side table that
  `lookup_prototype_method` already consults on the instance-lookup miss
  path.

## Test plan

- [x] New gap test `test_gap_2159_defineproperty_class_prototype.ts`
  pins the single-method install + full `applyMixins` shape + the
  `await thenable` assimilation. Byte-identical with
  `node --experimental-strip-types`.
- [x] `tests/release/packages/drizzle-mysql/entry.ts` switched from the
  explicit-`.execute()` workaround to idiomatic
  `await db.select().from(users)` form. Fixture passes (with MySQL
  running on 127.0.0.1; CI wiring is #804).
- [x] `cargo test --release -p perry-runtime --lib` — 735/735 pass.
- [x] `cargo fmt --all -- --check` clean.

## Related

- Closes #2159
- Closes the `.execute()` workaround in #489 (drizzle-mysql fixture).
- Builds on #586 (`js_assimilate_thenable` — already in place; this fix
  is what makes `lookup_class_method_in_chain` actually find the
  inherited `then`).
