### PR TITLE
fix(runtime): link Object.create synthetic class_id to original class chain (#1805)

### DIFF
--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1071,6 +1071,21 @@ pub extern "C" fn js_object_create(proto_value: f64) -> f64 {
                     write.as_mut().unwrap().insert(cid, proto_ptr as usize);
                 }
                 unsafe { js_register_class_id(cid) };
+                // #1805: link the synthetic class_id into the original class's
+                // inheritance chain. `Object.getPrototypeOf(instance)` returns
+                // the instance pointer itself in Perry's model (see
+                // `js_object_get_prototype_of`), so `proto_ptr` here is a real
+                // class instance whose `class_id` field IS the user class's
+                // id. Registering it as the synthetic cid's parent lets
+                // `js_instanceof`'s `get_parent_class_id` walk reach the
+                // original class and match — without this, the chain stopped
+                // at the unregistered synthetic id and `Object.create(proto)
+                // instanceof C` was always false even though property /
+                // getter dispatch through the chain worked correctly.
+                let parent_class_id = unsafe { (*proto_ptr).class_id };
+                if parent_class_id != 0 && parent_class_id != cid {
+                    register_class(cid, parent_class_id);
+                }
                 class_id = cid;
             }
         }

--- a/test-files/test_issue_1805_object_create_instanceof.ts
+++ b/test-files/test_issue_1805_object_create_instanceof.ts
@@ -1,0 +1,53 @@
+// Refs #1805: `Object.create(Object.getPrototypeOf(instance))` must be
+// `instanceof` the original class. Property reads and getter dispatch
+// already walked the synthetic-prototype chain correctly (#711 / #809);
+// only `instanceof` lagged because it keys off the class-id parent
+// chain (`get_parent_class_id`) and the synthetic class id allocated
+// by `js_object_create` had no parent edge linking it to the original
+// class.
+//
+// Fix: at synthetic-cid registration time, also record
+// `(synthetic_cid → proto_ptr.class_id)` in CLASS_REGISTRY when the
+// proto pointer carries a non-zero class_id (the typical case where
+// `Object.getPrototypeOf(instance)` returns the instance itself per
+// Perry's model). The `js_instanceof` chain walk then reaches the
+// original class.
+//
+// Surfaces in effect's `SchemaAST.annotations`, which clones AST nodes
+// via `Object.create(Object.getPrototypeOf(ast),
+// Object.getOwnPropertyDescriptors(ast))`. Refs #1758, #809.
+
+class C {
+    x = 1;
+}
+const a = new C();
+const a_proto = Object.getPrototypeOf(a);
+
+// Plain Object.create(proto).
+const clone1 = Object.create(a_proto);
+console.log(clone1 instanceof C);
+
+// The descriptor form.
+class TypeLiteral {
+    _tag = "TypeLiteral";
+}
+const ast = new TypeLiteral();
+const clone2 = Object.create(
+    Object.getPrototypeOf(ast),
+    Object.getOwnPropertyDescriptors(ast),
+);
+console.log(clone2._tag);
+console.log(clone2 instanceof TypeLiteral);
+
+// Control: original instance is still instanceof.
+console.log(a instanceof C);
+console.log(ast instanceof TypeLiteral);
+
+// Chained Object.create — `clone3` should still be instanceof C through
+// the synthetic→synthetic chain.
+const clone3 = Object.create(Object.getPrototypeOf(clone1));
+console.log(clone3 instanceof C);
+
+// Negative: Object.create(null) is NOT instanceof Object (no proto).
+const bare: any = Object.create(null);
+console.log(bare instanceof C);


### PR DESCRIPTION
## Summary

Fix #1805 — `Object.create(Object.getPrototypeOf(instance))` produced
an object that wasn't `instanceof` the original class, even though
property reads and getter dispatch through the synthetic-prototype
chain worked correctly (the #711 / #809 wiring).

`js_instanceof`'s chain walk keys off `get_parent_class_id`, but the
synthetic class id allocated by `js_object_create` had no parent edge
linking it to the original class — so the walk stopped at the
unregistered synthetic id and returned false.

Fix: at synthetic-cid registration time, also record `(synthetic_cid →
proto_ptr.class_id)` in `CLASS_REGISTRY` when the proto pointer
carries a non-zero class_id. In Perry's model
`Object.getPrototypeOf(instance)` returns the instance itself (see
`js_object_get_prototype_of`), so `proto_ptr` here is a real class
instance whose `class_id` field IS the user class's id. Linking it as
the synthetic cid's parent lets the chain walk reach the original
class; chained `Object.create` cases keep working because the walk
transitively reaches the root via `synthetic_2 → synthetic_1 →
ClassId`.

Surfaced by effect's `SchemaAST.annotations`, which clones AST nodes
via `Object.create(Object.getPrototypeOf(ast),
Object.getOwnPropertyDescriptors(ast))`. Refs #1758, #809.

## Test plan

- [x] `test-files/test_issue_1805_object_create_instanceof.ts` covers
  plain `Object.create(proto)`, the descriptor form, the chained case,
  and the `Object.create(null)` negative — byte-identical with Node.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo test --release -p perry-runtime --lib` — 2 flaky failures
  (`gc::tests::copying::test_copying_minor_rewrites_exact_object_pointer_slot_only`,
  `object::tests::text_encoding_stream_globals_construct_readable_writable_shape`)
  both pass in isolation; pre-existing thread-state flakiness.
