### PR TITLE
Reject stream.promises.finished on later stream errors

### DIFF
--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -1151,6 +1151,13 @@ mod tests {
     #[test]
     fn stream_promises_finished_resolves_for_clean_stub_stream() {
         let stream = crate::node_stream::js_node_stream_passthrough_new(undefined_value());
+        let end = get_object_property(stream, b"end").expect("stream.end should exist");
+        let prev_this = crate::object::js_implicit_this_set(stream);
+        unsafe {
+            let _ = crate::closure::js_native_call_value(end, std::ptr::null(), 0);
+        }
+        crate::object::js_implicit_this_set(prev_this);
+
         let promise_value = thunk_streamP_finished(std::ptr::null(), stream, undefined_value());
         let promise = promise_ptr(promise_value);
 
@@ -1169,6 +1176,26 @@ mod tests {
 
         let promise_value = thunk_streamP_finished(std::ptr::null(), stream, undefined_value());
         let promise = promise_ptr(promise_value);
+
+        assert_eq!(crate::promise::js_promise_state(promise), 2);
+        assert_eq!(
+            crate::promise::js_promise_reason(promise).to_bits(),
+            err.to_bits()
+        );
+    }
+
+    #[test]
+    fn stream_promises_finished_rejects_later_destroy_error() {
+        let stream = crate::node_stream::js_node_stream_readable_new(undefined_value());
+        let promise_value = thunk_streamP_finished(std::ptr::null(), stream, undefined_value());
+        let promise = promise_ptr(promise_value);
+
+        assert_eq!(crate::promise::js_promise_state(promise), 0);
+
+        let err = string_value("later-error");
+        let handle = object_ptr_from_value(stream).expect("stream object") as i64;
+        let _ = crate::node_stream::js_node_stream_method_destroy(handle, err);
+        let _ = crate::promise::js_promise_run_microtasks();
 
         assert_eq!(crate::promise::js_promise_state(promise), 2);
         assert_eq!(

--- a/crates/perry-runtime/src/node_submodules/stream_promises.rs
+++ b/crates/perry-runtime/src/node_submodules/stream_promises.rs
@@ -12,7 +12,8 @@
 
 use super::fs_promises::{promise_rejected, promise_undefined};
 use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64, ClosureHeader,
+    js_closure_alloc, js_closure_get_capture_f64, js_closure_get_capture_ptr,
+    js_closure_set_capture_f64, js_closure_set_capture_ptr, ClosureHeader,
 };
 use crate::object::{js_object_get_field_by_name_f64, ObjectHeader};
 use crate::string::js_string_from_bytes;
@@ -99,6 +100,14 @@ pub(crate) fn abort_error_value() -> f64 {
     value_from_ptr(err as *const u8)
 }
 
+fn premature_close_error_value() -> f64 {
+    let msg = b"Premature close";
+    let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_error_new_with_name_message(b"Error", msg_ptr);
+    crate::node_submodules::register_error_code_pub(msg_ptr, "ERR_STREAM_PREMATURE_CLOSE");
+    value_from_ptr(err as *const u8)
+}
+
 pub(crate) fn signal_reason(signal: f64) -> f64 {
     match get_object_property(signal, b"reason") {
         Some(reason) if !JSValue::from_bits(reason.to_bits()).is_undefined() => reason,
@@ -136,6 +145,94 @@ pub(crate) fn register_abort_listener(signal: f64, promise: *mut crate::promise:
 fn pending_abortable_promise(signal: f64) -> f64 {
     let promise = crate::promise::js_promise_new();
     register_abort_listener(signal, promise);
+    promise_value_from_ptr(promise)
+}
+
+fn event_value(name: &[u8]) -> f64 {
+    let ptr = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    f64::from_bits(JSValue::string_ptr(ptr).bits())
+}
+
+extern "C" fn stream_promises_finished_error_listener(
+    closure: *const ClosureHeader,
+    err: f64,
+) -> f64 {
+    let promise = js_closure_get_capture_ptr(closure, 0) as *mut crate::promise::Promise;
+    crate::promise::js_promise_reject(promise, err);
+    undefined_value()
+}
+
+extern "C" fn stream_promises_finished_done_listener(closure: *const ClosureHeader) -> f64 {
+    let promise = js_closure_get_capture_ptr(closure, 0) as *mut crate::promise::Promise;
+    crate::promise::js_promise_resolve(promise, undefined_value());
+    undefined_value()
+}
+
+extern "C" fn stream_promises_finished_close_listener(closure: *const ClosureHeader) -> f64 {
+    let promise = js_closure_get_capture_ptr(closure, 0) as *mut crate::promise::Promise;
+    let stream = f64::from_bits(js_closure_get_capture_ptr(closure, 1) as u64);
+    if let Some(err) = crate::node_stream::js_node_stream_hidden_error_after_read(stream) {
+        crate::promise::js_promise_reject(promise, err);
+    } else if crate::node_stream::js_node_stream_is_stub_ended_after_read(stream) {
+        crate::promise::js_promise_resolve(promise, undefined_value());
+    } else {
+        crate::promise::js_promise_reject(promise, premature_close_error_value());
+    }
+    undefined_value()
+}
+
+fn listener_value(listener: *mut ClosureHeader) -> f64 {
+    value_from_ptr(listener as *const u8)
+}
+
+fn add_once_listener(stream_handle: i64, event: &[u8], listener: f64) {
+    let event = event_value(event);
+    let _ = crate::node_stream::js_node_stream_method_once(stream_handle, event, listener);
+}
+
+fn register_finished_listener_arities() {
+    crate::closure::js_register_closure_arity(
+        stream_promises_finished_error_listener as *const u8,
+        1,
+    );
+    crate::closure::js_register_closure_arity(
+        stream_promises_finished_done_listener as *const u8,
+        0,
+    );
+    crate::closure::js_register_closure_arity(
+        stream_promises_finished_close_listener as *const u8,
+        0,
+    );
+}
+
+fn pending_finished_promise(stream: f64, signal: Option<f64>) -> f64 {
+    register_finished_listener_arities();
+    let promise = crate::promise::js_promise_new();
+    let handle = raw_ptr_from_value(stream) as i64;
+    if handle == 0 {
+        crate::promise::js_promise_resolve(promise, undefined_value());
+        return promise_value_from_ptr(promise);
+    }
+
+    let error_listener = js_closure_alloc(stream_promises_finished_error_listener as *const u8, 1);
+    js_closure_set_capture_ptr(error_listener, 0, promise as i64);
+    add_once_listener(handle, b"error", listener_value(error_listener));
+
+    let done_listener = js_closure_alloc(stream_promises_finished_done_listener as *const u8, 1);
+    js_closure_set_capture_ptr(done_listener, 0, promise as i64);
+    let done_listener = listener_value(done_listener);
+    add_once_listener(handle, b"end", done_listener);
+    add_once_listener(handle, b"finish", done_listener);
+
+    let close_listener = js_closure_alloc(stream_promises_finished_close_listener as *const u8, 2);
+    js_closure_set_capture_ptr(close_listener, 0, promise as i64);
+    js_closure_set_capture_ptr(close_listener, 1, stream.to_bits() as i64);
+    add_once_listener(handle, b"close", listener_value(close_listener));
+
+    if let Some(signal) = signal {
+        register_abort_listener(signal, promise);
+    }
+
     promise_value_from_ptr(promise)
 }
 
@@ -212,12 +309,14 @@ pub(crate) extern "C" fn thunk_streamP_finished(
         if crate::node_stream::js_node_stream_is_stub_ended_after_read(stream) {
             return promise_undefined();
         }
-        return pending_abortable_promise(signal);
+        return pending_finished_promise(stream, Some(signal));
     }
 
     if let Some(err) = crate::node_stream::js_node_stream_hidden_error_after_read(stream) {
         promise_rejected(err)
-    } else {
+    } else if crate::node_stream::js_node_stream_is_stub_ended_after_read(stream) {
         promise_undefined()
+    } else {
+        pending_finished_promise(stream, None)
     }
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -944,12 +944,6 @@
     "category": "bug-open",
     "reason": "node:stream: destroy() inside _read() — readCalls count or close-event behavior wrong. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/promises/finished-rejects-on-error": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: promises.finished() — does not reject when stream errors. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/read-multibyte-boundary": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- keep stream.promises.finished() pending for live streams until end/finish/close/error
- reject with the stream error emitted after finished() is called
- remove the fixed parity case from known failures

## Verification
- cargo fmt --all -- --check
- ./scripts/check_file_size.sh
- jq empty test-parity/known_failures.json
- git diff --check
- RUST_TEST_THREADS=1 cargo test -p perry-runtime
- CARGO_BUILD_JOBS=1 cargo test --workspace --exclude perry-runtime --exclude perry-ui-macos --exclude perry-ui-ios --exclude perry-ui-visionos --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows
- ./scripts/regen_api_docs.sh && git diff --quiet -- docs/src/api/reference.md docs/api/perry.d.ts
- python3.11 -m unittest tests.test_compiler_output_regression
- cargo build -p perry
- python3.11 scripts/compiler_output_regression.py suite --suite native-region-proof --perry target/debug/perry --benchmark-mode smoke --runs 1 --perf-counters off --print-summary
- python3.11 scripts/compiler_output_regression.py capture --perry target/debug/perry --workload vectorized_buffer_transform --benchmark-mode smoke --runs 1 --perf-counters off --gate --print-summary
- python3.11 scripts/compiler_output_regression.py capture --perry target/debug/perry --workload hir_fact_rewrite --benchmark-mode smoke --runs 1 --perf-counters off --gate --print-summary
- python3.11 scripts/compiler_output_regression.py capture --perry target/debug/perry --workload fma_contract --benchmark-mode smoke --runs 1 --perf-counters off --gate --fp-contract=on --expect-fma=on --out-dir target/compiler-output-regression/fma_contract-fp-contract-on-local
- python3.11 scripts/compiler_output_regression.py capture --perry target/debug/perry --workload fma_contract --benchmark-mode smoke --runs 1 --perf-counters off --gate --fast-math --fp-contract=off --expect-fma=off --out-dir target/compiler-output-regression/fma_contract-fast-no-contract-local
- ./run_parity_tests.sh --suite node-suite --module stream/promises --filter finished-rejects-on-error
- ./run_parity_tests.sh --suite node-suite --module stream/promises

Note: the CI FP-contraction commands include --clang-arg=-march=haswell. On this Apple Silicon host, clang rejects that x86 flag while targeting arm64, so I ran the same FP workload locally without the CI-only architecture flag.