### PR TITLE
fix(runtime): clone buffer bytes before gc probing

### DIFF
--- a/crates/perry-runtime/src/array/flat_clone.rs
+++ b/crates/perry-runtime/src/array/flat_clone.rs
@@ -234,6 +234,14 @@ pub extern "C" fn js_array_clone(src: *const ArrayHeader) -> *mut ArrayHeader {
         0
     };
 
+    // Buffers allocated from the small-buffer slab do not carry a GC header.
+    // Detect them before any GC-header probing below; otherwise arbitrary slab
+    // bytes immediately before the BufferHeader can be misread as a String or
+    // Object header and `Array.from(buf)` materializes nonsense.
+    if raw_addr != 0 && crate::buffer::is_registered_buffer(raw_addr) {
+        return crate::buffer::buffer_to_array(raw_addr as *const crate::buffer::BufferHeader);
+    }
+
     // `Array.from(string)` iterates the source by Unicode codepoint
     // (each codepoint becomes a 1-char string element) per ECMA-262
     // §23.1.2.1. Pre-fix this fell through to the array memcpy path
@@ -361,10 +369,6 @@ pub extern "C" fn js_array_clone(src: *const ArrayHeader) -> *mut ArrayHeader {
             return crate::typedarray::typed_array_to_array(
                 raw_addr as *const crate::typedarray::TypedArrayHeader,
             );
-        }
-        // Uint8Array (legacy Buffer-backed): same materialization story.
-        if crate::buffer::is_registered_buffer(raw_addr) {
-            return crate::buffer::buffer_to_array(raw_addr as *const crate::buffer::BufferHeader);
         }
     }
     let src = clean_arr_ptr(src);

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -75,6 +75,35 @@ fn test_array_from_f64() {
 }
 
 #[test]
+fn test_array_clone_prefers_buffer_registry_before_gc_header_probe() {
+    let mut adjacent = None;
+    for _ in 0..4 {
+        let fake_prev = crate::buffer::buffer_alloc(8);
+        let buf = crate::buffer::buffer_alloc(4);
+        let expected_next = fake_prev as usize
+            + ((std::mem::size_of::<crate::buffer::BufferHeader>() + 8 + 7) & !7);
+        if buf as usize == expected_next {
+            adjacent = Some((fake_prev, buf));
+            break;
+        }
+    }
+    let (fake_prev, buf) = adjacent.expect("expected adjacent small-buffer slab allocations");
+
+    unsafe {
+        *crate::buffer::buffer_data_mut(fake_prev) = crate::gc::GC_TYPE_STRING;
+        (*buf).length = 4;
+        std::ptr::copy_nonoverlapping(
+            [1u8, 2, 3, 4].as_ptr(),
+            crate::buffer::buffer_data_mut(buf),
+            4,
+        );
+    }
+
+    let cloned = js_array_clone(buf as *const ArrayHeader);
+    assert_numeric_raw_values(cloned, &[1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
 fn test_array_set() {
     let arr = js_array_alloc(3);
     js_array_push_f64(arr, 1.0);

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1483,11 +1483,5 @@
     "added": "2026-05-25",
     "category": "bug-open",
     "reason": "node:stream/promises: pipeline(src, transform, asyncFnSink) — collected output wrong/empty. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/consumers/buffer-byte-exact": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream/consumers: buffer() from raw-byte Buffer chunks — byte sequence or Array.from output differs from Node. Flips to PASS when #1532 lands."
   }
 }


### PR DESCRIPTION
## Summary
- make Array.from(Buffer) materialize registered Buffers before any GC-header probing
- add a runtime regression for slab Buffers whose preceding bytes resemble a String GC header
- remove the now-passing stream/consumers buffer byte exact known failure

## Verification
- ./run_parity_tests.sh --suite node-suite --module stream --filter consumers/buffer-byte-exact
- ./run_parity_tests.sh --suite node-suite --module stream --filter consumers/buffer
- cargo test -p perry-runtime test_array_clone_prefers_buffer_registry_before_gc_header_probe
- cargo check -p perry-runtime -p perry-stdlib -p perry-codegen
- cargo fmt --check
- jq empty test-parity/known_failures.json
- git diff --check