### PR TITLE
fix(net): expose Socket EventEmitter introspection (.listeners/.rawListeners) (#2211)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -582,6 +582,11 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("net", "removeAllListeners", true, Some("Socket")),
     method("net", "listenerCount", true, Some("Socket")),
     method("net", "eventNames", true, Some("Socket")),
+    // Issue #2211 — `socket.listeners(event)` / `socket.rawListeners(event)`.
+    // Returns a real JS array of registered callbacks; the introspection
+    // methods `test-http-agent-*` exercises after `request.on('socket', ...)`.
+    method("net", "listeners", true, Some("Socket")),
+    method("net", "rawListeners", true, Some("Socket")),
     method("net", "resetAndDestroy", true, Some("Socket")),
     // Issue #1123 followup — `net.Server` instance methods backing
     // `createServer(...).listen/.close/.address/.on`. Mirrors the
@@ -604,6 +609,10 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("net", "removeAllListeners", true, Some("Server")),
     method("net", "listenerCount", true, Some("Server")),
     method("net", "eventNames", true, Some("Server")),
+    // Issue #2211 — `server.listeners(event)` / `server.rawListeners(event)`,
+    // twin of the Socket entries above (shared handle/listener namespace).
+    method("net", "listeners", true, Some("Server")),
+    method("net", "rawListeners", true, Some("Server")),
     // Issue #811 — IP classification helpers + Happy-Eyeballs default
     // accessors. Pure string/global-flag functions.
     method("net", "isIP", false, None),

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -487,6 +487,32 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         args: &[],
         ret: NR_OBJ_FROM_JSON_STR,
     },
+    // Issue #2211 — `socket.listeners(event)` / `socket.rawListeners(event)`.
+    // Returns a real JS array of registered callbacks; consumers do
+    // `socket.listeners('timeout').length` etc. Returned as NR_PTR so
+    // the runtime ArrayHeader is NaN-boxed POINTER_TAG. Perry collapses
+    // `once` into the listener vector + a removal side-table, so
+    // `listeners` and `rawListeners` share an impl — the onceWrapper
+    // distinction is unobservable to callers that read the array before
+    // any event has fired (which is the shape the radar tests use).
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "listeners",
+        class_filter: Some("Socket"),
+        runtime: "js_net_socket_listeners",
+        args: &[NA_STR],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "rawListeners",
+        class_filter: Some("Socket"),
+        runtime: "js_net_socket_raw_listeners",
+        args: &[NA_STR],
+        ret: NR_PTR,
+    },
     // Issue #2131 — `socket.resetAndDestroy()` is the "send RST then
     // destroy" variant; we alias to `destroy()` (FIN-then-close) for
     // now since the connected peer treats both as an abrupt close in
@@ -674,6 +700,27 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         runtime: "js_net_server_event_names",
         args: &[],
         ret: NR_OBJ_FROM_JSON_STR,
+    },
+    // Issue #2211 — mirror of the Socket listeners/rawListeners surface
+    // for net.Server. Same impl since socket and server handles share
+    // the `statics::listeners()` map keyed by id.
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "listeners",
+        class_filter: Some("Server"),
+        runtime: "js_net_server_listeners",
+        args: &[NA_STR],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "net",
+        has_receiver: true,
+        method: "rawListeners",
+        class_filter: Some("Server"),
+        runtime: "js_net_server_raw_listeners",
+        args: &[NA_STR],
+        ret: NR_PTR,
     },
     // ========== node:stream — Readable.from(iterable) (#631) ==========
     // The other stream constructors (`new Readable(opts)` etc.) are wired

--- a/crates/perry-ext-net/src/lifecycle.rs
+++ b/crates/perry-ext-net/src/lifecycle.rs
@@ -20,7 +20,7 @@
 //! `NativeModSig` rows live in
 //! `perry-codegen/src/lower_call/native_table/net_events.rs`.
 
-use perry_ffi::{alloc_string, StringHeader};
+use perry_ffi::{alloc_string, ArrayHeader, JsValue, StringHeader};
 use std::collections::HashSet;
 
 use crate::statics;
@@ -223,6 +223,36 @@ fn event_names_json(handle: i64) -> String {
     format!("[{}]", parts.join(","))
 }
 
+/// Issue #2211 — build a JS array of the listener callbacks registered
+/// on `(handle, event)`. Each `cb` slot stores the raw closure pointer
+/// (`*const RawClosureHeader`) cast to `i64`; we NaN-box it back as
+/// POINTER_TAG so the returned array is full of callable JS values.
+/// Both `listeners()` and `rawListeners()` go through this helper — Node
+/// returns the wrapped onceWrapper for `rawListeners` and the unwrapped
+/// callback for `listeners`, but Perry's `once`-listener implementation
+/// drains the entry from the listener vector on first emit (the
+/// once-flag side table is just a removal set), so the wrap/unwrap
+/// distinction never observes a difference for callers that only ask
+/// before any event has fired. Matching Node's "the array is a real
+/// snapshot of current listeners" is what the
+/// `socket.listeners('timeout').length` check needs.
+fn listeners_array_for_event(handle: i64, event: &str) -> *mut ArrayHeader {
+    let snapshot: Vec<i64> = statics::listeners()
+        .lock()
+        .ok()
+        .and_then(|m| m.get(&handle).and_then(|p| p.get(event)).cloned())
+        .unwrap_or_default();
+    let mut arr = unsafe { perry_ffi::js_array_alloc(snapshot.len() as u32) };
+    for cb in snapshot {
+        if cb == 0 {
+            continue;
+        }
+        let value = JsValue::from_object_ptr(cb as *mut u8);
+        arr = unsafe { perry_ffi::js_array_push(arr, value) };
+    }
+    arr
+}
+
 fn json_escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for ch in s.chars() {
@@ -310,6 +340,36 @@ pub unsafe extern "C" fn js_net_socket_event_names(handle: i64) -> *mut StringHe
     alloc_string(&json).as_raw()
 }
 
+/// Issue #2211 — `socket.listeners(event)` / `socket.rawListeners(event)`.
+/// Both return a JS array of the registered callbacks. The codegen
+/// dispatches this through `NR_PTR`, so the raw ArrayHeader pointer is
+/// NaN-boxed with POINTER_TAG and reaches the caller as a real JS array
+/// (length, indexing, iteration). `rawListeners` shares the same impl
+/// because Perry collapses `once`-registered callbacks into the
+/// listener vector — see the helper's doc comment for the
+/// once-wrap/unwrap discussion.
+///
+/// # Safety
+///
+/// `event_ptr` must be null or a Perry-runtime `StringHeader` pointer.
+#[no_mangle]
+pub unsafe extern "C" fn js_net_socket_listeners(handle: i64, event_ptr: i64) -> i64 {
+    let Some(event) = read_event(event_ptr) else {
+        return unsafe { perry_ffi::js_array_alloc(0) } as i64;
+    };
+    listeners_array_for_event(handle, &event) as i64
+}
+
+/// `socket.rawListeners(event)` — see `js_net_socket_listeners`.
+///
+/// # Safety
+///
+/// Same as `js_net_socket_listeners`.
+#[no_mangle]
+pub unsafe extern "C" fn js_net_socket_raw_listeners(handle: i64, event_ptr: i64) -> i64 {
+    js_net_socket_listeners(handle, event_ptr)
+}
+
 /// `socket.resetAndDestroy()` — Node treats this as "send RST then
 /// destroy" but exposes the same teardown surface as `destroy()` from
 /// the caller's point of view (the `'close'` event still fires). We
@@ -389,6 +449,31 @@ pub unsafe extern "C" fn js_net_server_event_names(handle: i64) -> *mut StringHe
     alloc_string(&json).as_raw()
 }
 
+/// `server.listeners(event)` — mirror of `js_net_socket_listeners` since
+/// net.Server and net.Socket share the `statics::listeners()` keyed by
+/// handle id. Same NR_PTR/POINTER_TAG return contract.
+///
+/// # Safety
+///
+/// `event_ptr` must be null or a Perry-runtime `StringHeader` pointer.
+#[no_mangle]
+pub unsafe extern "C" fn js_net_server_listeners(handle: i64, event_ptr: i64) -> i64 {
+    let Some(event) = read_event(event_ptr) else {
+        return unsafe { perry_ffi::js_array_alloc(0) } as i64;
+    };
+    listeners_array_for_event(handle, &event) as i64
+}
+
+/// `server.rawListeners(event)` — see `js_net_server_listeners`.
+///
+/// # Safety
+///
+/// Same as `js_net_server_listeners`.
+#[no_mangle]
+pub unsafe extern "C" fn js_net_server_raw_listeners(handle: i64, event_ptr: i64) -> i64 {
+    js_net_server_listeners(handle, event_ptr)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -453,6 +538,42 @@ mod tests {
         assert_eq!(listener_count_at_handle(handle, "end"), 0.0);
         let no_once_left = statics::once_flags().lock().unwrap().get(&handle).is_none();
         assert!(no_once_left);
+
+        reset_handle(handle);
+    }
+
+    /// Issue #2211 — `listeners_array_for_event` returns an
+    /// ArrayHeader holding one NaN-boxed POINTER_TAG value per
+    /// registered callback. The pointer round-trips bit-exact so the
+    /// runtime sees the closure handle the original `on()` call
+    /// stored.
+    #[test]
+    fn listeners_array_round_trips_callback_pointers() {
+        let handle = -91_237;
+        reset_handle(handle);
+
+        // Use raw pointer-shaped values (high bit clear) — the helper
+        // only re-NaN-boxes them, never dereferences.
+        register_listener_with_flag(handle, "timeout".to_string(), 0x1234, false);
+        register_listener_with_flag(handle, "timeout".to_string(), 0x5678, false);
+
+        let arr = listeners_array_for_event(handle, "timeout");
+        assert!(!arr.is_null());
+        let len = unsafe { (*arr).length };
+        assert_eq!(len, 2);
+
+        let v0 = unsafe { perry_ffi::js_array_get(arr, 0) };
+        let v1 = unsafe { perry_ffi::js_array_get(arr, 1) };
+        assert!(v0.is_pointer());
+        assert!(v1.is_pointer());
+        assert_eq!(v0.as_pointer::<u8>() as usize, 0x1234);
+        assert_eq!(v1.as_pointer::<u8>() as usize, 0x5678);
+
+        // Unknown event name → empty array (zero allocations beyond
+        // the header), not a panic.
+        let empty = listeners_array_for_event(handle, "never");
+        assert!(!empty.is_null());
+        assert_eq!(unsafe { (*empty).length }, 0);
 
         reset_handle(handle);
     }

--- a/crates/perry-hir/src/lower/expr_call/prescans.rs
+++ b/crates/perry-hir/src/lower/expr_call/prescans.rs
@@ -11,7 +11,8 @@ use swc_ecma_ast as ast;
 use crate::ir::Expr;
 use crate::lower_patterns::{
     pre_scan_fastify_handler_params, pre_scan_node_http_client_callback_params,
-    pre_scan_node_http_create_server_params, pre_scan_node_http_upgrade_params,
+    pre_scan_node_http_client_request_socket_params, pre_scan_node_http_create_server_params,
+    pre_scan_node_http_upgrade_params,
 };
 
 use super::super::{try_desugar_reactive_animate, try_desugar_reactive_text, LoweringContext};
@@ -88,6 +89,16 @@ pub(super) fn run_call_prescans(
     // entries in NATIVE_MODULE_TABLE.
     if let Some(ws_id_name) = pre_scan_node_http_upgrade_params(ctx, call) {
         ctx.register_native_instance(ws_id_name, "ws".to_string(), "Client".to_string());
+    }
+
+    // Issue #2211 — `request.on('socket', sock => …)` on a `ClientRequest`
+    // hands the consumer the underlying TCP socket; pre-tag the arrow param
+    // as a `("net", "Socket")` native instance so EventEmitter introspection
+    // (`sock.listeners('timeout')`, `sock.eventNames()`, etc.) inside the
+    // handler dispatches through the class-filtered Socket rows in
+    // NATIVE_MODULE_TABLE.
+    if let Some(sock_name) = pre_scan_node_http_client_request_socket_params(ctx, call) {
+        ctx.register_native_instance(sock_name, "net".to_string(), "Socket".to_string());
     }
 
     // perry/ui reactive Text: `Text(\`...${state.value}...\`)` where at least one

--- a/crates/perry-hir/src/lower_patterns.rs
+++ b/crates/perry-hir/src/lower_patterns.rs
@@ -522,6 +522,69 @@ pub(crate) fn pre_scan_node_http_upgrade_params(
     Some(ws_id_name)
 }
 
+/// Issue #2211 — pre-scan for `request.on('socket', sock => …)` (and the
+/// `'connect'`/`'connection'` aliases). When the receiver is a
+/// `ClientRequest` native instance and the event name is `'socket'`,
+/// register the SINGLE arrow param as a `("net", "Socket")` native
+/// instance BEFORE the body is lowered, so introspection calls inside
+/// the handler — `sock.listeners('timeout')`, `sock.eventNames()`,
+/// `sock.removeListener(...)` — dispatch through the class-filtered
+/// Socket rows in NATIVE_MODULE_TABLE instead of failing the codegen-
+/// emitted `value is not a function` check.
+///
+/// Returns `Some(socket_local_name)` when the pattern matches.
+pub(crate) fn pre_scan_node_http_client_request_socket_params(
+    ctx: &crate::lower::LoweringContext,
+    call: &ast::CallExpr,
+) -> Option<String> {
+    use ast::Callee;
+    let callee_expr = match &call.callee {
+        Callee::Expr(e) => e,
+        _ => return None,
+    };
+    let member = match callee_expr.as_ref() {
+        ast::Expr::Member(m) => m,
+        _ => return None,
+    };
+    let obj_ident = match member.obj.as_ref() {
+        ast::Expr::Ident(i) => i,
+        _ => return None,
+    };
+    let obj_name = obj_ident.sym.to_string();
+    let (module, class) = ctx.lookup_native_instance(&obj_name)?;
+    if module != "http" || class != "ClientRequest" {
+        return None;
+    }
+    let method_name = match &member.prop {
+        ast::MemberProp::Ident(i) => i.sym.to_string(),
+        _ => return None,
+    };
+    if method_name != "on" && method_name != "addListener" && method_name != "once" {
+        return None;
+    }
+    // First arg must be `'socket'` / `'connect'` / `'connection'`. Node
+    // fires the same socket reference on all three so the same param-tag
+    // applies; pinning the literal here keeps unrelated events (`'response'`,
+    // `'error'`) untouched.
+    let event_arg = call.args.first()?;
+    let event_name = match event_arg.expr.as_ref() {
+        ast::Expr::Lit(ast::Lit::Str(s)) => s.value.as_str().unwrap_or(""),
+        _ => return None,
+    };
+    if !matches!(event_name, "socket" | "connect" | "connection") {
+        return None;
+    }
+    let handler_arg = call.args.get(1)?;
+    if handler_arg.spread.is_some() {
+        return None;
+    }
+    let arrow = match handler_arg.expr.as_ref() {
+        ast::Expr::Arrow(a) => a,
+        _ => return None,
+    };
+    arrow.params.first().and_then(pat_ident_name)
+}
+
 /// Detect if an expression represents a native handle instance (Big, Decimal, etc.)
 /// Returns the module name if it does.
 ///

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -900,6 +900,10 @@ unsafe fn dispatch_external_net_socket(handle: i64, method: &str, args: &[f64]) 
         fn js_net_socket_listener_count(handle: i64, event_ptr: i64) -> f64;
         fn js_net_socket_event_names(handle: i64) -> *mut perry_runtime::StringHeader;
         fn js_net_socket_reset_and_destroy(handle: i64) -> i64;
+        // Issue #2211 — listeners()/rawListeners() return a *mut ArrayHeader
+        // cast to i64; NaN-box with POINTER_TAG to surface as a real JS array.
+        fn js_net_socket_listeners(handle: i64, event_ptr: i64) -> i64;
+        fn js_net_socket_raw_listeners(handle: i64, event_ptr: i64) -> i64;
     }
 
     // Parse a runtime StringHeader pointer (`address` / `eventNames`
@@ -982,6 +986,19 @@ unsafe fn dispatch_external_net_socket(handle: i64, method: &str, args: &[f64]) 
             js_net_socket_listener_count(handle, event_ptr)
         }
         "eventNames" => json_str_to_value(js_net_socket_event_names(handle)),
+        // Issue #2211 — `socket.listeners(event)` / `socket.rawListeners(event)`
+        // for any-typed receivers. FFI returns a *mut ArrayHeader cast to i64;
+        // NaN-box with POINTER_TAG (0x7FFD) so callers see a real JS array.
+        "listeners" if !args.is_empty() => {
+            let event_ptr = unbox_to_i64(args[0]);
+            let arr = js_net_socket_listeners(handle, event_ptr);
+            f64::from_bits(0x7FFD_0000_0000_0000u64 | (arr as u64 & 0x0000_FFFF_FFFF_FFFF))
+        }
+        "rawListeners" if !args.is_empty() => {
+            let event_ptr = unbox_to_i64(args[0]);
+            let arr = js_net_socket_raw_listeners(handle, event_ptr);
+            f64::from_bits(0x7FFD_0000_0000_0000u64 | (arr as u64 & 0x0000_FFFF_FFFF_FFFF))
+        }
         "address" => json_str_to_value(js_net_socket_address(handle)),
         "resetAndDestroy" => {
             js_net_socket_reset_and_destroy(handle);

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1437 entries across 82 modules
+// Coverage: 1441 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1437 entries across 82 modules.
+Total: 1441 entries across 82 modules.
 
 ## Modules
 
@@ -1081,12 +1081,16 @@ Total: 1437 entries across 82 modules.
 - `listen` — instance *(class: `Server`)*
 - `listenerCount` — instance *(class: `Socket`)*
 - `listenerCount` — instance *(class: `Server`)*
+- `listeners` — instance *(class: `Socket`)*
+- `listeners` — instance *(class: `Server`)*
 - `off` — instance *(class: `Socket`)*
 - `off` — instance *(class: `Server`)*
 - `on` — instance *(class: `Socket`)*
 - `once` — instance *(class: `Socket`)*
 - `once` — instance *(class: `Server`)*
 - `pause` — instance *(class: `Socket`)*
+- `rawListeners` — instance *(class: `Socket`)*
+- `rawListeners` — instance *(class: `Server`)*
 - `ref` — instance *(class: `Socket`)*
 - `removeAllListeners` — instance *(class: `Socket`)*
 - `removeAllListeners` — instance *(class: `Server`)*

--- a/test-parity/node-suite/http/agent/socket-event-introspection.ts
+++ b/test-parity/node-suite/http/agent/socket-event-introspection.ts
@@ -1,0 +1,51 @@
+// Issue #2211 — EventEmitter introspection on a net.Socket. Tests in
+// the `test-http-agent-*` and `test-http-server-*` families call
+// `socket.listeners('timeout')`, `socket.eventNames()`,
+// `socket.rawListeners(...)`, etc. on the socket handed to
+// `request.on('socket', sock => …)`. Pre-#2211 each threw "value is
+// not a function" because perry-ext-net's NativeModSig surface only
+// exposed `on`/`once`/`removeListener`/`removeAllListeners`/
+// `listenerCount`/`eventNames` (PRs #2131/#2173).
+//
+// The test exercises the same introspection surface against a
+// directly-constructed `net.Socket` so it doesn't depend on Perry's
+// `http.request` firing a `'socket'` event (which is independently
+// gated on the client-side wiring). The class is the same; the FFI
+// dispatch the patch adds is what the parity check pins.
+import { Socket } from "node:net";
+
+// typeof on the method-value is intentionally not checked: Perry
+// reports `number` for native method-value reads vs. Node's `function`
+// (separate issue family, #1380-shape). The relevant fix is the
+// callable surface; the actual invocations below pin the dispatch.
+
+const sock = new Socket();
+
+const handlerA = () => {};
+const handlerB = () => {};
+sock.on("timeout", handlerA);
+sock.on("timeout", handlerB);
+
+const ls = sock.listeners("timeout");
+console.log("listeners isArray:", Array.isArray(ls));
+console.log("listeners length>=2:", ls.length >= 2);
+console.log("listenerCount>=2:", sock.listenerCount("timeout") >= 2);
+
+const raw = sock.rawListeners("timeout");
+console.log("rawListeners isArray:", Array.isArray(raw));
+console.log("rawListeners length>=2:", raw.length >= 2);
+
+const names = sock.eventNames();
+console.log("eventNames isArray:", Array.isArray(names));
+console.log("eventNames includes timeout:", names.includes("timeout"));
+
+sock.removeListener("timeout", handlerA);
+console.log(
+  "listenerCount after removeListener>=1:",
+  sock.listenerCount("timeout") >= 1,
+);
+
+sock.removeAllListeners("timeout");
+console.log("listenerCount after removeAll:", sock.listenerCount("timeout"));
+
+sock.destroy();


### PR DESCRIPTION
## Summary

- Adds the missing `socket.listeners(event)` / `socket.rawListeners(event)` EventEmitter introspection methods to perry-ext-net's Socket and Server surface. The arrays are built from the existing `statics::listeners()` storage and returned via `NR_PTR` so callers see a real JS array (Array.isArray, indexing, .length).
- Pre-scans `request.on('socket' | 'connect' | 'connection', sock => …)` on a `ClientRequest` receiver and tags the arrow param as `("net", "Socket")` so introspection inside the handler dispatches through the class-filtered Socket rows in `NATIVE_MODULE_TABLE`. This is the shape `test-http-agent-timeout-option.js` uses (`socket.listeners('timeout').length` etc).
- Routes the new FFIs through perry-stdlib's `external-net-pump` any-typed-receiver dispatcher so `Map.get(sock).listeners(...)` shapes still hit the same impl.
- Adds the matching `("net", "Socket")` and `("net", "Server")` manifest entries (`#463` drift gate).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --release -p perry-codegen -p perry-hir -p perry-api-manifest -p perry-ext-net` green (incl. the `every_dispatch_entry_has_manifest_counterpart` drift check and a new `listeners_array_round_trips_callback_pointers` unit test)
- [x] Added `test-parity/node-suite/http/agent/socket-event-introspection.ts` — byte-identical against `node --experimental-strip-types` for `new Socket()` → multi-listener `.listeners('timeout')` / `.rawListeners` / `.eventNames` / `.removeListener` / `.removeAllListeners` / `.listenerCount`.

Closes #2211.
