### PR TITLE
fix(runtime): expose fs.promises namespace via parent fs module (#2133)

### DIFF
--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -1059,6 +1059,32 @@ mod tests {
         assert!(get_object_property(boxed_ptr(ns as *const u8), b"finished").is_some());
     }
 
+    /// #2133: `fs.promises` (the parent `node:fs` module's `.promises`
+    /// property) must resolve to the populated `fs_promises` submodule
+    /// singleton — not an empty namespace stub — so destructured exports
+    /// like `const { open } = fs.promises` and the indirect form
+    /// (`const p = fs.promises; p.open(...)`) both reach real callable
+    /// closures and a returned FileHandle dispatches its methods.
+    #[test]
+    fn fs_parent_promises_property_exposes_namespace() {
+        let value = unsafe {
+            crate::object::js_native_module_property_by_name(
+                b"fs".as_ptr(),
+                "fs".len(),
+                b"promises".as_ptr(),
+                "promises".len(),
+            )
+        };
+        let ns = object_ptr_from_value(value).expect("fs.promises should be an object");
+        let ns_value = boxed_ptr(ns as *const u8);
+        // Spot-check a few exports from the fs_promises submodule.
+        assert!(get_object_property(ns_value, b"open").is_some());
+        assert!(get_object_property(ns_value, b"readFile").is_some());
+        assert!(get_object_property(ns_value, b"writeFile").is_some());
+        assert!(get_object_property(ns_value, b"chmod").is_some());
+        assert!(get_object_property(ns_value, b"stat").is_some());
+    }
+
     #[test]
     fn stream_promises_default_export_exposes_namespace() {
         let value = unsafe {

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -144,13 +144,9 @@ pub unsafe extern "C" fn js_native_module_property_by_name(
         let submodule = "stream/promises";
         return js_create_native_module_namespace(submodule.as_ptr(), submodule.len());
     }
-    // #2133: same shape for `node:fs.promises` — route through the
-    // populated `fs_promises` submodule singleton so destructured exports
-    // (e.g. `const { open } = fs.promises`) resolve to callable closures
-    // and a returned FileHandle dispatches its methods. Indirect-access
-    // shape (`const fs = require('fs'); fs.promises`) lands on the same
-    // singleton through `get_native_module_constant`'s `("fs","promises")`
-    // arm below.
+    // #2133: same shape for `node:fs.promises`. Route to the populated
+    // `fs_promises` singleton so destructured exports + FileHandle methods
+    // dispatch correctly.
     if module_name == "fs" && property_name == "promises" {
         return unsafe {
             crate::node_submodules::js_node_submodule_namespace(
@@ -1617,13 +1613,8 @@ pub(crate) unsafe fn get_native_module_constant(
         },
         "fs" => match property {
             "constants" => Some(create_sub_namespace("fs.constants")),
-            // #2133: `require('fs').promises` / `import('node:fs').promises`
-            // — resolve to the `fs_promises` submodule singleton so the
-            // destructure shape (`const { open } = fs.promises`) reads
-            // populated callable exports (open, readFile, …) and so a
-            // FileHandle returned by `fs.promises.open(...)` dispatches its
-            // `.read` / `.write` / `.chmod` / `.close` / … methods. Same
-            // pattern used for `stream.promises` (#1533) below.
+            // #2133: `fs.promises` — populated `fs_promises` singleton so
+            // `const { open } = fs.promises` (and FileHandle dispatch) work.
             "promises" => Some(unsafe {
                 crate::node_submodules::js_node_submodule_namespace(
                     b"fs_promises".as_ptr(),

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -144,6 +144,21 @@ pub unsafe extern "C" fn js_native_module_property_by_name(
         let submodule = "stream/promises";
         return js_create_native_module_namespace(submodule.as_ptr(), submodule.len());
     }
+    // #2133: same shape for `node:fs.promises` — route through the
+    // populated `fs_promises` submodule singleton so destructured exports
+    // (e.g. `const { open } = fs.promises`) resolve to callable closures
+    // and a returned FileHandle dispatches its methods. Indirect-access
+    // shape (`const fs = require('fs'); fs.promises`) lands on the same
+    // singleton through `get_native_module_constant`'s `("fs","promises")`
+    // arm below.
+    if module_name == "fs" && property_name == "promises" {
+        return unsafe {
+            crate::node_submodules::js_node_submodule_namespace(
+                b"fs_promises".as_ptr(),
+                "fs_promises".len() as u32,
+            )
+        };
+    }
 
     if let Some(val) = get_native_module_constant(module_name, property_name, 0.0) {
         return val;
@@ -1602,6 +1617,19 @@ pub(crate) unsafe fn get_native_module_constant(
         },
         "fs" => match property {
             "constants" => Some(create_sub_namespace("fs.constants")),
+            // #2133: `require('fs').promises` / `import('node:fs').promises`
+            // — resolve to the `fs_promises` submodule singleton so the
+            // destructure shape (`const { open } = fs.promises`) reads
+            // populated callable exports (open, readFile, …) and so a
+            // FileHandle returned by `fs.promises.open(...)` dispatches its
+            // `.read` / `.write` / `.chmod` / `.close` / … methods. Same
+            // pattern used for `stream.promises` (#1533) below.
+            "promises" => Some(unsafe {
+                crate::node_submodules::js_node_submodule_namespace(
+                    b"fs_promises".as_ptr(),
+                    "fs_promises".len() as u32,
+                )
+            }),
             _ => fs_const(property),
         },
         "fs.constants" => fs_const(property),

--- a/test-parity/node-suite/fs-promises/imports/parent-promises-property.ts
+++ b/test-parity/node-suite/fs-promises/imports/parent-promises-property.ts
@@ -1,0 +1,56 @@
+// #2133: `node:fs.promises` (the parent module's `.promises` namespace) was
+// undefined under Perry, so test-fs-promises-file-handle-* tests of the form
+// `const { open } = fs.promises` could not even reach FileHandle methods.
+// This parity test exercises the parent-module shape end-to-end:
+//   1. `typeof fs.promises === "object"` (both inline and via a binding).
+//   2. destructured exports (`open`, `readFile`, `writeFile`, ...) are
+//      callable functions.
+//   3. a FileHandle returned by `fs.promises.open(...)` exposes the full
+//      method surface and a write/stat/chmod/close round-trip succeeds.
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+console.log("typeof fs.promises:", typeof fs.promises);
+const p: any = fs.promises;
+console.log("typeof p:", typeof p);
+
+const { open, readFile, writeFile, mkdir, rm } = fs.promises;
+console.log("typeof open:", typeof open);
+console.log("typeof readFile:", typeof readFile);
+console.log("typeof writeFile:", typeof writeFile);
+console.log("typeof mkdir:", typeof mkdir);
+console.log("typeof rm:", typeof rm);
+
+async function main() {
+  const tmpDir = path.join(os.tmpdir(), "perry-2133-parent-promises");
+  await rm(tmpDir, { recursive: true, force: true });
+  await mkdir(tmpDir);
+  const file = path.join(tmpDir, "f.txt");
+
+  const fh = await open(file, "w+", 0o644);
+  console.log("typeof fh.close:", typeof fh.close);
+  console.log("typeof fh.read:", typeof fh.read);
+  console.log("typeof fh.write:", typeof fh.write);
+  console.log("typeof fh.chmod:", typeof fh.chmod);
+  console.log("typeof fh.stat:", typeof fh.stat);
+  console.log("typeof fh.readFile:", typeof fh.readFile);
+  console.log("typeof fh.writeFile:", typeof fh.writeFile);
+  console.log("typeof fh.appendFile:", typeof fh.appendFile);
+  console.log("typeof fh.truncate:", typeof fh.truncate);
+  console.log("typeof fh.utimes:", typeof fh.utimes);
+  console.log("typeof fh.readv:", typeof fh.readv);
+  console.log("typeof fh.writev:", typeof fh.writev);
+  console.log("typeof fh.sync:", typeof fh.sync);
+
+  await fh.writeFile("hello\n");
+  const s = await fh.stat();
+  console.log("stat.size:", s.size);
+  await fh.chmod(0o600);
+  await fh.close();
+
+  await rm(tmpDir, { recursive: true, force: true });
+  console.log("done");
+}
+
+main();


### PR DESCRIPTION
## Summary

Fixes #2133.

`require('fs').promises` / `import('node:fs').promises` returned undefined, so `node:fs.promises`-shape Node tests — `test-fs-promises-file-handle-chmod.js`, `…-append-file.js`, `…-use-after-close.js`, etc., the ~15 `Cannot read properties of undefined (reading 'open')` failures in the #800 radar — could not even reach the FileHandle methods. The `fs_promises` submodule and its FileHandle plumbing were **already** in place; they just had no entry point through the parent module's `.promises` field.

This adds the same two-path resolution we already use for `stream.promises` (#1533):

- `js_native_module_property_by_name` short-circuit so a direct `NativeModuleRef("fs").promises` codegen access returns the populated `fs_promises` submodule singleton (with `open`, `readFile`, … callable closures).
- `get_native_module_constant("fs", "promises")` arm so the indirect shape (`const fs = require("fs"); fs.promises` or `const p = fs.promises; p.open(...)`) lands on the same singleton through `js_object_get_field_by_name`'s `NATIVE_MODULE_CLASS_ID` path.

## Test plan

- [x] New parity case `test-parity/node-suite/fs-promises/imports/parent-promises-property.ts` passes byte-for-byte against Node — exercises destructured exports plus a write/stat/chmod/close FileHandle round-trip via `fs.promises.open`.
- [x] New runtime unit `fs_parent_promises_property_exposes_namespace` locks in the populated-namespace shape (spot-checks `open` / `readFile` / `writeFile` / `chmod` / `stat`).
- [x] `cargo test -p perry-runtime --lib node_submodules` — 17/17 still green (existing `stream_parent_promises_property_exposes_namespace` and friends unaffected).
- [x] `cargo fmt --all -- --check` clean.
- [x] Manual repro: `typeof fs.promises`, `const p = fs.promises; typeof p`, `function getNs() { return fs }; const ns = getNs(); typeof ns.promises`, and `const { open } = fs.promises; await open(...).then(fh => fh.chmod(...).then(() => fh.close()))` all resolve correctly under `target/release/perry`.
