### PR TITLE
fix(node:zlib): match modern constants table

### DIFF
--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1336,9 +1336,9 @@ pub(crate) unsafe fn get_native_module_constant(
     };
 
     // `zlib.constants` — the Z_*/DEFLATE/INFLATE/GZIP/BROTLI_*/ZSTD_*
-    // table Node exposes on `require('node:zlib').constants`. Values
-    // are taken straight from `node-internal/zlib/constants.h` (the
-    // upstream lib snapshots) so reads are byte-identical to Node.
+    // table Node exposes on `require('node:zlib').constants`. Match the
+    // JavaScript-visible table rather than blindly mirroring every zlib.h
+    // macro: modern Node exposes ZLIB_VERNUM but omits Z_TREES.
     // Required by axios for its stream wiring.
     let zlib_const = |prop: &str| -> Option<f64> {
         let v: i64 = match prop {
@@ -1353,6 +1353,7 @@ pub(crate) unsafe fn get_native_module_constant(
             "Z_RLE" => 3,
             "Z_FIXED" => 4,
             "Z_DEFAULT_STRATEGY" => 0,
+            "ZLIB_VERNUM" => 0x1310,
             // Flush values
             "Z_NO_FLUSH" => 0,
             "Z_PARTIAL_FLUSH" => 1,
@@ -1360,7 +1361,6 @@ pub(crate) unsafe fn get_native_module_constant(
             "Z_FULL_FLUSH" => 3,
             "Z_FINISH" => 4,
             "Z_BLOCK" => 5,
-            "Z_TREES" => 6,
             // Return codes
             "Z_OK" => 0,
             "Z_STREAM_END" => 1,

--- a/test-parity/node-suite/zlib/constants/modern-version-table.ts
+++ b/test-parity/node-suite/zlib/constants/modern-version-table.ts
@@ -1,0 +1,8 @@
+import { constants } from "node:zlib";
+
+console.log("ZLIB_VERNUM typeof:", typeof constants.ZLIB_VERNUM);
+console.log(
+  "ZLIB_VERNUM positive integer:",
+  Number.isInteger(constants.ZLIB_VERNUM) && constants.ZLIB_VERNUM > 0,
+);
+console.log("Z_TREES:", constants.Z_TREES);


### PR DESCRIPTION
## Summary
- expose `zlib.constants.ZLIB_VERNUM` as a numeric constant
- stop exposing `zlib.constants.Z_TREES`, matching modern Node
- add granular parity coverage for the constants-table shape

## Issue
- Part of #793 (`node:zlib` module inventory parity)

## Evidence
- Baseline exact `node-suite/zlib/constants/modern-version-table`: FAIL, `test-parity/reports/parity_report_20260528_094351.json`
- Final exact `node-suite/zlib/constants/modern-version-table`: PASS, `test-parity/reports/parity_report_20260528_094542.json`
- Full granular `node-suite/zlib`: PASS 47/47, `test-parity/reports/parity_report_20260528_094630.json`
- Broad top-level `test_parity_zlib`: still FAILS, `test-parity/reports/parity_report_20260528_094717.json`; residual diff is zstd APIs and zlib stream instance methods, not these constants
- `cargo check -p perry-runtime -p perry-stdlib -p perry-codegen`: PASS with existing warnings
- `cargo fmt --check`: PASS
- `jq empty test-parity/known_failures.json`: PASS
- `git diff --check`: PASS

## DeepWiki
- `reference/deepwiki/nodejs-node-zlib-modern-constants-2026-05-28.md`

## Non-goals
- no zstd codec implementation
- no zlib stream instance `.close()` / `.params()` / `.reset()` / `.bytesWritten` support
- no broad top-level zlib inventory cleanup
- no exact linked-zlib version emulation beyond exposing the numeric `ZLIB_VERNUM` surface
