### PR TITLE
fix(node:https): full Agent.getName parity for https (#2132)

### DIFF
--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -773,18 +773,33 @@ pub unsafe extern "C" fn js_https_agent_new(options_f64: f64) -> Handle {
 }
 
 /// `agent.getName([options])` — Node's canonical key under which sockets
-/// are pooled. Format: `${host}:${port}:${localAddress}` with optional
-/// `:${socketPath}` or `:${family}` appended. Tests assert exact strings
-/// (see `test/parallel/test-http-agent-getname.js`).
+/// are pooled. The base shape is `${host}:${port}:${localAddress}` with
+/// optional `:${family}` and `:${socketPath}` appended. For https.Agent
+/// instances Node appends 20 extra fields (ca, cert, ciphers, key, …)
+/// per `lib/https.js`. Tests assert exact strings (see
+/// `test/parallel/test-http-agent-getname.js` and
+/// `test/parallel/test-https-agent-getname.js`).
 #[no_mangle]
 pub unsafe extern "C" fn js_http_agent_get_name(
     handle: Handle,
     options_f64: f64,
 ) -> *mut StringHeader {
-    let _ = handle; // name is computed purely from `options`
-    let opts = match parse_options_object(options_f64) {
+    let is_https = get_handle_mut::<AgentHandle>(handle)
+        .and_then(|a| a.protocol.as_deref().map(|p| p == "https:"))
+        .unwrap_or(false);
+
+    let opts = parse_options_object(options_f64);
+    let mut name = build_http_agent_name(opts.as_ref());
+    if is_https {
+        append_https_agent_name_fields(&mut name, opts.as_ref());
+    }
+    alloc_string(&name).as_raw()
+}
+
+fn build_http_agent_name(opts: Option<&serde_json::Value>) -> String {
+    let opts = match opts {
         Some(v) => v,
-        None => return alloc_string("localhost::").as_raw(),
+        None => return "localhost::".to_string(),
     };
 
     let host = opts
@@ -808,20 +823,153 @@ pub unsafe extern "C" fn js_http_agent_get_name(
 
     let mut name = format!("{}:{}:{}", host, port, local_address);
 
-    if let Some(socket_path) = opts.get("socketPath").and_then(|v| v.as_str()) {
-        name.push(':');
-        name.push_str(socket_path);
-    } else if let Some(family) = opts.get("family") {
-        // Node only appends family when it is exactly 4 or 6; every
-        // other value (0, null, undefined, strings) is silently dropped.
+    // Per Node's `lib/_http_agent.js`: family is appended first when it
+    // is exactly 4 or 6, then socketPath. Both are independent.
+    if let Some(family) = opts.get("family") {
         let f = family.as_i64().unwrap_or(0);
         if f == 4 || f == 6 {
             name.push(':');
             name.push_str(&f.to_string());
         }
     }
+    if let Some(socket_path) = opts.get("socketPath").and_then(|v| v.as_str()) {
+        name.push(':');
+        name.push_str(socket_path);
+    }
 
-    alloc_string(&name).as_raw()
+    name
+}
+
+/// Append the 20 extension fields that `lib/https.js`'s Agent.getName
+/// adds on top of the http parent. Each field has its own `:` separator
+/// regardless of whether the value is present, so an Agent with no
+/// options produces 20 trailing colons.
+fn append_https_agent_name_fields(name: &mut String, opts: Option<&serde_json::Value>) {
+    let opts = match opts {
+        Some(v) => v,
+        None => {
+            for _ in 0..20 {
+                name.push(':');
+            }
+            return;
+        }
+    };
+
+    let host_str = opts.get("host").and_then(|v| v.as_str()).unwrap_or("");
+
+    let push_truthy_string = |name: &mut String, field: &str| {
+        name.push(':');
+        if let Some(v) = opts.get(field) {
+            if json_value_is_truthy(v) {
+                name.push_str(&json_value_to_string(v));
+            }
+        }
+    };
+    let push_defined = |name: &mut String, field: &str| {
+        name.push(':');
+        if let Some(v) = opts.get(field) {
+            if !v.is_null() {
+                name.push_str(&json_value_to_string(v));
+            }
+        }
+    };
+
+    push_truthy_string(name, "ca");
+    push_truthy_string(name, "cert");
+    push_truthy_string(name, "clientCertEngine");
+    push_truthy_string(name, "ciphers");
+    push_truthy_string(name, "key");
+    push_truthy_string(name, "pfx");
+    push_defined(name, "rejectUnauthorized");
+
+    // servername appears only when truthy AND distinct from host.
+    name.push(':');
+    if let Some(sn) = opts.get("servername") {
+        if json_value_is_truthy(sn) {
+            let sn_str = json_value_to_string(sn);
+            if sn_str != host_str {
+                name.push_str(&sn_str);
+            }
+        }
+    }
+
+    push_truthy_string(name, "minVersion");
+    push_truthy_string(name, "maxVersion");
+    push_truthy_string(name, "secureProtocol");
+    push_truthy_string(name, "crl");
+    push_defined(name, "honorCipherOrder");
+    push_truthy_string(name, "ecdhCurve");
+    push_truthy_string(name, "dhparam");
+    push_defined(name, "secureOptions");
+    push_truthy_string(name, "sessionIdContext");
+
+    // sigalgs goes through JSON.stringify per Node.
+    name.push(':');
+    if let Some(v) = opts.get("sigalgs") {
+        if json_value_is_truthy(v) {
+            name.push_str(&serde_json::to_string(v).unwrap_or_default());
+        }
+    }
+
+    push_truthy_string(name, "privateKeyIdentifier");
+    push_truthy_string(name, "privateKeyEngine");
+}
+
+/// JS-style truthiness check on a `serde_json::Value`. Mirrors Node's
+/// `if (options.field)` guard.
+fn json_value_is_truthy(v: &serde_json::Value) -> bool {
+    match v {
+        serde_json::Value::Null => false,
+        serde_json::Value::Bool(b) => *b,
+        serde_json::Value::Number(n) => {
+            n.as_f64().map(|f| f != 0.0 && !f.is_nan()).unwrap_or(false)
+        }
+        serde_json::Value::String(s) => !s.is_empty(),
+        // Arrays/objects are always truthy in JS regardless of contents.
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => true,
+    }
+}
+
+/// JS-style ToString coercion on a `serde_json::Value`, mirroring how
+/// `name += options.field` flows through Array.prototype.toString and
+/// Buffer.prototype.toString:
+/// - arrays comma-join their element ToStrings
+/// - the `{"type":"Buffer","data":[…]}` shape that `JSON.stringify(buf)`
+///   emits becomes the UTF-8 string of the bytes, matching
+///   `Buffer.toString()`
+/// - other objects fall back to `"[object Object]"`
+fn json_value_to_string(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::Bool(b) => {
+            if *b {
+                "true".to_string()
+            } else {
+                "false".to_string()
+            }
+        }
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Array(arr) => arr
+            .iter()
+            .map(json_value_to_string)
+            .collect::<Vec<_>>()
+            .join(","),
+        serde_json::Value::Object(map) => {
+            if let (Some(serde_json::Value::String(ty)), Some(serde_json::Value::Array(data))) =
+                (map.get("type"), map.get("data"))
+            {
+                if ty == "Buffer" {
+                    let bytes: Vec<u8> = data
+                        .iter()
+                        .filter_map(|el| el.as_u64().map(|n| n as u8))
+                        .collect();
+                    return String::from_utf8_lossy(&bytes).into_owned();
+                }
+            }
+            "[object Object]".to_string()
+        }
+    }
 }
 
 #[no_mangle]

--- a/crates/perry-stdlib/src/http.rs
+++ b/crates/perry-stdlib/src/http.rs
@@ -238,6 +238,74 @@ unsafe fn get_object_number_field(obj_f64: f64, field_name: &str) -> Option<f64>
     None
 }
 
+/// Helper to fetch a raw NaN-boxed field value from a JS object by name.
+/// Returns None when the receiver is not a pointer-like value; returns
+/// `Some(JSValue::undefined())` when the field is absent (matches the
+/// underlying `js_object_get_field_by_name` behavior for `obj.missing`).
+unsafe fn get_object_field_raw(obj_f64: f64, field_name: &str) -> Option<JSValue> {
+    let obj_bits = obj_f64.to_bits();
+    let upper = obj_bits >> 48;
+    let obj_ptr = if upper >= 0x7FF8 {
+        (obj_bits & 0x0000_FFFF_FFFF_FFFF) as *const perry_runtime::ObjectHeader
+    } else if upper == 0 && obj_bits >= 0x10000 {
+        obj_bits as *const perry_runtime::ObjectHeader
+    } else {
+        return None;
+    };
+    if obj_ptr.is_null() {
+        return None;
+    }
+    let key_str = js_string_from_bytes(field_name.as_ptr(), field_name.len() as u32);
+    Some(js_object_get_field_by_name(obj_ptr, key_str))
+}
+
+/// Returns true iff the JS value is "truthy" enough that Node's
+/// `name += options.field` branch fires (i.e. `if (options.field)`):
+/// not undefined, not null, not the empty string, not 0, not false.
+fn jsvalue_is_truthy(v: JSValue) -> bool {
+    if v.is_undefined() || v.is_null() {
+        return false;
+    }
+    if v.is_bool() {
+        return v.as_bool();
+    }
+    if v.is_int32() {
+        return v.as_int32() != 0;
+    }
+    if v.is_number() {
+        let n = v.as_number();
+        return n != 0.0 && !n.is_nan();
+    }
+    if v.is_string() || v.is_short_string() {
+        let s_ptr = perry_runtime::value::js_get_string_pointer_unified(f64::from_bits(v.bits()));
+        if s_ptr == 0 {
+            return false;
+        }
+        let header = s_ptr as *const StringHeader;
+        unsafe { (*header).byte_len > 0 }
+    } else {
+        // Other pointer values (objects, arrays, buffers) are always truthy
+        // in JS.
+        true
+    }
+}
+
+/// Coerce a JS value to its string representation, matching how
+/// `name += options.field` does ToString in JS. Strings/numbers/bools
+/// flow through directly; arrays comma-join; buffers stringify their
+/// content; objects fall back to "[object Object]".
+unsafe fn jsvalue_to_string(v: JSValue) -> String {
+    let header = perry_runtime::value::js_jsvalue_to_string(f64::from_bits(v.bits()));
+    string_from_header(header).unwrap_or_default()
+}
+
+/// `JSON.stringify(v)` as a Rust `String`. Used by https.Agent.getName
+/// for the `sigalgs` field, which Node serializes as JSON.
+unsafe fn jsvalue_to_json_string(v: JSValue) -> String {
+    let header = perry_runtime::json::js_json_stringify(f64::from_bits(v.bits()), 0);
+    string_from_header(header).unwrap_or_default()
+}
+
 /// Helper to extract headers from a NaN-boxed JS headers object
 unsafe fn extract_headers_from_object(obj_f64: f64) -> HashMap<String, String> {
     let mut result = HashMap::new();
@@ -1038,22 +1106,36 @@ unsafe fn js_http_agent_new_with_protocol(
 }
 
 /// `agent.getName([options])` — Node's canonical key under which sockets are
-/// pooled. Format: `${host}:${port}:${localAddress}` with optional
-/// `:${socketPath}` or `:${family}` appended. Tests assert exact strings;
-/// see `test/parallel/test-http-agent-getname.js`.
+/// pooled. The base shape is `${host}:${port}:${localAddress}` with optional
+/// `:${family}` and `:${socketPath}` appended. For https.Agent instances
+/// 20 extra fields are appended (ca, cert, ciphers, key, …) per Node's
+/// `lib/https.js`. Tests assert exact strings; see
+/// `test/parallel/test-http-agent-getname.js` and
+/// `test/parallel/test-https-agent-getname.js`.
 #[no_mangle]
 pub unsafe extern "C" fn js_http_agent_get_name(
     handle: Handle,
     options_f64: f64,
 ) -> *mut StringHeader {
-    let _ = handle; // name is computed purely from options
+    let is_https = get_handle_mut::<AgentHandle>(handle)
+        .and_then(|a| a.protocol.as_deref().map(|p| p == "https:"))
+        .unwrap_or(false);
+
+    let mut name = build_http_agent_name(options_f64);
+    if is_https {
+        append_https_agent_name_fields(&mut name, options_f64);
+    }
+    js_string_from_bytes(name.as_ptr(), name.len() as u32)
+}
+
+/// Compute the http.Agent.getName portion of the pool key.
+unsafe fn build_http_agent_name(options_f64: f64) -> String {
     let opts_bits = options_f64.to_bits();
     let opts_undef =
         opts_bits == JSValue::undefined().bits() || opts_bits == JSValue::null().bits();
 
     if opts_undef {
-        let s = "localhost::";
-        return js_string_from_bytes(s.as_ptr(), s.len() as u32);
+        return "localhost::".to_string();
     }
 
     let host =
@@ -1063,22 +1145,107 @@ pub unsafe extern "C" fn js_http_agent_get_name(
 
     let mut name = format!("{}:{}:{}", host, port, local_address);
 
-    if let Some(socket_path) = get_object_string_field(options_f64, "socketPath") {
-        name.push(':');
-        name.push_str(&socket_path);
-    } else if let Some(family) = get_object_number_field(options_f64, "family") {
-        // Node only appends family when it is 4 or 6 — every other value
-        // (0, NaN, strings) is silently dropped. `get_object_number_field`
-        // turns missing into None and strings into None too, so we only
-        // see the cases that survived.
+    // Per Node's lib/_http_agent.js: family is appended FIRST (when 4 or 6),
+    // then socketPath. Both are independent — Node appends each separately
+    // if present.
+    if let Some(family) = get_object_number_field(options_f64, "family") {
         let f = family as i64;
         if f == 4 || f == 6 {
             name.push(':');
             name.push_str(&f.to_string());
         }
     }
+    if let Some(socket_path) = get_object_string_field(options_f64, "socketPath") {
+        name.push(':');
+        name.push_str(&socket_path);
+    }
 
-    js_string_from_bytes(name.as_ptr(), name.len() as u32)
+    name
+}
+
+/// Append the 20 https.Agent.getName extension fields onto an already-built
+/// http.Agent.getName prefix. Mirrors `Agent.prototype.getName` in Node's
+/// `lib/https.js` (v22.x): every field gets its own `:` separator regardless
+/// of whether the value is present, so an Agent with no options produces 20
+/// trailing colons.
+unsafe fn append_https_agent_name_fields(name: &mut String, options_f64: f64) {
+    let opts_bits = options_f64.to_bits();
+    let opts_undef =
+        opts_bits == JSValue::undefined().bits() || opts_bits == JSValue::null().bits();
+
+    if opts_undef {
+        // 20 empty fields → 20 trailing colons (1 separator per field).
+        for _ in 0..20 {
+            name.push(':');
+        }
+        return;
+    }
+
+    // Most fields use the `if (options.field) name += options.field;` shape
+    // — truthy → append ToString-coerced value. A small group
+    // (rejectUnauthorized, honorCipherOrder, secureOptions) checks
+    // `!== undefined` instead, so `false` and `0` are appended.
+    let host_value = get_object_field_raw(options_f64, "host");
+
+    let push_truthy_string = |name: &mut String, field: &str| {
+        name.push(':');
+        if let Some(v) = get_object_field_raw(options_f64, field) {
+            if jsvalue_is_truthy(v) {
+                name.push_str(&jsvalue_to_string(v));
+            }
+        }
+    };
+    let push_defined = |name: &mut String, field: &str| {
+        name.push(':');
+        if let Some(v) = get_object_field_raw(options_f64, field) {
+            if !v.is_undefined() {
+                name.push_str(&jsvalue_to_string(v));
+            }
+        }
+    };
+
+    push_truthy_string(name, "ca");
+    push_truthy_string(name, "cert");
+    push_truthy_string(name, "clientCertEngine");
+    push_truthy_string(name, "ciphers");
+    push_truthy_string(name, "key");
+    push_truthy_string(name, "pfx");
+    push_defined(name, "rejectUnauthorized");
+
+    // servername appears only when defined AND distinct from host.
+    name.push(':');
+    if let Some(sn) = get_object_field_raw(options_f64, "servername") {
+        if jsvalue_is_truthy(sn) {
+            let same_as_host = match host_value {
+                Some(h) if jsvalue_is_truthy(h) => jsvalue_to_string(h) == jsvalue_to_string(sn),
+                _ => false,
+            };
+            if !same_as_host {
+                name.push_str(&jsvalue_to_string(sn));
+            }
+        }
+    }
+
+    push_truthy_string(name, "minVersion");
+    push_truthy_string(name, "maxVersion");
+    push_truthy_string(name, "secureProtocol");
+    push_truthy_string(name, "crl");
+    push_defined(name, "honorCipherOrder");
+    push_truthy_string(name, "ecdhCurve");
+    push_truthy_string(name, "dhparam");
+    push_defined(name, "secureOptions");
+    push_truthy_string(name, "sessionIdContext");
+
+    // sigalgs is JSON-stringified (Node: `name += JSONStringify(options.sigalgs)`).
+    name.push(':');
+    if let Some(v) = get_object_field_raw(options_f64, "sigalgs") {
+        if jsvalue_is_truthy(v) {
+            name.push_str(&jsvalue_to_json_string(v));
+        }
+    }
+
+    push_truthy_string(name, "privateKeyIdentifier");
+    push_truthy_string(name, "privateKeyEngine");
 }
 
 /// `agent.destroy()` / `.close()` — release pooled sockets. Perry doesn't


### PR DESCRIPTION
## Summary
- `https.Agent.prototype.getName(options)` now matches Node v22 byte-for-byte: it appends the 20 TLS-specific extension fields (`ca`, `cert`, `clientCertEngine`, `ciphers`, `key`, `pfx`, `rejectUnauthorized`, `servername`, `minVersion`, `maxVersion`, `secureProtocol`, `crl`, `honorCipherOrder`, `ecdhCurve`, `dhparam`, `secureOptions`, `sessionIdContext`, JSON-stringified `sigalgs`, `privateKeyIdentifier`, `privateKeyEngine`) onto the http base, picking the variant by reading the AgentHandle's `protocol` field at runtime.
- Both http stacks need the change: `perry-stdlib/src/http.rs` (non-auto-optimize) reads JS-object fields directly; `perry-ext-http/src/lib.rs` (auto-optimize) extends the existing serde_json::Value pipeline with JS-compatible truthiness + ToString coercion, including the `{type:"Buffer",data:[…]}` shape so `crl: [Buffer.from('c'), Buffer.from('r'), Buffer.from('l')]` flattens to `c,r,l`.
- Bonus http parity fix: `family` and `socketPath` are independent appends per Node, not `if/else`. The previous `else if` dropped `socketPath` when `family` was also set.

Verified against `vendor/nodejs/test/parallel/test-https-agent-getname.js` and `test-http-agent-getname.js` — both byte-identical to Node v22, and the http/https radar sweep moves from `pass 3 → pass 9, compile-fail 38 → 0, parity 6.7% → 20%` (auto-optimize sweep, --max-per-api 30).

Part of the #2132 cluster (post #2184 / #2197).

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p perry-stdlib --lib http::` — 1 passed
- [x] `cargo test -p perry-ext-http --lib` — 6 passed
- [x] `vendor/nodejs/test/parallel/test-https-agent-getname.js` — exit 0 (matches Node)
- [x] `vendor/nodejs/test/parallel/test-http-agent-getname.js` — exit 0 (no regression)
- [x] `scripts/node_core_subset.py --root vendor/nodejs --api http https --max-per-api 30 --auto-optimize` — parity rises from 6.7% to 20.0%
