### PR TITLE
fix(perry/setup): use `where.exe` to locate xwin on Windows (#1821)

### DIFF
--- a/crates/perry/src/commands/setup/mod.rs
+++ b/crates/perry/src/commands/setup/mod.rs
@@ -140,14 +140,22 @@ pub fn run(args: SetupArgs) -> Result<()> {
 
 /// Locate `xwin.exe` on PATH (Windows wizard helper). Returns `None` if
 /// not installed; the wizard then offers to install it via `cargo install xwin`.
+///
+/// `which` is not a built-in on Windows shells, so the wizard always failed
+/// to find an already-installed `xwin.exe` (#1821). Use `where.exe` on
+/// Windows — its output is one absolute path per matching extension on
+/// PATH, so take the first line.
 pub(crate) fn find_xwin_exe() -> Option<PathBuf> {
-    if let Ok(out) = Command::new("which").arg("xwin").output() {
-        if out.status.success() {
-            let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
-            if !p.is_empty() {
-                return Some(PathBuf::from(p));
-            }
-        }
+    let lookup = if cfg!(windows) { "where" } else { "which" };
+    let out = Command::new(lookup).arg("xwin").output().ok()?;
+    if !out.status.success() {
+        return None;
     }
-    None
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let first = stdout.lines().next()?.trim();
+    if first.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(first))
+    }
 }


### PR DESCRIPTION
## Summary

`perry setup windows` shells out to `Command::new("which").arg("xwin")` to locate an installed `xwin.exe`, but Windows shells don't ship `which` as a builtin or in PATH by default. The wizard always failed the lookup and instructed the user to `cargo install xwin --locked --version 0.9.0` even when `xwin.exe` was already on PATH (#1821, reported by @TheGoddessInari).

Fix is the one the reporter suggested: use `where` (`where.exe`) on Windows, keep `which` everywhere else. `where` lists one absolute path per `PATHEXT` extension match, so take the first line of stdout.

Scope kept tight to the wizard helper. The other two `Command::new("which")` callsites (`commands/typecheck.rs` for `tsgo`, `commands/compile/sandbox_buildrs.rs` for `cargo`) are out of scope: the sandbox-exec path is macOS-only, and `tsgo` lookup is a separate code path with its own follow-on fallbacks.

Closes #1821.

## Test plan

- [x] `cargo build --release -p perry` succeeds on macOS.
- [x] `cargo fmt --all -- --check` clean.
- [ ] On Windows, `perry setup windows` with `xwin.exe` on PATH finds it and skips the "install xwin" prompt. (Cannot verify locally — Windows-only path; CI compiles for Linux/macOS.)
