### PR TITLE
feat(node:worker_threads): isMainThread / threadId / resourceLimits (#2135)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1900,6 +1900,14 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         TypeSpec::Any,
     ),
     method("worker_threads", "postMessage", true, None),
+    // node:worker_threads — value-shaped exports (#2135). Perry doesn't
+    // spawn JS workers, so the main thread is the only thread: isMainThread
+    // is always true, threadId is 0, resourceLimits is an empty object.
+    // The values themselves are returned by `js_native_module_property_by_name`
+    // (see `crates/perry-runtime/src/object/native_module.rs`).
+    property("worker_threads", "isMainThread"),
+    property("worker_threads", "threadId"),
+    property("worker_threads", "resourceLimits"),
     method_sig(
         "ethers",
         "getAddress",

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1734,6 +1734,23 @@ pub(crate) unsafe fn get_native_module_constant(
             }
             _ => None,
         },
+        // node:worker_threads value-shaped exports. Perry doesn't spawn JS
+        // workers, so the main thread is the only thread — `isMainThread`
+        // is always true, `threadId` is 0, `resourceLimits` is empty.
+        // Pre-fix `const { isMainThread } = require('worker_threads')` read
+        // `undefined`, which made the `if (!isMainThread) common.skip(...)`
+        // guard Node uses in main-thread-only tests fire under Perry, so
+        // ~8 process tests in the node-core radar (#2135) were "skipping"
+        // when they should have been running. (#2135)
+        "worker_threads" => match property {
+            "isMainThread" => Some(f64::from_bits(JSValue::bool(true).bits())),
+            "threadId" => Some(0.0),
+            "resourceLimits" => {
+                let obj = crate::object::js_object_alloc(0, 0);
+                Some(crate::value::js_nanbox_pointer(obj as i64))
+            }
+            _ => None,
+        },
         // `zlib.constants` and the top-level Z_*/DEFLATE/INFLATE shortcuts
         // Node also exposes directly on `require('node:zlib')`.
         "zlib" => match property {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1441 entries across 82 modules
+// Coverage: 1444 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -2111,6 +2111,12 @@ declare module "validator" {
 }
 
 declare module "worker_threads" {
+  /** stdlib */
+  export const isMainThread: any;
+  /** stdlib */
+  export const resourceLimits: any;
+  /** stdlib */
+  export const threadId: any;
   /** stdlib */
   export function getEnvironmentData(p0: any): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1441 entries across 82 modules.
+Total: 1444 entries across 82 modules.
 
 ## Modules
 
@@ -1994,6 +1994,12 @@ Total: 1441 entries across 82 modules.
 - `postMessage` — instance
 - `setEnvironmentData` — module
 - `workerData` — module
+
+### Properties
+
+- `isMainThread`
+- `resourceLimits`
+- `threadId`
 
 ## `ws`
 

--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -98,6 +98,14 @@ crates/perry-runtime/src/node_stream_tests.rs
 # #1787 instance-field init replay (#2074) + web-stream class
 # wiring (#1641/#2110). Split tracked under #1435.
 crates/perry-runtime/src/object/class_registry.rs
+# Native-module namespace property/method dispatcher
+# (`get_native_module_constant` is one big match — one arm per
+# stdlib namespace, every property literal inline). Splitting per
+# namespace would scatter arms that share helpers (`fs_const`,
+# `os_signal_const`, …) and the constants tables they index.
+# Crossed the limit at 2014 LOC after the #2135 worker_threads
+# value-export arm. Split tracked under #1435.
+crates/perry-runtime/src/object/native_module.rs
 EOF
 )
 


### PR DESCRIPTION
## Summary

- Adds `worker_threads.isMainThread` (always `true`), `threadId` (`0`), and `resourceLimits` (`{}`) so the named imports / namespace reads resolve to real values instead of `undefined`.
- Unblocks the dominant pattern under [#2135](https://github.com/PerryTS/perry/issues/2135): 8 of 16 `diff` entries in the node-core process radar were the shim's `1..0 # Skipped: ...` output because Node's main-thread-only tests start with `if (!isMainThread) common.skip(...)`. Pre-fix `isMainThread` read as `undefined` under Perry, so every such guard skipped instead of running the actual assertions.

## Why this shape

Perry doesn't spawn JS workers — the main thread is the only thread — so `isMainThread = true`, `threadId = 0`, and a placeholder empty `resourceLimits` object match what Node returns for the parent process. The values flow through the existing `js_native_module_property_by_name` → `get_native_module_constant` slot every other namespace constant uses; the only manifest cost is three `property(...)` entries to satisfy the #463 strict-API gate.

## Radar impact (process API)

Before: pass=15  diff=16  rt-fail=34  compile-fail=3  node-skip=26  → 22.1%
After:  pass=15  diff=3   rt-fail=47  compile-fail=3  node-skip=26  → 22.1%

13 tests moved from `diff` (which was a false-pass-by-skip) to `runtime-fail` — the parity number is unchanged, but the verdict is now honest. The remaining `runtime-fail` work (real `process.abort` stderr shape, beforeExit/exit ordering, chdir error formatting, symbol-key throws on `process.env`, …) is the rest of #2135 and gets handled separately.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --release -p perry-api-manifest`
- [x] `scripts/regen_api_docs.sh` (no drift — three new entries reflected in `docs/api/perry.d.ts` + `docs/src/api/reference.md`)
- [x] Manual repro of the gap: `const { isMainThread, threadId } = require('worker_threads'); console.log(isMainThread, threadId)` — pre-fix logged `undefined undefined`, post-fix logs `true 0`.
- [x] `scripts/node_core_subset.py --root vendor/nodejs --api process --max-per-api 200` — 8 process diffs flip from skip-on-falsey-isMainThread to actually-run.
