### PR TITLE
fix(node:assert): apply RegExp validator props in throws/rejects matcher (#2014)

### DIFF
--- a/crates/perry-runtime/src/object/assert.rs
+++ b/crates/perry-runtime/src/object/assert.rs
@@ -108,6 +108,15 @@ fn object_matcher_matches(actual: f64, expected: f64) -> bool {
         // names `code`/`errno`/`name`/`message`, the thrown error must carry
         // an equal value. A missing or mismatching value on the thrown error
         // is a mismatch (#2014) — there is no "optional code" carve-out.
+        // A RegExp validator value (e.g. `{ message: /bad/ }`) is tested
+        // against the thrown error's prop instead of being deep-equal-ed,
+        // matching Node's `deepStrictEqual`-with-RegExp-special-case shape.
+        if let Some(re_matches) = regex_test_value(expected_prop, actual_prop) {
+            if !re_matches {
+                return false;
+            }
+            continue;
+        }
         if !assert_same_value(actual_prop, expected_prop)
             && crate::value::js_jsvalue_loose_equals(actual_prop, expected_prop) == 0
         {

--- a/test-parity/node-suite/assert/errors/throws-matcher-regexp-prop.ts
+++ b/test-parity/node-suite/assert/errors/throws-matcher-regexp-prop.ts
@@ -1,0 +1,55 @@
+// #2014 follow-up: a plain-object validator passed to `assert.throws` must
+// treat a RegExp value on a key (e.g. `message: /bad/`) as a `regex.test`
+// against the thrown error's prop, NOT as a deep-equal compare. Without
+// this, `{ code: "X", message: /bad/ }` rejected every error because the
+// thrown `message` string was never `=== /bad/`.
+import assert from "node:assert";
+
+function check(label: string, fn: () => void): void {
+  try { fn(); console.log(label + ": pass"); }
+  catch (err: any) { console.log(label + ":", err?.name, err?.code || err?.operator || "no-code"); }
+}
+
+// `message: RegExp` matches when the regex tests against the thrown message.
+check(
+  "object {message:/bad/} matches",
+  () =>
+    assert.throws(
+      () => { throw new Error("bad input"); },
+      { message: /bad/ },
+    ),
+);
+
+// And rejects when it doesn't.
+check(
+  "object {message:/good/} rejects",
+  () =>
+    assert.throws(
+      () => { throw new Error("bad input"); },
+      { message: /good/ },
+    ),
+);
+
+// Combined: every key must hold — code is === and message is a RegExp.
+check(
+  "object {code, message:/bad/} matches",
+  () => {
+    const e: any = new Error("bad input"); e.code = "ERR_X";
+    assert.throws(() => { throw e; }, { code: "ERR_X", message: /bad/ });
+  },
+);
+
+// And one wrong key still rejects.
+check(
+  "object {code:wrong, message:/bad/} rejects",
+  () => {
+    const e: any = new Error("bad input"); e.code = "ERR_X";
+    assert.throws(() => { throw e; }, { code: "ERR_Y", message: /bad/ });
+  },
+);
+
+// name RegExp also tests the thrown error's name (a class string).
+check(
+  "object {name:/Type/} matches TypeError",
+  () => assert.throws(() => { throw new TypeError("x"); }, { name: /Type/ }),
+);


### PR DESCRIPTION
## Summary

Closes #2014.

`assert.throws(fn, { code: "X", message: /bad/ })` rejected every error: `object_matcher_matches` compared validator props with `assert_same_value` / loose-equal, so a `RegExp` on the validator was never `===` the string on the thrown error and the match always failed (verified byte-for-byte against Node v22.x).

Node's behavior: each key on a plain-object validator is checked independently, and a `RegExp` value triggers `regex.test(thrown[key])` instead of equality. Apply the same `regex_test_value` helper that the top-level RegExp-validator form already uses (`assert.throws(fn, /regex/)`).

## Test plan

- [x] New parity case `test-parity/node-suite/assert/errors/throws-matcher-regexp-prop.ts` — passes byte-for-byte against Node. Covers:
  - `{ message: /bad/ }` matches a thrown `Error("bad input")`.
  - `{ message: /good/ }` rejects.
  - Combined `{ code, message: /bad/ }` matches when both hold; rejects when `code` is wrong.
  - `{ name: /Type/ }` matches a `TypeError`.
- [x] `cargo fmt --all -- --check` clean.
- [x] `crates/perry-runtime/src/object/assert.rs` is 749 lines (well under the 2000-line gate).
