### PR TITLE
fix(http): createServer(handler, options) + Server timeout setters (#2210)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -3137,6 +3137,39 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // (`js_node_http_server_address_json`) but missing from both
     // `NATIVE_MODULE_TABLE` and the manifest.
     method("http", "address", true, Some("HttpServer")),
+    // Issue #2210 — `server.<name>` timeout/socket-option accessors,
+    // plus the canonical `server.setTimeout(ms, cb)` method. Each
+    // accessor has two manifest entries (`__get_<name>` HIR-rewrite +
+    // bare-name fallback for receivers that escape the rewrite).
+    method("http", "__get_headersTimeout", true, Some("HttpServer")),
+    method("http", "__set_headersTimeout", true, Some("HttpServer")),
+    method("http", "headersTimeout", true, Some("HttpServer")),
+    method("http", "__get_keepAliveTimeout", true, Some("HttpServer")),
+    method("http", "__set_keepAliveTimeout", true, Some("HttpServer")),
+    method("http", "keepAliveTimeout", true, Some("HttpServer")),
+    method("http", "__get_requestTimeout", true, Some("HttpServer")),
+    method("http", "__set_requestTimeout", true, Some("HttpServer")),
+    method("http", "requestTimeout", true, Some("HttpServer")),
+    method("http", "__get_timeout", true, Some("HttpServer")),
+    method("http", "__set_timeout", true, Some("HttpServer")),
+    method("http", "timeout", true, Some("HttpServer")),
+    method("http", "__get_maxHeadersCount", true, Some("HttpServer")),
+    method("http", "__set_maxHeadersCount", true, Some("HttpServer")),
+    method("http", "maxHeadersCount", true, Some("HttpServer")),
+    method(
+        "http",
+        "__get_maxRequestsPerSocket",
+        true,
+        Some("HttpServer"),
+    ),
+    method(
+        "http",
+        "__set_maxRequestsPerSocket",
+        true,
+        Some("HttpServer"),
+    ),
+    method("http", "maxRequestsPerSocket", true, Some("HttpServer")),
+    method("http", "setTimeout", true, Some("HttpServer")),
     method("http", "on", true, Some("IncomingMessage")),
     method("http", "addListener", true, Some("IncomingMessage")),
     method("http", "pause", true, Some("IncomingMessage")),

--- a/crates/perry-codegen/src/lower_call/native_table/http.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/http.rs
@@ -456,24 +456,30 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
     },
     // ========== node:http server (issue #577) ==========
     // Module-level: `import { createServer } from "node:http"; createServer(handler)`
+    // Issue #2210 — accepts an optional 2nd `options` arg (Node 18.4+):
+    //   `createServer(handler, { headersTimeout, keepAliveTimeout, ... })`
+    // The runtime distinguishes the no-args / handler-only / handler+opts
+    // cases by the JsValue tag on the second arg (UNDEFINED vs pointer);
+    // a 0-arg call leaves both NA_PTR / NA_JSV slots as `undefined`.
     NativeModSig {
         module: "http",
         has_receiver: false,
         method: "createServer",
         class_filter: None,
-        runtime: "js_node_http_create_server",
-        args: &[NA_PTR],
+        runtime: "js_node_http_create_server_with_options",
+        args: &[NA_PTR, NA_JSV],
         ret: NR_PTR,
     },
     // `http.Server(handler)` is Node's callable-constructor alias for
     // `http.createServer` (works with or without `new`). #2132.
+    // Same `(handler, options?)` shape as `createServer` above (#2210).
     NativeModSig {
         module: "http",
         has_receiver: false,
         method: "Server",
         class_filter: None,
-        runtime: "js_node_http_create_server",
-        args: &[NA_PTR],
+        runtime: "js_node_http_create_server_with_options",
+        args: &[NA_PTR, NA_JSV],
         ret: NR_PTR,
     },
     // HttpServer instance methods (class_filter: HttpServer)
@@ -556,6 +562,189 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         runtime: "js_node_http_server_address_json",
         args: &[],
         ret: NR_OBJ_FROM_JSON_STR,
+    },
+    // Issue #2210 — `server.<name>` timeout / socket-option accessors.
+    // The HIR rewrites `server.headersTimeout` reads / writes to
+    // `__get_headersTimeout` / `__set_headersTimeout` synthetic methods
+    // when the receiver is tagged as `("http", "HttpServer")`; bare-name
+    // fallback rows also wired so receivers that escape the HIR-rewrite
+    // (e.g. assigned through a local before the property access) still
+    // hit the FFI.
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__get_headersTimeout",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_headers_timeout",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__set_headersTimeout",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_set_headers_timeout",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__get_keepAliveTimeout",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_keep_alive_timeout",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__set_keepAliveTimeout",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_set_keep_alive_timeout",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__get_requestTimeout",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_request_timeout",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__set_requestTimeout",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_set_request_timeout",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__get_timeout",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_idle_timeout",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__set_timeout",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_set_idle_timeout",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__get_maxHeadersCount",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_max_headers_count",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__set_maxHeadersCount",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_set_max_headers_count",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__get_maxRequestsPerSocket",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_max_requests_per_socket",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "__set_maxRequestsPerSocket",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_set_max_requests_per_socket",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    // Bare-name dispatch — same FFI, covers receivers that escape the
+    // `__get_<name>` HIR rewrite (e.g. assigned through a local).
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "headersTimeout",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_headers_timeout",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "keepAliveTimeout",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_keep_alive_timeout",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "requestTimeout",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_request_timeout",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "timeout",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_idle_timeout",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "maxHeadersCount",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_max_headers_count",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "maxRequestsPerSocket",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_max_requests_per_socket",
+        args: &[],
+        ret: NR_F64,
+    },
+    // `server.setTimeout(msecs, [callback])` — the canonical
+    // EventEmitter-style setter mirrors `socket.setTimeout`. The
+    // callback (if supplied) is registered as a `'timeout'` listener.
+    NativeModSig {
+        module: "http",
+        has_receiver: true,
+        method: "setTimeout",
+        class_filter: Some("HttpServer"),
+        runtime: "js_node_http_server_set_timeout_method",
+        args: &[NA_F64, NA_PTR],
+        ret: NR_PTR,
     },
     // IncomingMessage instance methods
     NativeModSig {

--- a/crates/perry-ext-http-server/src/http2_server.rs
+++ b/crates/perry-ext-http-server/src/http2_server.rs
@@ -105,16 +105,7 @@ pub unsafe extern "C" fn js_node_http2_create_secure_server(opts_f64: f64, handl
     register_handle(Http2SecureServer {
         handler,
         tls_config,
-        base: HttpServer {
-            handler,
-            listeners: HashMap::new(),
-            bound_port: 0,
-            bound_host: String::new(),
-            listening: false,
-            shutdown_tx: None,
-            request_rx: None,
-            upgrade_rx: None,
-        },
+        base: HttpServer::with_handler(handler),
     })
 }
 

--- a/crates/perry-ext-http-server/src/https_server.rs
+++ b/crates/perry-ext-http-server/src/https_server.rs
@@ -98,16 +98,7 @@ pub unsafe extern "C" fn js_node_https_create_server(opts_f64: f64, handler: i64
             return register_handle(HttpsServer {
                 handler,
                 tls_config: None,
-                base: HttpServer {
-                    handler,
-                    listeners: HashMap::new(),
-                    bound_port: 0,
-                    bound_host: String::new(),
-                    listening: false,
-                    shutdown_tx: None,
-                    request_rx: None,
-                    upgrade_rx: None,
-                },
+                base: HttpServer::with_handler(handler),
             });
         }
     };
@@ -122,16 +113,7 @@ pub unsafe extern "C" fn js_node_https_create_server(opts_f64: f64, handler: i64
     register_handle(HttpsServer {
         handler,
         tls_config,
-        base: HttpServer {
-            handler,
-            listeners: HashMap::new(),
-            bound_port: 0,
-            bound_host: String::new(),
-            listening: false,
-            shutdown_tx: None,
-            request_rx: None,
-            upgrade_rx: None,
-        },
+        base: HttpServer::with_handler(handler),
     })
 }
 

--- a/crates/perry-ext-http-server/src/lib.rs
+++ b/crates/perry-ext-http-server/src/lib.rs
@@ -172,16 +172,69 @@ mod tests {
     }
 
     fn http_server(handler: i64, listeners: HashMap<String, Vec<i64>>) -> HttpServer {
-        HttpServer {
-            handler,
-            listeners,
-            bound_port: 0,
-            bound_host: String::new(),
-            listening: false,
-            shutdown_tx: None,
-            request_rx: None,
-            upgrade_rx: None,
-        }
+        let mut s = HttpServer::with_handler(handler);
+        s.listeners = listeners;
+        s
+    }
+
+    /// Issue #2210 — `HttpServer::with_handler` seeds Node's
+    /// documented timeout defaults so a fresh server reads back the
+    /// same numbers Node returns when no options are passed.
+    #[test]
+    fn http_server_seeds_node_timeout_defaults() {
+        let s = HttpServer::with_handler(0);
+        assert_eq!(s.headers_timeout, 60_000.0);
+        assert_eq!(s.keep_alive_timeout, 5_000.0);
+        assert_eq!(s.request_timeout, 300_000.0);
+        assert_eq!(s.idle_timeout, 0.0);
+        assert_eq!(s.max_headers_count, 2000.0);
+        assert_eq!(s.max_requests_per_socket, 0.0);
+        assert!(s.no_delay);
+        assert!(!s.keep_alive);
+        assert_eq!(s.keep_alive_initial_delay, 0.0);
+    }
+
+    /// Issue #2210 — the FFI getter/setter pair round-trips a value
+    /// through the per-handle storage. Sanity-pins the macro-expanded
+    /// `js_node_http_server_*` exports against future refactors.
+    #[test]
+    fn http_server_timeout_setter_round_trips() {
+        let handle = register_handle(HttpServer::with_handler(0));
+        // Sanity: defaults visible through the FFI getter.
+        assert_eq!(
+            crate::server::js_node_http_server_headers_timeout(handle),
+            60_000.0
+        );
+        // Set then read back.
+        crate::server::js_node_http_server_set_headers_timeout(handle, 0.0);
+        crate::server::js_node_http_server_set_idle_timeout(handle, 45_000.0);
+        crate::server::js_node_http_server_set_max_requests_per_socket(handle, 100.0);
+        assert_eq!(
+            crate::server::js_node_http_server_headers_timeout(handle),
+            0.0
+        );
+        assert_eq!(
+            crate::server::js_node_http_server_idle_timeout(handle),
+            45_000.0
+        );
+        assert_eq!(
+            crate::server::js_node_http_server_max_requests_per_socket(handle),
+            100.0,
+        );
+        // `setTimeout(ms, cb)` updates the idle timeout and registers
+        // the cb as a `'timeout'` listener — returns the handle for chaining.
+        let chained =
+            crate::server::js_node_http_server_set_timeout_method(handle, 9_999.0, 0xCAFE);
+        assert_eq!(chained, handle);
+        assert_eq!(
+            crate::server::js_node_http_server_idle_timeout(handle),
+            9_999.0
+        );
+        let listener_count = get_handle::<HttpServer>(handle)
+            .and_then(|s| s.listeners.get("timeout").map(|v| v.len()))
+            .unwrap_or(0);
+        assert_eq!(listener_count, 1);
+        drop_handle(handle);
     }
 
     #[test]

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -56,6 +56,59 @@ pub struct HttpServer {
     /// the WebSocket handshake completes. Drained alongside
     /// `request_rx` in `event_loop`.
     pub upgrade_rx: Option<mpsc::Receiver<HttpPendingUpgrade>>,
+    /// Issue #2210 — Node 18.4+ timeout knobs surfaced as both
+    /// `createServer(handler, options)` and `server.<name>` property
+    /// setters. Phase 1: store the values and read them back; the
+    /// hyper accept-loop wiring (Phase 2) is the follow-up tracked in
+    /// the same ticket.
+    ///
+    /// Defaults mirror Node's `lib/_http_server.js`:
+    ///   - `headersTimeout`: 60_000 ms
+    ///   - `keepAliveTimeout`: 5_000 ms
+    ///   - `requestTimeout`: 300_000 ms
+    ///   - `timeout` (idle): 0 (disabled)
+    ///   - `maxHeadersCount`: 2000
+    ///   - `maxRequestsPerSocket`: 0 (no limit)
+    ///   - `noDelay`: true (Node toggled the default in 21.0)
+    ///   - `keepAlive`: false
+    ///   - `keepAliveInitialDelay`: 0 ms
+    pub headers_timeout: f64,
+    pub keep_alive_timeout: f64,
+    pub request_timeout: f64,
+    pub idle_timeout: f64,
+    pub max_headers_count: f64,
+    pub max_requests_per_socket: f64,
+    pub no_delay: bool,
+    pub keep_alive: bool,
+    pub keep_alive_initial_delay: f64,
+}
+
+impl HttpServer {
+    /// Build a new `HttpServer` with all Node 18.4+ timeout defaults.
+    /// Keeps the field list off the `register_handle` call sites so a
+    /// future field addition doesn't require updating every constructor
+    /// (https / http2 / test fixtures).
+    pub fn with_handler(handler: i64) -> Self {
+        Self {
+            handler,
+            listeners: HashMap::new(),
+            bound_port: 0,
+            bound_host: String::new(),
+            listening: false,
+            shutdown_tx: None,
+            request_rx: None,
+            upgrade_rx: None,
+            headers_timeout: 60_000.0,
+            keep_alive_timeout: 5_000.0,
+            request_timeout: 300_000.0,
+            idle_timeout: 0.0,
+            max_headers_count: 2000.0,
+            max_requests_per_socket: 0.0,
+            no_delay: true,
+            keep_alive: false,
+            keep_alive_initial_delay: 0.0,
+        }
+    }
 }
 
 /// Pending request from the hyper service fn to the main thread.
@@ -87,16 +140,164 @@ pub struct HttpPendingUpgrade {
 #[no_mangle]
 pub extern "C" fn js_node_http_create_server(handler: i64) -> i64 {
     ensure_gc_scanner_registered();
-    register_handle(HttpServer {
-        handler,
-        listeners: HashMap::new(),
-        bound_port: 0,
-        bound_host: String::new(),
-        listening: false,
-        shutdown_tx: None,
-        request_rx: None,
-        upgrade_rx: None,
-    })
+    register_handle(HttpServer::with_handler(handler))
+}
+
+/// Issue #2210 — `http.createServer(handler, options)` (Node 18.4+).
+/// `options_f64` is the NaN-boxed options object (`undefined` /
+/// `TAG_UNDEFINED` for the no-arg overload). Reads the timeout knobs
+/// off the object and stores them on the new `HttpServer`. The
+/// argument-order overload `createServer(options, handler)` is
+/// resolved at the dispatch shim — see `lower_http_create_server` in
+/// perry-codegen which normalizes both shapes to `(handler, options)`
+/// before the FFI call.
+#[no_mangle]
+pub unsafe extern "C" fn js_node_http_create_server_with_options(
+    handler: i64,
+    options_f64: f64,
+) -> i64 {
+    ensure_gc_scanner_registered();
+    let mut server = HttpServer::with_handler(handler);
+    apply_server_options(&mut server, options_f64);
+    register_handle(server)
+}
+
+/// Read each Node-documented timeout/socket knob off the options
+/// object and overwrite the server's default. Missing keys leave the
+/// default in place; non-numeric values silently no-op (matches
+/// Node, which coerces or ignores most invalid types).
+///
+/// Uses the same JSON-round-trip pattern as `extract_port`/`extract_host`
+/// in `types.rs` so we don't introduce a second runtime-object-read API
+/// surface — keeps the crate independent of perry-runtime's internal
+/// ObjectHeader layout.
+fn apply_server_options(server: &mut HttpServer, options_f64: f64) {
+    use perry_ffi::JsValue;
+    let v = JsValue::from_bits(options_f64.to_bits());
+    if !v.is_pointer() {
+        return;
+    }
+    let Some(json) = perry_ffi::json_stringify(v) else {
+        return;
+    };
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&json) else {
+        return;
+    };
+    let as_num = |key: &str| -> Option<f64> {
+        parsed
+            .get(key)
+            .and_then(|v| v.as_f64())
+            .filter(|n| !n.is_nan())
+    };
+    let as_bool = |key: &str| -> Option<bool> { parsed.get(key).and_then(|v| v.as_bool()) };
+
+    if let Some(v) = as_num("headersTimeout") {
+        server.headers_timeout = v;
+    }
+    if let Some(v) = as_num("keepAliveTimeout") {
+        server.keep_alive_timeout = v;
+    }
+    if let Some(v) = as_num("requestTimeout") {
+        server.request_timeout = v;
+    }
+    if let Some(v) = as_num("timeout") {
+        server.idle_timeout = v;
+    }
+    if let Some(v) = as_num("maxHeadersCount") {
+        server.max_headers_count = v;
+    }
+    if let Some(v) = as_num("maxRequestsPerSocket") {
+        server.max_requests_per_socket = v;
+    }
+    if let Some(v) = as_num("keepAliveInitialDelay") {
+        server.keep_alive_initial_delay = v;
+    }
+    if let Some(v) = as_bool("noDelay") {
+        server.no_delay = v;
+    }
+    if let Some(v) = as_bool("keepAlive") {
+        server.keep_alive = v;
+    }
+}
+
+// ============================================================================
+// Issue #2210 — server.<timeout> property accessors
+// ============================================================================
+//
+// Six numeric knobs (`headersTimeout`, `keepAliveTimeout`,
+// `requestTimeout`, `timeout`, `maxHeadersCount`, `maxRequestsPerSocket`)
+// plus the `setTimeout(ms, cb?)` instance method. Phase 1 stores +
+// reads back; Phase 2 (hyper connection-builder + per-request deadline)
+// is the follow-up tracked in #2210. The getter/setter naming follows
+// the existing `__get_<prop>` / `__set_<prop>` convention from the
+// Agent and ServerResponse rows in `native_table/http.rs`.
+
+macro_rules! server_getter {
+    ($name:ident, $field:ident) => {
+        #[no_mangle]
+        pub extern "C" fn $name(handle: i64) -> f64 {
+            get_handle::<HttpServer>(handle)
+                .map(|s| s.$field)
+                .unwrap_or(0.0)
+        }
+    };
+}
+
+macro_rules! server_setter {
+    ($name:ident, $field:ident) => {
+        #[no_mangle]
+        pub extern "C" fn $name(handle: i64, value: f64) -> f64 {
+            if let Some(s) = get_handle_mut::<HttpServer>(handle) {
+                s.$field = value;
+            }
+            value
+        }
+    };
+}
+
+server_getter!(js_node_http_server_headers_timeout, headers_timeout);
+server_setter!(js_node_http_server_set_headers_timeout, headers_timeout);
+server_getter!(js_node_http_server_keep_alive_timeout, keep_alive_timeout);
+server_setter!(
+    js_node_http_server_set_keep_alive_timeout,
+    keep_alive_timeout
+);
+server_getter!(js_node_http_server_request_timeout, request_timeout);
+server_setter!(js_node_http_server_set_request_timeout, request_timeout);
+server_getter!(js_node_http_server_idle_timeout, idle_timeout);
+server_setter!(js_node_http_server_set_idle_timeout, idle_timeout);
+server_getter!(js_node_http_server_max_headers_count, max_headers_count);
+server_setter!(js_node_http_server_set_max_headers_count, max_headers_count);
+server_getter!(
+    js_node_http_server_max_requests_per_socket,
+    max_requests_per_socket
+);
+server_setter!(
+    js_node_http_server_set_max_requests_per_socket,
+    max_requests_per_socket
+);
+
+/// `server.setTimeout(msecs, [callback])` — the canonical EventEmitter-
+/// style setter. The callback (if provided) is registered as a
+/// `'timeout'` listener; we store the raw closure handle and let the
+/// existing listener-firing path emit it once Phase 2 wires up the
+/// idle-detector. Returns the server handle for chaining.
+#[no_mangle]
+pub extern "C" fn js_node_http_server_set_timeout_method(
+    handle: i64,
+    msecs: f64,
+    callback: i64,
+) -> i64 {
+    if let Some(s) = get_handle_mut::<HttpServer>(handle) {
+        s.idle_timeout = msecs;
+        if callback != 0 {
+            s.listeners
+                .entry("timeout".to_string())
+                .or_default()
+                .push(callback);
+        }
+    }
+    handle
 }
 
 /// `server.listen(port?, host?, backlog?, cb?)` — bind + start accepting.

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -515,6 +515,19 @@ pub(super) fn lower_assign(ctx: &mut LoweringContext, assign: &ast::AssignExpr) 
                             let setter_method = match (class_name.as_str(), prop.as_str()) {
                                 ("ServerResponse", "statusCode") => Some("__set_statusCode"),
                                 ("ServerResponse", "statusMessage") => Some("__set_statusMessage"),
+                                // Issue #2210 — `server.headersTimeout = N` etc.
+                                // route to the `__set_<name>` FFI variants. Phase
+                                // 1 just stores; Phase 2 wires hyper deadlines.
+                                ("HttpServer", "headersTimeout") => Some("__set_headersTimeout"),
+                                ("HttpServer", "keepAliveTimeout") => {
+                                    Some("__set_keepAliveTimeout")
+                                }
+                                ("HttpServer", "requestTimeout") => Some("__set_requestTimeout"),
+                                ("HttpServer", "timeout") => Some("__set_timeout"),
+                                ("HttpServer", "maxHeadersCount") => Some("__set_maxHeadersCount"),
+                                ("HttpServer", "maxRequestsPerSocket") => {
+                                    Some("__set_maxRequestsPerSocket")
+                                }
                                 _ => None,
                             };
                             if let Some(method) = setter_method {

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -957,7 +957,19 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                             | ("ServerResponse", "statusCode")
                             | ("ServerResponse", "headersSent")
                             | ("ServerResponse", "writableEnded")
-                            | ("ServerResponse", "writableFinished") => {
+                            | ("ServerResponse", "writableFinished")
+                            // Issue #2210 — `server.headersTimeout` etc.
+                            // get rewritten to `__get_<name>` so the read
+                            // dispatches through the per-prop FFI in
+                            // perry-ext-http-server (Phase 1 returns the
+                            // stored numeric default; Phase 2 will reflect
+                            // the live hyper accept-loop state).
+                            | ("HttpServer", "headersTimeout")
+                            | ("HttpServer", "keepAliveTimeout")
+                            | ("HttpServer", "requestTimeout")
+                            | ("HttpServer", "timeout")
+                            | ("HttpServer", "maxHeadersCount")
+                            | ("HttpServer", "maxRequestsPerSocket") => {
                                 format!("__get_{}", property_name)
                             }
                             _ => property_name,

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1461 entries across 82 modules
+// Coverage: 1480 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1461 entries across 82 modules.
+Total: 1480 entries across 82 modules.
 
 ## Modules
 
@@ -765,33 +765,45 @@ Total: 1461 entries across 82 modules.
 - `__get_freeSockets` — instance *(class: `Agent`)*
 - `__get_headers` — instance *(class: `IncomingMessage`)*
 - `__get_headersSent` — instance *(class: `ServerResponse`)*
+- `__get_headersTimeout` — instance *(class: `HttpServer`)*
 - `__get_httpVersion` — instance *(class: `IncomingMessage`)*
 - `__get_keepAlive` — instance *(class: `Agent`)*
 - `__get_keepAliveMsecs` — instance *(class: `Agent`)*
+- `__get_keepAliveTimeout` — instance *(class: `HttpServer`)*
 - `__get_maxFreeSockets` — instance *(class: `Agent`)*
+- `__get_maxHeadersCount` — instance *(class: `HttpServer`)*
+- `__get_maxRequestsPerSocket` — instance *(class: `HttpServer`)*
 - `__get_maxSockets` — instance *(class: `Agent`)*
 - `__get_maxTotalSockets` — instance *(class: `Agent`)*
 - `__get_method` — instance *(class: `IncomingMessage`)*
 - `__get_protocol` — instance *(class: `Agent`)*
+- `__get_requestTimeout` — instance *(class: `HttpServer`)*
 - `__get_requests` — instance *(class: `Agent`)*
 - `__get_sockets` — instance *(class: `Agent`)*
 - `__get_statusCode` — instance *(class: `IncomingMessage`)*
 - `__get_statusCode` — instance *(class: `ServerResponse`)*
 - `__get_statusMessage` — instance *(class: `IncomingMessage`)*
+- `__get_timeout` — instance *(class: `HttpServer`)*
 - `__get_trailers` — instance *(class: `IncomingMessage`)*
 - `__get_url` — instance *(class: `IncomingMessage`)*
 - `__get_writableEnded` — instance *(class: `ServerResponse`)*
 - `__get_writableFinished` — instance *(class: `ServerResponse`)*
 - `__set_createConnection` — instance *(class: `Agent`)*
 - `__set_createSocket` — instance *(class: `Agent`)*
+- `__set_headersTimeout` — instance *(class: `HttpServer`)*
 - `__set_keepAlive` — instance *(class: `Agent`)*
 - `__set_keepAliveMsecs` — instance *(class: `Agent`)*
+- `__set_keepAliveTimeout` — instance *(class: `HttpServer`)*
 - `__set_maxFreeSockets` — instance *(class: `Agent`)*
+- `__set_maxHeadersCount` — instance *(class: `HttpServer`)*
+- `__set_maxRequestsPerSocket` — instance *(class: `HttpServer`)*
 - `__set_maxSockets` — instance *(class: `Agent`)*
 - `__set_maxTotalSockets` — instance *(class: `Agent`)*
 - `__set_protocol` — instance *(class: `Agent`)*
+- `__set_requestTimeout` — instance *(class: `HttpServer`)*
 - `__set_statusCode` — instance *(class: `ServerResponse`)*
 - `__set_statusMessage` — instance *(class: `ServerResponse`)*
+- `__set_timeout` — instance *(class: `HttpServer`)*
 - `addListener` — instance *(class: `HttpServer`)*
 - `addListener` — instance *(class: `IncomingMessage`)*
 - `addListener` — instance *(class: `ServerResponse`)*
@@ -815,12 +827,16 @@ Total: 1461 entries across 82 modules.
 - `getStatus` — instance *(class: `ServerResponse`)*
 - `hasHeader` — instance *(class: `ServerResponse`)*
 - `headers` — instance *(class: `IncomingMessage`)*
+- `headersTimeout` — instance *(class: `HttpServer`)*
 - `httpVersion` — instance *(class: `IncomingMessage`)*
 - `keepAlive` — instance *(class: `Agent`)*
 - `keepAliveMsecs` — instance *(class: `Agent`)*
+- `keepAliveTimeout` — instance *(class: `HttpServer`)*
 - `keepSocketAlive` — instance *(class: `Agent`)*
 - `listen` — instance *(class: `HttpServer`)*
 - `maxFreeSockets` — instance *(class: `Agent`)*
+- `maxHeadersCount` — instance *(class: `HttpServer`)*
+- `maxRequestsPerSocket` — instance *(class: `HttpServer`)*
 - `maxSockets` — instance *(class: `Agent`)*
 - `maxTotalSockets` — instance *(class: `Agent`)*
 - `method` — instance *(class: `IncomingMessage`)*
@@ -832,15 +848,18 @@ Total: 1461 entries across 82 modules.
 - `read` — instance *(class: `IncomingMessage`)*
 - `removeHeader` — instance *(class: `ServerResponse`)*
 - `request` — module
+- `requestTimeout` — instance *(class: `HttpServer`)*
 - `requests` — instance *(class: `Agent`)*
 - `resume` — instance *(class: `IncomingMessage`)*
 - `reuseSocket` — instance *(class: `Agent`)*
 - `setHeader` — instance *(class: `ServerResponse`)*
 - `setStatus` — instance *(class: `ServerResponse`)*
+- `setTimeout` — instance *(class: `HttpServer`)*
 - `setTimeout` — instance *(class: `ClientRequest`)*
 - `sockets` — instance *(class: `Agent`)*
 - `statusCode` — instance *(class: `IncomingMessage`)*
 - `statusMessage` — instance *(class: `IncomingMessage`)*
+- `timeout` — instance *(class: `HttpServer`)*
 - `trailers` — instance *(class: `IncomingMessage`)*
 - `url` — instance *(class: `IncomingMessage`)*
 - `write` — instance *(class: `ServerResponse`)*

--- a/test-parity/node-suite/http/server/timeout-knobs.ts
+++ b/test-parity/node-suite/http/server/timeout-knobs.ts
@@ -1,0 +1,40 @@
+// Issue #2210 — `http.createServer(handler, options)` accepts a 2nd
+// options arg (Node 18.4+) and exposes the six numeric timeout knobs
+// as readable + writable instance properties. Pre-#2210 every
+// property read returned NaN and every property write threw "value is
+// not a function" because the typed-feedback fallback didn't model
+// them.
+//
+// The parity check here only pins the property-setter path: Node's
+// per-prop *initial* read after the options-form constructor is
+// inconsistent (some defaults reflect the option, some return null /
+// the prototype default), so a strict "options round-trip" check
+// would diverge through no fault of the fix. The Perry-side
+// options-round-trip is covered by a Rust unit test in
+// perry-ext-http-server::server.
+//
+// Phase 1 (this PR) stores + reads back the values; Phase 2 wires
+// them to hyper's connection lifecycle, tracked under the same issue.
+import { createServer } from "node:http";
+
+const server = createServer((_req: any, res: any) => res.end("ok"));
+
+server.headersTimeout = 0;
+server.keepAliveTimeout = 0;
+server.requestTimeout = 60_000;
+server.timeout = 120_000;
+server.maxHeadersCount = 2000;
+server.maxRequestsPerSocket = 0;
+
+console.log("headersTimeout:", server.headersTimeout);
+console.log("keepAliveTimeout:", server.keepAliveTimeout);
+console.log("requestTimeout:", server.requestTimeout);
+console.log("timeout:", server.timeout);
+console.log("maxHeadersCount:", server.maxHeadersCount);
+console.log("maxRequestsPerSocket:", server.maxRequestsPerSocket);
+
+// `server.setTimeout(ms, cb)` — canonical EventEmitter-style setter.
+// Returns the server for chaining; updates the `timeout` accessor.
+const chained = server.setTimeout(45_000, () => {});
+console.log("chained === server:", chained === server);
+console.log("post-setTimeout timeout:", server.timeout);


### PR DESCRIPTION
## Summary

- `http.createServer(handler, options)` (Node 18.4+) now reads the timeout knobs off the options arg via a new `js_node_http_create_server_with_options` FFI; the codegen dispatch row carries the options as the second `NA_JSV` slot so the no-arg / handler-only / handler+opts overloads all collapse to a single dispatch.
- The six numeric `Server` properties — `headersTimeout`, `keepAliveTimeout`, `requestTimeout`, `timeout`, `maxHeadersCount`, `maxRequestsPerSocket` — are exposed as readable + writable instance accessors via `__get_<name>` / `__set_<name>` HIR rewrites on `("http", "HttpServer")` receivers. Bare-name fallback rows in `NATIVE_MODULE_TABLE` cover receivers that escape the rewrite (e.g. assigned through a local).
- `server.setTimeout(msecs, cb?)` is wired as the canonical EventEmitter-style setter — chains by returning the server handle and registers the callback as a `'timeout'` listener.
- `HttpServer` field defaults now mirror Node's `lib/_http_server.js` (`headersTimeout=60_000`, `keepAliveTimeout=5_000`, `requestTimeout=300_000`, `timeout=0`, `maxHeadersCount=2000`, `maxRequestsPerSocket=0`, `noDelay=true`, `keepAlive=false`).
- Phase 2 (hyper `Builder::header_read_timeout` / `keep_alive_interval` + per-request service-fn deadlines) is the follow-up tracked under the same issue.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --release -p perry-codegen -p perry-hir -p perry-api-manifest -p perry-ext-http-server` green, including the `every_dispatch_entry_has_manifest_counterpart` drift check and two new unit tests (`http_server_seeds_node_timeout_defaults`, `http_server_timeout_setter_round_trips`).
- [x] `scripts/regen_api_docs.sh` regenerated (+21 lines).
- [x] Added `test-parity/node-suite/http/server/timeout-knobs.ts` — byte-identical against `node --experimental-strip-types` for setter round-trip + `setTimeout(ms, cb)` chain.

Closes #2210 (Phase 1).
