### PR TITLE
fix(runtime): hide WeakRef/WeakMap/WeakSet/FinalizationRegistry internal slots (#1766)

### DIFF
--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -40,10 +40,12 @@ pub(crate) fn weak_wrapper_inspect_label(obj: *const ObjectHeader) -> Option<&'s
 }
 
 /// Allocate a `WeakRef` wrapper object that strongly holds the target value
-/// in a single field named `target`.
+/// in a single sentinel-named field. #1766: the field name uses a `__perry_`
+/// prefix so user code reading `(wr as any).target` returns `undefined` like
+/// Node, instead of leaking the internal storage slot.
 #[no_mangle]
 pub extern "C" fn js_weakref_new(target: f64) -> *mut ObjectHeader {
-    let packed = b"target\0";
+    let packed = b"__perry_wr_target\0";
     let obj = js_object_alloc_with_shape(WEAKREF_SHAPE_ID, 1, packed.as_ptr(), packed.len() as u32);
     js_object_set_field(obj, 0, JSValue::from_bits(target.to_bits()));
     unsafe {
@@ -62,7 +64,7 @@ pub extern "C" fn js_weakref_deref(weakref: f64) -> f64 {
     if ptr.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    let key_ptr = crate::string::js_string_from_bytes(b"target".as_ptr(), 6);
+    let key_ptr = crate::string::js_string_from_bytes(b"__perry_wr_target".as_ptr(), 17);
     let val = js_object_get_field_by_name(ptr, key_ptr);
     if val.is_undefined() {
         f64::from_bits(TAG_UNDEFINED)
@@ -76,7 +78,9 @@ pub extern "C" fn js_weakref_deref(weakref: f64) -> f64 {
 /// 2-element `[token, held]` array used by `unregister(token)` to find matches.
 #[no_mangle]
 pub extern "C" fn js_finreg_new(callback: f64) -> *mut ObjectHeader {
-    let packed = b"callback\0entries\0";
+    // #1766: sentinel-name internal slots so `(fr as any).callback` /
+    // `.entries` return `undefined` like Node.
+    let packed = b"__perry_fr_callback\0__perry_fr_entries\0";
     let obj = js_object_alloc_with_shape(FINREG_SHAPE_ID, 2, packed.as_ptr(), packed.len() as u32);
     js_object_set_field(obj, 0, JSValue::from_bits(callback.to_bits()));
     let entries_arr = js_array_alloc(0);
@@ -98,7 +102,7 @@ pub extern "C" fn js_finreg_register(registry: f64, _target: f64, held: f64, tok
     if reg_ptr.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    let entries_key = crate::string::js_string_from_bytes(b"entries".as_ptr(), 7);
+    let entries_key = crate::string::js_string_from_bytes(b"__perry_fr_entries".as_ptr(), 18);
     let entries_val = js_object_get_field_by_name(reg_ptr, entries_key);
     let entries_ptr = (entries_val.bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ArrayHeader;
     if entries_ptr.is_null() {
@@ -123,7 +127,7 @@ pub extern "C" fn js_finreg_unregister(registry: f64, token: f64) -> f64 {
     if reg_ptr.is_null() {
         return f64::from_bits(TAG_FALSE);
     }
-    let entries_key = crate::string::js_string_from_bytes(b"entries".as_ptr(), 7);
+    let entries_key = crate::string::js_string_from_bytes(b"__perry_fr_entries".as_ptr(), 18);
     let entries_val = js_object_get_field_by_name(reg_ptr, entries_key);
     let entries_ptr = (entries_val.bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ArrayHeader;
     if entries_ptr.is_null() {
@@ -222,14 +226,16 @@ pub unsafe fn try_weak_method_dispatch(
 }
 
 unsafe fn entries_array(reg: *mut ObjectHeader) -> *mut ArrayHeader {
-    let entries_key = crate::string::js_string_from_bytes(b"entries".as_ptr(), 7);
+    let entries_key = crate::string::js_string_from_bytes(b"__perry_wk_entries".as_ptr(), 18);
     let entries_val = js_object_get_field_by_name(reg, entries_key);
     (entries_val.bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ArrayHeader
 }
 
 #[no_mangle]
 pub extern "C" fn js_weakmap_new() -> *mut ObjectHeader {
-    let packed = b"entries\0";
+    // #1766: sentinel-named slot so `(wm as any).entries` returns
+    // `undefined` like Node, instead of leaking the [k, v]-pair array.
+    let packed = b"__perry_wk_entries\0";
     let obj = js_object_alloc_with_shape(WEAKMAP_SHAPE_ID, 1, packed.as_ptr(), packed.len() as u32);
     let entries_arr = js_array_alloc(0);
     js_object_set_field(obj, 0, JSValue::array_ptr(entries_arr));
@@ -368,7 +374,9 @@ pub extern "C" fn js_weakmap_delete(map: f64, key: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_weakset_new() -> *mut ObjectHeader {
-    let packed = b"entries\0";
+    // #1766: shares the sentinel name with js_weakmap_new so the same
+    // `entries_array` helper reaches the [k,v]-pair storage.
+    let packed = b"__perry_wk_entries\0";
     let obj = js_object_alloc_with_shape(WEAKSET_SHAPE_ID, 1, packed.as_ptr(), packed.len() as u32);
     let entries_arr = js_array_alloc(0);
     js_object_set_field(obj, 0, JSValue::array_ptr(entries_arr));

--- a/test-files/test_issue_1766_weakref_internal_fields.ts
+++ b/test-files/test_issue_1766_weakref_internal_fields.ts
@@ -1,0 +1,49 @@
+// Refs #1766: WeakMap / WeakSet / WeakRef / FinalizationRegistry wrappers
+// previously exposed their backing-storage field names (`entries`, `target`,
+// `callback`) as user-visible properties — `(wm as any).entries` returned the
+// internal `[key, value]` pair array instead of `undefined` like Node. The
+// runtime now uses `__perry_*` sentinel names for those slots so user-level
+// property reads land on undefined and the functional WeakMap/WeakSet/WeakRef
+// methods continue to work through the same internal accessors.
+
+// === WeakMap ===
+const wm = new WeakMap<object, number>();
+const k1 = {};
+const k2 = {};
+wm.set(k1, 11);
+wm.set(k2, 22);
+
+// Internal field is hidden.
+console.log((wm as any).entries);
+
+// Public API still works.
+console.log(wm.has(k1), wm.has(k2));
+console.log(wm.get(k1), wm.get(k2));
+wm.delete(k1);
+console.log(wm.has(k1), wm.has(k2));
+
+// === WeakSet ===
+const ws = new WeakSet<object>();
+ws.add(k1);
+ws.add(k2);
+
+console.log((ws as any).entries);
+console.log(ws.has(k1), ws.has(k2));
+ws.delete(k1);
+console.log(ws.has(k1), ws.has(k2));
+
+// === WeakRef ===
+const wr = new WeakRef(k1);
+console.log((wr as any).target);
+console.log(wr.deref() === k1);
+
+// === FinalizationRegistry ===
+const fr = new FinalizationRegistry((_held: any) => {});
+console.log((fr as any).callback);
+console.log((fr as any).entries);
+
+const tok = {};
+fr.register(k1, "h1", tok);
+// unregister returns true when an entry matched the token (Node) — Perry now
+// agrees because the lookup hits the sentinel-named slot.
+console.log(fr.unregister(tok));


### PR DESCRIPTION
## Summary

- WeakRef / WeakMap / WeakSet / FinalizationRegistry stored their backing data under user-visible field names (`target`, `entries`, `callback`). User code reading `(wr as any).target` or `(wm as any).entries` returned the raw internal slot (the `[key,value]`-pair array, the WeakRef target, the cleanup callback) instead of `undefined` like Node — the weak-wrapper abstraction leaked.
- Rename all four shapes to `__perry_*` sentinels (`__perry_wr_target`, `__perry_wk_entries` shared by WeakMap/WeakSet, `__perry_fr_callback` + `__perry_fr_entries`) so the user-level property reads land on `undefined`. The internal accessors (`entries_array`, `js_weakref_deref`, `js_finreg_register`/`_unregister`) use the same sentinels so functional methods stay byte-identical with Node.

## Test plan

- New gap test `test-files/test_issue_1766_weakref_internal_fields.ts` byte-identical with Node — covers the leak surface for all four wrapper kinds plus a positive functional round-trip per kind.
- Existing `test_gap_weakmap_dynamic.ts` and `test_gap_weakref_finalization.ts` parity tests still byte-identical with Node (no regression).
- `cargo fmt --all -- --check` clean.
- `cargo test --release -p perry-runtime --lib` — 736 tests pass.
