### PR TITLE
feat(hir): class [Symbol.asyncIterator] resolvable via member access (#1838)

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -414,9 +414,21 @@ pub fn lower_class_decl(
                                 } else {
                                     "__perry_dispose__".to_string()
                                 }
+                            } else if wk == "asyncIterator"
+                                && !method.is_static
+                                && matches!(method.kind, ast::MethodKind::Method)
+                            {
+                                // #1838 follow-up: `[Symbol.asyncIterator]() {}`
+                                // on a class — register under `@@asyncIterator`
+                                // so the symbol resolver in `runtime/src/symbol.rs`
+                                // (`well_known_symbol_method_key`) binds it as
+                                // `instance[Symbol.asyncIterator]`. Mirrors the
+                                // `@@iterator` path; for-await over a class
+                                // instance picks the same vtable entry.
+                                "@@asyncIterator".to_string()
                             } else {
-                                // Other well-known (toPrimitive, asyncIterator)
-                                // on a class: not yet implemented, skip.
+                                // Other well-known (toPrimitive) on a class:
+                                // not yet implemented, skip.
                                 continue;
                             }
                         } else {

--- a/test-files/test_gap_class_symbol_async_iterator.ts
+++ b/test-files/test_gap_class_symbol_async_iterator.ts
@@ -1,0 +1,59 @@
+// #1838 follow-up: a class's computed `[Symbol.asyncIterator]() {}` is
+// resolvable via member access. Class lowering names it `@@asyncIterator`
+// in the vtable (mirroring `@@iterator`), so `instance[Symbol.asyncIterator]`,
+// `Symbol.asyncIterator in instance`, and the explicit driver pattern
+// `(await it.next()).value` all find it.
+//
+// Scope: member access / `in` / direct `await it.next()` round-trip. The
+// `for await (...)` lowering on a class instance goes through a separate
+// codegen path and is a follow-up. Validated byte-for-byte against Node.
+
+class AsyncRange {
+  n: number;
+  constructor(n: number) {
+    this.n = n;
+  }
+  [Symbol.asyncIterator]() {
+    let i = 0;
+    const n = this.n;
+    return {
+      next: () =>
+        Promise.resolve(
+          i < n ? { value: i++, done: false } : { value: undefined, done: true },
+        ),
+    };
+  }
+}
+
+async function main(): Promise<void> {
+  const r = new AsyncRange(3);
+  console.log("has:", Symbol.asyncIterator in r); // true
+  console.log("typeof:", typeof (r as any)[Symbol.asyncIterator]); // function
+
+  // Direct driver: explicit `await it.next()` over the resolved iterator.
+  const it = (r as any)[Symbol.asyncIterator]();
+  const out: number[] = [];
+  let v = await it.next();
+  while (!v.done) {
+    out.push(v.value);
+    v = await it.next();
+  }
+  console.log("direct:", out.join(",")); // 0,1,2
+
+  // Inherited [Symbol.asyncIterator] resolves through the class chain.
+  class Sub extends AsyncRange {}
+  const s = new Sub(2);
+  console.log("inherited has:", Symbol.asyncIterator in s);
+  const sit = (s as any)[Symbol.asyncIterator]();
+  const sout: number[] = [];
+  let sv = await sit.next();
+  while (!sv.done) {
+    sout.push(sv.value);
+    sv = await sit.next();
+  }
+  console.log("inherited direct:", sout.join(",")); // 0,1
+
+  console.log("ALL CLASS-SYMBOL-ASYNC-ITERATOR TESTS PASSED");
+}
+
+main();


### PR DESCRIPTION
## Summary

Follow-up to #1838 / PR #1841 — extends `[Symbol.iterator]` member-access resolution to its async sibling `[Symbol.asyncIterator]`.

The runtime side (`well_known_symbol_method_key` in `crates/perry-runtime/src/symbol.rs`) already maps `Symbol.asyncIterator` to the synthetic `@@asyncIterator` vtable key, so the resolver was ready — but HIR class lowering explicitly skipped this method:

```rust
} else {
    // Other well-known (toPrimitive, asyncIterator)
    // on a class: not yet implemented, skip.
    continue;
}
```

Effect on user code: `Symbol.asyncIterator in instance` returned `false`, `(instance as any)[Symbol.asyncIterator]` was `undefined`, and the direct `await it.next()` driver pattern fell through to `next is not a function` the moment `it` was sourced via member access.

This adds the `asyncIterator` instance-method arm next to the `iterator` one — name the method `@@asyncIterator` and let it flow through the regular `methods.push(func)` path. The symbol resolver binds it to the instance via `js_class_method_bind` the same way it binds `@@iterator`.

## Test plan

- [x] New gap test `test-files/test_gap_class_symbol_async_iterator.ts` passes byte-for-byte against `node --experimental-strip-types`. Covers:
  - `Symbol.asyncIterator in instance` → `true`.
  - `typeof instance[Symbol.asyncIterator]` → `"function"`.
  - Direct `await it.next()` round-trip yields the expected values.
  - Inherited resolution through `class Sub extends AsyncRange`.
- [x] Existing `test_gap_class_symbol_iterator.ts` (sync `@@iterator`) still green — the new arm is gated on `wk == "asyncIterator"` and doesn't touch the `@@iterator` path or the dispose-family renames above it.
- [x] `cargo fmt --all -- --check` clean.

## Out of scope

`for await (const v of instance)` lowering — codegen still needs an async-iter driver for class instances. The explicit-driver pattern (`(instance as any)[Symbol.asyncIterator]() …`) is the one unblocked here, mirroring the scope of the original #1838 fix (`yield*` + explicit driver, with for-of via a separate special-case).
