### PR TITLE
fix(runtime): #1831 — yield* over an array iterates via array_values_iter

### DIFF
--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -898,15 +898,16 @@ fn class_chain_has_method(class_id: u32, name: &str) -> bool {
 /// method. This helper returns that iterator, or `val` unchanged when `val` is
 /// already an iterator / not iterable.
 ///
-/// Arrays are intentionally returned unchanged: perry has no real array
-/// iterator object (`Array.prototype.values` yields an array, not a
-/// `.next`-bearing iterator, and for-of over arrays is special-cased), so
-/// `yield* [..]` is a separate follow-up (#1831 array sub-case) — handling it
-/// here would route through `values` and mis-drive.
+/// Arrays now route through `array_values_iter` — the runtime has a real
+/// `.next`-bearing iterator (`ARRAY_ITERATOR_CLASS_ID`) since #321's
+/// `arr.values()` dispatch landed, so `yield* [..]` and any other consumer
+/// that drives `js_get_iterator(...).next()` works on a plain array. The
+/// for-of and spread fast paths still special-case arrays earlier (in the
+/// array-memcpy / index-loop arms) so they don't reach this helper.
 #[no_mangle]
 pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
     if crate::array::js_array_is_array(val_f64).to_bits() == crate::value::TAG_TRUE {
-        return val_f64;
+        return crate::array::array_values_iter(val_f64);
     }
     let iter_wk = well_known_symbol("iterator");
     if !iter_wk.is_null() {

--- a/test-files/test_gap_1831_yield_star_array.ts
+++ b/test-files/test_gap_1831_yield_star_array.ts
@@ -1,0 +1,70 @@
+// #1831 (array sub-case): `yield*` over a plain Array must iterate the
+// values, not infinite-loop over an empty/undefined iterator result.
+//
+// The object-iterable sub-case (`yield* { [Symbol.iterator]() {…} }`) was
+// fixed in #1839; arrays were intentionally left as a follow-up because
+// `js_get_iterator` returned arrays unchanged. With the runtime
+// `ARRAY_ITERATOR_CLASS_ID` from #321 in place, `js_get_iterator(arr)` can
+// now return `array_values_iter(arr)` — a real `.next()`-bearing iterator
+// object that `js_native_call_method` dispatches.
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+function* g() {
+  yield* [1, 2, 3] as any;
+  yield 4;
+}
+console.log("array:", [...g()].join(","));
+
+// Object iterable still works (#1839 regression check).
+const iterable = {
+  [Symbol.iterator]() {
+    let i = 0;
+    return {
+      next: () => (i < 2 ? { value: i++, done: false } : { value: undefined, done: true }),
+    };
+  },
+};
+function* h() {
+  yield* iterable as any;
+  yield 9;
+}
+console.log("object:", [...h()].join(","));
+
+// Mixed: arrays + object iterable + nested generator.
+function* inner() {
+  yield "a";
+  yield "b";
+}
+function* mixed() {
+  yield* [1, 2] as any;
+  yield* inner();
+  yield* ["x", "y"] as any;
+  yield "end";
+}
+console.log("mixed:", [...mixed()].join(","));
+
+// Empty array — must terminate cleanly.
+function* empty() {
+  yield* [] as any;
+  yield 1;
+  yield* [99] as any;
+}
+console.log("empty:", [...empty()].join(","));
+
+// String elements + spread into a let-bound array.
+function* strs() {
+  yield* ["x", "y"] as any;
+}
+const out: string[] = [...strs()];
+console.log("strs:", out.join(","));
+
+// Regression: for-of / spread over a plain array still use their fast
+// paths (don't reach js_get_iterator), so unchanged behavior.
+const arr = [10, 20, 30];
+const fo: number[] = [];
+for (const v of arr) fo.push(v);
+console.log("for-of:", fo.join(","));
+console.log("spread:", [...arr].join(","));
+
+console.log("ALL 1831 YIELD-STAR-OVER-ARRAY TESTS PASSED");


### PR DESCRIPTION
## Summary

`yield* [1, 2, 3]` mis-iterated (infinite-yielded undefined) because `js_get_iterator(arr)` returned the array unchanged — Perry had no `.next()`-bearing array iterator at the time, so `js_array_values` materialized a shallow clone and the `yield*` driver's `__del_iter.next()` ran on the array itself.

The runtime has had a real array-iterator class (`ARRAY_ITERATOR_CLASS_ID`, added with #321's `arr.values()` dispatch tower) for a while; `js_native_call_method` already dispatches `.next()` on it. This change just routes `js_get_iterator(arr)` through `array_values_iter(arr)` so the consumer sees a real iterator.

Scope kept tight to `yield*` over arrays:

- For-of and spread over a plain array fast-path before reaching `js_get_iterator` (array memcpy / index-loop arms in `flat_clone.rs` and the for-of desugar), so behavior is unchanged.
- `arr.values().next()` *directly* still mis-dispatches because the value-level `arr.values()` lowers to `Expr::ArrayValues` → `js_array_values` (returns a clone, not a real iterator object). That's a separate axis (codegen lowering, not runtime), left for a follow-up.

## Test plan

- [x] New `test-files/test_gap_1831_yield_star_array.ts` covers array `yield*`, object-iterable `yield*`, mixed `yield*`, empty-array `yield*`, string-element `yield*`, plus for-of and spread over a plain array as regression anchors. Byte-identical against `node --experimental-strip-types`.
- [x] Existing iterator/array gap tests still pass: `test_gap_class_symbol_iterator.ts`, `test_gap_array_iterator_next.ts`, `test_gap_array_symbol_iterator.ts`, `test_compat_arrays_iterators.ts`.
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` (cold from worktree, 6m54s).
- [x] `cargo fmt --all -- --check` clean.

Closes #1831.
