### PR TITLE
fix(codegen): function .name inference for named fn expressions and obj-literal methods (#2076)

### DIFF
--- a/crates/perry-codegen-arkts/src/tests.rs
+++ b/crates/perry-codegen-arkts/src/tests.rs
@@ -28,6 +28,7 @@ fn empty_module() -> Module {
         has_top_level_await: false,
         init_kind: perry_hir::ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen-arkts/tests/phase2_full_app_smoke.rs
+++ b/crates/perry-codegen-arkts/tests/phase2_full_app_smoke.rs
@@ -52,6 +52,7 @@ fn empty_module() -> Module {
         has_top_level_await: false,
         init_kind: perry_hir::ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -1200,28 +1200,64 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
     //       nested closures keep the anonymous label, matching Node
     //       (Node uses `inferred-name` only for direct assignments,
     //       which are exactly these top-level lets).
+    // (a) Top-level user functions — keyed against the singleton-wrapper
+    // address (`__perry_wrap_<sym>`). #2076: prefer the HIR display-name
+    // override (set by lower_fn_expr / lower_method_prop) so synthetic
+    // names like `__obj_method_method_42` register as `"method"`.
     let mut user_fn_display_names: Vec<(String, String)> = hir
         .functions
         .iter()
         .filter_map(|f| {
-            if f.name.is_empty() || f.name.starts_with('_') {
-                return None;
-            }
+            let display = hir.closure_display_names.get(&f.id).cloned().or_else(|| {
+                if f.name.is_empty() || f.name.starts_with('_') {
+                    None
+                } else {
+                    Some(f.name.clone())
+                }
+            })?;
             func_names
                 .get(&f.id)
-                .map(|sym| (format!("__perry_wrap_{}", sym), f.name.clone()))
+                .map(|sym| (format!("__perry_wrap_{}", sym), display))
         })
         .collect();
+    // (b) Closures bound to a top-level `let`/`const`. #2076: a named
+    // function expression's own name takes precedence over the binding
+    // name (`const bar = function namedBar(){}` ⇒ `"namedBar"`).
+    let mut named_inline_closure_ids: std::collections::HashSet<perry_types::FuncId> =
+        std::collections::HashSet::new();
     for stmt in &hir.init {
         if let perry_hir::Stmt::Let { name, init, .. } = stmt {
             if name.is_empty() || name.starts_with('_') {
                 continue;
             }
             if let Some(perry_hir::Expr::Closure { func_id, .. }) = init {
+                let display = hir
+                    .closure_display_names
+                    .get(func_id)
+                    .cloned()
+                    .unwrap_or_else(|| name.clone());
                 let sym = format!("perry_closure_{}__{}", module_prefix, func_id);
-                user_fn_display_names.push((sym, name.clone()));
+                user_fn_display_names.push((sym, display));
+                named_inline_closure_ids.insert(*func_id);
             }
         }
+    }
+    // (c) Inline closures with a HIR display name that weren't picked up
+    // by (a) or (b) — e.g. an object-literal shorthand method that
+    // captured locals or used `this` and lowered to an inline Closure
+    // instead of a FuncRef. Skip ids already covered above and any id
+    // that hir.functions already produced a wrapper entry for.
+    let registered_fn_ids: std::collections::HashSet<perry_types::FuncId> =
+        hir.functions.iter().map(|f| f.id).collect();
+    for (func_id, display) in &hir.closure_display_names {
+        if display.is_empty() || named_inline_closure_ids.contains(func_id) {
+            continue;
+        }
+        if registered_fn_ids.contains(func_id) {
+            continue;
+        }
+        let sym = format!("perry_closure_{}__{}", module_prefix, func_id);
+        user_fn_display_names.push((sym, display.clone()));
     }
 
     emit_string_pool(

--- a/crates/perry-codegen/tests/large_object_barriers.rs
+++ b/crates/perry-codegen/tests/large_object_barriers.rs
@@ -125,6 +125,7 @@ fn module_with_large_pointer_array_literal(element_count: usize) -> Module {
         has_top_level_await: false,
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 
@@ -186,6 +187,7 @@ fn module_with_large_local_array_push(element_count: usize) -> Module {
         has_top_level_await: false,
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/native_proof_buffer_views.rs
+++ b/crates/perry-codegen/tests/native_proof_buffer_views.rs
@@ -103,6 +103,7 @@ fn module_with_classes_and_params(
         has_top_level_await: false,
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -103,6 +103,7 @@ fn module_with_classes_and_params(
         has_top_level_await: false,
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/shadow_slot_hygiene.rs
+++ b/crates/perry-codegen/tests/shadow_slot_hygiene.rs
@@ -118,6 +118,7 @@ fn shadow_hygiene_module() -> Module {
         has_top_level_await: false,
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 
@@ -168,6 +169,7 @@ fn top_level_shadow_module(name: &str) -> Module {
         has_top_level_await: false,
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 
@@ -247,6 +249,7 @@ fn flat_const_row_alias_shadow_module() -> Module {
         has_top_level_await: false,
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 
@@ -298,6 +301,7 @@ fn reassigned_any_shadow_module() -> Module {
         has_top_level_await: false,
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 
@@ -364,6 +368,7 @@ fn mixed_any_alias_shadow_module() -> Module {
         has_top_level_await: false,
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 
@@ -435,6 +440,7 @@ fn closure_captured_write_shadow_module() -> Module {
         has_top_level_await: false,
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -143,6 +143,7 @@ fn module_with_classes(
         has_top_level_await: false,
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/typed_shape_descriptor.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptor.rs
@@ -127,6 +127,7 @@ fn module_with_new(class: Class) -> Module {
         has_top_level_await: false,
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/typed_shape_descriptors.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptors.rs
@@ -141,6 +141,7 @@ fn base_module(name: &str, body: Vec<Stmt>, interfaces: Vec<Interface>) -> Modul
         has_top_level_await: false,
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-hir/src/ir/module.rs
+++ b/crates/perry-hir/src/ir/module.rs
@@ -75,6 +75,14 @@ pub struct Module {
     /// returning a Promise (no busy-wait pump needed). Populated by the
     /// transform pass; consumed by codegen.
     pub async_step_closures: std::collections::HashSet<perry_types::FuncId>,
+    /// Issue #2076: display name overrides for `fn.name`/`console.log`.
+    /// Populated at lowering for two cases the binding-name registration
+    /// path can't see:
+    ///   • named function expressions (`const x = function f(){}` → `"f"`)
+    ///   • object-literal shorthand/method properties (`{m(){}}` → `"m"`)
+    /// Keyed by the closure/function's HIR FuncId; consumed by codegen
+    /// when emitting `js_register_function_name` calls.
+    pub closure_display_names: std::collections::HashMap<perry_types::FuncId, String>,
 }
 
 impl Module {
@@ -102,6 +110,7 @@ impl Module {
             has_top_level_await: false,
             init_kind: ModuleInitKind::Eager,
             async_step_closures: std::collections::HashSet::new(),
+            closure_display_names: std::collections::HashMap::new(),
         }
     }
 }

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -59,6 +59,7 @@ impl LoweringContext {
             source_file_path: source_file_path.into(),
             exportable_object_vars: HashSet::new(),
             pending_functions: Vec::new(),
+            closure_display_names: HashMap::new(),
             func_return_native_instances: Vec::new(),
             pending_classes: Vec::new(),
             func_return_types: Vec::new(),

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -550,6 +550,16 @@ pub(crate) fn lower_fn_expr(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) ->
 
     let (captures, mutable_captures) = compute_closure_captures(ctx, &body, &outer_locals, &params);
 
+    // #2076: a named function expression's own ident is its `fn.name`
+    // per spec, regardless of the binding identifier it's later assigned
+    // to. `const bar = function namedBar(){}` ⇒ `bar.name === "namedBar"`.
+    if let Some(ident) = &fn_expr.ident {
+        let own_name = ident.sym.to_string();
+        if !own_name.is_empty() {
+            ctx.closure_display_names.insert(func_id, own_name);
+        }
+    }
+
     Ok(Expr::Closure {
         func_id,
         params,

--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -126,6 +126,16 @@ fn lower_method_prop(
     };
     let key: String = key_label.clone();
     let func_id = ctx.fresh_func();
+    // #2076: an object-literal shorthand method's `fn.name` is the
+    // property key per spec (`{m(){}}.m.name === "m"`). The synthetic
+    // function name we mint below (`__obj_method_<key>_<id>`) starts
+    // with `_`, so the artifacts.rs registration loop would skip it
+    // without this override.
+    if let MethodKeyKind::Static(s) = &method_key {
+        if !s.is_empty() {
+            ctx.closure_display_names.insert(func_id, s.clone());
+        }
+    }
     // Use a unique synthetic name to avoid collisions
     let func_name = format!("__obj_method_{}_{}", key, func_id);
 

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -348,6 +348,11 @@ pub fn lower_module_full(
         for func in ctx.pending_functions.drain(..) {
             module.functions.push(func);
         }
+        // Flush #2076 display-name overrides recorded for named fn
+        // expressions and object-literal methods.
+        for (id, name) in ctx.closure_display_names.drain() {
+            module.closure_display_names.insert(id, name);
+        }
         // Flush any pending classes created during expression lowering
         // (e.g., class expressions in `new (class extends Command { ... })()`)
         for class in ctx.pending_classes.drain(..) {

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -158,6 +158,11 @@ pub struct LoweringContext {
     /// Functions created during expression lowering (e.g., object literal methods)
     /// These are flushed to the module after the enclosing statement is lowered.
     pub(crate) pending_functions: Vec<Function>,
+    /// Issue #2076: display-name overrides keyed by FuncId. Populated for
+    /// named function expressions (own ident) and object-literal methods
+    /// (static property key); flushed into `Module.closure_display_names`
+    /// alongside `pending_functions`.
+    pub(crate) closure_display_names: HashMap<FuncId, String>,
     /// Functions that return native module instances: func_name -> (module_name, class_name)
     /// Tracks user-defined functions whose return type annotation is a native module type
     /// (e.g., initializePool(): mysql.Pool -> ("mysql2/promise", "Pool"))

--- a/crates/perry-hir/src/stable_hash/module.rs
+++ b/crates/perry-hir/src/stable_hash/module.rs
@@ -32,6 +32,7 @@ impl SH for Module {
             has_top_level_await,
             init_kind,
             async_step_closures,
+            closure_display_names,
         } = self;
         name.hash(h);
         imports.hash(h);
@@ -58,6 +59,14 @@ impl SH for Module {
         let mut ids: Vec<u32> = async_step_closures.iter().copied().collect();
         ids.sort_unstable();
         ids.hash(h);
+        // HashMap has nondeterministic iteration order; sort by key.
+        let mut display_pairs: Vec<(u32, &String)> =
+            closure_display_names.iter().map(|(k, v)| (*k, v)).collect();
+        display_pairs.sort_unstable_by_key(|(k, _)| *k);
+        for (id, name) in display_pairs {
+            id.hash(h);
+            name.hash(h);
+        }
     }
 }
 

--- a/test-files/test_gap_function_name_inference_2076.ts
+++ b/test-files/test_gap_function_name_inference_2076.ts
@@ -1,0 +1,26 @@
+// #2076: function .name inference for named function expressions and
+// object-literal shorthand methods. Verified against
+// `node --experimental-strip-types`.
+
+// (1) Named function expression — own name wins over binding name.
+const bar = function namedBar() {};
+console.log(bar.name);
+
+// (2) Object-literal shorthand method — key becomes the function name.
+const obj = { method() {} };
+console.log(obj.method.name);
+
+// (3) Console formatting picks up the same registry.
+console.log(bar);
+console.log(obj.method);
+
+// (4) Regression: anonymous arrow assigned to a `const` still inherits
+// the binding name (existing behavior must not break).
+const baz = () => {};
+console.log(baz.name);
+
+// (5) Regression: named declaration `function foo(){}` still resolves
+// to its own name.
+function foo() {}
+console.log(foo.name);
+console.log(foo);


### PR DESCRIPTION
## Summary

Fixes the two `fn.name` inference gaps from #2076 (follow-up to #2059).

### Before
```js
const bar = function namedBar() {};   // perry: "bar"      node: "namedBar"
const obj = { method() {} };           // perry: ""         node: "method"
```

### After
Byte-identical to `node --experimental-strip-types` for both shapes, including `console.log(bar)` / `console.log(obj.method)` which consult the same registry.

## Approach

New side table on `Module`:

```rust
pub closure_display_names: HashMap<FuncId, String>,
```

Populated at HIR lowering for the two shapes the binding-name registration loop in `codegen/artifacts.rs` couldn't see:

* `lower_fn_expr` — records `(func_id → ident.sym)` when the FnExpr has an own name. The Let-binding loop in artifacts.rs now prefers the side-table entry over the binding name (`const bar = function namedBar(){}` ⇒ `"namedBar"`, not `"bar"`).
* `lower_method_prop` — records `(func_id → key)` for static-key shorthand methods. The `hir.functions` loop now accepts side-table overrides for synthetic names (`__obj_method_<key>_<id>` was previously skipped by the leading-underscore filter). A third pass picks up closures with captures or `this` usage that lowered to inline `Expr::Closure` instead of `FuncRef`.

Both fixes also flow into `console.log(fn)` formatting since it consults the same `function_name_registry`.

## Test plan

- [x] `test-files/test_gap_function_name_inference_2076.ts` byte-identical to node (covers both shapes + regression checks for anonymous arrow and named declaration).
- [x] `cargo test --release -p perry-hir` green.
- [x] `cargo test --release -p perry-codegen` green (12 tests in artifacts suite — touched Module-literal sites in 7 test files updated for the new field).
- [x] `cargo fmt --all -- --check` clean.
- [x] Gap-test sweep across `test-files/test_gap_*.ts`: 95/100 pass; the 5 failures (`class_advanced`, `console_methods`, `derived_param_props`, `json_map_set`, `param_prop_array_index`) all fail identically on `main` — pre-existing.

Closes #2076.
