### PR TITLE
fix(runtime): process.chdir() throws Node-shaped Error on failure (#2135)

### DIFF
--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -1038,7 +1038,10 @@ pub extern "C" fn js_process_next_tick(callback: *const crate::closure::ClosureH
     crate::builtins::js_queue_next_tick(callback as i64);
 }
 
-/// process.chdir(directory) — change working directory.
+/// process.chdir(directory) — change working directory. Throws a Node-shaped
+/// `Error` (`code`/`syscall`/`path` populated) when the target can't be entered,
+/// matching `ENOENT: no such file or directory, chdir '<cwd>' -> '<target>'`.
+/// Refs #2135 (process parity, chdir error message gap).
 #[no_mangle]
 pub extern "C" fn js_process_chdir(dir_ptr: *const StringHeader) {
     unsafe {
@@ -1048,10 +1051,53 @@ pub extern "C" fn js_process_chdir(dir_ptr: *const StringHeader) {
         let len = (*dir_ptr).byte_len as usize;
         let data = (dir_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
         let bytes = std::slice::from_raw_parts(data, len);
-        if let Ok(s) = std::str::from_utf8(bytes) {
-            let _ = std::env::set_current_dir(s);
+        let Ok(target) = std::str::from_utf8(bytes) else {
+            return;
+        };
+        if let Err(err) = std::env::set_current_dir(target) {
+            throw_chdir_error(&err, target);
         }
     }
+}
+
+/// libuv-style POSIX `ERR_*` for an `io::Error`, scoped to the kinds
+/// `chdir(2)` can return.
+fn chdir_error_code(err: &std::io::Error) -> &'static str {
+    use std::io::ErrorKind;
+    match err.kind() {
+        ErrorKind::NotFound => "ENOENT",
+        ErrorKind::PermissionDenied => "EACCES",
+        ErrorKind::NotADirectory => "ENOTDIR",
+        _ => "EIO",
+    }
+}
+
+/// Human-readable description matching Node's libuv `chdir` error strings.
+/// Node hardcodes these in its libuv error table; `io::Error::to_string()`
+/// uses Rust's text (e.g. "entity not found"), which would diverge from
+/// Node's output byte-for-byte.
+fn chdir_error_description(code: &str) -> &'static str {
+    match code {
+        "ENOENT" => "no such file or directory",
+        "EACCES" => "permission denied",
+        "ENOTDIR" => "not a directory",
+        _ => "i/o error",
+    }
+}
+
+unsafe fn throw_chdir_error(err: &std::io::Error, target: &str) -> ! {
+    let code = chdir_error_code(err);
+    let desc = chdir_error_description(code);
+    let cwd = std::env::current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    let message = format!("{code}: {desc}, chdir '{cwd}' -> '{target}'");
+    let msg_ptr = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    crate::node_submodules::register_error_code_pub(msg_ptr, code);
+    crate::node_submodules::register_error_syscall(msg_ptr, "chdir");
+    crate::node_submodules::register_error_path(msg_ptr, target.to_string());
+    let err_ptr = crate::error::js_error_new_with_message(msg_ptr);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err_ptr as i64));
 }
 
 /// process.kill(pid, signal?) — send signal to process. signal=0 means existence check.

--- a/test-files/test_issue_2135_chdir_error.ts
+++ b/test-files/test_issue_2135_chdir_error.ts
@@ -1,0 +1,30 @@
+// Refs #2135: `process.chdir()` to a missing / non-directory target previously
+// no-op'd silently. Node throws an `Error` with `code` / `syscall` / `path`
+// set and a libuv-formatted message:
+//   ENOENT: no such file or directory, chdir '<cwd>' -> '<target>'
+// The runtime now mirrors that shape so user code that catches and inspects
+// the error matches Node byte-for-byte.
+
+const origCwd = process.cwd();
+
+// Success round-trip: chdir-then-chdir-back leaves the cwd unchanged.
+process.chdir("/tmp");
+console.log(process.cwd());
+process.chdir(origCwd);
+console.log(process.cwd() === origCwd);
+
+// Missing directory → ENOENT
+try {
+    process.chdir("/this/dir/does/not/exist_perry_2135");
+    console.log("no throw");
+} catch (e: any) {
+    console.log(e.code, e.syscall);
+}
+
+// Existing path that is not a directory → ENOTDIR (every Unix host has /etc/hosts)
+try {
+    process.chdir("/etc/hosts");
+    console.log("no throw");
+} catch (e: any) {
+    console.log(e.code, e.syscall);
+}


### PR DESCRIPTION
## Summary

- `process.chdir(target)` previously silently discarded the underlying `io::Error`, so a caller's `try/catch` saw no error and the post-call code ran with an unchanged cwd. Match Node by throwing an `Error` with a libuv-style message and the existing side-table for `.code` / `.syscall` / `.path`:

      ENOENT: no such file or directory, chdir '<cwd>' -> '<target>'

- POSIX codes mapped: `ENOENT` / `EACCES` / `ENOTDIR`. The human-readable description is hardcoded against the code (not `io::Error::to_string()`), because Rust's "entity not found" text would diverge from Node's libuv "no such file or directory" byte-for-byte.

Closes one of the chdir-error-message output diffs tracked in #2135.

## Test plan

- New gap test `test-files/test_issue_2135_chdir_error.ts` byte-identical with Node — covers success round-trip, missing-dir (`ENOENT`), and not-a-directory (`/etc/hosts`, `ENOTDIR`).
- `cargo fmt --all -- --check` clean.
- `cargo test --release -p perry-runtime --lib` — 738 tests pass.
