### PR TITLE
fix(node:buffer): estimate base64 byte length

### DIFF
--- a/crates/perry-runtime/src/buffer/query.rs
+++ b/crates/perry-runtime/src/buffer/query.rs
@@ -171,8 +171,19 @@ pub extern "C" fn js_buffer_byte_length_value(value: f64, encoding: f64) -> i32 
             return (len / 2) as i32;
         }
         if eq_ascii_lower(enc_bytes, b"base64") || eq_ascii_lower(enc_bytes, b"base64url") {
-            let decoded = base64_decode_into_buffer(bytes);
-            return (*decoded).length as i32;
+            // Node's Buffer.byteLength assumes valid base64/base64url input
+            // instead of decoding. It only discounts up to two trailing `=`
+            // padding characters, then applies the 3/4 base64 ratio.
+            let mut code_units = std::str::from_utf8(bytes)
+                .map(|s| s.encode_utf16().count())
+                .unwrap_or(len);
+            if code_units > 0 && bytes.last() == Some(&b'=') {
+                code_units -= 1;
+                if code_units > 1 && bytes.get(bytes.len().saturating_sub(2)) == Some(&b'=') {
+                    code_units -= 1;
+                }
+            }
+            return ((code_units * 3) / 4) as i32;
         }
         if eq_ascii_lower(enc_bytes, b"ascii")
             || eq_ascii_lower(enc_bytes, b"latin1")


### PR DESCRIPTION
Part of #793.

## Summary
- Match Node's `Buffer.byteLength(str, "base64"|"base64url")` estimate instead of decoding first.
- Count UTF-16 code units for string inputs, discount up to two trailing `=` padding characters, and apply the 3/4 base64 ratio.
- Keep Buffer.from/base64 decode behavior, invalid-base64 validation, and non-base64 encodings out of scope.

## Evidence
- Baseline exact `node-suite/buffer/byte-length/edge-encodings`: FAIL, report `test-parity/reports/parity_report_20260528_110221.json`.
- Final exact `node-suite/buffer/byte-length/edge-encodings`: PASS, report `test-parity/reports/parity_report_20260528_110601.json`.
- Full `node-suite/buffer/byte-length`: PASS 6/6, report `test-parity/reports/parity_report_20260528_110654.json`.
- Full granular `node-suite/buffer`: 104 PASS / 11 parity FAIL / 1 compile FAIL, report `test-parity/reports/parity_report_20260528_110702.json`; byte-length is green, with allocation/concat residuals covered by open PRs #2274/#2271.
- `cargo check -p perry-runtime -p perry-stdlib -p perry-codegen`: PASS with existing warnings.
- `cargo fmt --check`, `jq empty test-parity/known_failures.json`, and `git diff --check`: PASS.

DeepWiki note saved locally at `reference/deepwiki/nodejs-node-buffer-byte-length-base64-edge-2026-05-28.md` (not staged).

## Non-goals
- No Buffer.from base64 decode semantics.
- No invalid-base64 validation.
- No hex/ascii/utf16 byteLength changes.
- No broad buffer inventory cleanup.