### PR TITLE
test(parity): bisect #1635 gap-bisect bundles — 3 pass, 2 split into #2277/#2278

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -14,29 +14,17 @@
     "category": "bug-stale",
     "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #655 is closed. Deliberate failing repro/harness — kept as a regression canary. Canonical regression-catcher for issue #655. Flips to PASS when the underlying fix lands. Keep regardless of CI verdict — it's a deliberate failing repro."
   },
-  "test_edge_regression": {
-    "issue": "1635",
-    "added": "2026-05-15",
-    "category": "gap-bisect",
-    "reason": "Tracked in #1635 (gap-bisect backlog). Broad edge-case bundle covering multiple historical regressions. Bisect needed to pin which sub-case still fails so a tracking issue can be filed against that specific behavior. Not a recent regression."
-  },
   "test_edge_type_narrowing": {
-    "issue": "1635",
+    "issue": "2277",
     "added": "2026-05-15",
-    "category": "gap-bisect",
-    "reason": "Tracked in #1635 (gap-bisect backlog). Several TS type-narrowing patterns (control-flow narrowing, discriminated unions through generics, `in` operator narrowing) Perry's HIR doesn't track yet. Surfaced multiple narrow-fix candidates; split into per-pattern issues before tackling."
-  },
-  "test_gap_array_methods": {
-    "issue": "1635",
-    "added": "2026-05-15",
-    "category": "gap-bisect",
-    "reason": "Tracked in #1635 (gap-bisect backlog). Array method coverage probe — small divergences (flat/flatMap/finally specific edge cases). Targeted bisect needed; not a recent regression. File a tracking issue once a specific sub-case is pinned."
+    "category": "bug-open",
+    "reason": "Bisected 2026-05-28 for #1635: single residual sub-case is `typeof === \"string\"` narrowing on a `string | number[]` union — else-branch leaves the array remainder mis-typed as string, so `.join` lowers as a string method and throws. Tracked under #2277."
   },
   "test_gap_class_advanced": {
-    "issue": "1635",
+    "issue": "2278",
     "added": "2026-05-17",
-    "category": "gap-bisect",
-    "reason": "Tracked in #1635 (gap-bisect backlog). Advanced class features (static blocks, private brand checks, etc.) — bisect required to identify which sub-feature fails byte-for-byte vs Node."
+    "category": "bug-open",
+    "reason": "Bisected 2026-05-28 for #1635: single residual sub-case is a static class block assigning `true` to a declared `static initialized: boolean` field — read-back returns `0` instead of `true`. Tracked under #2278."
   },
   "test_gap_regexp_advanced": {
     "issue": null,
@@ -79,12 +67,6 @@
     "added": "2026-05-24",
     "category": "bug-stale",
     "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #922 is closed. Deliberate failing repro/harness — kept as a regression canary. Regression test from #922 (P0 production /api crash). Deliberate failing repro until the underlying codegen bug is fixed; #934 added a circuit breaker that converts the runaway loop into [PERRY ABORT] (so test fails by design — the abort message diverges from Node's success output)."
-  },
-  "test_jsruntime_mixed_async_ordering_matrix": {
-    "issue": "1635",
-    "added": "2026-05-17",
-    "category": "gap-bisect",
-    "reason": "Tracked in #1635 (gap-bisect backlog). Mixed async ordering between native + V8-fallback promise chains. Long-tail jsruntime parity work; bisect needed to identify which interleaving shape diverges."
   },
   "test_net_min": {
     "issue": "1634",


### PR DESCRIPTION
## Summary

Bisected the 5 `gap-bisect` bundles filed against #1635:

| Bundle | Verdict | Action |
| --- | --- | --- |
| `test_edge_regression` | now byte-identical to Node | removed from skip-list |
| `test_gap_array_methods` | now byte-identical to Node | removed from skip-list |
| `test_jsruntime_mixed_async_ordering_matrix` | source file no longer exists in `test-files/` | removed from skip-list |
| `test_edge_type_narrowing` | single residual sub-case | retargeted to #2277 |
| `test_gap_class_advanced` | single residual sub-case | retargeted to #2278 |

### Residuals

- **#2277**: `typeof === "string"` narrowing on `string | number[]` leaves the else-branch mis-typed as string, so `.join` lowers as a string method and throws. The rest of the file (control-flow narrowing, discriminated-union dispatch, `in`-operator narrowing) passes.
- **#2278**: a `static {}` block assigning `true` to a declared `static initialized: boolean` reads back `0` instead of `true`. The rest of the advanced-class probes (private brand checks, decorator metadata, etc.) pass.

Net effect: three bundles cleared, two bundle entries downgraded from "fan-out gap-bisect" to "focused per-feature bug" (category `bug-open`).

## Test plan

- [x] `cargo fmt --all -- --check` clean (only a JSON edit).
- [x] Each removed bundle verified `BYTE-IDENTICAL` to `node --experimental-strip-types`.
- [x] Each residual entry's repro (in #2277 / #2278) reproduces only the single isolated sub-case noted.

Refs #1635.
