### PR TITLE
fix(node:buffer): expose default iterator

### DIFF
--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -784,6 +784,26 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
             }
         }
     }
+    // Buffers inherit TypedArray iteration semantics in Node: the default
+    // iterator is `values()`, yielding numeric bytes.
+    let raw_addr = if (bits >> 48) >= 0x7FF8 {
+        (bits & POINTER_MASK) as usize
+    } else {
+        bits as usize
+    };
+    if raw_addr >= 0x1000 && crate::buffer::is_registered_buffer(raw_addr) {
+        let iter_wk = well_known_symbol("iterator");
+        if !iter_wk.is_null() {
+            let iter_f64 =
+                f64::from_bits(crate::value::JSValue::pointer(iter_wk as *const u8).bits());
+            if sym_key_from_f64(sym_f64) == sym_key_from_f64(iter_f64) {
+                let this_f64 =
+                    f64::from_bits(crate::value::js_nanbox_pointer(raw_addr as i64).to_bits());
+                let mname = b"values";
+                return crate::object::js_class_method_bind(this_f64, mname.as_ptr(), mname.len());
+            }
+        }
+    }
     // #321: arrays expose `Symbol.iterator`. perry has no standalone array
     // iterator object (for-of is special-cased), but `arr[Symbol.iterator]`
     // must resolve to a callable so `Symbol.iterator in arr` is true


### PR DESCRIPTION
Part of #793.

## Summary
- Expose Buffer `Symbol.iterator` as a bound `values()` method.
- Reuse Perry's existing BufferIterator implementation so `for...of` over Buffers yields numeric byte values.
- Leave Buffer `keys()`/`entries()`, typed-array iterator internals, and generic for-of lowering out of scope.

## Evidence
- Baseline filter `node-suite/buffer/properties/iterator`: 1 PASS / 1 FAIL, report `test-parity/reports/parity_report_20260528_111516.json`.
- Final filter `node-suite/buffer/properties/iterator`: PASS 2/2, report `test-parity/reports/parity_report_20260528_111907.json`.
- Full `node-suite/buffer/properties`: PASS 14/14, report `test-parity/reports/parity_report_20260528_111955.json`.
- Full granular `node-suite/buffer`: 104 PASS / 11 parity FAIL / 1 compile FAIL, report `test-parity/reports/parity_report_20260528_112011.json`; `properties/iterator` is green, with allocation/byteLength/concat residuals covered by open PRs #2274/#2276/#2271.
- `cargo check -p perry-runtime -p perry-stdlib -p perry-codegen`: PASS with existing warnings.
- `cargo fmt --check`, `jq empty test-parity/known_failures.json`, and `git diff --check`: PASS.

DeepWiki note saved locally at `reference/deepwiki/nodejs-node-buffer-for-of-iterator-2026-05-28.md` (not staged).

## Non-goals
- No typed-array iterator rewrite.
- No Buffer keys/entries behavior changes.
- No generic for-of lowering changes.
- No broad buffer inventory cleanup.