### PR TITLE
fix(runtime): close SSO short-string blind spots in object key paths (#1781)

### DIFF
--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -567,10 +567,21 @@ pub unsafe extern "C" fn js_object_copy_own_fields(dst_i64: i64, src_f64: f64) {
     // silently dropped 9th..Nth properties.
     for i in 0..key_count {
         let key_val = crate::array::js_array_get(src_keys, i as u32);
-        if !key_val.is_string() {
+        // #1781: SSO-aware copy — pre-fix the `is_string()` here
+        // silently dropped any ≤5-byte key stored as a SHORT_STRING_TAG
+        // value, so `Object.assign(target, src)` lost `src.id`,
+        // `src.tag`, `src.name`, etc. when those slots used inline SSO.
+        // Route SSO through `js_get_string_pointer_unified` so the
+        // destination set-by-name path sees a stable heap pointer.
+        if !key_val.is_any_string() {
             continue;
         }
-        let key_ptr = key_val.as_string_ptr();
+        let key_f64 = f64::from_bits(key_val.bits());
+        let key_ptr =
+            crate::value::js_get_string_pointer_unified(key_f64) as *const crate::StringHeader;
+        if key_ptr.is_null() {
+            continue;
+        }
         let field_f64 = if i < alloc_limit {
             let field_bits = *src_fields.add(i);
             f64::from_bits(field_bits)
@@ -658,12 +669,18 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
         let header_size = std::mem::size_of::<ObjectHeader>();
         let src_fields = (src as *const u8).add(header_size) as *const u64;
         // Same overflow-aware iteration as `js_object_copy_own_fields`.
+        // #1781: SSO-aware — see the sibling helper above.
         for i in 0..key_count {
             let key_val = crate::array::js_array_get(src_keys, i as u32);
-            if !key_val.is_string() {
+            if !key_val.is_any_string() {
                 continue;
             }
-            let key_ptr = key_val.as_string_ptr();
+            let key_f64 = f64::from_bits(key_val.bits());
+            let key_ptr =
+                crate::value::js_get_string_pointer_unified(key_f64) as *const crate::StringHeader;
+            if key_ptr.is_null() {
+                continue;
+            }
             let field_f64 = if i < alloc_limit {
                 let field_bits = *src_fields.add(i);
                 f64::from_bits(field_bits)

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -26,12 +26,12 @@ pub extern "C" fn js_object_delete_field(
         let mut found_idx: Option<usize> = None;
         for i in 0..key_count {
             let key_val = crate::array::js_array_get(keys, i as u32);
-            if key_val.is_string() {
-                let stored_key = key_val.as_string_ptr();
-                if crate::string::js_string_equals(key, stored_key) != 0 {
-                    found_idx = Some(i);
-                    break;
-                }
+            // #1781: SSO-aware match — pre-fix `delete obj.id` on an
+            // object whose `id` lived as an inline SSO key reported
+            // success vacuously without actually deleting anything.
+            if crate::string::js_string_key_matches(key_val, key) {
+                found_idx = Some(i);
+                break;
             }
         }
 
@@ -186,14 +186,20 @@ pub extern "C" fn js_object_rest(
             crate::array::js_array_length(exclude_keys) as usize
         };
 
-        // Collect indices of keys to include (not in exclude list and not undefined/deleted)
+        // Collect indices of keys to include (not in exclude list and not undefined/deleted).
+        // #1781: SSO-aware — the pre-fix `is_string()` on the source
+        // key dropped ≤5-byte SSO keys from `rest`; the exclude-loop's
+        // `is_string()` similarly missed inline-SSO exclude entries,
+        // so a `{a, ...rest}` pattern silently kept `a` in `rest` when
+        // both the source key and the exclude key were SSO.
         let mut include_indices: Vec<usize> = Vec::new();
+        let mut src_buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
         for i in 0..key_count {
             let key_val = crate::array::js_array_get(keys, i as u32);
-            if !key_val.is_string() {
-                continue;
-            }
-            let key_str = key_val.as_string_ptr();
+            let key_bytes = match crate::string::js_string_key_bytes(key_val, &mut src_buf) {
+                Some(b) => b.to_vec(),
+                None => continue,
+            };
 
             // Check if field was deleted
             let field_val = js_object_get_field(src, i as u32);
@@ -205,12 +211,9 @@ pub extern "C" fn js_object_rest(
             let mut excluded = false;
             for j in 0..exclude_count {
                 let ex_val = crate::array::js_array_get(exclude_keys, j as u32);
-                if ex_val.is_string() {
-                    let ex_str = ex_val.as_string_ptr();
-                    if crate::string::js_string_equals(key_str, ex_str) != 0 {
-                        excluded = true;
-                        break;
-                    }
+                if crate::string::js_string_key_matches_bytes(ex_val, &key_bytes) {
+                    excluded = true;
+                    break;
                 }
             }
             if !excluded {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -95,8 +95,10 @@ unsafe fn own_data_field_by_name(
     let alloc_limit = std::cmp::max((*obj).field_count, 8) as usize;
     for i in 0..key_count {
         let key_val = crate::array::js_array_get(keys, i as u32);
-        if key_val.is_string() && crate::string::js_string_equals(key, key_val.as_string_ptr()) != 0
-        {
+        // #1781: accept inline SSO short keys — `is_string()` is
+        // STRING_TAG-only, so the pre-fix shape silently skipped any
+        // ≤5-byte key stored as a `SHORT_STRING_TAG` value.
+        if crate::string::js_string_key_matches(key_val, key) {
             if i < alloc_limit {
                 return Some(js_object_get_field(obj, i as u32));
             }
@@ -556,19 +558,16 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
         }
         // Slow path: filter out non-enumerable keys.
         let filtered = crate::array::js_array_alloc(len as u32);
+        let mut sso_buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
         for i in 0..len {
             let key_val = crate::array::js_array_get(keys, i as u32);
-            if !key_val.is_string() {
-                continue;
-            }
-            let stored_key = key_val.as_string_ptr();
-            if stored_key.is_null() {
-                continue;
-            }
-            let name_ptr =
-                (stored_key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-            let name_len = (*stored_key).byte_len as usize;
-            let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
+            // #1781: accept inline SSO short keys (≤5 bytes) — the
+            // pre-fix `is_string()` skipped them and Object.keys silently
+            // dropped them from the result.
+            let name_bytes = match crate::string::js_string_key_bytes(key_val, &mut sso_buf) {
+                Some(b) => b,
+                None => continue,
+            };
             let key_str = match std::str::from_utf8(name_bytes) {
                 Ok(s) => s,
                 Err(_) => continue,
@@ -868,16 +867,15 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
         let key_count = crate::array::js_array_length(keys) as usize;
         for i in 0..key_count {
             let stored_key_val = crate::array::js_array_get(keys, i as u32);
-            if stored_key_val.is_string() {
-                let stored_key = stored_key_val.as_string_ptr();
-                if crate::string::js_string_equals(key_str, stored_key) != 0 {
-                    // Check if the field was deleted (set to undefined by delete operator)
-                    let field_val = js_object_get_field(obj_ptr, i as u32);
-                    if field_val.is_undefined() {
-                        return nanbox_false;
-                    }
-                    return nanbox_true;
+            // #1781: accept inline SSO short keys (the closure-style
+            // `key in obj` path previously dropped them too).
+            if crate::string::js_string_key_matches(stored_key_val, key_str) {
+                // Check if the field was deleted (set to undefined by delete operator)
+                let field_val = js_object_get_field(obj_ptr, i as u32);
+                if field_val.is_undefined() {
+                    return nanbox_false;
                 }
+                return nanbox_true;
             }
         }
 
@@ -2067,8 +2065,10 @@ pub extern "C" fn js_object_get_field_by_name(
             let idx = field_idx as usize;
             let cache_hit_valid = if idx < key_count {
                 let key_val = crate::array::js_array_get(keys, field_idx);
-                key_val.is_string()
-                    && crate::string::js_string_equals(key, key_val.as_string_ptr()) != 0
+                // #1781: SSO-aware match — pre-fix the `is_string()` here
+                // false-invalidated cache hits for ≤5-byte keys stored
+                // as SHORT_STRING_TAG values.
+                crate::string::js_string_key_matches(key_val, key)
             } else {
                 false
             };
@@ -2112,38 +2112,38 @@ pub extern "C" fn js_object_get_field_by_name(
 
         for i in 0..key_count {
             let key_val = crate::array::js_array_get(keys, i as u32);
-            if key_val.is_string() {
-                let stored_key = key_val.as_string_ptr();
-                if crate::string::js_string_equals(key, stored_key) != 0 {
-                    // Cache this lookup for next time
-                    FIELD_CACHE.with(|c| {
-                        let cache = &mut *c.get();
-                        cache[cache_idx] = (keys_id, key_hash, i as u32);
-                    });
-                    // Accessor short-circuit (see fast path above).
-                    if ACCESSORS_IN_USE.with(|c| c.get()) {
-                        if let Ok(name) = std::str::from_utf8(key_bytes) {
-                            if let Some(acc) = get_accessor_descriptor(obj as usize, name) {
-                                if acc.get != 0 {
-                                    let closure = (acc.get & crate::value::POINTER_MASK)
-                                        as *const crate::closure::ClosureHeader;
-                                    if !closure.is_null() {
-                                        let result_f64 = crate::closure::js_closure_call0(closure);
-                                        return JSValue::from_bits(result_f64.to_bits());
-                                    }
+            // #1781: accept inline SSO short keys here too — the
+            // slow-path lookup is what backs `obj[k]` for ≤5-byte
+            // keys after a field-cache miss.
+            if crate::string::js_string_key_matches(key_val, key) {
+                // Cache this lookup for next time
+                FIELD_CACHE.with(|c| {
+                    let cache = &mut *c.get();
+                    cache[cache_idx] = (keys_id, key_hash, i as u32);
+                });
+                // Accessor short-circuit (see fast path above).
+                if ACCESSORS_IN_USE.with(|c| c.get()) {
+                    if let Ok(name) = std::str::from_utf8(key_bytes) {
+                        if let Some(acc) = get_accessor_descriptor(obj as usize, name) {
+                            if acc.get != 0 {
+                                let closure = (acc.get & crate::value::POINTER_MASK)
+                                    as *const crate::closure::ClosureHeader;
+                                if !closure.is_null() {
+                                    let result_f64 = crate::closure::js_closure_call0(closure);
+                                    return JSValue::from_bits(result_f64.to_bits());
                                 }
-                                return JSValue::undefined();
                             }
+                            return JSValue::undefined();
                         }
                     }
-                    if i < alloc_limit {
-                        return js_object_get_field(obj, i as u32);
-                    } else {
-                        return match overflow_get(obj as usize, i) {
-                            Some(bits) => JSValue::from_bits(bits),
-                            None => JSValue::undefined(),
-                        };
-                    }
+                }
+                if i < alloc_limit {
+                    return js_object_get_field(obj, i as u32);
+                } else {
+                    return match overflow_get(obj as usize, i) {
+                        Some(bits) => JSValue::from_bits(bits),
+                        None => JSValue::undefined(),
+                    };
                 }
             }
         }

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -673,60 +673,60 @@ pub extern "C" fn js_object_set_field_by_name(
 
         for i in 0..key_count {
             let key_val = crate::array::js_array_get(keys, i as u32);
-            // Keys are stored as string pointers (NaN-boxed)
-            if key_val.is_string() {
-                let stored_key = key_val.as_string_ptr();
-                if crate::string::js_string_equals(key, stored_key) != 0 {
-                    // Found it - update the field. Frozen objects must
-                    // throw a TypeError on writes to existing keys
-                    // (issue #615 — strict-mode behavior, default for TS).
-                    if is_frozen {
-                        let key_str = key_to_str_for_diag(key);
-                        crate::error::throw_immutable_write(0, &key_str);
-                    }
-                    // Accessor short-circuit: if a setter is registered, invoke
-                    // it instead of writing the slot. A property with `get` but
-                    // no `set` silently ignores the write (non-strict mode).
-                    if ACCESSORS_IN_USE.with(|c| c.get()) {
-                        if let Some(ref k) = incoming_key_str {
-                            if let Some(acc) = get_accessor_descriptor(obj as usize, k) {
-                                if acc.set != 0 {
-                                    let closure = (acc.set & crate::value::POINTER_MASK)
-                                        as *const crate::closure::ClosureHeader;
-                                    if !closure.is_null() {
-                                        crate::closure::js_closure_call1(closure, value);
-                                    }
-                                }
-                                return;
-                            }
-                        }
-                    }
-                    // Per-property writable check (set by Object.defineProperty / freeze).
-                    // Issue #615 — strict-mode throw on read-only assign.
-                    if PROPERTY_ATTRS_IN_USE.with(|c| c.get()) {
-                        if let Some(ref k) = incoming_key_str {
-                            if let Some(attrs) = get_property_attrs(obj as usize, k) {
-                                if !attrs.writable() {
-                                    crate::error::throw_immutable_write(0, k);
-                                }
-                            }
-                        }
-                    }
-                    if i < alloc_limit {
-                        js_object_set_field(obj, i as u32, JSValue::from_bits(value.to_bits()));
-                    } else {
-                        // This key was previously stored in the overflow map — update it there
-                        let vbits = value.to_bits();
-                        let vbits =
-                            if (vbits >> 48) == 0x7FFD && (vbits & 0x0000_FFFF_FFFF_FFFF) == 0 {
-                                crate::value::TAG_UNDEFINED
-                            } else {
-                                vbits
-                            };
-                        overflow_set(obj as usize, i, vbits);
-                    }
-                    return;
+            // #1781: SSO-aware match — keys are stored as either a
+            // STRING_TAG pointer OR a SHORT_STRING_TAG inline value for
+            // ≤5-byte names. Pre-fix the assignment `obj.id = v` would
+            // append a duplicate `id` key instead of updating the slot
+            // when the original `id` was stored inline as SSO.
+            if crate::string::js_string_key_matches(key_val, key) {
+                // Found it - update the field. Frozen objects must
+                // throw a TypeError on writes to existing keys
+                // (issue #615 — strict-mode behavior, default for TS).
+                if is_frozen {
+                    let key_str = key_to_str_for_diag(key);
+                    crate::error::throw_immutable_write(0, &key_str);
                 }
+                // Accessor short-circuit: if a setter is registered, invoke
+                // it instead of writing the slot. A property with `get` but
+                // no `set` silently ignores the write (non-strict mode).
+                if ACCESSORS_IN_USE.with(|c| c.get()) {
+                    if let Some(ref k) = incoming_key_str {
+                        if let Some(acc) = get_accessor_descriptor(obj as usize, k) {
+                            if acc.set != 0 {
+                                let closure = (acc.set & crate::value::POINTER_MASK)
+                                    as *const crate::closure::ClosureHeader;
+                                if !closure.is_null() {
+                                    crate::closure::js_closure_call1(closure, value);
+                                }
+                            }
+                            return;
+                        }
+                    }
+                }
+                // Per-property writable check (set by Object.defineProperty / freeze).
+                // Issue #615 — strict-mode throw on read-only assign.
+                if PROPERTY_ATTRS_IN_USE.with(|c| c.get()) {
+                    if let Some(ref k) = incoming_key_str {
+                        if let Some(attrs) = get_property_attrs(obj as usize, k) {
+                            if !attrs.writable() {
+                                crate::error::throw_immutable_write(0, k);
+                            }
+                        }
+                    }
+                }
+                if i < alloc_limit {
+                    js_object_set_field(obj, i as u32, JSValue::from_bits(value.to_bits()));
+                } else {
+                    // This key was previously stored in the overflow map — update it there
+                    let vbits = value.to_bits();
+                    let vbits = if (vbits >> 48) == 0x7FFD && (vbits & 0x0000_FFFF_FFFF_FFFF) == 0 {
+                        crate::value::TAG_UNDEFINED
+                    } else {
+                        vbits
+                    };
+                    overflow_set(obj as usize, i, vbits);
+                }
+                return;
             }
         }
 

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -85,18 +85,13 @@ pub extern "C" fn js_create_native_module_namespace(
 pub(crate) unsafe fn read_native_module_name(
     obj_ptr: *const crate::object::ObjectHeader,
 ) -> Option<String> {
-    const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
     let field = crate::object::js_object_get_field(obj_ptr, 0);
-    if !field.is_string() {
-        return None;
-    }
-    let str_ptr = (field.bits() & POINTER_MASK) as *const crate::string::StringHeader;
-    if str_ptr.is_null() || (str_ptr as usize) < 0x1000 {
-        return None;
-    }
-    let len = (*str_ptr).byte_len as usize;
-    let data = (str_ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
-    let bytes = std::slice::from_raw_parts(data, len);
+    // #1781: SSO-aware — a native-module name of ≤ 5 bytes (e.g. `"fs"`,
+    // `"os"`, `"tty"`, `"net"`, `"path"`) is stored as a SHORT_STRING_TAG
+    // value. Pre-fix `is_string()` (STRING_TAG-only) returned None and
+    // the auto-optimize sweep couldn't determine the requested module.
+    let mut sso_buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let bytes = crate::string::js_string_key_bytes(field, &mut sso_buf)?;
     std::str::from_utf8(bytes).ok().map(|s| s.to_string())
 }
 
@@ -998,14 +993,23 @@ pub(crate) unsafe fn get_module_name_from_namespace(namespace_obj: f64) -> &'sta
         return "";
     }
     let module_field = js_object_get_field(obj as *mut _, 0);
-    if module_field.is_string() {
-        let str_ptr = module_field.as_string_ptr();
-        let len = (*str_ptr).byte_len as usize;
-        let data = (str_ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-        std::str::from_utf8(std::slice::from_raw_parts(data, len)).unwrap_or("")
-    } else {
-        ""
+    if !module_field.is_any_string() {
+        return "";
     }
+    // #1781: SSO-aware — ≤5-byte module names (fs, os, …) arrive as
+    // SHORT_STRING_TAG values; route through `js_get_string_pointer_unified`
+    // so SSO materializes onto the GC-managed heap (where its bytes
+    // share the lifetime story the STRING_TAG path already assumes
+    // for the `&'static` lie this signature carries).
+    let module_f64 = f64::from_bits(module_field.bits());
+    let str_ptr =
+        crate::value::js_get_string_pointer_unified(module_f64) as *const crate::StringHeader;
+    if str_ptr.is_null() || (str_ptr as usize) < 0x1000 {
+        return "";
+    }
+    let len = (*str_ptr).byte_len as usize;
+    let data = (str_ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    std::str::from_utf8(std::slice::from_raw_parts(data, len)).unwrap_or("")
 }
 
 /// Return constant (non-method) property values for native modules.

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -637,11 +637,12 @@ unsafe fn ensure_key_in_keys_array(obj: *mut ObjectHeader, key: *const crate::St
     let key_count = crate::array::js_array_length(keys) as usize;
     for i in 0..key_count {
         let stored = crate::array::js_array_get(keys, i as u32);
-        if stored.is_string() {
-            let stored_key = stored.as_string_ptr();
-            if crate::string::js_string_equals(key, stored_key) != 0 {
-                return; // already present
-            }
+        // #1781: SSO-aware match — pre-fix an existing inline-SSO key
+        // wasn't seen here, so `Object.defineProperty(obj, "id", ...)`
+        // on an object that already had `id` as an SSO key
+        // double-inserted instead of overwriting.
+        if crate::string::js_string_key_matches(stored, key) {
+            return; // already present
         }
     }
     // Clone shared keys array if needed, then append.
@@ -933,11 +934,10 @@ unsafe fn own_key_present(obj: *mut ObjectHeader, key: *const crate::StringHeade
     }
     for i in 0..key_count {
         let stored = crate::array::js_array_get(keys, i as u32);
-        if stored.is_string() {
-            let stored_key = stored.as_string_ptr();
-            if !stored_key.is_null() && crate::string::js_string_equals(key, stored_key) != 0 {
-                return true;
-            }
+        // #1781: SSO-aware match — `hasOwnProperty("id")` previously
+        // returned false when "id" lived as an inline SSO key.
+        if crate::string::js_string_key_matches(stored, key) {
+            return true;
         }
     }
     false
@@ -1002,25 +1002,20 @@ pub extern "C" fn js_object_get_own_field_or_undef(
         let alloc_limit = std::cmp::max((*obj).field_count, 8) as usize;
         for i in 0..key_count {
             let key_val = crate::array::js_array_get(keys, i as u32);
-            if key_val.is_string() {
-                let stored_key = key_val.as_string_ptr();
-                if !stored_key.is_null() {
-                    let stored_data =
-                        (stored_key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-                    let stored_len = (*stored_key).byte_len as usize;
-                    let stored_bytes = std::slice::from_raw_parts(stored_data, stored_len);
-                    if stored_bytes == key_bytes {
-                        let val = if i < alloc_limit {
-                            js_object_get_field(obj, i as u32)
-                        } else {
-                            match overflow_get(obj as usize, i) {
-                                Some(bits) => crate::JSValue::from_bits(bits),
-                                None => return f64::from_bits(TAG_UNDEF),
-                            }
-                        };
-                        return f64::from_bits(val.bits());
+            // #1781: SSO-aware match by byte slice — the
+            // own-property-or-undef path was the route through which
+            // hono's `c.req.X` dispatch decided to invoke the vtable
+            // getter, and pre-fix a SSO-stored `X` was invisible here.
+            if crate::string::js_string_key_matches_bytes(key_val, key_bytes) {
+                let val = if i < alloc_limit {
+                    js_object_get_field(obj, i as u32)
+                } else {
+                    match overflow_get(obj as usize, i) {
+                        Some(bits) => crate::JSValue::from_bits(bits),
+                        None => return f64::from_bits(TAG_UNDEF),
                     }
-                }
+                };
+                return f64::from_bits(val.bits());
             }
         }
         f64::from_bits(TAG_UNDEF)
@@ -1678,5 +1673,36 @@ mod sso_tests_1781 {
             )),
             "different content"
         );
+    }
+
+    /// #1781: an object with an inline-SSO key must answer
+    /// `hasOwnProperty("id")` truthfully. Pre-fix the
+    /// `is_string()`-gated keys-array iteration in `own_key_present`
+    /// skipped the SSO key silently and the call returned false.
+    #[test]
+    fn own_key_present_finds_sso_stored_key() {
+        unsafe {
+            let obj = super::super::alloc::js_object_alloc(0, 4);
+            // Build a keys array with a single SSO-tagged key directly
+            // (skipping `js_object_set_field_by_name`, which would
+            // intern the key to heap and bypass the SSO blind spot
+            // we're regression-testing).
+            let keys = crate::array::js_array_alloc(4);
+            let sso = JSValue::try_short_string(b"id").expect("SSO");
+            crate::array::js_array_push_f64(keys, f64::from_bits(sso.bits()));
+            super::super::set_object_keys_array(obj, keys);
+
+            let incoming = crate::string::js_string_from_bytes(b"id".as_ptr(), 2);
+            assert!(
+                own_key_present(obj, incoming),
+                "SSO key 'id' should be visible to own_key_present"
+            );
+
+            let incoming_other = crate::string::js_string_from_bytes(b"tag".as_ptr(), 3);
+            assert!(
+                !own_key_present(obj, incoming_other),
+                "absent key 'tag' must not match"
+            );
+        }
     }
 }

--- a/crates/perry-runtime/src/string/compare.rs
+++ b/crates/perry-runtime/src/string/compare.rs
@@ -71,6 +71,117 @@ pub extern "C" fn js_string_equals(a: *const StringHeader, b: *const StringHeade
     }
 }
 
+/// SSO-aware key match: compare a stored-key `JSValue` (which may be a
+/// `STRING_TAG` heap pointer OR a `SHORT_STRING_TAG` inline SSO value)
+/// against an incoming heap `*const StringHeader` key.
+///
+/// This is the safe replacement for the `key_val.is_string() && js_string_equals(key, key_val.as_string_ptr())`
+/// pattern that recurs in `object/field_get_set.rs`, `object/object_ops.rs`,
+/// `object/delete_rest.rs`, etc. — `is_string()` is STRING_TAG-only, so
+/// any SSO-stored key is silently skipped, which makes `Object.keys`,
+/// `key in obj`, `delete obj[k]`, `obj[k] = v`, and `Object.assign`
+/// drop or duplicate keys whose name is ≤ 5 ASCII bytes (#1781).
+///
+/// Returns `true` iff the stored value is some kind of string AND its
+/// byte contents are equal to the incoming heap key. Returns `false`
+/// for non-string stored values or a null incoming key.
+///
+/// Inline byte comparison — no allocation, no heap materialization of
+/// the SSO operand. Safe on the hot path.
+#[inline]
+pub(crate) unsafe fn js_string_key_matches(
+    stored: crate::JSValue,
+    incoming: *const StringHeader,
+) -> bool {
+    if incoming.is_null() {
+        return false;
+    }
+    // Heap-stored key: defer to the existing equals routine.
+    if stored.is_string() {
+        return js_string_equals(incoming, stored.as_string_ptr()) != 0;
+    }
+    // SSO-stored key: compare the incoming heap bytes against the
+    // inline SSO bytes without materializing the SSO to the heap.
+    if stored.is_short_string() {
+        let incoming_len = (*incoming).byte_len as usize;
+        let sso_len = stored.short_string_len();
+        if incoming_len != sso_len {
+            return false;
+        }
+        let incoming_data = (incoming as *const u8).add(std::mem::size_of::<StringHeader>());
+        let incoming_bytes = std::slice::from_raw_parts(incoming_data, incoming_len);
+        let mut sso_buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+        let n = stored.short_string_to_buf(&mut sso_buf);
+        return &sso_buf[..n] == incoming_bytes;
+    }
+    false
+}
+
+/// SSO-aware byte-slice match for cases where the incoming key already
+/// lives as a `&[u8]` slice (typed-feedback guards, `js_object_get_own_field_or_undef`,
+/// etc.) — same SSO blind-spot fix as [`js_string_key_matches`] but
+/// without the round-trip through a heap `StringHeader` for the
+/// incoming side. Returns `true` iff the stored value is some kind of
+/// string and its bytes equal `incoming_bytes`.
+#[inline]
+pub(crate) unsafe fn js_string_key_matches_bytes(
+    stored: crate::JSValue,
+    incoming_bytes: &[u8],
+) -> bool {
+    if stored.is_string() {
+        let stored_ptr = stored.as_string_ptr();
+        if stored_ptr.is_null() {
+            return false;
+        }
+        let stored_len = (*stored_ptr).byte_len as usize;
+        if stored_len != incoming_bytes.len() {
+            return false;
+        }
+        let stored_data = (stored_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        let stored_slice = std::slice::from_raw_parts(stored_data, stored_len);
+        return stored_slice == incoming_bytes;
+    }
+    if stored.is_short_string() {
+        let sso_len = stored.short_string_len();
+        if sso_len != incoming_bytes.len() {
+            return false;
+        }
+        let mut sso_buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+        let n = stored.short_string_to_buf(&mut sso_buf);
+        return &sso_buf[..n] == incoming_bytes;
+    }
+    false
+}
+
+/// Extract the bytes of a stored-key JSValue (STRING_TAG or SHORT_STRING_TAG)
+/// into a caller-provided buffer + length. Returns `None` for non-string
+/// stored values. The slice borrowing into either the SSO buffer
+/// (`stored_buf`) or the heap pointer is the caller's responsibility.
+///
+/// Used by paths like `Object.keys` and `Object.assign` that need to
+/// materialize the key string into a usable form regardless of which
+/// representation it currently has.
+#[inline]
+pub(crate) unsafe fn js_string_key_bytes<'a>(
+    stored: crate::JSValue,
+    stored_buf: &'a mut [u8; crate::value::SHORT_STRING_MAX_LEN],
+) -> Option<&'a [u8]> {
+    if stored.is_string() {
+        let stored_ptr = stored.as_string_ptr();
+        if stored_ptr.is_null() {
+            return None;
+        }
+        let len = (*stored_ptr).byte_len as usize;
+        let data = (stored_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        return Some(std::slice::from_raw_parts(data, len));
+    }
+    if stored.is_short_string() {
+        let n = stored.short_string_to_buf(stored_buf);
+        return Some(&stored_buf[..n]);
+    }
+    None
+}
+
 /// Check if a string starts with a prefix
 #[no_mangle]
 pub extern "C" fn js_string_starts_with(
@@ -381,4 +492,95 @@ pub extern "C" fn js_string_to_well_formed(s: *const StringHeader) -> *mut Strin
         }
     }
     js_string_from_bytes(result.as_ptr(), result.len() as u32)
+}
+
+#[cfg(test)]
+mod tests_sso_helpers {
+    use super::*;
+    use crate::value::SHORT_STRING_MAX_LEN;
+    use crate::{js_string_from_bytes, JSValue};
+
+    /// #1781: a STRING_TAG heap key and a SHORT_STRING_TAG inline key
+    /// with the same bytes must both match an incoming heap key.
+    #[test]
+    fn key_matches_heap_and_sso_for_same_bytes() {
+        for name in ["a", "id", "tag", "name", "mango"] {
+            let bytes = name.as_bytes();
+            assert!(bytes.len() <= SHORT_STRING_MAX_LEN);
+
+            let incoming = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) };
+            let heap_stored = JSValue::string_ptr(incoming);
+            let sso_stored = JSValue::try_short_string(bytes).expect("len<=5 encodes as SSO");
+            assert!(sso_stored.is_short_string(), "{name:?} should be SSO");
+
+            unsafe {
+                assert!(
+                    js_string_key_matches(heap_stored, incoming),
+                    "heap match failed for {name:?}"
+                );
+                assert!(
+                    js_string_key_matches(sso_stored, incoming),
+                    "SSO match failed for {name:?}"
+                );
+                assert!(
+                    js_string_key_matches_bytes(heap_stored, bytes),
+                    "heap bytes-match failed for {name:?}"
+                );
+                assert!(
+                    js_string_key_matches_bytes(sso_stored, bytes),
+                    "SSO bytes-match failed for {name:?}"
+                );
+            }
+        }
+    }
+
+    /// Different-length stored vs incoming must return false even when one
+    /// is SSO and the other is heap.
+    #[test]
+    fn key_matches_rejects_different_bytes_across_reps() {
+        let incoming = unsafe { js_string_from_bytes(b"id".as_ptr(), 2) };
+        let sso_other = JSValue::try_short_string(b"tag").expect("SSO");
+        let heap_other_ptr = unsafe { js_string_from_bytes(b"other".as_ptr(), 5) };
+        let heap_other = JSValue::string_ptr(heap_other_ptr);
+
+        unsafe {
+            assert!(!js_string_key_matches(sso_other, incoming));
+            assert!(!js_string_key_matches(heap_other, incoming));
+        }
+    }
+
+    /// Non-string stored values (undefined / number / pointer) must return false
+    /// without dereferencing the payload.
+    #[test]
+    fn key_matches_rejects_non_string_stored() {
+        let incoming = unsafe { js_string_from_bytes(b"id".as_ptr(), 2) };
+        for stored in [
+            JSValue::undefined(),
+            JSValue::null(),
+            JSValue::int32(42),
+            JSValue::bool(true),
+        ] {
+            unsafe {
+                assert!(!js_string_key_matches(stored, incoming));
+                assert!(!js_string_key_matches_bytes(stored, b"id"));
+            }
+        }
+    }
+
+    /// SSO key_bytes() round-trip: returns the inline bytes for SSO,
+    /// the heap bytes for STRING_TAG, None for everything else.
+    #[test]
+    fn key_bytes_round_trips_sso_and_heap() {
+        let sso = JSValue::try_short_string(b"path").expect("SSO");
+        let heap = JSValue::string_ptr(unsafe { js_string_from_bytes(b"longish".as_ptr(), 7) });
+        let mut buf = [0u8; SHORT_STRING_MAX_LEN];
+        unsafe {
+            assert_eq!(js_string_key_bytes(sso, &mut buf), Some(b"path".as_ref()));
+            assert_eq!(
+                js_string_key_bytes(heap, &mut buf),
+                Some(b"longish".as_ref())
+            );
+            assert_eq!(js_string_key_bytes(JSValue::int32(7), &mut buf), None);
+        }
+    }
 }

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -52,6 +52,10 @@ pub use compare::{
     js_string_is_well_formed, js_string_locale_compare, js_string_normalize, js_string_starts_with,
     js_string_starts_with_at, js_string_to_well_formed,
 };
+// #1781: SSO-aware key lookup helpers, used to retire the
+// `is_string() && js_string_equals(key, key_val.as_string_ptr())` shape
+// across object/.
+pub(crate) use compare::{js_string_key_bytes, js_string_key_matches, js_string_key_matches_bytes};
 pub use concat::{
     js_string_concat, js_string_concat_box, js_string_concat_chain, js_string_concat_value,
     js_value_concat_string,

--- a/crates/perry-runtime/src/typed_feedback/guards.rs
+++ b/crates/perry-runtime/src/typed_feedback/guards.rs
@@ -21,19 +21,12 @@ fn object_has_own_key_bytes(obj: *const ObjectHeader, key_bytes: &[u8]) -> bool 
         }
         for i in 0..key_count {
             let stored = crate::array::js_array_get(keys, i as u32);
-            if !stored.is_string() {
-                continue;
-            }
-            let string = stored.as_string_ptr();
-            if string.is_null() {
-                continue;
-            }
-            let len = (*string).byte_len as usize;
-            if len != key_bytes.len() {
-                continue;
-            }
-            let data = (string as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-            if std::slice::from_raw_parts(data, len) == key_bytes {
+            // #1781: SSO-aware shape match — pre-fix the `is_string()`
+            // here returned false for a stored inline-SSO key, so the
+            // typed-feedback hot-path guard fell back to the slow
+            // generic dispatch on every read of an object whose shape
+            // included a ≤5-byte key.
+            if crate::string::js_string_key_matches_bytes(stored, key_bytes) {
                 return true;
             }
         }


### PR DESCRIPTION
## Summary

`JSValue::is_string()` is `STRING_TAG`-only (0x7FFF) and returns false for inline SSO short strings (`SHORT_STRING_TAG = 0x7FF9`, length 0..=5 stored in the NaN-box payload). The recurring `if jsval.is_string() { /* read as *StringHeader */ } else { /* skip / treat as pointer */ }` shape across `object/`, `typed_feedback/guards.rs`, and `native_module.rs` silently misses any key whose name is ≤ 5 ASCII bytes (`id`, `tag`, `name`, `path`, `data`, `error`, `value`, …). That breaks `Object.keys`, `key in obj`, `delete obj[k]`, `obj[k] = v`, `hasOwnProperty`, `Object.assign`, and a couple of `NativeModuleRef` lookups whenever a key happens to live as SSO (typically after `JSON.parse`, `string.slice(...)`-as-key, or a spread/rest pattern preserving an SSO source).

The fix is 3 centralized helpers in `string::compare`:

- `js_string_key_matches(stored: JSValue, incoming: *StringHeader)`
- `js_string_key_matches_bytes(stored: JSValue, incoming_bytes: &[u8])`
- `js_string_key_bytes(stored, &mut sso_buf) -> Option<&[u8]>`

…that compare/extract a stored-key `JSValue` (heap `STRING_TAG` *or* inline `SHORT_STRING_TAG`) against the incoming key without materializing the SSO value to the heap. Inline byte compare — no allocation, safe on the hot path.

Routed through every blind-spot site identified in #1781's audit:

| File | Sites |
|---|---|
| `field_get_set.rs` | 4 — `lookup_field_in_keys`, `Object.keys` slow-path enumerable filter, closure-style `in` check, field-cache validity + slow-path field lookup |
| `object_ops.rs` | 3 — define-property dedup, `own_key_present` (hasOwnProperty), `js_object_get_own_field_or_undef` |
| `delete_rest.rs` | 3 — `delete obj.k` lookup + rest pattern's source-key extract and exclude match |
| `alloc.rs` | 2 — `Object.assign(target, src)` overflow-aware copy in both helpers |
| `field_set_by_name.rs` | 1 — `obj[k] = v` existing-key update (pre-fix appended a duplicate key when the original was SSO) |
| `native_module.rs` | 2 — `read_native_module_name`, `get_module_name_from_namespace` for short modules like `"fs"`/`"os"`/`"tty"`/`"net"` |
| `typed_feedback/guards.rs` | 1 — shape-guard byte-slice match |

The 5 historical point-fixes the issue body cites (#833, #1151, #1767, +the v0.5.937 truthy crash) all remain in place; this PR collapses the recurring shape into the durable helpers so adding a new keys-array consumer can't silently re-open the blind spot.

## Test plan

- [x] `cargo test -p perry-runtime --lib string::compare::tests_sso_helpers` — 4 unit tests pass (heap-only, SSO-only, mixed-rep, length-mismatch, non-string stored)
- [x] `cargo test -p perry-runtime --lib sso_tests_1781` — `own_key_present_finds_sso_stored_key` plants a `SHORT_STRING_TAG` key into a keys_array via `JSValue::try_short_string` and asserts the SSO-aware match flow finds it (pre-fix `is_string()` path returned false)
- [x] `cargo test -p perry-runtime --lib object` — 67/68 passing; the 1 flake (`text_encoding_stream_globals_construct_readable_writable_shape`) is unrelated to this change and passes when re-run individually
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` — clean
- [x] `cargo fmt --all -- --check` — clean

Tracker: #1781.
