### PR TITLE
fix(node:buffer): expose inspect surface

### DIFF
--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -22,6 +22,7 @@ pub fn is_buffer_method_name(name: &str) -> bool {
     matches!(
         name,
         "toString"
+            | "inspect"
             | "slice"
             | "subarray"
             | "set"
@@ -291,6 +292,9 @@ pub unsafe fn dispatch_buffer_method(
                 crate::buffer::js_buffer_to_string(buf_ptr, enc)
             };
             f64::from_bits(JSValue::string_ptr(str_ptr).bits())
+        }
+        "inspect" => {
+            crate::builtins::js_util_inspect(buf_f64, f64::from_bits(crate::value::TAG_UNDEFINED))
         }
         "slice" | "subarray" => {
             let len = (*buf_ptr).length as i32;

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1505,6 +1505,28 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
         let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
         return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
     }
+    let raw_addr = if jsv.is_pointer() {
+        (bits & POINTER_MASK) as usize
+    } else if bits > 0x1000 && (bits >> 48) == 0 {
+        bits as usize
+    } else {
+        0
+    };
+    if raw_addr >= 0x1000 && crate::buffer::is_registered_buffer(raw_addr) {
+        let tag = if crate::buffer::is_array_buffer(raw_addr) {
+            "ArrayBuffer"
+        } else if crate::buffer::is_shared_array_buffer(raw_addr) {
+            "SharedArrayBuffer"
+        } else if crate::buffer::is_data_view(raw_addr) {
+            "DataView"
+        } else {
+            "Uint8Array"
+        };
+        let formatted = format!("[object {}]", tag);
+        let bytes = formatted.as_bytes();
+        let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+        return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
+    }
     if let Some(tag) = web_stream_to_string_tag(value) {
         let formatted = format!("[object {}]", tag);
         let bytes = formatted.as_bytes();
@@ -1518,11 +1540,7 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
     }
     // Heap-allocated pointers: discriminate Array / Error from generic
     // Object via the GC header type byte.
-    let raw_ptr = if jsv.is_pointer() {
-        (bits & POINTER_MASK) as *const u8
-    } else {
-        bits as *const u8
-    };
+    let raw_ptr = raw_addr as *const u8;
     if !raw_ptr.is_null() && (raw_ptr as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
         let gc_header = raw_ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
         let gc_type = (*gc_header).obj_type;

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1632,6 +1632,7 @@ pub(crate) unsafe fn get_native_module_constant(
             // packages feature-detect the Buffer surface without falling over.
             "kMaxLength" => Some(4294967296.0),
             "kStringMaxLength" => Some(536870888.0),
+            "INSPECT_MAX_BYTES" => Some(50.0),
             _ => None,
         },
         "buffer.constants" => match property {


### PR DESCRIPTION
Part of #793.

## Summary
- expose top-level `node:buffer` `INSPECT_MAX_BYTES` as Node's default `50`
- bind `Buffer.prototype.inspect()` through Perry's existing `util.inspect` formatter
- detect registered Buffer-backed values in `Object.prototype.toString` before generic GC-header array/error probing so Buffers tag as `[object Uint8Array]`

## Verification
- DeepWiki: `reference/deepwiki/nodejs-node-buffer-inspect-surface-2026-05-28.md` (local only)
- Baseline exact `node-suite/buffer/json-inspect/inspect-limits`: FAIL, report `test-parity/reports/parity_report_20260528_112902.json`
- Final exact `node-suite/buffer/json-inspect/inspect-limits`: PASS, report `test-parity/reports/parity_report_20260528_113617.json`
- Full granular `node-suite/buffer/json-inspect`: PASS 4/4, report `test-parity/reports/parity_report_20260528_113701.json`
- Full granular `node-suite/buffer`: 104 PASS / 11 parity FAIL / 1 compile FAIL, report `test-parity/reports/parity_report_20260528_113708.json`; `json-inspect/inspect-limits` is green. `properties/iterator` is covered by open PR #2280, while allocation/byteLength/concat residuals are covered by open PRs #2274/#2276/#2271.
- `cargo check -p perry-runtime -p perry-stdlib -p perry-codegen`: PASS with existing warnings
- `cargo fmt --check`: PASS
- `jq empty test-parity/known_failures.json`: PASS
- `git diff --check`: PASS

## Non-goals
- no mutable setter for `INSPECT_MAX_BYTES`
- no hidden inspect property extras
- no full typed-array prototype/toStringTag rewrite
- no Buffer.from/write/fill coercion cleanup