### PR TITLE
fix(node:buffer): reject primitive from inputs

### DIFF
--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+fn throw_invalid_buffer_from_first_arg() -> ! {
+    let message = b"The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object.";
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    crate::node_submodules::register_error_code_pub(msg, "ERR_INVALID_ARG_TYPE");
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
 /// Create a Buffer from a string
 /// encoding: 0 = utf8 (default), 1 = hex, 2 = base64, 3 = base64url, 4 = latin1/binary, 5 = ascii
 #[no_mangle]
@@ -150,6 +158,17 @@ pub extern "C" fn js_buffer_from_value(value: i64, encoding: i32) -> *mut Buffer
         let mut tmp = [0u8; crate::value::SHORT_STRING_MAX_LEN];
         let len = jsval.short_string_to_buf(&mut tmp);
         return buffer_from_str_bytes(&tmp[..len], encoding);
+    }
+
+    if jsval.is_undefined()
+        || jsval.is_null()
+        || jsval.is_bool()
+        || jsval.is_int32()
+        || jsval.is_number()
+        || jsval.is_bigint()
+        || unsafe { crate::symbol::js_is_symbol(f64::from_bits(bits)) != 0 }
+    {
+        throw_invalid_buffer_from_first_arg();
     }
 
     // Extract the raw pointer


### PR DESCRIPTION
Part of #793.

## Summary
- add a catchable `TypeError [ERR_INVALID_ARG_TYPE]` helper for invalid `Buffer.from` first arguments
- reject primitive non-string `Buffer.from` inputs before raw pointer extraction
- prevents nullish values from becoming empty Buffers and numeric primitives from being misread as heap pointers

## Verification
- DeepWiki: `reference/deepwiki/nodejs-node-buffer-from-primitive-errors-2026-05-28.md` (local only)
- Baseline exact `node-suite/buffer/from/primitive-errors`: FAIL, report `test-parity/reports/parity_report_20260528_114613.json`; Perry printed empty buffers for nullish inputs and then segfaulted after the numeric primitive
- Final exact `node-suite/buffer/from/primitive-errors`: PASS, report `test-parity/reports/parity_report_20260528_115001.json`
- Full granular `node-suite/buffer/from`: 14 PASS / 2 parity FAIL, report `test-parity/reports/parity_report_20260528_115045.json`; target is green and the remaining reds are existing array-like/valueOf coercion gaps
- Full granular `node-suite/buffer`: 104 PASS / 11 parity FAIL / 1 compile FAIL, report `test-parity/reports/parity_report_20260528_115103.json`; `from/primitive-errors` is green. Several sibling reds are covered by open PRs #2274/#2276/#2271/#2280/#2282 or by separate coercion/range-error work.
- `cargo check -p perry-runtime -p perry-stdlib -p perry-codegen`: PASS with existing warnings
- `cargo fmt --check`: PASS
- `jq empty test-parity/known_failures.json`: PASS
- `git diff --check`: PASS

## Non-goals
- no `Buffer.from` object `valueOf` / `Symbol.toPrimitive` support
- no array-like length coercion cleanup
- no function/object invalid-input validation
- no Buffer.alloc/write/fill coercion cleanup