### PR TITLE
fix(node:buffer): honor compare range args

### DIFF
--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -425,14 +425,32 @@ pub unsafe fn dispatch_buffer_method(
                 other_bits
             };
             let other = other_addr as *const crate::buffer::BufferHeader;
-            if args.len() >= 5 {
+            if args.len() >= 2 {
+                let target_len = if other.is_null() {
+                    0
+                } else {
+                    (*other).length as i32
+                };
+                let source_len = (*buf_ptr).length as i32;
+                let arg_i32_or = |i: usize, default: i32| -> i32 {
+                    if i < args.len() {
+                        let value = JSValue::from_bits(args[i].to_bits());
+                        if value.is_undefined() {
+                            default
+                        } else {
+                            args[i] as i32
+                        }
+                    } else {
+                        default
+                    }
+                };
                 i32_num(crate::buffer::js_buffer_compare_range(
                     buf_ptr,
                     other,
-                    arg_i32(1),
-                    arg_i32(2),
-                    arg_i32(3),
-                    arg_i32(4),
+                    arg_i32_or(1, 0),
+                    arg_i32_or(2, target_len),
+                    arg_i32_or(3, 0),
+                    arg_i32_or(4, source_len),
                 ))
             } else {
                 i32_num(crate::buffer::js_buffer_compare(buf_ptr, other))


### PR DESCRIPTION
Part of #793.

## Summary
- route `buf.compare(target, targetStart?, targetEnd?, sourceStart?, sourceEnd?)` through the range-aware helper whenever range args are supplied
- apply Node defaults for omitted/undefined bounds: `targetStart=0`, `targetEnd=target.length`, `sourceStart=0`, `sourceEnd=this.length`
- preserves the one-argument full-buffer compare path

## Verification
- DeepWiki: `reference/deepwiki/nodejs-node-buffer-compare-range-args-2026-05-28.md` (local only)
- Baseline exact `node-suite/buffer/compare/bounds-errors`: FAIL, report `test-parity/reports/parity_report_20260528_115628.json`
- Final exact `node-suite/buffer/compare/bounds-errors`: PASS, report `test-parity/reports/parity_report_20260528_120128.json`
- Full granular `node-suite/buffer/compare`: PASS 2/2, report `test-parity/reports/parity_report_20260528_120214.json`
- Full granular `node-suite/buffer`: 104 PASS / 11 parity FAIL / 1 compile FAIL, report `test-parity/reports/parity_report_20260528_120221.json`; `compare/bounds-errors` is green. Several sibling reds are covered by open PRs #2274/#2276/#2271/#2280/#2282/#2287 or by separate coercion/range-error work.
- `cargo check -p perry-runtime -p perry-stdlib -p perry-codegen`: PASS with existing warnings
- `cargo fmt --check`: PASS
- `jq empty test-parity/known_failures.json`: PASS
- `git diff --check`: PASS

## Non-goals
- no compare target type validation
- no exact error message text cleanup
- no range-error output cleanup beyond this optional-argument path
- no Buffer.from/write/fill coercion work