### PR TITLE
fix(node:buffer): throw on read int range errors

### DIFF
--- a/crates/perry-runtime/src/buffer/numeric.rs
+++ b/crates/perry-runtime/src/buffer/numeric.rs
@@ -20,6 +20,11 @@ fn buffer_slice_at<'a>(buf: *const BufferHeader, offset: i32, n: usize) -> Optio
 }
 
 #[inline]
+fn buffer_slice_at_or_throw<'a>(buf: *const BufferHeader, offset: i32, n: usize) -> &'a [u8] {
+    buffer_slice_at(buf, offset, n).unwrap_or_else(|| throw_out_of_range())
+}
+
+#[inline]
 fn buffer_slice_at_mut<'a>(buf: *mut BufferHeader, offset: i32, n: usize) -> Option<&'a mut [u8]> {
     if buf.is_null() || offset < 0 {
         return None;
@@ -90,91 +95,71 @@ fn checked_int_write_value(value: f64, bits: u32) -> i64 {
 #[no_mangle]
 pub extern "C" fn js_buffer_read_uint8(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    match buffer_slice_at(buf, offset, 1) {
-        Some(s) => s[0] as f64,
-        None => 0.0,
-    }
+    let s = buffer_slice_at_or_throw(buf, offset, 1);
+    s[0] as f64
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_int8(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    match buffer_slice_at(buf, offset, 1) {
-        Some(s) => (s[0] as i8) as f64,
-        None => 0.0,
-    }
+    let s = buffer_slice_at_or_throw(buf, offset, 1);
+    (s[0] as i8) as f64
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_uint16_be(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    match buffer_slice_at(buf, offset, 2) {
-        Some(s) => u16::from_be_bytes([s[0], s[1]]) as f64,
-        None => 0.0,
-    }
+    let s = buffer_slice_at_or_throw(buf, offset, 2);
+    u16::from_be_bytes([s[0], s[1]]) as f64
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_uint16_le(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    match buffer_slice_at(buf, offset, 2) {
-        Some(s) => u16::from_le_bytes([s[0], s[1]]) as f64,
-        None => 0.0,
-    }
+    let s = buffer_slice_at_or_throw(buf, offset, 2);
+    u16::from_le_bytes([s[0], s[1]]) as f64
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_int16_be(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    match buffer_slice_at(buf, offset, 2) {
-        Some(s) => i16::from_be_bytes([s[0], s[1]]) as f64,
-        None => 0.0,
-    }
+    let s = buffer_slice_at_or_throw(buf, offset, 2);
+    i16::from_be_bytes([s[0], s[1]]) as f64
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_int16_le(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    match buffer_slice_at(buf, offset, 2) {
-        Some(s) => i16::from_le_bytes([s[0], s[1]]) as f64,
-        None => 0.0,
-    }
+    let s = buffer_slice_at_or_throw(buf, offset, 2);
+    i16::from_le_bytes([s[0], s[1]]) as f64
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_uint32_be(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    match buffer_slice_at(buf, offset, 4) {
-        Some(s) => u32::from_be_bytes([s[0], s[1], s[2], s[3]]) as f64,
-        None => 0.0,
-    }
+    let s = buffer_slice_at_or_throw(buf, offset, 4);
+    u32::from_be_bytes([s[0], s[1], s[2], s[3]]) as f64
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_uint32_le(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    match buffer_slice_at(buf, offset, 4) {
-        Some(s) => u32::from_le_bytes([s[0], s[1], s[2], s[3]]) as f64,
-        None => 0.0,
-    }
+    let s = buffer_slice_at_or_throw(buf, offset, 4);
+    u32::from_le_bytes([s[0], s[1], s[2], s[3]]) as f64
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_int32_be(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    match buffer_slice_at(buf, offset, 4) {
-        Some(s) => i32::from_be_bytes([s[0], s[1], s[2], s[3]]) as f64,
-        None => 0.0,
-    }
+    let s = buffer_slice_at_or_throw(buf, offset, 4);
+    i32::from_be_bytes([s[0], s[1], s[2], s[3]]) as f64
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_int32_le(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    match buffer_slice_at(buf, offset, 4) {
-        Some(s) => i32::from_le_bytes([s[0], s[1], s[2], s[3]]) as f64,
-        None => 0.0,
-    }
+    let s = buffer_slice_at_or_throw(buf, offset, 4);
+    i32::from_le_bytes([s[0], s[1], s[2], s[3]]) as f64
 }
 
 #[no_mangle]


### PR DESCRIPTION
Part of #793.

Summary:
- Fixed-width `Buffer` integer reads now throw `RangeError ERR_OUT_OF_RANGE` when the requested offset is negative or would read beyond the buffer.
- Added a shared throwing slice helper and routed `readUInt*`/`readInt*` fixed-width helpers through it.
- Left float/double reads, variable-width reads, write offset cleanup, and exact error message text out of scope.

Verification:
- DeepWiki: `reference/deepwiki/nodejs-node-buffer-read-int-range-errors-2026-05-28.md`.
- Baseline exact `node-suite/buffer/read-write-int/range-errors-extra`: FAIL, report `test-parity/reports/parity_report_20260528_120828.json`.
- Final exact `node-suite/buffer/read-write-int/range-errors-extra`: PASS, report `test-parity/reports/parity_report_20260528_121233.json`.
- Full `node-suite/buffer/read-write-int`: PASS 8/8, report `test-parity/reports/parity_report_20260528_121316.json`.
- Full granular `node-suite/buffer`: 104 PASS / 11 parity FAIL / 1 compile FAIL, report `test-parity/reports/parity_report_20260528_121328.json`; target is green and sibling reds are covered by open PRs or separate coercion/compile work.
- `cargo check -p perry-runtime -p perry-stdlib -p perry-codegen`: PASS with existing warnings.
- `cargo fmt --check`, `jq empty test-parity/known_failures.json`, and `git diff --check`: PASS.

Non-goals:
- No float/double read bounds cleanup.
- No variable-width read offset/byteLength cleanup.
- No write offset cleanup.
- No exact error message text cleanup.