### PR TITLE
test(parity): trim 30 stale skip-list entries for closed issues #1532/#1531/#1558/#912

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -230,12 +230,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline() callback never fires (depends on stream event delivery). Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/object-mode": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Readable objectMode push/data events don't deliver. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/set-encoding": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -247,18 +241,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: unshift+data chain doesn't deliver. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/writable/drain-event": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: write() return + drain event semantics not delivered. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/error/error-event": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: destroy(err) → error event chain doesn't deliver. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/from-async-iterable": {
     "issue": "1532",
@@ -380,12 +362,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline for already-ended source doesn't invoke callback. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/read-no-arg": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: read() with no arg should return the entire buffered chunk. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/finished/options-config": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -422,12 +398,6 @@
     "category": "bug-open",
     "reason": "node:stream: read + unshift + re-read sequence doesn't deliver chunks in the right order. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/error/error-no-listener": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: destroy(err) + error listener doesn't deliver the message to handler. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/object-mode/read-single-object": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -440,29 +410,11 @@
     "category": "bug-open",
     "reason": "node:stream: stream.compose(asyncGenerator) doesn't run the async stage / forward data. Reopened #1539 for pipeline execution."
   },
-  "node-suite/stream/pipe/four-stage-chain": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: four-stage pipe chain does not propagate through. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipe/repipe-after-unpipe": {
     "issue": "1532",
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: re-piping after unpipe does not flow / sink does not end. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/error/error-then-end-order": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: after error, end event should NOT fire. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/options/auto-destroy-false": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: autoDestroy:false option not honored. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/options/construct-cb-error": {
     "issue": "1532",
@@ -548,12 +500,6 @@
     "category": "bug-open",
     "reason": "node:stream: readable.unshift(chunk, encoding) — second-arg encoding form not honored. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/iter-helpers/map-returns-readable": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: readable.map() returns iterable but not a Readable instance — `instanceof Readable` is false. Flips to PASS when #1558 lands."
-  },
   "node-suite/stream/pipeline/premature-close-code": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -589,12 +535,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pipe(dst, {end: false}) — destination still ended when source ends. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/events/readable-event-order": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: 'readable' event ordering relative to 'end' — extra readable before end missing or out-of-order. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/finished/with-cleanup-option": {
     "issue": "1532",
@@ -662,12 +602,6 @@
     "category": "gap-categorical",
     "reason": "#1278: console.trace / Error.stack frame format diverges from Node (Perry prints native frame addresses like `0: __mh_execute_header` instead of `at <fn> (file:///…:line:col)`). Requires source-position retention through HIR/transform + native-frame → TS-source mapping. The other two divergences in this fixture (#1276 spurious `Values` column on array-of-arrays, #1277 timer ms numbers) are not gating: #1276 was fixed in v0.5.1019+; #1277 is a misdiagnosis — Perry's `Instant::now()` is correct and the apparent 1000× gap is just AOT-vs-interpreted speedup on the trivial loop workload. Flips to PASS when #1278 lands."
   },
-  "test_issue_express_map_undefined": {
-    "issue": "912",
-    "added": "2026-05-17",
-    "category": "bug-open",
-    "reason": "Regression test from #911 (express map undefined / http.METHODS). The METHODS property is now in the manifest (PR adding it alongside this entry); the test may still diverge from Node in the exact METHODS list shape. Re-evaluate once express compiles cleanly."
-  },
   "node-suite/stream/readable/object-mode-read-returns-object": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -710,12 +644,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: getReader({mode:'byob'}) on non-byte stream does not throw TypeError. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/iter-helpers/map-with-thisarg": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: iter-helper closure capture — outer-var reference in arrow fn yields wrong values. Flips to PASS when #1558 lands."
-  },
   "node-suite/stream/readable/unshift-increases-length": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -733,12 +661,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: read() inside 'readable' listener — while-loop drain pattern produces wrong output. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/read-n-consumes-exactly-n": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: read(N) — consumes wrong byte count from buffered stream. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/flow/sequential-reads": {
     "issue": "1532",
@@ -781,24 +703,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: unshift() return value — not undefined. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/pipeline/promise-form": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pipeline() from node:stream/promises — return value not a Promise<undefined>. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/iter-helpers/spread-tarray-result": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: toArray() result not spreadable array (wrong type or shape). Flips to PASS when #1558 lands."
-  },
-  "node-suite/stream/pipe/end-true-explicit": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pipe(dst, {end:true}) — explicit form behaves differently from default. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/buffer-preserves": {
     "issue": "1531",
@@ -860,18 +764,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: getReader({mode:'byob'}) on bytes-type stream fails or returns wrong shape. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/pipe/source-error-no-propagation": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pipe(src,dst) source-error handling — wrong error count on src or dst. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/error-event-arg-shape": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: 'error' event arg — identity / instanceof Error / message wrong. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/pipethrough-preventclose-flag": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -920,12 +812,6 @@
     "category": "bug-open",
     "reason": "node:stream: destroy() inside _read() — readCalls count or close-event behavior wrong. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/read-multibyte-boundary": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: read(1) on multibyte UTF-8 chunk — fails to compile (Buffer-length access). Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/writable/sink-write-rejection-becomes-error": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -943,12 +829,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: ReadableStream.from(asyncGen()) — iteration wrong or fails. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/pipe/objectmode-pipe": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: objectMode pipe — raw object data not preserved through pipe. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/unshift-while-flowing": {
     "issue": "1532",
@@ -998,12 +878,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.from(asyncGen yielding mixed types) — types lost or wrong. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/read-returns-buffer-default": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: read() in non-encoded mode — does not return Buffer instance. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipe/pipe-autodestroy-default": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1039,12 +913,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Readable.from(array with one Promise.reject) — error not emitted at the right point. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/pipe/r-t-w-end-to-end": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: simple R→T→W e2e pipe — received chunks wrong (transform/uppercase not applied). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/iter-helpers/every-async-rejection": {
     "issue": "1558",
@@ -1148,12 +1016,6 @@
     "category": "bug-open",
     "reason": "node:stream: post-pipe-end destroyed flags wrong on source or destination. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/options-autoDestroy-explicit": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: autoDestroy: false — stream still destroyed after 'end' or 'close' fires when it shouldn't. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/sink-all-four-methods": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -1165,12 +1027,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pipeline middle-stream error — does not destroy source AND sink. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/iter-helpers/take-then-filter": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: chained take(N).filter(fn) — wrong output. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/web/from-promise-iterable": {
     "issue": "1545",
@@ -1238,12 +1094,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable({captureRejections}) — async listener throws not caught as 'error'. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/pipe/pipe-error-handler-on-source": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: src.on('error') during pipe — handler receives wrong error / not called. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/iter-helpers/some-finds-match": {
     "issue": "1558",
     "added": "2026-05-24",
@@ -1256,12 +1106,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline(asyncIterable, dst, cb) — async-iterable source not handled. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/pipe/source-immediate-error": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pipe() src immediate error — error not fired on src listener. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/destroyed-after-finish": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1273,12 +1117,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: encoding option in ctor — readableEncoding wrong or data not string. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/pipe/pipe-to-plain-writable": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pipe() to plain Writable — collected wrong / empty. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/byob-reader-method-shape": {
     "issue": "1545",
@@ -1340,12 +1178,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose(src, t1, PassThrough, t2) — chain produces wrong output. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/pipe/end-true-explicit-still-ends": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pipe(dst,{end:true}) — dst not ended after source ends. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/pipeline/sync-iterable-source": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1405,18 +1237,6 @@
     "added": "2026-05-25",
     "category": "bug-open",
     "reason": "node:stream: generator with explicit return — values yielded after return statement aren't reached. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/pipe/four-stage-chain-v2": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: 4-stage pipe — wrong output. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/pipe/many-listeners-on-dst": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: multi 'data' listeners on dst — count or values wrong. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/from-gen-return-value-ignored": {
     "issue": "1532",


### PR DESCRIPTION
## Summary

Re-validated `test-parity/known_failures.json` against the actual byte-for-byte parity of the current `main` binary. Sampled the 173 `bug-open` entries pointing to already-closed tracking issues — **30 now pass byte-identical** against `node --experimental-strip-types` and are removed from the skip-list.

### Per-issue breakdown

| Closed issue | Entries removed | Notes |
| --- | --- | --- |
| #1532 (stream events / lifecycle) | 24 | pipe chains, autoDestroy, error-event ordering, options.auto-destroy-false, etc. |
| #1558 (Readable iterator helpers) | 4 | map+thisArg, spread-tarray, take-then-filter, map-returns-readable |
| #1531 (stream constructors) | 1 | options-autoDestroy-explicit |
| #912 (express map-undefined, merged) | 1 | test_issue_express_map_undefined |

The remaining 141 entries pointing to closed issues still diff (or hang) — left in place pending per-test triage.

### Methodology

Compiled each candidate with `./target/release/perry` and compared executable output against `node --experimental-strip-types` under a 5s `gtimeout`. Two known hangs (`stream/events/once-returns-promise`, `stream/events/once-static-promise`) are left in the skip-list — those will need separate work to unhang the runtime stream/events bridge.

## Test plan

- [x] Each removed entry re-verified byte-identical against Node.
- [x] CI (api-docs-drift, cargo-test, lint, security-audit) will run on this PR.
