### PR TITLE
fix(codegen): skip string-method dispatch for array-only methods on Union<String, T>

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -24,6 +24,27 @@ fn is_event_target_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     matches!(receiver_class_name(ctx, e).as_deref(), Some("EventTarget"))
 }
 
+/// Methods that exist on `Array.prototype` but NOT on `String.prototype`.
+/// Used to keep the string-method dispatch from claiming a call site
+/// like `(s | T[]).join(",")` where the static type is permissive
+/// (Union with String — see `is_string_expr`'s Union arm) but the
+/// method itself isn't part of the string surface. Falling through to
+/// the runtime dispatcher (`js_native_call_method`) lets the actual
+/// runtime shape pick the right path. Refs #2277.
+fn is_array_only_method_name(name: &str) -> bool {
+    matches!(
+        name,
+        // Mutating
+        "push" | "pop" | "shift" | "unshift" | "splice" | "sort" | "reverse" | "fill" | "copyWithin"
+        // Aggregation / iteration
+        | "join" | "every" | "some" | "filter" | "map" | "forEach" | "reduce" | "reduceRight"
+        | "find" | "findIndex" | "findLast" | "findLastIndex" | "flat" | "flatMap"
+        | "keys" | "values" | "entries"
+        // Immutable variants
+        | "toReversed" | "toSorted" | "toSpliced" | "with"
+    )
+}
+
 /// Try to lower a `Call { callee: PropertyGet { .. } }` via the
 /// string/array/class/Map/Set/Promise/fetch/static/instance method
 /// dispatch tower. Returns `Ok(None)` when the callee shape doesn't
@@ -228,7 +249,7 @@ pub fn try_lower_property_get_method_call(
             return Ok(Some(nanbox_string_inline(blk, &handle)));
         }
     }
-    if is_string_expr(ctx, object) {
+    if is_string_expr(ctx, object) && !is_array_only_method_name(property) {
         return Ok(Some(lower_string_method(ctx, object, property, args)?));
     }
     // String method fallback for Any-typed receivers: when the method

--- a/test-files/test_gap_union_typeof_narrowing.ts
+++ b/test-files/test_gap_union_typeof_narrowing.ts
@@ -1,0 +1,65 @@
+// `typeof x === "string"` narrowing on a `string | T[]` union.
+// Perry's `is_string_expr` returns true for any `Union` whose members
+// include `String` (the nullable-string narrowing case, `s: string |
+// null`). When the method itself is array-only (`.join`, `.push`, …),
+// blindly routing to `lower_string_method` made the runtime fall into
+// the string-method catch-all and throw
+// `TypeError: (string).join is not a function` even though the actual
+// runtime value was an array — i.e. the else branch of the narrow.
+//
+// Fix: at the property-method dispatch site, skip the string-method
+// route when the method name is on `Array.prototype` but NOT on
+// `String.prototype`; runtime dispatch then picks the right path by
+// the receiver's actual shape.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+// (1) The original #2277 repro: `string | number[]` narrowed via
+//     `typeof === "string"`. The else branch calls `.join(",")` on
+//     `input` typed as the still-Union (TS narrowing not in HIR), so
+//     it must resolve at runtime.
+function processInput(input: string | number[]): string {
+  if (typeof input === "string") {
+    return input.toUpperCase();
+  } else {
+    return input.join(",");
+  }
+}
+console.log("(1)", processInput("hello"));
+console.log("(1)", processInput([1, 2, 3]));
+
+// (2) Mirror for `string | T[]` with a different array-only method.
+//     Confirms the array path covers more than `.join`.
+function describe(x: string | number[]): string {
+  if (typeof x === "string") {
+    return "s:" + x.length;
+  } else {
+    return "a:" + x.filter((n: number) => n > 0).length;
+  }
+}
+console.log("(2)", describe("hello"));
+console.log("(2)", describe([1, -2, 3, -4, 5]));
+
+// (3) Reverse position — the array variant first in the union. The
+//     fix must work regardless of variant order.
+function joinOrUpper(x: number[] | string): string {
+  if (typeof x === "string") {
+    return x.toUpperCase();
+  }
+  return x.join("-");
+}
+console.log("(3)", joinOrUpper("perry"));
+console.log("(3)", joinOrUpper([10, 20, 30]));
+
+// (4) The nullable-string narrowing case must still work — `.toUpperCase`
+//     on `string | null` after a null-guard should still route through
+//     `lower_string_method`. (Regression check for the existing
+//     `is_string_expr` Union arm.)
+function maybeUpper(x: string | null): string {
+  if (x !== null) {
+    return x.toUpperCase();
+  }
+  return "(null)";
+}
+console.log("(4)", maybeUpper("ok"));
+console.log("(4)", maybeUpper(null));

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -14,12 +14,6 @@
     "category": "bug-stale",
     "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #655 is closed. Deliberate failing repro/harness — kept as a regression canary. Canonical regression-catcher for issue #655. Flips to PASS when the underlying fix lands. Keep regardless of CI verdict — it's a deliberate failing repro."
   },
-  "test_edge_type_narrowing": {
-    "issue": "2277",
-    "added": "2026-05-15",
-    "category": "bug-open",
-    "reason": "Bisected 2026-05-28 for #1635: single residual sub-case is `typeof === \"string\"` narrowing on a `string | number[]` union — else-branch leaves the array remainder mis-typed as string, so `.join` lowers as a string method and throws. Tracked under #2277."
-  },
   "test_gap_regexp_advanced": {
     "issue": null,
     "added": "2026-05-15",


### PR DESCRIPTION
## Summary

Closes #2277.

`is_string_expr` returns true for any `LocalGet` whose static type is a `Union` containing `String` — by design, so `(s: string | null).toUpperCase()` after a `!= null` guard still routes through `lower_string_method`. But that also caught `(input: string | number[]).join(",")` in the *else* branch of `typeof input === "string"` — Perry doesn't do TS narrowing in HIR, so `input`'s static type stays the union, and `is_string_expr` waves it through. `lower_string_method`'s catch-all then throws `TypeError: (string).join is not a function` even though the runtime value is a number array, because `.join` isn't on `String.prototype`.

This was bisected out of #1635 as #2277, the single residual failure of `test_edge_type_narrowing.ts`.

Fix: gate the string-method route on the method name actually being something other than an array-only name (`.join`, `.push`, `.map`, `.filter`, …). When the name is array-only, fall through to the runtime dispatcher (`js_native_call_method`), which inspects the receiver's actual shape and dispatches to the array path. The nullable-string narrowing case (`.toUpperCase`, `.split`, …) is untouched — those names aren't array-only, so they still route to `lower_string_method` as before.

## Repro (now passes byte-identical with Node)

```ts
function processInput(input: string | number[]): string {
  if (typeof input === "string") return input.toUpperCase();
  else                          return input.join(",");
}
console.log(processInput("hello"));    // HELLO
console.log(processInput([1, 2, 3]));  // 1,2,3   ← was: TypeError: (string).join is not a function
```

## Scope

- `crates/perry-codegen/src/lower_call/property_get.rs`: add `is_array_only_method_name` helper + gate the string-method route on `!is_array_only_method_name(property)`.
- `test-files/test_gap_union_typeof_narrowing.ts`: new parity test covering both narrowing directions (`string | T[]` and `T[] | string`), a second array-only method (`.filter`), and a regression check for the `string | null` nullable case.
- `test-parity/known_failures.json`: drop `test_edge_type_narrowing` — bisected residual was this exact shape and is now byte-identical with Node.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --release -p perry-codegen` (all green)
- [x] `diff <(node --experimental-strip-types test_edge_type_narrowing.ts) <(./perry compile … && /tmp/out)` — empty
- [x] `diff … test_gap_union_typeof_narrowing.ts …` — empty
- [x] `diff … test_gap_array_methods.ts …` / `test_gap_string_methods.ts` / `test_gap_class_advanced.ts` — empty (no regressions on the array/string/class gap tests)
- [x] Nullable-string narrow (`(s: string | null).toUpperCase()` after `!= null` guard) — byte-identical with Node
