### PR TITLE
fix(node:buffer): honor fill value coercions

### DIFF
--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -562,6 +562,97 @@ pub extern "C" fn js_buffer_fill_range(
     buf
 }
 
+/// Fill an existing buffer by repeating/truncating a Node-compatible fill value.
+#[no_mangle]
+pub extern "C" fn js_buffer_fill_value_range(
+    buf: *mut BufferHeader,
+    fill_value: f64,
+    start: i32,
+    end: i32,
+    encoding: i32,
+) -> *mut BufferHeader {
+    if buf.is_null() || (buf as u64) < 0x1000 {
+        return buf;
+    }
+    let buf = {
+        let bits = buf as u64;
+        let top16 = (bits >> 48) as u16;
+        if top16 >= 0x7FF8 {
+            (bits & 0x0000_FFFF_FFFF_FFFF) as *mut BufferHeader
+        } else {
+            buf
+        }
+    };
+    unsafe {
+        let len = (*buf).length as usize;
+        let start = if start < 0 {
+            ((len as i32) + start).max(0) as usize
+        } else {
+            (start as usize).min(len)
+        };
+        let end = if end < 0 {
+            ((len as i32) + end).max(0) as usize
+        } else {
+            (end as usize).min(len)
+        };
+        if start >= end {
+            return buf;
+        }
+
+        let data = buffer_data_mut(buf);
+        let dst = data.add(start);
+        let count = end - start;
+        let bits = fill_value.to_bits();
+        let jsval = crate::JSValue::from_bits(bits);
+
+        let write_byte = |byte: u8| {
+            ptr::write_bytes(dst, byte, count);
+            super::view::propagate_written_range_from_receiver(
+                buf as usize,
+                start as u32,
+                dst,
+                count as u32,
+            );
+        };
+
+        if jsval.is_number() {
+            write_byte(fill_value as i64 as u8);
+            return buf;
+        }
+        if jsval.is_int32() {
+            write_byte(jsval.as_int32() as u8);
+            return buf;
+        }
+        if jsval.is_bool() {
+            write_byte(if jsval.as_bool() { 1 } else { 0 });
+            return buf;
+        }
+        if jsval.is_undefined() || jsval.is_null() {
+            write_byte(0);
+            return buf;
+        }
+
+        let src = js_buffer_from_value(bits as i64, encoding);
+        if src.is_null() || (*src).length == 0 {
+            write_byte(0);
+            return buf;
+        }
+
+        let src_len = (*src).length as usize;
+        let src_data = buffer_data(src);
+        for i in 0..count {
+            *dst.add(i) = *src_data.add(i % src_len);
+        }
+        super::view::propagate_written_range_from_receiver(
+            buf as usize,
+            start as u32,
+            dst,
+            count as u32,
+        );
+    }
+    buf
+}
+
 /// Allocate an uninitialized buffer
 #[no_mangle]
 pub extern "C" fn js_buffer_alloc_unsafe(size: i32) -> *mut BufferHeader {

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -38,10 +38,10 @@ pub use header::{
 // ---- Re-exports: Buffer.from / alloc / concat (FFI) ----
 pub use from::{
     js_array_buffer_new, js_buffer_alloc, js_buffer_alloc_fill_value, js_buffer_alloc_unsafe,
-    js_buffer_concat, js_buffer_fill, js_buffer_fill_range, js_buffer_from_array,
-    js_buffer_from_arraybuffer_slice, js_buffer_from_string, js_buffer_from_value,
-    js_data_view_new, js_encoding_tag_from_value, js_shared_array_buffer_new, js_uint8array_alloc,
-    js_uint8array_from_array, js_uint8array_new,
+    js_buffer_concat, js_buffer_fill, js_buffer_fill_range, js_buffer_fill_value_range,
+    js_buffer_from_array, js_buffer_from_arraybuffer_slice, js_buffer_from_string,
+    js_buffer_from_value, js_data_view_new, js_encoding_tag_from_value, js_shared_array_buffer_new,
+    js_uint8array_alloc, js_uint8array_from_array, js_uint8array_new,
 };
 
 // ---- Re-exports: predicates / byteLength (FFI) ----

--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -398,7 +398,16 @@ pub unsafe fn dispatch_buffer_method(
             let len = (*buf_ptr).length as i32;
             let start = if args.len() >= 2 { arg_i32(1) } else { 0 };
             let end = if args.len() >= 3 { arg_i32(2) } else { len };
-            let result = crate::buffer::js_buffer_fill_range(buf_ptr, arg_i32(0), start, end);
+            let value = args
+                .first()
+                .copied()
+                .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
+            let enc = if args.len() >= 4 {
+                crate::buffer::js_encoding_tag_from_value(args[3])
+            } else {
+                0
+            };
+            let result = crate::buffer::js_buffer_fill_value_range(buf_ptr, value, start, end, enc);
             f64::from_bits(JSValue::pointer(result as *mut u8).bits())
         }
         "equals" => {


### PR DESCRIPTION
Part of #793.

Summary:
- Routed instance `Buffer.prototype.fill` through a value-aware fill helper instead of reducing the fill value to `i32` at dispatch.
- Matched Node-visible coercions for numeric/int32/boolean/nullish fills and repeated Buffer/Uint8Array/string-derived fill bytes over the requested range.
- Preserved return-by-receiver behavior and the existing clamped range handling.

Verification:
- DeepWiki: `reference/deepwiki/nodejs-node-buffer-fill-value-coercions-2026-05-28.md`.
- Baseline exact `node-suite/buffer/fill-write/fill-coercions-extra`: FAIL, report `test-parity/reports/parity_report_20260528_123235.json`.
- Final exact `node-suite/buffer/fill-write/fill-coercions-extra`: PASS, report `test-parity/reports/parity_report_20260528_123538.json`.
- Full `node-suite/buffer/fill-write`: 7 PASS / 1 parity FAIL, report `test-parity/reports/parity_report_20260528_123621.json`; only `write-coercions` remains red.
- Full granular `node-suite/buffer`: 104 PASS / 11 parity FAIL / 1 compile FAIL, report `test-parity/reports/parity_report_20260528_123635.json`; target is green.
- `cargo check -p perry-runtime -p perry-stdlib -p perry-codegen`: PASS with existing warnings.
- `cargo fmt --check`, `jq empty test-parity/known_failures.json`, and `git diff --check`: PASS.

Non-goals:
- No `buf.write` coercion cleanup.
- No zero-length Buffer/Uint8Array fill exception.
- No exact fill error-message shape.
- No unrelated Buffer.from coercion cleanup.