### PR TITLE
fix(node:buffer): validate write coercions

### DIFF
--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -6,6 +6,42 @@
 use super::*;
 use base64::Engine as _;
 
+fn throw_buffer_type_error_with_code(message: &'static str, code: &'static str) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    crate::node_submodules::register_error_code_pub(msg, code);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+fn is_buffer_dispatch_number(value: f64) -> bool {
+    let jsval = JSValue::from_bits(value.to_bits());
+    jsval.is_number() || jsval.is_int32()
+}
+
+fn is_buffer_dispatch_string(value: f64) -> bool {
+    let jsval = JSValue::from_bits(value.to_bits());
+    jsval.is_string() || jsval.is_short_string()
+}
+
+fn buffer_dispatch_i32(value: f64) -> i32 {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if jsval.is_int32() {
+        jsval.as_int32()
+    } else {
+        value as i32
+    }
+}
+
+fn buffer_write_encoding_tag_or_throw(value: f64) -> i32 {
+    if !is_buffer_dispatch_string(value) {
+        throw_buffer_type_error_with_code("Invalid Buffer encoding", "ERR_INVALID_ARG_TYPE");
+    }
+    if crate::buffer::js_buffer_is_encoding(value) == 0 {
+        throw_buffer_type_error_with_code("Unknown encoding", "ERR_UNKNOWN_ENCODING");
+    }
+    crate::buffer::js_encoding_tag_from_value(value)
+}
+
 /// Dispatch a Buffer / Uint8Array instance method call. Receiver address
 /// is the raw heap pointer (already stripped of NaN-box tags). Routes
 /// the Node-style numeric read/write/search/swap method family through
@@ -344,27 +380,45 @@ pub unsafe fn dispatch_buffer_method(
                 str_bits
             };
             let str_ptr = str_addr as *const crate::string::StringHeader;
-            let offset = if args.len() >= 2 { arg_i32(1) } else { 0 };
+            let mut offset = 0;
+            let mut arg_index = 1;
+            let mut enc = 0;
+            if args.len() >= 2 {
+                if args.len() == 2 && is_buffer_dispatch_string(args[1]) {
+                    enc = buffer_write_encoding_tag_or_throw(args[1]);
+                    arg_index = 2;
+                } else if is_buffer_dispatch_number(args[1]) {
+                    offset = buffer_dispatch_i32(args[1]);
+                    arg_index = 2;
+                } else {
+                    throw_buffer_type_error_with_code(
+                        "Invalid Buffer offset",
+                        "ERR_INVALID_ARG_TYPE",
+                    );
+                }
+            }
             // Detect trailing encoding arg (string) vs length arg (number).
             // Common forms: write(str), write(str, offset), write(str, offset, enc),
             // write(str, offset, length, enc).
-            let (max_len, enc) = if args.len() >= 4 {
-                (
-                    arg_i32(2),
-                    crate::buffer::js_encoding_tag_from_value(args[3]),
-                )
-            } else if args.len() >= 3 {
-                let third_bits = args[2].to_bits();
-                if (third_bits >> 48) == 0x7FFF {
-                    (
-                        (*buf_ptr).length as i32 - offset,
-                        crate::buffer::js_encoding_tag_from_value(args[2]),
-                    )
+            let max_len = if arg_index < args.len() {
+                if is_buffer_dispatch_string(args[arg_index]) {
+                    enc = buffer_write_encoding_tag_or_throw(args[arg_index]);
+                    (*buf_ptr).length as i32 - offset
+                } else if is_buffer_dispatch_number(args[arg_index]) {
+                    let len = buffer_dispatch_i32(args[arg_index]);
+                    arg_index += 1;
+                    if arg_index < args.len() {
+                        enc = buffer_write_encoding_tag_or_throw(args[arg_index]);
+                    }
+                    len
                 } else {
-                    (arg_i32(2), 0)
+                    throw_buffer_type_error_with_code(
+                        "Invalid Buffer length",
+                        "ERR_INVALID_ARG_TYPE",
+                    );
                 }
             } else {
-                ((*buf_ptr).length as i32 - offset, 0)
+                (*buf_ptr).length as i32 - offset
             };
             crate::buffer::js_buffer_write_len(buf_ptr, str_ptr, offset, max_len, enc) as f64
         }


### PR DESCRIPTION
Part of #793.

Summary:
- validate `Buffer.prototype.write` offset, length, and encoding arguments before writing
- keep `write(str, encoding)` as the encoding overload only when no length argument is supplied
- surface `ERR_INVALID_ARG_TYPE` for invalid offset/length arguments and `ERR_UNKNOWN_ENCODING` for unknown encodings

Verification:
- DeepWiki: `reference/deepwiki/nodejs-node-buffer-write-coercion-errors-2026-05-28.md`
- Baseline exact `node-suite/buffer/fill-write/write-coercions`: FAIL, report `test-parity/reports/parity_report_20260528_124326.json`
- Final exact `node-suite/buffer/fill-write/write-coercions`: PASS, report `test-parity/reports/parity_report_20260528_124704.json`
- Full `node-suite/buffer/fill-write`: 7 PASS / 1 parity FAIL, report `test-parity/reports/parity_report_20260528_124749.json`; target green, sibling fill residual covered by #2294
- Full `node-suite/buffer`: 104 PASS / 11 parity FAIL / 1 compile FAIL, report `test-parity/reports/parity_report_20260528_124805.json`; target green
- `cargo check -p perry-runtime -p perry-stdlib -p perry-codegen`: PASS with existing warnings
- `cargo fmt --check`: PASS
- `jq empty test-parity/known_failures.json`: PASS
- `git diff --check`: PASS

Non-goals:
- no out-of-range write offset/length RangeError cleanup
- no `buf.write` UTF-16LE implementation
- no fill value coercion work, covered by #2294
- no exact error message text cleanup