### PR TITLE
fix(runtime): implement process.getgroups() (#2135)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2135,6 +2135,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("process", "geteuid", false, None),
     method("process", "getgid", false, None),
     method("process", "getegid", false, None),
+    method("process", "getgroups", false, None),
     method("process", "emitWarning", false, None),
     method("process", "on", false, None),
     method("process", "addListener", false, None),

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -659,6 +659,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         | "geteuid"
                         | "getgid"
                         | "getegid"
+                        | "getgroups"
                         | "emitWarning"
                         | "on"
                         | "addListener"

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -178,6 +178,17 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_STR],
         ret: NR_VOID,
     },
+    // #2135 (Node process parity): process.getgroups() — Array<number>
+    // of supplementary GIDs from libc::getgroups (empty on non-unix).
+    NativeModSig {
+        module: "process",
+        has_receiver: false,
+        method: "getgroups",
+        class_filter: None,
+        runtime: "js_process_getgroups",
+        args: &[],
+        ret: NR_F64,
+    },
     // ========== Node URL ==========
     // `new Number/String/Boolean(...)` now lowers to
     // `Expr::BoxedPrimitiveNew` (see crates/perry-hir/src/lower/expr_new.rs)

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -274,6 +274,20 @@ pub(super) fn try_native_module_methods(
                                 crate::ir::PosixCredentialKind::Egid,
                             )));
                         }
+                        "getgroups" => {
+                            // #2135: process.getgroups() — supplementary
+                            // group IDs as a number array. Dispatch through
+                            // the generic NativeMethodCall path; the
+                            // node_core table row routes to
+                            // `js_process_getgroups`.
+                            return Ok(Ok(Expr::NativeMethodCall {
+                                module: "process".to_string(),
+                                class_name: None,
+                                object: None,
+                                method: "getgroups".to_string(),
+                                args,
+                            }));
+                        }
                         "emitWarning" => {
                             // process.emitWarning(warning[, type, code, ctor])
                             // — writes a formatted warning to stderr. Perry

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -356,6 +356,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("process", "geteuid")
             | ("process", "getgid")
             | ("process", "getegid")
+            | ("process", "getgroups")
             | ("process", "emitWarning")
             | ("process", "on")
             | ("process", "addListener")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -358,6 +358,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
             crate::process::js_process_load_env_file(optional_path_str_ptr(0));
             f64::from_bits(crate::value::TAG_UNDEFINED)
         }
+        ("process", "getgroups") => crate::process::js_process_getgroups(),
         ("process", "kill") => {
             crate::os::js_process_kill(arg(0), arg(1));
             f64::from_bits(crate::value::TAG_UNDEFINED)

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -183,6 +183,38 @@ pub extern "C" fn js_process_getegid() -> f64 {
     }
 }
 
+/// `process.getgroups()` — supplementary group IDs the process is a member
+/// of, as a JS array of numbers. Wraps `libc::getgroups(2)`; on non-unix
+/// targets returns an empty array (Node throws there, but Perry's existing
+/// `getuid`/etc. family already returns `0` rather than throwing on
+/// Windows, so matching that shape keeps the surface consistent). #2135.
+#[no_mangle]
+pub extern "C" fn js_process_getgroups() -> f64 {
+    #[cfg(unix)]
+    let gids: Vec<u32> = unsafe {
+        let count = libc::getgroups(0, std::ptr::null_mut());
+        if count <= 0 {
+            Vec::new()
+        } else {
+            let mut buf: Vec<libc::gid_t> = vec![0; count as usize];
+            let got = libc::getgroups(count, buf.as_mut_ptr());
+            if got <= 0 {
+                Vec::new()
+            } else {
+                buf.truncate(got as usize);
+                buf.into_iter().map(|g| g as u32).collect()
+            }
+        }
+    };
+    #[cfg(not(unix))]
+    let gids: Vec<u32> = Vec::new();
+    let arr = crate::array::js_array_alloc(gids.len() as u32);
+    for g in gids {
+        crate::array::js_array_push_f64(arr, g as f64);
+    }
+    f64::from_bits(JSValue::array_ptr(arr).bits())
+}
+
 /// process.resourceUsage() -> object with getrusage(RUSAGE_SELF)
 /// counters matching Node's shape (#1376). Linux's `ru_maxrss` is in
 /// kilobytes; macOS/BSD's is in bytes — Node normalizes Linux to bytes,

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1481 entries across 82 modules
+// Coverage: 1482 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1788,6 +1788,8 @@ declare module "process" {
   export function geteuid(...args: any[]): any;
   /** stdlib */
   export function getgid(...args: any[]): any;
+  /** stdlib */
+  export function getgroups(...args: any[]): any;
   /** stdlib */
   export function getuid(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1481 entries across 82 modules.
+Total: 1482 entries across 82 modules.
 
 ## Modules
 
@@ -1678,6 +1678,7 @@ Total: 1481 entries across 82 modules.
 - `getegid` — module
 - `geteuid` — module
 - `getgid` — module
+- `getgroups` — module
 - `getuid` — module
 - `hrtime` — module
 - `kill` — module

--- a/test-files/test_issue_2135_getgroups.ts
+++ b/test-files/test_issue_2135_getgroups.ts
@@ -1,0 +1,22 @@
+// Refs #2135 (node:process stubbed methods): `process.getgroups()` is a
+// POSIX accessor that returns the supplementary group IDs for the
+// current process. Previously it read back as a 0 (typeof `"number"`),
+// so duck-type guards (`typeof process.getgroups === "function"`) saw
+// the stub and downstream code that called the value never ran.
+//
+// The runtime now wraps `libc::getgroups(2)`. The HIR lowers the static
+// `process.getgroups()` call through the generic NativeMethodCall path
+// which routes to `js_process_getgroups` via the node_core table; the
+// property-read form returns a bound-method closure (`typeof "function"`,
+// matching Node) via the existing process-callable-export whitelist.
+
+console.log(typeof process.getgroups);
+console.log(Array.isArray(process.getgroups()));
+console.log(process.getgroups().length >= 1);
+console.log(typeof process.getgroups()[0]);
+
+// The set we return matches the OS `id -G` output (every entry is a
+// non-negative integer GID). Sanity-check the shape without pinning a
+// host-specific count.
+const groups = process.getgroups();
+console.log(groups.every((g: number) => Number.isInteger(g) && g >= 0));


### PR DESCRIPTION
## Summary

- `typeof process.getgroups` returned `"number"` (a stub value of 0) instead of `"function"`, and the call form was unreachable. Wire it through the same path as the existing `getuid`/`geteuid`/`getgid`/`getegid` family:
  - `js_process_getgroups` in `process.rs` wraps `libc::getgroups(2)` to produce an `Array<number>` of supplementary GIDs (empty on non-unix).
  - Property-read whitelist (`is_native_module_callable_export`, `property_get.rs`) returns a bound-method closure so `typeof === "function"` matches Node.
  - HIR lowering routes the call form through `NativeMethodCall`; the `node_core` table row dispatches to `js_process_getgroups`, with a matching dynamic-dispatch arm + manifest entry.

Closes another #2135 process-tracker stubbed-method gap.

## Test plan

- New gap test `test-files/test_issue_2135_getgroups.ts` byte-identical with Node — covers `typeof`, `Array.isArray`, element typeof, length > 0, and an integer-shape assertion that doesn't pin host-specific GIDs.
- `cargo fmt --all -- --check` clean.
- `cargo test --release -p perry-codegen --test manifest_consistency` passes (manifest+dispatch+table are in sync).
- `scripts/check_file_size.sh` OK (no Rust files over the 2000-line gate).
- `scripts/regen_api_docs.sh` clean (committed diff included).
