### PR TITLE
fix(node:buffer): handle Buffer.from object sources

### DIFF
--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -133,6 +133,52 @@ fn buffer_byte_from_js_value(value: f64) -> u8 {
     }
 }
 
+unsafe fn buffer_from_object_value_of(
+    ptr: usize,
+    original_value: f64,
+    encoding: i32,
+) -> Option<*mut BufferHeader> {
+    if ptr < 0x1000 {
+        return None;
+    }
+    let gc_type = *((ptr - crate::gc::GC_HEADER_SIZE) as *const u8);
+    if gc_type != crate::gc::GC_TYPE_OBJECT {
+        return None;
+    }
+
+    let value_of_key = js_string_from_bytes(b"valueOf".as_ptr(), 7);
+    let value_of = crate::object::js_object_get_field_by_name(
+        ptr as *const crate::object::ObjectHeader,
+        value_of_key,
+    );
+    if !value_of.is_pointer() {
+        return None;
+    }
+    let closure_ptr = value_of.as_pointer::<u8>() as usize;
+    if !crate::closure::is_closure_ptr(closure_ptr) {
+        return None;
+    }
+
+    let converted = crate::object::js_native_call_method(
+        original_value,
+        b"valueOf".as_ptr() as *const i8,
+        7,
+        ptr::null(),
+        0,
+    );
+    if converted.to_bits() == original_value.to_bits() {
+        return None;
+    }
+    let converted_value = crate::JSValue::from_bits(converted.to_bits());
+    if converted_value.is_null() || converted_value.is_undefined() {
+        return None;
+    }
+    if converted_value.is_any_string() || converted_value.is_pointer() {
+        return Some(js_buffer_from_value(converted.to_bits() as i64, encoding));
+    }
+    None
+}
+
 unsafe fn buffer_from_array_like_object(ptr: usize) -> Option<*mut BufferHeader> {
     if ptr < 0x1000 {
         return None;
@@ -176,12 +222,25 @@ unsafe fn buffer_from_array_like_object(ptr: usize) -> Option<*mut BufferHeader>
     Some(buf)
 }
 
+unsafe fn buffer_from_object_to_primitive(value: f64, encoding: i32) -> Option<*mut BufferHeader> {
+    let primitive = crate::symbol::js_to_primitive(value, 2);
+    if primitive.to_bits() == value.to_bits() {
+        return None;
+    }
+    let primitive_value = crate::JSValue::from_bits(primitive.to_bits());
+    if primitive_value.is_any_string() {
+        return Some(js_buffer_from_value(primitive.to_bits() as i64, encoding));
+    }
+    None
+}
+
 /// Create a Buffer from a value (auto-detects string vs array vs buffer)
 /// This is used by Buffer.from() which accepts multiple input types.
 #[no_mangle]
 pub extern "C" fn js_buffer_from_value(value: i64, encoding: i32) -> *mut BufferHeader {
     let bits = value as u64;
     let jsval = crate::JSValue::from_bits(bits);
+    let value_f64 = f64::from_bits(bits);
 
     // Check if it's a NaN-boxed heap string
     if jsval.is_string() {
@@ -248,7 +307,11 @@ pub extern "C" fn js_buffer_from_value(value: i64, encoding: i32) -> *mut Buffer
             }
             buf
         }
+    } else if let Some(buf) = unsafe { buffer_from_object_value_of(ptr, value_f64, encoding) } {
+        buf
     } else if let Some(buf) = unsafe { buffer_from_array_like_object(ptr) } {
+        buf
+    } else if let Some(buf) = unsafe { buffer_from_object_to_primitive(value_f64, encoding) } {
         buf
     } else {
         // Assume it's an array of numbers

--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -124,6 +124,58 @@ pub extern "C" fn js_encoding_tag_from_value(value: f64) -> i32 {
     }
 }
 
+fn buffer_byte_from_js_value(value: f64) -> u8 {
+    let number = crate::builtins::js_number_coerce(value);
+    if number.is_finite() {
+        ((number as i64) & 0xFF) as u8
+    } else {
+        0
+    }
+}
+
+unsafe fn buffer_from_array_like_object(ptr: usize) -> Option<*mut BufferHeader> {
+    if ptr < 0x1000 {
+        return None;
+    }
+    let gc_type = *((ptr - crate::gc::GC_HEADER_SIZE) as *const u8);
+    if gc_type != crate::gc::GC_TYPE_OBJECT {
+        return None;
+    }
+
+    let length_key = js_string_from_bytes(b"length".as_ptr(), 6);
+    let length_value = crate::object::js_object_get_field_by_name(
+        ptr as *const crate::object::ObjectHeader,
+        length_key,
+    );
+    if length_value.is_undefined() {
+        return None;
+    }
+
+    let length = if length_value.is_int32() {
+        length_value.as_int32() as f64
+    } else if length_value.is_number() {
+        length_value.as_number()
+    } else {
+        return Some(buffer_alloc(0));
+    };
+
+    if !length.is_finite() || length <= 0.0 {
+        return Some(buffer_alloc(0));
+    }
+
+    let len = length.trunc().min(u32::MAX as f64) as u32;
+    let buf = buffer_alloc(len);
+    (*buf).length = len;
+    let buf_data = buffer_data_mut(buf);
+
+    for i in 0..len {
+        let value = crate::object::js_object_get_index_polymorphic(ptr as i64, i as f64);
+        *buf_data.add(i as usize) = buffer_byte_from_js_value(value);
+    }
+
+    Some(buf)
+}
+
 /// Create a Buffer from a value (auto-detects string vs array vs buffer)
 /// This is used by Buffer.from() which accepts multiple input types.
 #[no_mangle]
@@ -196,6 +248,8 @@ pub extern "C" fn js_buffer_from_value(value: i64, encoding: i32) -> *mut Buffer
             }
             buf
         }
+    } else if let Some(buf) = unsafe { buffer_from_array_like_object(ptr) } {
+        buf
     } else {
         // Assume it's an array of numbers
         js_buffer_from_array(ptr as *const ArrayHeader)
@@ -225,22 +279,7 @@ pub extern "C" fn js_buffer_from_array(arr_ptr: *const ArrayHeader) -> *mut Buff
         let buf_data = buffer_data_mut(buf);
 
         for i in 0..len {
-            let val = *arr_data.add(i);
-            // Array elements may be NaN-boxed INT32, raw f64 numbers, or
-            // NaN-boxed pointers/strings (rare for byte literals). Decode
-            // numeric kinds; non-numeric values become 0.
-            let bits = val.to_bits();
-            let top16 = bits >> 48;
-            let byte = if top16 == 0x7FFE {
-                // INT32_TAG: lower 32 bits are an i32
-                ((bits as u32) & 0xFF) as u8
-            } else if !val.is_nan() {
-                // Raw double — convert via i64 to handle negatives correctly
-                ((val as i64) & 0xFF) as u8
-            } else {
-                0
-            };
-            *buf_data.add(i) = byte;
+            *buf_data.add(i) = buffer_byte_from_js_value(*arr_data.add(i));
         }
 
         buf


### PR DESCRIPTION
Part of #793.

Summary:
- detect plain object array-like inputs in `Buffer.from` before the `ArrayHeader` fallback
- require a numeric `length`, return empty for non-number/non-positive lengths, and truncate fractional lengths
- honor custom `valueOf()` string/object results and string-returning `Symbol.toPrimitive` sources
- read indexed properties through object lookup and share byte coercion with array sources

Verification:
- DeepWiki: `reference/deepwiki/nodejs-node-buffer-from-arraylike-coercions-2026-05-28.md`
- DeepWiki: `reference/deepwiki/nodejs-node-buffer-from-object-primitives-2026-05-28.md`
- Baseline exact `node-suite/buffer/from/arraylike-coercions`: FAIL, report `test-parity/reports/parity_report_20260528_125501.json`
- Final exact `node-suite/buffer/from/arraylike-coercions`: PASS, report `test-parity/reports/parity_report_20260528_125818.json`
- Baseline exact `node-suite/buffer/from/valueof-symbol-to-primitive`: FAIL, report `test-parity/reports/parity_report_20260528_130501.json`
- Final exact `node-suite/buffer/from/valueof-symbol-to-primitive`: PASS, report `test-parity/reports/parity_report_20260528_130903.json`
- Full `node-suite/buffer/from`: 15 PASS / 1 parity FAIL, report `test-parity/reports/parity_report_20260528_130955.json`; only primitive input validation remains red and is covered by #2287
- Full `node-suite/buffer`: 105 PASS / 10 parity FAIL / 1 compile FAIL, report `test-parity/reports/parity_report_20260528_131022.json`; targets green
- `cargo check -p perry-runtime -p perry-stdlib -p perry-codegen`: PASS with existing warnings
- `cargo fmt --check`: PASS
- `jq empty test-parity/known_failures.json`: PASS
- `git diff --check`: PASS

Non-goals:
- no primitive input validation, covered by #2287
- no non-string `Symbol.toPrimitive` TypeError cleanup
- no ArrayBuffer offset validation
- no broad Buffer.from error-message cleanup