### PR TITLE
fix(node:path): support matchesGlob brace alternation

### DIFF
--- a/crates/perry-runtime/src/path.rs
+++ b/crates/perry-runtime/src/path.rs
@@ -706,13 +706,37 @@ pub extern "C" fn js_path_to_namespaced_path(path_ptr: *const StringHeader) -> *
     }
 }
 
-/// Convert a glob pattern (`*`, `?`, `[abc]`, `**`) into a regex, anchored
-/// at both ends. Mirrors Node's `path.matchesGlob` semantics, which Node
-/// documents as identical to `picomatch` defaults: `*` matches any chars
-/// except `/`, `**` matches across `/`, `?` matches a single char except
-/// `/`, character classes `[...]` work like regex.
-fn glob_to_regex(pattern: &str) -> String {
-    let mut out = String::from("^");
+fn brace_alternation<'a>(pattern: &'a str, open: usize) -> Option<(usize, Vec<&'a str>)> {
+    let bytes = pattern.as_bytes();
+    let mut depth = 0usize;
+    let mut arm_start = open + 1;
+    let mut arms = Vec::new();
+    let mut saw_comma = false;
+    let mut i = open + 1;
+    while i < bytes.len() {
+        match bytes[i] as char {
+            '{' => depth += 1,
+            '}' if depth == 0 => {
+                if !saw_comma {
+                    return None;
+                }
+                arms.push(&pattern[arm_start..i]);
+                return Some((i, arms));
+            }
+            '}' => depth -= 1,
+            ',' if depth == 0 => {
+                saw_comma = true;
+                arms.push(&pattern[arm_start..i]);
+                arm_start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+fn push_glob_regex(pattern: &str, out: &mut String) {
     let bytes = pattern.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
@@ -742,7 +766,23 @@ fn glob_to_regex(pattern: &str) -> String {
                 }
                 out.push(']');
             }
-            '.' | '+' | '(' | ')' | '|' | '^' | '$' | '{' | '}' | '\\' => {
+            '{' => {
+                if let Some((close, arms)) = brace_alternation(pattern, i) {
+                    out.push_str("(?:");
+                    for (idx, arm) in arms.iter().enumerate() {
+                        if idx > 0 {
+                            out.push('|');
+                        }
+                        push_glob_regex(arm, out);
+                    }
+                    out.push(')');
+                    i = close;
+                } else {
+                    out.push('\\');
+                    out.push(c);
+                }
+            }
+            '.' | '+' | '(' | ')' | '|' | '^' | '$' | '}' | '\\' => {
                 out.push('\\');
                 out.push(c);
             }
@@ -750,6 +790,16 @@ fn glob_to_regex(pattern: &str) -> String {
         }
         i += 1;
     }
+}
+
+/// Convert a glob pattern (`*`, `?`, `[abc]`, `{a,b}`, `**`) into a regex,
+/// anchored at both ends. Mirrors Node's `path.matchesGlob` basics: `*`
+/// matches any chars except `/`, `**` matches across `/`, `?` matches a
+/// single char except `/`, character classes `[...]` work like regex, and
+/// brace alternation expands alternatives such as `*.{md,txt}`.
+fn glob_to_regex(pattern: &str) -> String {
+    let mut out = String::from("^");
+    push_glob_regex(pattern, &mut out);
     out.push('$');
     out
 }
@@ -1247,6 +1297,25 @@ pub extern "C" fn js_path_win32_relative(
         let mut parts: Vec<&str> = std::iter::repeat_n("..", ups).collect();
         parts.extend(to_segs[common..].iter().copied());
         string_to_js(&parts.join("\\"))
+    }
+}
+
+#[cfg(test)]
+mod glob_tests {
+    use super::glob_to_regex;
+
+    #[test]
+    fn brace_alternation_expands_to_group() {
+        assert_eq!(glob_to_regex("*.{md,txt}"), "^[^/]*\\.(?:md|txt)$");
+        assert_eq!(
+            glob_to_regex("src/{app,test}.ts"),
+            "^src/(?:app|test)\\.ts$"
+        );
+    }
+
+    #[test]
+    fn braces_without_alternation_stay_literal() {
+        assert_eq!(glob_to_regex("file.{md}"), "^file\\.\\{md\\}$");
     }
 }
 


### PR DESCRIPTION
## Summary
- expand comma-bearing `{...}` groups in the `path.matchesGlob` glob-to-regex path so patterns like `*.{md,txt}` match either suffix
- keep braces without alternation literal and preserve existing `*`, `**`, `?`, character class, and anchored matching behavior
- add focused runtime unit coverage for brace expansion

## Issue
- Part of Node compatibility work tracked under #793.

## Verification
- Baseline exact `node-suite/path/matchesGlob/edge-cases`: FAIL, report `test-parity/reports/parity_report_20260528_132224.json`
- `cargo test -p perry-runtime glob_tests`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/path/matchesGlob/edge-cases` -> PASS, report `test-parity/reports/parity_report_20260528_132822.json`
- `./run_parity_tests.sh --suite node-suite --module path` -> 78 PASS / 4 parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260528_132931.json`; remaining failures are unrelated `parse/dotfiles-and-roots`, `toNamespacedPath/edge-cases`, `win32/posix-looking-paths`, and `win32/unc-and-drive-relative`
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p perry-runtime`

## DeepWiki
- Saved local reference: `reference/deepwiki/node-path-matchesglob-braces.md`
- Invariant used: Node routes `path.matchesGlob` through minimatch, brace expansion happens before matching, single-star stays within a segment, globstar crosses segments, and matching is full-string anchored.

## Non-goals
- no full minimatch implementation
- no dotfile option work
- no win32 path separator/case overhaul
- no fixes for the remaining path parse/toNamespaced/win32 residuals
