### PR TITLE
fix(node:stream): emit 'close' after 'end' on readable-only streams

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -2384,6 +2384,18 @@ fn emit_readable_end_once(stream: f64) {
         refresh_readable_aborted_flag(stream);
         let _ = emit_stream_event(stream, string_value(b"end"), &[]);
         end_pipe_destinations(stream);
+        // For a Readable-only stream (no writable side), 'close' follows
+        // 'end' — Node's spec emits `close` after the stream's resources
+        // are released. A Duplex defers `close` until BOTH 'end' and
+        // 'finish' have fired; that path is handled separately in the
+        // writable-side `ns_end1` (which also emits `close` after
+        // `finish`). Without this, `Readable.from([...])` never fired
+        // `close`, so `readable.closed` reported `false` after the data
+        // was fully consumed. Refs node-suite/stream/readable/closed-flag.
+        if get_hidden_value(stream, hidden_writable_flag_key()).is_none() {
+            mark_stream_closed(stream);
+            let _ = emit_stream_event(stream, string_value(b"close"), &[]);
+        }
     }
 }
 

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1,36 +1,36 @@
 {
   "_schema": {
-    "description": "Each entry maps a parity-suite test name to a structured record. The CI gate in .github/workflows/test.yml reads `keys[]` from this file — a test that fails AND is not a key here breaks CI. Add entries here only with full provenance (issue + added date) so we can revalidate.",
+    "description": "Each entry maps a parity-suite test name to a structured record. The CI gate in .github/workflows/test.yml reads `keys[]` from this file \u2014 a test that fails AND is not a key here breaks CI. Add entries here only with full provenance (issue + added date) so we can revalidate.",
     "fields": {
-      "issue": "Open GitHub issue number tracking this failure (e.g. \"793\"), or null when the failure is environmental / pending triage. Closed issues must be re-evaluated — flag the entry as `category: bug-stale` until a new tracking issue is filed.",
+      "issue": "Open GitHub issue number tracking this failure (e.g. \"793\"), or null when the failure is environmental / pending triage. Closed issues must be re-evaluated \u2014 flag the entry as `category: bug-stale` until a new tracking issue is filed.",
       "added": "ISO date (YYYY-MM-DD) when the test was first skip-listed. Use 2026-05-15 for entries inherited from the pre-audit format where the historical date is unknown.",
-      "category": "ci-env | module-inventory | bug-open | bug-stale | gap-categorical | gap-bisect — see test-parity/README.md for definitions.",
-      "reason": "Free-text explanation. Keep the most-actionable signal first — what changes the verdict (a fixture, a Perry fix, a Node spec change)."
+      "category": "ci-env | module-inventory | bug-open | bug-stale | gap-categorical | gap-bisect \u2014 see test-parity/README.md for definitions.",
+      "reason": "Free-text explanation. Keep the most-actionable signal first \u2014 what changes the verdict (a fixture, a Perry fix, a Node spec change)."
     }
   },
   "issue_655_repro": {
     "issue": "655",
     "added": "2026-05-24",
     "category": "bug-stale",
-    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #655 is closed. Deliberate failing repro/harness — kept as a regression canary. Canonical regression-catcher for issue #655. Flips to PASS when the underlying fix lands. Keep regardless of CI verdict — it's a deliberate failing repro."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #655 is closed. Deliberate failing repro/harness \u2014 kept as a regression canary. Canonical regression-catcher for issue #655. Flips to PASS when the underlying fix lands. Keep regardless of CI verdict \u2014 it's a deliberate failing repro."
   },
   "test_gap_regexp_advanced": {
     "issue": null,
     "added": "2026-05-15",
     "category": "gap-categorical",
-    "reason": "Lookbehind regex assertions — Rust's `regex` crate doesn't support `(?<=)` / `(?<!)`. Documented in CLAUDE.md as a known categorical gap. Unblocking requires swapping the regex backend or implementing a separate matcher for lookbehind."
+    "reason": "Lookbehind regex assertions \u2014 Rust's `regex` crate doesn't support `(?<=)` / `(?<!)`. Documented in CLAUDE.md as a known categorical gap. Unblocking requires swapping the regex backend or implementing a separate matcher for lookbehind."
   },
   "test_harness_class_mixins": {
     "issue": "806",
     "added": "2026-05-24",
     "category": "bug-stale",
-    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #806 is closed. Deliberate failing repro/harness — kept as a regression canary. #806 harness for `class X extends Fn(...)<...>` patterns. Two sub-cases surface real Perry gaps today: (1) bare-factory subclass loses the base's field initializer (`bare.kind: undefined` vs Node's `bare.kind: bare`); (2) chained mixin `WithA(WithB(WithC(Base)))` throws `TypeError: value is not a function` at construction. Captured-factory + Effect double-call shapes pass post-#740 — the harness verifies that survives. Linked to #321 umbrella; will flip to PASS as each sub-case lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #806 is closed. Deliberate failing repro/harness \u2014 kept as a regression canary. #806 harness for `class X extends Fn(...)<...>` patterns. Two sub-cases surface real Perry gaps today: (1) bare-factory subclass loses the base's field initializer (`bare.kind: undefined` vs Node's `bare.kind: bare`); (2) chained mixin `WithA(WithB(WithC(Base)))` throws `TypeError: value is not a function` at construction. Captured-factory + Effect double-call shapes pass post-#740 \u2014 the harness verifies that survives. Linked to #321 umbrella; will flip to PASS as each sub-case lands."
   },
   "test_issue_422_socket_connect": {
     "issue": "1634",
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Tracked in #1634 (parity CI environment fixtures). #422 closed (net.Socket connect/error events + factory). The test passes locally with an echo server running but fails on Linux CI because no echo fixture server runs. Environmental — needs a CI-side fixture, not a Perry fix."
+    "reason": "Tracked in #1634 (parity CI environment fixtures). #422 closed (net.Socket connect/error events + factory). The test passes locally with an echo server running but fails on Linux CI because no echo fixture server runs. Environmental \u2014 needs a CI-side fixture, not a Perry fix."
   },
   "test_issue_561_sigv4_chain": {
     "issue": "793",
@@ -54,163 +54,163 @@
     "issue": "922",
     "added": "2026-05-24",
     "category": "bug-stale",
-    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #922 is closed. Deliberate failing repro/harness — kept as a regression canary. Regression test from #922 (P0 production /api crash). Deliberate failing repro until the underlying codegen bug is fixed; #934 added a circuit breaker that converts the runaway loop into [PERRY ABORT] (so test fails by design — the abort message diverges from Node's success output)."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #922 is closed. Deliberate failing repro/harness \u2014 kept as a regression canary. Regression test from #922 (P0 production /api crash). Deliberate failing repro until the underlying codegen bug is fixed; #934 added a circuit breaker that converts the runaway loop into [PERRY ABORT] (so test fails by design \u2014 the abort message diverges from Node's success output)."
   },
   "test_net_min": {
     "issue": "1634",
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — needs a CI-side fixture, not a Perry fix."
+    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 needs a CI-side fixture, not a Perry fix."
   },
   "test_net_socket": {
     "issue": "1634",
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — needs a CI-side fixture, not a Perry fix."
+    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 needs a CI-side fixture, not a Perry fix."
   },
   "test_net_upgrade_tls": {
     "issue": "1634",
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test needs a TLS-capable echo server fixture; not available on CI. Environmental — needs a CI-side fixture."
+    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test needs a TLS-capable echo server fixture; not available on CI. Environmental \u2014 needs a CI-side fixture."
   },
   "test_parity_buffer": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:buffer` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:buffer` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_crypto": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:crypto` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:crypto` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_dgram": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:dgram` (UDP) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:dgram` (UDP) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_dns": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:dns` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:dns` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_dns_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:dns/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:dns/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_http": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:http` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:http` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_http2": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:http2` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:http2` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_https": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:https` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:https` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_module": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:module` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:module` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_net": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:net` socket-layer surface not implemented (Server/Socket classes, BlockList, SocketAddress). Classification helpers landed via #811. Tracker for surface coverage; flips to PASS as each API lands."
+    "reason": "Node.js module inventory \u2014 `node:net` socket-layer surface not implemented (Server/Socket classes, BlockList, SocketAddress). Classification helpers landed via #811. Tracker for surface coverage; flips to PASS as each API lands."
   },
   "test_parity_readline": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:readline` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:readline` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_readline_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:readline/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:readline/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_sqlite": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:sqlite` (Node 22.5+ built-in) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:sqlite` (Node 22.5+ built-in) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:stream` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:stream` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream_web": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:stream/web` (WHATWG streams) surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:stream/web` (WHATWG streams) surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_test": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:test` (built-in test runner) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:test` (built-in test runner) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_tls": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:tls` surface not fully implemented (Socket-level TLS upgrade works via net.upgradeToTLS; the higher-level tls.connect/Server is partial). Tracker for surface coverage."
+    "reason": "Node.js module inventory \u2014 `node:tls` surface not fully implemented (Socket-level TLS upgrade works via net.upgradeToTLS; the higher-level tls.connect/Server is partial). Tracker for surface coverage."
   },
   "test_parity_util": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:util` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:util` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_worker_threads": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:worker_threads` surface not implemented (perry/thread provides a Perry-native alternative). Tracker for surface coverage; flips to PASS as each API lands."
+    "reason": "Node.js module inventory \u2014 `node:worker_threads` surface not implemented (perry/thread provides a Perry-native alternative). Tracker for surface coverage; flips to PASS as each API lands."
   },
   "test_parity_zlib": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:zlib` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:zlib` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_sock_write_map": {
     "issue": "1634",
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — issue #91 dispatch fix landed in v0.5.581 and is no longer the cause; needs a CI-side fixture."
+    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 issue #91 dispatch fix landed in v0.5.581 and is no longer the cause; needs a CI-side fixture."
   },
   "test_ramda_sum": {
     "issue": "1634",
     "added": "2026-05-18",
     "category": "ci-env",
-    "reason": "Tracked in #1634 (parity CI environment fixtures). Ramda npm-package fixture failure on Linux CI; observed on #1038's CI run pre-merge. Companion to the existing test_ramda_user_import skip in the compile-smoke list — the parity harness can't npm-install ramda. File a CI-side fixture issue if/when this matters for sweep coverage."
+    "reason": "Tracked in #1634 (parity CI environment fixtures). Ramda npm-package fixture failure on Linux CI; observed on #1038's CI run pre-merge. Companion to the existing test_ramda_user_import skip in the compile-smoke list \u2014 the parity harness can't npm-install ramda. File a CI-side fixture issue if/when this matters for sweep coverage."
   },
   "test_stream_on": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream EventEmitter wiring incomplete — re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS. Real Perry gap (not ci-env); rolled under the open stream-events tracker #1532."
+    "reason": "node:stream EventEmitter wiring incomplete \u2014 re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS. Real Perry gap (not ci-env); rolled under the open stream-events tracker #1532."
   },
   "node-suite/stream/pipeline/basic": {
     "issue": "1532",
@@ -234,25 +234,19 @@
     "issue": "1532",
     "added": "2026-05-23",
     "category": "bug-open",
-    "reason": "node:stream: Readable.from(asyncIterable) → data event chain doesn't deliver. Flips to PASS when #1532 lands."
+    "reason": "node:stream: Readable.from(asyncIterable) \u2192 data event chain doesn't deliver. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/from-generator": {
     "issue": "1532",
     "added": "2026-05-23",
     "category": "bug-open",
-    "reason": "node:stream: Readable.from(generator) → data event chain doesn't deliver. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/closed-flag": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.closed flag + close event don't deliver. Flips to PASS when #1531 lands."
+    "reason": "node:stream: Readable.from(generator) \u2192 data event chain doesn't deliver. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipeline/three-stream-chain": {
     "issue": "1532",
     "added": "2026-05-23",
     "category": "bug-open",
-    "reason": "node:stream: pipeline with intermediate transform doesn't propagate data → end. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipeline with intermediate transform doesn't propagate data \u2192 end. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/finished/with-options-signal": {
     "issue": "1532",
@@ -450,31 +444,31 @@
     "issue": "1532",
     "added": "2026-05-23",
     "category": "bug-open",
-    "reason": "node:stream: duplexPair() — fails to compile (export not yet wired through perry-stdlib stream re-exports). Flips to PASS when #1532 lands."
+    "reason": "node:stream: duplexPair() \u2014 fails to compile (export not yet wired through perry-stdlib stream re-exports). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/finished/error-false-option": {
     "issue": "1532",
     "added": "2026-05-23",
     "category": "bug-open",
-    "reason": "node:stream: finished({error:false}) option ignored — callback still fires on destroy(err). Flips to PASS when #1532 lands."
+    "reason": "node:stream: finished({error:false}) option ignored \u2014 callback still fires on destroy(err). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/single-sync-fn": {
     "issue": "1531",
     "added": "2026-05-23",
     "category": "bug-open",
-    "reason": "node:stream: compose(readable, asyncGenFn) — fails to compile (single-fn compose form not yet wired). Flips to PASS when #1531 lands."
+    "reason": "node:stream: compose(readable, asyncGenFn) \u2014 fails to compile (single-fn compose form not yet wired). Flips to PASS when #1531 lands."
   },
   "node-suite/stream/duplex/from-async-iterable": {
     "issue": "1532",
     "added": "2026-05-23",
     "category": "bug-open",
-    "reason": "node:stream: Duplex.from(asyncIterable) — async-gen → Duplex form not yet wired. Flips to PASS when #1532 lands."
+    "reason": "node:stream: Duplex.from(asyncIterable) \u2014 async-gen \u2192 Duplex form not yet wired. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/instance-method": {
     "issue": "1531",
     "added": "2026-05-23",
     "category": "bug-open",
-    "reason": "node:stream: Readable.prototype.compose(stream) instance method — not yet exposed (only free compose() works). Flips to PASS when #1531 lands."
+    "reason": "node:stream: Readable.prototype.compose(stream) instance method \u2014 not yet exposed (only free compose() works). Flips to PASS when #1531 lands."
   },
   "node-suite/stream/readable/read-size-passed-to-_read": {
     "issue": "1531",
@@ -486,7 +480,7 @@
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: readable.unshift(chunk, encoding) — second-arg encoding form not honored. Flips to PASS when #1531 lands."
+    "reason": "node:stream: readable.unshift(chunk, encoding) \u2014 second-arg encoding form not honored. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/pipeline/premature-close-code": {
     "issue": "1532",
@@ -498,13 +492,13 @@
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Duplex with finish/end/close event ordering — fails to compile (this/method context inside arrow callback). Flips to PASS when #1532 lands."
+    "reason": "node:stream: Duplex with finish/end/close event ordering \u2014 fails to compile (this/method context inside arrow callback). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/duplex/from-object-form": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Duplex.from({readable, writable}) — combine-form not yet wired. Flips to PASS when #1532 lands."
+    "reason": "node:stream: Duplex.from({readable, writable}) \u2014 combine-form not yet wired. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipe/pipe-twice-same-dest": {
     "issue": "1532",
@@ -516,55 +510,49 @@
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.from(iter, options) — 2nd-arg stream options (objectMode/highWaterMark) ignored. Flips to PASS when #1532 lands."
+    "reason": "node:stream: Readable.from(iter, options) \u2014 2nd-arg stream options (objectMode/highWaterMark) ignored. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipe/end-false-option": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pipe(dst, {end: false}) — destination still ended when source ends. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipe(dst, {end: false}) \u2014 destination still ended when source ends. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/finished/with-cleanup-option": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: finished({cleanup: true}) — temporary listeners not auto-removed after callback. Flips to PASS when #1532 lands."
+    "reason": "node:stream: finished({cleanup: true}) \u2014 temporary listeners not auto-removed after callback. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/compose-array-form": {
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: compose(src, transform, sink) — spread-arg form does not produce a working pipeline. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/web/writable-stream-start-hook": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: WritableStream sink.start() hook not awaited before first write. Flips to PASS when #1545 lands."
+    "reason": "node:stream: compose(src, transform, sink) \u2014 spread-arg form does not produce a working pipeline. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/readable/from-infinite-take": {
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.from(infiniteGen).take(N) — take helper does not abort upstream early; iteration hangs or returns wrong items. Flips to PASS when #1558 lands."
+    "reason": "node:stream: Readable.from(infiniteGen).take(N) \u2014 take helper does not abort upstream early; iteration hangs or returns wrong items. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/web/desired-size-backpressure": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: writer.desiredSize w/ CountQueuingStrategy — fails to compile (CountQueuingStrategy constructor not on globalThis). Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: writer.desiredSize w/ CountQueuingStrategy \u2014 fails to compile (CountQueuingStrategy constructor not on globalThis). Flips to PASS when #1545 lands."
   },
   "node-suite/stream/events/once-returns-promise": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: events.once(stream, 'end') — Promise-returning form does not resolve correctly. Flips to PASS when #1532 lands."
+    "reason": "node:stream: events.once(stream, 'end') \u2014 Promise-returning form does not resolve correctly. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/error-mid-chain": {
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: compose() — error in middle transform does not propagate to composite 'error' event. Flips to PASS when #1531 lands."
+    "reason": "node:stream: compose() \u2014 error in middle transform does not propagate to composite 'error' event. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/iter-helpers/to-array-erroring": {
     "issue": "1558",
@@ -576,19 +564,19 @@
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: read() after end — does not consistently return null. Flips to PASS when #1532 lands."
+    "reason": "node:stream: read() after end \u2014 does not consistently return null. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/transform-cancel-propagates": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: TransformStream readable.cancel() does not propagate to writable — writes still succeed after cancel. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: TransformStream readable.cancel() does not propagate to writable \u2014 writes still succeed after cancel. Flips to PASS when #1545 lands."
   },
   "test_gap_console_methods": {
     "issue": "1278",
     "added": "2026-05-21",
     "category": "gap-categorical",
-    "reason": "#1278: console.trace / Error.stack frame format diverges from Node (Perry prints native frame addresses like `0: __mh_execute_header` instead of `at <fn> (file:///…:line:col)`). Requires source-position retention through HIR/transform + native-frame → TS-source mapping. The other two divergences in this fixture (#1276 spurious `Values` column on array-of-arrays, #1277 timer ms numbers) are not gating: #1276 was fixed in v0.5.1019+; #1277 is a misdiagnosis — Perry's `Instant::now()` is correct and the apparent 1000× gap is just AOT-vs-interpreted speedup on the trivial loop workload. Flips to PASS when #1278 lands."
+    "reason": "#1278: console.trace / Error.stack frame format diverges from Node (Perry prints native frame addresses like `0: __mh_execute_header` instead of `at <fn> (file:///\u2026:line:col)`). Requires source-position retention through HIR/transform + native-frame \u2192 TS-source mapping. The other two divergences in this fixture (#1276 spurious `Values` column on array-of-arrays, #1277 timer ms numbers) are not gating: #1276 was fixed in v0.5.1019+; #1277 is a misdiagnosis \u2014 Perry's `Instant::now()` is correct and the apparent 1000\u00d7 gap is just AOT-vs-interpreted speedup on the trivial loop workload. Flips to PASS when #1278 lands."
   },
   "node-suite/stream/readable/object-mode-read-returns-object": {
     "issue": "1532",
@@ -600,31 +588,31 @@
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: readable.map(asyncFn) — rejection in fn does not abort iteration / propagate as throw. Flips to PASS when #1558 lands."
+    "reason": "node:stream: readable.map(asyncFn) \u2014 rejection in fn does not abort iteration / propagate as throw. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/iter-helpers/reduce-no-initial": {
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: reduce(fn) without initial — first item not used as accumulator. Flips to PASS when #1558 lands."
+    "reason": "node:stream: reduce(fn) without initial \u2014 first item not used as accumulator. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/pipeline/async-fn-sink": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pipeline(src, async fn) — fn-as-sink form not yet wired (cb not called, collected is empty). Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipeline(src, async fn) \u2014 fn-as-sink form not yet wired (cb not called, collected is empty). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/unshift-after-end": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: unshift() after end — does not emit 'error' / ERR_STREAM_PUSH_AFTER_EOF. Flips to PASS when #1532 lands."
+    "reason": "node:stream: unshift() after end \u2014 does not emit 'error' / ERR_STREAM_PUSH_AFTER_EOF. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/async-handler-promise": {
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: compose(src, asyncGenWithAwait) — async-await handler not iterated correctly. Flips to PASS when #1531 lands."
+    "reason": "node:stream: compose(src, asyncGenWithAwait) \u2014 async-await handler not iterated correctly. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/web/byob-reader-getReader": {
     "issue": "1545",
@@ -636,43 +624,43 @@
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: unshift() — readableLength does not grow by chunk size. Flips to PASS when #1532 lands."
+    "reason": "node:stream: unshift() \u2014 readableLength does not grow by chunk size. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/instance-chain": {
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: r.compose(t1).compose(t2) — chained compose() returns Duplex but pipeline breaks. Flips to PASS when #1531 lands."
+    "reason": "node:stream: r.compose(t1).compose(t2) \u2014 chained compose() returns Duplex but pipeline breaks. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/readable/read-in-readable-listener": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: read() inside 'readable' listener — while-loop drain pattern produces wrong output. Flips to PASS when #1532 lands."
+    "reason": "node:stream: read() inside 'readable' listener \u2014 while-loop drain pattern produces wrong output. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/flow/sequential-reads": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: sequential read(N) drain — buffer order or chunk boundaries wrong. Flips to PASS when #1532 lands."
+    "reason": "node:stream: sequential read(N) drain \u2014 buffer order or chunk boundaries wrong. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/async-iter-handler-rejection": {
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: compose() async-gen handler throw — composite does not emit 'error'. Flips to PASS when #1531 lands."
+    "reason": "node:stream: compose() async-gen handler throw \u2014 composite does not emit 'error'. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/pipe/dest-error-propagates": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pipe error semantics — destination error or source close state differs from Node. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipe error semantics \u2014 destination error or source close state differs from Node. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/options/auto-destroy-true-default": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: autoDestroy:true default — stream not destroyed after 'end', 'close' may not fire. Flips to PASS when #1532 lands."
+    "reason": "node:stream: autoDestroy:true default \u2014 stream not destroyed after 'end', 'close' may not fire. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/custom-strategy-nan-size": {
     "issue": "1545",
@@ -684,31 +672,25 @@
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.from(POJO-with-Symbol.iterator) — does not iterate the custom iterable. Flips to PASS when #1532 lands."
+    "reason": "node:stream: Readable.from(POJO-with-Symbol.iterator) \u2014 does not iterate the custom iterable. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/unshift-return-value": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: unshift() return value — not undefined. Flips to PASS when #1532 lands."
+    "reason": "node:stream: unshift() return value \u2014 not undefined. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/buffer-preserves": {
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: compose() — Buffer chunks not preserved through pipeline (typed as string?). Flips to PASS when #1531 lands."
+    "reason": "node:stream: compose() \u2014 Buffer chunks not preserved through pipeline (typed as string?). Flips to PASS when #1531 lands."
   },
   "node-suite/stream/readable/iter-yields-buffer-no-encoding": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: for-await on Readable without setEncoding — chunks are not Buffer instances. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/web/byte-stream-construction": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: new ReadableStream({type:'bytes'}) — byte stream construction fails or BYOB unavailable. Flips to PASS when #1545 lands."
+    "reason": "node:stream: for-await on Readable without setEncoding \u2014 chunks are not Buffer instances. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/error-propagates-to-source": {
     "issue": "1531",
@@ -720,13 +702,13 @@
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: compose(stream) — single-stream form does not return Duplex wrap. Flips to PASS when #1531 lands."
+    "reason": "node:stream: compose(stream) \u2014 single-stream form does not return Duplex wrap. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/readable/unshift-buffer": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: unshift(Buffer) — explicit Buffer not properly added to front of buffer queue. Flips to PASS when #1532 lands."
+    "reason": "node:stream: unshift(Buffer) \u2014 explicit Buffer not properly added to front of buffer queue. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/desired-size-restores-after-drain": {
     "issue": "1545",
@@ -738,241 +720,217 @@
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pause() inside 'data' listener — does not stop further synchronous emits. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pause() inside 'data' listener \u2014 does not stop further synchronous emits. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/iter-helpers/find-returns-promise": {
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: find() — return value is not a Promise<value|undefined>. Flips to PASS when #1558 lands."
-  },
-  "node-suite/stream/web/byob-on-byte-stream": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: getReader({mode:'byob'}) on bytes-type stream fails or returns wrong shape. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/web/pipethrough-preventclose-flag": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: pipeThrough(transform, {preventClose:true}) — transform.writable should remain unlocked. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/web/cancel-during-pipeto": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: rs.cancel() during pipeTo — should reject (locked stream); resolves or wrong err name. Flips to PASS when #1545 lands."
+    "reason": "node:stream: find() \u2014 return value is not a Promise<value|undefined>. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/web/transform-stream-with-strategies": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: TransformStream(t, writableStrategy, readableStrategy) — 3-arg constructor form not honored. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: TransformStream(t, writableStrategy, readableStrategy) \u2014 3-arg constructor form not honored. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/readable/compose-multi-async-fn": {
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: r.compose(t1).compose(t2) chained — output stream produces wrong chunks. Flips to PASS when #1531 lands."
+    "reason": "node:stream: r.compose(t1).compose(t2) chained \u2014 output stream produces wrong chunks. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/events/emit-error-with-capture": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: captureRejections — async listener throws not caught into 'error' event. Flips to PASS when #1532 lands."
+    "reason": "node:stream: captureRejections \u2014 async listener throws not caught into 'error' event. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/abort-during-pipeto": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: ws.abort() during active pipeTo — pipeTo Promise doesn't reject. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: ws.abort() during active pipeTo \u2014 pipeTo Promise doesn't reject. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/readable/wrap-pipe-chain": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: wrap(EE) + pipe(dst) — piped output empty or wrong. Flips to PASS when #1532 lands."
+    "reason": "node:stream: wrap(EE) + pipe(dst) \u2014 piped output empty or wrong. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/destroy/destroy-during-read": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: destroy() inside _read() — readCalls count or close-event behavior wrong. Flips to PASS when #1532 lands."
+    "reason": "node:stream: destroy() inside _read() \u2014 readCalls count or close-event behavior wrong. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/writable/sink-write-rejection-becomes-error": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: sink write cb(err) — does not emit 'error' event. Flips to PASS when #1532 lands."
+    "reason": "node:stream: sink write cb(err) \u2014 does not emit 'error' event. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/empty-pure-end": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pure-end Readable (push(null) only) — 'end' fires with wrong data count or doesn't fire. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pure-end Readable (push(null) only) \u2014 'end' fires with wrong data count or doesn't fire. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/from-async-generator-function": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: ReadableStream.from(asyncGen()) — iteration wrong or fails. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: ReadableStream.from(asyncGen()) \u2014 iteration wrong or fails. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/readable/unshift-while-flowing": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: unshift() during flowing mode — chunk not re-emitted in order. Flips to PASS when #1532 lands."
+    "reason": "node:stream: unshift() during flowing mode \u2014 chunk not re-emitted in order. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/compose-with-passthrough": {
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: compose(src, PassThrough) — data not preserved through PT in composite. Flips to PASS when #1531 lands."
+    "reason": "node:stream: compose(src, PassThrough) \u2014 data not preserved through PT in composite. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/web/byte-stream-non-buffer-throws": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: bytes-typed RS — enqueue(string) does not throw TypeError. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: bytes-typed RS \u2014 enqueue(string) does not throw TypeError. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/pipe/end-false-then-write": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pipe(dst,{end:false}) then manual dst.write — output order/count wrong. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipe(dst,{end:false}) then manual dst.write \u2014 output order/count wrong. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/events/once-static-promise": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: events.once(stream, 'end') Promise — args shape wrong. Flips to PASS when #1532 lands."
+    "reason": "node:stream: events.once(stream, 'end') Promise \u2014 args shape wrong. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipeline/async-fn-rejection-propagates": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pipeline async-fn throwing — cb does not receive the error. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipeline async-fn throwing \u2014 cb does not receive the error. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/iter-helpers/filter-then-toarray": {
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: filter(fn).toArray() — chain produces wrong result. Flips to PASS when #1558 lands."
+    "reason": "node:stream: filter(fn).toArray() \u2014 chain produces wrong result. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/readable/from-async-iter-mixed-values": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.from(asyncGen yielding mixed types) — types lost or wrong. Flips to PASS when #1532 lands."
+    "reason": "node:stream: Readable.from(asyncGen yielding mixed types) \u2014 types lost or wrong. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipe/pipe-autodestroy-default": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pipe() autoDestroy default — src or dst not destroyed after pipe. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipe() autoDestroy default \u2014 src or dst not destroyed after pipe. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipe/three-stage-mid-error": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pipeline 3-stage mid-error — src/sink destroy flags or err wrong. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipeline 3-stage mid-error \u2014 src/sink destroy flags or err wrong. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/destroyed-during-data-flow": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: destroy() inside 'data' listener — emits wrong data count. Flips to PASS when #1532 lands."
+    "reason": "node:stream: destroy() inside 'data' listener \u2014 emits wrong data count. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/from-array-of-promises": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.from([P1, P2, P3]) — does not await each Promise. Flips to PASS when #1532 lands."
+    "reason": "node:stream: Readable.from([P1, P2, P3]) \u2014 does not await each Promise. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/iter-helpers/flat-map-async-gen": {
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: flatMap(asyncGenFn) — multi-yield per input not flattened. Flips to PASS when #1558 lands."
+    "reason": "node:stream: flatMap(asyncGenFn) \u2014 multi-yield per input not flattened. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/readable/from-rejected-promise-in-array": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.from(array with one Promise.reject) — error not emitted at the right point. Flips to PASS when #1532 lands."
+    "reason": "node:stream: Readable.from(array with one Promise.reject) \u2014 error not emitted at the right point. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/iter-helpers/every-async-rejection": {
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: every(asyncFn) — fn rejection does not propagate as Promise reject. Flips to PASS when #1558 lands."
+    "reason": "node:stream: every(asyncFn) \u2014 fn rejection does not propagate as Promise reject. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/iter-helpers/find-async-fn": {
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: find(asyncFn) — returns wrong value. Flips to PASS when #1558 lands."
+    "reason": "node:stream: find(asyncFn) \u2014 returns wrong value. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/readable/from-gen-yield-order": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.from(gen()) — yield order lost. Flips to PASS when #1532 lands."
+    "reason": "node:stream: Readable.from(gen()) \u2014 yield order lost. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/double-pipe-through": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: pipeThrough().pipeThrough() chain — second transform output wrong. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: pipeThrough().pipeThrough() chain \u2014 second transform output wrong. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/web/from-iterable-of-buffers": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: ReadableStream.from(arrayOfBuffers) — chunk count or type wrong. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: ReadableStream.from(arrayOfBuffers) \u2014 chunk count or type wrong. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/readable/from-iterator-throws": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.from(iter that throws on next) — 'error' event not emitted. Flips to PASS when #1532 lands."
+    "reason": "node:stream: Readable.from(iter that throws on next) \u2014 'error' event not emitted. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/iter-helpers/some-async-rejection": {
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: some(asyncFn) — rejection in fn does not propagate. Flips to PASS when #1558 lands."
+    "reason": "node:stream: some(asyncFn) \u2014 rejection in fn does not propagate. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/web/transform-readable-cancel-propagates": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: TS readable.cancel — writable.write does not reject after. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/web/for-await-on-transform": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: for-await directly on TransformStream.readable — empty or wrong output. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: TS readable.cancel \u2014 writable.write does not reject after. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/iter-helpers/for-each-await-each": {
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: forEach(asyncFn) — does not await each call sequentially. Flips to PASS when #1558 lands."
+    "reason": "node:stream: forEach(asyncFn) \u2014 does not await each call sequentially. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/readable/from-async-iter-nested": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.from(asyncIter with awaits) — wrong collected output. Flips to PASS when #1532 lands."
+    "reason": "node:stream: Readable.from(asyncIter with awaits) \u2014 wrong collected output. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/pipe-to-with-pre-aborted-signal": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: pipeTo with pre-aborted signal — does not reject immediately. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: pipeTo with pre-aborted signal \u2014 does not reject immediately. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/pipe/pipe-adds-listener-on-dst": {
     "issue": "1532",
@@ -984,19 +942,19 @@
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: map(fn).toArray() — chain returns non-Array or wrong values. Flips to PASS when #1558 lands."
+    "reason": "node:stream: map(fn).toArray() \u2014 chain returns non-Array or wrong values. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/readable/readable-mode-only": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: 'readable' event with read() drain — chunk order or count wrong. Flips to PASS when #1532 lands."
+    "reason": "node:stream: 'readable' event with read() drain \u2014 chunk order or count wrong. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/writable-stream-bytes-type": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: WritableStream({type:'bytes'}) — handling differs from Node (accept-and-ignore or throw). Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: WritableStream({type:'bytes'}) \u2014 handling differs from Node (accept-and-ignore or throw). Flips to PASS when #1545 lands."
   },
   "node-suite/stream/pipe/cleanup-state-after-end": {
     "issue": "1532",
@@ -1004,95 +962,89 @@
     "category": "bug-open",
     "reason": "node:stream: post-pipe-end destroyed flags wrong on source or destination. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/web/sink-all-four-methods": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: sink with start+write+close+abort — methods not invoked in correct order or some skipped. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/pipeline/error-middle-aborts-all": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pipeline middle-stream error — does not destroy source AND sink. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipeline middle-stream error \u2014 does not destroy source AND sink. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/from-promise-iterable": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: ReadableStream.from(customIterable) — value or done wrong. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: ReadableStream.from(customIterable) \u2014 value or done wrong. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/web/writer-write-resolves-after-sink": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: writer.write() Promise resolution timing — resolves before sink processes chunk. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: writer.write() Promise resolution timing \u2014 resolves before sink processes chunk. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/iter-helpers/compose-then-toarray": {
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: compose(transform).toArray() — chain produces wrong result. Flips to PASS when #1558 lands."
+    "reason": "node:stream: compose(transform).toArray() \u2014 chain produces wrong result. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/pipeline/three-async-fns": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pipeline with multiple async-gen stages — fails to deliver final collected output. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipeline with multiple async-gen stages \u2014 fails to deliver final collected output. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipeline/null-cb-error-form": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pipeline cb on success — err arg not null/undefined or wrong type. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipeline cb on success \u2014 err arg not null/undefined or wrong type. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/destroy/_destroy-user-impl": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
+    "reason": "node:stream: user _destroy(err, cb) \u2014 not invoked or receives wrong error. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/readable-event-with-objectmode": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: objectMode 'readable' event — read() returns wrong object values. Flips to PASS when #1532 lands."
+    "reason": "node:stream: objectMode 'readable' event \u2014 read() returns wrong object values. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/from-async-gen-throws-mid": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: RS.from(asyncGen throws mid) — read() does not reject. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: RS.from(asyncGen throws mid) \u2014 read() does not reject. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/web/cancel-during-pull": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: cancel() during pull — read() does not resolve {done:true}. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: cancel() during pull \u2014 read() does not resolve {done:true}. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/readable/iter-with-custom-return": {
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: for-await break — custom iterator.return() not invoked. Flips to PASS when #1531 lands."
+    "reason": "node:stream: for-await break \u2014 custom iterator.return() not invoked. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/events/captureRejections-constructor": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable({captureRejections}) — async listener throws not caught as 'error'. Flips to PASS when #1532 lands."
+    "reason": "node:stream: Readable({captureRejections}) \u2014 async listener throws not caught as 'error'. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/iter-helpers/some-finds-match": {
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: some() — does not short-circuit at first match (calls > N). Flips to PASS when #1558 lands."
+    "reason": "node:stream: some() \u2014 does not short-circuit at first match (calls > N). Flips to PASS when #1558 lands."
   },
   "node-suite/stream/pipeline/async-iter-source": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pipeline(asyncIterable, dst, cb) — async-iterable source not handled. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipeline(asyncIterable, dst, cb) \u2014 async-iterable source not handled. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/destroyed-after-finish": {
     "issue": "1532",
@@ -1104,7 +1056,7 @@
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: encoding option in ctor — readableEncoding wrong or data not string. Flips to PASS when #1532 lands."
+    "reason": "node:stream: encoding option in ctor \u2014 readableEncoding wrong or data not string. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/byob-reader-method-shape": {
     "issue": "1545",
@@ -1116,115 +1068,115 @@
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: detached instance method called without `this` — wrong behavior (Perry should throw). Flips to PASS when #1532 lands."
+    "reason": "node:stream: detached instance method called without `this` \u2014 wrong behavior (Perry should throw). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/pipe/dst-write-returns-false-pauses-src": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pipe() src pause/resume events on backpressure — wrong order/missing. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipe() src pause/resume events on backpressure \u2014 wrong order/missing. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/three-stages-order": {
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: compose(src,t1,t2) — output transformation order wrong. Flips to PASS when #1531 lands."
+    "reason": "node:stream: compose(src,t1,t2) \u2014 output transformation order wrong. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/pipeline/async-source-throws-mid": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pipeline(asyncGen src throws mid, dst, cb) — error not received in cb. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipeline(asyncGen src throws mid, dst, cb) \u2014 error not received in cb. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/compose-non-stream-throws": {
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: compose(string) — does not throw TypeError. Flips to PASS when #1531 lands."
+    "reason": "node:stream: compose(string) \u2014 does not throw TypeError. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/readable/static-from-with-options": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.from(iter, opts) — objectMode/hwm 2nd-arg not applied. Flips to PASS when #1532 lands."
+    "reason": "node:stream: Readable.from(iter, opts) \u2014 objectMode/hwm 2nd-arg not applied. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/two-stage-error-stops": {
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: compose 2-stage err — composite 'error' event not fired. Flips to PASS when #1531 lands."
+    "reason": "node:stream: compose 2-stage err \u2014 composite 'error' event not fired. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/readable/push-string-with-encoding-set": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: setEncoding + push(string) — data not delivered as string. Flips to PASS when #1532 lands."
+    "reason": "node:stream: setEncoding + push(string) \u2014 data not delivered as string. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/with-passthrough-mid": {
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: compose(src, t1, PassThrough, t2) — chain produces wrong output. Flips to PASS when #1531 lands."
+    "reason": "node:stream: compose(src, t1, PassThrough, t2) \u2014 chain produces wrong output. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/pipeline/sync-iterable-source": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: pipeline(array, dst, cb) — sync iterable source not wired. Flips to PASS when #1532 lands."
+    "reason": "node:stream: pipeline(array, dst, cb) \u2014 sync iterable source not wired. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/transform-stream-instanceof-check": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: TransformStream instance — fails instanceof checks vs RS/WS for readable/writable sides. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: TransformStream instance \u2014 fails instanceof checks vs RS/WS for readable/writable sides. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/iter-helpers/reduce-with-initial": {
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: reduce(fn, initial) — initial value not used or wrong sum. Flips to PASS when #1558 lands."
+    "reason": "node:stream: reduce(fn, initial) \u2014 initial value not used or wrong sum. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/iter-helpers/for-each-empty-stream": {
     "issue": "1558",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: forEach() on empty — calls non-zero or result not undefined. Flips to PASS when #1558 lands."
+    "reason": "node:stream: forEach() on empty \u2014 calls non-zero or result not undefined. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/readable/readable-stream-id-properties": {
     "issue": "1532",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: distinct Readable instances — same identity or wrong prototype shared. Flips to PASS when #1532 lands."
+    "reason": "node:stream: distinct Readable instances \u2014 same identity or wrong prototype shared. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/transform-piped-twice": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: pipeThrough().pipeThrough() — second transform output wrong. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: pipeThrough().pipeThrough() \u2014 second transform output wrong. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/web/strategy-size-non-number": {
     "issue": "1545",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream/web: strategy.size returning non-number — doesn't throw on enqueue. Flips to PASS when #1545 lands."
+    "reason": "node:stream/web: strategy.size returning non-number \u2014 doesn't throw on enqueue. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/compose/just-source-only": {
     "issue": "1531",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: compose(src) — only source given, Duplex output empty. Flips to PASS when #1531 lands."
+    "reason": "node:stream: compose(src) \u2014 only source given, Duplex output empty. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/iter-helpers/map-async-with-concurrency": {
     "issue": "1558",
     "added": "2026-05-25",
     "category": "bug-open",
-    "reason": "node:stream: map(asyncFn, {concurrency}) — toArray output wrong. Flips to PASS when #1558 lands."
+    "reason": "node:stream: map(asyncFn, {concurrency}) \u2014 toArray output wrong. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/readable/from-gen-with-early-return": {
     "issue": "1532",
     "added": "2026-05-25",
     "category": "bug-open",
-    "reason": "node:stream: generator with explicit return — values yielded after return statement aren't reached. Flips to PASS when #1532 lands."
+    "reason": "node:stream: generator with explicit return \u2014 values yielded after return statement aren't reached. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/readable/from-gen-return-value-ignored": {
     "issue": "1532",
@@ -1242,18 +1194,18 @@
     "issue": "1532",
     "added": "2026-05-25",
     "category": "bug-open",
-    "reason": "node:stream: 5-stage promises-pipeline — final sink doesn't receive chunks. Flips to PASS when #1532 lands."
+    "reason": "node:stream: 5-stage promises-pipeline \u2014 final sink doesn't receive chunks. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/promises/pipeline-array-source-promise": {
     "issue": "1532",
     "added": "2026-05-25",
     "category": "bug-open",
-    "reason": "node:stream: promises.pipeline(array, dst) — sync iterable source not collected. Flips to PASS when #1532 lands."
+    "reason": "node:stream: promises.pipeline(array, dst) \u2014 sync iterable source not collected. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/promises/pipeline-with-transform-collect": {
     "issue": "1532",
     "added": "2026-05-25",
     "category": "bug-open",
-    "reason": "node:stream/promises: pipeline(src, transform, asyncFnSink) — collected output wrong/empty. Flips to PASS when #1532 lands."
+    "reason": "node:stream/promises: pipeline(src, transform, asyncFnSink) \u2014 collected output wrong/empty. Flips to PASS when #1532 lands."
   }
 }


### PR DESCRIPTION
## Summary

`Readable.from([...])` and other readable-only streams never fired the `'close'` event after consuming all data — Perry only emitted `'close'` from the writable-side `finish` path, so a pure Readable stayed with `r.closed === false` even after `'end'`, and `r.on('close', ...)` never called the listener.

Spec: `'close'` follows `'end'` on a readable-only stream (resources are released right after the source signals completion). A Duplex defers `'close'` until BOTH `'end'` and `'finish'` have fired, but that path already runs `mark_stream_closed` + `emit('close')` after `'finish'` in `ns_end1`; this PR only adds the equivalent tail for the readable-only case.

Fix: at the end of `emit_readable_end_once`, when the stream has no writable side (`hidden_writable_flag_key()` is `None`), call `mark_stream_closed` and emit `'close'`. The existing Duplex / Writable path is untouched.

## Local sweep impact

Against the stream-suite known_failures for #1531 / #1532 / #1545 / #1539 / #1572 (~150 tests), **8 tests flip to PASS, no regressions** on those test files or my prior gap-test set (`test_gap_array_methods`, `test_gap_string_methods`, `test_gap_class_advanced`, `test_gap_class_static_blocks`, `test_gap_union_typeof_narrowing`).

The 8 newly-passing tests:
- `node-suite/stream/readable/closed-flag` — the direct repro
- `node-suite/stream/web/writable-stream-start-hook`
- `node-suite/stream/web/byte-stream-construction`
- `node-suite/stream/web/byob-on-byte-stream`
- `node-suite/stream/web/pipethrough-preventclose-flag`
- `node-suite/stream/web/cancel-during-pipeto`
- `node-suite/stream/web/for-await-on-transform`
- `node-suite/stream/web/sink-all-four-methods`

The Web Streams flips are downstream beneficiaries — they're built on the same readable-end-emission path, and pre-fix the absent `'close'` event left their teardown listeners pending.

## Scope

- `crates/perry-runtime/src/node_stream.rs`: add the close-after-end tail to `emit_readable_end_once`, gated on the writable side being absent so Duplex / Writable behaviour stays the same.
- `test-parity/known_failures.json`: drop the 8 entries above; they're byte-identical with Node post-fix.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] Direct: `Readable.from(["x"])` + `r.on('close', () => log(r.closed))` — pre-fix nothing; post-fix `closed: true` (matches Node).
- [x] No regressions on `test_gap_array_methods`, `test_gap_string_methods`, `test_gap_class_advanced`, `test_gap_class_static_blocks`, `test_gap_union_typeof_narrowing`.
