### PR TITLE
fix(stream): drive async-iterable mapper result in Readable.flatMap (#1572)

### DIFF
--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -146,6 +146,28 @@ fn has_named_next(value: f64) -> bool {
     is_callable_value(named_field(value, b"next"))
 }
 
+/// Issue #1572 — node:stream uses this from `node_stream::ns_iter_flat_map`
+/// to drive an async-iterable mapper result (an `async function*` return
+/// value) without re-deriving the `Symbol.asyncIterator` lookup +
+/// implicit-this dance.
+pub(crate) fn call_symbol_async_iterator_for_flat_map(value: f64) -> Option<f64> {
+    call_symbol_async_iterator(value)
+}
+
+/// Issue #1572 — same as `js_async_iterator_to_array` but reachable from
+/// the node_stream crate path so flatMap can flatten an `async function*`
+/// mapper result without duplicating the next()/done/value loop.
+pub(crate) fn async_iterator_to_array_for_flat_map(iter_f64: f64) -> *mut ArrayHeader {
+    js_async_iterator_to_array(iter_f64)
+}
+
+/// Issue #1572 — true when `value` is itself an iterator object (has a
+/// callable `.next()` own field). Used by flatMap to recognise a bare
+/// generator object that doesn't carry `[Symbol.asyncIterator]`.
+pub(crate) fn has_iterator_next(value: f64) -> bool {
+    has_named_next(value)
+}
+
 fn call_symbol_async_iterator(value: f64) -> Option<f64> {
     let sym = crate::symbol::well_known_symbol("asyncIterator");
     if sym.is_null() {

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -56,6 +56,13 @@ pub use self::iter_object::{
     ARRAY_ITERATOR_CLASS_ID,
 };
 pub use self::iterator::{js_for_of_to_array, js_iterator_to_array};
+// Issue #1572 — flatten helpers reused by `node_stream::ns_iter_flat_map`
+// so an `async function*` mapper return is driven through the iterator
+// protocol instead of being appended as a single chunk.
+pub(crate) use self::iterator::{
+    async_iterator_to_array_for_flat_map, call_symbol_async_iterator_for_flat_map,
+    has_iterator_next,
+};
 pub use self::jsvalue_api::{
     js_array_from_jsvalue, js_array_get, js_array_get_jsvalue, js_array_push,
     js_array_push_jsvalue, js_array_set, js_array_set_jsvalue, js_array_set_jsvalue_extend,

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -1470,9 +1470,11 @@ extern "C" fn ns_iter_flat_map(closure: *const ClosureHeader, mapper: f64, opts:
             let el = crate::array::js_array_get_f64(arr, i);
             let mapped = call_settled(cb, el);
             // flatMap flattens one level: an array result is spread, a
-            // Readable result contributes its retained chunks, anything
-            // else is appended as a single chunk. (A bare async-generator
-            // mapper isn't flattened yet — tracked separately.)
+            // Readable result contributes its retained chunks, an
+            // async-iterable (e.g. an `async function*` mapper return —
+            // issue #1572) is driven through its `[Symbol.asyncIterator]()`
+            // and its yields flattened in order, anything else is
+            // appended as a single chunk.
             if is_array_like_value(mapped) {
                 out = extend_with_array(out, raw_ptr_from_value(mapped) as *const _);
             } else if let Some(inner) = readable_hidden_chunks(mapped) {
@@ -1481,6 +1483,8 @@ extern "C" fn ns_iter_flat_map(closure: *const ClosureHeader, mapper: f64, opts:
                 } else {
                     out = crate::array::js_array_push_f64(out, mapped);
                 }
+            } else if let Some(flat) = flatten_async_iterable_value(mapped) {
+                out = extend_with_array(out, flat as *const _);
             } else {
                 out = crate::array::js_array_push_f64(out, mapped);
             }
@@ -1489,6 +1493,49 @@ extern "C" fn ns_iter_flat_map(closure: *const ClosureHeader, mapper: f64, opts:
     let result = readable_from_chunks(out);
     propagate_stream_state(this, opts, result);
     result
+}
+
+/// Issue #1572 — drive an async-iterable value (an `async function*` mapper
+/// return, or any object exposing `[Symbol.asyncIterator]` /
+/// `[Symbol.iterator]` / a bare `.next()` method) through its iterator
+/// protocol and collect the yielded values into a flat array.
+///
+/// The order of probes matches what `Array.fromAsync` / `for await of`
+/// already does in `array/iterator.rs`:
+///   1. `[Symbol.asyncIterator]()` — the async-generator path. Each
+///      `.next()` returns a `Promise<{value, done}>`; the per-step
+///      promise is settled synchronously by pumping microtasks.
+///   2. The value is itself an iterator (bare `.next()` method) —
+///      sync-drive it. Covers caller-provided iterator objects.
+///   3. Sync iterables — `[Symbol.iterator]()`. Caught earlier by
+///      `is_array_like_value`/`readable_hidden_chunks` for the array
+///      and Readable cases; remaining sync iterables (Map/Set/Buffer
+///      iterators, custom `[Symbol.iterator]` objects) land here.
+///
+/// `None` signals "not iterable" so the caller can fall back to the
+/// "append as a single chunk" path that pre-#1572 was the only branch.
+fn flatten_async_iterable_value(value: f64) -> Option<*mut crate::array::ArrayHeader> {
+    use crate::array::{
+        async_iterator_to_array_for_flat_map, call_symbol_async_iterator_for_flat_map,
+        has_iterator_next,
+    };
+    use crate::symbol::js_get_iterator;
+    if let Some(async_iter) = call_symbol_async_iterator_for_flat_map(value) {
+        return Some(async_iterator_to_array_for_flat_map(async_iter));
+    }
+    if has_iterator_next(value) {
+        // Async generator step values may be already-settled promises that
+        // `async_iterator_to_array_for_flat_map` unwraps; drive the same
+        // helper for a bare-iterator receiver too — `js_async_iterator_to_array`
+        // is a strict superset of `js_iterator_to_array` (it transparently
+        // returns non-promise step results unchanged).
+        return Some(async_iterator_to_array_for_flat_map(value));
+    }
+    let sync_iter = js_get_iterator(value);
+    if sync_iter.to_bits() != value.to_bits() {
+        return Some(async_iterator_to_array_for_flat_map(sync_iter));
+    }
+    None
 }
 
 extern "C" fn ns_iter_take(closure: *const ClosureHeader, count: f64) -> f64 {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -404,12 +404,6 @@
     "category": "bug-open",
     "reason": "node:stream: construct() callback receiving Error does not propagate via error event. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/iter-helpers/flat-map-async": {
-    "issue": "1572",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.flatMap with an async-generator mapper isn't driven through the async-iterator protocol yet (the other iterator helpers + AbortSignal landed in #1558). Flips to PASS when #1572 lands."
-  },
   "node-suite/stream/compose/single-transform": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -853,12 +847,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Readable.from([P1, P2, P3]) \u2014 does not await each Promise. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/iter-helpers/flat-map-async-gen": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: flatMap(asyncGenFn) \u2014 multi-yield per input not flattened. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/readable/from-rejected-promise-in-array": {
     "issue": "1532",


### PR DESCRIPTION
## Summary

- `Readable.from(arr).flatMap(asyncGenFn)` now drives the async-generator return through `[Symbol.asyncIterator]()` and flattens the yields, matching Node's `[1, 100, 2, 200]` shape from the issue's repro.
- Pre-fix `ns_iter_flat_map` only flattened array results and Readable's hidden chunks; an async-generator mapper return fell through to the "append as a single chunk" path, so `.toArray().join(",")` came back as `,`.
- The new `flatten_async_iterable_value` helper probes the value in order: `[Symbol.asyncIterator]()` → bare `.next()` (already an iterator object) → `[Symbol.iterator]()`, then reuses the existing `js_async_iterator_to_array` driver in `array::iterator`. That driver transparently unwraps already-settled `Promise<{value, done}>` steps, so a sync iterable (Map/Set/custom `[Symbol.iterator]`) returns its yields unchanged.
- The driver helpers in `array::iterator` were crate-private; added three `pub(crate)` shims and re-exported them through `array::mod` so `node_stream` reaches them without flipping the inner module to `pub`.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo test --release -p perry-runtime --lib` — 744/744 green (no regressions).
- [x] Flipped two skip-list entries to passing — `node-suite/stream/iter-helpers/flat-map-async` (the issue's exact repro) and `node-suite/stream/iter-helpers/flat-map-async-gen` (routed to #1558 but unblocked by the same fix). Both now byte-identical to `node --experimental-strip-types`.
- [x] Verified the sync-mapper path (`flat-map.ts`) doesn't regress — still byte-identical.

Closes #1572.
