### PR TITLE
fix(runtime): implement process.setgroups + initgroups (#2135)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2140,6 +2140,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("process", "seteuid", false, None),
     method("process", "setgid", false, None),
     method("process", "setegid", false, None),
+    method("process", "setgroups", false, None),
+    method("process", "initgroups", false, None),
     method("process", "emitWarning", false, None),
     method("process", "on", false, None),
     method("process", "addListener", false, None),

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -664,6 +664,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         | "seteuid"
                         | "setgid"
                         | "setegid"
+                        | "setgroups"
+                        | "initgroups"
                         | "emitWarning"
                         | "on"
                         | "addListener"

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -227,6 +227,26 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_VOID,
     },
+    // #2135: process.setgroups(groups[]) — JSValue array of numeric GIDs.
+    NativeModSig {
+        module: "process",
+        has_receiver: false,
+        method: "setgroups",
+        class_filter: None,
+        runtime: "js_process_setgroups",
+        args: &[NA_JSV],
+        ret: NR_VOID,
+    },
+    // #2135: process.initgroups(user, extra_gid) — username + numeric GID.
+    NativeModSig {
+        module: "process",
+        has_receiver: false,
+        method: "initgroups",
+        class_filter: None,
+        runtime: "js_process_initgroups",
+        args: &[NA_JSV, NA_F64],
+        ret: NR_VOID,
+    },
     // ========== Node URL ==========
     // `new Number/String/Boolean(...)` now lowers to
     // `Expr::BoxedPrimitiveNew` (see crates/perry-hir/src/lower/expr_new.rs)

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -303,6 +303,21 @@ pub(super) fn try_native_module_methods(
                                 args,
                             }));
                         }
+                        // #2135: process.setgroups(groups[]) takes an
+                        // array of numeric GIDs; process.initgroups(user,
+                        // extra_gid) takes a username string + numeric
+                        // GID. The runtime decodes the JSValues itself, so
+                        // both pass through the generic NativeMethodCall.
+                        "setgroups" | "initgroups" => {
+                            let method_name = method_ident.sym.as_ref().to_string();
+                            return Ok(Ok(Expr::NativeMethodCall {
+                                module: "process".to_string(),
+                                class_name: None,
+                                object: None,
+                                method: method_name,
+                                args,
+                            }));
+                        }
                         "emitWarning" => {
                             // process.emitWarning(warning[, type, code, ctor])
                             // — writes a formatted warning to stderr. Perry

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -361,6 +361,8 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("process", "seteuid")
             | ("process", "setgid")
             | ("process", "setegid")
+            | ("process", "setgroups")
+            | ("process", "initgroups")
             | ("process", "emitWarning")
             | ("process", "on")
             | ("process", "addListener")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -375,6 +375,14 @@ pub(crate) unsafe fn dispatch_native_module_method(
             crate::process::js_process_setegid(arg(0));
             f64::from_bits(crate::value::TAG_UNDEFINED)
         }
+        ("process", "setgroups") => {
+            crate::process::js_process_setgroups(arg(0));
+            f64::from_bits(crate::value::TAG_UNDEFINED)
+        }
+        ("process", "initgroups") => {
+            crate::process::js_process_initgroups(arg(0), arg(1));
+            f64::from_bits(crate::value::TAG_UNDEFINED)
+        }
         ("process", "kill") => {
             crate::os::js_process_kill(arg(0), arg(1));
             f64::from_bits(crate::value::TAG_UNDEFINED)

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -266,6 +266,84 @@ pub extern "C" fn js_process_setegid(gid: f64) {
     }
 }
 
+/// `process.setgroups(groups)` — replace the calling process's
+/// supplementary GID list with the IDs from a JS number array. Each non-
+/// finite / out-of-range / non-numeric entry is silently skipped. On
+/// non-unix targets this is a no-op (#2135).
+#[no_mangle]
+pub extern "C" fn js_process_setgroups(groups: f64) {
+    let arr_jsval = JSValue::from_bits(groups.to_bits());
+    if !arr_jsval.is_pointer() {
+        return;
+    }
+    let arr_ptr = arr_jsval.as_pointer::<crate::array::ArrayHeader>();
+    if arr_ptr.is_null() {
+        return;
+    }
+    let len = unsafe { crate::array::js_array_length(arr_ptr) } as u32;
+    #[cfg(unix)]
+    {
+        let mut gids: Vec<libc::gid_t> = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            let v = unsafe { crate::array::js_array_get_f64(arr_ptr, i) };
+            if let Some(id) = unix_id_arg(v) {
+                gids.push(id as libc::gid_t);
+            }
+        }
+        if !gids.is_empty() {
+            unsafe {
+                libc::setgroups(gids.len() as _, gids.as_ptr());
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = len;
+    }
+}
+
+/// `process.initgroups(user, extra_gid)` — initialize the supplementary
+/// group access list using `getgrouplist(3)`-style semantics. The first
+/// argument is a username string (or numeric UID); the second is an
+/// extra group ID to include. Perry today only accepts the username-as-
+/// string + numeric extra_gid form via `libc::initgroups`; numeric user
+/// or non-string first argument silently no-ops. Non-unix targets no-op
+/// entirely (#2135).
+#[no_mangle]
+pub extern "C" fn js_process_initgroups(user: f64, extra_gid: f64) {
+    #[cfg(unix)]
+    {
+        let user_jsval = JSValue::from_bits(user.to_bits());
+        if !user_jsval.is_any_string() {
+            return;
+        }
+        let user_ptr = crate::value::js_get_string_pointer_unified(user);
+        if user_ptr == 0 {
+            return;
+        }
+        let user_str_ptr = user_ptr as *const StringHeader;
+        let len = unsafe { (*user_str_ptr).byte_len } as usize;
+        let data = unsafe { (user_str_ptr as *const u8).add(std::mem::size_of::<StringHeader>()) };
+        let bytes = unsafe { std::slice::from_raw_parts(data, len) };
+        let Ok(name) = std::str::from_utf8(bytes) else {
+            return;
+        };
+        let Some(extra) = unix_id_arg(extra_gid) else {
+            return;
+        };
+        let Ok(cname) = std::ffi::CString::new(name) else {
+            return;
+        };
+        unsafe {
+            libc::initgroups(cname.as_ptr(), extra as _);
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (user, extra_gid);
+    }
+}
+
 /// `process.getgroups()` — supplementary group IDs the process is a member
 /// of, as a JS array of numbers. Wraps `libc::getgroups(2)`; on non-unix
 /// targets returns an empty array (Node throws there, but Perry's existing

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1486 entries across 82 modules
+// Coverage: 1488 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1795,6 +1795,8 @@ declare module "process" {
   /** stdlib */
   export function hrtime(...args: any[]): any;
   /** stdlib */
+  export function initgroups(...args: any[]): any;
+  /** stdlib */
   export function kill(...args: any[]): any;
   /** stdlib */
   export function listenerCount(...args: any[]): any;
@@ -1832,6 +1834,8 @@ declare module "process" {
   export function seteuid(...args: any[]): any;
   /** stdlib */
   export function setgid(...args: any[]): any;
+  /** stdlib */
+  export function setgroups(...args: any[]): any;
   /** stdlib */
   export function setuid(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1486 entries across 82 modules.
+Total: 1488 entries across 82 modules.
 
 ## Modules
 
@@ -1681,6 +1681,7 @@ Total: 1486 entries across 82 modules.
 - `getgroups` — module
 - `getuid` — module
 - `hrtime` — module
+- `initgroups` — module
 - `kill` — module
 - `listenerCount` — module
 - `listeners` — module
@@ -1700,6 +1701,7 @@ Total: 1486 entries across 82 modules.
 - `setegid` — module
 - `seteuid` — module
 - `setgid` — module
+- `setgroups` — module
 - `setuid` — module
 - `threadCpuUsage` — module
 - `umask` — module

--- a/test-files/test_issue_2135_setgroups_initgroups.ts
+++ b/test-files/test_issue_2135_setgroups_initgroups.ts
@@ -1,0 +1,13 @@
+// Refs #2135 (node:process stubbed methods): `process.setgroups` and
+// `process.initgroups` previously read back as `0` (typeof `"number"`),
+// so duck-type guards (`typeof process.setgroups === "function"`) saw
+// the stub. Both are now wired to libc as no-op-on-bad-input wrappers.
+//
+// The non-root call form throws `EPERM` in Node by surfacing the libc
+// error; Perry's wrapper currently silently drops errors (matching the
+// other `set*id` family it sits next to), so the gap test only pins the
+// `typeof` shape — exercising the call form here would diverge from
+// Node and isn't the surface the original #2135 entry was tracking.
+
+console.log(typeof process.setgroups);
+console.log(typeof process.initgroups);


### PR DESCRIPTION
## Summary

- `typeof process.setgroups` and `typeof process.initgroups` returned the stub `"number"` (the bare-field value `0`), so duck-type guards saw the stubs and the call form was unreachable. Wire both through the same path as the other POSIX setters that landed in this issue.

- Implementation:
  - `js_process_setgroups(groups)` walks a JS number array and calls `libc::setgroups` once (non-finite / out-of-range entries are skipped via the shared `unix_id_arg` coercion). Non-unix targets no-op.
  - `js_process_initgroups(user, extra_gid)` accepts the username-as-string form and a numeric extra GID, calls `libc::initgroups`. Numeric-UID first arg silently no-ops (Node accepts that form too, but resolving it needs `getpwuid_r` plumbing that's out of scope here).
  - Property-read whitelist returns bound-method closures so the `typeof` reads match Node. HIR lowering, `node_core` table rows, dynamic-dispatch arms, and manifest entries are all wired.

Closes two more #2135 process-tracker stubbed-method gaps.

## Test plan

- New gap test `test-files/test_issue_2135_setgroups_initgroups.ts` byte-identical with Node — pins the `typeof` shape. (The non-root call form throws `EPERM` in Node; Perry's wrapper silently drops errors to stay aligned with the rest of the `set*id` family, so the gap test deliberately doesn't exercise that path — the original #2135 entry was tracking the typeof gap, not error-shape parity.)
- `cargo fmt --all -- --check` clean.
- `cargo test --release -p perry-codegen --test manifest_consistency` passes.
- `scripts/check_file_size.sh` OK.
- `scripts/regen_api_docs.sh` clean (regenerated diff committed).
