### PR TITLE
fix(runtime): fire process beforeExit event at event loop exit (#2135)

### DIFF
--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -9,7 +9,7 @@ use crate::expr::FnCtx;
 use crate::module::LlModule;
 use crate::stmt;
 use crate::strings::StringPool;
-use crate::types::{I32, I8, PTR, VOID};
+use crate::types::{DOUBLE, I32, I8, PTR, VOID};
 
 use super::helpers::{
     emit_namespace_populator, enable_module_init_shadow_frame, init_static_fields_early,
@@ -472,8 +472,25 @@ pub(super) fn compile_module_entry(
                 ctx.block().call_void("js_wait_for_event", &[]);
                 ctx.block().br(&header_label);
 
-                // loop_exit: done
+                // loop_exit: fire `beforeExit` (#2135) with the would-be
+                // exit code, then drain microtasks/timers once more so any
+                // last-minute work the listener queued still runs before
+                // we ret. Mirrors Node's "event loop drained → one
+                // beforeExit pass" semantics.
+                //
+                // We pass `0` as the code today: Perry doesn't yet wire
+                // `process.exitCode` into this codegen path, and the test
+                // surface in #2135 only pins the firing + the default
+                // code. Explicit `process.exit(N)` bypasses this whole
+                // block via libc::_exit.
                 ctx.current_block = exit_idx;
+                let zero_code = "0x0".to_string();
+                ctx.block()
+                    .call_void("js_process_emit_before_exit", &[(DOUBLE, &zero_code)]);
+                let _ = ctx.block().call(I32, "js_promise_run_microtasks", &[]);
+                let _ = ctx.block().call(I32, "js_timer_tick", &[]);
+                let _ = ctx.block().call(I32, "js_callback_timer_tick", &[]);
+                let _ = ctx.block().call(I32, "js_interval_timer_tick", &[]);
                 ctx.block().ret(I32, "0");
             }
         }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -571,6 +571,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_prepend_listener", DOUBLE, &[I64, I64]);
     module.declare_function("js_process_prepend_once_listener", DOUBLE, &[I64, I64]);
     module.declare_function("js_process_emit", DOUBLE, &[I64, I64]);
+    module.declare_function("js_process_emit_before_exit", VOID, &[DOUBLE]);
     module.declare_function("js_process_remove_listener", DOUBLE, &[I64, I64]);
     module.declare_function("js_process_off", DOUBLE, &[I64, I64]);
     module.declare_function("js_process_remove_all_listeners", DOUBLE, &[I64]);

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -866,6 +866,17 @@ pub extern "C" fn js_process_prepend_once_listener(
     register_process_listener(event_ptr, handler, true, true)
 }
 
+/// Emit the synthetic `beforeExit` event with the would-be exit code as a
+/// numeric argument. Called from the codegen-emitted event-loop epilogue
+/// once the loop has drained all real work (#2135). Node's semantics fire
+/// this hook *only* when the event loop is exiting on its own; an explicit
+/// `process.exit()` skips it. Perry's `js_process_exit` calls `libc::_exit`
+/// directly without going through this hook, so that contract is preserved.
+#[no_mangle]
+pub extern "C" fn js_process_emit_before_exit(code: f64) {
+    let _ = emit_process_event("beforeExit", &[code]);
+}
+
 #[no_mangle]
 pub extern "C" fn js_process_emit(event_ptr: *const StringHeader, args: *const ArrayHeader) -> f64 {
     let Some(event) = read_event_name(event_ptr) else {

--- a/test-files/test_issue_2135_before_exit.ts
+++ b/test-files/test_issue_2135_before_exit.ts
@@ -1,0 +1,19 @@
+// Refs #2135 (node:process output diffs): `beforeExit` was registered as
+// an event the runtime understood (`process.on("beforeExit", ...)` and
+// `js_process_emit` both worked manually), but the codegen-emitted
+// event-loop epilogue never fired the synthetic emission, so the
+// listener was a dead callback. Node's contract: when the event loop is
+// about to exit on its own (no real work pending), emit `beforeExit`
+// with the would-be exit code as the single argument; explicit
+// `process.exit()` bypasses it.
+//
+// The runtime now exposes `js_process_emit_before_exit(code)`; codegen
+// calls it from the loop-exit block once the loop has drained, then runs
+// one more microtask/timer-tick pass so any work the listener queued
+// still gets a chance to run before the final ret.
+
+console.log("body");
+
+process.prependListener("beforeExit", () => console.log("listener 0 (prepended)"));
+process.on("beforeExit", () => console.log("listener 1"));
+process.on("beforeExit", (code) => console.log("listener 2, code=" + code));


### PR DESCRIPTION
## Summary

- Node fires `beforeExit` with the would-be exit code as the single argument when the event loop is about to exit on its own. Listeners registered via `process.on("beforeExit", ...)` already had a working registration + emit path through `PROCESS_EMITTER`, but the codegen-emitted event-loop epilogue never called the emit hook, so the listener was a dead callback.

- Wire it in:
  - New runtime function `js_process_emit_before_exit(code)` in `os.rs` forwards to the existing `emit_process_event("beforeExit", &[code])` pipeline.
  - Codegen's `exit_idx` block now calls the runtime function with code `0` (Perry doesn't yet wire `process.exitCode` into this codegen path, and the surface this issue tracks only pins the firing + default code), then drains microtasks/timers once more so last-minute work the listener queued still runs before the final `ret`.
  - Explicit `process.exit(N)` continues to bypass via `libc::_exit`, so Node's "exit() skips beforeExit" contract is preserved.

Closes another #2135 process-tracker output-diff gap.

## Test plan

- New gap test `test-files/test_issue_2135_before_exit.ts` byte-identical with Node — covers fire-after-body, ordering across `on` + `prependListener`, and the `code` arg.
- All 6 existing `test_issue_2135_*` gap tests still PASS (no regression of chdir / loadEnvFile / getgroups / posix-setters / setgroups-initgroups).
- `cargo fmt --all -- --check` clean.
- `cargo test --release -p perry-runtime --lib` — 746 tests pass.
- `scripts/check_file_size.sh` OK.
- `scripts/regen_api_docs.sh` clean (no manifest change).
