### PR TITLE
fix(node:url): bind URLSearchParams forEach thisArg

### DIFF
--- a/crates/perry-codegen/src/expr/url_main.rs
+++ b/crates/perry-codegen/src/expr/url_main.rs
@@ -414,13 +414,22 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 .bitcast_i64_to_double(crate::nanbox::TAG_UNDEFINED_I64))
         }
 
-        Expr::UrlSearchParamsForEach { params, callback } => {
+        Expr::UrlSearchParamsForEach {
+            params,
+            callback,
+            this_arg,
+        } => {
             let p_v = lower_expr(ctx, params)?;
             let p_ptr = unbox_to_i64(ctx.block(), &p_v);
             let cb_v = lower_expr(ctx, callback)?;
+            let this_v = if let Some(this_arg) = this_arg {
+                lower_expr(ctx, this_arg)?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
             ctx.block().call_void(
                 "js_url_search_params_for_each",
-                &[(I64, &p_ptr), (DOUBLE, &cb_v)],
+                &[(I64, &p_ptr), (DOUBLE, &cb_v), (DOUBLE, &this_v)],
             );
             Ok(ctx
                 .block()

--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -664,11 +664,16 @@ pub fn try_lower_property_get_method_call(
         if is_url_search_params_expr(ctx, object) {
             let p_box = lower_expr(ctx, object)?;
             let cb_box = lower_expr(ctx, &args[0])?;
+            let this_arg = if args.len() >= 2 {
+                lower_expr(ctx, &args[1])?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
             let blk = ctx.block();
             let p_handle = unbox_to_i64(blk, &p_box);
             blk.call_void(
                 "js_url_search_params_for_each",
-                &[(I64, &p_handle), (DOUBLE, &cb_box)],
+                &[(I64, &p_handle), (DOUBLE, &cb_box), (DOUBLE, &this_arg)],
             );
             return Ok(Some(double_literal(0.0)));
         }

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -546,7 +546,11 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_url_search_params_keys_arr", DOUBLE, &[I64]);
     module.declare_function("js_url_search_params_values_arr", DOUBLE, &[I64]);
     module.declare_function("js_url_search_params_sort", VOID, &[I64]);
-    module.declare_function("js_url_search_params_for_each", VOID, &[I64, DOUBLE]);
+    module.declare_function(
+        "js_url_search_params_for_each",
+        VOID,
+        &[I64, DOUBLE, DOUBLE],
+    );
     module.declare_function("js_url_path_to_file_url", DOUBLE, &[DOUBLE]);
     module.declare_function("js_url_domain_to_ascii", DOUBLE, &[DOUBLE]);
     module.declare_function("js_url_domain_to_unicode", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -994,9 +994,16 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
             collect_assigned_locals_expr(name, assigned);
             collect_assigned_locals_expr(value, assigned);
         }
-        Expr::UrlSearchParamsForEach { params, callback } => {
+        Expr::UrlSearchParamsForEach {
+            params,
+            callback,
+            this_arg,
+        } => {
             collect_assigned_locals_expr(params, assigned);
             collect_assigned_locals_expr(callback, assigned);
+            if let Some(this_arg) = this_arg {
+                collect_assigned_locals_expr(this_arg, assigned);
+            }
         }
         Expr::UrlSearchParamsToString(params)
         | Expr::UrlSearchParamsEntries(params)

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1660,10 +1660,11 @@ pub enum Expr {
     UrlSearchParamsValues(Box<Expr>),
     /// params.sort() -> undefined (mutates in place)
     UrlSearchParamsSort(Box<Expr>),
-    /// params.forEach(callback) -> undefined
+    /// params.forEach(callback[, thisArg]) -> undefined
     UrlSearchParamsForEach {
         params: Box<Expr>,
         callback: Box<Expr>,
+        this_arg: Option<Box<Expr>>,
     },
 
     // Delete operator

--- a/crates/perry-hir/src/lower/expr_call/url_search_params.rs
+++ b/crates/perry-hir/src/lower/expr_call/url_search_params.rs
@@ -70,10 +70,13 @@ pub(super) fn build_url_search_params_method_call(
         "values" => Ok(Expr::UrlSearchParamsValues(Box::new(recv))),
         "entries" => Ok(Expr::UrlSearchParamsEntries(Box::new(recv))),
         "forEach" if !args.is_empty() => {
-            let callback = args.into_iter().next().unwrap();
+            let mut iter = args.into_iter();
+            let callback = iter.next().unwrap();
+            let this_arg = iter.next().map(Box::new);
             Ok(Expr::UrlSearchParamsForEach {
                 params: Box::new(recv),
                 callback: Box::new(callback),
+                this_arg,
             })
         }
         "getAll" if !args.is_empty() => {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -467,7 +467,7 @@ impl SH for Expr {
             Expr::UrlSearchParamsKeys(e) => { tag(h, 701); e.as_ref().hash(h); }
             Expr::UrlSearchParamsValues(e) => { tag(h, 702); e.as_ref().hash(h); }
             Expr::UrlSearchParamsSort(e) => { tag(h, 703); e.as_ref().hash(h); }
-            Expr::UrlSearchParamsForEach { params, callback } => { tag(h, 704); params.as_ref().hash(h); callback.as_ref().hash(h); }
+            Expr::UrlSearchParamsForEach { params, callback, this_arg } => { tag(h, 704); params.as_ref().hash(h); callback.as_ref().hash(h); match this_arg { Some(v) => { tag(h, 1); v.as_ref().hash(h); } None => tag(h, 0), } }
             Expr::Delete(e) => { tag(h, 381); e.as_ref().hash(h); }
             Expr::Closure { func_id, params, return_type, body, captures, mutable_captures, captures_this, enclosing_class, is_async, is_generator, } => { tag(h, 382); func_id.hash(h); params.hash(h); return_type.hash(h); body.hash(h); captures.hash(h); mutable_captures.hash(h); captures_this.hash(h); enclosing_class.hash(h); is_async.hash(h); is_generator.hash(h); }
             Expr::RegExp { pattern, flags } => { tag(h, 383); pattern.hash(h); flags.hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -334,9 +334,16 @@ where
             f(count);
         }
 
-        Expr::UrlSearchParamsForEach { params, callback } => {
+        Expr::UrlSearchParamsForEach {
+            params,
+            callback,
+            this_arg,
+        } => {
             f(params);
             f(callback);
+            if let Some(this_arg) = this_arg {
+                f(this_arg);
+            }
         }
 
         Expr::TaggedTemplateStrings { cooked, .. } => {

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -335,9 +335,16 @@ where
             f(count);
         }
 
-        Expr::UrlSearchParamsForEach { params, callback } => {
+        Expr::UrlSearchParamsForEach {
+            params,
+            callback,
+            this_arg,
+        } => {
             f(params);
             f(callback);
+            if let Some(this_arg) = this_arg {
+                f(this_arg);
+            }
         }
 
         Expr::TaggedTemplateStrings { cooked, .. } => {

--- a/crates/perry-runtime/src/url/search_params.rs
+++ b/crates/perry-runtime/src/url/search_params.rs
@@ -790,7 +790,11 @@ pub extern "C" fn js_url_search_params_sort(params: *mut ObjectHeader) {
 }
 
 #[no_mangle]
-pub extern "C" fn js_url_search_params_for_each(params: *mut ObjectHeader, callback: f64) {
+pub extern "C" fn js_url_search_params_for_each(
+    params: *mut ObjectHeader,
+    callback: f64,
+    this_arg: f64,
+) {
     let entries = get_url_search_params_entries(params);
     let this_value = crate::value::js_nanbox_pointer(params as i64);
     for (key, value) in entries {
@@ -800,7 +804,9 @@ pub extern "C" fn js_url_search_params_for_each(params: *mut ObjectHeader, callb
             this_value,
         ];
         unsafe {
+            let prev_this = crate::object::js_implicit_this_set(this_arg);
             let _ = crate::closure::js_native_call_value(callback, args.as_ptr(), args.len());
+            crate::object::js_implicit_this_set(prev_this);
         }
     }
 }


### PR DESCRIPTION
## Summary
- thread optional `thisArg` through URLSearchParams.forEach HIR and codegen paths
- bind Perry implicit `this` while invoking each URLSearchParams forEach callback
- preserve callback arguments as `(value, key, params)`

## Issue
- Part of Node compatibility work tracked under #793.

## Verification
- Baseline full `node-suite/url`: 37 PASS / 11 parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260528_141634.json`
- Baseline exact `node-suite/url/search-params/forEach-thisarg`: FAIL, report `test-parity/reports/parity_report_20260528_141727.json`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/url/search-params/forEach-thisarg` -> PASS, report `test-parity/reports/parity_report_20260528_142341.json`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/url/search-params` -> 11 PASS / 1 parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260528_142505.json`; remaining failure is `constructor-inputs-extra`
- `./run_parity_tests.sh --suite node-suite --module url` -> 38 PASS / 10 parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260528_142529.json`
- `cargo check -p perry-hir -p perry-codegen -p perry-runtime`
- `cargo fmt --check`
- `git diff --check`

## DeepWiki
- Saved local reference: `reference/deepwiki/node-urlsearchparams-foreach-thisarg.md`
- Invariant used: Node calls `callback.call(thisArg, value, key, this)` for each URLSearchParams entry, with `thisArg` defaulting to undefined.

## Non-goals
- no URLSearchParams constructor-input cleanup
- no URL parser or formatter encoding changes
- no file URL conversion changes
- no broad URL module rewrite