### PR TITLE
fix(geisterhand): link the geisterhand-built stdlib, not the auto-optimized one (#1383)

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -63,9 +63,10 @@ pub use library_search::find_library;
 pub(crate) use library_search::host_target_triple;
 use library_search::{
     build_geisterhand_libs, find_geisterhand_library, find_geisterhand_runtime,
-    find_geisterhand_ui, find_harmonyos_sdk, find_lld_link, find_llvm_tool, find_msvc_lib_paths,
-    find_msvc_link_exe, find_perry_windows_sdk, find_runtime_library, find_stdlib_library,
-    find_ui_library, find_wasm_host_library, windows_pe_subsystem_flag,
+    find_geisterhand_stdlib, find_geisterhand_ui, find_harmonyos_sdk, find_lld_link,
+    find_llvm_tool, find_msvc_lib_paths, find_msvc_link_exe, find_perry_windows_sdk,
+    find_runtime_library, find_stdlib_library, find_ui_library, find_wasm_host_library,
+    windows_pe_subsystem_flag,
 };
 use link::build_and_run_link;
 pub use lock_scan::collect_native_archives_for_lock;
@@ -4734,6 +4735,7 @@ pub fn run_with_parse_cache(
         // step and is idempotent — that check then finds them present.
         let gh_missing = find_geisterhand_runtime(target.as_deref()).is_none()
             || find_geisterhand_library(target.as_deref()).is_none()
+            || (ctx.needs_stdlib && find_geisterhand_stdlib(target.as_deref()).is_none())
             || (ctx.needs_ui && find_geisterhand_ui(target.as_deref()).is_none());
         if gh_missing {
             build_geisterhand_libs(target.as_deref(), format)?;
@@ -4747,7 +4749,24 @@ pub fn run_with_parse_cache(
     } else {
         find_runtime_library(target.as_deref())?
     };
-    let stdlib_lib = stdlib_lib_resolved.clone();
+    // #1383 — under --enable-geisterhand, prefer the geisterhand-built stdlib
+    // over the auto-optimized one. `build_geisterhand_libs` (already run above
+    // when selecting `runtime_lib`) compiles perry-stdlib into target/geisterhand
+    // with its full default feature set (incl. `async-runtime` → the
+    // `perry_ffi_promise_*` shims) against the geisterhand-featured, hash-
+    // consistent perry-runtime. The auto-optimized stdlib (`stdlib_lib_resolved`)
+    // is rebuilt with --no-default-features and a feature set computed from the
+    // app's *TS* imports, so it omits async-runtime when the async surface comes
+    // from a native binding (@perryts/storekit/google-auth/play-billing) rather
+    // than TS — producing the `Undefined symbols: _perry_ffi_promise_new` link
+    // failure this issue describes. Linking the geisterhand stdlib also keeps the
+    // bundled perry-runtime hash-consistent with `gh_runtime`. Fall back to the
+    // auto-optimized stdlib when geisterhand is off or its stdlib isn't present.
+    let stdlib_lib = if ctx.needs_geisterhand {
+        find_geisterhand_stdlib(target.as_deref()).or_else(|| stdlib_lib_resolved.clone())
+    } else {
+        stdlib_lib_resolved.clone()
+    };
     let is_watchos = matches!(
         target.as_deref(),
         Some("watchos") | Some("watchos-simulator")

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -1186,6 +1186,24 @@ pub(super) fn find_geisterhand_runtime(target: Option<&str>) -> Option<PathBuf> 
     find_geisterhand_lib(name, target)
 }
 
+pub(super) fn find_geisterhand_stdlib(target: Option<&str>) -> Option<PathBuf> {
+    // The geisterhand auto-build (`build_geisterhand_libs`) compiles
+    // perry-stdlib into target/geisterhand alongside the geisterhand-featured
+    // perry-runtime, so this archive carries perry-stdlib's full default
+    // feature set (incl. `async-runtime` → the `perry_ffi_promise_*` shims)
+    // and shares a hash-consistent `perry-runtime` with `find_geisterhand_runtime`.
+    // Only the geisterhand build dirs are searched (no `find_library` fallback)
+    // so we never select the auto-optimized stdlib, whose feature set is
+    // computed from the app's TS imports and omits async-runtime when the async
+    // surface comes from a native binding — the #1383 link failure.
+    let name = if matches!(target, Some("windows")) || cfg!(target_os = "windows") {
+        "perry_stdlib.lib"
+    } else {
+        "libperry_stdlib.a"
+    };
+    find_geisterhand_lib(name, target)
+}
+
 pub(super) fn find_geisterhand_ui(target: Option<&str>) -> Option<PathBuf> {
     let name = if matches!(target, Some("ios-simulator") | Some("ios")) {
         "libperry_ui_ios.a"

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -31,10 +31,10 @@ use crate::OutputFormat;
 
 use super::{
     apple_sdk_version, build_geisterhand_libs, find_geisterhand_library, find_geisterhand_runtime,
-    find_geisterhand_ui, find_lld_link, find_llvm_tool, find_msvc_lib_paths, find_msvc_link_exe,
-    find_perry_windows_sdk, find_stdlib_library, find_ui_library, find_visionos_swift_runtime,
-    find_watchos_swift_runtime, rust_target_triple, strip_duplicate_objects_from_lib,
-    windows_pe_subsystem_flag, CompilationContext,
+    find_geisterhand_stdlib, find_geisterhand_ui, find_lld_link, find_llvm_tool,
+    find_msvc_lib_paths, find_msvc_link_exe, find_perry_windows_sdk, find_stdlib_library,
+    find_ui_library, find_visionos_swift_runtime, find_watchos_swift_runtime, rust_target_triple,
+    strip_duplicate_objects_from_lib, windows_pe_subsystem_flag, CompilationContext,
 };
 
 mod platform_cmd;
@@ -1208,6 +1208,7 @@ pub(super) fn build_and_run_link(
         // Auto-build geisterhand libraries if any are missing
         let gh_missing = find_geisterhand_library(target).is_none()
             || find_geisterhand_runtime(target).is_none()
+            || (ctx.needs_stdlib && find_geisterhand_stdlib(target).is_none())
             || (ctx.needs_ui && find_geisterhand_ui(target).is_none());
         if gh_missing {
             build_geisterhand_libs(target, format)?;


### PR DESCRIPTION
## Summary

Fixes the remaining **link-side** half of #1383. PR #1385 already fixed the build side (`-p perry-stdlib` is in the geisterhand cargo invocation), but the stdlib that actually got **linked** under `--enable-geisterhand` was still the *auto-optimized* one.

The auto-optimized stdlib is built `--no-default-features` with a feature set derived from the app's **TS imports**. A geisterhand UI app pulls its async surface from a **native binding** (`@perryts/storekit` / `google-auth` / `play-billing`, all using `perry_ffi::async_runtime::JsPromise`), not TS — so auto-optimize never enables `async-runtime`, the linked stdlib lacks `perry_ffi_promise_*`, and the link dies with:

```
Undefined symbols for architecture arm64:
  "_perry_ffi_promise_new", referenced from: … libperry_storekit.a …
```

## Fix

- **`find_geisterhand_stdlib(target)`** — new finder mirroring `find_geisterhand_runtime`; searches only the `target/geisterhand/…` dirs, so it returns the geisterhand-built stdlib (full default features incl. `async-runtime`, sharing a hash-consistent `perry-runtime`) and never the auto-optimized one.
- **`compile.rs`** — when `ctx.needs_geisterhand`, select that stdlib for the link (falling back to the auto-optimized stdlib if absent). Keeps the bundled `perry-runtime` hash-consistent with `gh_runtime`.
- **`gh_missing` cold-build check** (both the compile.rs runtime-selection site and the link/mod.rs link site) now includes the geisterhand stdlib, so a stale `target/geisterhand` dir built before the stdlib was added rebuilds instead of silently falling back.

## Verification

- `cargo build --release -p perry` — compiles clean (no new warnings/errors).
- `cargo fmt --all -- --check` — clean.
- **Not** verified end-to-end: the native-FFI iOS link needs the iOS toolchain + the `@perryts/*` native-binding crates, which aren't available in this environment. The change is gated on `ctx.needs_geisterhand` and falls back to prior behavior when no geisterhand stdlib is present, so non-async geisterhand links are unaffected.

Closes #1383.
