### PR TITLE
fix(node:url): route imported URL static parse helpers

### DIFF
--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1874,6 +1874,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::UrlCanParse(..)
         | Expr::UrlCanParseWithBase { .. }
         | Expr::UrlParse(..)
+        | Expr::UrlParseWithBase { .. }
         | Expr::UrlSearchParamsNew(..)
         | Expr::UrlSearchParamsGet { .. }
         | Expr::UrlSearchParamsHas { .. }

--- a/crates/perry-codegen/src/expr/url_main.rs
+++ b/crates/perry-codegen/src/expr/url_main.rs
@@ -203,6 +203,28 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(blk.select(I1, &is_null, DOUBLE, &null_box, &success))
         }
 
+        Expr::UrlParseWithBase { input, base } => {
+            let input_v = lower_expr(ctx, input)?;
+            let input_ptr =
+                ctx.block()
+                    .call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &input_v)]);
+            let base_v = lower_expr(ctx, base)?;
+            let base_ptr =
+                ctx.block()
+                    .call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &base_v)]);
+            let obj = ctx.block().call(
+                I64,
+                "js_url_parse_with_base",
+                &[(I64, &input_ptr), (I64, &base_ptr)],
+            );
+            let blk = ctx.block();
+            let is_null = blk.icmp_eq(I64, &obj, "0");
+            let success = nanbox_pointer_inline(blk, &obj);
+            let null_box = blk.bitcast_i64_to_double(crate::nanbox::TAG_NULL_I64);
+            let blk = ctx.block();
+            Ok(blk.select(I1, &is_null, DOUBLE, &null_box, &success))
+        }
+
         Expr::UrlSearchParamsNew(init) => {
             // Pre-#575 this routed every init through `js_url_search_params_new`
             // which only accepts a string — object literals (`new

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -515,6 +515,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_url_can_parse", I32, &[I64]);
     module.declare_function("js_url_can_parse_with_base", I32, &[I64, I64]);
     module.declare_function("js_url_parse", I64, &[I64]);
+    module.declare_function("js_url_parse_with_base", I64, &[I64, I64]);
     // Issue #650: URL setters — mutate field + re-derive href.
     module.declare_function("js_url_set_pathname", VOID, &[I64, I64]);
     module.declare_function("js_url_set_search", VOID, &[I64, I64]);

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -953,6 +953,10 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
             collect_assigned_locals_expr(input, assigned);
             collect_assigned_locals_expr(base, assigned);
         }
+        Expr::UrlParseWithBase { input, base } => {
+            collect_assigned_locals_expr(input, assigned);
+            collect_assigned_locals_expr(base, assigned);
+        }
         // URLSearchParams operations
         Expr::UrlSearchParamsNew(init) => {
             if let Some(init_expr) = init {

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1554,6 +1554,11 @@ pub enum Expr {
     /// URL.parse(input) -> URL | null. Issue #650: non-throwing variant
     /// of `new URL()` added in Node 22. Returns null when parsing fails.
     UrlParse(Box<Expr>),
+    /// URL.parse(input, base) -> URL | null.
+    UrlParseWithBase {
+        input: Box<Expr>,
+        base: Box<Expr>,
+    },
     /// `urlInstance.toString()` -> string. Issue #650: WHATWG `URL.prototype.toString`
     /// is `URL.prototype.toJSON` is alias for `href`. Without this variant the
     /// call fell through to the generic Object.prototype.toString and returned

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -1309,9 +1309,15 @@ pub(super) fn try_module_static_methods(
                         return Ok(Ok(Expr::UrlCanParse(Box::new(input))));
                     }
                     if method_name == "parse" && !args.is_empty() {
-                        return Ok(Ok(Expr::UrlParse(Box::new(
-                            args.into_iter().next().unwrap(),
-                        ))));
+                        let mut iter = args.into_iter();
+                        let input = iter.next().unwrap();
+                        if let Some(base) = iter.next() {
+                            return Ok(Ok(Expr::UrlParseWithBase {
+                                input: Box::new(input),
+                                base: Box::new(base),
+                            }));
+                        }
+                        return Ok(Ok(Expr::UrlParse(Box::new(input))));
                     }
                     // Issue #1211: `URL.createObjectURL(blob)` /
                     // `URL.revokeObjectURL(url)` route to the

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -1128,7 +1128,35 @@ pub(super) fn try_native_module_methods(
                 }
             }
 
-            if let Some((module_name, _imported_method)) = ctx.lookup_native_module(&obj_name) {
+            if let Some((module_name, imported_method)) = ctx.lookup_native_module(&obj_name) {
+                if module_name == "url" && imported_method == Some("URL") {
+                    if let ast::MemberProp::Ident(method_ident) = &member.prop {
+                        let method_name = method_ident.sym.as_ref();
+                        if method_name == "canParse" && !args.is_empty() {
+                            let mut iter = args.into_iter();
+                            let input = iter.next().unwrap();
+                            if let Some(base) = iter.next() {
+                                return Ok(Ok(Expr::UrlCanParseWithBase {
+                                    input: Box::new(input),
+                                    base: Box::new(base),
+                                }));
+                            }
+                            return Ok(Ok(Expr::UrlCanParse(Box::new(input))));
+                        }
+                        if method_name == "parse" && !args.is_empty() {
+                            let mut iter = args.into_iter();
+                            let input = iter.next().unwrap();
+                            if let Some(base) = iter.next() {
+                                return Ok(Ok(Expr::UrlParseWithBase {
+                                    input: Box::new(input),
+                                    base: Box::new(base),
+                                }));
+                            }
+                            return Ok(Ok(Expr::UrlParse(Box::new(input))));
+                        }
+                    }
+                }
+
                 // Skip modules handled specifically below (path, fs, child_process, etc.)
                 // `net` used to be in this list back when its method calls
                 // were short-circuited into `Expr::NetCreateConnection` etc.

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -445,6 +445,7 @@ impl SH for Expr {
             Expr::UrlCanParse(e) => { tag(h, 365); e.as_ref().hash(h); }
             Expr::UrlCanParseWithBase { input, base } => { tag(h, 700); input.as_ref().hash(h); base.as_ref().hash(h); }
             Expr::UrlParse(e) => { tag(h, 366); e.as_ref().hash(h); }
+            Expr::UrlParseWithBase { input, base } => { tag(h, 705); input.as_ref().hash(h); base.as_ref().hash(h); }
             Expr::UrlInstanceToString(e) => { tag(h, 367); e.as_ref().hash(h); }
             Expr::UrlInstanceToJSON(e) => { tag(h, 368); e.as_ref().hash(h); }
             Expr::UrlSetPathname { url, value } => { tag(h, 369); url.as_ref().hash(h); value.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -313,6 +313,11 @@ where
             f(base);
         }
 
+        Expr::UrlParseWithBase { input, base } => {
+            f(input);
+            f(base);
+        }
+
         Expr::NativeArenaView {
             owner,
             byte_offset,

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -314,6 +314,11 @@ where
             f(base);
         }
 
+        Expr::UrlParseWithBase { input, base } => {
+            f(input);
+            f(base);
+        }
+
         Expr::NativeArenaView {
             owner,
             byte_offset,

--- a/crates/perry-runtime/src/url/mod.rs
+++ b/crates/perry-runtime/src/url/mod.rs
@@ -41,9 +41,9 @@ pub use self::url_class::{
     js_url_can_parse, js_url_can_parse_with_base, js_url_get_hash, js_url_get_host,
     js_url_get_hostname, js_url_get_href, js_url_get_origin, js_url_get_pathname, js_url_get_port,
     js_url_get_protocol, js_url_get_search, js_url_get_search_params, js_url_new,
-    js_url_new_with_base, js_url_parse, js_url_set_hash, js_url_set_hostname, js_url_set_password,
-    js_url_set_pathname, js_url_set_port, js_url_set_protocol, js_url_set_search,
-    js_url_set_username,
+    js_url_new_with_base, js_url_parse, js_url_parse_with_base, js_url_set_hash,
+    js_url_set_hostname, js_url_set_password, js_url_set_pathname, js_url_set_port,
+    js_url_set_protocol, js_url_set_search, js_url_set_username,
 };
 
 // ---------------------------------------------------------------------------

--- a/crates/perry-runtime/src/url/parse.rs
+++ b/crates/perry-runtime/src/url/parse.rs
@@ -480,12 +480,80 @@ pub(crate) fn is_valid_absolute_url(s: &str) -> bool {
         if !after_scheme.starts_with("//") {
             return false;
         }
-        // file:// is allowed to have an empty host, every other scheme needs one.
-        if scheme != "file" && after_scheme.len() <= 2 {
+        let authority = after_scheme[2..]
+            .split(['/', '?', '#'])
+            .next()
+            .unwrap_or_default();
+        if !is_valid_url_authority(scheme, authority) {
             return false;
         }
     } else if after_scheme.is_empty() {
         return false;
     }
     true
+}
+
+fn is_valid_url_authority(scheme: &str, authority: &str) -> bool {
+    // file:// is allowed to have an empty host, every other special scheme
+    // needs one.
+    if scheme != "file" && authority.is_empty() {
+        return false;
+    }
+    if authority.bytes().any(|b| b <= 0x20 || b == 0x7f) {
+        return false;
+    }
+
+    let host_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    if scheme != "file" && host_port.is_empty() {
+        return false;
+    }
+
+    let host = if let Some(rest) = host_port.strip_prefix('[') {
+        let Some(bracket_end) = rest.find(']') else {
+            return false;
+        };
+        let after_bracket = &rest[bracket_end + 1..];
+        if !after_bracket.is_empty()
+            && !after_bracket
+                .strip_prefix(':')
+                .is_some_and(|port| port.bytes().all(|b| b.is_ascii_digit()))
+        {
+            return false;
+        }
+        &host_port[..=bracket_end + 1]
+    } else if let Some(port_idx) = host_port.rfind(':') {
+        let port = &host_port[port_idx + 1..];
+        if !port.bytes().all(|b| b.is_ascii_digit()) {
+            return false;
+        }
+        &host_port[..port_idx]
+    } else {
+        host_port
+    };
+
+    if scheme != "file" && host.is_empty() {
+        return false;
+    }
+    !has_invalid_percent_escape(host)
+}
+
+fn has_invalid_percent_escape(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            if i + 2 >= bytes.len()
+                || !bytes[i + 1].is_ascii_hexdigit()
+                || !bytes[i + 2].is_ascii_hexdigit()
+            {
+                return true;
+            }
+            i += 3;
+        } else {
+            i += 1;
+        }
+    }
+    false
 }

--- a/crates/perry-runtime/src/url/url_class.rs
+++ b/crates/perry-runtime/src/url/url_class.rs
@@ -330,6 +330,26 @@ pub extern "C" fn js_url_parse(input: *mut crate::StringHeader) -> *mut ObjectHe
     create_url_object(&s)
 }
 
+#[no_mangle]
+pub extern "C" fn js_url_parse_with_base(
+    input: *mut crate::StringHeader,
+    base: *mut crate::StringHeader,
+) -> *mut ObjectHeader {
+    let input_s = string_from_header(input);
+    let base_s = string_from_header(base);
+    if is_valid_absolute_url(&input_s) {
+        return create_url_object(&input_s);
+    }
+    if !is_valid_absolute_url(&base_s) || input_s.trim().is_empty() {
+        return std::ptr::null_mut();
+    }
+    let resolved = resolve_url(&input_s, &base_s);
+    if !is_valid_absolute_url(&resolved) {
+        return std::ptr::null_mut();
+    }
+    create_url_object(&resolved)
+}
+
 /// Get the pathname property from a URL
 #[no_mangle]
 pub extern "C" fn js_url_get_pathname(url: *mut ObjectHeader) -> f64 {


### PR DESCRIPTION
## Summary
- Route named-imported `URL` from `node:url` through the existing static `URL.canParse` lowering, including the optional base argument.
- Add a base-aware `URL.parse(input, base)` HIR/codegen/runtime path that returns a URL object or `null` without throwing.
- Tighten static URL authority validation so invalid host percent escapes like `http://%zz` return `false`/`null` instead of constructing a URL.

## Verification
- Baseline exact `node-suite/url/module/url-canparse-parse-edge`: FAIL, `test-parity/reports/parity_report_20260528_143223.json`.
- Baseline guardrail `node-suite/url/url/static-can-parse`: PASS, `test-parity/reports/parity_report_20260528_143353.json`.
- Final exact `node-suite/url/module/url-canparse-parse-edge`: PASS, `test-parity/reports/parity_report_20260528_144550.json`.
- Final full granular `node-suite/url`: 38 PASS / 10 parity FAIL / 0 compile FAIL, `test-parity/reports/parity_report_20260528_144639.json`. Remaining failures are unrelated URL formatter/path/domain/search-param/URL mutation gaps, plus `forEach-thisarg` because PR #2314 is separate.
- `cargo check -p perry-hir -p perry-codegen -p perry-runtime`: PASS with existing warnings.
- `cargo fmt --check`: PASS.
- `git diff --check`: PASS.

## Notes
- DeepWiki reference saved locally at `reference/deepwiki/node-url-canparse-parse-base.md`; not staged.
- Scope intentionally excludes a broad WHATWG URL parser rewrite, file URL conversion changes, URL formatter/query encoding cleanup, and URLSearchParams constructor-shape work.
