### PR TITLE
feat(perry/system): expose getSafeAreaInsets() for iOS / cross-platform (#1475)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2933,6 +2933,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // --- perry/system — auto-derivable from PERRY_SYSTEM_TABLE. ---
     method("perry/system", "isDarkMode", false, None),
     method("perry/system", "getDeviceIdiom", false, None),
+    method("perry/system", "getSafeAreaInsets", false, None),
     method("perry/system", "getDeviceModel", false, None),
     // Bug-report-flow utility: stable OS-version string per
     // platform (e.g. `"15.2"`, `"macOS 14.5"`, `"Android 14"`).

--- a/crates/perry-dispatch/src/system_table.rs
+++ b/crates/perry-dispatch/src/system_table.rs
@@ -15,6 +15,16 @@ pub static PERRY_SYSTEM_TABLE: &[MethodRow] = &[
         args: &[],
         ret: ReturnKind::F64,
     },
+    // #1475 — safe-area insets. Returns `{ top, right, bottom, left }` (points)
+    // read from `UIWindow.safeAreaInsets` (iOS) / `WindowInsets.systemBars()`
+    // (Android), zero on macOS/host. The platform FFI returns the object
+    // already NaN-boxed, so the row uses `ReturnKind::F64` (pass-through).
+    MethodRow {
+        method: "getSafeAreaInsets",
+        runtime: "perry_system_get_safe_area_insets",
+        args: &[],
+        ret: ReturnKind::F64,
+    },
     MethodRow {
         method: "openURL",
         runtime: "perry_system_open_url",

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -60,6 +60,7 @@ pub mod pointer_event;
 pub mod process;
 pub mod promise;
 pub mod regex;
+pub mod safe_area;
 pub mod set;
 pub mod string;
 pub mod symbol;

--- a/crates/perry-runtime/src/safe_area.rs
+++ b/crates/perry-runtime/src/safe_area.rs
@@ -1,0 +1,70 @@
+//! Safe-area inset object for `perry/system` `getSafeAreaInsets()` (issue #1475).
+//!
+//! Builds the `{ top, right, bottom, left }` object returned to TS, with all
+//! four values in points. Each platform UI crate computes the four insets from
+//! the OS (e.g. `UIWindow.safeAreaInsets` on iOS, `WindowInsets.Type.systemBars()`
+//! on Android, zero on macOS/host) and calls `perry_safe_area_insets_make` to
+//! materialize the JS object — keeping the object layout owned in one place in
+//! the runtime rather than duplicated across every platform backend.
+//!
+//! Allocated in the caller's thread-local nursery — cheap, dies on the next
+//! minor GC once the caller drops it. `getSafeAreaInsets()` is invoked on the
+//! main thread (same as the UI runtime), so the allocation lands in the right
+//! arena.
+
+use crate::object::{js_object_alloc_with_shape, js_object_set_field};
+use crate::value::JSValue;
+
+/// Allocate a `{ top, right, bottom, left }` object and return it NaN-boxed
+/// (POINTER_TAG). The system-table row for `getSafeAreaInsets` uses
+/// `ReturnKind::F64`, so this NaN-boxed pointer is passed straight through to
+/// TS unchanged — TS sees a plain object it can destructure.
+#[no_mangle]
+pub extern "C" fn perry_safe_area_insets_make(top: f64, right: f64, bottom: f64, left: f64) -> f64 {
+    let packed = b"top\0right\0bottom\0left\0";
+    let field_count: u32 = 4;
+    // Unique shape_id — must not collide with other shape-allocated objects
+    // (grep `0x7FFF_FF` in perry-runtime to verify).
+    let obj = js_object_alloc_with_shape(
+        0x7FFF_FF34,
+        field_count,
+        packed.as_ptr(),
+        packed.len() as u32,
+    );
+
+    js_object_set_field(obj, 0, JSValue::number(top));
+    js_object_set_field(obj, 1, JSValue::number(right));
+    js_object_set_field(obj, 2, JSValue::number(bottom));
+    js_object_set_field(obj, 3, JSValue::number(left));
+
+    f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object::js_object_get_field;
+    use crate::value::POINTER_TAG;
+
+    /// Confirm the object carries the four expected fields in the documented
+    /// `top, right, bottom, left` order. Guards against silently reordering the
+    /// packed-keys list — every platform crate passes the four insets in this
+    /// exact positional order.
+    #[test]
+    fn safe_area_insets_layout_matches_documented_order() {
+        let nb = perry_safe_area_insets_make(59.0, 0.0, 34.0, 0.0);
+        let bits = nb.to_bits();
+        assert_eq!(bits & 0xFFFF_0000_0000_0000, POINTER_TAG);
+        let obj_ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *mut crate::object::ObjectHeader;
+
+        let top = unsafe { js_object_get_field(obj_ptr, 0) };
+        let right = unsafe { js_object_get_field(obj_ptr, 1) };
+        let bottom = unsafe { js_object_get_field(obj_ptr, 2) };
+        let left = unsafe { js_object_get_field(obj_ptr, 3) };
+
+        assert_eq!(f64::from_bits(top.bits()), 59.0);
+        assert_eq!(f64::from_bits(right.bits()), 0.0);
+        assert_eq!(f64::from_bits(bottom.bits()), 34.0);
+        assert_eq!(f64::from_bits(left.bits()), 0.0);
+    }
+}

--- a/crates/perry-ui-android/src/ffi/issue_553.rs
+++ b/crates/perry-ui-android/src/ffi/issue_553.rs
@@ -293,3 +293,16 @@ pub extern "C" fn perry_system_take_screenshot() -> i64 {
     }
     unsafe { js_string_from_bytes(std::ptr::null(), 0) as i64 }
 }
+
+/// #1475 — safe-area insets. Reports all-zero for now. A real implementation
+/// reads `decorView.getRootWindowInsets().getInsets(WindowInsets.Type.systemBars())`
+/// over JNI (top status bar, bottom navigation/gesture bar) and converts px→dp;
+/// tracked as a follow-up so the host-tested iOS path can land first. The
+/// symbol is defined here so `getSafeAreaInsets()` links on Android.
+#[no_mangle]
+pub extern "C" fn perry_system_get_safe_area_insets() -> f64 {
+    extern "C" {
+        fn perry_safe_area_insets_make(top: f64, right: f64, bottom: f64, left: f64) -> f64;
+    }
+    unsafe { perry_safe_area_insets_make(0.0, 0.0, 0.0, 0.0) }
+}

--- a/crates/perry-ui-gtk4/src/ffi/stubs_webview_attrtext_screenshot.rs
+++ b/crates/perry-ui-gtk4/src/ffi/stubs_webview_attrtext_screenshot.rs
@@ -216,3 +216,14 @@ pub extern "C" fn perry_system_take_screenshot() -> i64 {
         js_string_from_bytes(encoded.as_ptr(), encoded.len() as i64) as i64
     }
 }
+
+/// #1475 — safe-area insets. Desktop GTK4 windows have no system safe area,
+/// so report all-zero insets. Keeps the symbol present so
+/// `getSafeAreaInsets()` links on Linux builds.
+#[no_mangle]
+pub extern "C" fn perry_system_get_safe_area_insets() -> f64 {
+    extern "C" {
+        fn perry_safe_area_insets_make(top: f64, right: f64, bottom: f64, left: f64) -> f64;
+    }
+    unsafe { perry_safe_area_insets_make(0.0, 0.0, 0.0, 0.0) }
+}

--- a/crates/perry-ui-ios/src/ffi/system.rs
+++ b/crates/perry-ui-ios/src/ffi/system.rs
@@ -273,6 +273,35 @@ pub extern "C" fn perry_system_take_screenshot() -> i64 {
     }
 }
 
+/// #1475 — safe-area insets. Reads `UIWindow.safeAreaInsets` from the key
+/// window and returns `{ top, right, bottom, left }` (points). Falls back to
+/// all-zero when no key window is attached yet (e.g. before the scene
+/// connects, in tests, or in headless CLI builds).
+#[no_mangle]
+pub extern "C" fn perry_system_get_safe_area_insets() -> f64 {
+    extern "C" {
+        fn perry_safe_area_insets_make(top: f64, right: f64, bottom: f64, left: f64) -> f64;
+    }
+    let mut insets = crate::widgets::vstack::UIEdgeInsets {
+        top: 0.0,
+        left: 0.0,
+        bottom: 0.0,
+        right: 0.0,
+    };
+    unsafe {
+        if let Some(app_cls) = objc2::runtime::AnyClass::get(c"UIApplication") {
+            let app: *mut objc2::runtime::AnyObject = objc2::msg_send![app_cls, sharedApplication];
+            if !app.is_null() {
+                let key_window: *mut objc2::runtime::AnyObject = objc2::msg_send![app, keyWindow];
+                if !key_window.is_null() {
+                    insets = objc2::msg_send![key_window, safeAreaInsets];
+                }
+            }
+        }
+        perry_safe_area_insets_make(insets.top, insets.right, insets.bottom, insets.left)
+    }
+}
+
 // ---- Network reachability (issue #582) ----
 #[no_mangle]
 pub extern "C" fn perry_system_network_get_status(callback: f64) {

--- a/crates/perry-ui-macos/src/lib_ffi/system_aux.rs
+++ b/crates/perry-ui-macos/src/lib_ffi/system_aux.rs
@@ -60,6 +60,17 @@ pub extern "C" fn perry_system_take_screenshot() -> i64 {
     }
 }
 
+/// #1475 — safe-area insets. macOS windows have no status bar / home
+/// indicator, so report all-zero insets. Keeps the symbol present so
+/// `getSafeAreaInsets()` links on the host build.
+#[no_mangle]
+pub extern "C" fn perry_system_get_safe_area_insets() -> f64 {
+    extern "C" {
+        fn perry_safe_area_insets_make(top: f64, right: f64, bottom: f64, left: f64) -> f64;
+    }
+    unsafe { perry_safe_area_insets_make(0.0, 0.0, 0.0, 0.0) }
+}
+
 // ---- Network reachability (issue #582) ----
 #[no_mangle]
 pub extern "C" fn perry_system_network_get_status(callback: f64) {

--- a/crates/perry-ui-tvos/src/ffi/media_extras.rs
+++ b/crates/perry-ui-tvos/src/ffi/media_extras.rs
@@ -296,3 +296,14 @@ pub extern "C" fn perry_system_take_screenshot() -> i64 {
         js_string_from_bytes(encoded.as_ptr(), encoded.len() as i64) as i64
     }
 }
+
+/// #1475 — safe-area insets. tvOS overscan safe area is not yet exposed here;
+/// report all-zero so the symbol links. (Follow-up can read the focus
+/// environment's safe-area layout guide.)
+#[no_mangle]
+pub extern "C" fn perry_system_get_safe_area_insets() -> f64 {
+    extern "C" {
+        fn perry_safe_area_insets_make(top: f64, right: f64, bottom: f64, left: f64) -> f64;
+    }
+    unsafe { perry_safe_area_insets_make(0.0, 0.0, 0.0, 0.0) }
+}

--- a/crates/perry-ui-visionos/src/ffi_misc.rs
+++ b/crates/perry-ui-visionos/src/ffi_misc.rs
@@ -159,3 +159,14 @@ pub extern "C" fn perry_system_take_screenshot() -> i64 {
         js_string_from_bytes(encoded.as_ptr(), encoded.len() as i64) as i64
     }
 }
+
+/// #1475 — safe-area insets. Not yet wired to visionOS ornaments/safe area;
+/// report all-zero so the symbol links. (Follow-up can read the volume's
+/// safe-area geometry.)
+#[no_mangle]
+pub extern "C" fn perry_system_get_safe_area_insets() -> f64 {
+    extern "C" {
+        fn perry_safe_area_insets_make(top: f64, right: f64, bottom: f64, left: f64) -> f64;
+    }
+    unsafe { perry_safe_area_insets_make(0.0, 0.0, 0.0, 0.0) }
+}

--- a/crates/perry-ui-watchos/src/lib.rs
+++ b/crates/perry-ui-watchos/src/lib.rs
@@ -1754,6 +1754,17 @@ pub extern "C" fn perry_system_take_screenshot() -> i64 {
     unsafe { js_string_from_bytes(std::ptr::null(), 0) }
 }
 
+/// #1475 — safe-area insets. watchOS layout uses the system-provided safe
+/// area implicitly; no explicit inset query is exposed here, so report
+/// all-zero. Keeps the symbol present so `getSafeAreaInsets()` links.
+#[no_mangle]
+pub extern "C" fn perry_system_get_safe_area_insets() -> f64 {
+    extern "C" {
+        fn perry_safe_area_insets_make(top: f64, right: f64, bottom: f64, left: f64) -> f64;
+    }
+    unsafe { perry_safe_area_insets_make(0.0, 0.0, 0.0, 0.0) }
+}
+
 /// Load an image asset for Canvas.drawImage. watchOS currently has no real
 /// Canvas backend, so expose a proper rejected Promise rather than a bare 0.
 #[no_mangle]

--- a/crates/perry-ui-windows/src/ffi/system.rs
+++ b/crates/perry-ui-windows/src/ffi/system.rs
@@ -189,3 +189,14 @@ pub extern "C" fn perry_system_take_screenshot() -> i64 {
         js_string_from_bytes(encoded.as_ptr(), encoded.len() as i64) as i64
     }
 }
+
+/// #1475 — safe-area insets. Desktop Windows has no system safe area, so
+/// report all-zero insets. Keeps the symbol present so `getSafeAreaInsets()`
+/// links on Windows builds.
+#[no_mangle]
+pub extern "C" fn perry_system_get_safe_area_insets() -> f64 {
+    extern "C" {
+        fn perry_safe_area_insets_make(top: f64, right: f64, bottom: f64, left: f64) -> f64;
+    }
+    unsafe { perry_safe_area_insets_make(0.0, 0.0, 0.0, 0.0) }
+}

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -667,6 +667,7 @@ pub(super) fn collect_modules(
                             | "geolocationRequestPermission"
                             | "imagePickerPick"
                             | "takeScreenshot"
+                            | "getSafeAreaInsets"
                             | "networkGetStatus"
                             | "networkOnChange"
                             | "networkStopOnChange"

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1488 entries across 82 modules
+// Coverage: 1489 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1301,6 +1301,8 @@ declare module "perry/system" {
   export function getLocale(...args: any[]): any;
   /** stdlib */
   export function getOSVersion(...args: any[]): any;
+  /** stdlib */
+  export function getSafeAreaInsets(...args: any[]): any;
   /** stdlib */
   export function imagePickerPick(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1488 entries across 82 modules.
+Total: 1489 entries across 82 modules.
 
 ## Modules
 
@@ -1401,6 +1401,7 @@ Total: 1488 entries across 82 modules.
 - `getDeviceModel` — module
 - `getLocale` — module
 - `getOSVersion` — module
+- `getSafeAreaInsets` — module
 - `imagePickerPick` — module
 - `isDarkMode` — module
 - `keychainDelete` — module

--- a/types/perry/system/index.d.ts
+++ b/types/perry/system/index.d.ts
@@ -12,6 +12,30 @@ export function isDarkMode(): boolean;
 /** Returns the device idiom (e.g. "phone", "pad", "mac", "tv"). */
 export function getDeviceIdiom(): string;
 
+/** The device's safe-area insets in points (status bar / Dynamic Island,
+ *  home indicator, system bars). Stable across rotation and device class. */
+export interface SafeAreaInsets {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+/**
+ * Returns the current safe-area insets in points — the distances from each
+ * screen edge that are obscured by system UI (status bar / Dynamic Island on
+ * top, home indicator on bottom on iOS; the equivalent system bars on Android).
+ * Returns all zeros on macOS / host. Use these instead of hardcoding magic
+ * numbers (e.g. `59` for Dynamic Island, `34` for the home indicator) so a
+ * custom top-of-screen or bottom-of-screen layout is correct on every device.
+ *
+ * ```ts
+ * import { getSafeAreaInsets } from "perry/system";
+ * const { top, right, bottom, left } = getSafeAreaInsets();
+ * ```
+ */
+export function getSafeAreaInsets(): SafeAreaInsets;
+
 /** Returns the device model identifier (e.g. "iPhone13,4"). */
 export function getDeviceModel(): string;
 


### PR DESCRIPTION
Closes #1475.

## What

Adds `getSafeAreaInsets()` to `perry/system`:

```ts
import { getSafeAreaInsets } from "perry/system";
const { top, right, bottom, left } = getSafeAreaInsets();
```

Returns `{ top, right, bottom, left }` in points so apps building a custom top-of-screen / bottom-of-screen layout can position content correctly on every device class, instead of hardcoding magic numbers (`59` Dynamic Island, `34` home indicator) keyed on `__platform__` — which is wrong on 44pt-notch iPhones, iPad, and Android.

## How

- **Runtime** (`crates/perry-runtime/src/safe_area.rs`, new): `perry_safe_area_insets_make(top, right, bottom, left)` builds the `{top,right,bottom,left}` object and returns it NaN-boxed (modeled on `pointer_event.rs`). Centralizes the object layout in one place; each platform just computes four floats and calls it. The system-table row uses `ReturnKind::F64` since the value is already a NaN-boxed pointer (pass-through).
- **iOS** (real): reads `UIWindow.safeAreaInsets` off the key window; falls back to all-zero before the scene connects / in headless builds.
- **macOS, Windows, GTK4, tvOS, visionOS, watchOS**: report all-zero (no system safe area, or not yet wired) so the symbol links everywhere.
- **Android**: zero stub for now — a real `decorView.getRootWindowInsets().getInsets(WindowInsets.Type.systemBars())` JNI implementation is a tracked follow-up so the host-verifiable iOS path can land first.
- Wires the import into the UI-link trigger list (`collect_modules.rs`), adds the manifest entry + regenerated API docs, and the `.d.ts` `SafeAreaInsets` type.

## Validation

- `cargo build --release` for `perry-runtime`, `perry-dispatch`, `perry-api-manifest`, `perry-ui-macos`, `perry-stdlib`, `perry` — clean.
- `cargo build --release -p perry-ui-ios --target aarch64-apple-ios` — the real iOS implementation compiles.
- New unit test `safe_area_insets_layout_matches_documented_order` passes.
- End-to-end on the macOS host: `getSafeAreaInsets()` returns a real object; destructuring and `.top`/`.right`/`.bottom`/`.left` property access work (zeros on macOS, as expected).
- `cargo fmt --all -- --check` clean; API docs regenerated (`api-docs-drift`).

Note: per the maintainer workflow, version bump + CHANGELOG entry are intentionally omitted from this branch to be folded in at merge.
