### PR TITLE
fix(cjs-wrap, codegen): preserve closure over IIFE-local lets for hoisted classes (#2310)

### DIFF
--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -1240,6 +1240,48 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         if let Some(ctor) = &c.constructor {
             scan_body(&ctor.params, &ctor.body, &mut referenced_from_fn);
         }
+        // Issue #2310 — static methods, getters/setters, and
+        // (static) field initializers were missing here, so a
+        // module-level `let n = 0; class C { static bump() { return
+        // n++; } }` left `n` un-globalized — codegen routed `n++` to
+        // a local alloca whose value was never observed by anything
+        // outside the static method, and reads via
+        // `_cjs.C.bump()` came back 0 every call. Including these
+        // bodies in the reference scan lets the `referenced_from_fn`
+        // → `module_globals` promotion below catch the same pattern
+        // as instance methods.
+        for sm in &c.static_methods {
+            scan_body(&sm.params, &sm.body, &mut referenced_from_fn);
+        }
+        for (_, getter_fn) in &c.getters {
+            scan_body(&getter_fn.params, &getter_fn.body, &mut referenced_from_fn);
+        }
+        for (_, setter_fn) in &c.setters {
+            scan_body(&setter_fn.params, &setter_fn.body, &mut referenced_from_fn);
+        }
+        // Field initializers are evaluated inside the constructor —
+        // most carry module-global refs only when they're closures
+        // (already walked by the closure pass below). Wrap each init
+        // expression as a synthetic `Stmt::Expr` so direct refs (like
+        // `static seed = RANDOM_POOL_SIZE`) also surface here.
+        for field in &c.fields {
+            if let Some(init) = &field.init {
+                scan_body(
+                    &[],
+                    &[perry_hir::Stmt::Expr(init.clone())],
+                    &mut referenced_from_fn,
+                );
+            }
+        }
+        for field in &c.static_fields {
+            if let Some(init) = &field.init {
+                scan_body(
+                    &[],
+                    &[perry_hir::Stmt::Expr(init.clone())],
+                    &mut referenced_from_fn,
+                );
+            }
+        }
     }
     // Also walk every closure body. A self-referencing recursive
     // closure (`let f = (n) => f(n-1)`) needs `f` to be globalized

--- a/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
@@ -224,6 +224,17 @@ pub fn extract_top_level_class_decls(source: &str) -> (String, Vec<String>, Stri
     let mut hoisted_names: Vec<String> = Vec::new();
     let mut elided: Vec<(usize, usize)> = Vec::new();
 
+    // Issue #2310 — collect the names of top-level `let`/`const`/`var`
+    // declarations in this CJS source so we can REFUSE to hoist a class
+    // whose body references any of them. Hoisting moves the class out of
+    // the IIFE wrap, which severs the closure over those bindings — the
+    // class's methods then see `unknown identifier` warnings and any
+    // `++`/`--` update on an IIFE-internal let hard-errors with
+    // `Undefined variable in update expression`. The conservative rule
+    // is to leave the class inside the IIFE when *any* of its referenced
+    // identifiers would lose their binding to the IIFE-local state.
+    let iife_locals = collect_top_level_let_const_var_names(source);
+
     let mut i = 0usize;
     while i < bytes.len() {
         // Anchor on a `class` keyword at the start of a line (after only
@@ -334,9 +345,14 @@ pub fn extract_top_level_class_decls(source: &str) -> (String, Vec<String>, Stri
                         r += 1;
                     }
                     if depth == 0 && r > body_start {
-                        // Successful brace-balanced match. Record the block.
+                        // Successful brace-balanced match. Record the block —
+                        // unless the body references an IIFE-local let/const/var,
+                        // in which case hoisting would sever the closure (#2310).
                         let block_text = std::str::from_utf8(&bytes[line_start..r]).unwrap_or("");
-                        if !hoisted_names.contains(&class_name) {
+                        let body_text = std::str::from_utf8(&bytes[body_start..r]).unwrap_or("");
+                        let references_iife_local =
+                            class_body_references_any(body_text, &iife_locals);
+                        if !hoisted_names.contains(&class_name) && !references_iife_local {
                             hoisted_blocks.push(block_text);
                             hoisted_names.push(class_name);
                             elided.push((line_start, r));
@@ -369,4 +385,222 @@ pub fn extract_top_level_class_decls(source: &str) -> (String, Vec<String>, Stri
 
     let hoisted_block = hoisted_blocks.join("\n");
     (hoisted_block, hoisted_names, out_source)
+}
+
+/// Issue #2310 — scan the source for **top-level** `let`/`const`/`var`
+/// declarations and return their bare identifier names. Used by
+/// `extract_top_level_class_decls` to refuse a hoist when the candidate
+/// class body references any of these — the wrap moves the class out of
+/// the IIFE so a hoisted class can't reach an IIFE-local binding, which
+/// surfaces as `Undefined variable in update expression` for `x++`/`x--`
+/// inside the class body.
+///
+/// Detection is intentionally textual (no SWC parse): the wrap layer
+/// already operates on raw source ranges, and the cost of a parse here
+/// is wasted work for the >95% of CJS files that don't trip this case.
+/// We accept the same anchor rule as the class scan: declarations at the
+/// start of a line (after only whitespace), brace-depth-aware so we
+/// ignore decls inside functions / classes / object literals.
+fn collect_top_level_let_const_var_names(source: &str) -> Vec<String> {
+    let bytes = source.as_bytes();
+    let mut names: Vec<String> = Vec::new();
+    let mut depth: i32 = 0;
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        let at_line_start = i == 0 || bytes[i - 1] == b'\n';
+        // Update brace depth for non-line-start bytes (and also at line start —
+        // a line starting with `}` decreases depth before the keyword scan).
+        match bytes[i] {
+            b'{' => {
+                depth += 1;
+                i += 1;
+                continue;
+            }
+            b'}' => {
+                depth -= 1;
+                i += 1;
+                continue;
+            }
+            b'"' | b'\'' => {
+                let q = bytes[i];
+                i += 1;
+                while i < bytes.len() && bytes[i] != q {
+                    if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                        i += 2;
+                        continue;
+                    }
+                    i += 1;
+                }
+                i += 1;
+                continue;
+            }
+            b'`' => {
+                i += 1;
+                while i < bytes.len() && bytes[i] != b'`' {
+                    if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                        i += 2;
+                        continue;
+                    }
+                    i += 1;
+                }
+                i += 1;
+                continue;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                if i + 1 < bytes.len() {
+                    i += 2;
+                }
+                continue;
+            }
+            _ => {}
+        }
+        if !at_line_start || depth != 0 {
+            i += 1;
+            continue;
+        }
+        // At column 0 of a line, depth 0: probe for let/const/var (optionally
+        // preceded by whitespace, though real CJS rarely indents top-level
+        // decls).
+        let mut p = i;
+        while p < bytes.len() && (bytes[p] == b' ' || bytes[p] == b'\t') {
+            p += 1;
+        }
+        let rest = &bytes[p..];
+        let kw_len = if rest.starts_with(b"const ") || rest.starts_with(b"const\t") {
+            6
+        } else if rest.starts_with(b"let ") || rest.starts_with(b"let\t") {
+            4
+        } else if rest.starts_with(b"var ") || rest.starts_with(b"var\t") {
+            4
+        } else {
+            i += 1;
+            continue;
+        };
+        let mut q = p + kw_len;
+        // Walk through one or more comma-separated declarators on the same
+        // logical line. Stop at `=` (initializer), `;`, or the end of line
+        // (semicolon optional in JS).
+        loop {
+            while q < bytes.len() && (bytes[q] == b' ' || bytes[q] == b'\t') {
+                q += 1;
+            }
+            let name_start = q;
+            while q < bytes.len()
+                && (bytes[q].is_ascii_alphanumeric() || bytes[q] == b'_' || bytes[q] == b'$')
+            {
+                q += 1;
+            }
+            if q > name_start {
+                let n = std::str::from_utf8(&bytes[name_start..q])
+                    .unwrap_or("")
+                    .to_string();
+                if !n.is_empty() && !names.contains(&n) {
+                    names.push(n);
+                }
+            }
+            // Skip ahead past an `=` initializer (brace/paren/bracket-aware so a
+            // `let m = { … }` doesn't trip our depth tracking) to the next
+            // comma or end of statement.
+            let mut inner: i32 = 0;
+            while q < bytes.len() {
+                match bytes[q] {
+                    b'(' | b'[' | b'{' => inner += 1,
+                    b')' | b']' | b'}' => inner -= 1,
+                    b'"' | b'\'' => {
+                        let qq = bytes[q];
+                        q += 1;
+                        while q < bytes.len() && bytes[q] != qq {
+                            if bytes[q] == b'\\' && q + 1 < bytes.len() {
+                                q += 2;
+                                continue;
+                            }
+                            q += 1;
+                        }
+                    }
+                    b'`' => {
+                        q += 1;
+                        while q < bytes.len() && bytes[q] != b'`' {
+                            if bytes[q] == b'\\' && q + 1 < bytes.len() {
+                                q += 2;
+                                continue;
+                            }
+                            q += 1;
+                        }
+                    }
+                    b',' if inner == 0 => {
+                        q += 1;
+                        break;
+                    }
+                    b';' | b'\n' if inner == 0 => {
+                        // End of declaration.
+                        i = q;
+                        break;
+                    }
+                    _ => {}
+                }
+                q += 1;
+            }
+            if q >= bytes.len() || bytes[q] == b';' || bytes[q] == b'\n' {
+                break;
+            }
+        }
+        // Advance past the line; the outer loop will keep scanning.
+        while i < bytes.len() && bytes[i] != b'\n' {
+            i += 1;
+        }
+        i += 1;
+    }
+
+    names
+}
+
+/// Issue #2310 — true if `class_body` contains any of the given names as a
+/// bare identifier (word-boundary match). Used to gate the hoist in
+/// `extract_top_level_class_decls`. We don't try to be precise about
+/// shadowing inside the class body — class-private fields and method
+/// parameters shadow only inside their scope, and the cost of a false
+/// "don't hoist" is a slower lookup (closure-captured) rather than a
+/// miscompile, so the conservative answer is acceptable here.
+fn class_body_references_any(class_body: &str, names: &[String]) -> bool {
+    if names.is_empty() {
+        return false;
+    }
+    let bytes = class_body.as_bytes();
+    for name in names {
+        let nbytes = name.as_bytes();
+        if nbytes.is_empty() {
+            continue;
+        }
+        let mut i = 0usize;
+        while i + nbytes.len() <= bytes.len() {
+            if &bytes[i..i + nbytes.len()] == nbytes {
+                let before_ok = i == 0
+                    || !(bytes[i - 1].is_ascii_alphanumeric()
+                        || bytes[i - 1] == b'_'
+                        || bytes[i - 1] == b'$'
+                        || bytes[i - 1] == b'.');
+                let after = i + nbytes.len();
+                let after_ok = after >= bytes.len()
+                    || !(bytes[after].is_ascii_alphanumeric()
+                        || bytes[after] == b'_'
+                        || bytes[after] == b'$');
+                if before_ok && after_ok {
+                    return true;
+                }
+            }
+            i += 1;
+        }
+    }
+    false
 }

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -760,4 +760,59 @@ module.exports = inner;
             wrapped
         );
     }
+
+    /// Issue #2310 — when a top-level class body references a let/const
+    /// declared at the IIFE's top level (the ws/lib/sender.js shape:
+    /// `let randomPoolPointer; class Sender { static frame(){ … r++ } }`),
+    /// hoisting the class out of the IIFE would sever the closure over
+    /// `randomPoolPointer` and the compile hard-errors with
+    /// `Undefined variable in update expression`. Verify the class stays
+    /// inside the IIFE body and is NOT in the hoisted-class block.
+    #[test]
+    fn issue_2310_class_referencing_iife_let_is_not_hoisted() {
+        let src = "'use strict';\n\
+                   const POOL_SIZE = 8;\n\
+                   let pointer = 0;\n\
+                   class Sender {\n\
+                     static next() { return pointer++; }\n\
+                   }\n\
+                   module.exports = Sender;\n";
+        let wrapped = wrap_commonjs(src, &PathBuf::from("/tmp/sender.js"));
+        // The IIFE body must still contain the class — i.e. the wrap must
+        // not lift it above the `const _cjs = (function() { ... })()` line.
+        let iife_open = wrapped
+            .find("const _cjs = (function()")
+            .expect("wrap must produce the IIFE wrapper");
+        let class_pos = wrapped
+            .find("class Sender")
+            .expect("wrap must keep `class Sender` somewhere");
+        assert!(
+            class_pos > iife_open,
+            "expected `class Sender` to stay inside the IIFE for #2310; got:\n{}",
+            wrapped
+        );
+    }
+
+    /// Issue #2310 — control case: a class that doesn't reference any
+    /// IIFE-local binding STILL gets hoisted (the v0.5.x #652 behavior).
+    /// Regression guard so the #2310 helper doesn't over-fire.
+    #[test]
+    fn issue_2310_self_contained_class_still_hoists() {
+        let src = "class Pure {\n\
+                     static greet() { return 'hi'; }\n\
+                   }\n\
+                   module.exports = Pure;\n";
+        let wrapped = wrap_commonjs(src, &PathBuf::from("/tmp/pure.js"));
+        let iife_open = wrapped
+            .find("const _cjs = (function()")
+            .expect("wrap must produce the IIFE wrapper");
+        let class_pos = wrapped
+            .find("class Pure")
+            .expect("wrap must keep `class Pure` somewhere");
+        assert!(
+            class_pos < iife_open,
+            "self-contained class must still hoist above the IIFE; got:\n{}",
+            wrapped
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Two narrow fixes for the cjs-wrapped-module pattern from `ws/lib/sender.js` that the bug report walks through:

```js
let randomPoolPointer = RANDOM_POOL_SIZE;
class Sender {
  static frame(data, options) { …  randomPoolPointer++ … }
}
```

1. **`cjs_wrap::extract_top_level_class_decls`** refuses to hoist a top-level `class X { … }` out of the wrap IIFE when the class body textually references any top-level `let`/`const`/`var` declared in the same source. Pre-fix every top-level class was unconditionally lifted above the IIFE, which severed the closure over IIFE-locals like `randomPoolPointer` — the static method then couldn't resolve those identifiers and the compile hard-errored with `Undefined variable in update expression: randomPoolPointer`.
2. **`referenced_from_fn` scan in `codegen/mod.rs`** now walks every class's `static_methods`, getters/setters, and (static) field initializer bodies — not just instance methods + the constructor. Pre-fix a `let n = 0; class C { static bump() { return n++; } }` at module level left `n` un-globalized, so the static method's `n++` wrote to a local alloca that nothing else observed; `C.bump()` came back 0 on every call.

Two new helpers (`collect_top_level_let_const_var_names`, `class_body_references_any`) stay inside the `cjs_wrap` module so the heuristic is testable in isolation.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo test --release -p perry-codegen -p perry-hir -p perry` green (no regressions; 51 `cjs_wrap` tests + my new 2 pass).
- [x] Two new unit tests: `issue_2310_class_referencing_iife_let_is_not_hoisted` (the issue's exact ws/Sender shape — class stays inside the IIFE) and `issue_2310_self_contained_class_still_hoists` (regression guard that a class with no IIFE-local refs still hoists).
- [x] Re-ran the issue's reproducer (`Sender.frame(null, { generateMask: true })`) — Perry now compiles the cjs-wrapped module without the `Undefined variable in update expression` error.
- [x] Minimal `let n = 0; class C { static bump() { return n++; } }` at module level: Perry now prints `0, 1, 2` (was `0, 0, 0`).

Closes #2310 for the cjs-wrap path; the deeper "class declared inside a function body whose methods closure-capture outer lets" shape is preserved as a follow-up — the cjs-wrap heuristic avoids it entirely for the reported repro by NOT hoisting.
