### PR TITLE
fix(node:url): align legacy format query escaping

### DIFF
--- a/crates/perry-runtime/src/url/node_compat.rs
+++ b/crates/perry-runtime/src/url/node_compat.rs
@@ -5,7 +5,43 @@
 use super::*;
 
 use super::parse::{create_url_object, is_valid_absolute_url, parse_url, resolve_url};
-use super::search_params::{url_decode, url_encode};
+use super::search_params::url_decode;
+
+const QUERYSTRING_ESCAPE_HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+fn legacy_querystring_escape(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for &b in input.as_bytes() {
+        match b {
+            b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'0'..=b'9'
+            | b'-'
+            | b'_'
+            | b'.'
+            | b'!'
+            | b'~'
+            | b'*'
+            | b'\''
+            | b'('
+            | b')' => out.push(b as char),
+            _ => {
+                out.push('%');
+                out.push(QUERYSTRING_ESCAPE_HEX[(b >> 4) as usize] as char);
+                out.push(QUERYSTRING_ESCAPE_HEX[(b & 0x0F) as usize] as char);
+            }
+        }
+    }
+    out
+}
+
+fn throw_url_format_invalid_arg() -> ! {
+    let msg = b"The \"urlObject\" argument must be of type object or string.";
+    let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    crate::node_submodules::register_error_code_pub(msg_ptr, "ERR_INVALID_ARG_TYPE");
+    let err = crate::error::js_typeerror_new(msg_ptr);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
 
 /// Convert a file:// URL to a filesystem path
 /// Strips the "file://" prefix and percent-decodes the result
@@ -182,8 +218,8 @@ fn legacy_format_from_object(obj: *mut ObjectHeader) -> String {
                 let val = crate::object::js_object_get_field_by_name_f64(qobj, val_key);
                 parts.push(format!(
                     "{}={}",
-                    url_encode(&key),
-                    url_encode(&get_string_content(val))
+                    legacy_querystring_escape(&key),
+                    legacy_querystring_escape(&get_string_content(val))
                 ));
             }
             if !parts.is_empty() {
@@ -205,7 +241,13 @@ fn legacy_format_from_object(obj: *mut ObjectHeader) -> String {
 #[no_mangle]
 pub extern "C" fn js_url_format(value: f64, options: f64) -> f64 {
     let Some(obj) = object_from_f64(value) else {
-        return create_string_f64("");
+        let js_value = crate::value::JSValue::from_bits(value.to_bits());
+        if js_value.is_any_string() {
+            let ptr =
+                crate::value::js_get_string_pointer_unified(value) as *mut crate::StringHeader;
+            return create_string_f64(&string_from_header(ptr));
+        }
+        throw_url_format_invalid_arg();
     };
     let href = object_prop_string(obj, "href");
     let mut out = if !href.is_empty() {


### PR DESCRIPTION
## Summary
- Use legacy querystring-style percent escaping for `url.format({ query })` keys and values, so spaces serialize as `%20` instead of URLSearchParams-style `+`.
- Throw a catchable `TypeError` with `ERR_INVALID_ARG_TYPE` for non-object/non-string `url.format()` inputs.
- Keep this scoped to the legacy `url.format` fixture; no broad URL parser or formatter rewrite.

## Verification
- Baseline exact `node-suite/url/legacy/format-auth-and-query`: FAIL, `test-parity/reports/parity_report_20260528_145323.json`.
- Final exact `node-suite/url/legacy/format-auth-and-query`: PASS, `test-parity/reports/parity_report_20260528_145947.json`.
- Final full granular `node-suite/url`: 38 PASS / 10 parity FAIL / 0 compile FAIL, `test-parity/reports/parity_report_20260528_150035.json`. Target is green; remaining failures are unrelated legacy parse, domain/file URL conversion, imported URL static helpers, URLSearchParams constructor/forEach, and URL mutation/base formatting gaps.
- `cargo check -p perry-runtime`: PASS with existing warnings.
- `cargo fmt --check`: PASS.
- `git diff --check`: PASS.

## References
- DeepWiki was attempted twice for this slice and both public queries returned a 500; the error is saved locally at `reference/deepwiki/node-url-format-query-primitive.md` and not staged.
- Fallback primary reference: Node docs state `url.format(urlObject)` uses `querystring.stringify(urlObject.query)` when `search` is absent and throws `TypeError` for non-object/non-string input; `querystring.stringify()` defaults to `querystring.escape()` for query percent-encoding.

## Non-goals
- No broad `url.format` rewrite.
- No array-valued query serialization changes.
- No URLSearchParams encoding changes.
- No URL parser/formatter mutation cleanup or file URL conversion changes.
