### PR TITLE
chore: triage dead_code-family warnings (#854)

### DIFF
--- a/crates/perry-codegen-arkts/src/types.rs
+++ b/crates/perry-codegen-arkts/src/types.rs
@@ -199,9 +199,15 @@ pub(crate) struct ViewBuilder {
     /// Function id (matches `Function::id` in the HIR).
     pub(crate) func_id: perry_types::FuncId,
     /// Function name (used for the synth view id when sanitized).
+    // #854: stashed on the harvest instance for a future diagnostic pass; the
+    // view id is currently derived inline at emit time, not read back here.
+    #[allow(dead_code)]
     pub(crate) func_name: String,
     /// Module-level container LocalId that this function adds children to
     /// via the terminal `widgetAddChild(LocalGet(target_id), X)` call.
+    // #854: kept for layout/diagnostics; the addChild target is resolved
+    // inline during fold, not read off this field yet.
+    #[allow(dead_code)]
     pub(crate) target_id: LocalId,
     /// Synth identifier for the target — `cv_<n>`. Stable across re-runs.
     pub(crate) target_synth: String,

--- a/crates/perry-codegen-js/src/emit/mod.rs
+++ b/crates/perry-codegen-js/src/emit/mod.rs
@@ -43,6 +43,9 @@ pub struct JsEmitter {
     /// Set of variable names already used (to avoid collisions)
     used_names: BTreeSet<String>,
     /// Module name (for cross-module references)
+    // #854: captured at construction for future cross-module reference
+    // emission; not read back on the current single-module emit path.
+    #[allow(dead_code)]
     module_name: String,
     /// Exported names from this module
     exported_names: BTreeSet<String>,

--- a/crates/perry-codegen-wasm/src/emit/func_emit_ctx.rs
+++ b/crates/perry-codegen-wasm/src/emit/func_emit_ctx.rs
@@ -24,6 +24,9 @@ pub(super) struct FuncEmitCtx<'a> {
     /// Index of a temp i64 local
     pub(super) temp_local: u32,
     /// Index of a temp i32 local (for mem_call base address)
+    // #854: reserved temp-local slot for the mem_call base-address path;
+    // assigned in `new()` but not consumed by the current emitter.
+    #[allow(dead_code)]
     pub(super) temp_local_i32: u32,
     /// Index of a second temp i64 local for emit_store_arg
     pub(super) temp_store_local: u32,

--- a/crates/perry-codegen/src/collectors/hir_facts.rs
+++ b/crates/perry-codegen/src/collectors/hir_facts.rs
@@ -15,8 +15,14 @@ pub(crate) struct NativeRegionFactGraph {
     pub bounds: BoundsFacts,
     pub alias_noalias: AliasNoAliasFacts,
     pub escape: EscapeFacts,
+    // #854: in-progress native-region fact subgraph; populated by the collector
+    // (Debug field) but not yet consumed by a codegen pass.
+    #[allow(dead_code)]
     pub purity: PurityFacts,
     pub platform_constants: PlatformConstantFacts,
+    // #854: in-progress native-region fact subgraph; populated by the collector
+    // (Debug field) but not yet consumed by a codegen pass.
+    #[allow(dead_code)]
     pub shape_stability: ShapeStabilityFacts,
     pub materialization_hazards: MaterializationHazardFacts,
 }
@@ -53,6 +59,9 @@ pub(crate) struct EscapeFacts {
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct PurityFacts {
+    // #854: in-progress purity subgraph; populated (Debug field) but no codegen
+    // consumer reads it yet.
+    #[allow(dead_code)]
     pub pure_helper_function_ids: HashSet<u32>,
 }
 
@@ -63,6 +72,9 @@ pub(crate) struct PlatformConstantFacts {
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ShapeStabilityFacts {
+    // #854: in-progress shape-stability subgraph; populated (Debug field) but no
+    // codegen consumer reads it yet.
+    #[allow(dead_code)]
     pub scalar_replaceable_object_locals: HashSet<u32>,
 }
 
@@ -201,6 +213,9 @@ pub(crate) fn collect_native_region_fact_graph(
     graph
 }
 
+// #854: thin wrapper over collect_native_region_fact_graph, currently only
+// exercised by this module's unit tests; kept as the focused-collector entry seam.
+#[allow(dead_code)]
 pub(crate) fn collect_hir_facts(
     stmts: &[Stmt],
     flat_const_ids: &HashSet<u32>,

--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -398,7 +398,6 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         1
                     };
                     let update_argc = update_argc_usize.to_string();
-                    let blk = ctx.block();
                     let update_args_buf = ctx.func.alloca_entry_array(DOUBLE, update_argc_usize);
                     {
                         let blk = ctx.block();

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -384,6 +384,9 @@ pub(crate) struct FnCtx<'a> {
     pub namespace_member_prefixes: &'a std::collections::HashMap<(String, String), String>,
     /// Names of imported functions that are async. Used to wrap
     /// cross-module calls in promise machinery.
+    // #854: cross-module async-import wrapping context; currently routed via
+    // other async-detection paths, so this borrowed field is not read yet.
+    #[allow(dead_code)]
     pub imported_async_funcs: &'a std::collections::HashSet<String>,
     /// FuncIds of locally-defined async functions in this module.
     /// Used by `is_promise_expr` to recognize that `let p = asyncFn();`

--- a/crates/perry-codegen/src/expr/range_facts.rs
+++ b/crates/perry-codegen/src/expr/range_facts.rs
@@ -415,6 +415,9 @@ pub(crate) fn while_condition_range_fact(
     }
 }
 
+// #854: width-1 convenience wrapper over bounds_for_buffer_access_width; all
+// current callers pass an explicit width, so this seam is unused for now.
+#[allow(dead_code)]
 pub(crate) fn bounds_for_buffer_access(
     ctx: &FnCtx<'_>,
     buffer_local_id: u32,

--- a/crates/perry-codegen/src/expr/typed_feedback.rs
+++ b/crates/perry-codegen/src/expr/typed_feedback.rs
@@ -9,7 +9,11 @@ pub(crate) enum TypedFeedbackKind {
     MethodCall,
     ClosureCall,
     ArrayElement,
+    // #854: in-progress typed-feedback kinds; the guard/observe emit sites that
+    // construct these are not wired into the codegen hot path yet.
+    #[allow(dead_code)]
     NumericFieldWrite,
+    #[allow(dead_code)]
     HelperReturn,
 }
 
@@ -54,6 +58,8 @@ impl TypedFeedbackContract {
         Self::new("method_direct_call_guard", "js_native_call_method")
     }
 
+    // #854: near-future typed-feedback contract seam, not yet emitted.
+    #[allow(dead_code)]
     pub(crate) const fn method_apply_call() -> Self {
         Self::new("method_call_guard", "js_native_call_method_apply")
     }
@@ -80,6 +86,8 @@ impl TypedFeedbackContract {
         Self::new("plain_array_index_set_guard", "js_array_set_f64_extend")
     }
 
+    // #854: near-future typed-feedback contract seam, not yet emitted.
+    #[allow(dead_code)]
     pub(crate) const fn bounded_array_set_index() -> Self {
         Self::new(
             "plain_array_index_set_guard",
@@ -91,6 +99,8 @@ impl TypedFeedbackContract {
         Self::new("numeric_array_index_set_guard", "js_array_set_f64_extend")
     }
 
+    // #854: near-future typed-feedback contract seam, not yet emitted.
+    #[allow(dead_code)]
     pub(crate) const fn bounded_numeric_array_set_index() -> Self {
         Self::new(
             "numeric_array_index_set_guard",
@@ -113,6 +123,8 @@ impl TypedFeedbackContract {
         )
     }
 
+    // #854: near-future typed-feedback contract seam, not yet emitted.
+    #[allow(dead_code)]
     pub(crate) const fn unboxed_numeric_field_write() -> Self {
         Self::new(
             "unboxed_numeric_field_write_guard",
@@ -120,6 +132,8 @@ impl TypedFeedbackContract {
         )
     }
 
+    // #854: near-future typed-feedback contract seam, not yet emitted.
+    #[allow(dead_code)]
     pub(crate) const fn helper_return() -> Self {
         Self::new("helper_return_shape_guard", "return_original_jsvalue")
     }
@@ -236,6 +250,9 @@ pub(crate) fn emit_typed_feedback_register_site(
     site_id.to_string()
 }
 
+// #854: near-future typed-feedback helper-return observation emitter; the call
+// sites that invoke it are not wired into the codegen hot path yet.
+#[allow(dead_code)]
 pub(crate) fn emit_typed_feedback_observe_helper_return(
     ctx: &mut FnCtx<'_>,
     operation: &str,

--- a/crates/perry-codegen/src/native_value/buffer.rs
+++ b/crates/perry-codegen/src/native_value/buffer.rs
@@ -50,6 +50,10 @@ pub(crate) enum BoundsProof {
     LoopGuard,
     MinLength,
     ExplicitGuard,
+    // #854: bounds-proof variant matched by uses_unsound_explicit_assume_guard
+    // but not yet constructed by any proof emitter; kept as part of the
+    // serialized BoundsProof contract.
+    #[allow(dead_code)]
     ExplicitAssume,
 }
 
@@ -83,7 +87,13 @@ pub(crate) enum AliasState {
     Unknown,
     MayAlias,
     NoAliasProven,
-    NoAliasGuarded { guard_id: String },
+    // #854: alias-state variant matched by allows_noalias but not yet
+    // constructed by any alias-guard emitter; kept as part of the serialized
+    // AliasState contract.
+    #[allow(dead_code)]
+    NoAliasGuarded {
+        guard_id: String,
+    },
 }
 
 impl AliasState {
@@ -207,6 +217,9 @@ pub(crate) struct BufferAccessProof {
     pub index: LoweredValue,
     pub access_mode: BufferAccessMode,
     pub bounds: BoundsState,
+    // #854: in-progress buffer-access fact bundle (Debug field); populated path
+    // not yet wired, no consumer reads it.
+    #[allow(dead_code)]
     pub facts: BufferAccessFacts,
     pub alias: AliasState,
     pub may_emit_inbounds: bool,

--- a/crates/perry-codegen/src/native_value/materialize.rs
+++ b/crates/perry-codegen/src/native_value/materialize.rs
@@ -12,10 +12,16 @@ use super::rep::{LoweredValue, NativeRep, SemanticKind};
 pub(crate) enum MaterializationReason {
     FunctionAbi,
     ReturnAbi,
+    // #854: materialization-reason variants not yet emitted by any
+    // materialization site; kept as part of the serialized reason taxonomy.
+    #[allow(dead_code)]
     GenericCall,
+    #[allow(dead_code)]
     DynamicPropertyAccess,
+    #[allow(dead_code)]
     ExceptionPath,
     RuntimeApi,
+    #[allow(dead_code)]
     DebugLogging,
     UnknownAlias,
     UnknownBounds,

--- a/crates/perry-codegen/src/native_value/rep.rs
+++ b/crates/perry-codegen/src/native_value/rep.rs
@@ -104,7 +104,11 @@ pub(crate) enum ExpectedNativeRep {
     F32,
     BufferLen,
     HandleId,
+    // #854: expected-rep variants matched by is_rep but not yet constructed by
+    // any ABI classifier; kept as part of the native-rep expectation taxonomy.
+    #[allow(dead_code)]
     NativeHandle,
+    #[allow(dead_code)]
     PromiseBoundary,
 }
 
@@ -218,6 +222,9 @@ impl LoweredValue {
         )
     }
 
+    // #854: near-future ABI rep-match predicate; not yet called by a codegen
+    // dispatch site.
+    #[allow(dead_code)]
     pub(crate) fn is_rep(&self, expected: ExpectedNativeRep) -> bool {
         matches!(
             (expected, &self.rep),

--- a/crates/perry-ext-ioredis/src/lib.rs
+++ b/crates/perry-ext-ioredis/src/lib.rs
@@ -22,6 +22,9 @@ use std::time::Duration;
 const DEFAULT_TIMEOUT_SECS: u64 = 10;
 
 pub(crate) struct RedisClient {
+    // #854: connection URL is looked up via the URLS side-map at connect time;
+    // this mirrored field is retained for the client record but not read back.
+    #[allow(dead_code)]
     url: String,
 }
 

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -15,6 +15,10 @@ use super::*;
 use crate::ir::*;
 
 impl LoweringContext {
+    // #854: single-arg constructor (delegates to `with_class_id_start`).
+    // Currently only exercised from the `#[cfg(test)]` lowering tests, so it
+    // reads as dead in a non-test build. Kept as the canonical entry point.
+    #[allow(dead_code)]
     pub fn new(source_file_path: impl Into<String>) -> Self {
         Self::with_class_id_start(source_file_path, 1)
     }

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -835,7 +835,10 @@ pub(super) fn try_global_builtins(
         }
     }
 
-    let callee_expr = lower_expr(ctx, expr)?;
+    // #854: lower the callee for its side effects (registration/tagging done
+    // inside `lower_expr`) even though the resulting value is unused on the
+    // fall-through path that hands the args back to the generic dispatcher.
+    let _callee_expr = lower_expr(ctx, expr)?;
 
     Ok(Err(args))
 }

--- a/crates/perry-hir/src/lower/expr_call/module_class_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_class_static.rs
@@ -18,7 +18,9 @@ use super::super::{
 
 pub(super) fn try_module_class_static(
     ctx: &mut LoweringContext,
-    call: &ast::CallExpr,
+    // #854: kept for the uniform `try_*` dispatch-helper signature; this arm
+    // works off `expr`, not the raw `CallExpr`.
+    _call: &ast::CallExpr,
     expr: &ast::Expr,
     args: Vec<Expr>,
 ) -> Result<Result<Expr, Vec<Expr>>> {

--- a/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
@@ -18,7 +18,9 @@ use super::super::{
 
 pub(super) fn try_static_method_and_instance(
     ctx: &mut LoweringContext,
-    call: &ast::CallExpr,
+    // #854: kept for the uniform `try_*` dispatch-helper signature; this arm
+    // works off `expr`, not the raw `CallExpr`.
+    _call: &ast::CallExpr,
     expr: &ast::Expr,
     args: Vec<Expr>,
 ) -> Result<Result<Expr, Vec<Expr>>> {

--- a/crates/perry-hir/src/lower/expr_call/wasm_exports.rs
+++ b/crates/perry-hir/src/lower/expr_call/wasm_exports.rs
@@ -16,7 +16,9 @@ use super::super::{
 
 pub(super) fn try_wasm_instance_exports(
     ctx: &mut LoweringContext,
-    call: &ast::CallExpr,
+    // #854: kept for the uniform `try_*` dispatch-helper signature; this arm
+    // works off `expr`, not the raw `CallExpr`.
+    _call: &ast::CallExpr,
     expr: &ast::Expr,
     args: Vec<Expr>,
 ) -> Result<Result<Expr, Vec<Expr>>> {

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -15,6 +15,9 @@ pub struct LoweringContext {
     /// Counter for generating unique local IDs
     pub(crate) next_local_id: LocalId,
     /// Counter for generating unique global IDs
+    // #854: initialized in `new` but not yet read by the lowerer (globals are
+    // allocated through a different path today). Kept for the ID-counter set.
+    #[allow(dead_code)]
     pub(crate) next_global_id: GlobalId,
     /// Counter for generating unique function IDs
     pub(crate) next_func_id: FuncId,
@@ -29,6 +32,9 @@ pub struct LoweringContext {
     /// Current scope's local variables: name -> (id, type)
     pub(crate) locals: Vec<(String, LocalId, Type)>,
     /// Global variables: name -> (id, type)
+    // #854: initialized in `new` but currently unread (globals tracked
+    // elsewhere). Retained alongside `next_global_id` for the global table.
+    #[allow(dead_code)]
     pub(crate) globals: Vec<(String, GlobalId, Type)>,
     /// Functions: name -> id
     pub(crate) functions: Vec<(String, FuncId)>,
@@ -154,6 +160,8 @@ pub struct LoweringContext {
     pub(crate) source_file_path: String,
     /// Variables that hold closures or other values needing cross-module export globals
     /// (arrow functions, object literals, call expressions, arrays, new expressions)
+    // #854: initialized in `new` but not yet read on this lowering path.
+    #[allow(dead_code)]
     pub(crate) exportable_object_vars: HashSet<String>,
     /// Functions created during expression lowering (e.g., object literal methods)
     /// These are flushed to the module after the enclosing statement is lowered.
@@ -321,6 +329,10 @@ pub struct LoweringContext {
     /// a stable hash and is deferred.
     pub(crate) anon_shape_classes: HashMap<String, String>,
     /// Counter for generating anon-class names (`__AnonShape_N`).
+    // #854: initialized in `new` but unread — anon-shape classes are now named
+    // by content-addressed FNV hash (see `synthesize_anon_shape_class`), not by
+    // this counter. Kept for the struct's field set.
+    #[allow(dead_code)]
     pub(crate) next_anon_shape_id: u32,
     /// Phase 4.1: method return types registry keyed by (class_name,
     /// method_name). Populated as methods are lowered so call-site inference

--- a/crates/perry-hir/src/monomorph/context.rs
+++ b/crates/perry-hir/src/monomorph/context.rs
@@ -86,6 +86,10 @@ pub(crate) struct ClassSpecRequest {
     /// Type arguments to substitute
     pub(crate) type_args: Vec<Type>,
     /// New class name for the specialized version
+    // #854: retained for the class-monomorphization spec record; not yet read
+    // by the (currently func-only) specialization driver. Mirrors the
+    // field-level allow on `FuncSpecRequest::original_name` above.
+    #[allow(dead_code)]
     pub(crate) new_name: String,
 }
 

--- a/crates/perry-hir/src/monomorph/inference_lookup.rs
+++ b/crates/perry-hir/src/monomorph/inference_lookup.rs
@@ -3,6 +3,10 @@ use super::*;
 /// Lightweight function info for inference during update phase
 #[derive(Clone)]
 pub(crate) struct FuncInfo {
+    // #854: populated by `from_module` for completeness; the inference-update
+    // consumer keys on the map entry, not this mirrored id. Kept for the
+    // self-describing record + future lookups.
+    #[allow(dead_code)]
     pub(crate) id: FuncId,
     pub(crate) type_params: Vec<perry_types::TypeParam>,
     pub(crate) params: Vec<Param>,
@@ -12,6 +16,9 @@ pub(crate) struct FuncInfo {
 /// Lightweight class info for inference during update phase
 #[derive(Clone)]
 pub(crate) struct ClassInfo {
+    // #854: populated by `from_module`; the map is keyed by class name so this
+    // mirrored copy is currently unread. Kept for the self-describing record.
+    #[allow(dead_code)]
     pub(crate) name: String,
     pub(crate) type_params: Vec<perry_types::TypeParam>,
     pub(crate) constructor_params: Option<Vec<Param>>,

--- a/crates/perry-runtime/src/array/alloc.rs
+++ b/crates/perry-runtime/src/array/alloc.rs
@@ -228,6 +228,9 @@ pub extern "C" fn js_array_alloc_literal(capacity: u32) -> *mut ArrayHeader {
 /// doesn't have a lazy-specific fast path (only `.length` does)
 /// should funnel through this so correctness is preserved under
 /// arbitrary JS code.
+// #854: lazy-array materialization accessor (issue #179 Phase 2); funnel point
+// for non-fast-path array accessors, retained for the lazy-array contract
+#[allow(dead_code)]
 #[inline]
 pub(crate) unsafe fn maybe_force_lazy(arr: *const ArrayHeader) -> *const ArrayHeader {
     if arr.is_null() {

--- a/crates/perry-runtime/src/async_hooks.rs
+++ b/crates/perry-runtime/src/async_hooks.rs
@@ -37,7 +37,11 @@ pub struct AsyncResourceIds {
 
 #[derive(Clone)]
 struct ResourceMeta {
+    // #854: async_hooks resource metadata; real createHook lifecycle is #789
+    #[allow(dead_code)]
     type_name: String,
+    // #854: async_hooks resource metadata; real createHook lifecycle is #789
+    #[allow(dead_code)]
     trigger_async_id: u64,
     resource: f64,
     destroyed: bool,
@@ -126,6 +130,8 @@ pub extern "C" fn js_async_hooks_trigger_async_id() -> f64 {
     trigger_async_id_u64() as f64
 }
 
+// #854: pointer-boxing helper retained for async_hooks resource tracking (#789)
+#[allow(dead_code)]
 #[inline]
 fn box_ptr(ptr: *const u8) -> f64 {
     f64::from_bits(POINTER_TAG | (ptr as u64 & POINTER_MASK))

--- a/crates/perry-runtime/src/buffer/view.rs
+++ b/crates/perry-runtime/src/buffer/view.rs
@@ -69,6 +69,8 @@ pub(crate) fn lookup(view_ptr: usize) -> Option<ViewInfo> {
 }
 
 #[inline]
+// #854: buffer-view backing accessor retained for the view subsystem
+#[allow(dead_code)]
 pub(crate) fn backing_of(buf_ptr: usize) -> usize {
     lookup(buf_ptr).map(|v| v.backing).unwrap_or(buf_ptr)
 }

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -813,7 +813,7 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                     if depth > inspect_depth_limit() {
                         return inspect_finish_circular(ptr as usize, "[Object]".to_string());
                     }
-                    let keys_array = (*obj_ptr).keys_array;
+                    let _keys_array = (*obj_ptr).keys_array;
 
                     // Always route through `format_object_as_json` so the
                     // `[util.inspect.custom]` hook lookup runs even for

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -118,7 +118,7 @@ pub extern "C" fn js_fs_read_file_sync_options(
 ) -> *mut StringHeader {
     validate::validate_path_or_fd("path", path_value, "read");
     unsafe {
-        let path_str_for_log = decode_path_value(path_value).unwrap_or_default();
+        let _path_str_for_log = decode_path_value(path_value).unwrap_or_default();
 
         // Debug: log path on Android
         #[cfg(target_os = "android")]

--- a/crates/perry-runtime/src/fs/stream.rs
+++ b/crates/perry-runtime/src/fs/stream.rs
@@ -187,6 +187,8 @@ pub(crate) extern "C" fn write_stream_write_impl(closure: *const ClosureHeader, 
 
 /// `ws.end()` — flush the buffer to disk, mark finished, and fire
 /// any pending finish listener.
+// #854: fs write-stream end helper retained for the stream subsystem
+#[allow(dead_code)]
 pub(crate) extern "C" fn write_stream_end0_impl(closure: *const ClosureHeader) -> f64 {
     write_stream_end_internal(closure, None)
 }

--- a/crates/perry-runtime/src/gc/barrier.rs
+++ b/crates/perry-runtime/src/gc/barrier.rs
@@ -796,6 +796,8 @@ pub(crate) fn runtime_store_external_jsvalue_slot(
     runtime_store_external_heap_word_slot(parent_user, slot_addr, value_bits);
 }
 
+// #854: GC write-barrier external-slot store-with-layout path
+#[allow(dead_code)]
 #[inline]
 pub(crate) fn runtime_store_external_jsvalue_slot_with_layout(
     parent_user: usize,

--- a/crates/perry-runtime/src/gc/oldgen.rs
+++ b/crates/perry-runtime/src/gc/oldgen.rs
@@ -487,6 +487,8 @@ pub(super) fn copied_minor_malloc_sweep_due(trigger_kind: GcTriggerKind) -> bool
 /// 9 `test_json_*.ts` × 4 mode combos, 18 memory-stability tests)
 /// since C3b landed; flipping the default makes those gains apply
 
+// #854: part of GC full mark-sweep fallback path (PERRY_GEN_GC=0)
+#[allow(dead_code)]
 pub(super) fn sweep() -> u64 {
     sweep_with_age_bump(false).freed_bytes
 }

--- a/crates/perry-runtime/src/gc/trace.rs
+++ b/crates/perry-runtime/src/gc/trace.rs
@@ -673,6 +673,8 @@ pub(super) unsafe fn trace_heap_rewrite_slots(
 /// Trace array elements.
 /// Elements may be NaN-boxed JSValues OR raw I64 pointers (codegen stores raw I64 for
 /// is_pointer/is_array/is_string typed arrays via js_array_set_jsvalue).
+// #854: part of GC fallback/verification trace path (also exercised by gc/tests)
+#[allow(dead_code)]
 pub(super) unsafe fn trace_array(
     user_ptr: *mut u8,
     valid_ptrs: &ValidPointerSet,
@@ -700,6 +702,8 @@ pub(super) unsafe fn trace_array(
 /// Trace object fields and keys array.
 /// Fields may be NaN-boxed JSValues OR raw I64 pointers (codegen stores some fields as raw I64).
 /// keys_array may be a raw pointer (*mut ArrayHeader) OR NaN-boxed (codegen may NaN-box it).
+// #854: part of GC fallback/verification trace path (also exercised by gc/tests)
+#[allow(dead_code)]
 pub(super) unsafe fn trace_object(
     user_ptr: *mut u8,
     valid_ptrs: &ValidPointerSet,
@@ -712,6 +716,8 @@ pub(super) unsafe fn trace_object(
 /// Trace closure captures
 /// Captures may be NaN-boxed JSValues OR raw I64 pointers bitcast to F64.
 /// Perry's codegen stores `is_string`/`is_array`/`is_closure` captures as raw I64 in some paths.
+// #854: part of GC fallback/verification trace path (also exercised by gc/tests)
+#[allow(dead_code)]
 pub(super) unsafe fn trace_closure(
     user_ptr: *mut u8,
     valid_ptrs: &ValidPointerSet,

--- a/crates/perry-runtime/src/gc/types.rs
+++ b/crates/perry-runtime/src/gc/types.rs
@@ -457,11 +457,15 @@ pub(crate) fn gc_type_is_movable(obj_type: u8) -> bool {
     gc_type_info(obj_type).is_some_and(|info| info.movable)
 }
 
+// #854: part of GC type-metadata verification contract (exercised by gc/tests)
+#[allow(dead_code)]
 #[inline]
 pub(crate) fn gc_type_external_byte_policy(obj_type: u8) -> GcExternalBytePolicy {
     gc_type_info(obj_type).map_or(GcExternalBytePolicy::None, |info| info.external_byte_policy)
 }
 
+// #854: part of GC type-metadata verification contract (exercised by gc/tests)
+#[allow(dead_code)]
 #[inline]
 pub(crate) fn gc_type_large_object_policy(obj_type: u8) -> GcLargeObjectPolicy {
     gc_type_info(obj_type).map_or(GcLargeObjectPolicy::NotApplicable, |info| {
@@ -469,6 +473,8 @@ pub(crate) fn gc_type_large_object_policy(obj_type: u8) -> GcLargeObjectPolicy {
     })
 }
 
+// #854: part of GC type-metadata verification contract (exercised by gc/tests)
+#[allow(dead_code)]
 #[inline]
 pub(crate) fn gc_type_is_pointer_free(obj_type: u8) -> bool {
     gc_type_info(obj_type).map_or(true, |info| info.pointer_free)
@@ -551,6 +557,8 @@ pub(super) fn gc_type_name(obj_type: u8) -> &'static str {
     gc_type_info(obj_type).map_or("unknown", |info| info.name)
 }
 
+// #854: part of GC type-metadata verification contract (exercised by gc/tests)
+#[allow(dead_code)]
 pub(crate) fn validate_gc_type_info(info: &GcTypeInfo) -> Result<(), &'static str> {
     let descriptor_is_leaf = info.rewrite_descriptor_kind == GcRewriteDescriptorKind::Leaf;
     if info.pointer_free {
@@ -605,6 +613,8 @@ pub(crate) fn validate_gc_type_info(info: &GcTypeInfo) -> Result<(), &'static st
     Ok(())
 }
 
+// #854: part of GC type-metadata verification contract (exercised by gc/tests)
+#[allow(dead_code)]
 pub(crate) fn validate_gc_type_metadata() -> Result<(), String> {
     for info in gc_type_infos() {
         validate_gc_type_info(info)

--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -517,6 +517,8 @@ pub(crate) fn nanbox_string_f64(ptr: *const StringHeader) -> f64 {
 
 /// NaN-box an object/array pointer as f64 (POINTER_TAG)
 #[inline]
+// #854: NaN-boxing pointer helper retained for the JSON subsystem (see CLAUDE.md)
+#[allow(dead_code)]
 pub(crate) fn nanbox_pointer_f64(ptr: *const u8) -> f64 {
     f64::from_bits(POINTER_TAG | (ptr as u64 & POINTER_MASK))
 }

--- a/crates/perry-runtime/src/json/parse_api.rs
+++ b/crates/perry-runtime/src/json/parse_api.rs
@@ -291,6 +291,8 @@ pub(crate) enum TapeMode {
 /// exercise every stringify / equality / compare consumer arm
 /// across both representations. Cached so the per-parse-call cost
 /// is one relaxed atomic load.
+// #854: SSO-emission gate retained for the JSON parse fast path
+#[allow(dead_code)]
 pub(crate) fn sso_emit_enabled() -> bool {
     use std::sync::OnceLock;
     static CACHED: OnceLock<bool> = OnceLock::new();

--- a/crates/perry-runtime/src/node_submodules/diagnostics.rs
+++ b/crates/perry-runtime/src/node_submodules/diagnostics.rs
@@ -613,6 +613,8 @@ pub(crate) fn catch_js<F: FnOnce() -> f64>(f: F) -> Result<f64, f64> {
     }
 }
 
+// #854: diagnostics_channel captured-error helper retained for the subsystem
+#[allow(dead_code)]
 pub(crate) extern "C" fn throw_captured_error(closure: *const ClosureHeader) -> f64 {
     let err = f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64);
     crate::exception::js_throw(err)
@@ -1528,6 +1530,8 @@ thread_local! {
     pub(crate) static DIAG_NOOP_CLOSURE: RefCell<Option<*mut ClosureHeader>> = const { RefCell::new(None) };
 }
 
+// #854: diagnostics_channel noop-closure helper retained for the subsystem
+#[allow(dead_code)]
 pub(crate) fn ensure_diag_noop_closure() -> *mut ClosureHeader {
     DIAG_NOOP_CLOSURE.with(|slot| {
         if let Some(ptr) = *slot.borrow() {

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1731,6 +1731,8 @@ unsafe fn set_object_keys_array(obj: *mut ObjectHeader, keys_array: *mut ArrayHe
 }
 
 #[inline]
+// #854: object field-slot bookkeeping helper retained for shape tracking
+#[allow(dead_code)]
 pub(super) unsafe fn note_object_field_slot(
     obj: *mut ObjectHeader,
     field_index: usize,

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1930,6 +1930,8 @@ unsafe fn http_methods_array() -> f64 {
 }
 
 /// Create (and cache) the fs.constants object with POSIX file system constants.
+// #854: fs.constants object builder retained for the native fs module
+#[allow(dead_code)]
 unsafe fn create_fs_constants_object() -> f64 {
     let cached = FS_CONSTANTS_CACHE.load(Ordering::Relaxed);
     if cached != 0 {

--- a/crates/perry-runtime/src/plugin.rs
+++ b/crates/perry-runtime/src/plugin.rs
@@ -76,6 +76,8 @@ struct ToolRegistration {
 
 struct ServiceRegistration {
     plugin_id: u64,
+    // #854: plugin manifest metadata retained for the plugin subsystem
+    #[allow(dead_code)]
     name: String,
     start_fn: u64,
     stop_fn: u64,
@@ -83,6 +85,8 @@ struct ServiceRegistration {
 
 struct RouteRegistration {
     plugin_id: u64,
+    // #854: plugin manifest metadata retained for the plugin subsystem
+    #[allow(dead_code)]
     path: String,
     handler_closure: u64,
 }

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -158,6 +158,8 @@ impl Observation {
         self.is_shape_keyed() && self.shape_addr != 0
     }
 
+    // #854: in-progress typed-feedback shape-change tracking
+    #[allow(dead_code)]
     fn affected_by_shape_change(&self, old_shape: usize, new_shape: usize, class_id: u32) -> bool {
         if !self.is_shape_keyed() {
             return false;
@@ -1677,6 +1679,8 @@ pub extern "C" fn js_typed_feedback_observe_helper_return(site_id: u64, value: f
     value
 }
 
+// #854: in-progress typed-feedback shape-change tracking
+#[allow(dead_code)]
 pub(crate) fn invalidate_shape_change(
     obj: *mut ObjectHeader,
     old_shape: *mut ArrayHeader,

--- a/crates/perry-stdlib/src/cheerio.rs
+++ b/crates/perry-stdlib/src/cheerio.rs
@@ -466,6 +466,10 @@ pub unsafe extern "C" fn js_cheerio_selection_attrs(
 // doesn't belong to either registry so the caller falls through to the
 // next dispatcher.
 // ============================================================================
+// #854: runtime fallback dispatcher for any-typed cheerio intermediates; the
+// codegen path that routes here (see module doc above) is not yet wired, so
+// this is currently unreferenced but intentionally retained.
+#[allow(dead_code)]
 pub(crate) unsafe fn dispatch_cheerio(handle: Handle, method: &str, args: &[f64]) -> Option<f64> {
     use crate::common::with_handle;
     const TAG_UNDEFINED_F64: u64 = 0x7FFC_0000_0000_0001;

--- a/crates/perry-stdlib/src/common/async_bridge.rs
+++ b/crates/perry-stdlib/src/common/async_bridge.rs
@@ -574,9 +574,9 @@ pub extern "C" fn js_stdlib_has_active_handles() -> i32 {
     // Check for active WebSocket servers/connections
     #[cfg(feature = "websocket")]
     {
-        extern "C" {
-            fn js_ws_process_pending() -> i32;
-        }
+        // #854: removed an unused `js_ws_process_pending` extern decl here —
+        // this block only checks for active handles; the drain path with its
+        // own extra decl lives earlier in the pump.
         // If there are pending WS events, keep running
         // (we don't drain here — just check)
         let has_ws = crate::ws::js_ws_has_active_handles();

--- a/crates/perry-stdlib/src/cron.rs
+++ b/crates/perry-stdlib/src/cron.rs
@@ -59,6 +59,9 @@ pub struct CronJobHandle {
 }
 
 // Global callback counter
+// #854: reserved for cron callback-id allocation; not wired into the current
+// CRON_TIMERS path (callbacks are keyed by timer_id) but kept for that use.
+#[allow(dead_code)]
 static CALLBACK_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 // ============================================================================
@@ -465,6 +468,9 @@ pub extern "C" fn js_cron_set_interval(_callback_id: f64, interval_ms: f64) -> H
 
     // Store running flag in a handle
     struct IntervalHandle {
+        // #854: the spawned task owns `running_clone`; this handle copy keeps
+        // the Arc alive for the handle's lifetime but isn't read back.
+        #[allow(dead_code)]
         running: Arc<AtomicBool>,
     }
 
@@ -498,6 +504,9 @@ pub extern "C" fn js_cron_set_timeout(_callback_id: f64, timeout_ms: f64) -> Han
     });
 
     struct TimeoutHandle {
+        // #854: the spawned task owns `cancelled_clone`; this handle copy keeps
+        // the Arc alive for the handle's lifetime but isn't read back.
+        #[allow(dead_code)]
         cancelled: Arc<AtomicBool>,
     }
 

--- a/crates/perry-stdlib/src/ioredis.rs
+++ b/crates/perry-stdlib/src/ioredis.rs
@@ -17,6 +17,9 @@ const DEFAULT_TIMEOUT_SECS: u64 = 10;
 
 /// Redis client handle - stores connection URL and cached connection
 pub(crate) struct RedisClient {
+    // #854: connection URL is read back via the `URLS` handle->url map at
+    // connect time; this field mirrors it for the handle but isn't read.
+    #[allow(dead_code)]
     url: String,
 }
 

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -731,7 +731,9 @@ pub fn build_async_step_driver_direct(
     let bool_ty = Type::Boolean;
 
     let promise_global = || Expr::GlobalGet(0);
-    let promise_resolve = |arg: Expr| Expr::Call {
+    // #854: paired resolve-builder kept alongside the used promise_reject for
+    // symmetry of the async-step driver; not emitted on the current path.
+    let _promise_resolve = |arg: Expr| Expr::Call {
         callee: Box::new(Expr::PropertyGet {
             object: Box::new(promise_global()),
             property: "resolve".to_string(),

--- a/crates/perry-transform/src/inline/exact_receivers.rs
+++ b/crates/perry-transform/src/inline/exact_receivers.rs
@@ -5,6 +5,9 @@ use std::collections::{HashMap, HashSet};
 
 use super::*;
 
+// #854: receiver-class resolver for the exact-receiver inliner; retained as a
+// pub helper of this pass, not wired into a call site on the current path.
+#[allow(dead_code)]
 pub fn resolve_receiver_class(
     obj: &Expr,
     local_types: &HashMap<LocalId, String>,

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -4289,7 +4289,10 @@ pub fn run_with_parse_cache(
     // layer (no `main` emission, `perry_module_init` entrypoint), but the
     // link step uses `ar` instead of `cc -shared`.
     let is_staticlib = args.output_type == "staticlib";
-    let is_library_output = is_dylib || is_staticlib;
+    // #854: kept as documentation of the library-output predicate; the
+    // exe_path closure below branches on is_dylib/is_staticlib directly,
+    // so this aggregate is currently unread.
+    let _is_library_output = is_dylib || is_staticlib;
     // Capture the args fields that helpers downstream of the
     // `args.output.unwrap_or_else(...)` partial-move still need.
     // Per the saved feedback note on this file: any helper extracted

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -580,6 +580,9 @@ fn read_registry_kits_root_10() -> Option<PathBuf> {
     None
 }
 
+// #854: cfg-symmetric stub — the Windows build calls this (line ~482); the
+// non-Windows build keeps the same signature so callers compile cross-platform.
+#[allow(dead_code)]
 #[cfg(not(target_os = "windows"))]
 fn read_registry_kits_root_10() -> Option<PathBuf> {
     None

--- a/crates/perry/src/commands/compile/targets.rs
+++ b/crates/perry/src/commands/compile/targets.rs
@@ -1221,6 +1221,9 @@ pub(super) fn compile_for_wearos_tile(
 }
 
 /// Compile for web target: emit JavaScript + HTML instead of native code
+// #854: web-target compile path; currently unreferenced from the dispatch
+// but kept as the JS+HTML emission entry point for `--target web`.
+#[allow(dead_code)]
 pub(super) fn compile_for_web(
     ctx: &CompilationContext,
     args: &CompileArgs,

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -19,6 +19,9 @@ pub struct CompileResult {
     pub output_path: PathBuf,
     pub target: String,
     pub bundle_id: Option<String>,
+    // #854: set by every target builder to record library-output shape; not
+    // currently read back, but part of the CompileResult contract.
+    #[allow(dead_code)]
     pub is_dylib: bool,
     /// V2.2 codegen cache stats from this build, when the cache was enabled.
     /// `None` when disabled (`--no-cache`, `PERRY_NO_CACHE=1`, or bitcode-link mode).
@@ -342,6 +345,9 @@ pub struct JsModule {
     /// Source code of the JS module
     pub source: String,
     /// Module specifier used in imports (e.g., "lodash", "./utils.js")
+    // #854: descriptive field on the JsModule record; not read on the
+    // current V8-free path but kept for the module-graph contract.
+    #[allow(dead_code)]
     pub specifier: String,
 }
 
@@ -363,6 +369,9 @@ pub struct CompilationContext {
     /// JavaScript modules to interpret via V8
     pub js_modules: BTreeMap<String, JsModule>,
     /// Mapping from import specifiers to resolved paths
+    // #854: populated import-graph metadata on the compilation context;
+    // not read on the current path but part of the context contract.
+    #[allow(dead_code)]
     pub import_map: BTreeMap<String, PathBuf>,
     /// Whether the WebAssembly host runtime is needed (codegen detected
     /// `WebAssembly.*` usage OR the user passed `--enable-wasm-runtime`).
@@ -439,6 +448,9 @@ pub struct CompilationContext {
     /// Cache for resolve_import results: (import_source, importer_dir) -> Option<(resolved_path, kind)>
     pub resolve_cache: HashMap<(String, PathBuf), Option<(PathBuf, ModuleKind)>>,
     /// Cache for find_node_modules results: start_dir -> Option<node_modules_dir>
+    // #854: resolver cache field on the compilation context; not read on the
+    // current path but kept as part of the context contract.
+    #[allow(dead_code)]
     pub node_modules_cache: HashMap<PathBuf, Option<PathBuf>>,
     /// Whether geisterhand (in-process input fuzzer) is enabled
     pub needs_geisterhand: bool,
@@ -668,6 +680,9 @@ pub struct NativeLibraryManifest {
     /// Package module name (e.g., "@honeide/editor")
     pub module: String,
     /// Resolved package directory path
+    // #854: set when parsing a native-library manifest; not read back yet
+    // but part of the NativeLibraryManifest record.
+    #[allow(dead_code)]
     pub package_dir: PathBuf,
     /// `perry.nativeLibrary.abiVersion` — semver range the wrapper
     /// declares it was built against. Validated against the bundled

--- a/crates/perry/src/commands/deps.rs
+++ b/crates/perry/src/commands/deps.rs
@@ -8,6 +8,9 @@ use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 /// Result of scanning a package for compatibility
+// #854: analysis record — `path`/`files_checked` are populated for
+// diagnostics but not consumed on the current report path.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct PackageCompatibility {
     pub name: String,
@@ -26,6 +29,9 @@ pub struct CompatibilityIssue {
     pub message: String,
 }
 
+// #854: issue-classification enum; `DynamicPropertyAccess`/`UnsupportedSyntax`
+// are handled in `severity()` but not yet constructed by any scan rule.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IssueKind {
     /// eval() or new Function() usage
@@ -56,6 +62,9 @@ impl IssueKind {
 }
 
 /// Dependency resolver that tracks all imports and their resolution status
+// #854: `resolved_packages` is populated during resolution but not read back
+// on the current path; kept as part of the resolver state.
+#[allow(dead_code)]
 pub struct DependencyResolver {
     /// Root directory of the project
     project_root: PathBuf,

--- a/crates/perry/src/commands/fixer.rs
+++ b/crates/perry/src/commands/fixer.rs
@@ -18,6 +18,8 @@ pub struct FixableIssue {
     /// Type of issue
     pub kind: FixableKind,
     /// Original source text
+    // #854: captured for diagnostics/preview; not read on the current path.
+    #[allow(dead_code)]
     pub original: String,
     /// Suggested replacement
     pub replacement: String,
@@ -33,6 +35,8 @@ pub enum FixableKind {
     /// `any` type that should be replaced
     AnyType {
         /// Inferred type if available, otherwise None (will use `unknown`)
+        // #854: carried on the AnyType fix variant; not read on the current path.
+        #[allow(dead_code)]
         inferred: Option<String>,
     },
     /// Template literal that needs conversion to concatenation
@@ -40,6 +44,8 @@ pub enum FixableKind {
 }
 
 /// Confidence level for fixes
+// #854: `Low` is part of the confidence scale but not yet emitted by any rule.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Confidence {
     /// Safe to apply automatically

--- a/crates/perry/src/commands/install/scanner/mod.rs
+++ b/crates/perry/src/commands/install/scanner/mod.rs
@@ -146,6 +146,9 @@ pub fn scan_package(pkg: &ScannedPackage) -> Vec<Finding> {
 /// Convenience wrapper around [`discover_packages`] + [`scan_packages`]
 /// for callers that don't need the package list afterwards. Phase 9
 /// (lifecycle execution) uses the split form so it can reuse the walk.
+// #854: convenience wrapper over discover_packages + scan_packages; callers
+// currently use the split form, but this is the documented one-shot entry.
+#[allow(dead_code)]
 pub fn scan_tree(
     node_modules: &Path,
     allow_risky: &[String],

--- a/crates/perry/src/commands/install/scanner/report.rs
+++ b/crates/perry/src/commands/install/scanner/report.rs
@@ -60,6 +60,9 @@ impl ScanReport {
         Ok(())
     }
 
+    // #854: severity-count accessors over the report findings; kept for
+    // callers/tests that summarize a ScanReport.
+    #[allow(dead_code)]
     pub fn p0_count(&self) -> usize {
         self.findings
             .iter()
@@ -67,6 +70,7 @@ impl ScanReport {
             .count()
     }
 
+    #[allow(dead_code)] // #854: severity-count accessor, see p0_count.
     pub fn p1_count(&self) -> usize {
         self.findings
             .iter()

--- a/crates/perry/src/commands/login.rs
+++ b/crates/perry/src/commands/login.rs
@@ -15,6 +15,9 @@ pub struct LoginArgs {
     pub server: Option<String>,
 }
 
+// #854: deserialized OAuth start response; `ok` is part of the wire shape
+// but the client only consumes `authorize_url`.
+#[allow(dead_code)]
 #[derive(Deserialize)]
 struct StartResponse {
     ok: bool,

--- a/crates/perry/src/commands/publish/config_types.rs
+++ b/crates/perry/src/commands/publish/config_types.rs
@@ -2,6 +2,8 @@ use super::*;
 
 // --- Config types matching perry.toml ---
 
+// #854: deserialized perry.toml table; not every key is read on every path.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(super) struct PerryToml {
     pub(super) project: Option<ProjectConfig>,
@@ -21,6 +23,8 @@ pub(super) struct PerryToml {
     pub(super) release_notes: Option<std::collections::HashMap<String, String>>,
 }
 
+// #854: deserialized [project] table; not every key is read.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(super) struct ProjectConfig {
     pub(super) name: Option<String>,
@@ -33,6 +37,8 @@ pub(super) struct ProjectConfig {
     pub(super) features: Option<Vec<String>>,
 }
 
+// #854: deserialized [app] table; not every key is read.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(super) struct AppConfig {
     pub(super) name: Option<String>,
@@ -49,6 +55,8 @@ pub(super) struct IconsConfig {
     pub(super) source: Option<String>,
 }
 
+// #854: deserialized [macos] table; not every key is read.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(super) struct MacosConfig {
     pub(super) bundle_id: Option<String>,
@@ -103,6 +111,8 @@ pub(super) struct IosConfig {
     pub(super) info_plist: Option<std::collections::HashMap<String, String>>,
 }
 
+// #854: deserialized [visionos] table; not every key is read.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(super) struct VisionosConfig {
     pub(super) bundle_id: Option<String>,
@@ -134,6 +144,8 @@ pub(super) struct AndroidConfig {
     pub(super) entry: Option<String>,
 }
 
+// #854: deserialized [watchos] table; not every key is read.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(super) struct WatchosConfig {
     pub(super) bundle_id: Option<String>,
@@ -144,6 +156,8 @@ pub(super) struct WatchosConfig {
     pub(super) signing_identity: Option<String>,
 }
 
+// #854: deserialized [tvos] table; not every key is read.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(super) struct TvosConfig {
     pub(super) bundle_id: Option<String>,
@@ -173,6 +187,8 @@ pub(super) struct WindowsConfig {
     pub(super) gcloud_service_account: Option<String>,
 }
 
+// #854: deserialized [build] table; out_dir not read on this path.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(super) struct BuildConfig {
     pub(super) out_dir: Option<String>,

--- a/crates/perry/src/commands/publish/server_api.rs
+++ b/crates/perry/src/commands/publish/server_api.rs
@@ -2,6 +2,9 @@ use super::*;
 
 // --- Server API types ---
 
+// #854: deserialized server response — full wire shape kept even where a
+// field isn't consumed on the client path.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(super) struct RegisterResponse {
     pub(super) license_key: String,
@@ -9,6 +12,8 @@ pub(super) struct RegisterResponse {
     pub(super) platforms: Vec<String>,
 }
 
+// #854: deserialized server response — full wire shape kept.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(super) struct BuildResponse {
     pub(super) job_id: String,
@@ -16,6 +21,9 @@ pub(super) struct BuildResponse {
     pub(super) position: usize,
 }
 
+// #854: full server-message protocol — every variant/field is part of the
+// deserialized wire contract; some payload fields aren't consumed yet.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(super) enum ServerMessage {

--- a/crates/perry/src/commands/run/remote.rs
+++ b/crates/perry/src/commands/run/remote.rs
@@ -237,6 +237,8 @@ pub async fn remote_build_and_launch(
     enum ServerMsg {
         JobCreated {
             #[serde(default)]
+            // #854: part of the deserialized JobCreated wire shape; not read.
+            #[allow(dead_code)]
             job_id: Option<String>,
         },
         QueueUpdate {

--- a/crates/perry/src/commands/setup/macos.rs
+++ b/crates/perry/src/commands/setup/macos.rs
@@ -371,6 +371,9 @@ pub fn macos_wizard(saved: &mut PerryConfig) -> Result<()> {
 
 /// Merge two .p12 files into the first one (appends the second's cert+key).
 /// Both must use the same password. Uses openssl to extract PEM and repackage.
+// #854: signing helper for the macOS distribute="both" cert-merge flow;
+// kept as the documented entry point even where currently unreferenced.
+#[allow(dead_code)]
 pub fn merge_p12_files(
     primary_p12: &std::path::Path,
     secondary_p12: &str,

--- a/crates/perry/src/commands/typecheck.rs
+++ b/crates/perry/src/commands/typecheck.rs
@@ -80,6 +80,9 @@ mod msgpack {
     }
 
     /// Encode nil
+    // #854: msgpack codec primitive; paired with the encode_*/decode helpers
+    // even though no caller emits nil yet.
+    #[allow(dead_code)]
     pub fn encode_nil(buf: &mut Vec<u8>) {
         buf.push(0xc0);
     }
@@ -477,6 +480,9 @@ impl TsGoClient {
     }
 
     /// Get type at a single position
+    // #854: tsgo client RPC method; single-position counterpart to the batch
+    // positions query, kept as part of the client API surface.
+    #[allow(dead_code)]
     pub fn get_type_at_position(&mut self, file: &str, position: u32) -> Result<Option<TypeInfo>> {
         let params = serde_json::json!({
             "file": file,


### PR DESCRIPTION
## Summary

Closes #854. Triages the ~99 `dead_code`-family warnings (fields/variants/functions/methods/constants/statics never used, plus a few unused locals) that were carved out of the warning-cleanup effort.

Per the issue's guidance, each site got case-by-case judgment with a **conservative bias**: symbols that are part of an externally-meaningful contract or an in-progress subsystem are kept with `#[allow(dead_code)]` + a `// #854:` one-line justification rather than deleted. Only genuine, self-contained cruft was removed.

## What was kept (with `#[allow(dead_code)]` + reason)

- **GC fallback / verification paths** — `sweep`, `trace_array/object/closure`, `gc_type_*`, `validate_gc_type_*`. These back the `PERRY_GEN_GC=0` full mark-sweep bisection path and are exercised by `gc/tests`.
- **NaN-boxing / value-encoding helpers** — `nanbox_pointer_f64`, `box_ptr` (documented value-encoding contract, see CLAUDE.md).
- **In-progress subsystems** — native-ABI, typed-feedback, buffer-view, pod-record taxonomy variants/helpers whose emit sites aren't wired yet.
- **Deserialized wire shapes** — `publish/server_api`, `perry.toml` config structs, OAuth responses. Not every field is read on every path; used **field-level** allows so no `derive(Deserialize/Debug/Clone)` is broken.
- **cfg-gated / FFI surface** live only on other targets (e.g. `read_registry_kits_root_10`, android-only `path_str_for_log`).

## What was deleted (self-contained, zero refs)

- A shadowed `let blk` local in `perry-codegen/src/expr/calls.rs` (immediately re-bound in the inner block).
- An unused `#[cfg(feature = "websocket")]` `js_ws_process_pending` extern decl in `async_bridge.rs` (the drain path has its own decl).

Unused locals that are pure derived values were `_`-prefixed (`_is_library_output`, `_promise_resolve`, `_call`, `_callee_expr`, `_keys_array`, `_path_str_for_log`).

## Validation

- `cargo build --release` → **0 `dead_code`-family warnings** (down from ~99), exit 0.
- `rustfmt --check` passes on all 54 changed files.
- No file-level deletions; net diff is +274 / −12 across 54 files (almost entirely attribute + comment additions).

## Notes for the maintainer

- Per the worktree-PR convention, this branch does **not** bump `Cargo.toml`/`CLAUDE.md` version or touch `CHANGELOG.md` — fold those in at merge.
- A handful of fields look like genuinely redundant duplicated state (flagged in code review, not acted on here): `RedisClient.url` (mirrors a `URLS` side-map), `LoweringContext.next_global_id`/`globals` (globals tracked elsewhere), `ClassSpecRequest.new_name` (driver re-derives the name). Left as `#[allow]` for a future cleanup rather than risk behavior changes.
