### PR TITLE
fix(node:url): reject invalid space domains

### DIFF
--- a/crates/perry-runtime/src/url/node_compat.rs
+++ b/crates/perry-runtime/src/url/node_compat.rs
@@ -58,6 +58,9 @@ pub extern "C" fn js_url_path_to_file_url(path_f64: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_url_domain_to_ascii(input_f64: f64) -> f64 {
     let input = get_string_content(input_f64);
+    if input.chars().any(|c| c.is_ascii_whitespace()) {
+        return create_string_f64("");
+    }
     let out = idna::domain_to_ascii(&input).unwrap_or_else(|_| String::new());
     create_string_f64(&out)
 }
@@ -65,6 +68,9 @@ pub extern "C" fn js_url_domain_to_ascii(input_f64: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_url_domain_to_unicode(input_f64: f64) -> f64 {
     let input = get_string_content(input_f64);
+    if input.chars().any(|c| c.is_ascii_whitespace()) {
+        return create_string_f64("");
+    }
     let (out, _) = idna::domain_to_unicode(&input);
     create_string_f64(&out)
 }


### PR DESCRIPTION
## Summary
- Return `""` from `domainToASCII()` and `domainToUnicode()` when the input domain contains ASCII whitespace.
- Keep valid IDNA/Punycode cases routed through the existing `idna` conversion path.
- Scope this to invalid space-containing domains; no broader host parser or IDNA rewrite.

## Verification
- Baseline exact `node-suite/url/module/domain-conversion-extra`: FAIL, `test-parity/reports/parity_report_20260528_150459.json`.
- Final exact `node-suite/url/module/domain-conversion-extra`: PASS, `test-parity/reports/parity_report_20260528_150732.json`.
- Final full granular `node-suite/url`: 38 PASS / 10 parity FAIL / 0 compile FAIL, `test-parity/reports/parity_report_20260528_150815.json`. Target is green; remaining failures are unrelated legacy format/parse, file URL conversion, imported URL static helpers, URLSearchParams constructor/forEach, and URL mutation/base formatting gaps.
- `cargo check -p perry-runtime`: PASS with existing warnings.
- `cargo fmt --check`: PASS.
- `git diff --check`: PASS.

## Reference
- DeepWiki: `reference/deepwiki/node-url-domain-invalid-space.md`.
- Invariant: Node returns the empty string when `domainToASCII` / `domainToUnicode` receive an invalid domain; spaces in the host are treated as failure.

## Non-goals
- No broad IDNA implementation.
- No host parser rewrite.
- No URL constructor/setter validation changes.
- No domain validation edge cases beyond ASCII whitespace.
