### PR TITLE
feat(node:http): invoke Agent.createConnection on the request path (#2154)

### DIFF
--- a/crates/perry-ext-http/src/agent.rs
+++ b/crates/perry-ext-http/src/agent.rs
@@ -20,11 +20,16 @@
 //!   new value (with the same validation as the constructor) instead
 //!   of being silently dropped.
 //! - **`createConnection` / `createSocket` setter storage** — the
-//!   user-supplied closure is now stored and GC-rooted on the agent so
-//!   later code reading `agent.createConnection` gets back the same
-//!   function. Invoking the override on the request path (Node's full
-//!   socket-injection semantics) needs net.Socket bridging that is
-//!   deferred — tracked as a follow-up off #2154.
+//!   user-supplied closure is stored and GC-rooted on the agent so later
+//!   code reading `agent.createConnection` gets back the same function.
+//! - **`createConnection` request-path invocation** — when `http.request`
+//!   services a request whose agent defines `createConnection`, the
+//!   override is invoked (on the main thread) to produce a `net.Socket`,
+//!   and the HTTP/1.1 exchange is driven over that socket via the raw-net
+//!   bridge (`perry_ffi::raw_net`, published by perry-ext-net) instead of
+//!   reqwest. See `try_create_connection_socket` here +
+//!   `dispatch_request_over_socket` in `lib.rs`. This is Node's full
+//!   socket-injection behavior (#2154).
 //!
 //! The implementation is mirrored in `crates/perry-stdlib/src/http.rs`
 //! so the default `full` build (perry-stdlib's `http-client` feature)
@@ -886,19 +891,70 @@ pub extern "C" fn js_http_agent_create_socket(handle: Handle) -> i64 {
     agent_field(handle, 0i64, |a| a.create_socket)
 }
 
-/// Invoke a stored `createConnection` override (if any). Called from
-/// the request-path follow-up. Returns the raw return-value the closure
-/// produced; `None` when no override was set.
-#[allow(dead_code)]
-pub(crate) fn invoke_create_connection(handle: Handle, options_f64: f64) -> Option<f64> {
+/// #2154 — if this agent has a `createConnection` override, build the
+/// connection-options object Node passes it (`{ host, port, path }`),
+/// invoke the override **on the calling (main) thread** — JS closure calls
+/// must never run on a tokio worker per the arena-safety rule — and return
+/// the `net.Socket` handle id it produced. Returns `None` when no override
+/// is set or the return value isn't a usable socket handle, so the caller
+/// falls back to the default reqwest transport.
+///
+/// # Safety
+///
+/// Must be called on the main thread. `handle` must be a live AgentHandle.
+pub(crate) unsafe fn try_create_connection_socket(
+    handle: Handle,
+    host: &str,
+    port: u16,
+    path: &str,
+) -> Option<i64> {
     let cc = agent_field(handle, 0i64, |a| a.create_connection);
     if cc == 0 {
         return None;
     }
-    Some(unsafe {
-        let closure = JsClosure::from_raw(cc as *const RawClosureHeader);
-        closure.call1(options_f64)
-    })
+    let options = build_connect_options(host, port, path);
+    let closure = JsClosure::from_raw(cc as *const RawClosureHeader);
+    let ret = closure.call1(options);
+
+    // `net.connect` / `net.createConnection` return the socket id NaN-boxed
+    // with POINTER_TAG; some codegen paths hand back a bare raw pointer.
+    // Extract the 48-bit handle id either way; reject anything else.
+    let bits = ret.to_bits();
+    let upper = bits >> 48;
+    let id = if upper == 0x7FFD {
+        (bits & PTR_MASK) as i64
+    } else if upper == 0 && bits >= 0x10000 {
+        bits as i64
+    } else {
+        return None;
+    };
+    (id > 0).then_some(id)
+}
+
+/// Build the `{ host, port, path }` options object handed to a
+/// `createConnection` override. Returns a NaN-boxed object pointer as `f64`,
+/// or NaN-boxed `undefined` on allocation failure.
+unsafe fn build_connect_options(host: &str, port: u16, path: &str) -> f64 {
+    let keys = ["host", "port", "path"];
+    let (packed, shape_id) = perry_ffi::build_object_shape(&keys);
+    let obj: *mut perry_ffi::ObjectHeader = perry_ffi::js_object_alloc_with_shape(
+        shape_id,
+        keys.len() as u32,
+        packed.as_ptr(),
+        packed.len() as u32,
+    );
+    if obj.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let host_s = alloc_string(host);
+    perry_ffi::js_object_set_field(obj, 0, JsValue::from_string_ptr(host_s.as_raw()));
+    // A plain f64 number is its own NaN-box; reconstruct the JsValue from its
+    // bits so the override reads `options.port` as a number.
+    perry_ffi::js_object_set_field(obj, 1, JsValue::from_bits((port as f64).to_bits()));
+    let path_s = alloc_string(path);
+    perry_ffi::js_object_set_field(obj, 2, JsValue::from_string_ptr(path_s.as_raw()));
+    let v = JsValue::from_object_ptr(obj as *mut u8);
+    f64::from_bits(v.bits())
 }
 
 // ------------------------------------------------------------------

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -255,8 +255,42 @@ async fn dispatch_plain_http_request(
         Err(e) => return Some(Err(e.to_string())),
     };
 
+    match parse_http_response(&raw) {
+        Ok(parsed) => {
+            push_event(PendingHttpEvent::Response {
+                request_handle,
+                status: parsed.status,
+                status_message: parsed.status_message,
+                headers: parsed.headers,
+                trailers: parsed.trailers,
+                body: parsed.body,
+            });
+            Some(Ok(()))
+        }
+        Err(e) => Some(Err(e)),
+    }
+}
+
+/// A parsed HTTP/1.1 response message (status line + headers + decoded body
+/// + trailers). Produced by [`parse_http_response`].
+struct ParsedHttpResponse {
+    status: u16,
+    status_message: String,
+    headers: Vec<(String, String)>,
+    trailers: Vec<(String, String)>,
+    body: Vec<u8>,
+}
+
+/// Parse a raw HTTP/1.1 response (the bytes read off a socket) into status /
+/// headers / decoded body / trailers. Decodes `Transfer-Encoding: chunked`
+/// (including a trailer block) and honors `Content-Length`; with neither it
+/// treats the remainder as the body (read-until-EOF transports). Shared by
+/// the trailer-aware reqwest-bypass path ([`dispatch_plain_http_request`])
+/// and the #2154 `agent.createConnection` socket path
+/// ([`dispatch_request_over_socket`]).
+fn parse_http_response(raw: &[u8]) -> Result<ParsedHttpResponse, String> {
     let Some(header_end) = raw.windows(4).position(|w| w == b"\r\n\r\n") else {
-        return Some(Err("invalid HTTP response".to_string()));
+        return Err("invalid HTTP response".to_string());
     };
     let head = String::from_utf8_lossy(&raw[..header_end]);
     let mut lines = head.split("\r\n");
@@ -327,15 +361,13 @@ async fn dispatch_plain_http_request(
         decoded.extend_from_slice(payload);
     }
 
-    push_event(PendingHttpEvent::Response {
-        request_handle,
+    Ok(ParsedHttpResponse {
         status,
         status_message,
         headers: hdrs,
         trailers,
         body: decoded,
-    });
-    Some(Ok(()))
+    })
 }
 
 // ------------------------------------------------------------------
@@ -639,6 +671,165 @@ fn dispatch_request(
     });
 }
 
+/// Serialize an HTTP/1.1 request (request line + headers + body) into the
+/// bytes to write onto a socket. Forces `Connection: close` (the raw socket
+/// path reads until EOF), drops any caller-supplied `Connection`/`Host`
+/// header (we set `Host` from the URL), and adds `Content-Length` when a
+/// body is present and the caller didn't.
+fn serialize_http_request(
+    method: &str,
+    path: &str,
+    host_header: &str,
+    headers: &HashMap<String, String>,
+    body: &[u8],
+) -> Vec<u8> {
+    let mut req = format!("{} {} HTTP/1.1\r\nHost: {}\r\n", method, path, host_header);
+    let mut has_content_length = false;
+    for (k, v) in headers {
+        if k.eq_ignore_ascii_case("content-length") {
+            has_content_length = true;
+        }
+        if k.eq_ignore_ascii_case("connection") || k.eq_ignore_ascii_case("host") {
+            continue;
+        }
+        req.push_str(k);
+        req.push_str(": ");
+        req.push_str(v);
+        req.push_str("\r\n");
+    }
+    req.push_str("Connection: close\r\n");
+    if !body.is_empty() && !has_content_length {
+        req.push_str(&format!("Content-Length: {}\r\n", body.len()));
+    }
+    req.push_str("\r\n");
+    let mut out = req.into_bytes();
+    out.extend_from_slice(body);
+    out
+}
+
+/// #2154 — run an HTTP exchange over a socket that the agent's
+/// `createConnection` override produced (`socket_id`), instead of through
+/// reqwest. Writes the serialized request, reads the response until the peer
+/// closes (we force `Connection: close`), parses it with
+/// [`parse_http_response`], and pushes the same `Response` / `Error` event
+/// the reqwest path produces — so the IncomingMessage surface is identical.
+///
+/// The socket I/O goes through perry-ffi's raw-net vtable (published by
+/// perry-ext-net), so this crate needs no link edge to perry-ext-net. If no
+/// net backend is linked the request errors out (the override couldn't have
+/// produced a socket without `net`, so this is a defensive guard).
+fn dispatch_request_over_socket(
+    request_handle: Handle,
+    method: String,
+    url: String,
+    headers: HashMap<String, String>,
+    body: Vec<u8>,
+    timeout_ms: Option<u64>,
+    socket_id: i64,
+) {
+    let parsed = match reqwest::Url::parse(&url) {
+        Ok(u) => u,
+        Err(e) => {
+            push_event(PendingHttpEvent::Error {
+                request_handle,
+                error_message: e.to_string(),
+            });
+            return;
+        }
+    };
+    let host = parsed.host_str().unwrap_or("localhost").to_string();
+    let host_header = match parsed.port() {
+        Some(p) => format!("{}:{}", host, p),
+        None => host,
+    };
+    let mut path = parsed.path().to_string();
+    if path.is_empty() {
+        path.push('/');
+    }
+    if let Some(q) = parsed.query() {
+        path.push('?');
+        path.push_str(q);
+    }
+    let req_bytes = serialize_http_request(&method, &path, &host_header, &headers, &body);
+    let deadline = std::time::Duration::from_millis(timeout_ms.unwrap_or(30_000));
+
+    spawn_blocking(move || {
+        let try_h = tokio::runtime::Handle::try_current();
+        std::hint::black_box(&try_h);
+        if try_h.is_err() {
+            eprintln!(
+                "[perry-ext-http] BUG: dispatch_request_over_socket Handle::try_current returned \
+                 Err — LTO has likely dead-stripped tokio's CONTEXT statics."
+            );
+            return;
+        }
+        let handle = tokio::runtime::Handle::current();
+        let jh = handle.spawn(async move {
+            let vtable = match perry_ffi::raw_net() {
+                Some(v) => v,
+                None => {
+                    push_event(PendingHttpEvent::Error {
+                        request_handle,
+                        error_message: "agent.createConnection requires node:net (not linked)"
+                            .to_string(),
+                    });
+                    return;
+                }
+            };
+            // Attach is idempotent — the request path also attaches on the
+            // main thread before this task runs, to close any data race.
+            (vtable.attach)(socket_id);
+            if (vtable.write)(socket_id, req_bytes.as_ptr(), req_bytes.len()) == 0 {
+                push_event(PendingHttpEvent::Error {
+                    request_handle,
+                    error_message: "failed to write request to agent socket".to_string(),
+                });
+                return;
+            }
+
+            let mut raw = Vec::new();
+            let mut chunk = [0u8; 16 * 1024];
+            let start = tokio::time::Instant::now();
+            loop {
+                let n = (vtable.poll_read)(socket_id, chunk.as_mut_ptr(), chunk.len());
+                if n > 0 {
+                    raw.extend_from_slice(&chunk[..n as usize]);
+                } else if n == 0 {
+                    break; // clean EOF — peer closed after the response
+                } else {
+                    if start.elapsed() >= deadline {
+                        (vtable.close)(socket_id);
+                        push_event(PendingHttpEvent::Error {
+                            request_handle,
+                            error_message: "request timed out".to_string(),
+                        });
+                        return;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                }
+            }
+            (vtable.close)(socket_id);
+
+            match parse_http_response(&raw) {
+                Ok(parsed) => push_event(PendingHttpEvent::Response {
+                    request_handle,
+                    status: parsed.status,
+                    status_message: parsed.status_message,
+                    headers: parsed.headers,
+                    trailers: parsed.trailers,
+                    body: parsed.body,
+                }),
+                Err(error_message) => push_event(PendingHttpEvent::Error {
+                    request_handle,
+                    error_message,
+                }),
+            }
+        });
+        std::hint::black_box(&jh);
+        std::mem::forget(jh);
+    });
+}
+
 // ------------------------------------------------------------------
 // FFI: http.request / https.request / http.get / https.get
 // ------------------------------------------------------------------
@@ -776,8 +967,50 @@ pub unsafe extern "C" fn js_http_client_request_end(handle: Handle, body_f64: f6
     };
 
     let (method, url, headers, body, timeout_ms, agent_handle) = snapshot;
+
+    // #2154 — if the agent supplied a `createConnection` override, invoke it
+    // here on the main thread (JS closure calls must not run on a tokio
+    // worker) and run the HTTP exchange over the socket it returns instead of
+    // through reqwest. Falls back to the reqwest path when there's no override
+    // or it didn't yield a usable socket.
+    if agent_handle != 0 {
+        if let Some((host, port, path)) = socket_connect_target(&url) {
+            if let Some(socket_id) =
+                agent::try_create_connection_socket(agent_handle, &host, port, &path)
+            {
+                // Attach raw mode now (main thread) so no inbound byte can be
+                // dispatched as a JS 'data' event before the task takes over.
+                if let Some(vt) = perry_ffi::raw_net() {
+                    (vt.attach)(socket_id);
+                }
+                dispatch_request_over_socket(
+                    handle, method, url, headers, body, timeout_ms, socket_id,
+                );
+                return handle;
+            }
+        }
+    }
+
     dispatch_request(handle, method, url, headers, body, timeout_ms, agent_handle);
     handle
+}
+
+/// Parse a request URL into the `(host, port, path)` an
+/// `agent.createConnection` override expects in its options object. Returns
+/// `None` if the URL doesn't parse or has no host.
+fn socket_connect_target(url: &str) -> Option<(String, u16, String)> {
+    let parsed = reqwest::Url::parse(url).ok()?;
+    let host = parsed.host_str()?.to_string();
+    let port = parsed.port_or_known_default().unwrap_or(80);
+    let mut path = parsed.path().to_string();
+    if path.is_empty() {
+        path.push('/');
+    }
+    if let Some(q) = parsed.query() {
+        path.push('?');
+        path.push_str(q);
+    }
+    Some((host, port, path))
 }
 
 /// `req.on(event, cb)` / `res.on(event, cb)` — register an event

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -35,11 +35,11 @@ use perry_ffi::{
     js_object_alloc_with_shape, js_object_set_field, nanbox_string_bits, BufferHeader,
     GcRootVisitor, JsClosure, JsPromise, JsValue, ObjectHeader, RawClosureHeader, StringHeader,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
@@ -192,6 +192,16 @@ static NET_GC_REGISTERED: std::sync::Once = std::sync::Once::new();
 pub(crate) fn ensure_gc_scanner_registered() {
     NET_GC_REGISTERED.call_once(|| {
         gc_register_mutable_root_scanner_named("perry-ext-net", scan_net_roots);
+        // #2154 — publish the raw-consumer vtable so perry-ext-http can drive
+        // an HTTP exchange over a socket produced by `agent.createConnection`.
+        // Runs on the first net FFI entry (any socket creation), so the
+        // vtable is in place before http could reference a socket.
+        perry_ffi::register_raw_net(perry_ffi::RawNetVtable {
+            attach: perry_net_raw_attach,
+            write: perry_net_raw_write,
+            poll_read: perry_net_raw_poll_read,
+            close: perry_net_raw_close,
+        });
     });
 }
 
@@ -224,6 +234,25 @@ pub(crate) struct SocketState {
     /// `TcpStream::connect`/`accept`. Drives `socket.address()` so the
     /// "undefined.address" cluster reports the actual bound port/family.
     pub(crate) local_addr: Option<SocketAddr>,
+    /// #2154 — raw-consumer mode. When `Some`, `run_socket_task` buffers
+    /// inbound bytes here for `perry-ext-http` to drain via the raw-net
+    /// vtable instead of dispatching them to the socket's JS `'data'`
+    /// listeners. Set by `perry_net_raw_attach` when `http.request`
+    /// drives an HTTP exchange over a socket the user's
+    /// `agent.createConnection` override produced.
+    raw: Option<Arc<Mutex<RawReadState>>>,
+}
+
+/// #2154 — backing buffer for a socket in raw-consumer mode. `run_socket_task`
+/// pushes inbound bytes into `buf`; the raw-net `poll_read` vtable entry drains
+/// them. `closed` flips on peer-FIN / destroy / error so a drained reader sees
+/// EOF; `error` carries the transport error message if one occurred.
+#[derive(Default)]
+pub(crate) struct RawReadState {
+    buf: VecDeque<u8>,
+    closed: bool,
+    #[allow(dead_code)]
+    error: Option<String>,
 }
 
 pub(crate) enum SocketCommand {
@@ -494,6 +523,28 @@ fn mark_closed(id: i64) {
     }
 }
 
+/// #2154 — return the raw-consumer buffer for `id` if the socket is in raw
+/// mode (an `http.request` over an `agent.createConnection` socket), else
+/// `None`. Cloning the `Arc` is cheap and lets `run_socket_task` route bytes
+/// without holding the sockets-map lock across the buffer mutation.
+fn raw_state_for(id: i64) -> Option<Arc<Mutex<RawReadState>>> {
+    statics::sockets()
+        .lock()
+        .ok()
+        .and_then(|g| g.get(&id).and_then(|s| s.raw.clone()))
+}
+
+/// #2154 — flip a raw-mode socket's buffer to closed (recording `error` if
+/// any) so a draining `poll_read` observes EOF. No-op for JS-mode sockets.
+fn raw_mark_closed(raw: &Arc<Mutex<RawReadState>>, error: Option<String>) {
+    if let Ok(mut st) = raw.lock() {
+        st.closed = true;
+        if error.is_some() {
+            st.error = error;
+        }
+    }
+}
+
 // ─── Spawning helper ─────────────────────────────────────────────────────────
 //
 // perry-ffi v0.5.x's only async-runtime entry point is `spawn_blocking`,
@@ -653,6 +704,7 @@ pub unsafe extern "C" fn js_net_socket_alloc() -> i64 {
             pending_rx: Some(rx),
             is_open: false,
             local_addr: None,
+            raw: None,
         },
     );
     statics::listeners()
@@ -900,6 +952,7 @@ pub unsafe extern "C" fn js_net_server_listen(handle: i64, port: f64, callback_i
                                         pending_rx: None,
                                         is_open: true,
                                         local_addr: accepted_local,
+                                        raw: None,
                                     },
                                 );
                                 statics::listeners()
@@ -1166,6 +1219,7 @@ fn spawn_socket_task(host: String, port: u16, direct_tls: Option<(String, bool)>
             pending_rx: None,
             is_open: false,
             local_addr: None,
+            raw: None,
         },
     );
     statics::listeners()
@@ -1238,21 +1292,41 @@ async fn run_socket_task(
             read_result = t.read(&mut buf) => {
                 match read_result {
                     Ok(0) => {
-                        // Issue #1852 — peer sent FIN. Fire `'end'` first
-                        // (readable side ended) then `'close'`, matching
-                        // Node's default `allowHalfOpen: false` socket
-                        // teardown order.
-                        push_event(PendingNetEvent::End(id));
-                        push_event(PendingNetEvent::Close(id));
+                        // #2154 — in raw mode `perry-ext-http` owns the byte
+                        // stream: signal EOF on the buffer and suppress the
+                        // JS `'end'`/`'close'` dispatch.
+                        if let Some(raw) = raw_state_for(id) {
+                            raw_mark_closed(&raw, None);
+                        } else {
+                            // Issue #1852 — peer sent FIN. Fire `'end'` first
+                            // (readable side ended) then `'close'`, matching
+                            // Node's default `allowHalfOpen: false` socket
+                            // teardown order.
+                            push_event(PendingNetEvent::End(id));
+                            push_event(PendingNetEvent::Close(id));
+                        }
                         mark_closed(id);
                         break;
                     }
                     Ok(n) => {
-                        push_event(PendingNetEvent::Data(id, buf[..n].to_vec()));
+                        // #2154 — raw mode buffers for `poll_read`; otherwise
+                        // dispatch a `'data'` event as usual.
+                        if let Some(raw) = raw_state_for(id) {
+                            if let Ok(mut st) = raw.lock() {
+                                st.buf.extend(buf[..n].iter().copied());
+                            }
+                        } else {
+                            push_event(PendingNetEvent::Data(id, buf[..n].to_vec()));
+                        }
                     }
                     Err(e) => {
-                        push_event(PendingNetEvent::Error(id, format!("{}", e)));
-                        push_event(PendingNetEvent::Close(id));
+                        let msg = format!("{}", e);
+                        if let Some(raw) = raw_state_for(id) {
+                            raw_mark_closed(&raw, Some(msg));
+                        } else {
+                            push_event(PendingNetEvent::Error(id, msg));
+                            push_event(PendingNetEvent::Close(id));
+                        }
                         mark_closed(id);
                         break;
                     }
@@ -1262,8 +1336,13 @@ async fn run_socket_task(
                 match cmd {
                     Some(SocketCommand::Write(bytes)) => {
                         if let Err(e) = t.write_all(&bytes).await {
-                            push_event(PendingNetEvent::Error(id, format!("{}", e)));
-                            push_event(PendingNetEvent::Close(id));
+                            let msg = format!("{}", e);
+                            if let Some(raw) = raw_state_for(id) {
+                                raw_mark_closed(&raw, Some(msg));
+                            } else {
+                                push_event(PendingNetEvent::Error(id, msg));
+                                push_event(PendingNetEvent::Close(id));
+                            }
                             mark_closed(id);
                             break;
                         }
@@ -1272,7 +1351,11 @@ async fn run_socket_task(
                         let _ = t.shutdown().await;
                     }
                     Some(SocketCommand::Destroy) | None => {
-                        push_event(PendingNetEvent::Close(id));
+                        if let Some(raw) = raw_state_for(id) {
+                            raw_mark_closed(&raw, None);
+                        } else {
+                            push_event(PendingNetEvent::Close(id));
+                        }
                         mark_closed(id);
                         break;
                     }
@@ -1381,6 +1464,101 @@ pub unsafe extern "C" fn js_net_socket_destroy(handle: i64) {
     if let Some(s) = sockets.get(&handle) {
         let _ = s.cmd_tx.send(SocketCommand::Destroy);
     }
+}
+
+// ─── #2154: raw-consumer bridge for http.Agent.createConnection ──────────────
+//
+// `perry-ext-http` drives a full HTTP/1.1 exchange over a socket the user's
+// `agent.createConnection` override produced (typically a `net.connect(...)`
+// result). These C-ABI entry points are published into perry-ffi's raw-net
+// slot (see `ensure_gc_scanner_registered`) so http can attach/write/read/
+// close the socket without a Cargo edge to this crate. They speak only raw
+// bytes — the HTTP framing lives in perry-ext-http.
+
+/// Switch socket `socket_id` into raw-consumer mode. Inbound bytes are
+/// buffered for `perry_net_raw_poll_read` instead of dispatched to JS
+/// `'data'` listeners. Returns `1` on success, `0` if the handle is unknown.
+extern "C" fn perry_net_raw_attach(socket_id: i64) -> i32 {
+    if let Ok(mut g) = statics::sockets().lock() {
+        if let Some(s) = g.get_mut(&socket_id) {
+            if s.raw.is_none() {
+                s.raw = Some(Arc::new(Mutex::new(RawReadState::default())));
+            }
+            return 1;
+        }
+    }
+    0
+}
+
+/// Enqueue `len` bytes at `ptr` to be written to socket `socket_id`. The
+/// write is buffered by the socket's command channel and flushed once the
+/// connection is established. Returns `1` if queued, `0` otherwise.
+extern "C" fn perry_net_raw_write(socket_id: i64, ptr: *const u8, len: usize) -> i32 {
+    let bytes = if len == 0 {
+        Vec::new()
+    } else if ptr.is_null() {
+        return 0;
+    } else {
+        unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec()
+    };
+    if let Ok(g) = statics::sockets().lock() {
+        if let Some(s) = g.get(&socket_id) {
+            return i32::from(s.cmd_tx.send(SocketCommand::Write(bytes)).is_ok());
+        }
+    }
+    0
+}
+
+/// Drain up to `max` buffered inbound bytes from socket `socket_id` into
+/// `out`. Returns the byte count (`> 0`), `0` for clean EOF once drained and
+/// the peer closed, or `-1` when nothing is available but the socket is still
+/// open ("would block" — the caller should yield and retry).
+extern "C" fn perry_net_raw_poll_read(socket_id: i64, out: *mut u8, max: usize) -> isize {
+    if out.is_null() || max == 0 {
+        return -1;
+    }
+    let raw = match raw_state_for(socket_id) {
+        Some(r) => r,
+        None => return -1,
+    };
+    let mut st = match raw.lock() {
+        Ok(s) => s,
+        Err(_) => return -1,
+    };
+    if st.buf.is_empty() {
+        return if st.closed { 0 } else { -1 };
+    }
+    let n = st.buf.len().min(max);
+    let out_slice = unsafe { std::slice::from_raw_parts_mut(out, n) };
+    for slot in out_slice.iter_mut() {
+        // `pop_front` can't fail: we just bounded `n` by `buf.len()`.
+        *slot = st.buf.pop_front().unwrap_or(0);
+    }
+    n as isize
+}
+
+/// Tear down socket `socket_id` (equivalent to `socket.destroy()`) and
+/// unregister it. `perry-ext-http` calls this once the HTTP exchange is
+/// done draining. Because raw mode suppresses the JS `Close` event (the
+/// path that normally removes the socket from the registry in
+/// `js_net_process_pending`), we must remove it here — otherwise the
+/// lingering entry keeps `js_net_has_pending` / `js_ext_net_has_active_handles`
+/// returning 1 and the program never exits.
+extern "C" fn perry_net_raw_close(socket_id: i64) {
+    // Signal the read/write task to stop (best-effort; dropping the
+    // SocketState below also closes the cmd channel, ending the task).
+    if let Ok(g) = statics::sockets().lock() {
+        if let Some(s) = g.get(&socket_id) {
+            let _ = s.cmd_tx.send(SocketCommand::Destroy);
+        }
+    }
+    let _ = statics::sockets().lock().map(|mut g| g.remove(&socket_id));
+    let _ = statics::listeners()
+        .lock()
+        .map(|mut g| g.remove(&socket_id));
+    let _ = statics::once_flags()
+        .lock()
+        .map(|mut g| g.remove(&socket_id));
 }
 
 // ─── FFI: chainable no-op socket/server options (issue #1852) ────────────────

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -35,7 +35,7 @@ use perry_ffi::{
     js_object_alloc_with_shape, js_object_set_field, nanbox_string_bits, BufferHeader,
     GcRootVisitor, JsClosure, JsPromise, JsValue, ObjectHeader, RawClosureHeader, StringHeader,
 };
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
@@ -61,6 +61,10 @@ mod tls;
 // the rest of the FFI surface.
 mod lifecycle;
 pub use lifecycle::*;
+// #2154 — raw-consumer bridge so perry-ext-http can drive an HTTP exchange
+// over a socket produced by `agent.createConnection` (split out for the gate).
+mod raw_bridge;
+use raw_bridge::RawReadState;
 
 use crate::tls::do_tls_handshake;
 
@@ -192,16 +196,9 @@ static NET_GC_REGISTERED: std::sync::Once = std::sync::Once::new();
 pub(crate) fn ensure_gc_scanner_registered() {
     NET_GC_REGISTERED.call_once(|| {
         gc_register_mutable_root_scanner_named("perry-ext-net", scan_net_roots);
-        // #2154 — publish the raw-consumer vtable so perry-ext-http can drive
-        // an HTTP exchange over a socket produced by `agent.createConnection`.
-        // Runs on the first net FFI entry (any socket creation), so the
-        // vtable is in place before http could reference a socket.
-        perry_ffi::register_raw_net(perry_ffi::RawNetVtable {
-            attach: perry_net_raw_attach,
-            write: perry_net_raw_write,
-            poll_read: perry_net_raw_poll_read,
-            close: perry_net_raw_close,
-        });
+        // #2154 — publish the raw-consumer vtable for perry-ext-http (runs on
+        // the first net FFI entry, before http could reference a socket).
+        raw_bridge::register();
     });
 }
 
@@ -234,25 +231,10 @@ pub(crate) struct SocketState {
     /// `TcpStream::connect`/`accept`. Drives `socket.address()` so the
     /// "undefined.address" cluster reports the actual bound port/family.
     pub(crate) local_addr: Option<SocketAddr>,
-    /// #2154 — raw-consumer mode. When `Some`, `run_socket_task` buffers
-    /// inbound bytes here for `perry-ext-http` to drain via the raw-net
-    /// vtable instead of dispatching them to the socket's JS `'data'`
-    /// listeners. Set by `perry_net_raw_attach` when `http.request`
-    /// drives an HTTP exchange over a socket the user's
-    /// `agent.createConnection` override produced.
+    /// #2154 — raw-consumer mode (see `raw_bridge`). When `Some`,
+    /// `run_socket_task` buffers inbound bytes here for `perry-ext-http` to
+    /// drain instead of firing JS `'data'` events.
     raw: Option<Arc<Mutex<RawReadState>>>,
-}
-
-/// #2154 — backing buffer for a socket in raw-consumer mode. `run_socket_task`
-/// pushes inbound bytes into `buf`; the raw-net `poll_read` vtable entry drains
-/// them. `closed` flips on peer-FIN / destroy / error so a drained reader sees
-/// EOF; `error` carries the transport error message if one occurred.
-#[derive(Default)]
-pub(crate) struct RawReadState {
-    buf: VecDeque<u8>,
-    closed: bool,
-    #[allow(dead_code)]
-    error: Option<String>,
 }
 
 pub(crate) enum SocketCommand {
@@ -520,28 +502,6 @@ fn push_event(ev: PendingNetEvent) {
 fn mark_closed(id: i64) {
     if let Some(s) = statics::sockets().lock().unwrap().get_mut(&id) {
         s.is_open = false;
-    }
-}
-
-/// #2154 — return the raw-consumer buffer for `id` if the socket is in raw
-/// mode (an `http.request` over an `agent.createConnection` socket), else
-/// `None`. Cloning the `Arc` is cheap and lets `run_socket_task` route bytes
-/// without holding the sockets-map lock across the buffer mutation.
-fn raw_state_for(id: i64) -> Option<Arc<Mutex<RawReadState>>> {
-    statics::sockets()
-        .lock()
-        .ok()
-        .and_then(|g| g.get(&id).and_then(|s| s.raw.clone()))
-}
-
-/// #2154 — flip a raw-mode socket's buffer to closed (recording `error` if
-/// any) so a draining `poll_read` observes EOF. No-op for JS-mode sockets.
-fn raw_mark_closed(raw: &Arc<Mutex<RawReadState>>, error: Option<String>) {
-    if let Ok(mut st) = raw.lock() {
-        st.closed = true;
-        if error.is_some() {
-            st.error = error;
-        }
     }
 }
 
@@ -1292,16 +1252,10 @@ async fn run_socket_task(
             read_result = t.read(&mut buf) => {
                 match read_result {
                     Ok(0) => {
-                        // #2154 — in raw mode `perry-ext-http` owns the byte
-                        // stream: signal EOF on the buffer and suppress the
-                        // JS `'end'`/`'close'` dispatch.
-                        if let Some(raw) = raw_state_for(id) {
-                            raw_mark_closed(&raw, None);
-                        } else {
-                            // Issue #1852 — peer sent FIN. Fire `'end'` first
-                            // (readable side ended) then `'close'`, matching
-                            // Node's default `allowHalfOpen: false` socket
-                            // teardown order.
+                        // #2154 raw mode: signal EOF on the buffer, suppress
+                        // JS events. Else (#1852) fire 'end' then 'close' per
+                        // Node's default `allowHalfOpen: false` teardown order.
+                        if !raw_bridge::mark_terminal(id, None) {
                             push_event(PendingNetEvent::End(id));
                             push_event(PendingNetEvent::Close(id));
                         }
@@ -1309,21 +1263,14 @@ async fn run_socket_task(
                         break;
                     }
                     Ok(n) => {
-                        // #2154 — raw mode buffers for `poll_read`; otherwise
-                        // dispatch a `'data'` event as usual.
-                        if let Some(raw) = raw_state_for(id) {
-                            if let Ok(mut st) = raw.lock() {
-                                st.buf.extend(buf[..n].iter().copied());
-                            }
-                        } else {
+                        // #2154 raw mode buffers for `poll_read`; else 'data'.
+                        if !raw_bridge::route_data(id, &buf[..n]) {
                             push_event(PendingNetEvent::Data(id, buf[..n].to_vec()));
                         }
                     }
                     Err(e) => {
                         let msg = format!("{}", e);
-                        if let Some(raw) = raw_state_for(id) {
-                            raw_mark_closed(&raw, Some(msg));
-                        } else {
+                        if !raw_bridge::mark_terminal(id, Some(msg.clone())) {
                             push_event(PendingNetEvent::Error(id, msg));
                             push_event(PendingNetEvent::Close(id));
                         }
@@ -1337,9 +1284,7 @@ async fn run_socket_task(
                     Some(SocketCommand::Write(bytes)) => {
                         if let Err(e) = t.write_all(&bytes).await {
                             let msg = format!("{}", e);
-                            if let Some(raw) = raw_state_for(id) {
-                                raw_mark_closed(&raw, Some(msg));
-                            } else {
+                            if !raw_bridge::mark_terminal(id, Some(msg.clone())) {
                                 push_event(PendingNetEvent::Error(id, msg));
                                 push_event(PendingNetEvent::Close(id));
                             }
@@ -1351,9 +1296,7 @@ async fn run_socket_task(
                         let _ = t.shutdown().await;
                     }
                     Some(SocketCommand::Destroy) | None => {
-                        if let Some(raw) = raw_state_for(id) {
-                            raw_mark_closed(&raw, None);
-                        } else {
+                        if !raw_bridge::mark_terminal(id, None) {
                             push_event(PendingNetEvent::Close(id));
                         }
                         mark_closed(id);
@@ -1464,101 +1407,6 @@ pub unsafe extern "C" fn js_net_socket_destroy(handle: i64) {
     if let Some(s) = sockets.get(&handle) {
         let _ = s.cmd_tx.send(SocketCommand::Destroy);
     }
-}
-
-// ─── #2154: raw-consumer bridge for http.Agent.createConnection ──────────────
-//
-// `perry-ext-http` drives a full HTTP/1.1 exchange over a socket the user's
-// `agent.createConnection` override produced (typically a `net.connect(...)`
-// result). These C-ABI entry points are published into perry-ffi's raw-net
-// slot (see `ensure_gc_scanner_registered`) so http can attach/write/read/
-// close the socket without a Cargo edge to this crate. They speak only raw
-// bytes — the HTTP framing lives in perry-ext-http.
-
-/// Switch socket `socket_id` into raw-consumer mode. Inbound bytes are
-/// buffered for `perry_net_raw_poll_read` instead of dispatched to JS
-/// `'data'` listeners. Returns `1` on success, `0` if the handle is unknown.
-extern "C" fn perry_net_raw_attach(socket_id: i64) -> i32 {
-    if let Ok(mut g) = statics::sockets().lock() {
-        if let Some(s) = g.get_mut(&socket_id) {
-            if s.raw.is_none() {
-                s.raw = Some(Arc::new(Mutex::new(RawReadState::default())));
-            }
-            return 1;
-        }
-    }
-    0
-}
-
-/// Enqueue `len` bytes at `ptr` to be written to socket `socket_id`. The
-/// write is buffered by the socket's command channel and flushed once the
-/// connection is established. Returns `1` if queued, `0` otherwise.
-extern "C" fn perry_net_raw_write(socket_id: i64, ptr: *const u8, len: usize) -> i32 {
-    let bytes = if len == 0 {
-        Vec::new()
-    } else if ptr.is_null() {
-        return 0;
-    } else {
-        unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec()
-    };
-    if let Ok(g) = statics::sockets().lock() {
-        if let Some(s) = g.get(&socket_id) {
-            return i32::from(s.cmd_tx.send(SocketCommand::Write(bytes)).is_ok());
-        }
-    }
-    0
-}
-
-/// Drain up to `max` buffered inbound bytes from socket `socket_id` into
-/// `out`. Returns the byte count (`> 0`), `0` for clean EOF once drained and
-/// the peer closed, or `-1` when nothing is available but the socket is still
-/// open ("would block" — the caller should yield and retry).
-extern "C" fn perry_net_raw_poll_read(socket_id: i64, out: *mut u8, max: usize) -> isize {
-    if out.is_null() || max == 0 {
-        return -1;
-    }
-    let raw = match raw_state_for(socket_id) {
-        Some(r) => r,
-        None => return -1,
-    };
-    let mut st = match raw.lock() {
-        Ok(s) => s,
-        Err(_) => return -1,
-    };
-    if st.buf.is_empty() {
-        return if st.closed { 0 } else { -1 };
-    }
-    let n = st.buf.len().min(max);
-    let out_slice = unsafe { std::slice::from_raw_parts_mut(out, n) };
-    for slot in out_slice.iter_mut() {
-        // `pop_front` can't fail: we just bounded `n` by `buf.len()`.
-        *slot = st.buf.pop_front().unwrap_or(0);
-    }
-    n as isize
-}
-
-/// Tear down socket `socket_id` (equivalent to `socket.destroy()`) and
-/// unregister it. `perry-ext-http` calls this once the HTTP exchange is
-/// done draining. Because raw mode suppresses the JS `Close` event (the
-/// path that normally removes the socket from the registry in
-/// `js_net_process_pending`), we must remove it here — otherwise the
-/// lingering entry keeps `js_net_has_pending` / `js_ext_net_has_active_handles`
-/// returning 1 and the program never exits.
-extern "C" fn perry_net_raw_close(socket_id: i64) {
-    // Signal the read/write task to stop (best-effort; dropping the
-    // SocketState below also closes the cmd channel, ending the task).
-    if let Ok(g) = statics::sockets().lock() {
-        if let Some(s) = g.get(&socket_id) {
-            let _ = s.cmd_tx.send(SocketCommand::Destroy);
-        }
-    }
-    let _ = statics::sockets().lock().map(|mut g| g.remove(&socket_id));
-    let _ = statics::listeners()
-        .lock()
-        .map(|mut g| g.remove(&socket_id));
-    let _ = statics::once_flags()
-        .lock()
-        .map(|mut g| g.remove(&socket_id));
 }
 
 // ─── FFI: chainable no-op socket/server options (issue #1852) ────────────────

--- a/crates/perry-ext-net/src/raw_bridge.rs
+++ b/crates/perry-ext-net/src/raw_bridge.rs
@@ -1,0 +1,177 @@
+//! #2154 — raw-consumer bridge for `http.Agent.createConnection`.
+//!
+//! `perry-ext-http` drives a full HTTP/1.1 exchange over a socket the user's
+//! `agent.createConnection` override produced (typically a `net.connect(...)`
+//! result). The C-ABI entry points here are published into perry-ffi's
+//! raw-net slot (see [`register`]) so http can attach/write/read/close the
+//! socket without a Cargo edge to this crate. They speak only raw bytes — the
+//! HTTP framing lives in perry-ext-http.
+//!
+//! Split out of `lib.rs` to keep that file under the 2000-line size gate.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use crate::{statics, SocketCommand};
+
+/// Backing buffer for a socket in raw-consumer mode. `run_socket_task` pushes
+/// inbound bytes into `buf`; [`perry_net_raw_poll_read`] drains them. `closed`
+/// flips on peer-FIN / destroy / error so a drained reader sees EOF; `error`
+/// carries the transport error message if one occurred.
+#[derive(Default)]
+pub(crate) struct RawReadState {
+    pub(crate) buf: VecDeque<u8>,
+    pub(crate) closed: bool,
+    #[allow(dead_code)]
+    pub(crate) error: Option<String>,
+}
+
+/// Return the raw-consumer buffer for `id` if the socket is in raw mode (an
+/// `http.request` over an `agent.createConnection` socket), else `None`.
+/// Cloning the `Arc` is cheap and lets `run_socket_task` route bytes without
+/// holding the sockets-map lock across the buffer mutation.
+pub(crate) fn raw_state_for(id: i64) -> Option<Arc<Mutex<RawReadState>>> {
+    statics::sockets()
+        .lock()
+        .ok()
+        .and_then(|g| g.get(&id).and_then(|s| s.raw.clone()))
+}
+
+/// Flip a raw-mode socket's buffer to closed (recording `error` if any) so a
+/// draining `poll_read` observes EOF. No-op for JS-mode sockets.
+fn raw_mark_closed(raw: &Arc<Mutex<RawReadState>>, error: Option<String>) {
+    if let Ok(mut st) = raw.lock() {
+        st.closed = true;
+        if error.is_some() {
+            st.error = error;
+        }
+    }
+}
+
+/// `run_socket_task` hook: route an inbound chunk for socket `id`. Returns
+/// `true` if the socket is in raw mode (bytes buffered for `poll_read`),
+/// `false` if the caller should emit a JS `'data'` event instead.
+pub(crate) fn route_data(id: i64, bytes: &[u8]) -> bool {
+    match raw_state_for(id) {
+        Some(raw) => {
+            if let Ok(mut st) = raw.lock() {
+                st.buf.extend(bytes.iter().copied());
+            }
+            true
+        }
+        None => false,
+    }
+}
+
+/// `run_socket_task` hook: mark socket `id` terminal (EOF / destroy / error).
+/// Returns `true` if the socket is in raw mode (buffer flagged closed, no JS
+/// events), `false` if the caller should emit the JS End/Close or Error/Close
+/// events. `error` is recorded on the buffer in raw mode.
+pub(crate) fn mark_terminal(id: i64, error: Option<String>) -> bool {
+    match raw_state_for(id) {
+        Some(raw) => {
+            raw_mark_closed(&raw, error);
+            true
+        }
+        None => false,
+    }
+}
+
+/// Switch socket `socket_id` into raw-consumer mode. Inbound bytes are
+/// buffered for [`perry_net_raw_poll_read`] instead of dispatched to JS
+/// `'data'` listeners. Returns `1` on success, `0` if the handle is unknown.
+extern "C" fn perry_net_raw_attach(socket_id: i64) -> i32 {
+    if let Ok(mut g) = statics::sockets().lock() {
+        if let Some(s) = g.get_mut(&socket_id) {
+            if s.raw.is_none() {
+                s.raw = Some(Arc::new(Mutex::new(RawReadState::default())));
+            }
+            return 1;
+        }
+    }
+    0
+}
+
+/// Enqueue `len` bytes at `ptr` to be written to socket `socket_id`. The write
+/// is buffered by the socket's command channel and flushed once the connection
+/// is established. Returns `1` if queued, `0` otherwise.
+extern "C" fn perry_net_raw_write(socket_id: i64, ptr: *const u8, len: usize) -> i32 {
+    let bytes = if len == 0 {
+        Vec::new()
+    } else if ptr.is_null() {
+        return 0;
+    } else {
+        unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec()
+    };
+    if let Ok(g) = statics::sockets().lock() {
+        if let Some(s) = g.get(&socket_id) {
+            return i32::from(s.cmd_tx.send(SocketCommand::Write(bytes)).is_ok());
+        }
+    }
+    0
+}
+
+/// Drain up to `max` buffered inbound bytes from socket `socket_id` into `out`.
+/// Returns the byte count (`> 0`), `0` for clean EOF once drained and the peer
+/// closed, or `-1` when nothing is available but the socket is still open
+/// ("would block" — the caller should yield and retry).
+extern "C" fn perry_net_raw_poll_read(socket_id: i64, out: *mut u8, max: usize) -> isize {
+    if out.is_null() || max == 0 {
+        return -1;
+    }
+    let raw = match raw_state_for(socket_id) {
+        Some(r) => r,
+        None => return -1,
+    };
+    let mut st = match raw.lock() {
+        Ok(s) => s,
+        Err(_) => return -1,
+    };
+    if st.buf.is_empty() {
+        return if st.closed { 0 } else { -1 };
+    }
+    let n = st.buf.len().min(max);
+    let out_slice = unsafe { std::slice::from_raw_parts_mut(out, n) };
+    for slot in out_slice.iter_mut() {
+        // `pop_front` can't fail: we just bounded `n` by `buf.len()`.
+        *slot = st.buf.pop_front().unwrap_or(0);
+    }
+    n as isize
+}
+
+/// Tear down socket `socket_id` (equivalent to `socket.destroy()`) and
+/// unregister it. `perry-ext-http` calls this once the HTTP exchange is done
+/// draining. Because raw mode suppresses the JS `Close` event (the path that
+/// normally removes the socket from the registry in `js_net_process_pending`),
+/// we must remove it here — otherwise the lingering entry keeps
+/// `js_net_has_pending` / `js_ext_net_has_active_handles` returning 1 and the
+/// program never exits.
+extern "C" fn perry_net_raw_close(socket_id: i64) {
+    // Signal the read/write task to stop (best-effort; dropping the
+    // SocketState below also closes the cmd channel, ending the task).
+    if let Ok(g) = statics::sockets().lock() {
+        if let Some(s) = g.get(&socket_id) {
+            let _ = s.cmd_tx.send(SocketCommand::Destroy);
+        }
+    }
+    let _ = statics::sockets().lock().map(|mut g| g.remove(&socket_id));
+    let _ = statics::listeners()
+        .lock()
+        .map(|mut g| g.remove(&socket_id));
+    let _ = statics::once_flags()
+        .lock()
+        .map(|mut g| g.remove(&socket_id));
+}
+
+/// Publish the raw-net vtable into perry-ffi's slot so perry-ext-http can drive
+/// an HTTP exchange over a socket produced by `agent.createConnection`. Called
+/// once from the net GC-scanner init (first net FFI entry, i.e. any socket
+/// creation), so the vtable is in place before http could reference a socket.
+pub(crate) fn register() {
+    perry_ffi::register_raw_net(perry_ffi::RawNetVtable {
+        attach: perry_net_raw_attach,
+        write: perry_net_raw_write,
+        poll_read: perry_net_raw_poll_read,
+        close: perry_net_raw_close,
+    });
+}

--- a/crates/perry-ffi/src/lib.rs
+++ b/crates/perry-ffi/src/lib.rs
@@ -88,6 +88,9 @@ pub use json::json_stringify;
 mod event_pump;
 pub use event_pump::notify_main_thread;
 
+mod raw_net;
+pub use raw_net::{raw_net, register_raw_net, RawNetVtable};
+
 // `runtime-link` gates this `extern crate` so external npm-packaged
 // wrappers (which lack perry-runtime in their Cargo graph) compile
 // without it. In-tree extension crates that need the runtime

--- a/crates/perry-ffi/src/raw_net.rs
+++ b/crates/perry-ffi/src/raw_net.rs
@@ -1,0 +1,71 @@
+//! Cross-crate "raw socket" bridge (#2154).
+//!
+//! `http.Agent` lets user code override how a connection is produced
+//! (`agent.createConnection = (opts, cb) => net.connect(...)`). When
+//! `http.request({ agent })` services a request, Node writes the raw
+//! HTTP bytes onto whatever `net.Socket` the override returned. To honor
+//! that in Perry, `perry-ext-http` has to drive byte-level read/write
+//! over a socket that `perry-ext-net` created and owns.
+//!
+//! The two crates are linked as independent well-known-flip staticlibs
+//! (`node:http` → perry-ext-http, `node:net` → perry-ext-net). They have
+//! no Cargo edge between them and can't share Rust channel types across
+//! the boundary. So perry-ext-net publishes a small C-ABI vtable into
+//! this slot at startup, and perry-ext-http looks it up at request time:
+//!
+//! - If net is linked (any program that calls `net.connect`, which an
+//!   `agent.createConnection` override does), the slot is populated and
+//!   the HTTP request flows over the user's socket.
+//! - If net is *not* linked (an http-only binary), the slot stays empty
+//!   and perry-ext-http falls back to its own transport. No unconditional
+//!   `extern` edge is created, so http-only programs still link.
+//!
+//! The vtable speaks only C-ABI primitives (socket id, byte pointers,
+//! lengths), keeping the layering clean and the linkage decoupled.
+
+use std::sync::OnceLock;
+
+/// C-ABI surface a `net` backend exposes so an `http` backend can drive
+/// raw I/O over a socket it created. All functions take the `i64` socket
+/// handle id that `net.connect` / `net.createConnection` returned.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct RawNetVtable {
+    /// Switch the socket into "raw" mode: inbound bytes are buffered for
+    /// [`RawNetVtable::poll_read`] instead of being dispatched to the
+    /// socket's JS `'data'` listeners. Returns `1` on success, `0` if the
+    /// handle is unknown. Idempotent.
+    pub attach: extern "C" fn(socket_id: i64) -> i32,
+    /// Enqueue `len` bytes at `ptr` to be written to the socket. Returns
+    /// `1` if queued, `0` on an unknown/closed handle. The write is
+    /// buffered if the socket hasn't finished connecting yet.
+    pub write: extern "C" fn(socket_id: i64, ptr: *const u8, len: usize) -> i32,
+    /// Drain up to `max` buffered inbound bytes into `out`. Returns the
+    /// number of bytes copied (`> 0`), `0` for clean EOF once the buffer
+    /// is drained and the peer closed, or `-1` when no bytes are
+    /// currently available but the socket is still open ("would block").
+    pub poll_read: extern "C" fn(socket_id: i64, out: *mut u8, max: usize) -> isize,
+    /// Tear the socket down (sends the equivalent of `socket.destroy()`).
+    pub close: extern "C" fn(socket_id: i64),
+}
+
+// SAFETY: the vtable holds only `extern "C" fn` pointers into
+// program-global code; sharing it across threads is sound.
+unsafe impl Send for RawNetVtable {}
+unsafe impl Sync for RawNetVtable {}
+
+static RAW_NET: OnceLock<RawNetVtable> = OnceLock::new();
+
+/// Publish the raw-net vtable. Called once by `perry-ext-net` from a
+/// guaranteed-early entry point (e.g. when the first socket is created).
+/// Subsequent calls are ignored — the first registration wins.
+pub fn register_raw_net(vtable: RawNetVtable) {
+    let _ = RAW_NET.set(vtable);
+}
+
+/// Fetch the registered raw-net vtable, or `None` when no `net` backend
+/// is linked into this binary. `perry-ext-http` uses this to decide
+/// whether it can honor an `agent.createConnection` override.
+pub fn raw_net() -> Option<&'static RawNetVtable> {
+    RAW_NET.get()
+}

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -528,6 +528,21 @@ pub(super) fn lower_assign(ctx: &mut LoweringContext, assign: &ast::AssignExpr) 
                                 ("HttpServer", "maxRequestsPerSocket") => {
                                     Some("__set_maxRequestsPerSocket")
                                 }
+                                // #2154 — `http.Agent` / `https.Agent` tunable
+                                // properties + the `createConnection` /
+                                // `createSocket` overrides. PR #2264 added the
+                                // FFI setters + native-table entries but never
+                                // wired the assignment path, so `agent.<prop> =
+                                // x` silently no-op'd. Route them to the
+                                // `__set_<name>` NativeMethodCall here.
+                                ("Agent", "protocol") => Some("__set_protocol"),
+                                ("Agent", "maxSockets") => Some("__set_maxSockets"),
+                                ("Agent", "maxFreeSockets") => Some("__set_maxFreeSockets"),
+                                ("Agent", "maxTotalSockets") => Some("__set_maxTotalSockets"),
+                                ("Agent", "keepAlive") => Some("__set_keepAlive"),
+                                ("Agent", "keepAliveMsecs") => Some("__set_keepAliveMsecs"),
+                                ("Agent", "createConnection") => Some("__set_createConnection"),
+                                ("Agent", "createSocket") => Some("__set_createSocket"),
                                 _ => None,
                             };
                             if let Some(method) = setter_method {

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -430,6 +430,14 @@ pub(crate) unsafe fn stringify_value(value: f64, type_hint: u32, buf: &mut Strin
     }
 
     if let Some(ptr) = extract_pointer(bits) {
+        // #2154 — see stringify_value_depth: skip native handle ids (small
+        // POINTER_TAG values) that aren't real heap objects, so JSON.stringify
+        // of an object holding e.g. an `http.Agent` emits `null` instead of
+        // segfaulting on a low-memory deref.
+        if (ptr as usize) < 0x1000 {
+            buf.push_str("null");
+            return;
+        }
         if type_hint == TYPE_OBJECT {
             stringify_object(ptr, buf);
             return;
@@ -602,6 +610,16 @@ pub(crate) unsafe fn stringify_value_depth(
     }
 
     if let Some(ptr) = extract_pointer(bits) {
+        // #2154 — a POINTER_TAG value can carry a native *handle id* (a small
+        // integer like `2`, e.g. an `http.Agent` placed in an object literal)
+        // rather than a real heap pointer. Such values aren't JSON-serializable
+        // and dereferencing them (gc_obj_type → is_object_pointer / array probe)
+        // segfaults. Emit `null`, the same way closures are dropped. Real heap
+        // objects live far above this low-memory guard (matches gc_obj_type).
+        if (ptr as usize) < 0x1000 {
+            buf.push_str("null");
+            return;
+        }
         if type_hint == TYPE_OBJECT {
             stringify_object_inner(ptr, buf, depth);
             return;
@@ -794,7 +812,12 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
             } else {
                 std::ptr::null()
             };
-            if !ptr_candidate.is_null() {
+            // #2154 — a POINTER_TAG field can be a native *handle id* (a small
+            // integer, e.g. an `http.Agent` stored in an object literal), not a
+            // real heap pointer. Reading the CLOSURE_MAGIC tag at offset 12 of
+            // such a value segfaults. Skip anything in the low-memory guard
+            // range (matches gc_obj_type); real closures live far above it.
+            if (ptr_candidate as usize) >= 0x1000 {
                 let type_tag = *(ptr_candidate.add(12) as *const u32);
                 if type_tag == crate::closure::CLOSURE_MAGIC {
                     found = true;

--- a/test-parity/node-suite/http/agent/request-create-connection.ts
+++ b/test-parity/node-suite/http/agent/request-create-connection.ts
@@ -1,0 +1,45 @@
+// Issue #2154 — `http.Agent.createConnection` override invoked on the
+// request path. PR #2264 shipped the Agent surface (validation, pool
+// accessors, per-agent reqwest client, setter storage) but explicitly
+// deferred *invoking* a user-supplied `createConnection` when servicing
+// `http.request`. This test pins the full socket-injection behavior: the
+// override is called, it produces a real `net.connect` socket, and the
+// HTTP exchange flows over that socket back to the response handler.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+import http from "node:http";
+import net from "node:net";
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { "Content-Type": "text/plain" });
+  res.end("hello from server");
+});
+
+server.listen(0, () => {
+  const addr = server.address();
+  const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+  const agent = new http.Agent();
+  let created = false;
+  agent.createConnection = (options: any) => {
+    created = true;
+    return net.connect(options.port, options.host);
+  };
+
+  const req = http.request(
+    { host: "localhost", port, path: "/", agent },
+    (res: any) => {
+      let body = "";
+      res.on("data", (chunk: any) => {
+        body += chunk.toString();
+      });
+      res.on("end", () => {
+        console.log("status:", res.statusCode);
+        console.log("body:", body);
+        console.log("createConnection called:", created);
+        server.close();
+      });
+    },
+  );
+  req.end();
+});


### PR DESCRIPTION
## What

Closes the remaining piece of #2154: invoke a user-supplied
`http.Agent.createConnection` override on the `http.request` path and
actually carry the HTTP traffic over the `net.Socket` the override
returns — Node's full socket-injection semantics.

PR #2264 shipped the Agent surface (arg validation, `sockets`/
`freeSockets`/`requests` accessors, per-agent reqwest client,
`createConnection`/`createSocket` setter storage) but explicitly deferred
*invoking* the override on the request path. This finishes it.

```ts
const agent = new http.Agent();
agent.createConnection = (opts) => net.connect(opts.port, opts.host);
http.request({ host, port, path: "/", agent }, (res) => { /* ... */ });
// the request now flows over the user's socket, not reqwest
```

## How

Node builds its HTTP client on a `net.Socket`; Perry's normally builds on
reqwest, which can't accept an externally-supplied socket. So when (and
only when) an agent defines `createConnection`, the request bypasses
reqwest and speaks raw HTTP/1.1 over the override's socket:

- **perry-ffi `raw_net`** — a small C-ABI vtable (`attach` / `write` /
  `poll_read` / `close`) published by perry-ext-net into a `OnceLock` and
  read by perry-ext-http. The two well-known-flip crates (`node:net` →
  perry-ext-net, `node:http` → perry-ext-http) have no Cargo edge; this
  keeps them decoupled and lets http-only binaries link without net.
- **perry-ext-net** — a per-socket "raw mode" (`SocketState.raw`) buffers
  inbound bytes for the http consumer instead of firing JS `'data'`
  events; `raw_close` unregisters the socket so the event loop exits
  (raw mode suppresses the `'close'` event that normally removes it).
- **perry-ext-http** — on `req.end()`, if the agent has a
  `createConnection`, the override is invoked on the main thread (JS
  closure calls must never run on a tokio worker), then the request is
  serialized, written, and the response read back over the socket and
  surfaced through the existing `PendingHttpEvent::Response` path so the
  IncomingMessage surface is identical. The HTTP/1.1 response parser is
  factored out and shared with the existing trailer-aware path.

### Two prerequisite fixes uncovered along the way

- **perry-hir** — `agent.<prop> = x` (including `createConnection`) was
  never lowered to the `__set_<prop>` `NativeMethodCall`. #2264 added the
  FFI setters + native-table entries but not the assignment wiring, so
  every Agent property assignment silently no-op'd. Added the `Agent`
  setter mappings (`createConnection`, `createSocket`, `maxSockets`,
  `keepAlive`, …).
- **perry-runtime json** — `JSON.stringify` of an object holding a native
  handle (e.g. an `http.Agent` in an options literal) segfaulted: the
  closure-tag probe and value recursion dereferenced the small handle id
  as a heap pointer. Guarded low-memory "pointers" → emit `null`. This
  also fixed a **pre-existing crash** in plain `http.request({ agent })`.

## Testing

- New node-suite parity test
  `test-parity/node-suite/http/agent/request-create-connection.ts` —
  matches `node --experimental-strip-types` byte-for-byte and exits
  cleanly.
- `JSON.stringify` regression check: normal nested objects are
  byte-identical to Node; an object containing an `http.Agent` no longer
  crashes.
- Existing `http/agent/socket-event-introspection` parity test still
  matches Node (no net regression).
- `cargo test` green for perry-ffi / perry-ext-net / perry-ext-http /
  perry-hir / perry-runtime (json). `cargo fmt --all -- --check` clean.

## Scope note

The override path is implemented in perry-ext-http, which the well-known
flip always routes `node:http` through. perry-stdlib's legacy http copy
is not used for `node:http` and is left as-is (its agent setter already
stores the closure and would fall back to reqwest, not crash, if ever
hit).
