### PR TITLE
fix(node:url): resolve relative pathToFileURL paths

### DIFF
--- a/crates/perry-runtime/src/path.rs
+++ b/crates/perry-runtime/src/path.rs
@@ -60,7 +60,7 @@ fn string_from_header_or_throw(ptr: *const StringHeader) -> String {
     unsafe { string_from_header(ptr) }.unwrap_or_else(|| throw_invalid_path_arg_type())
 }
 
-fn resolve_posix_str(path_str: &str) -> String {
+pub(crate) fn resolve_posix_str(path_str: &str) -> String {
     if path_str.is_empty() {
         return std::env::current_dir()
             .map(|cwd| cwd.to_string_lossy().to_string())

--- a/crates/perry-runtime/src/url/node_compat.rs
+++ b/crates/perry-runtime/src/url/node_compat.rs
@@ -36,6 +36,7 @@ pub extern "C" fn js_url_file_url_to_path(url_f64: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_url_path_to_file_url(path_f64: f64) -> f64 {
     let path = get_string_content(path_f64);
+    let path = crate::path::resolve_posix_str(&path);
     let mut encoded = String::new();
     for b in path.bytes() {
         match b {

--- a/test-parity/node-suite/url/module/path-to-file-url-relative.ts
+++ b/test-parity/node-suite/url/module/path-to-file-url-relative.ts
@@ -1,0 +1,5 @@
+import { pathToFileURL } from "node:url";
+
+for (const p of ["relative/path", "./relative/../target #?.txt", "relative/", ""]) {
+  console.log("pathToFileURL:", JSON.stringify(p), "=>", pathToFileURL(p).href);
+}


### PR DESCRIPTION
## Summary
- Resolve POSIX `pathToFileURL()` inputs through Perry's cwd-aware POSIX resolver before creating the file URL.
- Add focused parity coverage for relative paths, normalized relative paths, trailing slash relative paths, and empty string input.
- Keep Windows `pathToFileURL` options and `fileURLToPath` validation/decoding out of scope.

## Verification
- Baseline exact `node-suite/url/module/path-to-file-url-relative`: FAIL, `test-parity/reports/parity_report_20260528_152539.json`.
- Final exact `node-suite/url/module/path-to-file-url-relative`: PASS, `test-parity/reports/parity_report_20260528_152911.json`.
- Sibling `node-suite/url/module/file-url-windows-and-encoded`: FAIL, `test-parity/reports/parity_report_20260528_153003.json`; the `pathToFileURL("relative/path")` line now matches Node, remaining diffs are separate `fileURLToPath` decoding/validation behavior.
- Full `node-suite/url`: 38 PASS / 11 parity FAIL / 0 compile FAIL, `test-parity/reports/parity_report_20260528_153031.json`.
- `cargo check -p perry-runtime`: PASS with existing warnings.
- `cargo fmt --check`: PASS.
- `git diff --check`: PASS.

## Reference
- DeepWiki notes saved locally at `reference/deepwiki/node-url-path-to-file-url-relative.md`.

## Non-goals
- No Windows `pathToFileURL` options.
- No `fileURLToPath` validation/decoding cleanup.
- No URL encoding whitelist expansion.
- No broad URL parser changes.
