### PR TITLE
feat(compile): module-graph tree-shaking / DCE for compilePackages (#2309)

### DIFF
--- a/crates/perry-hir/src/deferral.rs
+++ b/crates/perry-hir/src/deferral.rs
@@ -1,0 +1,82 @@
+//! Deferred refusals for tree-shaking (#2309).
+//!
+//! Perry compiles every import-reachable module and refuses (hard-errors)
+//! during lowering when a module contains a genuinely-runtime `new Function`
+//! (the [`crate::eval_classifier`] `RuntimeUnknown` bucket) or an
+//! unimplemented Node/Web API (#463). When tree-shaking is enabled, a module
+//! that is reachable only via a dead barrel edge or a dead `process.env`
+//! branch will be *pruned* before codegen — so refusing on it during
+//! collection is premature: the offending code never ships.
+//!
+//! This module provides a thread-local **deferral sink**. The compile driver
+//! arms it around the lowering of a `node_modules` module (and only when the
+//! tree-shake flag is on); while armed, refusal sites record a
+//! [`DeferredRefusal`] and fall through to their legacy lowering instead of
+//! erroring. After the full module graph is collected and reachability is
+//! computed, the driver re-raises any deferred refusal whose module survived
+//! the prune (see `compile::reachability`). A refusal in a *surviving* module
+//! is still a hard error — we never silently ship broken code.
+//!
+//! User/host source is never armed, so refusals the user wrote stay fatal and
+//! span-precise exactly as before. With the flag off the sink is never armed,
+//! so behaviour is byte-identical to today.
+
+use std::cell::RefCell;
+
+/// A refusal recorded during lowering of a `node_modules` module while the
+/// deferral sink was armed. The module path is filled in by the compile
+/// driver after lowering (it knows the canonical path of the module it just
+/// lowered); lowering only knows the message + line.
+#[derive(Debug, Clone)]
+pub struct DeferredRefusal {
+    /// Canonical path of the module the refusal came from. Empty when first
+    /// recorded by lowering; the driver tags it after the lower returns.
+    pub module: String,
+    /// 1-based source line of the offending site, if resolvable.
+    pub line: Option<usize>,
+    /// The original refusal message (re-raised verbatim if the module
+    /// survives pruning).
+    pub message: String,
+}
+
+thread_local! {
+    /// `Some(vec)` when armed. Lowering pushes refusals here instead of
+    /// erroring. `None` (default) means refusals are fatal as usual.
+    static DEFERRAL_SINK: RefCell<Option<Vec<DeferredRefusal>>> = const { RefCell::new(None) };
+}
+
+/// Arm the deferral sink on the current thread. Call before lowering a
+/// `node_modules` module when tree-shaking is enabled; pair with
+/// [`disarm_deferral_sink`]. Re-arming clears any prior contents.
+pub fn arm_deferral_sink() {
+    DEFERRAL_SINK.with(|s| *s.borrow_mut() = Some(Vec::new()));
+}
+
+/// Disarm the sink and return everything recorded while it was armed. Returns
+/// an empty vec if it was not armed.
+pub fn disarm_deferral_sink() -> Vec<DeferredRefusal> {
+    DEFERRAL_SINK.with(|s| s.borrow_mut().take().unwrap_or_default())
+}
+
+/// Try to defer a refusal. Returns `true` if the sink was armed (the refusal
+/// was recorded and the caller should fall through to its legacy lowering),
+/// `false` otherwise (the caller should raise its normal hard error).
+///
+/// `byte_offset` is `span.lo.0`, used to resolve a source line via the
+/// active `CURRENT_MODULE_SOURCE` thread-local.
+pub fn try_defer_refusal(message: String, byte_offset: u32) -> bool {
+    DEFERRAL_SINK.with(|s| {
+        let mut sink = s.borrow_mut();
+        if let Some(v) = sink.as_mut() {
+            let line = crate::ir::current_module_line_at(byte_offset);
+            v.push(DeferredRefusal {
+                module: String::new(),
+                line,
+                message,
+            });
+            true
+        } else {
+            false
+        }
+    })
+}

--- a/crates/perry-hir/src/eval_classifier.rs
+++ b/crates/perry-hir/src/eval_classifier.rs
@@ -303,6 +303,14 @@ pub fn check_site(
     let classification = classify(surface, body_arg, source_file_path, span.lo.0);
     report(&classification);
     if classification.is_refused() && !eval_override_enabled() {
+        // #2309: when the tree-shake deferral sink is armed (a node_modules
+        // module being lowered under tree-shaking), record the refusal and
+        // fall through instead of erroring — the module may be pruned as
+        // unreachable, in which case this refusal never matters. The driver
+        // re-raises any deferred refusal that survives the prune.
+        if crate::deferral::try_defer_refusal(classification.refusal_message(), span.lo.0) {
+            return Ok(());
+        }
         return Err(anyhow::Error::new(crate::error::LowerError::new(
             classification.refusal_message(),
             span,

--- a/crates/perry-hir/src/lib.rs
+++ b/crates/perry-hir/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod analysis;
 pub mod audit;
 pub mod capability;
+pub mod deferral;
 pub(crate) mod destructuring;
 pub mod dynamic_import;
 pub mod egress;
@@ -27,6 +28,7 @@ pub mod walker;
 pub use analysis::{collect_local_refs_expr, collect_local_refs_stmt};
 pub use audit::{audit_module, AuditManifest, ModuleAudit};
 pub use capability::{audit_module_capabilities, CapabilityPolicy, CapabilityViolation};
+pub use deferral::{arm_deferral_sink, disarm_deferral_sink, try_defer_refusal, DeferredRefusal};
 pub use dynamic_import::{
     collect_module_const_locals, detect_top_level_await, flatten_exports,
     for_each_dynamic_import_mut, resolve_import_path, resolve_import_path_with_consts, FlatExport,

--- a/crates/perry-hir/src/lower/expr_call/module_class_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_class_static.rs
@@ -90,14 +90,16 @@ pub(super) fn try_module_class_static(
                             )
                             .map(|h| format!(" {h}"))
                             .unwrap_or_default();
-                            crate::lower_bail!(
-                                outer_member.span,
+                            let msg = format!(
                                 "`{}.{}` is not implemented in Perry — see `perry --print-api-manifest` for the supported surface, \
                                  or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463){}",
-                                module_name,
-                                class_name,
-                                hint,
+                                module_name, class_name, hint,
                             );
+                            // #2309: defer under tree-shaking; re-raised only
+                            // if the module survives pruning.
+                            if !crate::try_defer_refusal(msg.clone(), outer_member.span.lo.0) {
+                                crate::lower_bail!(outer_member.span, "{}", msg);
+                            }
                         }
                         if !is_sub_namespace {
                             if let ast::MemberProp::Ident(method_ident) = &outer_member.prop {

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -1173,14 +1173,16 @@ pub(super) fn try_native_module_methods(
                             )
                             .map(|h| format!(" {h}"))
                             .unwrap_or_default();
-                            crate::lower_bail!(
-                                member.span,
+                            let msg = format!(
                                 "`{}.{}` is not implemented in Perry — see `perry --print-api-manifest` for the supported surface, \
                                  or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463){}",
-                                module_name,
-                                method_name,
-                                hint,
+                                module_name, method_name, hint,
                             );
+                            // #2309: defer under tree-shaking; re-raised only
+                            // if the module survives pruning.
+                            if !crate::try_defer_refusal(msg.clone(), member.span.lo.0) {
+                                crate::lower_bail!(member.span, "{}", msg);
+                            }
                         }
                         return Ok(Ok(Expr::NativeMethodCall {
                             module: module_name.to_string(),

--- a/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
+++ b/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
@@ -265,12 +265,18 @@ pub(super) fn try_web_crypto_subtle(
                                         let allow_unimplemented =
                                             std::env::var_os("PERRY_ALLOW_UNIMPLEMENTED").is_some();
                                         if !allow_unimplemented {
-                                            crate::lower_bail!(
-                                                outer_member.span,
+                                            let msg = format!(
                                                 "`crypto.subtle.{}` is not implemented in Perry — supported subtle methods are digest, importKey, sign, verify, encrypt, decrypt, generateKey, wrapKey, unwrapKey (HMAC + SHA-1/256/384/512; encrypt/decrypt/generateKey/wrapKey currently AES-GCM/AES-KW only). \
                                                  See `perry --print-api-manifest` and #561, or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore.",
                                                 method,
                                             );
+                                            // #2309: defer under tree-shaking.
+                                            if !crate::try_defer_refusal(
+                                                msg.clone(),
+                                                outer_member.span.lo.0,
+                                            ) {
+                                                crate::lower_bail!(outer_member.span, "{}", msg);
+                                            }
                                         }
                                     }
                                 }
@@ -317,12 +323,15 @@ pub(super) fn try_util_types_namespace(
                                 && perry_api_manifest::module_has_symbol("util/types", method_name)
                                     .is_none()
                             {
-                                crate::lower_bail!(
-                                    outer_member.span,
+                                let msg = format!(
                                     "`util.types.{}` is not implemented in Perry — see `perry --print-api-manifest` for the supported surface, \
                                      or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463)",
                                     method_name,
                                 );
+                                // #2309: defer under tree-shaking.
+                                if !crate::try_defer_refusal(msg.clone(), outer_member.span.lo.0) {
+                                    crate::lower_bail!(outer_member.span, "{}", msg);
+                                }
                             }
                             return Ok(Ok(Expr::NativeMethodCall {
                                 module: "util/types".to_string(),

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1301,14 +1301,16 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
             let hint = super::unimpl_hints::module_member_hint(module, prop)
                 .map(|h| format!(" {h}"))
                 .unwrap_or_default();
-            crate::lower_bail!(
-                member.span,
+            let msg = format!(
                 "`{}.{}` is not implemented in Perry — see `perry --print-api-manifest` for the supported surface, \
                  or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463){}",
-                module,
-                prop,
-                hint,
+                module, prop, hint,
             );
+            // #2309: defer when tree-shaking (sink armed for this node_modules
+            // module); re-raised only if the module survives pruning.
+            if !crate::try_defer_refusal(msg.clone(), member.span.lo.0) {
+                crate::lower_bail!(member.span, "{}", msg);
+            }
         }
     }
 

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -588,6 +588,16 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                                 return Ok(Expr::EnvGet(var_name));
                             }
                             ast::MemberProp::Computed(computed) => {
+                                // process.env["NAME"] with a string-literal key
+                                // is a *static* access — lower to EnvGet so it
+                                // matches the dot form (and #2309 build-time
+                                // folding sees it). Non-literal keys stay
+                                // dynamic.
+                                if let ast::Expr::Lit(ast::Lit::Str(s)) = computed.expr.as_ref() {
+                                    if let Some(name) = s.value.as_str() {
+                                        return Ok(Expr::EnvGet(name.to_string()));
+                                    }
+                                }
                                 // process.env[expr] (dynamic key)
                                 let key_expr = Box::new(lower_expr(ctx, &computed.expr)?);
                                 return Ok(Expr::EnvGetDynamic(key_expr));

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -24,6 +24,7 @@ mod bundle_ios;
 mod cjs_wrap;
 mod codegen_steps;
 mod collect_modules;
+mod env_fold;
 mod harmonyos_shim;
 mod host_config;
 mod i18n_emit;

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -36,6 +36,7 @@ mod optimized_libs;
 mod parse_cache;
 mod post_link;
 mod precompile_capture;
+mod reachability;
 mod resolve;
 mod resources;
 mod sandbox_buildrs;
@@ -290,6 +291,18 @@ pub fn run_with_parse_cache(
     )?;
 
     run_post_collect_preflight(&args, &mut ctx, format)?;
+
+    // #2309: tree-shake the final module graph — prune unreachable
+    // node_modules modules and re-raise any deferred refusal that survives.
+    // No-op unless tree-shaking is enabled (byte-identical to pre-#2309).
+    {
+        let entry_canonical = ctx.entry_canonical.clone().unwrap_or_else(|| {
+            args.input
+                .canonicalize()
+                .unwrap_or_else(|_| args.input.clone())
+        });
+        reachability::tree_shake(&mut ctx, &entry_canonical)?;
+    }
 
     // --- Web/WASM target: emit WASM binary + JS runtime bridge ---
     if matches!(args.target.as_deref(), Some("web") | Some("wasm")) {

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -519,6 +519,14 @@ pub(super) fn collect_modules(
     let (mut hir_module, new_next_class_id) = lower_result?;
     *next_class_id = new_next_class_id; // Update the global class_id counter
 
+    // #2309 Stage 2: fold build-time `process.env` branches BEFORE dynamic
+    // `import()` edges are registered below, so a dead `import()` inside a
+    // statically-false branch never enters the module graph. No-op unless
+    // tree-shaking is enabled.
+    if ctx.tree_shake {
+        super::env_fold::fold_env_branches(&mut hir_module, &ctx.define, is_in_node_modules);
+    }
+
     // Issue #100: const-fold dynamic `import()` paths, register each
     // resolved target as a regular import edge (marked `is_dynamic`), and
     // detect top-level `await` so codegen can chain the init Promise on

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -475,6 +475,15 @@ pub(super) fn collect_modules(
     // any violation site without re-reading the file. Cleared right
     // after the lower call so it can't leak to unrelated work on this
     // thread.
+    // #2309: arm the tree-shake deferral sink so `new Function` / #463
+    // refusals in this module are recorded (and fall through) instead of
+    // hard-erroring — but only for node_modules modules under tree-shaking.
+    // User/host source refusals stay fatal. The sink is thread-local
+    // (rayon-safe) and drained right after the lower below.
+    let tree_shake_defer_armed = ctx.tree_shake && is_in_node_modules;
+    if tree_shake_defer_armed {
+        perry_hir::arm_deferral_sink();
+    }
     perry_hir::set_current_module_source(source.clone());
     // #1681: re-install build-time precompile state on the (possibly rayon
     // worker) lowering thread — capture mode emits `precompile(EXPR)` source;
@@ -496,6 +505,17 @@ pub(super) fn collect_modules(
     perry_hir::clear_compile_packages_override();
     perry_hir::clear_current_module_source();
     perry_hir::clear_precompile_state();
+    // #2309: drain refusals deferred during this lower and tag them with the
+    // canonical module path so the post-collection prune can decide whether
+    // they survive. Done before the `?` below so a non-deferrable error can't
+    // leak the armed sink onto the next module on this thread.
+    if tree_shake_defer_armed {
+        let module_str = canonical.to_string_lossy().to_string();
+        for mut d in perry_hir::disarm_deferral_sink() {
+            d.module = module_str.clone();
+            ctx.deferred_refusals.push(d);
+        }
+    }
     let (mut hir_module, new_next_class_id) = lower_result?;
     *next_class_id = new_next_class_id; // Update the global class_id counter
 

--- a/crates/perry/src/commands/compile/env_fold.rs
+++ b/crates/perry/src/commands/compile/env_fold.rs
@@ -1,0 +1,340 @@
+//! #2309 Stage 2: build-time `process.env` folding + dead-branch elimination.
+//!
+//! Runs (under tree-shaking) on each freshly-lowered module BEFORE its dynamic
+//! `import()` edges are registered, so a dead `import()` inside a statically
+//! false branch is removed before it enters the module graph. This is how
+//! `ink`'s `if (process.env['DEV'] === 'true') { await import('./devtools.js') }`
+//! drops the entire `ws`/`react-devtools` subtree.
+//!
+//! It evaluates the condition of an `if` statement against build-time-known
+//! `process.env.<NAME>` values — explicit `perry.define` entries, plus an
+//! implicit `NODE_ENV → "production"` default applied only to `node_modules`
+//! code. When the condition const-folds to a definite truthiness, the dead
+//! branch (and everything in it) is spliced out. Anything not provably
+//! constant is left untouched — never folds an un-configured runtime env read.
+//!
+//! Scope (PR): statement-level `if` in module init + function bodies and the
+//! nested blocks they contain (`if`/`while`/`for`/`do`/`try`/`switch`/
+//! labeled). Ternary `import()` gating and closures nested inside expressions
+//! are out of scope for now (the ink gate is a statement-level `if`).
+
+use std::collections::HashMap;
+
+use perry_hir::{CompareOp, Expr, LogicalOp, Module, Stmt, UnaryOp};
+
+use super::DefineValue;
+
+/// Fold build-time env branches in a module. No-op when there is nothing to
+/// resolve (no defines and not node_modules code).
+pub(super) fn fold_env_branches(
+    module: &mut Module,
+    define: &HashMap<String, DefineValue>,
+    is_node_modules: bool,
+) {
+    if define.is_empty() && !is_node_modules {
+        return;
+    }
+    let env = Env {
+        define,
+        is_node_modules,
+    };
+    fold_stmts(&mut module.init, &env);
+    for f in &mut module.functions {
+        fold_stmts(&mut f.body, &env);
+    }
+}
+
+struct Env<'a> {
+    define: &'a HashMap<String, DefineValue>,
+    is_node_modules: bool,
+}
+
+impl Env<'_> {
+    /// Resolve `process.env.<key>` to a build-time constant, if known.
+    fn lookup(&self, key: &str) -> Option<Const> {
+        if let Some(dv) = self.define.get(&format!("process.env.{key}")) {
+            return Some(match dv {
+                DefineValue::Str(s) => Const::Str(s.clone()),
+                DefineValue::Bool(b) => Const::Bool(*b),
+                DefineValue::Number(n) => Const::Num(*n),
+                DefineValue::Null => Const::Null,
+            });
+        }
+        // Implicit production default for dependency code only (#2309 decision).
+        if self.is_node_modules && key == "NODE_ENV" {
+            return Some(Const::Str("production".to_string()));
+        }
+        None
+    }
+}
+
+#[derive(Clone)]
+enum Const {
+    Str(String),
+    Bool(bool),
+    Num(f64),
+    Null,
+    Undef,
+}
+
+impl Const {
+    fn truthy(&self) -> bool {
+        match self {
+            Const::Str(s) => !s.is_empty(),
+            Const::Bool(b) => *b,
+            Const::Num(n) => *n != 0.0 && !n.is_nan(),
+            Const::Null | Const::Undef => false,
+        }
+    }
+}
+
+/// Splice out statically-dead `if` branches in a statement list, recursing
+/// into nested blocks.
+fn fold_stmts(stmts: &mut Vec<Stmt>, env: &Env) {
+    let mut out: Vec<Stmt> = Vec::with_capacity(stmts.len());
+    for mut stmt in std::mem::take(stmts) {
+        recurse_stmt(&mut stmt, env);
+        if let Stmt::If {
+            condition,
+            then_branch,
+            else_branch,
+        } = &mut stmt
+        {
+            if let Some(c) = try_const(condition, env) {
+                // Condition is build-time-constant: keep only the live branch.
+                let mut taken = if c.truthy() {
+                    std::mem::take(then_branch)
+                } else {
+                    else_branch.take().unwrap_or_default()
+                };
+                fold_stmts(&mut taken, env);
+                out.extend(taken);
+                continue;
+            }
+        }
+        out.push(stmt);
+    }
+    *stmts = out;
+}
+
+/// Recurse into the nested statement lists a statement owns (so a dead branch
+/// deeper in the tree is also eliminated).
+fn recurse_stmt(stmt: &mut Stmt, env: &Env) {
+    match stmt {
+        Stmt::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            fold_stmts(then_branch, env);
+            if let Some(eb) = else_branch {
+                fold_stmts(eb, env);
+            }
+        }
+        Stmt::While { body, .. } | Stmt::DoWhile { body, .. } | Stmt::For { body, .. } => {
+            fold_stmts(body, env);
+        }
+        Stmt::Labeled { body, .. } => recurse_stmt(body, env),
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            fold_stmts(body, env);
+            if let Some(c) = catch {
+                fold_stmts(&mut c.body, env);
+            }
+            if let Some(f) = finally {
+                fold_stmts(f, env);
+            }
+        }
+        Stmt::Switch { cases, .. } => {
+            for case in cases {
+                fold_stmts(&mut case.body, env);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Try to evaluate an expression to a build-time constant. Returns `None` for
+/// anything not provably constant — the safe default (no fold).
+fn try_const(e: &Expr, env: &Env) -> Option<Const> {
+    match e {
+        Expr::EnvGet(key) => env.lookup(key),
+        Expr::String(s) => Some(Const::Str(s.clone())),
+        Expr::Bool(b) => Some(Const::Bool(*b)),
+        Expr::Number(n) => Some(Const::Num(*n)),
+        Expr::Null => Some(Const::Null),
+        Expr::Undefined => Some(Const::Undef),
+        Expr::Unary {
+            op: UnaryOp::Not,
+            operand,
+        } => try_const(operand, env).map(|c| Const::Bool(!c.truthy())),
+        Expr::Logical { op, left, right } => {
+            let l = try_const(left, env)?;
+            match op {
+                LogicalOp::And => {
+                    if !l.truthy() {
+                        Some(l)
+                    } else {
+                        try_const(right, env)
+                    }
+                }
+                LogicalOp::Or => {
+                    if l.truthy() {
+                        Some(l)
+                    } else {
+                        try_const(right, env)
+                    }
+                }
+                LogicalOp::Coalesce => match l {
+                    Const::Null | Const::Undef => try_const(right, env),
+                    other => Some(other),
+                },
+            }
+        }
+        Expr::Compare { op, left, right } => {
+            let l = try_const(left, env)?;
+            let r = try_const(right, env)?;
+            eval_compare(*op, &l, &r)
+        }
+        _ => None,
+    }
+}
+
+/// Evaluate a comparison of two constants. Strict eq/ne are total (cross-type
+/// ⇒ unequal); loose eq/ne and ordering only fold within matching types to
+/// avoid replicating full JS coercion semantics. `None` ⇒ don't fold.
+fn eval_compare(op: CompareOp, l: &Const, r: &Const) -> Option<Const> {
+    let strict_equal = match (l, r) {
+        (Const::Str(a), Const::Str(b)) => Some(a == b),
+        (Const::Bool(a), Const::Bool(b)) => Some(a == b),
+        (Const::Num(a), Const::Num(b)) => Some(a == b),
+        (Const::Null, Const::Null) | (Const::Undef, Const::Undef) => Some(true),
+        // Different constant kinds are never `===`.
+        _ => Some(false),
+    };
+    match op {
+        CompareOp::Eq => strict_equal.map(Const::Bool),
+        CompareOp::Ne => strict_equal.map(|b| Const::Bool(!b)),
+        CompareOp::LooseEq | CompareOp::LooseNe => {
+            // Only fold loose (in)equality between same-typed constants; the
+            // null/undefined cross-case and numeric coercion are left to
+            // runtime to stay correct.
+            let same_type_eq = match (l, r) {
+                (Const::Str(a), Const::Str(b)) => Some(a == b),
+                (Const::Bool(a), Const::Bool(b)) => Some(a == b),
+                (Const::Num(a), Const::Num(b)) => Some(a == b),
+                (Const::Null | Const::Undef, Const::Null | Const::Undef) => Some(true),
+                _ => None,
+            }?;
+            Some(Const::Bool(if matches!(op, CompareOp::LooseEq) {
+                same_type_eq
+            } else {
+                !same_type_eq
+            }))
+        }
+        CompareOp::Lt | CompareOp::Le | CompareOp::Gt | CompareOp::Ge => match (l, r) {
+            (Const::Num(a), Const::Num(b)) => Some(Const::Bool(match op {
+                CompareOp::Lt => a < b,
+                CompareOp::Le => a <= b,
+                CompareOp::Gt => a > b,
+                CompareOp::Ge => a >= b,
+                _ => unreachable!(),
+            })),
+            _ => None,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env_with(pairs: &[(&str, DefineValue)], nm: bool) -> HashMap<String, DefineValue> {
+        let _ = nm;
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    fn if_stmt(cond: Expr, then_n: usize, else_n: usize) -> Stmt {
+        Stmt::If {
+            condition: cond,
+            then_branch: (0..then_n).map(|_| Stmt::Break).collect(),
+            else_branch: if else_n == 0 {
+                None
+            } else {
+                Some((0..else_n).map(|_| Stmt::Continue).collect())
+            },
+        }
+    }
+
+    fn count(stmts: &[Stmt]) -> (usize, usize) {
+        let breaks = stmts.iter().filter(|s| matches!(s, Stmt::Break)).count();
+        let conts = stmts.iter().filter(|s| matches!(s, Stmt::Continue)).count();
+        (breaks, conts)
+    }
+
+    #[test]
+    fn dead_branch_eliminated_via_define() {
+        // if (process.env.DEV === "true") { B } else { C } with DEV="false"
+        let define = env_with(
+            &[("process.env.DEV", DefineValue::Str("false".into()))],
+            false,
+        );
+        let cond = Expr::Compare {
+            op: CompareOp::Eq,
+            left: Box::new(Expr::EnvGet("DEV".into())),
+            right: Box::new(Expr::String("true".into())),
+        };
+        let mut stmts = vec![if_stmt(cond, 2, 1)];
+        let env = Env {
+            define: &define,
+            is_node_modules: false,
+        };
+        fold_stmts(&mut stmts, &env);
+        // condition false ⇒ then(2 breaks) dropped, else(1 continue) kept.
+        assert_eq!(count(&stmts), (0, 1));
+    }
+
+    #[test]
+    fn node_env_production_default_keeps_then() {
+        // if (process.env.NODE_ENV === "production") { B } in node_modules.
+        let define = HashMap::new();
+        let cond = Expr::Compare {
+            op: CompareOp::Eq,
+            left: Box::new(Expr::EnvGet("NODE_ENV".into())),
+            right: Box::new(Expr::String("production".into())),
+        };
+        let mut stmts = vec![if_stmt(cond, 2, 0)];
+        let env = Env {
+            define: &define,
+            is_node_modules: true,
+        };
+        fold_stmts(&mut stmts, &env);
+        assert_eq!(count(&stmts), (2, 0), "production-true branch kept");
+    }
+
+    #[test]
+    fn unconfigured_env_not_folded() {
+        // No define, not node_modules ⇒ condition stays runtime, if untouched.
+        let define = HashMap::new();
+        let cond = Expr::Compare {
+            op: CompareOp::Eq,
+            left: Box::new(Expr::EnvGet("DEBUG".into())),
+            right: Box::new(Expr::String("1".into())),
+        };
+        let mut stmts = vec![if_stmt(cond, 2, 1)];
+        let env = Env {
+            define: &define,
+            is_node_modules: false,
+        };
+        fold_stmts(&mut stmts, &env);
+        // If preserved (1 If stmt), branches intact.
+        assert_eq!(stmts.len(), 1);
+        assert!(matches!(stmts[0], Stmt::If { .. }));
+    }
+}

--- a/crates/perry/src/commands/compile/host_config.rs
+++ b/crates/perry/src/commands/compile/host_config.rs
@@ -35,6 +35,16 @@ pub(super) fn apply_pkg_and_toml_config(
 )> {
     let mut fp_contract_explicit = false;
 
+    // #2309: tree-shaking opt-in via env var (checked unconditionally, even
+    // with no host package.json). `perry.experiments.treeShake: true` in the
+    // package.json is OR'd in below. Default off ⇒ byte-identical to pre-#2309.
+    if let Ok(v) = std::env::var("PERRY_TREE_SHAKE") {
+        let v = v.trim().to_ascii_lowercase();
+        if !matches!(v.as_str(), "" | "0" | "off" | "false" | "no") {
+            ctx.tree_shake = true;
+        }
+    }
+
     // Read perry.packageAliases from the project's package.json (if present)
     // This allows mapping npm package imports to native Perry packages at compile time.
     // Example: { "@parse/node-apn": "perry-push", "@prisma/client": "perry-prisma" }
@@ -168,6 +178,32 @@ pub(super) fn apply_pkg_and_toml_config(
                     .and_then(|v| v.as_bool())
                 {
                     ctx.fast_math = fm;
+                }
+                // #2309: perry.experiments.treeShake — host opt-in to
+                // tree-shaking / dead-code elimination (OR'd with the
+                // PERRY_TREE_SHAKE env var checked above).
+                if let Some(true) = pkg
+                    .get("perry")
+                    .and_then(|p| p.get("experiments"))
+                    .and_then(|e| e.get("treeShake"))
+                    .and_then(|v| v.as_bool())
+                {
+                    ctx.tree_shake = true;
+                }
+                // #2309 (Stage 2): perry.define — esbuild-style build-time
+                // substitutions. Only `process.env.<NAME>` keys are honored;
+                // values are JSON literals (string/bool/number/null). Host
+                // package.json only (same trust boundary as compilePackages).
+                if let Some(defines) = pkg
+                    .get("perry")
+                    .and_then(|p| p.get("define"))
+                    .and_then(|d| d.as_object())
+                {
+                    for (key, val) in defines {
+                        if let Some(dv) = json_to_define_value(val) {
+                            ctx.define.insert(key.clone(), dv);
+                        }
+                    }
                 }
                 // perry.fpContract: explicit contraction mode, separated
                 // from broad fast-math reassociation.
@@ -677,4 +713,17 @@ fn parse_fp_contract_mode(value: &str, source: &str) -> Result<FpContractMode> {
             value
         )
     })
+}
+
+/// #2309 (Stage 2): convert a `perry.define` JSON value into a [`DefineValue`].
+/// Strings/bools/numbers/null are honored; arrays/objects are rejected
+/// (returns `None` — too complex to inline-fold safely).
+fn json_to_define_value(val: &serde_json::Value) -> Option<super::DefineValue> {
+    match val {
+        serde_json::Value::String(s) => Some(super::DefineValue::Str(s.clone())),
+        serde_json::Value::Bool(b) => Some(super::DefineValue::Bool(*b)),
+        serde_json::Value::Number(n) => n.as_f64().map(super::DefineValue::Number),
+        serde_json::Value::Null => Some(super::DefineValue::Null),
+        _ => None,
+    }
 }

--- a/crates/perry/src/commands/compile/reachability.rs
+++ b/crates/perry/src/commands/compile/reachability.rs
@@ -1,0 +1,810 @@
+//! #2309 Stage 1: tree-shaking / dead-code elimination over the module graph.
+//!
+//! Perry collects every import-reachable module at module granularity and
+//! refuses (during lowering) on genuinely-runtime `new Function` and
+//! unimplemented APIs — even when the offending module is only reachable via a
+//! dead re-export-barrel edge and never actually runs. This pass, run after
+//! the full graph is collected (and after `rerun_collect_with_class_field_types`
+//! so it operates on the final `native_modules`), computes binding-level
+//! reachability from the user code and prunes unreachable `node_modules`
+//! modules before codegen. Refusals deferred during collection
+//! (see [`perry_hir::deferral`]) are then re-raised only for modules that
+//! survive — so dead code's refusals are dropped, live code's are still fatal.
+//!
+//! ## Model
+//!
+//! Each module reaches one of two states in a monotone fixpoint:
+//! - **Rooted** — the whole module is live (its init runs and every static
+//!   import edge is followed). All user (non-`node_modules`) modules are
+//!   seeded Rooted, so user code is never pruned and we only ever drop dead
+//!   transitive dependencies.
+//! - **Bindings(set)** — only specific exported names are needed. We keep this
+//!   sub-module precision **only** for *pure re-export barrels* in packages
+//!   marked `"sideEffects": false` (the spec-sanctioned signal). For these we
+//!   follow only the import edges feeding the needed exports and drop bare
+//!   side-effect imports — exactly what removes `es-toolkit`'s `template.mjs`
+//!   (`new Function`) when a consumer imports only `throttle`. Any binding
+//!   demand on any other module escalates it to Rooted (module granularity).
+//!
+//! All ambiguous shapes (namespace import, `export *`, dynamic `import()`,
+//! unresolvable specifiers) conservatively mark the whole target Rooted. The
+//! default is always "keep"; pruning only happens on precise binding paths.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use perry_hir::{Export, Import, ImportSpecifier};
+
+use super::resolve::cached_resolve_import;
+use super::{CompilationContext, SideEffects};
+
+/// Entry point: prune unreachable `node_modules` modules and re-raise any
+/// deferred refusal that survives. No-op (byte-identical to pre-#2309) unless
+/// `ctx.tree_shake` is set.
+pub(super) fn tree_shake(ctx: &mut CompilationContext, entry_canonical: &Path) -> Result<()> {
+    if !ctx.tree_shake {
+        return Ok(());
+    }
+
+    let paths: Vec<PathBuf> = ctx.native_modules.keys().cloned().collect();
+    let key_set: HashSet<PathBuf> = paths.iter().cloned().collect();
+
+    // --- snapshot per-module metadata (imports/exports + barrel-ness) ---
+    let mut barrel: HashMap<PathBuf, bool> = HashMap::new();
+    let mut raw: HashMap<PathBuf, (Vec<Import>, Vec<Export>)> = HashMap::new();
+    for p in &paths {
+        let m = &ctx.native_modules[p];
+        barrel.insert(p.clone(), is_pure_reexport_barrel(m));
+        raw.insert(p.clone(), (m.imports.clone(), m.exports.clone()));
+    }
+
+    // --- resolve every edge target to a native_modules key + precompute the
+    //     `sideEffects: false` flag per module (needs &mut ctx for caches;
+    //     native_modules is not borrowed here since we cloned above) ---
+    let mut se_none: HashMap<PathBuf, bool> = HashMap::new();
+    for p in &paths {
+        se_none.insert(
+            p.clone(),
+            matches!(side_effects_of(ctx, p), SideEffects::None),
+        );
+    }
+
+    let mut graph: HashMap<PathBuf, ResolvedModule> = HashMap::new();
+    for p in &paths {
+        let (imports, exports) = &raw[p];
+        let mut rimports = Vec::new();
+        for imp in imports {
+            if imp.type_only {
+                continue;
+            }
+            let target = resolve_edge(ctx, p, imp.resolved_path.as_deref(), &imp.source, &key_set);
+            let target_se_none = target.as_ref().map(|t| se_none[t]).unwrap_or(false);
+            // One reachability edge per specifier so every imported name is
+            // demanded (collapsing a multi-specifier decl to one edge would
+            // under-demand and risk pruning a live module).
+            for kind in specifier_kinds(&imp.specifiers) {
+                rimports.push(ResolvedImport {
+                    target: target.clone(),
+                    target_se_none,
+                    kind,
+                    is_dynamic: imp.is_dynamic,
+                });
+            }
+        }
+        let mut rexports = Vec::new();
+        for exp in exports {
+            rexports.push(resolve_export(ctx, p, exp, &key_set));
+        }
+        graph.insert(
+            p.clone(),
+            ResolvedModule {
+                imports: rimports,
+                exports: rexports,
+            },
+        );
+    }
+
+    // --- fixpoint ---
+    // Seed: every user (non-node_modules) module is a root, so user code is
+    // never pruned and bundle-extension / multi-entry roots are covered.
+    let mut roots: Vec<PathBuf> = paths
+        .iter()
+        .filter(|p| !is_in_node_modules(p))
+        .cloned()
+        .collect();
+    roots.push(entry_canonical.to_path_buf());
+    let reachable = compute_reachable(&graph, &barrel, &se_none, &roots);
+
+    // --- prune unreachable node_modules modules (never user code) ---
+    let pruned: HashSet<PathBuf> = paths
+        .iter()
+        .filter(|p| !reachable.contains(*p) && is_in_node_modules(p))
+        .cloned()
+        .collect();
+
+    if pruned.is_empty() {
+        return reraise_surviving_refusals(ctx, &key_set);
+    }
+
+    // Rewrite surviving modules so no import/export edge points at a pruned
+    // module (only pure barrels reached via Bindings can have such dangling
+    // edges; init-order already tolerates missing targets but codegen of a
+    // re-export to a pruned module would dangle). Drop those edges + the
+    // exports that depended on them — safe, since a pruned target was never
+    // demanded by live code.
+    rewrite_pruned_edges(ctx, &pruned);
+
+    let before = ctx.native_modules.len();
+    ctx.native_modules.retain(|p, _| !pruned.contains(p));
+    let removed = before - ctx.native_modules.len();
+    if removed > 0 {
+        if let Ok(v) = std::env::var("PERRY_TREE_SHAKE_DIAG") {
+            if v != "0" {
+                eprintln!("[tree-shake] pruned {removed} unreachable node_modules module(s)");
+            }
+        }
+    }
+
+    let surviving: HashSet<PathBuf> = ctx.native_modules.keys().cloned().collect();
+    reraise_surviving_refusals(ctx, &surviving)
+}
+
+/// The pure reachability fixpoint, decoupled from `CompilationContext` for
+/// testability. Returns the set of modules that must be compiled.
+fn compute_reachable(
+    graph: &HashMap<PathBuf, ResolvedModule>,
+    barrel: &HashMap<PathBuf, bool>,
+    se_none: &HashMap<PathBuf, bool>,
+    roots: &[PathBuf],
+) -> HashSet<PathBuf> {
+    let mut state: HashMap<PathBuf, St> = HashMap::new();
+    let mut work: VecDeque<PathBuf> = VecDeque::new();
+    for r in roots {
+        demand_root(&mut state, &mut work, r);
+    }
+    let mut reachable: HashSet<PathBuf> = HashSet::new();
+    while let Some(p) = work.pop_front() {
+        let Some(rm) = graph.get(&p).cloned() else {
+            continue;
+        };
+        match state.get(&p).cloned() {
+            Some(St::Rooted) => {
+                reachable.insert(p.clone());
+                follow_all(&mut state, &mut work, &rm);
+            }
+            Some(St::Bindings(needed)) => {
+                reachable.insert(p.clone());
+                let is_barrel =
+                    *barrel.get(&p).unwrap_or(&false) && *se_none.get(&p).unwrap_or(&false);
+                if is_barrel {
+                    for name in &needed {
+                        follow_export_binding(&mut state, &mut work, &p, &rm, name);
+                    }
+                } else {
+                    // Module granularity: any binding demand on a non-barrel
+                    // module makes the whole module live.
+                    demand_root(&mut state, &mut work, &p);
+                }
+            }
+            None => {}
+        }
+    }
+    reachable
+}
+
+/// Re-raise the first deferred refusal whose module survived the prune. Dead
+/// modules' refusals are dropped silently — the offending code never ships.
+fn reraise_surviving_refusals(
+    ctx: &CompilationContext,
+    surviving: &HashSet<PathBuf>,
+) -> Result<()> {
+    for d in &ctx.deferred_refusals {
+        let module_path = PathBuf::from(&d.module);
+        if surviving.contains(&module_path) {
+            let loc = d
+                .line
+                .map(|l| format!("{}:{}", d.module, l))
+                .unwrap_or_else(|| d.module.clone());
+            return Err(anyhow::anyhow!("{}\n  in {}", d.message, loc));
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Resolved graph types
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct ResolvedModule {
+    imports: Vec<ResolvedImport>,
+    exports: Vec<ResolvedExport>,
+}
+
+#[derive(Clone)]
+struct ResolvedImport {
+    /// Resolved native_modules key, if the target is a compiled module.
+    target: Option<PathBuf>,
+    /// Target package declares `sideEffects: false`.
+    target_se_none: bool,
+    kind: ImpKind,
+    is_dynamic: bool,
+}
+
+#[derive(Clone)]
+enum ImpKind {
+    /// `import { imported as local }` — carries the imported (source) name.
+    Named(String),
+    Default,
+    Namespace,
+    /// Bare side-effect import `import "x"` (no specifiers).
+    Bare,
+}
+
+#[derive(Clone)]
+struct ResolvedExport {
+    target: Option<PathBuf>,
+    kind: ExpKind,
+}
+
+#[derive(Clone)]
+enum ExpKind {
+    /// `export { imported as exported } from "src"`.
+    ReExport { imported: String, exported: String },
+    /// `export { local as exported }` (no source).
+    Named { local: String, exported: String },
+    /// `export * from "src"`.
+    Star,
+    /// `export * as ns from "src"`.
+    NamespaceStar,
+}
+
+/// One [`ImpKind`] edge per specifier (Bare when the decl has none).
+fn specifier_kinds(specs: &[ImportSpecifier]) -> Vec<ImpKind> {
+    if specs.is_empty() {
+        return vec![ImpKind::Bare];
+    }
+    specs
+        .iter()
+        .map(|s| match s {
+            ImportSpecifier::Named { imported, .. } => ImpKind::Named(imported.clone()),
+            ImportSpecifier::Default { .. } => ImpKind::Default,
+            ImportSpecifier::Namespace { .. } => ImpKind::Namespace,
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Fixpoint demand helpers
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+enum St {
+    Bindings(HashSet<String>),
+    Rooted,
+}
+
+fn demand_root(state: &mut HashMap<PathBuf, St>, work: &mut VecDeque<PathBuf>, p: &Path) {
+    match state.get(p) {
+        Some(St::Rooted) => {}
+        _ => {
+            state.insert(p.to_path_buf(), St::Rooted);
+            work.push_back(p.to_path_buf());
+        }
+    }
+}
+
+fn demand_binding(
+    state: &mut HashMap<PathBuf, St>,
+    work: &mut VecDeque<PathBuf>,
+    p: &Path,
+    name: &str,
+) {
+    match state.get_mut(p) {
+        Some(St::Rooted) => {}
+        Some(St::Bindings(s)) => {
+            if s.insert(name.to_string()) {
+                work.push_back(p.to_path_buf());
+            }
+        }
+        None => {
+            let mut s = HashSet::new();
+            s.insert(name.to_string());
+            state.insert(p.to_path_buf(), St::Bindings(s));
+            work.push_back(p.to_path_buf());
+        }
+    }
+}
+
+/// Follow every edge of a Rooted module.
+fn follow_all(state: &mut HashMap<PathBuf, St>, work: &mut VecDeque<PathBuf>, rm: &ResolvedModule) {
+    for imp in &rm.imports {
+        let Some(target) = &imp.target else { continue };
+        if imp.is_dynamic {
+            demand_root(state, work, target);
+            continue;
+        }
+        match &imp.kind {
+            ImpKind::Named(imported) => demand_binding(state, work, target, imported),
+            ImpKind::Default => demand_binding(state, work, target, "default"),
+            ImpKind::Namespace => demand_root(state, work, target),
+            ImpKind::Bare => {
+                // A bare side-effect import is droppable only if the target
+                // package declares `sideEffects: false`; otherwise its
+                // top-level side effect must run, so keep it.
+                if !imp.target_se_none {
+                    demand_root(state, work, target);
+                }
+            }
+        }
+    }
+    for exp in &rm.exports {
+        let Some(target) = &exp.target else { continue };
+        match &exp.kind {
+            ExpKind::ReExport { imported, .. } => demand_binding(state, work, target, imported),
+            ExpKind::Star | ExpKind::NamespaceStar => demand_root(state, work, target),
+            ExpKind::Named { .. } => {}
+        }
+    }
+}
+
+/// Follow only the edges feeding a single needed export of a pure barrel.
+fn follow_export_binding(
+    state: &mut HashMap<PathBuf, St>,
+    work: &mut VecDeque<PathBuf>,
+    p: &Path,
+    rm: &ResolvedModule,
+    name: &str,
+) {
+    // 1. explicit re-export of `name`?
+    for exp in &rm.exports {
+        match &exp.kind {
+            ExpKind::ReExport { exported, imported } if exported == name => {
+                if let Some(target) = &exp.target {
+                    demand_binding(state, work, target, imported);
+                }
+                return;
+            }
+            ExpKind::Named { local, exported } if exported == name => {
+                // import-then-export: find the import binding `local`.
+                if follow_import_local(state, work, rm, local) {
+                    return;
+                }
+                // local def in a "pure barrel" shouldn't happen; be safe.
+                demand_root(state, work, p);
+                return;
+            }
+            _ => {}
+        }
+    }
+    // 2. not an explicit export — could come from a star export.
+    let mut had_star = false;
+    for exp in &rm.exports {
+        if matches!(exp.kind, ExpKind::Star | ExpKind::NamespaceStar) {
+            if let Some(target) = &exp.target {
+                had_star = true;
+                demand_root(state, work, target);
+            }
+        }
+    }
+    if !had_star {
+        // Can't resolve the name precisely — keep the whole module.
+        demand_root(state, work, p);
+    }
+}
+
+/// Follow the import edge that binds `local` in a barrel. Returns true if an
+/// import provided it.
+fn follow_import_local(
+    state: &mut HashMap<PathBuf, St>,
+    work: &mut VecDeque<PathBuf>,
+    rm: &ResolvedModule,
+    local: &str,
+) -> bool {
+    for imp in &rm.imports {
+        let Some(target) = &imp.target else { continue };
+        match &imp.kind {
+            // import_kind collapses a decl's named specifiers to the first
+            // imported name; for the barrel re-export case the local equals the
+            // imported name (`export { x }` from `import { x }`), so demand the
+            // same name on the target. When they differ we conservatively
+            // demand `local` too.
+            ImpKind::Named(imported) if imported == local => {
+                demand_binding(state, work, target, imported);
+                return true;
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// Edge rewriting (drop references to pruned modules from survivors)
+// ---------------------------------------------------------------------------
+
+fn rewrite_pruned_edges(ctx: &mut CompilationContext, pruned: &HashSet<PathBuf>) {
+    let surviving: Vec<PathBuf> = ctx
+        .native_modules
+        .keys()
+        .filter(|p| !pruned.contains(*p))
+        .cloned()
+        .collect();
+    // native_modules keys after prune-decision (pruned not yet removed).
+    let key_set: HashSet<PathBuf> = ctx.native_modules.keys().cloned().collect();
+    for p in surviving {
+        let (imports, exports) = {
+            let m = &ctx.native_modules[&p];
+            (m.imports.clone(), m.exports.clone())
+        };
+
+        // Which imports point at a pruned module? Drop them and record the
+        // local names they bound (so dependent exports go too).
+        let mut import_keep = Vec::with_capacity(imports.len());
+        let mut dropped_locals: HashSet<String> = HashSet::new();
+        for imp in &imports {
+            let target = resolve_edge(ctx, &p, imp.resolved_path.as_deref(), &imp.source, &key_set);
+            let drop = target.as_ref().map(|t| pruned.contains(t)).unwrap_or(false);
+            import_keep.push(!drop);
+            if drop {
+                for s in &imp.specifiers {
+                    match s {
+                        ImportSpecifier::Named { local, .. }
+                        | ImportSpecifier::Default { local }
+                        | ImportSpecifier::Namespace { local } => {
+                            dropped_locals.insert(local.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Which exports reference a pruned source, or a now-dropped local?
+        let mut export_keep = Vec::with_capacity(exports.len());
+        for exp in &exports {
+            let keep = match exp {
+                Export::ReExport { source, .. }
+                | Export::ExportAll { source }
+                | Export::NamespaceReExport { source, .. } => {
+                    let t = resolve_edge(ctx, &p, None, source, &key_set);
+                    !t.as_ref().map(|t| pruned.contains(t)).unwrap_or(false)
+                }
+                Export::Named { local, .. } => !dropped_locals.contains(local),
+            };
+            export_keep.push(keep);
+        }
+
+        if import_keep.iter().all(|k| *k) && export_keep.iter().all(|k| *k) {
+            continue; // nothing to rewrite
+        }
+
+        let m = ctx.native_modules.get_mut(&p).unwrap();
+        let mut ii = 0;
+        m.imports.retain(|_| {
+            let keep = import_keep[ii];
+            ii += 1;
+            keep
+        });
+        let mut ei = 0;
+        m.exports.retain(|_| {
+            let keep = export_keep[ei];
+            ei += 1;
+            keep
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resolution + classification helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve an import/export edge to its canonical `native_modules` key, if the
+/// target is a compiled module present in the graph. Prefers the precomputed
+/// `resolved_path` (set during collection), falling back to the resolver.
+fn resolve_edge(
+    ctx: &mut CompilationContext,
+    importer: &Path,
+    resolved_path: Option<&str>,
+    source: &str,
+    key_set: &HashSet<PathBuf>,
+) -> Option<PathBuf> {
+    if let Some(rp) = resolved_path {
+        let canon = PathBuf::from(rp);
+        let canon = canon.canonicalize().unwrap_or(canon);
+        if key_set.contains(&canon) {
+            return Some(canon);
+        }
+    }
+    let (p, _kind) = cached_resolve_import(source, importer, ctx)?;
+    let canon = p.canonicalize().unwrap_or(p);
+    if key_set.contains(&canon) {
+        Some(canon)
+    } else {
+        None
+    }
+}
+
+fn resolve_export(
+    ctx: &mut CompilationContext,
+    importer: &Path,
+    exp: &Export,
+    key_set: &HashSet<PathBuf>,
+) -> ResolvedExport {
+    match exp {
+        Export::ReExport {
+            source,
+            imported,
+            exported,
+        } => ResolvedExport {
+            target: resolve_edge(ctx, importer, None, source, key_set),
+            kind: ExpKind::ReExport {
+                imported: imported.clone(),
+                exported: exported.clone(),
+            },
+        },
+        Export::Named { local, exported } => ResolvedExport {
+            target: None,
+            kind: ExpKind::Named {
+                local: local.clone(),
+                exported: exported.clone(),
+            },
+        },
+        Export::ExportAll { source } => ResolvedExport {
+            target: resolve_edge(ctx, importer, None, source, key_set),
+            kind: ExpKind::Star,
+        },
+        Export::NamespaceReExport { source, .. } => ResolvedExport {
+            target: resolve_edge(ctx, importer, None, source, key_set),
+            kind: ExpKind::NamespaceStar,
+        },
+    }
+}
+
+/// A pure re-export barrel: no executable definitions or top-level statements,
+/// only imports + exports. Edge-skipping is sound only for these (their entire
+/// observable behaviour *is* their re-export list).
+fn is_pure_reexport_barrel(m: &perry_hir::Module) -> bool {
+    m.functions.is_empty()
+        && m.classes.is_empty()
+        && m.globals.is_empty()
+        && m.enums.is_empty()
+        && m.init.is_empty()
+        && m.exported_native_instances.is_empty()
+        && m.exported_func_return_native_instances.is_empty()
+        && m.widgets.is_empty()
+        && m.extern_funcs.is_empty()
+}
+
+fn is_in_node_modules(p: &Path) -> bool {
+    p.to_string_lossy().contains("node_modules")
+}
+
+/// Read (and cache) a module's package `sideEffects` field, walking up to the
+/// nearest `package.json`. Absent / `true` / array-of-globs ⇒ `Unknown`
+/// (conservative; never drops). Only `false` ⇒ `None`.
+fn side_effects_of(ctx: &mut CompilationContext, module_path: &Path) -> SideEffects {
+    // Find nearest package.json dir.
+    let mut dir = module_path.parent().map(Path::to_path_buf);
+    while let Some(d) = dir {
+        let candidate = d.join("package.json");
+        if candidate.exists() {
+            if let Some(cached) = ctx.side_effects_cache.get(&d) {
+                return cached.clone();
+            }
+            let se = parse_side_effects(&candidate);
+            ctx.side_effects_cache.insert(d.clone(), se.clone());
+            return se;
+        }
+        dir = d.parent().map(Path::to_path_buf);
+    }
+    SideEffects::Unknown
+}
+
+fn parse_side_effects(pkg_json: &Path) -> SideEffects {
+    let Ok(content) = std::fs::read_to_string(pkg_json) else {
+        return SideEffects::Unknown;
+    };
+    let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return SideEffects::Unknown;
+    };
+    match val.get("sideEffects") {
+        Some(serde_json::Value::Bool(false)) => SideEffects::None,
+        Some(serde_json::Value::Array(arr)) => {
+            // Conservative for PR1: a glob list means *some* files have side
+            // effects; without per-file glob matching we keep the package
+            // side-effectful (never drop). Captured as Globs for future use.
+            let globs = arr
+                .iter()
+                .filter_map(|g| g.as_str().map(str::to_string))
+                .collect();
+            SideEffects::Globs(globs)
+        }
+        _ => SideEffects::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    fn named(imported: &str, target: &str, se_none: bool) -> ResolvedImport {
+        ResolvedImport {
+            target: Some(p(target)),
+            target_se_none: se_none,
+            kind: ImpKind::Named(imported.to_string()),
+            is_dynamic: false,
+        }
+    }
+    fn namespace(target: &str) -> ResolvedImport {
+        ResolvedImport {
+            target: Some(p(target)),
+            target_se_none: false,
+            kind: ImpKind::Namespace,
+            is_dynamic: false,
+        }
+    }
+    fn bare(target: &str, se_none: bool) -> ResolvedImport {
+        ResolvedImport {
+            target: Some(p(target)),
+            target_se_none: se_none,
+            kind: ImpKind::Bare,
+            is_dynamic: false,
+        }
+    }
+    fn exp_named(local: &str, exported: &str) -> ResolvedExport {
+        ResolvedExport {
+            target: None,
+            kind: ExpKind::Named {
+                local: local.to_string(),
+                exported: exported.to_string(),
+            },
+        }
+    }
+    fn exp_star(target: &str) -> ResolvedExport {
+        ResolvedExport {
+            target: Some(p(target)),
+            kind: ExpKind::Star,
+        }
+    }
+    fn module(imports: Vec<ResolvedImport>, exports: Vec<ResolvedExport>) -> ResolvedModule {
+        ResolvedModule { imports, exports }
+    }
+
+    /// A pure `sideEffects:false` barrel: importing one named binding drops
+    /// the unused leaf (and its `new Function`) plus the bare side-effect edge.
+    #[test]
+    fn barrel_drops_unused_leaf_and_bare_import() {
+        let mut graph = HashMap::new();
+        graph.insert(
+            p("entry"),
+            module(vec![named("throttle", "barrel", true)], vec![]),
+        );
+        graph.insert(
+            p("barrel"),
+            module(
+                vec![
+                    named("throttle", "throttle.mjs", true),
+                    named("template", "template.mjs", true),
+                    bare("compat.mjs", true),
+                ],
+                vec![
+                    exp_named("throttle", "throttle"),
+                    exp_named("template", "template"),
+                ],
+            ),
+        );
+        graph.insert(p("throttle.mjs"), module(vec![], vec![]));
+        graph.insert(p("template.mjs"), module(vec![], vec![]));
+        graph.insert(
+            p("compat.mjs"),
+            module(vec![named("template", "template.mjs", true)], vec![]),
+        );
+
+        let mut barrel = HashMap::new();
+        barrel.insert(p("barrel"), true);
+        let mut se = HashMap::new();
+        for m in ["barrel", "throttle.mjs", "template.mjs", "compat.mjs"] {
+            se.insert(p(m), true);
+        }
+
+        let r = compute_reachable(&graph, &barrel, &se, &[p("entry")]);
+        assert!(r.contains(&p("entry")));
+        assert!(r.contains(&p("barrel")));
+        assert!(r.contains(&p("throttle.mjs")));
+        assert!(
+            !r.contains(&p("template.mjs")),
+            "unused leaf must be pruned"
+        );
+        assert!(
+            !r.contains(&p("compat.mjs")),
+            "bare sideEffects:false import must be dropped"
+        );
+    }
+
+    /// A namespace import of the same barrel keeps everything (we can't tell
+    /// which members are used) — except a bare `sideEffects:false` edge.
+    #[test]
+    fn namespace_import_keeps_all_named_leaves() {
+        let mut graph = HashMap::new();
+        graph.insert(p("entry"), module(vec![namespace("barrel")], vec![]));
+        graph.insert(
+            p("barrel"),
+            module(
+                vec![
+                    named("throttle", "throttle.mjs", true),
+                    named("template", "template.mjs", true),
+                    bare("compat.mjs", true),
+                ],
+                vec![
+                    exp_named("throttle", "throttle"),
+                    exp_named("template", "template"),
+                ],
+            ),
+        );
+        graph.insert(p("throttle.mjs"), module(vec![], vec![]));
+        graph.insert(p("template.mjs"), module(vec![], vec![]));
+        graph.insert(p("compat.mjs"), module(vec![], vec![]));
+        let mut barrel = HashMap::new();
+        barrel.insert(p("barrel"), true);
+        let mut se = HashMap::new();
+        for m in ["barrel", "throttle.mjs", "template.mjs", "compat.mjs"] {
+            se.insert(p(m), true);
+        }
+        let r = compute_reachable(&graph, &barrel, &se, &[p("entry")]);
+        assert!(
+            r.contains(&p("template.mjs")),
+            "namespace import keeps named leaves"
+        );
+        assert!(r.contains(&p("throttle.mjs")));
+        assert!(
+            !r.contains(&p("compat.mjs")),
+            "bare sideEffects:false edge still droppable"
+        );
+    }
+
+    /// `export *` from a barrel forces the star source live (can't resolve the
+    /// member precisely) — no false prune.
+    #[test]
+    fn star_export_keeps_source() {
+        let mut graph = HashMap::new();
+        graph.insert(p("entry"), module(vec![named("x", "barrel", true)], vec![]));
+        graph.insert(p("barrel"), module(vec![], vec![exp_star("leaf")]));
+        graph.insert(p("leaf"), module(vec![], vec![]));
+        let mut barrel = HashMap::new();
+        barrel.insert(p("barrel"), true);
+        let mut se = HashMap::new();
+        se.insert(p("barrel"), true);
+        se.insert(p("leaf"), true);
+        let r = compute_reachable(&graph, &barrel, &se, &[p("entry")]);
+        assert!(r.contains(&p("leaf")), "export* source must stay live");
+    }
+
+    /// A binding demand on a NON-barrel module escalates it to whole-module
+    /// (module granularity), following all its edges.
+    #[test]
+    fn non_barrel_binding_escalates_to_rooted() {
+        let mut graph = HashMap::new();
+        graph.insert(p("entry"), module(vec![named("a", "lib", false)], vec![]));
+        graph.insert(
+            p("lib"),
+            module(
+                vec![named("dep", "dep.mjs", false)],
+                vec![exp_named("a", "a")],
+            ),
+        );
+        graph.insert(p("dep.mjs"), module(vec![], vec![]));
+        let barrel = HashMap::new(); // lib is NOT a barrel
+        let se = HashMap::new();
+        let r = compute_reachable(&graph, &barrel, &se, &[p("entry")]);
+        assert!(r.contains(&p("lib")));
+        assert!(
+            r.contains(&p("dep.mjs")),
+            "non-barrel binding pulls whole module"
+        );
+    }
+}

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -597,6 +597,56 @@ pub struct CompilationContext {
     /// makes the dangerous "compile this random npm package into the
     /// binary" surface a two-key opt-in.
     pub allow_compile_packages: Vec<String>,
+    /// #2309: tree-shaking / dead-code elimination enabled for this build.
+    /// Off (default) ⇒ behaviour is byte-identical to pre-#2309: no refusal
+    /// deferral, no reachability prune, no `process.env` define-folding.
+    /// Sources (any enables): `PERRY_TREE_SHAKE=1` env, or
+    /// `perry.experiments.treeShake: true` in the host `package.json`.
+    pub tree_shake: bool,
+    /// #2309: refusals (`new Function` RuntimeUnknown, #463 unimplemented APIs)
+    /// recorded while lowering `node_modules` modules under tree-shaking,
+    /// instead of hard-erroring. After reachability is computed, any whose
+    /// module survived the prune is re-raised; the rest are dropped silently
+    /// (the offending code never ships). Tagged with the canonical module path
+    /// by the collect driver after each lower.
+    pub deferred_refusals: Vec<perry_hir::DeferredRefusal>,
+    /// #2309: cache of each package's `sideEffects` field, keyed by the
+    /// package directory (the dir containing the owning `package.json`).
+    /// Drives whether a bare side-effect import edge of a reachable module may
+    /// be dropped during the prune.
+    pub side_effects_cache: HashMap<PathBuf, SideEffects>,
+    /// #2309 (Stage 2): build-time `process.env.X` substitutions, esbuild
+    /// `define`-style. Read from `perry.define` in the host `package.json`
+    /// only (same trust boundary as `compilePackages`), plus an implicit
+    /// `NODE_ENV → "production"` default applied to `node_modules` code unless
+    /// overridden. Keyed by the full `process.env.<NAME>` string.
+    pub define: HashMap<String, DefineValue>,
+}
+
+/// #2309: a package's declared `sideEffects` (package.json). `Unknown` (the
+/// default for an absent/unparseable field) is treated as side-effectful —
+/// the conservative choice that never drops code.
+#[derive(Debug, Clone)]
+pub enum SideEffects {
+    /// `"sideEffects": false` — no module in the package has observable
+    /// top-level side effects; bare side-effect import edges are droppable.
+    None,
+    /// `"sideEffects": true`, absent, or unparseable — treat every module as
+    /// side-effectful (conservative).
+    Unknown,
+    /// `"sideEffects": ["glob", ...]` — only files matching a glob have side
+    /// effects; others are droppable. Globs are relative to the package dir.
+    Globs(Vec<String>),
+}
+
+/// #2309 (Stage 2): a build-time `define` value. Parsed from `perry.define`
+/// (JSON value) into a folded HIR literal.
+#[derive(Debug, Clone)]
+pub enum DefineValue {
+    Str(String),
+    Bool(bool),
+    Number(f64),
+    Null,
 }
 
 impl std::fmt::Debug for CompilationContext {
@@ -658,6 +708,10 @@ impl CompilationContext {
             allow_dynamic_hosts: false,
             allow_native_library: Vec::new(),
             allow_compile_packages: Vec::new(),
+            tree_shake: false,
+            deferred_refusals: Vec::new(),
+            side_effects_cache: HashMap::new(),
+            define: HashMap::new(),
         }
     }
 }


### PR DESCRIPTION
## What

Implements the module-graph dead-code-elimination phase from #2309 — the bundler-equivalent step Perry was missing. Both stages, behind a default-OFF flag (`PERRY_TREE_SHAKE=1` or `perry.experiments.treeShake: true`). With the flag off, behaviour is byte-identical to before.

This is general `compilePackages` infrastructure (helps Hono/Drizzle/Effect/any npm tree), surfaced by the #348 ink recheck: Perry compiles every import-reachable module and hard-errors on `new Function` / unimplemented APIs in **dead** transitive code that never runs.

## Stage 1 — binding-level reachability + `sideEffects` prune

- **Deferred refusals** (`perry-hir/src/deferral.rs`): while lowering a `node_modules` module under tree-shaking, `new Function` (eval_classifier) and the 5 `#463` unimplemented gates record the refusal and fall through instead of hard-erroring. Re-raised after pruning **only** for modules that survive — dead code's refusals are dropped, live code's stay fatal and span-precise.
- **Reachability fixpoint** (`compile/reachability.rs`): monotone Rooted/Bindings lattice. User (non-`node_modules`) modules seed Rooted, so user code is never pruned — we only ever drop dead dependencies. Honors package.json `"sideEffects": false`: a pure re-export barrel reached only via named bindings follows just the edges feeding the needed exports and drops bare side-effect imports. Every ambiguous shape (namespace import, `export *`, dynamic `import()`, unresolvable specifier) conservatively roots the whole target. Surviving barrels have dangling edges to pruned modules rewritten away.

## Stage 2 — `process.env` define-folding + dead-branch elimination

- **`compile/env_fold.rs`**: a build-time constant folder over `if` conditions, run before dynamic-`import()` edges are registered, so an env-gated dead `import()` never enters the graph. Resolves `process.env.<NAME>` from explicit `perry.define` (esbuild-style, host package.json only) plus an implicit `NODE_ENV → "production"` default for `node_modules` code. Folds Compare/Logical/Unary over literals; strict eq/ne total, loose eq/ne + ordering only within matching types (never replicates full JS coercion); anything not provably constant is left as a runtime read.
- `expr_member.rs`: `process.env["NAME"]` with a string-literal key now lowers to `EnvGet` (matching the dot form), so the fold sees ink's bracket access. Runtime-identical to the prior `EnvGetDynamic(String)` path.

## Validation

- **Real `import { throttle } from "es-toolkit/compat"`** (the headline CASE A): tree-shaking prunes **430** unreachable modules including `template.mjs` (the `new Function` leaf) and the program compiles + runs. Flag-off, the same import hits the `new Function` wall.
- **Env-gated dead `import()`** (CASE B): a `new Function` module behind `if (process.env['DEV'] === 'true')` fails without a define (branch kept → leaf reached) and compiles+runs with `define: { "process.env.DEV": "false" }` — both dot and bracket access.
- **Flag-off** path verified byte-identical on plain programs.
- Unit tests: 4 reachability fixpoint (barrel-drop / namespace-keeps-all / `export*`-keeps-source / non-barrel-escalate) + 3 env-fold + deferral. Full `perry-hir` suite (116 tests) green; `cargo fmt` clean.

## Scope / non-goals

- Makes ink (and other npm trees) **compile**, not **render** — yoga-layout (WASM) is genuinely reached and DCE can't strip it. #348 stays a smoke test; `perry/tui` remains the product TUI path.
- Module granularity everywhere except pure `sideEffects:false` re-export barrels (the only sub-module pruning); ternary `import()` gating and closures nested inside expressions are left for follow-up.
- Fixes the codegen bug #2310 in practice by never reaching it (its `ws` module is in the env-gated dead branch).

Closes #2309
