### PR TITLE
fix(node:url): reject invalid URLSearchParams tuples

### DIFF
--- a/crates/perry-runtime/src/url/search_params.rs
+++ b/crates/perry-runtime/src/url/search_params.rs
@@ -17,6 +17,16 @@ pub(crate) const URL_SEARCH_PARAMS_ENTRIES: u32 = 0; // Array of [key, value] pa
 pub(crate) const URL_SEARCH_PARAMS_OWNER: u32 = 1;
 pub(crate) const URL_SEARCH_PARAMS_FIELD_COUNT: u32 = 2;
 
+fn throw_invalid_query_pair_tuple() -> ! {
+    let msg = b"Each query pair must be an iterable [name, value] tuple";
+    let s = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    crate::node_submodules::register_error_code_pub(s, "ERR_INVALID_TUPLE");
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(f64::from_bits(
+        crate::value::JSValue::pointer(err as *const u8).bits(),
+    ))
+}
+
 // URL field constant alias — we only need URL_SEARCH from `super::parse` for
 // the params→owner-URL sync path.
 use super::parse::URL_SEARCH;
@@ -287,10 +297,9 @@ pub extern "C" fn js_url_search_params_new_any(init: f64) -> *mut ObjectHeader {
 /// a 2-element array `[key, value]`. Strings (key + value) are
 /// extracted via `get_string_content`, which handles SSO + heap
 /// strings + INT32 / number coercion so `new URLSearchParams([["n", 1]])`
-/// silently stringifies the value to `"1"` to match Node. Non-array
-/// entries are skipped (Node would throw, but Perry's loose-iter
-/// stance is to accept what we can read and drop garbage rather than
-/// abort the whole construction).
+/// silently stringifies the value to `"1"` to match Node. Array entries must
+/// be exactly two items; Node throws `ERR_INVALID_TUPLE` for shorter or longer
+/// query pairs before appending them.
 pub(crate) fn read_iterable_pair_entries(arr: *const ArrayHeader) -> Vec<(String, String)> {
     if arr.is_null() {
         return Vec::new();
@@ -320,8 +329,8 @@ pub(crate) fn read_iterable_pair_entries(arr: *const ArrayHeader) -> Vec<(String
         }
         let pair = pair_ptr_i64 as *const ArrayHeader;
         let pair_len = unsafe { (*pair).length };
-        if pair_len < 2 {
-            continue;
+        if pair_len != 2 {
+            throw_invalid_query_pair_tuple();
         }
         let k = get_string_content(crate::array::js_array_get_f64(pair, 0));
         let v = get_string_content(crate::array::js_array_get_f64(pair, 1));

--- a/test-parity/node-suite/url/search-params/constructor-inputs-extra.ts
+++ b/test-parity/node-suite/url/search-params/constructor-inputs-extra.ts
@@ -1,4 +1,6 @@
 for (const input of [{ a: "1", b: "2" }, [["a", "1"], ["a", "2"]], new URLSearchParams("x=1")] as any[]) {
   try { const p = new URLSearchParams(input); console.log("params:", p.toString()); } catch (err: any) { console.log("params err:", err?.name, err?.code || "no-code"); }
 }
-try { new URLSearchParams([["a"]] as any); console.log("bad tuple no throw"); } catch (err: any) { console.log("bad tuple:", err?.name, err?.code || "no-code"); }
+for (const bad of [[["a"]], [[]], [["a", "1", "extra"]]] as any[]) {
+  try { new URLSearchParams(bad); console.log("bad tuple no throw:", JSON.stringify(bad)); } catch (err: any) { console.log("bad tuple:", err?.name, err?.code || "no-code"); }
+}


### PR DESCRIPTION
## Summary
- Throw `TypeError ERR_INVALID_TUPLE` for URLSearchParams array-of-pairs constructor entries whose length is not exactly two.
- Extend the focused constructor fixture to cover too-short, empty, and too-long array pairs.
- Keep generic iterable-pair support and `forEach(thisArg)` behavior out of scope.

## Verification
- Baseline exact `node-suite/url/search-params/constructor-inputs-extra`: FAIL, `test-parity/reports/parity_report_20260528_153514.json`.
- Final exact `node-suite/url/search-params/constructor-inputs-extra`: PASS, `test-parity/reports/parity_report_20260528_153712.json`.
- Focused `node-suite/url/search-params`: 11 PASS / 1 parity FAIL / 0 compile FAIL, `test-parity/reports/parity_report_20260528_153756.json`; remaining failure is `forEach-thisarg`, covered by a separate open PR.
- Full `node-suite/url`: 38 PASS / 10 parity FAIL / 0 compile FAIL, `test-parity/reports/parity_report_20260528_153812.json`.
- `cargo check -p perry-runtime`: PASS with existing warnings.
- `cargo fmt --check`: PASS.
- `git diff --check`: PASS.

## Reference
- DeepWiki notes saved locally at `reference/deepwiki/node-urlsearchparams-invalid-tuple.md`.

## Non-goals
- No generic iterable-pair support.
- No non-array pair validation.
- No URLSearchParams `forEach(thisArg)` changes.
- No broad constructor rewrite.
