### PR TITLE
fix(node:url): parse legacy authority edges

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -312,7 +312,7 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         method: "parse",
         class_filter: None,
         runtime: "js_url_legacy_parse",
-        args: &[NA_F64, NA_F64],
+        args: &[NA_F64, NA_F64, NA_F64],
         ret: NR_F64,
     },
     NativeModSig {

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -552,7 +552,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_url_domain_to_unicode", DOUBLE, &[DOUBLE]);
     module.declare_function("js_url_to_http_options", DOUBLE, &[DOUBLE]);
     module.declare_function("js_url_format", DOUBLE, &[DOUBLE, DOUBLE]);
-    module.declare_function("js_url_legacy_parse", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_url_legacy_parse", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_url_legacy_resolve", DOUBLE, &[DOUBLE, DOUBLE]);
 
     // ========== WebSocket ==========

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1071,7 +1071,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("url", "domainToUnicode") => crate::url::js_url_domain_to_unicode(arg(0)),
         ("url", "urlToHttpOptions") => crate::url::js_url_to_http_options(arg(0)),
         ("url", "format") => crate::url::js_url_format(arg(0), arg(1)),
-        ("url", "parse") => crate::url::js_url_legacy_parse(arg(0), arg(1)),
+        ("url", "parse") => crate::url::js_url_legacy_parse(arg(0), arg(1), arg(2)),
         ("url", "resolve") => crate::url::js_url_legacy_resolve(arg(0), arg(1)),
 
         // ── console module namespace (`node:console` / `console`) ──

--- a/crates/perry-runtime/src/url/node_compat.rs
+++ b/crates/perry-runtime/src/url/node_compat.rs
@@ -230,9 +230,44 @@ pub extern "C" fn js_url_format(value: f64, options: f64) -> f64 {
 }
 
 #[no_mangle]
-pub extern "C" fn js_url_legacy_parse(input: f64, parse_query_string: f64) -> f64 {
+pub extern "C" fn js_url_legacy_parse(
+    input: f64,
+    parse_query_string: f64,
+    slashes_denote_host: f64,
+) -> f64 {
     let s = get_string_content(input);
-    let (protocol, mut host, mut hostname, port, pathname, search, hash) = parse_url(&s);
+    let (protocol, mut host, mut hostname, mut port, mut pathname, search, hash) = parse_url(&s);
+    let bool_true_bits = 0x7FFC_0000_0000_0004u64;
+    let slashes_host = slashes_denote_host.to_bits() == bool_true_bits;
+    let protocol_is_null = protocol.is_empty() && slashes_host && s.starts_with("//");
+
+    if protocol_is_null {
+        let rest = pathname.strip_prefix("//").unwrap_or(&pathname);
+        let path_idx = rest.find('/').unwrap_or(rest.len());
+        host = rest[..path_idx].to_string();
+        pathname = if path_idx < rest.len() {
+            rest[path_idx..].to_string()
+        } else {
+            "/".to_string()
+        };
+        hostname = host.clone();
+        if let Some(port_idx) = host.rfind(':') {
+            let potential_port = &host[port_idx + 1..];
+            if !potential_port.is_empty() && potential_port.chars().all(|c| c.is_ascii_digit()) {
+                hostname = host[..port_idx].to_string();
+                port = potential_port.to_string();
+            }
+        }
+    }
+
+    if let Some(percent_idx) = host.find('%') {
+        let invalid_tail = format!("{}{}", &host[percent_idx..], pathname);
+        host.truncate(percent_idx);
+        hostname = host.clone();
+        port.clear();
+        pathname = invalid_tail;
+    }
+
     let mut auth = String::new();
     if let Some(at_idx) = host.rfind('@') {
         auth = host[..at_idx].to_string();
@@ -249,7 +284,7 @@ pub extern "C" fn js_url_legacy_parse(input: f64, parse_query_string: f64) -> f6
             rest
         };
     }
-    let parse_qs = parse_query_string.to_bits() == 0x7FFC_0000_0000_0004u64;
+    let parse_qs = parse_query_string.to_bits() == bool_true_bits;
     let query = if parse_qs {
         let mut map = serde_json::Map::new();
         let raw = search.strip_prefix('?').unwrap_or(&search);
@@ -261,8 +296,13 @@ pub extern "C" fn js_url_legacy_parse(input: f64, parse_query_string: f64) -> f6
     } else {
         serde_json::Value::String(search.strip_prefix('?').unwrap_or(&search).to_string())
     };
+    let protocol_value = if protocol_is_null {
+        serde_json::Value::Null
+    } else {
+        serde_json::Value::String(protocol)
+    };
     json_to_value(serde_json::json!({
-        "protocol": protocol,
+        "protocol": protocol_value,
         "host": host,
         "hostname": hostname,
         "port": port,


### PR DESCRIPTION
## Summary
- Pass the third `slashesDenoteHost` argument through legacy `url.parse` lowering/runtime dispatch.
- Parse leading `//host/path` as host plus pathname with `protocol: null` when `slashesDenoteHost` is true.
- Move `%` host tails into `pathname` for the legacy parser instead of keeping invalid host text.

## Verification
- Baseline exact `node-suite/url/legacy/parse-ipv6-and-invalid`: FAIL, `test-parity/reports/parity_report_20260528_154313.json`.
- Final exact `node-suite/url/legacy/parse-ipv6-and-invalid`: PASS, `test-parity/reports/parity_report_20260528_154722.json`.
- Focused `node-suite/url/legacy`: 6 PASS / 1 parity FAIL / 0 compile FAIL, `test-parity/reports/parity_report_20260528_154806.json`; remaining failure is `format-auth-and-query`, covered by a separate open PR.
- Full `node-suite/url`: 38 PASS / 10 parity FAIL / 0 compile FAIL, `test-parity/reports/parity_report_20260528_154820.json`.
- `cargo check -p perry-codegen -p perry-runtime`: PASS with existing warnings.
- `cargo fmt --check`: PASS.
- `git diff --check`: PASS.

## Reference
- DeepWiki notes saved locally at `reference/deepwiki/node-url-legacy-parse-authority.md`.
- Direct Node output was used for the `%` host behavior because the DeepWiki prose mixed in a throwing-invalid-URL claim that does not match the current fixture behavior.

## Non-goals
- No broad legacy parser rewrite.
- No deprecation-warning emulation.
- No full forbidden-host-character model.
- No legacy `url.format` query escaping work.
- No WHATWG URL mutation changes.
