### PR TITLE
fix(fs): extend Node arg-validation to closeSync/readSync/writeSync/fchmodSync/chmodSync/renameSync (#2013)

### DIFF
--- a/crates/perry-runtime/src/fs/fd_ops.rs
+++ b/crates/perry-runtime/src/fs/fd_ops.rs
@@ -123,6 +123,7 @@ pub extern "C" fn js_fs_open_sync(path_value: f64, flags_value: f64) -> f64 {
 /// `fs.closeSync(fd)` — close a registry fd.
 #[no_mangle]
 pub extern "C" fn js_fs_close_sync(fd_value: f64) -> i32 {
+    crate::fs::validate::validate_fd_open(fd_value, "close");
     let fd = fd_value as i32;
     FD_REGISTRY.with(|r| {
         if r.borrow_mut().remove(&fd).is_some() {
@@ -148,6 +149,7 @@ pub extern "C" fn js_fs_read_sync(
     length_value: f64,
     position_value: f64,
 ) -> f64 {
+    crate::fs::validate::validate_fd_open(fd_value, "read");
     let fd = fd_value as i32;
     let offset = offset_value.max(0.0) as usize;
     let length = length_value.max(0.0) as usize;
@@ -225,7 +227,7 @@ pub extern "C" fn js_fs_write_string_sync_options(
     data_value: f64,
     position_value: f64,
 ) -> f64 {
-    crate::fs::validate::validate_fd(fd_value);
+    crate::fs::validate::validate_fd_open(fd_value, "write");
     write_string_sync_inner(fd_value as i32, data_value, position_value)
 }
 
@@ -265,7 +267,7 @@ pub extern "C" fn js_fs_write_buffer_sync(
     length_value: f64,
     position_value: f64,
 ) -> f64 {
-    crate::fs::validate::validate_fd(fd_value);
+    crate::fs::validate::validate_fd_open(fd_value, "write");
     write_buffer_sync_inner(
         fd_value as i32,
         buffer_value,
@@ -351,6 +353,21 @@ pub extern "C" fn js_fs_write_sync_options_dispatch(
 /// `fs.readvSync(fd, buffers[, position])` — deterministic Buffer[] subset.
 #[no_mangle]
 pub extern "C" fn js_fs_readv_sync(fd_value: f64, buffers_value: f64, position_value: f64) -> f64 {
+    // #2013: always reject a non-number fd; only run the EBADF registry
+    // probe when the iovec array is non-empty. Node's empty-array path
+    // surfaces `EINVAL` from the syscall instead of the JS-level EBADF —
+    // matching that exact code would need an `EINVAL` throw here that
+    // doesn't fit the validate-then-pass shape, so we settle for the
+    // common-case `readv(123, [buf])` → `EBADF` parity and leave the
+    // empty-array divergence as a follow-up.
+    let buffers_for_check = array_ptr_from_value(buffers_value);
+    let buffers_nonempty = !buffers_for_check.is_null()
+        && unsafe { crate::array::js_array_length(buffers_for_check) } > 0;
+    if buffers_nonempty {
+        crate::fs::validate::validate_fd_open(fd_value, "read");
+    } else {
+        crate::fs::validate::validate_fd(fd_value);
+    }
     let fd = fd_value as i32;
     let position = if position_value.is_finite() && position_value >= 0.0 {
         Some(position_value as u64)
@@ -427,7 +444,11 @@ pub extern "C" fn js_fs_writev_sync(fd_value: f64, buffers_value: f64, position_
     let buffers_nonempty = !buffers_for_check.is_null()
         && unsafe { crate::array::js_array_length(buffers_for_check) } > 0;
     if buffers_nonempty {
-        crate::fs::validate::validate_fd(fd_value);
+        // #2013: upgrade from type-only validation to type + EBADF so
+        // `fs.writevSync(123, [buf])` matches Node's
+        // `EBADF: bad file descriptor, writev` instead of silently
+        // returning 0.
+        crate::fs::validate::validate_fd_open(fd_value, "writev");
     }
     writev_sync_inner(fd_value as i32, buffers_value, position_value)
 }

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -543,6 +543,11 @@ pub extern "C" fn js_fs_unlink_sync(path_value: f64) -> i32 {
 /// Returns 1 on success, 0 on error. No-op + success on Windows where POSIX modes don't apply.
 #[no_mangle]
 pub extern "C" fn js_fs_chmod_sync(path_value: f64, mode: f64) -> i32 {
+    // #2013: path-only validation. Mode coercion goes through Node's
+    // `parseFileMode` which throws ERR_INVALID_ARG_VALUE (not the
+    // ERR_INVALID_ARG_TYPE / ERR_OUT_OF_RANGE shape `validate_int32`
+    // emits) — left as a follow-up to keep the diff small.
+    crate::fs::validate::validate_path("path", path_value);
     unsafe {
         let path_str = match decode_path_value(path_value) {
             Some(s) => s,
@@ -886,6 +891,8 @@ fn open_file_for_write_flag(path: &str, flag: &str) -> std::io::Result<fs::File>
 /// `fs.renameSync(from, to)` — returns 1 on success, 0 on failure.
 #[no_mangle]
 pub extern "C" fn js_fs_rename_sync(from_value: f64, to_value: f64) -> i32 {
+    crate::fs::validate::validate_path("oldPath", from_value);
+    crate::fs::validate::validate_path("newPath", to_value);
     unsafe {
         let from = match decode_path_value(from_value) {
             Some(s) => s,
@@ -1217,7 +1224,7 @@ pub extern "C" fn js_fs_ftruncate_sync(fd_value: f64, len_value: f64) -> i32 {
 /// `fs.fsyncSync(fd)` — flush an open registry fd.
 #[no_mangle]
 pub extern "C" fn js_fs_fsync_sync(fd_value: f64) -> i32 {
-    crate::fs::validate::validate_fd(fd_value);
+    crate::fs::validate::validate_fd_open(fd_value, "fsync");
     fsync_sync_inner(fd_value as i32)
 }
 
@@ -1242,7 +1249,7 @@ pub(crate) fn fsync_sync_inner(fd: i32) -> i32 {
 /// Perry maps this to `sync_data`, falling back to fsync-like semantics.
 #[no_mangle]
 pub extern "C" fn js_fs_fdatasync_sync(fd_value: f64) -> i32 {
-    crate::fs::validate::validate_fd(fd_value);
+    crate::fs::validate::validate_fd_open(fd_value, "fdatasync");
     fdatasync_sync_inner(fd_value as i32)
 }
 
@@ -1263,6 +1270,12 @@ pub(crate) fn fdatasync_sync_inner(fd: i32) -> i32 {
 /// `fs.fchmodSync(fd, mode)`.
 #[no_mangle]
 pub extern "C" fn js_fs_fchmod_sync(fd_value: f64, mode: f64) -> i32 {
+    // #2013: fd validation (type + range) + EBADF on missing fd. Mode
+    // validation deliberately omitted — Node uses `parseFileMode`,
+    // which throws `ERR_INVALID_ARG_VALUE`, before the fd check; adding
+    // the same shape here is a separate follow-up tracked alongside the
+    // mode-on-existing-path gap in `lchmodSync`.
+    crate::fs::validate::validate_fd_open(fd_value, "fchmod");
     let fd = fd_value as i32;
     FD_REGISTRY.with(|r| {
         let reg = r.borrow();
@@ -1289,9 +1302,17 @@ pub extern "C" fn js_fs_fchmod_sync(fd_value: f64, mode: f64) -> i32 {
 /// `fs.fchownSync(fd, uid, gid)`.
 #[no_mangle]
 pub extern "C" fn js_fs_fchown_sync(fd_value: f64, uid_value: f64, gid_value: f64) -> i32 {
+    // #2013 order: validate fd type, uid type+range, gid type+range,
+    // THEN bounce on EBADF. Node's `validateInteger(uid)` fires before
+    // the syscall, so `fchownSync(1, "", 0)` throws ERR_INVALID_ARG_TYPE
+    // for `uid`, not EBADF for `fd` — preserve that order even though
+    // the missing-fd case still needs EBADF after all args check out.
     crate::fs::validate::validate_fd(fd_value);
     crate::fs::validate::validate_int32(uid_value, "uid", -1, u32::MAX as i64);
     crate::fs::validate::validate_int32(gid_value, "gid", -1, u32::MAX as i64);
+    if !crate::fs::fd_is_registered(fd_value as i32) {
+        crate::fs::validate::throw_ebadf_pub("fchown");
+    }
     fchown_sync_inner(fd_value as i32, uid_value, gid_value)
 }
 

--- a/crates/perry-runtime/src/fs/validate.rs
+++ b/crates/perry-runtime/src/fs/validate.rs
@@ -167,6 +167,28 @@ pub(crate) fn validate_fd(value: f64) {
     validate_int32(value, "fd", 0, i32::MAX as i64);
 }
 
+/// Issue #2013 — validate an `fd` argument AND verify it's an open
+/// descriptor in Perry's `FD_REGISTRY`. Mirrors Node's "validate fd
+/// type, then bounce on EBADF" pattern for the fd-only sync surface
+/// (`fs.closeSync`, `fs.readSync`, `fs.readvSync`, `fs.fsyncSync`,
+/// `fs.fdatasyncSync`, `fs.fchmodSync`, `fs.fchownSync`, …). Path-or-fd
+/// readers/writers route through `validate_path_or_fd` instead, which
+/// has its own EBADF branch keyed on the same registry probe.
+pub(crate) fn validate_fd_open(value: f64, syscall: &'static str) {
+    validate_fd(value);
+    let jv = JSValue::from_bits(value.to_bits());
+    let fd = numeric_to_i32(jv);
+    if !crate::fs::fd_is_registered(fd) {
+        throw_ebadf_pub(syscall);
+    }
+}
+
+/// Public alias for `throw_ebadf` so the fs entry points can throw a
+/// matching `EBADF` from outside this module (#2013).
+pub(crate) fn throw_ebadf_pub(syscall: &'static str) -> ! {
+    throw_ebadf(syscall)
+}
+
 /// Validate that `value` is a finite integer in `[min, max]`. On type or
 /// range failure throws Node's `ERR_INVALID_ARG_TYPE` / `ERR_OUT_OF_RANGE`
 /// with the same `Received` clause shape Node uses.

--- a/test-parity/node-suite/fs/sync/arg-validation.ts
+++ b/test-parity/node-suite/fs/sync/arg-validation.ts
@@ -63,6 +63,50 @@ probe("writeSync({},'x')", () => fs.writeSync({} as any, "x"));
 probe("writevSync(null,[])", () => fs.writevSync(null as any, []));
 probe("writevSync(null,[Buffer.from('x')])", () => fs.writevSync(null as any, [Buffer.from("x")]));
 
+// #2013 extension — gap-fill for fd-only / path-mutator surface that
+// PR #2035 didn't reach: each new probe pins both the
+// non-numeric → ERR_INVALID_ARG_TYPE branch and the numeric-but-not-open
+// → EBADF branch where applicable. Trimmed shapes only; the upper block
+// already covers boolean-vs-object-vs-NaN-vs-Infinity for the legacy set.
+
+// closeSync(fd) — fd validation + EBADF on a closed/unknown fd.
+probe("closeSync(true)", () => fs.closeSync(true as any));
+probe("closeSync(123)", () => fs.closeSync(123 as any));
+
+// readSync(fd, buf, …) — same shape; needs a real buffer arg to clear
+// the buffer-shape check before the fd path runs.
+probe("readSync(true,buf,0,1,0)", () =>
+  fs.readSync(true as any, Buffer.alloc(1), 0, 1, 0),
+);
+probe("readSync(123,buf,0,1,0)", () =>
+  fs.readSync(123 as any, Buffer.alloc(1), 0, 1, 0),
+);
+
+// readvSync(fd, buffers) — non-empty iovec branch triggers EBADF.
+probe("readvSync(true,[buf])", () =>
+  fs.readvSync(true as any, [Buffer.alloc(1)]),
+);
+probe("readvSync(123,[buf])", () =>
+  fs.readvSync(123 as any, [Buffer.alloc(1)]),
+);
+
+// fchmodSync(fd, mode) — fd validation, plus mode out-of-range on a
+// valid (numeric) fd via the EBADF path.
+probe("fchmodSync(true,0o755)", () => fs.fchmodSync(true as any, 0o755));
+probe("fchmodSync(123,0o755)", () => fs.fchmodSync(123 as any, 0o755));
+
+// writeSync(fd, …) — numeric-but-unknown fd must flip from "no-throw,
+// returns 0" to EBADF.
+probe("writeSync(123,'x')", () => fs.writeSync(123 as any, "x"));
+probe("writeSync(123,buf)", () => fs.writeSync(123 as any, Buffer.from("x")));
+
+// chmodSync(path, mode) — path-only validation.
+probe("chmodSync(true,0o755)", () => fs.chmodSync(true as any, 0o755));
+
+// renameSync(oldPath, newPath) — both args path-validated.
+probe("renameSync(true,'/x')", () => fs.renameSync(true as any, "/x"));
+probe("renameSync('/x',42)", () => fs.renameSync("/x", 42 as any));
+
 // `existsSync` never throws on bad input (Node 22+ instead prints DEP0187
 // to stderr, which the parity runner would capture into the diff). The
 // no-throw contract is exercised by other tests in this suite.


### PR DESCRIPTION
## Summary

PR #2035 added the validation pattern for `fs.readFileSync` / `fs.accessSync` / `fs.statSync` / `fs.openSync`; the issue's follow-up call-out lists ~27 fs functions that still hit "Missing expected exception" because they don't yet validate. This gap-fills the fd-only sync surface and the path-mutator sync surface so each:

- throws `TypeError [ERR_INVALID_ARG_TYPE]` on a non-fd / non-path first argument (matches Node);
- throws `Error [EBADF]` on a numeric fd that isn't open in perry-runtime's `FD_REGISTRY` (matches Node's syscall surface).

Touched entry points:

- `closeSync`, `readSync`, `readvSync`, `writeSync` (string + buffer), `writevSync`, `fchmodSync`, `fsyncSync`, `fdatasyncSync`, `fchownSync` — fd validation + EBADF
- `chmodSync`, `renameSync` — path validation

New `validate_fd_open(value, syscall)` helper combines the existing `validate_fd` type+range probe with an `FD_REGISTRY` membership check + EBADF throw. Callers that need the validation order preserved (`fchownSync`: validate uid+gid BEFORE EBADF, per Node's `validateInteger` ordering) keep the bare `validate_fd` and issue the EBADF after the rest of the int32 validations. `validate_fd` itself stays single-purpose so the FileHandle wrappers — which can legitimately hold a `-1` sentinel from a failed open — keep their silent no-op fallback.

Mode validation in `fchmodSync` and `chmodSync` is deliberately omitted: Node uses `parseFileMode` which throws `ERR_INVALID_ARG_VALUE`, not the `validate_int32` shape — left as a follow-up to keep the diff focused.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo test --release -p perry-runtime --lib` — 746/746 green (no regressions).
- [x] `test-parity/node-suite/fs/sync/arg-validation.ts` extended with 13 new probes (closeSync, readSync, readvSync, writeSync ×2, fchmodSync ×2, chmodSync, renameSync ×2 covering both type-error and EBADF branches). Byte-identical against `node --experimental-strip-types`; the existing legacy block stays byte-identical.

Closes the fd-only + path-mutator slice of #2013; the remaining ~80 tests across buffer / net / zlib / http / process / crypto / url stay tracked under the same issue.
