### PR TITLE
fix(hir): allow optional require in try blocks

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -109,6 +109,7 @@ impl LoweringContext {
             object_static_method_aliases: HashMap::new(),
             is_entry_module: false,
             is_external_module: false,
+            optional_require_try_depth: 0,
         }
     }
 

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -36,6 +36,7 @@ pub(super) fn try_require_literal_bail(ctx: &LoweringContext, call: &ast::CallEx
             // unknown-callee path) until we wire up real `require(literal)`
             // lowering.
             if !ctx.is_external_module
+                && ctx.optional_require_try_depth == 0
                 && ident.sym.as_ref() == "require"
                 && ctx.lookup_local("require").is_none()
                 && ctx.lookup_func("require").is_none()

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -410,4 +410,11 @@ pub struct LoweringContext {
     /// `@perryts/redis` deliberately use `require(literal)` to defer
     /// cycle-breaking imports inside method bodies that may never execute.
     pub(crate) is_external_module: bool,
+    /// Depth of nested `try { ... }` bodies currently being lowered.
+    /// Optional platform modules in Electron-style code commonly use
+    /// `try { var x = require("native-addon") } catch {}`. Let those sites
+    /// lower to the existing runtime failure path so the catch block can
+    /// observe the failure instead of rejecting the whole user source at
+    /// compile time. Outside try blocks, `require(literal)` still hard-errors.
+    pub(crate) optional_require_try_depth: u32,
 }

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -1147,7 +1147,11 @@ pub(crate) fn lower_stmt(
         }
         ast::Stmt::Try(try_stmt) => {
             // try body is its own lexical scope
-            let body = lower_block_stmt_scoped(ctx, &try_stmt.block)?;
+            let previous_optional_require_try_depth = ctx.optional_require_try_depth;
+            ctx.optional_require_try_depth = previous_optional_require_try_depth.saturating_add(1);
+            let body_result = lower_block_stmt_scoped(ctx, &try_stmt.block);
+            ctx.optional_require_try_depth = previous_optional_require_try_depth;
+            let body = body_result?;
 
             // Lower catch clause (if present)
             let catch = if let Some(ref catch_clause) = try_stmt.handler {

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -754,7 +754,11 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
         }
         ast::Stmt::Try(try_stmt) => {
             // try body is its own lexical scope
-            let body = lower_block_stmt_scoped(ctx, &try_stmt.block)?;
+            let previous_optional_require_try_depth = ctx.optional_require_try_depth;
+            ctx.optional_require_try_depth = previous_optional_require_try_depth.saturating_add(1);
+            let body_result = lower_block_stmt_scoped(ctx, &try_stmt.block);
+            ctx.optional_require_try_depth = previous_optional_require_try_depth;
+            let body = body_result?;
 
             // Lower catch clause (if present)
             let catch = if let Some(ref catch_clause) = try_stmt.handler {

--- a/crates/perry-hir/tests/optional_require_try.rs
+++ b/crates/perry-hir/tests/optional_require_try.rs
@@ -1,0 +1,53 @@
+use perry_hir::lower_module;
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_result(src: &str) -> Result<(), String> {
+    let mut cache = Default::default();
+    let parsed = parse_typescript_with_cache(src, "test.ts", &mut cache)
+        .map_err(|e| format!("parse failed: {e:?}"))?;
+    lower_module(&parsed.module, "test", "test.ts")
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+#[test]
+fn optional_require_in_try_body_lowers() {
+    let src = r#"
+        var optionalNative = null;
+        try {
+            optionalNative = require("missing-optional-native-addon");
+        } catch {
+            optionalNative = null;
+        }
+    "#;
+
+    lower_result(src).expect("optional require inside try should lower");
+}
+
+#[test]
+fn require_outside_try_still_errors() {
+    let src = r#"
+        const nativeAddon = require("missing-optional-native-addon");
+    "#;
+
+    let err = lower_result(src).expect_err("require outside try must keep failing fast");
+    assert!(
+        err.contains("CommonJS `require(\"missing-optional-native-addon\")` is not supported"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn optional_require_in_function_try_body_lowers() {
+    let src = r#"
+        function loadOptional() {
+            try {
+                return require("missing-optional-native-addon");
+            } catch {
+                return null;
+            }
+        }
+    "#;
+
+    lower_result(src).expect("optional require inside function try should lower");
+}


### PR DESCRIPTION
## Summary
- allow user-source `require(literal)` inside `try` bodies to lower instead of hard-failing
- keep the existing hard error for `require(literal)` outside `try`
- add HIR regression coverage for module and function try blocks

## Why
Tabby/Electron-style optional native modules commonly use try/catch around platform-specific native dependencies. This lets the catch path handle unsupported hosts instead of rejecting the source during lowering.

This is intentionally not full CommonJS support.

## Validation
- `cargo fmt --check`
- `cargo build -p perry`
- `cargo test -p perry-hir --test optional_require_try`
- Windows Tabby probe: compiling `tabby-electron/src/pty.ts` with `--no-link --no-auto-optimize` now gets past the optional native `require()` calls and stops at the next separate blocker, unresolved namespace import `ps-node`.
