### PR TITLE
fix(node:url): preserve base path for query relatives

### DIFF
--- a/crates/perry-runtime/src/url/parse.rs
+++ b/crates/perry-runtime/src/url/parse.rs
@@ -154,7 +154,30 @@ pub(crate) fn resolve_url(url_str: &str, base_str: &str) -> String {
         return url_str.to_string();
     }
 
-    let (base_protocol, base_host, _, _, base_pathname, _, _) = parse_url(base_str);
+    let (base_protocol, base_host, _, _, base_pathname, base_search, _) = parse_url(base_str);
+
+    if url_str.starts_with('?') {
+        if base_protocol == "file:" || base_host.is_empty() {
+            return format!("{}{}{}", base_protocol, base_pathname, url_str);
+        }
+        return format!(
+            "{}//{}{}{}",
+            base_protocol, base_host, base_pathname, url_str
+        );
+    }
+
+    if url_str.starts_with('#') {
+        if base_protocol == "file:" || base_host.is_empty() {
+            return format!(
+                "{}{}{}{}",
+                base_protocol, base_pathname, base_search, url_str
+            );
+        }
+        return format!(
+            "{}//{}{}{}{}",
+            base_protocol, base_host, base_pathname, base_search, url_str
+        );
+    }
 
     if url_str.starts_with("//") {
         // Protocol-relative URL


### PR DESCRIPTION
## Summary
- preserve the base pathname when resolving query-only relative URLs like `?q=1`
- preserve the base pathname and search when resolving hash-only relative URLs like `#h`
- leave ordinary path-relative and protocol-relative URL resolution paths unchanged

## Verification
- Baseline exact `node-suite/url/url/base-and-relative`: FAIL, report `test-parity/reports/parity_report_20260528_162053.json`
- Final exact `node-suite/url/url/base-and-relative`: PASS, report `test-parity/reports/parity_report_20260528_162351.json`
- Focused `node-suite/url/url`: 14 PASS / 2 parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260528_162437.json`; remaining failures are #2330’s unmerged invalid-setters fix and the older URL normalization residual
- `cargo check -p perry-runtime` PASS with existing warnings
- `cargo fmt --check` PASS
- `git diff --check` PASS

## Notes
Direct Node output from `test-parity/node-suite/url/url/base-and-relative.ts` was used for the query/hash-only relative URL behavior.