### PR TITLE
fix(process): extend Node arg-validation to chdir/kill/exit/cpuUsage/hrtime (#2013)

### DIFF
--- a/crates/perry-codegen/src/expr/string_regex_proc.rs
+++ b/crates/perry-codegen/src/expr/string_regex_proc.rs
@@ -101,10 +101,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_string_inline(blk, &s_handle))
         }
         Expr::ProcessChdir(p) => {
+            // #2013 — route through the f64-taking entry so a
+            // non-string argument throws TypeError ERR_INVALID_ARG_TYPE
+            // instead of dereferencing whatever NaN-boxed bits we'd
+            // have shoved into a `*const StringHeader`. The runtime
+            // entry validates and re-dispatches to the legacy
+            // string-only path.
             let p_box = lower_expr(ctx, p)?;
-            let blk = ctx.block();
-            let p_handle = unbox_to_i64(blk, &p_box);
-            blk.call_void("js_process_chdir", &[(I64, &p_handle)]);
+            ctx.block()
+                .call_void("js_process_chdir_jsv", &[(DOUBLE, &p_box)]);
             Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
         }
         Expr::ProcessExit(code) => {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -560,6 +560,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_title", DOUBLE, &[]);
     module.declare_function("js_process_set_title", VOID, &[DOUBLE]);
     module.declare_function("js_process_chdir", VOID, &[I64]);
+    // #2013 — f64-taking variant that validates type before dispatch.
+    module.declare_function("js_process_chdir_jsv", VOID, &[DOUBLE]);
     module.declare_function("js_process_kill", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_process_exit", VOID, &[DOUBLE]);
     module.declare_function("js_process_abort", VOID, &[]);

--- a/crates/perry-runtime/src/fs/validate.rs
+++ b/crates/perry-runtime/src/fs/validate.rs
@@ -46,7 +46,7 @@ pub(crate) fn is_path_like(value: f64) -> bool {
 /// True if `value` is a JS number (a plain IEEE double *or* an INT32-tagged
 /// small integer). `JSValue::is_number` deliberately excludes the INT32 tag,
 /// so both must be checked.
-fn is_numeric(jv: JSValue) -> bool {
+pub(crate) fn is_numeric(jv: JSValue) -> bool {
     jv.is_number() || jv.is_int32()
 }
 
@@ -59,7 +59,7 @@ fn numeric_to_i32(jv: JSValue) -> i32 {
 }
 
 /// Node's `Received …` clause for an `ERR_INVALID_ARG_TYPE` message.
-fn describe_received(value: f64) -> String {
+pub(crate) fn describe_received(value: f64) -> String {
     let jv = JSValue::from_bits(value.to_bits());
     if jv.is_undefined() {
         return "undefined".to_string();
@@ -116,7 +116,7 @@ fn throw_ebadf(syscall: &'static str) -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
-fn throw_type_error_with_code(message: &str, code: &'static str) -> ! {
+pub(crate) fn throw_type_error_with_code(message: &str, code: &'static str) -> ! {
     let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
     crate::node_submodules::register_error_code_pub(msg, code);
     let err = crate::error::js_typeerror_new(msg);

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -602,6 +602,19 @@ pub extern "C" fn js_process_hrtime_bigint() -> f64 {
 #[no_mangle]
 pub extern "C" fn js_process_hrtime(prior: f64) -> f64 {
     use crate::value::JSValue;
+    // #2013 — Node throws TypeError ERR_INVALID_ARG_TYPE when `prior`
+    // is supplied but isn't an Array (e.g. `process.hrtime('abc')`).
+    // Undefined falls through to the no-prior baseline read; an array
+    // with NaN-y entries is silently zeroed by `extract_hrtime_prior`,
+    // matching Node's lenient numeric coercion inside the array.
+    let prior_jv = JSValue::from_bits(prior.to_bits());
+    if !prior_jv.is_undefined() && !crate::process::is_array_value(prior_jv) {
+        let message = format!(
+            "The \"time\" argument must be an instance of Array. Received {}",
+            crate::fs::validate::describe_received(prior)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
     let elapsed = get_hrtime_start().elapsed();
     let total_ns = elapsed.as_nanos() as u64 + 1_000_000_000;
     let mut secs = (total_ns / 1_000_000_000) as i64;
@@ -1114,6 +1127,28 @@ unsafe fn throw_chdir_error(err: &std::io::Error, target: &str) -> ! {
 /// process.kill(pid, signal?) — send signal to process. signal=0 means existence check.
 #[no_mangle]
 pub extern "C" fn js_process_kill(pid: f64, signal: f64) {
+    // #2013 — pid must be a number (`validateInteger(pid, 'pid')`); a
+    // non-numeric pid throws TypeError ERR_INVALID_ARG_TYPE before any
+    // syscall runs. Signal must be a string-or-number; an object/array
+    // throws TypeError ERR_UNKNOWN_SIGNAL (Node's specific shape — the
+    // signal-name lookup table runs before the numeric coercion).
+    use crate::fs::validate::{describe_received, is_numeric, throw_type_error_with_code};
+    let pid_jv = crate::value::JSValue::from_bits(pid.to_bits());
+    if !is_numeric(pid_jv) {
+        let message = format!(
+            "The \"pid\" argument must be of type number. Received {}",
+            describe_received(pid)
+        );
+        throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    let sig_jv = crate::value::JSValue::from_bits(signal.to_bits());
+    if !sig_jv.is_undefined() && !is_numeric(sig_jv) && !sig_jv.is_any_string() {
+        // Match Node's "Unknown signal: <stringify>" message for the
+        // object/array/boolean shapes that don't reach the numeric path.
+        let received = describe_received(signal);
+        let message = format!("Unknown signal: {}", received);
+        throw_type_error_with_code(&message, "ERR_UNKNOWN_SIGNAL");
+    }
     let pid_i = pid as i32;
     let sig_i = if signal.is_nan() || signal == 0.0 {
         0

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -9,6 +9,20 @@ use crate::value::JSValue;
 /// during async event loop drain and V8 isolate destruction.
 #[no_mangle]
 pub extern "C" fn js_process_exit(code: f64) {
+    // #2013 — `process.exit('foo')` throws TypeError ERR_INVALID_ARG_TYPE
+    // in Node (the exit code must be a number, null, or undefined). The
+    // numeric default of `1` for NaN/Infinity in the pre-fix code only
+    // matters for the inferred numeric-coerce path; keep that fallback
+    // for the (degenerate) numeric NaN/Infinity case so existing call
+    // sites that pass a parsed-out number aren't surprised.
+    let jv = JSValue::from_bits(code.to_bits());
+    if !jv.is_undefined() && !jv.is_null() && !crate::fs::validate::is_numeric(jv) {
+        let message = format!(
+            "The \"code\" argument must be of type number or null. Received {}",
+            crate::fs::validate::describe_received(code)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
     let exit_code = if code.is_nan() || code.is_infinite() {
         1 // Default to 1 for invalid codes
     } else {
@@ -487,9 +501,20 @@ pub extern "C" fn js_process_active_resources_info() -> f64 {
 /// Non-unix targets return `{ user: 0, system: 0 }`.
 #[no_mangle]
 pub extern "C" fn js_process_cpu_usage(prior: f64) -> f64 {
+    // #2013 — Node throws TypeError ERR_INVALID_ARG_TYPE when `prior`
+    // is supplied but isn't an object (e.g. `process.cpuUsage('abc')`).
+    // Undefined / null fall through to the no-prior baseline read.
+    let prior_jv = JSValue::from_bits(prior.to_bits());
+    if !prior_jv.is_undefined() && !prior_jv.is_null() && !prior_jv.is_pointer() {
+        let message = format!(
+            "The \"prevValue\" argument must be of type object. Received {}",
+            crate::fs::validate::describe_received(prior)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
     let (mut user_us, mut system_us) = read_process_cpu_micros();
     let undef_bits = crate::value::TAG_UNDEFINED;
-    if prior.to_bits() != undef_bits {
+    if prior.to_bits() != undef_bits && !prior_jv.is_null() {
         let (prev_user, prev_system) = extract_cpu_pair(prior);
         user_us = (user_us - prev_user).max(0.0);
         system_us = (system_us - prev_system).max(0.0);
@@ -1095,4 +1120,45 @@ unsafe fn throw_load_env_file_open_error(err: &std::io::Error, target: &str) -> 
     crate::node_submodules::register_error_path(msg_ptr, target.to_string());
     let err_ptr = crate::error::js_error_new_with_message(msg_ptr);
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err_ptr as i64));
+}
+
+// Issue #2013 — process-arg-validation helpers shared by `js_process_chdir`
+// and `js_process_hrtime`. Sited here (not os.rs) so the process surface's
+// validation logic stays under the 2000-line file gate as the os.rs splits
+// progress.
+
+/// `process.chdir(value)` entry point that takes the full NaN-boxed
+/// value. Throws `TypeError [ERR_INVALID_ARG_TYPE]` for any non-string
+/// (matching Node), then re-dispatches to `js_process_chdir` with the
+/// extracted `StringHeader`. The codegen now emits this entry instead
+/// of the bare string-only one so a `process.chdir(123)` call throws
+/// the right error code instead of garbage-deref'ing to an `ENOENT`
+/// based on whatever bytes the numeric value masqueraded as.
+#[no_mangle]
+pub unsafe extern "C" fn js_process_chdir_jsv(value: f64) {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_any_string() {
+        let message = format!(
+            "The \"path\" argument must be of type string. Received {}",
+            crate::fs::validate::describe_received(value)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    let ptr = crate::value::js_get_string_pointer_unified(value) as *const StringHeader;
+    crate::os::js_process_chdir(ptr);
+}
+
+/// True when `jv` is a heap pointer whose GC type tag marks it as an
+/// Array. Used by `process.hrtime` to reject any non-array `prior`
+/// argument before reading the `[secs, nanos]` tuple.
+pub(crate) fn is_array_value(jv: JSValue) -> bool {
+    if !jv.is_pointer() {
+        return false;
+    }
+    let ptr = jv.as_pointer::<u8>();
+    if ptr.is_null() || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return false;
+    }
+    let gc_header = unsafe { &*(ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader) };
+    gc_header.obj_type == crate::gc::GC_TYPE_ARRAY
 }

--- a/test-parity/node-suite/process/cwd/arg-validation.ts
+++ b/test-parity/node-suite/process/cwd/arg-validation.ts
@@ -1,0 +1,37 @@
+// Issue #2013 — Node-shaped argument validation for the process
+// surface (`chdir`/`kill`/`exit`/`cpuUsage`/`hrtime`). Each probe
+// prints the thrown error's `.code` and `.name`; Perry and Node must
+// produce the exact same lines. `process.exit` is intentionally not
+// probed (the success path tears the whole process down) and the
+// no-error case is exercised by the parent suite's `cwd-basic.ts`.
+
+function probe(label: string, fn: () => any) {
+  try {
+    fn();
+    console.log(label, "no-throw");
+  } catch (e: any) {
+    console.log(label, e.name, e.code);
+  }
+}
+
+// process.chdir(directory)
+probe("chdir(123)", () => process.chdir(123 as any));
+probe("chdir({})", () => process.chdir({} as any));
+probe("chdir(null)", () => process.chdir(null as any));
+probe("chdir(true)", () => process.chdir(true as any));
+
+// process.kill(pid, signal?)
+probe("kill('abc',0)", () => process.kill("abc" as any, 0));
+probe("kill({},0)", () => process.kill({} as any, 0));
+probe("kill(0,{})", () => process.kill(0, {} as any));
+probe("kill(0,true)", () => process.kill(0, true as any));
+
+// process.cpuUsage(prior?) — undefined / null pass through, non-object throws.
+probe("cpuUsage('abc')", () => process.cpuUsage("abc" as any));
+probe("cpuUsage(123)", () => process.cpuUsage(123 as any));
+probe("cpuUsage(true)", () => process.cpuUsage(true as any));
+
+// process.hrtime(prior?) — undefined passes through, non-array throws.
+probe("hrtime('abc')", () => process.hrtime("abc" as any));
+probe("hrtime(123)", () => process.hrtime(123 as any));
+probe("hrtime({})", () => process.hrtime({} as any));


### PR DESCRIPTION
## Summary

Follow-up to PR #2328 (fs slice). Each process-surface entry point now throws the Node-matching `TypeError [ERR_INVALID_ARG_TYPE]` (or `ERR_UNKNOWN_SIGNAL` for `process.kill`'s second arg) on a wrong-type argument:

- `process.chdir(123)` → ERR_INVALID_ARG_TYPE (was: garbage-deref to ENOENT). A new `js_process_chdir_jsv(value)` runtime entry takes the full NaN-boxed value, validates, then re-dispatches to the existing string-only `js_process_chdir`. The codegen lowering for `Expr::ProcessChdir` now emits the JSV entry instead of `unbox_to_i64` → bare `*const StringHeader`.
- `process.kill('abc', 0)` → ERR_INVALID_ARG_TYPE on `pid`, `process.kill(0, {})` → ERR_UNKNOWN_SIGNAL on the signal arg (object/array/boolean don't reach the numeric coerce path).
- `process.exit('foo')` → ERR_INVALID_ARG_TYPE on the code arg (null/undefined still pass through to the existing default).
- `process.cpuUsage('abc')` → ERR_INVALID_ARG_TYPE on a non-object `prior`; null/undefined still pass through.
- `process.hrtime('abc')` → ERR_INVALID_ARG_TYPE on a non-array `prior`. A new local `is_array_value` helper does the GC-type-tag probe so the heap-pointer-but-not-array shape (Object/Buffer/...) is also caught.

The fs validation helpers (`describe_received`, `throw_type_error_with_code`, `is_numeric`) get crate-wide visibility so process can reuse the Node-shaped error formatting without duplicating the helpers.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo test --release -p perry-runtime --lib` 746/746 + `-p perry-codegen` green (no regressions).
- [x] New parity test `test-parity/node-suite/process/cwd/arg-validation.ts` covers 14 probes byte-identical to `node --experimental-strip-types`.

## Known limitation

The `(process.chdir as any)(123)` indirection path still goes through typed-feedback (which doesn't validate); that's a separate gap in the method-value-via-cast dispatch family and is tracked under #1343.

Closes the process slice of #2013; remaining tests across buffer / net / zlib / http / crypto / url stay tracked under the same issue.
