### PR TITLE
fix(node:url): punycode hostname setter values

### DIFF
--- a/crates/perry-runtime/src/url/parse.rs
+++ b/crates/perry-runtime/src/url/parse.rs
@@ -411,6 +411,17 @@ pub(crate) unsafe fn rebuild_url_href(url: *mut ObjectHeader) {
     js_object_set_field_f64(url, URL_HREF, create_string_f64(&href));
 }
 
+pub(crate) unsafe fn rebuild_url_origin(url: *mut ObjectHeader) {
+    let protocol = get_string_content(crate::object::js_object_get_field_f64(url, URL_PROTOCOL));
+    let host = get_string_content(crate::object::js_object_get_field_f64(url, URL_HOST));
+    let origin = if protocol == "file:" || host.is_empty() {
+        "null".to_string()
+    } else {
+        format!("{}//{}", protocol, host)
+    };
+    js_object_set_field_f64(url, URL_ORIGIN, create_string_f64(&origin));
+}
+
 /// Recompose `host` (`hostname[:port]`) from the URL's `hostname` and `port`
 /// fields, stripping default ports for known hierarchical schemes.
 pub(crate) unsafe fn rebuild_url_host(url: *mut ObjectHeader) {
@@ -433,6 +444,7 @@ pub(crate) unsafe fn rebuild_url_host(url: *mut ObjectHeader) {
         format!("{}:{}", hostname, port)
     };
     js_object_set_field_f64(url, URL_HOST, create_string_f64(&host));
+    rebuild_url_origin(url);
 }
 
 /// Validate that `s` looks like a parseable absolute URL — has a scheme

--- a/crates/perry-runtime/src/url/url_class.rs
+++ b/crates/perry-runtime/src/url/url_class.rs
@@ -11,6 +11,24 @@ use super::search_params::{
     create_url_search_params_object, parse_query_string, URL_SEARCH_PARAMS_OWNER,
 };
 
+fn normalize_hostname_value(raw: &str) -> Option<String> {
+    if raw.is_empty()
+        || raw.chars().any(|c| {
+            c.is_ascii_control()
+                || matches!(
+                    c,
+                    ' ' | '#' | '/' | ':' | '<' | '>' | '?' | '@' | '[' | '\\' | ']' | '^' | '|'
+                )
+        })
+    {
+        return None;
+    }
+    match idna::domain_to_ascii(raw) {
+        Ok(ascii) if !ascii.is_empty() => Some(ascii),
+        _ => None,
+    }
+}
+
 /// Create a new URL from a string
 /// js_url_new(url: *mut StringHeader) -> *mut ObjectHeader (URL object)
 #[no_mangle]
@@ -183,7 +201,9 @@ pub extern "C" fn js_url_set_hostname(url: *mut ObjectHeader, value: *mut crate:
     if url.is_null() {
         return;
     }
-    let raw = string_header_to_string(value);
+    let Some(raw) = normalize_hostname_value(&string_header_to_string(value)) else {
+        return;
+    };
     unsafe {
         js_object_set_field_f64(url, URL_HOSTNAME, create_string_f64(&raw));
         rebuild_url_host(url);

--- a/test-parity/node-suite/url/url/hostname-setter-punycode-origin.ts
+++ b/test-parity/node-suite/url/url/hostname-setter-punycode-origin.ts
@@ -1,0 +1,6 @@
+const u = new URL("https://example.com:8080/a?x=1#h");
+u.hostname = "mañana.com";
+console.log("href:", u.href);
+console.log("origin:", u.origin);
+console.log("hostname:", u.hostname);
+console.log("host:", u.host);


### PR DESCRIPTION
## Summary
- normalize assigned WHATWG `URL.hostname` values through IDNA/Punycode
- ignore clearly invalid hostname setter values instead of storing them raw
- refresh `origin` when host recomposition changes the URL host

## Verification
- Baseline exact `node-suite/url/url/hostname-setter-punycode-origin`: FAIL, report `test-parity/reports/parity_report_20260528_162914.json`
- Final exact `node-suite/url/url/hostname-setter-punycode-origin`: PASS, report `test-parity/reports/parity_report_20260528_163236.json`
- Guardrail `node-suite/url/url/setters`: PASS, report `test-parity/reports/parity_report_20260528_163321.json`
- Focused `node-suite/url/url`: 14 PASS / 3 parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260528_163337.json`; target fixture is green, remaining failures are separate open PRs #2330/#2331 and the username/password/path/hash percent-encoding residual
- `cargo check -p perry-runtime` PASS with existing warnings
- `cargo fmt --check` PASS
- `git diff --check` PASS

## DeepWiki
- `reference/deepwiki/node-url-hostname-setter-punycode-origin.md`

## Non-goals
- no constructor hostname punycode cleanup
- no broad WHATWG URL parser rewrite
- no username/password/path/hash percent-encoding
- no invalid `href` setter or query/hash-only relative URL changes