### PR TITLE
fix(node:url): percent-encode path and hash setters

### DIFF
--- a/crates/perry-runtime/src/url/url_class.rs
+++ b/crates/perry-runtime/src/url/url_class.rs
@@ -69,6 +69,41 @@ fn percent_encode_userinfo(raw: &str) -> String {
     out
 }
 
+fn should_strip_url_ascii_whitespace(b: u8) -> bool {
+    matches!(b, b'\t' | b'\n' | b'\r')
+}
+
+fn should_percent_encode_path_byte(b: u8) -> bool {
+    b <= 0x1F
+        || b >= 0x7F
+        || matches!(
+            b,
+            b' ' | b'"' | b'#' | b'<' | b'>' | b'?' | b'`' | b'{' | b'}'
+        )
+}
+
+fn should_percent_encode_fragment_byte(b: u8) -> bool {
+    b <= 0x1F || b >= 0x7F || matches!(b, b' ' | b'"' | b'<' | b'>' | b'`')
+}
+
+fn percent_encode_url_component(raw: &str, should_encode: impl Fn(u8) -> bool) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut out = String::with_capacity(raw.len());
+    for &b in raw.as_bytes() {
+        if should_strip_url_ascii_whitespace(b) {
+            continue;
+        }
+        if should_encode(b) {
+            out.push('%');
+            out.push(HEX[(b >> 4) as usize] as char);
+            out.push(HEX[(b & 0x0F) as usize] as char);
+        } else {
+            out.push(b as char);
+        }
+    }
+    out
+}
+
 fn url_can_have_credentials(url: *mut ObjectHeader) -> bool {
     let host = get_string_content(crate::object::js_object_get_field_f64(url, URL_HOST));
     let protocol = get_string_content(crate::object::js_object_get_field_f64(url, URL_PROTOCOL));
@@ -91,6 +126,14 @@ fn normalize_hostname_value(raw: &str) -> Option<String> {
         Ok(ascii) if !ascii.is_empty() => Some(ascii),
         _ => None,
     }
+}
+
+fn percent_encode_path(raw: &str) -> String {
+    percent_encode_url_component(raw, should_percent_encode_path_byte)
+}
+
+fn percent_encode_fragment(raw: &str) -> String {
+    percent_encode_url_component(raw, should_percent_encode_fragment_byte)
 }
 
 /// Create a new URL from a string
@@ -192,7 +235,8 @@ pub extern "C" fn js_url_set_pathname(url: *mut ObjectHeader, value: *mut crate:
         } else {
             raw
         };
-        js_object_set_field_f64(url, URL_PATHNAME, create_string_f64(&normalized));
+        let encoded = percent_encode_path(&normalized);
+        js_object_set_field_f64(url, URL_PATHNAME, create_string_f64(&encoded));
         rebuild_url_href(url);
     }
 }
@@ -400,8 +444,9 @@ pub extern "C" fn js_url_set_hash(url: *mut ObjectHeader, value: *mut crate::Str
     } else {
         format!("#{}", raw)
     };
+    let encoded = percent_encode_fragment(&normalized);
     unsafe {
-        js_object_set_field_f64(url, URL_HASH, create_string_f64(&normalized));
+        js_object_set_field_f64(url, URL_HASH, create_string_f64(&encoded));
         rebuild_url_href(url);
     }
 }

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1501 entries across 82 modules
+// Coverage: 1505 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -2077,6 +2077,10 @@ declare module "util/types" {
   /** stdlib */
   export function isArrayBufferView(...args: any[]): any;
   /** stdlib */
+  export function isBigInt64Array(...args: any[]): any;
+  /** stdlib */
+  export function isBigUint64Array(...args: any[]): any;
+  /** stdlib */
   export function isBooleanObject(...args: any[]): any;
   /** stdlib */
   export function isBoxedPrimitive(...args: any[]): any;
@@ -2086,6 +2090,10 @@ declare module "util/types" {
   export function isFloat32Array(...args: any[]): any;
   /** stdlib */
   export function isFloat64Array(...args: any[]): any;
+  /** stdlib */
+  export function isGeneratorFunction(...args: any[]): any;
+  /** stdlib */
+  export function isGeneratorObject(...args: any[]): any;
   /** stdlib */
   export function isInt16Array(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1501 entries across 82 modules.
+Total: 1505 entries across 82 modules.
 
 ## Modules
 
@@ -1997,11 +1997,15 @@ Total: 1501 entries across 82 modules.
 - `isAnyArrayBuffer` — module
 - `isArrayBuffer` — module
 - `isArrayBufferView` — module
+- `isBigInt64Array` — module
+- `isBigUint64Array` — module
 - `isBooleanObject` — module
 - `isBoxedPrimitive` — module
 - `isDate` — module
 - `isFloat32Array` — module
 - `isFloat64Array` — module
+- `isGeneratorFunction` — module
+- `isGeneratorObject` — module
 - `isInt16Array` — module
 - `isInt32Array` — module
 - `isInt8Array` — module

--- a/test-parity/node-suite/url/url/pathname-hash-setter-percent-encoding.ts
+++ b/test-parity/node-suite/url/url/pathname-hash-setter-percent-encoding.ts
@@ -1,0 +1,20 @@
+const u = new URL("https://example.com/a?x=1#old");
+u.pathname = "/c d";
+u.hash = "frag ment";
+console.log("href:", u.href);
+console.log("pathname:", u.pathname);
+console.log("hash:", u.hash);
+
+const encoded = new URL("https://example.com/");
+encoded.pathname = "/a%20b";
+encoded.hash = "x%20y";
+console.log("encoded href:", encoded.href);
+console.log("encoded pathname:", encoded.pathname);
+console.log("encoded hash:", encoded.hash);
+
+const unicode = new URL("https://example.com/");
+unicode.pathname = "/\u00e9";
+unicode.hash = "\u03c0";
+console.log("unicode href:", unicode.href);
+console.log("unicode pathname:", unicode.pathname);
+console.log("unicode hash:", unicode.hash);


### PR DESCRIPTION
## Summary
- Percent-encode `URL.pathname` setter values with the WHATWG path encode set before rebuilding `href`.
- Percent-encode `URL.hash` setter values with the fragment encode set while preserving literal percent bytes.
- Add a targeted Node parity fixture for spaces, existing percent bytes, and UTF-8 escape inputs.

## Verification
- Baseline exact `node-suite/url/url/pathname-hash-setter-percent-encoding`: FAIL, report `test-parity/reports/parity_report_20260528_164727.json`.
- Final exact `node-suite/url/url/pathname-hash-setter-percent-encoding`: PASS, report `test-parity/reports/parity_report_20260528_165046.json`.
- Guardrail `node-suite/url/url/setters`: PASS, report `test-parity/reports/parity_report_20260528_165140.json`.
- Mutation fixture `node-suite/url/url/mutation-properties`: still FAIL, report `test-parity/reports/parity_report_20260528_165147.json`, but path/hash now match; remaining diffs are userinfo/hostname covered by PRs #2334/#2333.
- Focused `node-suite/url/url`: 14 PASS / 3 parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260528_165155.json`; remaining failures are open PRs #2330/#2331 and userinfo/hostname residuals covered by #2334/#2333.
- `cargo check -p perry-runtime`: PASS with existing warnings.
- `cargo fmt --check`: PASS.
- `git diff --check`: PASS.

## Non-goals
- No username/password userinfo percent-encoding.
- No hostname punycode/origin cleanup.
- No broad WHATWG URL parser rewrite.