### PR TITLE
Define GC pause and progress contract

### DIFF
--- a/crates/perry-runtime/src/arena/block.rs
+++ b/crates/perry-runtime/src/arena/block.rs
@@ -281,6 +281,13 @@ impl Arena {
         // and reclaims at least one fully-empty block (via
         // `arena_reset_empty_blocks`), we may be able to reuse that
         // block instead of pushing a new one.
+        //
+        // This is still the legacy synchronous trigger path: allocation
+        // pressure can run a whole collection here instead of spending a
+        // bounded work-unit budget. The GC progress contract labels it as
+        // `legacy_synchronous`; the later cycle state machine/debt pacer must
+        // replace this direct collection with bounded progress plus optional
+        // mutator assist.
         crate::gc::gc_check_trigger();
 
         // Retry the (possibly newly-reset) current block. arena.current

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -7,6 +7,21 @@
 //! - Mark phase: precise thread-local roots + optional conservative stack scan + type-specific tracing
 //! - Sweep phase: free malloc objects; arena objects added to free list for reuse
 //! - Trigger: only checked on new arena block allocation or explicit gc() call
+//!
+//! Low-pause contract:
+//! - Normal automatic GC work and mutator assists must eventually advance in
+//!   bounded work-unit steps, independent of heap size.
+//! - Explicit `gc()` calls may synchronously run the configured collection
+//!   because the caller requested that pause; traces distinguish manual minor
+//!   work from explicit full collection.
+//! - Emergency full collections are reserved for allocation failure recovery,
+//!   only outside suppressed, reentrant, or unsafe regions, and must be
+//!   reported separately.
+//!
+//! Current threshold-triggered work in `gc_check_trigger()` is still a
+//! behavior-compatible synchronous collection. Trace output labels that path
+//! as `legacy_synchronous` until the cycle state machine and debt pacer turn
+//! allocation pressure into bounded progress.
 
 use std::alloc::{alloc, dealloc, realloc, Layout};
 use std::cell::{Cell, RefCell};

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -1,5 +1,145 @@
 use super::*;
 
+/// Hard work budget for ordinary automatic GC steps once the collector is
+/// split into resumable phases.
+pub const GC_NORMAL_INCREMENTAL_WORK_UNITS: usize = 2_048;
+/// Soft telemetry target for ordinary automatic GC steps.
+pub const GC_NORMAL_INCREMENTAL_SOFT_PAUSE_US: u64 = 2_000;
+/// Hard work budget for allocation-side mutator assist steps.
+pub const GC_MUTATOR_ASSIST_WORK_UNITS: usize = 256;
+/// Soft telemetry target for allocation-side mutator assist steps.
+pub const GC_MUTATOR_ASSIST_SOFT_PAUSE_US: u64 = 500;
+
+/// Runtime-visible classification for GC progress.
+///
+/// Only `NormalIncremental` and `MutatorAssist` satisfy the low-pause
+/// invariant today defined by this contract: bounded by work units, not heap
+/// size. Explicit synchronous work and emergency full collections are allowed
+/// to be unbounded only because they are separately requested or separately
+/// reported.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GcProgressKind {
+    NormalIncremental,
+    MutatorAssist,
+    ExplicitSynchronous,
+    ExplicitFull,
+    EmergencyFull,
+    LegacySynchronous,
+}
+
+impl GcProgressKind {
+    #[inline]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NormalIncremental => "normal_incremental",
+            Self::MutatorAssist => "mutator_assist",
+            Self::ExplicitSynchronous => "explicit_synchronous",
+            Self::ExplicitFull => "explicit_full",
+            Self::EmergencyFull => "emergency_full",
+            Self::LegacySynchronous => "legacy_synchronous",
+        }
+    }
+
+    #[inline]
+    pub const fn is_budgeted(self) -> bool {
+        matches!(self, Self::NormalIncremental | Self::MutatorAssist)
+    }
+
+    #[inline]
+    pub const fn report_class(self) -> &'static str {
+        match self {
+            Self::NormalIncremental | Self::MutatorAssist => "ordinary_budgeted",
+            Self::ExplicitSynchronous | Self::ExplicitFull => "explicit",
+            Self::EmergencyFull => "emergency",
+            Self::LegacySynchronous => "legacy",
+        }
+    }
+}
+
+/// Hard work-unit limit plus a soft pause target for telemetry.
+///
+/// `None` means the path is intentionally unbounded and must be labeled by its
+/// `GcProgressKind`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GcPauseBudget {
+    pub work_units: Option<usize>,
+    pub pause_us: Option<u64>,
+}
+
+impl GcPauseBudget {
+    #[inline]
+    pub const fn bounded(work_units: usize, pause_us: u64) -> Self {
+        Self {
+            work_units: Some(work_units),
+            pause_us: Some(pause_us),
+        }
+    }
+
+    #[inline]
+    pub const fn unbounded() -> Self {
+        Self {
+            work_units: None,
+            pause_us: None,
+        }
+    }
+
+    #[inline]
+    pub const fn is_bounded(self) -> bool {
+        self.work_units.is_some()
+    }
+}
+
+/// GC progress policy exposed to runtime and trace consumers.
+///
+/// Current automatic threshold collections do not use the finite budgets yet;
+/// they are reported as `LegacySynchronous` until allocation pressure is paced
+/// into `NormalIncremental` or `MutatorAssist` work.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GcProgressContract {
+    pub normal_step_budget: GcPauseBudget,
+    pub assist_budget: GcPauseBudget,
+    pub explicit_synchronous_policy: GcPauseBudget,
+    pub explicit_full_policy: GcPauseBudget,
+    pub emergency_policy: GcPauseBudget,
+}
+
+impl GcProgressContract {
+    #[inline]
+    pub const fn budget_for(self, kind: GcProgressKind) -> GcPauseBudget {
+        match kind {
+            GcProgressKind::NormalIncremental => self.normal_step_budget,
+            GcProgressKind::MutatorAssist => self.assist_budget,
+            GcProgressKind::ExplicitSynchronous => self.explicit_synchronous_policy,
+            GcProgressKind::ExplicitFull => self.explicit_full_policy,
+            GcProgressKind::EmergencyFull => self.emergency_policy,
+            GcProgressKind::LegacySynchronous => GcPauseBudget::unbounded(),
+        }
+    }
+}
+
+impl Default for GcProgressContract {
+    fn default() -> Self {
+        Self {
+            normal_step_budget: GcPauseBudget::bounded(
+                GC_NORMAL_INCREMENTAL_WORK_UNITS,
+                GC_NORMAL_INCREMENTAL_SOFT_PAUSE_US,
+            ),
+            assist_budget: GcPauseBudget::bounded(
+                GC_MUTATOR_ASSIST_WORK_UNITS,
+                GC_MUTATOR_ASSIST_SOFT_PAUSE_US,
+            ),
+            explicit_synchronous_policy: GcPauseBudget::unbounded(),
+            explicit_full_policy: GcPauseBudget::unbounded(),
+            emergency_policy: GcPauseBudget::unbounded(),
+        }
+    }
+}
+
+/// Return Perry's process-wide GC progress contract.
+pub fn gc_progress_contract() -> GcProgressContract {
+    GcProgressContract::default()
+}
+
 pub(super) const GC_FLAG_IN_ALLOC: u8 = 0b01;
 /// Bit 1 of GC_FLAGS — suppression flag (JSON.parse).
 pub(super) const GC_FLAG_SUPPRESSED: u8 = 0b10;
@@ -222,6 +362,22 @@ impl GcTriggerKind {
             GcTriggerKind::SurvivorPromotionBytes => "survivor_promotion_bytes",
             GcTriggerKind::Manual => "manual",
             GcTriggerKind::Direct => "direct",
+        }
+    }
+
+    #[inline]
+    pub(super) const fn progress_kind(self, collection_kind: GcCollectionKind) -> GcProgressKind {
+        match (self, collection_kind) {
+            (GcTriggerKind::Manual, GcCollectionKind::Full) => GcProgressKind::ExplicitFull,
+            (GcTriggerKind::Manual, GcCollectionKind::Minor) => GcProgressKind::ExplicitSynchronous,
+            (
+                GcTriggerKind::ArenaBytes
+                | GcTriggerKind::MallocCount
+                | GcTriggerKind::OldGenBytes
+                | GcTriggerKind::SurvivorPromotionBytes
+                | GcTriggerKind::Direct,
+                _,
+            ) => GcProgressKind::LegacySynchronous,
         }
     }
 }

--- a/crates/perry-runtime/src/gc/telemetry.rs
+++ b/crates/perry-runtime/src/gc/telemetry.rs
@@ -448,6 +448,7 @@ pub(super) enum BarrierTraceCounter {
 pub(super) struct GcCycleTrace {
     pub(super) collection_kind: GcCollectionKind,
     pub(super) trigger_kind: GcTriggerKind,
+    pub(super) progress_kind: GcProgressKind,
     pub(super) steps_before: GcStepSnapshot,
     pub(super) pause_us: u64,
     pub(super) phase_us: BTreeMap<&'static str, u64>,
@@ -500,6 +501,7 @@ impl GcCycleTrace {
         Some(Self {
             collection_kind,
             trigger_kind: trigger.kind,
+            progress_kind: trigger.kind.progress_kind(collection_kind),
             steps_before,
             pause_us: 0,
             phase_us,
@@ -719,6 +721,15 @@ impl GcCycleTrace {
         let trigger_json = serde_json::json!({
             "kind": self.trigger_kind.as_str(),
         });
+        let progress_budget = gc_progress_contract().budget_for(self.progress_kind);
+        let progress_contract_json = serde_json::json!({
+            "kind": self.progress_kind.as_str(),
+            "budget_unit": "work_units",
+            "configured_work_budget": progress_budget.work_units,
+            "soft_pause_target_us": progress_budget.pause_us,
+            "ordinary_budgeted": self.progress_kind.is_budgeted(),
+            "class": self.progress_kind.report_class(),
+        });
         let steps_value = steps_json(self.steps_before, steps_after);
         serde_json::json!({
             "event": "gc_cycle",
@@ -745,6 +756,7 @@ impl GcCycleTrace {
             "sweep": sweep_json,
             "write_barrier": write_barrier_json,
             "trigger": trigger_json,
+            "progress_contract": progress_contract_json,
             "steps": steps_value,
         })
     }

--- a/crates/perry-runtime/src/gc/tests/contract.rs
+++ b/crates/perry-runtime/src/gc/tests/contract.rs
@@ -1,0 +1,91 @@
+use super::super::*;
+
+#[test]
+fn test_gc_progress_contract_defaults() {
+    let contract = gc_progress_contract();
+
+    assert_eq!(
+        contract.normal_step_budget,
+        GcPauseBudget::bounded(
+            GC_NORMAL_INCREMENTAL_WORK_UNITS,
+            GC_NORMAL_INCREMENTAL_SOFT_PAUSE_US,
+        )
+    );
+    assert_eq!(
+        contract.assist_budget,
+        GcPauseBudget::bounded(
+            GC_MUTATOR_ASSIST_WORK_UNITS,
+            GC_MUTATOR_ASSIST_SOFT_PAUSE_US,
+        )
+    );
+    assert!(contract.normal_step_budget.is_bounded());
+    assert!(contract.assist_budget.is_bounded());
+    assert_eq!(
+        contract.explicit_synchronous_policy,
+        GcPauseBudget::unbounded()
+    );
+    assert_eq!(contract.explicit_full_policy, GcPauseBudget::unbounded());
+    assert_eq!(contract.emergency_policy, GcPauseBudget::unbounded());
+    assert_eq!(
+        GcProgressKind::ExplicitSynchronous.as_str(),
+        "explicit_synchronous"
+    );
+    assert_eq!(GcProgressKind::ExplicitFull.as_str(), "explicit_full");
+    assert_eq!(GcProgressKind::EmergencyFull.as_str(), "emergency_full");
+}
+
+#[test]
+fn test_gc_progress_kind_is_budgeted_only_for_incremental_and_assist() {
+    assert!(GcProgressKind::NormalIncremental.is_budgeted());
+    assert!(GcProgressKind::MutatorAssist.is_budgeted());
+    assert!(!GcProgressKind::ExplicitSynchronous.is_budgeted());
+    assert!(!GcProgressKind::ExplicitFull.is_budgeted());
+    assert!(!GcProgressKind::EmergencyFull.is_budgeted());
+    assert!(!GcProgressKind::LegacySynchronous.is_budgeted());
+}
+
+#[test]
+fn test_gc_progress_contract_trace_json_labels_automatic_as_legacy() {
+    let trace = GcCycleTrace::new(
+        GcCollectionKind::Minor,
+        GcTriggerSnapshot {
+            kind: GcTriggerKind::ArenaBytes,
+            steps_before: Some(GcStepSnapshot::current()),
+        },
+    )
+    .expect("test requested GC trace capture");
+
+    let event = trace.into_json(GcStepSnapshot::current());
+    let progress = &event["progress_contract"];
+
+    assert_eq!(progress["kind"].as_str(), Some("legacy_synchronous"));
+    assert_eq!(progress["budget_unit"].as_str(), Some("work_units"));
+    assert!(progress["configured_work_budget"].is_null());
+    assert!(progress["soft_pause_target_us"].is_null());
+    assert_eq!(progress["ordinary_budgeted"].as_bool(), Some(false));
+    assert_eq!(progress["class"].as_str(), Some("legacy"));
+}
+
+#[test]
+fn test_gc_progress_contract_trace_json_labels_manual_minor_as_explicit_sync() {
+    let trace = GcCycleTrace::new(
+        GcCollectionKind::Minor,
+        GcTriggerSnapshot {
+            kind: GcTriggerKind::Manual,
+            steps_before: Some(GcStepSnapshot::current()),
+        },
+    )
+    .expect("test requested GC trace capture");
+
+    let event = trace.into_json(GcStepSnapshot::current());
+    let progress = &event["progress_contract"];
+
+    assert_eq!(event["collection_kind"].as_str(), Some("minor"));
+    assert_eq!(event["trigger"]["kind"].as_str(), Some("manual"));
+    assert_eq!(progress["kind"].as_str(), Some("explicit_synchronous"));
+    assert_eq!(progress["budget_unit"].as_str(), Some("work_units"));
+    assert!(progress["configured_work_budget"].is_null());
+    assert!(progress["soft_pause_target_us"].is_null());
+    assert_eq!(progress["ordinary_budgeted"].as_bool(), Some(false));
+    assert_eq!(progress["class"].as_str(), Some("explicit"));
+}

--- a/crates/perry-runtime/src/gc/tests/mod.rs
+++ b/crates/perry-runtime/src/gc/tests/mod.rs
@@ -1,5 +1,6 @@
 mod alloc;
 mod barrier;
+mod contract;
 mod copying;
 mod evacuation;
 mod helper_stores;


### PR DESCRIPTION
## Summary
- Define Perry's low-pause GC progress contract and bounded budget model.
- Add telemetry shape for progress kind, budget unit, configured work budget, and soft pause target.
- Add focused runtime tests that lock the contract before the larger resumable-cycle PRs land.

## Verification
- 
running 4 tests
....
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 746 filtered out; finished in 0.00s
- 
- 
- 

This is the first small PR in the GC runtime improvement train; it is intentionally contract/scaffolding only so the later resumable-cycle and barrier/root PRs have a stable review target.