### PR TITLE
fix(node:util): preserve literal Uint8Array identity

### DIFF
--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -546,19 +546,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             //   - `new Uint8Array(N)` where N is a number → zero-filled buffer of length N
             //   - `new Uint8Array([1, 2, 3])` → buffer initialized from array
             // The codegen detects the literal-number case at compile time and routes
-            // it to `js_buffer_alloc` so we don't read garbage from a number-as-array.
-            // Other shapes flow through `js_uint8array_from_array` which reads
-            // from the array storage region.
+            // it to `js_uint8array_alloc` so we don't read garbage from a
+            // number-as-array while still preserving Uint8Array identity.
+            // Other shapes flow through `js_uint8array_new`, which dispatches
+            // between numeric lengths and source arrays at runtime.
             match arg.as_deref() {
                 None => {
                     let blk = ctx.block();
-                    let h = blk.call(I64, "js_buffer_alloc", &[(I32, "0"), (I32, "0")]);
+                    let h = blk.call(I64, "js_uint8array_alloc", &[(I32, "0")]);
                     Ok(nanbox_pointer_inline(blk, &h))
                 }
                 Some(Expr::Integer(n)) => {
                     let size_str = (*n as i32).to_string();
                     let blk = ctx.block();
-                    let h = blk.call(I64, "js_buffer_alloc", &[(I32, &size_str), (I32, "0")]);
+                    let h = blk.call(I64, "js_uint8array_alloc", &[(I32, &size_str)]);
                     Ok(nanbox_pointer_inline(blk, &h))
                 }
                 Some(Expr::Number(n))
@@ -566,7 +567,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 {
                     let size_str = (*n as i32).to_string();
                     let blk = ctx.block();
-                    let h = blk.call(I64, "js_buffer_alloc", &[(I32, &size_str), (I32, "0")]);
+                    let h = blk.call(I64, "js_uint8array_alloc", &[(I32, &size_str)]);
                     Ok(nanbox_pointer_inline(blk, &h))
                 }
                 Some(e) => {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1026,6 +1026,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // Uint8Array constructor wrapper that flags the resulting buffer so the
     // formatter prints `Uint8Array(N) [ ... ]` instead of `<Buffer ...>`.
     module.declare_function("js_uint8array_from_array", I64, &[I64]);
+    // `new Uint8Array(length)` — zero-filled BufferHeader marked as Uint8Array.
+    module.declare_function("js_uint8array_alloc", I64, &[I32]);
     // `new Uint8Array(x)` runtime dispatch — handles the non-literal case
     // where `x` could be a number (length) or an array (source data).
     module.declare_function("js_uint8array_new", I64, &[DOUBLE]);

--- a/test-parity/node-suite/util/types/uint8array-literal-identity.ts
+++ b/test-parity/node-suite/util/types/uint8array-literal-identity.ts
@@ -1,0 +1,13 @@
+import { types } from "node:util";
+
+const literal = new Uint8Array(1);
+const empty = new Uint8Array();
+const dynamicLength = 1;
+const dynamic = new Uint8Array(dynamicLength);
+
+console.log("literal uint8:", types.isUint8Array(literal));
+console.log("literal typed:", types.isTypedArray(literal));
+console.log("literal view:", types.isArrayBufferView(literal));
+console.log("empty uint8:", types.isUint8Array(empty));
+console.log("dynamic uint8:", types.isUint8Array(dynamic));
+console.log("arraybuffer uint8:", types.isUint8Array(new ArrayBuffer(1)));


### PR DESCRIPTION
## Summary
- route no-arg and literal-length `new Uint8Array(...)` through `js_uint8array_alloc` so buffers are marked as Uint8Array
- add a focused util.types parity fixture for literal Uint8Array identity

## Tests
- `./run_parity_tests.sh --suite node-suite --filter node-suite/util/types/uint8array-literal-identity`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/util/types/boxed-and-typedarrays-extra` (still fails on missing `isInt16Array` / `isBigInt64Array`; `uint8` now matches Node)
- `./run_parity_tests.sh --suite node-suite --filter node-suite/util/types/typed-arrays`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/util/types` (12 PASS / 2 FAIL; residuals are open #2340 and missing typed-array predicates)
- `cargo check -p perry-codegen`
- `cargo fmt --check`
- `git diff --check`