### PR TITLE
Tighten GC root and barrier contracts

### DIFF
--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -556,7 +556,7 @@ pub(super) fn init_static_fields_late(
                 }
                 let v = crate::expr::lower_expr(ctx, init_expr)?;
                 let g_ref = format!("@{}", global_name);
-                ctx.block().store(DOUBLE, &v, &g_ref);
+                crate::expr::emit_root_nanbox_store_on_block(ctx.block(), &v, &g_ref);
             }
         }
     }
@@ -786,7 +786,7 @@ pub(super) fn emit_namespace_populator(
         ],
     );
     let ns_name = format!("__perry_ns_{}", module_prefix);
-    blk.store(DOUBLE, &result, &format!("@{}", ns_name));
+    crate::expr::emit_root_nanbox_store_on_block(blk, &result, &format!("@{}", ns_name));
     let addr_i64 = blk.ptrtoint(&format!("@{}", ns_name), I64);
     blk.call_void("js_gc_register_global_root", &[(I64, &addr_i64)]);
 }

--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -198,7 +198,7 @@ pub(super) fn emit_string_pool(
         };
         let handle = blk.call(I64, init_fn, &[(PTR, &bytes_ref), (I32, &len_str)]);
         let nanboxed = blk.call(DOUBLE, "js_nanbox_string", &[(I64, &handle)]);
-        blk.store(DOUBLE, &nanboxed, &handle_ref);
+        crate::expr::emit_root_nanbox_store_on_block(blk, &nanboxed, &handle_ref);
         let addr_i64 = blk.ptrtoint(&handle_ref, I64);
         blk.call_void("js_gc_register_global_root", &[(I64, &addr_i64)]);
     }
@@ -260,7 +260,7 @@ pub(super) fn emit_string_pool(
                 (I32, &len_str),
             ],
         );
-        blk.store(I64, &arr, &format!("@{}", global_name));
+        crate::expr::emit_root_heap_word_store_on_block(blk, &arr, &format!("@{}", global_name));
     }
 
     // Register the parent-class chain for every class with a parent.

--- a/crates/perry-codegen/src/expr/array_push.rs
+++ b/crates/perry-codegen/src/expr/array_push.rs
@@ -36,10 +36,10 @@ use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 use super::{
     array_store_needs_layout_note, array_store_needs_write_barrier, buffer_alias_metadata_suffix,
     can_lower_expr_as_i32, emit_array_numeric_write_note_on_block,
-    emit_jsvalue_slot_store_on_block, emit_layout_note_slot_on_block, emit_shadow_slot_clear,
-    emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_typed_feedback_register_site, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block,
+    emit_jsvalue_slot_store_on_block, emit_layout_note_slot_on_block,
+    emit_root_nanbox_store_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
+    emit_string_literal_global, emit_typed_feedback_register_site, emit_v8_export_call,
+    emit_v8_member_method_call, emit_write_barrier, emit_write_barrier_slot_on_block,
     expr_has_numeric_pointer_free_array_layout, expr_is_known_non_pointer_shadow_value,
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
@@ -397,7 +397,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             } else if let Some(global_name) = ctx.module_globals.get(array_id).cloned() {
                 let g_ref = format!("@{}", global_name);
                 // GC_STORE_AUDIT(ROOT): module global array slot is a registered mutable GC root.
-                ctx.block().store(DOUBLE, &new_box, &g_ref);
+                emit_root_nanbox_store_on_block(ctx.block(), &new_box, &g_ref);
             } else {
                 return Err(anyhow!("ArrayPush({}): local not in scope", array_id));
             }
@@ -461,7 +461,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             } else if let Some(global_name) = ctx.module_globals.get(array_id).cloned() {
                 let g_ref = format!("@{}", global_name);
                 // GC_STORE_AUDIT(ROOT): module global array slot is a registered mutable GC root.
-                ctx.block().store(DOUBLE, &new_box, &g_ref);
+                emit_root_nanbox_store_on_block(ctx.block(), &new_box, &g_ref);
             } else {
                 return Err(anyhow!("ArrayPushSpread({}): local not in scope", array_id));
             }

--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -36,9 +36,9 @@ use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 #[allow(unused_imports)]
 use super::{
     buffer_access_materialization_reason, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
+    emit_root_nanbox_store_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
+    emit_string_literal_global, emit_v8_export_call, emit_v8_member_method_call,
+    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
     lower_array_literal, lower_buffer_load, lower_buffer_store, lower_channel_reduction,
@@ -974,7 +974,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             } else if let Some(global_name) = ctx.module_globals.get(array_id).cloned() {
                 let g_ref = format!("@{}", global_name);
                 // GC_STORE_AUDIT(ROOT): module global array slot is a registered mutable GC root.
-                ctx.block().store(DOUBLE, &new_box, &g_ref);
+                emit_root_nanbox_store_on_block(ctx.block(), &new_box, &g_ref);
             }
             let blk = ctx.block();
             let len_i32 = blk.call(I32, "js_array_length", &[(I64, &new_handle)]);

--- a/crates/perry-codegen/src/expr/bigint_set.rs
+++ b/crates/perry-codegen/src/expr/bigint_set.rs
@@ -32,9 +32,9 @@ use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 #[allow(unused_imports)]
 use super::{
     buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
+    emit_root_nanbox_store_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
+    emit_string_literal_global, emit_v8_export_call, emit_v8_member_method_call,
+    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
     lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
@@ -256,7 +256,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             } else if let Some(global_name) = ctx.module_globals.get(set_id).cloned() {
                 let g_ref = format!("@{}", global_name);
                 // GC_STORE_AUDIT(ROOT): module global Set slot is a registered mutable GC root.
-                ctx.block().store(DOUBLE, &new_box, &g_ref);
+                emit_root_nanbox_store_on_block(ctx.block(), &new_box, &g_ref);
             }
             Ok(new_box)
         }

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -37,9 +37,10 @@ use super::{
     array_store_needs_layout_note, array_store_needs_write_barrier,
     buffer_access_materialization_reason, buffer_alias_metadata_suffix, can_lower_expr_as_i32,
     emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
-    emit_layout_note_slot_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
-    emit_string_literal_global, emit_typed_feedback_register_site, emit_v8_export_call,
-    emit_v8_member_method_call, emit_write_barrier, emit_write_barrier_slot_on_block,
+    emit_layout_note_slot_on_block, emit_root_nanbox_store_on_block, emit_shadow_slot_clear,
+    emit_shadow_slot_update_for_expr, emit_string_literal_global,
+    emit_typed_feedback_register_site, emit_v8_export_call, emit_v8_member_method_call,
+    emit_write_barrier, emit_write_barrier_slot_on_block,
     expr_has_numeric_pointer_free_array_layout, expr_is_known_non_pointer_shadow_value,
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
@@ -496,7 +497,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         let new_box = nanbox_pointer_inline(blk, &new_handle);
                         let g_ref = format!("@{}", global_name);
                         // GC_STORE_AUDIT(ROOT): module global array slot is a registered mutable GC root.
-                        ctx.block().store(DOUBLE, &new_box, &g_ref);
+                        emit_root_nanbox_store_on_block(ctx.block(), &new_box, &g_ref);
                         // Gen-GC Phase C2: write barrier on array element store.
                         if write_barrier_needed {
                             let val_bits = ctx.block().bitcast_double_to_i64(&val_double);

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -32,9 +32,9 @@ use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 #[allow(unused_imports)]
 use super::{
     buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
+    emit_root_nanbox_store_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
+    emit_string_literal_global, emit_v8_export_call, emit_v8_member_method_call,
+    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
     lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
@@ -724,7 +724,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             } else if let Some(global_name) = ctx.module_globals.get(array_id).cloned() {
                 let g_ref = format!("@{}", global_name);
                 // GC_STORE_AUDIT(ROOT): module global array slot is a registered mutable GC root.
-                ctx.block().store(DOUBLE, &modified_box, &g_ref);
+                emit_root_nanbox_store_on_block(ctx.block(), &modified_box, &g_ref);
             }
             // Return the deleted array (NaN-boxed) as the splice
             // expression's value.

--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -33,9 +33,9 @@ use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 #[allow(unused_imports)]
 use super::{
     buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
+    emit_root_nanbox_store_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
+    emit_string_literal_global, emit_v8_export_call, emit_v8_member_method_call,
+    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
     lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
@@ -554,7 +554,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     } else if let Some(global_name) = ctx.module_globals.get(id).cloned() {
                         let g_ref = format!("@{}", global_name);
                         // GC_STORE_AUDIT(ROOT): module global slot is registered as a mutable GC root.
-                        ctx.block().store(DOUBLE, &v_dbl, &g_ref);
+                        emit_root_nanbox_store_on_block(ctx.block(), &v_dbl, &g_ref);
                     }
                     if let Some(slot_idx) = ctx.shadow_slot_map.get(id).copied() {
                         emit_shadow_slot_clear(ctx, slot_idx);
@@ -631,7 +631,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             } else if let Some(global_name) = ctx.module_globals.get(id).cloned() {
                 let g_ref = format!("@{}", global_name);
                 // GC_STORE_AUDIT(ROOT): module global slot is registered as a mutable GC root.
-                ctx.block().store(DOUBLE, &v, &g_ref);
+                emit_root_nanbox_store_on_block(ctx.block(), &v, &g_ref);
             }
             super::record_native_arena_owner_assignment(ctx, *id, value.as_ref());
             if ctx.buffer_view_slots.contains_key(id)
@@ -710,10 +710,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     return Ok(if *prefix { new } else { old });
                 }
             }
-            let storage = if let Some(slot) = ctx.locals.get(id).cloned() {
-                slot
+            let (storage, storage_is_root) = if let Some(slot) = ctx.locals.get(id).cloned() {
+                (slot, false)
             } else if let Some(global_name) = ctx.module_globals.get(id).cloned() {
-                format!("@{}", global_name)
+                (format!("@{}", global_name), true)
             } else {
                 // Soft fallback: silently increment a throwaway value.
                 return Ok(double_literal(0.0));
@@ -724,8 +724,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 UpdateOp::Increment => blk.fadd(&old, "1.0"),
                 UpdateOp::Decrement => blk.fsub(&old, "1.0"),
             };
-            // GC_STORE_AUDIT(STACK): update writes a local alloca or registered module-global root slot.
-            blk.store(DOUBLE, &new, &storage);
+            // GC_STORE_AUDIT(STACK/ROOT): update writes a local alloca or registered module-global root slot.
+            if storage_is_root {
+                emit_root_nanbox_store_on_block(blk, &new, &storage);
+            } else {
+                blk.store(DOUBLE, &new, &storage);
+            }
             // Keep the parallel i32 counter slot in sync (if active).
             // This costs one `add i32, 1` per iteration but saves a
             // `fptosi double → i32` on every IndexGet/IndexSet use.

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -119,7 +119,8 @@ pub(crate) use v8_interop::{
 };
 pub(crate) use write_barrier::{
     emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
-    emit_layout_note_slot_on_block, emit_write_barrier, emit_write_barrier_slot_on_block,
+    emit_layout_note_slot_on_block, emit_root_heap_word_store_on_block,
+    emit_root_nanbox_store_on_block, emit_write_barrier, emit_write_barrier_slot_on_block,
     lower_node_stream_super_init, lower_stream_super_init,
 };
 

--- a/crates/perry-codegen/src/expr/pod_record.rs
+++ b/crates/perry-codegen/src/expr/pod_record.rs
@@ -10,7 +10,9 @@ use crate::native_value::{
 };
 use crate::types::{DOUBLE, F32, I32, I64, I8};
 
-use super::{lower_expr, lower_expr_native, nanbox_pointer_inline, FnCtx};
+use super::{
+    emit_root_nanbox_store_on_block, lower_expr, lower_expr_native, nanbox_pointer_inline, FnCtx,
+};
 
 pub(crate) fn materialize_pod_local(
     ctx: &mut FnCtx<'_>,
@@ -229,7 +231,7 @@ pub(crate) fn lower_pod_local_reassignment(
     }
     if let Some(global_name) = ctx.module_globals.get(&local_id).cloned() {
         let global_ref = format!("@{}", global_name);
-        ctx.block().store(DOUBLE, &value_js, &global_ref);
+        emit_root_nanbox_store_on_block(ctx.block(), &value_js, &global_ref);
     }
     record_pod_dynamic_fallback(
         ctx,
@@ -381,7 +383,7 @@ fn materialize_pod_parts(
     );
     if let Some(global_name) = ctx.module_globals.get(&local_id).cloned() {
         let global_ref = format!("@{}", global_name);
-        ctx.block().store(DOUBLE, &materialized_value, &global_ref);
+        emit_root_nanbox_store_on_block(ctx.block(), &materialized_value, &global_ref);
     }
     materialized_value
 }

--- a/crates/perry-codegen/src/expr/static_field_meta.rs
+++ b/crates/perry-codegen/src/expr/static_field_meta.rs
@@ -32,9 +32,9 @@ use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 #[allow(unused_imports)]
 use super::{
     buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
+    emit_root_nanbox_store_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
+    emit_string_literal_global, emit_v8_export_call, emit_v8_member_method_call,
+    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
     lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
@@ -70,7 +70,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             if let Some(global_name) = ctx.static_field_globals.get(&key).cloned() {
                 let g_ref = format!("@{}", global_name);
                 // GC_STORE_AUDIT(ROOT): static field global slot is registered as a mutable GC root.
-                ctx.block().store(DOUBLE, &v, &g_ref);
+                emit_root_nanbox_store_on_block(ctx.block(), &v, &g_ref);
             }
             // v0.5.747: also register the static field in the runtime
             // CLASS_DYNAMIC_PROPS side-table so dynamic-dispatch reads

--- a/crates/perry-codegen/src/expr/write_barrier.rs
+++ b/crates/perry-codegen/src/expr/write_barrier.rs
@@ -39,6 +39,21 @@ pub(crate) fn emit_write_barrier_slot_on_block(
     );
 }
 
+pub(crate) fn emit_root_nanbox_store_on_block(blk: &mut LlBlock, value: &str, root_slot: &str) {
+    blk.store(DOUBLE, value, root_slot);
+    let value_bits = blk.bitcast_double_to_i64(value);
+    blk.call_void("js_write_barrier_root_nanbox", &[(I64, &value_bits)]);
+}
+
+pub(crate) fn emit_root_heap_word_store_on_block(
+    blk: &mut LlBlock,
+    value_bits: &str,
+    root_slot: &str,
+) {
+    blk.store(I64, value_bits, root_slot);
+    blk.call_void("js_write_barrier_root_heap_word", &[(I64, value_bits)]);
+}
+
 /// GC layout-note emission (refs #1090) — at heap-slot stores whose
 /// content is known statically, record the per-slot value type so the
 /// generational GC can decide whether the slot can be pointer-free

--- a/crates/perry-codegen/src/lower_array_method.rs
+++ b/crates/perry-codegen/src/lower_array_method.rs
@@ -10,7 +10,8 @@ use anyhow::{bail, Result};
 use perry_hir::Expr;
 
 use crate::expr::{
-    lower_expr, nanbox_pointer_inline, nanbox_string_inline, unbox_str_handle, unbox_to_i64, FnCtx,
+    emit_root_nanbox_store_on_block, lower_expr, nanbox_pointer_inline, nanbox_string_inline,
+    unbox_str_handle, unbox_to_i64, FnCtx,
 };
 use crate::nanbox::double_literal;
 use crate::types::{DOUBLE, I32, I64, PTR};
@@ -701,7 +702,7 @@ pub(crate) fn lower_array_method(
                     ctx.block().store(DOUBLE, &modified_box, &slot);
                 } else if let Some(global_name) = ctx.module_globals.get(array_id).cloned() {
                     let g_ref = format!("@{}", global_name);
-                    ctx.block().store(DOUBLE, &modified_box, &g_ref);
+                    emit_root_nanbox_store_on_block(ctx.block(), &modified_box, &g_ref);
                 }
             }
             Ok(nanbox_pointer_inline(ctx.block(), &deleted_handle))

--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -26,7 +26,9 @@ use perry_dispatch::{ArgKind as UiArgKind, ReturnKind as UiReturnKind};
 use perry_hir::Expr;
 use perry_types::Type as HirType;
 
-use crate::expr::{lower_expr, nanbox_pointer_inline, unbox_to_i64, FnCtx};
+use crate::expr::{
+    emit_root_nanbox_store_on_block, lower_expr, nanbox_pointer_inline, unbox_to_i64, FnCtx,
+};
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
 use crate::types::{DOUBLE, I32, I64, PTR};
 
@@ -1986,7 +1988,7 @@ pub(crate) fn lower_native_method_call(
                         ctx.block().store(DOUBLE, &new_box, &slot);
                     } else if let Some(global_name) = ctx.module_globals.get(id).cloned() {
                         let g_ref = format!("@{}", global_name);
-                        ctx.block().store(DOUBLE, &new_box, &g_ref);
+                        emit_root_nanbox_store_on_block(ctx.block(), &new_box, &g_ref);
                     }
                 }
                 Expr::PropertyGet {
@@ -2072,7 +2074,7 @@ pub(crate) fn lower_native_method_call(
                         ctx.block().store(DOUBLE, &new_box, &slot);
                     } else if let Some(global_name) = ctx.module_globals.get(id).cloned() {
                         let g_ref = format!("@{}", global_name);
-                        ctx.block().store(DOUBLE, &new_box, &g_ref);
+                        emit_root_nanbox_store_on_block(ctx.block(), &new_box, &g_ref);
                     }
                 }
                 Expr::PropertyGet {

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -80,11 +80,15 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // GC can scan precise roots + RS instead of the full old-gen.
     //   js_write_barrier(parent_bits: u64, child_bits: u64)
     //   js_write_barrier_slot(parent_bits: u64, slot_addr: u64, child_bits: u64)
+    //   js_write_barrier_root_nanbox(child_bits: u64)
+    //   js_write_barrier_root_heap_word(child_bits: u64)
     //   js_gc_note_slot_layout(parent_bits: u64, slot_index: u32, value_bits: u64)
     //   js_gc_init_typed_shape_layout(obj: u64, slot_count: u32, raw_f64_mask_words: *const u64, raw_f64_mask_word_count: u32, pointer_mask_words: *const u64, pointer_mask_word_count: u32)
     //   js_gc_init_unboxed_object_layout(obj: u64, slot_count: u32, raw_f64_mask: u64, pointer_mask: u64)
     module.declare_function("js_write_barrier", VOID, &[I64, I64]);
     module.declare_function("js_write_barrier_slot", VOID, &[I64, I64, I64]);
+    module.declare_function("js_write_barrier_root_nanbox", VOID, &[I64]);
+    module.declare_function("js_write_barrier_root_heap_word", VOID, &[I64]);
     module.declare_function("js_gc_note_slot_layout", VOID, &[I64, I32, I64]);
     module.declare_function(
         "js_gc_init_typed_shape_layout",

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-use crate::expr::lower_expr_with_expected_type;
+use crate::expr::{emit_root_nanbox_store_on_block, lower_expr_with_expected_type};
 use crate::native_value::{
     AliasState, BufferAccessMode, BufferElem, BufferIndexUnit, BufferViewSlot, LengthSource,
     LoweredValue, MaterializationReason, NativeOwnedViewSlot, NativeRep, PodLayoutDecision,
@@ -686,7 +686,7 @@ pub(crate) fn lower_let(
         if let Some(init_expr) = init {
             let v = lower_expr_with_expected_type(ctx, init_expr, Some(&refined_ty))?;
             let g_ref = format!("@{}", global_name);
-            ctx.block().store(DOUBLE, &v, &g_ref);
+            emit_root_nanbox_store_on_block(ctx.block(), &v, &g_ref);
 
             // Buffer data-pointer slot: when the HIR facts identify a fresh
             // immutable u8 buffer, pre-compute the data base pointer (handle +

--- a/crates/perry-ffi/src/handle.rs
+++ b/crates/perry-ffi/src/handle.rs
@@ -336,10 +336,11 @@ where
 ///
 /// The scanner is called during every GC mark phase; it should call its `mark`
 /// callback with each NaN-boxed JsValue that should be kept alive. This API
-/// exposes copied values only. During copied-minor evacuation the runtime
-/// cannot rewrite wrapper-owned storage discovered through this API, so live
-/// young roots reported here are treated as copy-only fallback roots. Prefer
-/// [`gc_register_mutable_root_scanner`] for new scanners.
+/// exposes copied values only. The runtime cannot rewrite wrapper-owned storage
+/// discovered through this API, so registering any scanner here makes
+/// low-pause copied-minor GC ineligible. It remains supported for legacy
+/// fallback/full collection only. Prefer [`gc_register_mutable_root_scanner`]
+/// for new scanners and for low-pause compatibility.
 ///
 /// This registers through `perry_ffi_gc_register_root_scanner`, the stable
 /// C ABI bridge exported by the runtime.
@@ -361,6 +362,9 @@ where
 /// // Register once on first wrapper-method invocation.
 /// gc_register_root_scanner(scan_my_roots);
 /// ```
+#[deprecated(
+    note = "copy-only GC root scanners force fallback/full collection; use gc_register_mutable_root_scanner for low-pause GC"
+)]
 pub fn gc_register_root_scanner(scanner: fn(&mut dyn FnMut(f64))) {
     {
         let mut scanners = ROOT_SCANNERS

--- a/crates/perry-ffi/src/lib.rs
+++ b/crates/perry-ffi/src/lib.rs
@@ -60,11 +60,13 @@ pub use types::{
 };
 
 mod handle;
+#[allow(deprecated)]
+pub use handle::gc_register_root_scanner;
 pub use handle::{
     drop_handle, gc_register_mutable_root_scanner, gc_register_mutable_root_scanner_named,
-    gc_register_root_scanner, get_handle, get_handle_mut, handle_exists, iter_handle_ids_of,
-    iter_handles_of, iter_handles_of_mut, register_handle, take_handle, with_handle,
-    with_handle_mut, GcMutableRootScanner, GcRootVisitor, Handle, INVALID_HANDLE,
+    get_handle, get_handle_mut, handle_exists, iter_handle_ids_of, iter_handles_of,
+    iter_handles_of_mut, register_handle, take_handle, with_handle, with_handle_mut,
+    GcMutableRootScanner, GcRootVisitor, Handle, INVALID_HANDLE,
 };
 
 mod jsvalue;

--- a/crates/perry-runtime/src/box.rs
+++ b/crates/perry-runtime/src/box.rs
@@ -157,6 +157,7 @@ pub extern "C" fn js_box_set(ptr: *mut Box, value: f64) {
             return;
         }
         (*ptr).value = value;
+        crate::gc::runtime_write_barrier_root_nanbox(value.to_bits());
     }
 }
 
@@ -185,4 +186,9 @@ fn is_plausible_box_ptr(ptr: *mut Box) -> bool {
         return false;
     }
     true
+}
+
+#[cfg(test)]
+pub(crate) fn test_clear_box_registry() {
+    BOX_REGISTRY.with(|r| r.borrow_mut().clear());
 }

--- a/crates/perry-runtime/src/builtins/console.rs
+++ b/crates/perry-runtime/src/builtins/console.rs
@@ -141,9 +141,10 @@ pub extern "C" fn js_console_log_as_closure() -> f64 {
         let fresh = crate::closure::js_closure_alloc(console_log_callable_thunk as *const u8, 0);
         // CAS so concurrent first-use callers don't leak a closure.
         // The loser's allocation is unreachable by any user code path
-        // and will be reclaimed by the next GC sweep — only the winner
-        // is added to the root set via `scan_console_log_singleton_roots`.
-        match CONSOLE_LOG_SINGLETON.compare_exchange(
+        // and will be reclaimed by the next GC sweep. The winner is
+        // stored in the root slot through the root barrier path.
+        match crate::gc::runtime_compare_exchange_root_atomic_raw_i64(
+            &CONSOLE_LOG_SINGLETON,
             0,
             fresh as i64,
             Ordering::AcqRel,
@@ -1322,7 +1323,7 @@ pub unsafe extern "C" fn js_console_dir_with_options(value: f64, options_value: 
 
 #[cfg(test)]
 pub(crate) fn test_set_console_log_singleton(ptr: i64) {
-    CONSOLE_LOG_SINGLETON.store(ptr, Ordering::Release);
+    crate::gc::runtime_store_root_atomic_raw_i64(&CONSOLE_LOG_SINGLETON, ptr, Ordering::Release);
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/closure/alloc.rs
+++ b/crates/perry-runtime/src/closure/alloc.rs
@@ -171,6 +171,7 @@ pub extern "C" fn js_closure_alloc_singleton(func_ptr: *const u8) -> *mut Closur
     SINGLETON_CLOSURES.with(|s| {
         s.borrow_mut().insert(func_ptr as usize, allocated);
     });
+    crate::gc::runtime_write_barrier_root_heap_word(allocated as u64);
     allocated
 }
 
@@ -378,6 +379,10 @@ pub extern "C" fn js_closure_alloc_with_captures_singleton(
             std::ptr::copy_nonoverlapping(rewritten_captures.as_ptr(), dest, n);
             rebuild_closure_layout_and_barriers(allocated, n);
         }
+    }
+    crate::gc::runtime_write_barrier_root_heap_word(allocated as u64);
+    for &bits in &rewritten_captures {
+        crate::gc::runtime_write_barrier_root_heap_word(bits);
     }
     SINGLETON_CAPTURED_CLOSURES.with(|s| {
         let mut s = s.borrow_mut();

--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -33,8 +33,14 @@ pub fn closure_set_static_prototype(closure_ptr: usize, proto_bits: u64) {
     if closure_ptr == 0 {
         return;
     }
+    let mut slot_addr = 0usize;
     if let Ok(mut map) = get_closure_prototypes().lock() {
-        map.insert(closure_ptr, proto_bits);
+        let slot = map.entry(closure_ptr).or_insert(0);
+        *slot = proto_bits;
+        slot_addr = slot as *mut u64 as usize;
+    }
+    if slot_addr != 0 {
+        crate::gc::runtime_write_barrier_external_slot(closure_ptr, slot_addr, proto_bits);
     }
 }
 
@@ -80,6 +86,11 @@ pub(crate) fn closure_dynamic_props_owner_moved(old_owner: usize, new_owner: usi
             merge_closure_prop_map(&mut props, new_owner, old_props);
         }
     }
+    if let Ok(mut prototypes) = get_closure_prototypes().lock() {
+        if let Some(proto_bits) = prototypes.remove(&old_owner) {
+            prototypes.insert(new_owner, proto_bits);
+        }
+    }
 }
 
 pub(crate) fn visit_closure_dynamic_prop_values_mut(owner: usize, mut visit: impl FnMut(&mut f64)) {
@@ -112,7 +123,21 @@ pub(crate) fn visit_closure_dynamic_prop_value_slots_mut(
     });
 }
 
-/// Mutable GC scanner for the closure dynamic-property side-table.
+pub(crate) fn visit_closure_static_prototype_slot_mut(
+    owner: usize,
+    mut visit: impl FnMut(*mut u64),
+) {
+    if owner == 0 {
+        return;
+    }
+    if let Ok(mut prototypes) = get_closure_prototypes().lock() {
+        if let Some(proto_bits) = prototypes.get_mut(&owner) {
+            visit(proto_bits as *mut u64);
+        }
+    }
+}
+
+/// Mutable GC scanner for closure dynamic-property side-table metadata.
 ///
 /// The side table is keyed by closure address. The key itself is metadata
 /// (visited only so a moved closure has its entry re-keyed; the metadata
@@ -149,6 +174,22 @@ pub fn scan_closure_dynamic_props_roots_mut(visitor: &mut crate::gc::RuntimeRoot
         for (old_owner, new_owner) in moved {
             if let Some(old_props) = props.remove(&old_owner) {
                 merge_closure_prop_map(&mut props, new_owner, old_props);
+            }
+        }
+    }
+    let mut moved_prototypes = Vec::new();
+    if let Ok(mut prototypes) = get_closure_prototypes().lock() {
+        for (owner, proto_bits) in prototypes.iter_mut() {
+            let old_owner = *owner;
+            let mut new_owner = old_owner;
+            if visitor.visit_metadata_usize_slot(&mut new_owner) {
+                moved_prototypes.push((old_owner, new_owner));
+            }
+            visitor.visit_nanbox_u64_slot(proto_bits);
+        }
+        for (old_owner, new_owner) in moved_prototypes {
+            if let Some(proto_bits) = prototypes.remove(&old_owner) {
+                prototypes.insert(new_owner, proto_bits);
             }
         }
     }
@@ -247,6 +288,16 @@ pub fn closure_set_dynamic_prop(ptr: usize, prop: &str, value: f64) {
         let closure_props = props.entry(ptr).or_insert_with(HashMap::new);
         closure_props.insert(prop.to_string(), value);
         barrier_closure_dynamic_props(ptr, closure_props);
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_clear_closure_side_tables() {
+    if let Ok(mut props) = get_closure_props().lock() {
+        props.clear();
+    }
+    if let Ok(mut prototypes) = get_closure_prototypes().lock() {
+        prototypes.clear();
     }
 }
 

--- a/crates/perry-runtime/src/closure/mod.rs
+++ b/crates/perry-runtime/src/closure/mod.rs
@@ -43,9 +43,12 @@ pub use dispatch::{
 };
 pub(crate) use dispatch::{reset_throw_not_callable_counter, resolve_call2_direct};
 
+#[cfg(test)]
+pub(crate) use dynamic_props::test_clear_closure_side_tables;
 pub(crate) use dynamic_props::{
     clone_closure_rebind_this, closure_dynamic_props_owner_moved,
     visit_closure_dynamic_prop_value_slots_mut, visit_closure_dynamic_prop_values_mut,
+    visit_closure_static_prototype_slot_mut,
 };
 pub use dynamic_props::{
     closure_dynamic_props_snapshot, closure_get_dynamic_prop, closure_set_dynamic_prop,

--- a/crates/perry-runtime/src/exception.rs
+++ b/crates/perry-runtime/src/exception.rs
@@ -119,7 +119,7 @@ pub extern "C" fn js_throw(value: f64) -> ! {
     // on this thread; in practice UnsafeCell tolerates it but the
     // shorter scope keeps things tidy).
     let jb_ptr: *mut i32 = with_exception_state(|s| unsafe {
-        (*s).current_exception = value;
+        crate::gc::runtime_store_root_nanbox_f64_raw_slot(&raw mut (*s).current_exception, value);
         (*s).has_exception = true;
 
         if (*s).in_finally {
@@ -168,7 +168,7 @@ pub extern "C" fn js_has_exception() -> i32 {
 pub extern "C" fn js_clear_exception() {
     with_exception_state(|s| unsafe {
         (*s).has_exception = false;
-        (*s).current_exception = 0.0;
+        crate::gc::runtime_store_root_nanbox_f64_raw_slot(&raw mut (*s).current_exception, 0.0);
     });
 }
 
@@ -313,7 +313,7 @@ pub fn scan_exception_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>)
 #[cfg(test)]
 pub(crate) fn test_set_exception(value: f64) {
     with_exception_state(|s| unsafe {
-        (*s).current_exception = value;
+        crate::gc::runtime_store_root_nanbox_f64_raw_slot(&raw mut (*s).current_exception, value);
         (*s).has_exception = true;
     });
 }

--- a/crates/perry-runtime/src/gc/barrier.rs
+++ b/crates/perry-runtime/src/gc/barrier.rs
@@ -374,6 +374,14 @@ pub(super) unsafe fn scan_dirty_object_slots(
 // HashSet behavior.
 
 thread_local! {
+    /// Active full-incremental mark barrier state.
+    ///
+    /// The valid pointer set is owned by the current `GcCycleState`. This raw
+    /// pointer is installed only after that set has been built and is cleared
+    /// before sweep/reclaim or if the cycle is dropped.
+    pub(super) static INCREMENTAL_MARK_BARRIER_VALID_PTRS: Cell<*const ValidPointerSet> =
+        const { Cell::new(std::ptr::null()) };
+
     /// Dirty old-generation pages that have received a YOUNG-gen
     /// pointer since the last collection. This is Perry's compact
     /// modbuf: barriers log bounded page regions, and minor GC scans
@@ -415,6 +423,132 @@ thread_local! {
 }
 
 pub(super) static GENERATED_WRITE_BARRIERS_EMITTED: AtomicUsize = AtomicUsize::new(0);
+
+pub(super) fn incremental_mark_barrier_enable(valid_ptrs: &ValidPointerSet) {
+    INCREMENTAL_MARK_BARRIER_VALID_PTRS.with(|cell| {
+        cell.set(valid_ptrs as *const ValidPointerSet);
+    });
+}
+
+pub(super) fn incremental_mark_barrier_disable() {
+    INCREMENTAL_MARK_BARRIER_VALID_PTRS.with(|cell| {
+        cell.set(std::ptr::null());
+    });
+}
+
+#[inline]
+pub(super) fn incremental_mark_barrier_active() -> bool {
+    INCREMENTAL_MARK_BARRIER_VALID_PTRS.with(|cell| !cell.get().is_null())
+}
+
+#[inline]
+pub(super) fn heap_word_candidate_addr(bits: u64) -> Option<usize> {
+    let tag = bits & TAG_MASK;
+    if tag == POINTER_TAG || tag == STRING_TAG || tag == BIGINT_TAG {
+        let ptr = (bits & POINTER_MASK) as usize;
+        return (ptr != 0).then_some(ptr);
+    }
+    if tag >= 0x7FF8_0000_0000_0000 {
+        return None;
+    }
+    if (0x1000..=0x0000_FFFF_FFFF_FFFF).contains(&bits) {
+        Some(bits as usize)
+    } else {
+        None
+    }
+}
+
+#[inline]
+pub(super) unsafe fn plausible_arena_user_ptr_header(
+    header: *mut GcHeader,
+) -> Option<*mut GcHeader> {
+    if header.is_null() {
+        return None;
+    }
+    let obj_type = (*header).obj_type;
+    let size = (*header).size as usize;
+    if gc_type_info(obj_type).is_none()
+        || size < GC_HEADER_SIZE
+        || size > (1usize << 34)
+        || (*header).gc_flags & GC_FLAG_ARENA == 0
+        || (*header).gc_flags & GC_FLAG_FORWARDED != 0
+    {
+        None
+    } else {
+        Some(header)
+    }
+}
+
+pub(super) fn current_heap_header_for_user_ptr(
+    user_ptr: usize,
+    valid_ptrs: Option<&ValidPointerSet>,
+) -> Option<*mut GcHeader> {
+    if user_ptr < GC_HEADER_SIZE + 0x1000 {
+        return None;
+    }
+    if valid_ptrs.is_some_and(|ptrs| ptrs.contains(&user_ptr)) {
+        return Some(unsafe { header_from_user_ptr(user_ptr as *const u8) });
+    }
+
+    match crate::arena::classify_heap_generation(user_ptr) {
+        crate::arena::HeapGeneration::Unknown => {
+            let header = unsafe { header_from_user_ptr(user_ptr as *const u8) };
+            gc_malloc_header_is_tracked(header).then_some(header)
+        }
+        _ => unsafe {
+            plausible_arena_user_ptr_header(header_from_user_ptr(user_ptr as *const u8))
+        },
+    }
+}
+
+pub(super) fn current_heap_header_for_heap_word(
+    bits: u64,
+    valid_ptrs: Option<&ValidPointerSet>,
+) -> Option<(usize, *mut GcHeader)> {
+    let addr = heap_word_candidate_addr(bits)?;
+    let header = current_heap_header_for_user_ptr(addr, valid_ptrs)?;
+    Some((addr, header))
+}
+
+fn incremental_mark_barrier_value_with_valid_ptrs(
+    value_bits: u64,
+    valid_ptrs: &ValidPointerSet,
+) -> bool {
+    let Some((_addr, header)) = current_heap_header_for_heap_word(value_bits, Some(valid_ptrs))
+    else {
+        return false;
+    };
+    unsafe {
+        let flags = (*header).gc_flags;
+        if flags & (GC_FLAG_MARKED | GC_FLAG_PINNED | GC_FLAG_FORWARDED) != 0 {
+            return false;
+        }
+        (*header).gc_flags = flags | GC_FLAG_MARKED;
+        push_mark_seed(header);
+    }
+    true
+}
+
+pub(super) fn incremental_mark_barrier_value(value_bits: u64) -> bool {
+    INCREMENTAL_MARK_BARRIER_VALID_PTRS.with(|cell| {
+        let ptr = cell.get();
+        if ptr.is_null() {
+            return false;
+        }
+        let valid_ptrs = unsafe { &*ptr };
+        incremental_mark_barrier_value_with_valid_ptrs(value_bits, valid_ptrs)
+    })
+}
+
+pub(super) fn drain_incremental_mark_barrier_seeds(valid_ptrs: &ValidPointerSet) {
+    loop {
+        let mut worklist = take_mark_seeds();
+        if worklist.is_empty() {
+            return;
+        }
+        drain_trace_worklist(&mut worklist, valid_ptrs);
+    }
+}
 
 #[no_mangle]
 pub extern "C" fn js_gc_write_barriers_emitted(active: u32) {
@@ -532,6 +666,7 @@ pub(super) fn write_barrier_slot_inner(
     external_slot: bool,
 ) {
     bump_write_barrier_trace_counter(BarrierTraceCounter::Calls);
+    incremental_mark_barrier_value(child);
 
     // Decode child first: primitive stores are the most common skip.
     let child_addr = decode_heap_addr(child);
@@ -707,6 +842,7 @@ pub(super) fn mark_dirty_external_slot_page(header_addr: usize, page: usize) -> 
 
 pub(crate) fn runtime_write_barrier_slot(parent_addr: usize, slot_addr: usize, child_bits: u64) {
     if !write_barriers_enabled() {
+        incremental_mark_barrier_value(child_bits);
         return;
     }
     js_write_barrier_slot(parent_addr as u64, slot_addr as u64, child_bits);
@@ -732,6 +868,7 @@ pub(crate) fn runtime_write_barrier_external_slot(
     child_bits: u64,
 ) {
     if !write_barriers_enabled() {
+        incremental_mark_barrier_value(child_bits);
         return;
     }
     write_barrier_slot_inner(
@@ -744,6 +881,7 @@ pub(crate) fn runtime_write_barrier_external_slot(
 
 pub(crate) fn runtime_write_barrier_gc_slot(parent_addr: usize, slot_addr: usize, child_bits: u64) {
     if !write_barriers_enabled() {
+        incremental_mark_barrier_value(child_bits);
         return;
     }
     let parent_is_malloc_gc = matches!(
@@ -756,6 +894,86 @@ pub(crate) fn runtime_write_barrier_gc_slot(parent_addr: usize, slot_addr: usize
         child_bits,
         parent_is_malloc_gc,
     );
+}
+
+#[inline]
+pub(crate) fn runtime_write_barrier_root_heap_word(value_bits: u64) {
+    incremental_mark_barrier_value(value_bits);
+}
+
+#[inline]
+pub(crate) fn runtime_write_barrier_root_nanbox(value_bits: u64) {
+    incremental_mark_barrier_value(value_bits);
+}
+
+#[inline]
+pub(crate) fn runtime_write_barrier_root_raw_ptr<T>(ptr: *const T) {
+    if !ptr.is_null() {
+        incremental_mark_barrier_value(ptr as u64);
+    }
+}
+
+#[inline]
+pub(crate) unsafe fn runtime_store_root_nanbox_f64_raw_slot(slot: *mut f64, value: f64) {
+    std::ptr::write(slot, value);
+    runtime_write_barrier_root_nanbox(value.to_bits());
+}
+
+#[inline]
+pub(crate) unsafe fn runtime_store_root_raw_mut_ptr_slot<T>(slot: *mut *mut T, value: *mut T) {
+    std::ptr::write(slot, value);
+    runtime_write_barrier_root_raw_ptr(value);
+}
+
+#[inline]
+pub(crate) unsafe fn runtime_store_root_usize_slot(slot: *mut usize, value: usize) {
+    std::ptr::write(slot, value);
+    runtime_write_barrier_root_heap_word(value as u64);
+}
+
+#[inline]
+pub(crate) fn runtime_store_root_atomic_nanbox_u64(
+    slot: &std::sync::atomic::AtomicU64,
+    value_bits: u64,
+    ordering: std::sync::atomic::Ordering,
+) {
+    slot.store(value_bits, ordering);
+    runtime_write_barrier_root_nanbox(value_bits);
+}
+
+#[inline]
+pub(crate) fn runtime_store_root_atomic_raw_i64(
+    slot: &std::sync::atomic::AtomicI64,
+    value: i64,
+    ordering: std::sync::atomic::Ordering,
+) {
+    slot.store(value, ordering);
+    runtime_write_barrier_root_heap_word(value as u64);
+}
+
+#[inline]
+pub(crate) fn runtime_compare_exchange_root_atomic_raw_i64(
+    slot: &std::sync::atomic::AtomicI64,
+    current: i64,
+    new: i64,
+    success: std::sync::atomic::Ordering,
+    failure: std::sync::atomic::Ordering,
+) -> Result<i64, i64> {
+    let result = slot.compare_exchange(current, new, success, failure);
+    if result.is_ok() {
+        runtime_write_barrier_root_heap_word(new as u64);
+    }
+    result
+}
+
+#[no_mangle]
+pub extern "C" fn js_write_barrier_root_heap_word(value_bits: u64) {
+    runtime_write_barrier_root_heap_word(value_bits);
+}
+
+#[no_mangle]
+pub extern "C" fn js_write_barrier_root_nanbox(value_bits: u64) {
+    runtime_write_barrier_root_nanbox(value_bits);
 }
 
 #[inline]

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -125,19 +125,6 @@ impl CopyingPointerSet {
         })
     }
 
-    pub(super) fn ensure_malloc_registry_for_copy_only_preflight(&self) {
-        if self.malloc_registry_available.get() {
-            return;
-        }
-        MALLOC_STATE.with(|s| {
-            let mut s = s.borrow_mut();
-            ensure_set_built(&mut s);
-            if s.malloc_registry_available() {
-                self.malloc_registry_available.set(true);
-            }
-        });
-    }
-
     #[inline]
     pub(super) fn raw_pointer_candidate(bits: u64) -> bool {
         (0x1000..=POINTER_MASK).contains(&bits) && bits & 0x7 == 0
@@ -677,84 +664,6 @@ pub(super) fn scan_remembered_dirty_slots_copying(
     stats
 }
 
-pub(super) struct CopyOnlyRootPreflight<'a> {
-    pub(super) ptrs: &'a CopyingPointerSet,
-    pub(super) fallback_reason: Option<CopiedMinorFallbackReason>,
-    pub(super) stats: LegacyRootTraceStats,
-}
-
-impl<'a> CopyOnlyRootPreflight<'a> {
-    pub(super) fn new(
-        ptrs: &'a CopyingPointerSet,
-        registered_rust_scanners: usize,
-        registered_ffi_scanners: usize,
-    ) -> Self {
-        Self {
-            ptrs,
-            fallback_reason: None,
-            stats: LegacyRootTraceStats {
-                registered_rust_scanners,
-                registered_ffi_scanners,
-                ..LegacyRootTraceStats::default()
-            },
-        }
-    }
-
-    pub(super) fn check_bits(&mut self, bits: u64) {
-        self.stats.emitted_roots += 1;
-        let Some(addr) = self.decode_copy_only_addr(bits) else {
-            return;
-        };
-        let Some(ptr) = self.ptrs.classify_arena(addr) else {
-            self.ptrs.ensure_malloc_registry_for_copy_only_preflight();
-            if self.ptrs.classify_malloc(addr).is_some() {
-                self.stats.emitted_malloc_roots += 1;
-                self.fallback_reason = Some(CopiedMinorFallbackReason::CopyOnlyRoots);
-            } else {
-                self.stats.malformed_roots += 1;
-            }
-            return;
-        };
-
-        match ptr.kind {
-            CopyingPointerKind::Eden
-            | CopyingPointerKind::FromSurvivor
-            | CopyingPointerKind::ToSurvivor => {
-                self.stats.emitted_young_roots += 1;
-                self.fallback_reason = Some(CopiedMinorFallbackReason::CopyOnlyRoots);
-            }
-            CopyingPointerKind::Longlived | CopyingPointerKind::Old => {
-                self.stats.emitted_old_roots += 1;
-            }
-            CopyingPointerKind::Malloc => unreachable!("malloc roots are classified separately"),
-        }
-    }
-
-    pub(super) fn decode_copy_only_addr(&mut self, bits: u64) -> Option<usize> {
-        let tag = bits & TAG_MASK;
-        if tag == POINTER_TAG || tag == STRING_TAG || tag == BIGINT_TAG {
-            let addr = (bits & POINTER_MASK) as usize;
-            return (addr != 0).then_some(addr);
-        }
-        if tag >= 0x7FF8_0000_0000_0000 {
-            return None;
-        }
-        if !CopyingPointerSet::raw_pointer_candidate(bits) {
-            return None;
-        }
-        Some(bits as usize)
-    }
-}
-
-pub(super) extern "C" fn perry_ffi_copy_only_preflight_root(value: f64, ctx: *mut c_void) {
-    if ctx.is_null() {
-        return;
-    }
-    unsafe {
-        (*(ctx as *mut CopyOnlyRootPreflight<'_>)).check_bits(value.to_bits());
-    }
-}
-
 pub(super) struct CopiedMinorEligibility {
     pub(super) eligible: bool,
     pub(super) fallback_reason: CopiedMinorFallbackReason,
@@ -767,6 +676,13 @@ pub(super) struct CopiedMinorEligibility {
 
 impl CopiedMinorEligibility {
     pub(super) fn evaluate(trigger_kind: GcTriggerKind) -> Self {
+        Self::evaluate_with_stack_decision(trigger_kind, conservative_stack_scan_decision())
+    }
+
+    pub(super) fn evaluate_with_stack_decision(
+        trigger_kind: GcTriggerKind,
+        stack_decision: ConservativeStackScanDecision,
+    ) -> Self {
         let malloc_sweep_due = copied_minor_malloc_sweep_due(trigger_kind);
         if !old_to_young_tracking_complete() {
             return Self::fallback(
@@ -774,10 +690,7 @@ impl CopiedMinorEligibility {
                 malloc_sweep_due,
             );
         }
-        if matches!(
-            conservative_stack_scan_decision(),
-            ConservativeStackScanDecision::Scan
-        ) {
+        if matches!(stack_decision, ConservativeStackScanDecision::Scan) {
             return Self::fallback(
                 CopiedMinorFallbackReason::ConservativeStack,
                 malloc_sweep_due,
@@ -862,24 +775,17 @@ impl CopiedMinorEligibility {
     }
 
     pub(super) fn copy_only_root_preflight_reason(
-        ptrs: &CopyingPointerSet,
+        _ptrs: &CopyingPointerSet,
     ) -> (Option<CopiedMinorFallbackReason>, LegacyRootTraceStats) {
-        let scanners: Vec<fn(&mut dyn FnMut(f64))> = ROOT_SCANNERS.with(|s| s.borrow().clone());
-        let ffi_scanners: Vec<PerryFfiRootScanner> = FFI_ROOT_SCANNERS.with(|s| s.borrow().clone());
-        let mut preflight = CopyOnlyRootPreflight::new(ptrs, scanners.len(), ffi_scanners.len());
-
-        for scanner in scanners {
-            scanner(&mut |value: f64| {
-                preflight.check_bits(value.to_bits());
-            });
-        }
-
-        let ctx = &mut preflight as *mut CopyOnlyRootPreflight<'_> as *mut c_void;
-        for scanner in ffi_scanners {
-            scanner(perry_ffi_copy_only_preflight_root, ctx);
-        }
-
-        (preflight.fallback_reason, preflight.stats)
+        let (registered_rust_scanners, registered_ffi_scanners) = copy_only_root_scanner_counts();
+        let stats = LegacyRootTraceStats {
+            registered_rust_scanners,
+            registered_ffi_scanners,
+            ..LegacyRootTraceStats::default()
+        };
+        let reason = (registered_rust_scanners > 0 || registered_ffi_scanners > 0)
+            .then_some(CopiedMinorFallbackReason::CopyOnlyRoots);
+        (reason, stats)
     }
 
     pub(super) fn mutable_root_preflight_reason(
@@ -927,6 +833,14 @@ pub(super) fn gc_collect_minor_copying_fast_path(
     trigger_kind: GcTriggerKind,
 ) -> Option<CopiedMinorFastPathOutcome> {
     let eligibility = CopiedMinorEligibility::evaluate(trigger_kind);
+    gc_collect_minor_copying_fast_path_with_eligibility(trace, start, eligibility)
+}
+
+pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
+    trace: &mut Option<GcCycleTrace>,
+    start: Instant,
+    eligibility: CopiedMinorEligibility,
+) -> Option<CopiedMinorFastPathOutcome> {
     if let Some(trace) = trace.as_mut() {
         trace.copying_nursery = eligibility.trace_stats();
         trace.legacy_copy_only_scanner_pinned = eligibility.legacy_root_stats;

--- a/crates/perry-runtime/src/gc/cycle.rs
+++ b/crates/perry-runtime/src/gc/cycle.rs
@@ -634,7 +634,7 @@ impl GcCycleState {
         } else {
             let valid_ptrs = self.valid_ptrs.as_ref().expect("valid pointer set built");
             drain_incremental_mark_barrier_seeds(valid_ptrs);
-            self.live_old_to_young_sticky = Some(rebuild_live_old_to_young_remembered_set());
+            self.live_old_to_young_sticky = Some(rebuild_live_old_to_young_remembered_set(true));
             incremental_mark_barrier_disable();
         }
         self.phase = GcCyclePhase::Sweep;
@@ -729,7 +729,7 @@ impl GcCycleState {
 
         minor.evacuation = evacuation;
         minor.evacuation_sticky = evacuation_sticky;
-        self.live_old_to_young_sticky = Some(rebuild_live_old_to_young_remembered_set());
+        self.live_old_to_young_sticky = Some(rebuild_live_old_to_young_remembered_set(false));
     }
 
     fn step_sweep(&mut self) {

--- a/crates/perry-runtime/src/gc/cycle.rs
+++ b/crates/perry-runtime/src/gc/cycle.rs
@@ -91,13 +91,23 @@ impl TraceWorklistCycleState {
     }
 
     fn step(&mut self, valid_ptrs: &ValidPointerSet, budget: usize) -> bool {
-        drain_trace_worklist_step(
+        self.absorb_mark_seeds();
+        let done = drain_trace_worklist_step(
             &mut self.worklist,
             &mut self.cursor,
             valid_ptrs,
             self.minor_only,
             budget,
-        )
+        );
+        self.absorb_mark_seeds();
+        done && self.cursor >= self.worklist.len()
+    }
+
+    fn absorb_mark_seeds(&mut self) {
+        let mut seeds = take_mark_seeds();
+        if !seeds.is_empty() {
+            self.worklist.append(&mut seeds);
+        }
     }
 }
 
@@ -487,6 +497,10 @@ impl GcCycleState {
             .expect("valid-pointer builder exists");
         self.valid_ptrs = Some(builder.finish());
         trace_phase_record(&mut self.trace, "build_valid_pointer_set", phase_start);
+        if matches!(self.collection_kind, GcCollectionKind::Full) {
+            let valid_ptrs = self.valid_ptrs.as_ref().expect("valid pointer set built");
+            incremental_mark_barrier_enable(valid_ptrs);
+        }
 
         let active_elapsed_us = self.active_elapsed_us();
         if let Some(minor) = self.minor.as_mut() {
@@ -618,7 +632,10 @@ impl GcCycleState {
         if self.minor.is_some() {
             self.atomic_finalize_minor();
         } else {
+            let valid_ptrs = self.valid_ptrs.as_ref().expect("valid pointer set built");
+            drain_incremental_mark_barrier_seeds(valid_ptrs);
             self.live_old_to_young_sticky = Some(rebuild_live_old_to_young_remembered_set());
+            incremental_mark_barrier_disable();
         }
         self.phase = GcCyclePhase::Sweep;
     }
@@ -811,6 +828,17 @@ impl GcCycleState {
             trace: self.trace.take(),
         });
         self.phase = GcCyclePhase::Complete;
+    }
+}
+
+impl Drop for GcCycleState {
+    fn drop(&mut self) {
+        if matches!(self.collection_kind, GcCollectionKind::Full)
+            && self.phase != GcCyclePhase::Complete
+        {
+            incremental_mark_barrier_disable();
+            clear_mark_seeds();
+        }
     }
 }
 

--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -1152,6 +1152,9 @@ pub(super) unsafe fn visit_gc_rewrite_slot_descriptors(
             crate::closure::visit_closure_dynamic_prop_value_slots_mut(user_ptr as usize, |slot| {
                 visit(fixed_slot(slot));
             });
+            crate::closure::visit_closure_static_prototype_slot_mut(user_ptr as usize, |slot| {
+                visit(fixed_slot(slot));
+            });
         }
         GcRewriteDescriptorKind::Promise => {
             let promise = user_ptr as *mut crate::promise::Promise;

--- a/crates/perry-runtime/src/gc/roots.rs
+++ b/crates/perry-runtime/src/gc/roots.rs
@@ -128,7 +128,6 @@ pub(super) enum ConservativeStackScanMode {
 pub(super) enum ConservativeStackScanDecision {
     Scan,
     SkipDisabled,
-    SkipShadowStackActive,
 }
 
 impl ConservativeStackScanDecision {
@@ -137,7 +136,6 @@ impl ConservativeStackScanDecision {
         match self {
             Self::Scan => "scan",
             Self::SkipDisabled => "skip_disabled",
-            Self::SkipShadowStackActive => "skip_shadow_stack_active",
         }
     }
 }
@@ -172,15 +170,12 @@ pub(super) fn conservative_stack_scan_mode() -> ConservativeStackScanMode {
 #[inline]
 pub(super) fn conservative_stack_scan_decision_for(
     mode: ConservativeStackScanMode,
-    shadow_frame_active: bool,
+    _shadow_frame_active: bool,
 ) -> ConservativeStackScanDecision {
     match mode {
         ConservativeStackScanMode::Disabled => ConservativeStackScanDecision::SkipDisabled,
         ConservativeStackScanMode::Full => ConservativeStackScanDecision::Scan,
-        ConservativeStackScanMode::Auto if shadow_frame_active => {
-            ConservativeStackScanDecision::SkipShadowStackActive
-        }
-        ConservativeStackScanMode::Auto => ConservativeStackScanDecision::Scan,
+        ConservativeStackScanMode::Auto => ConservativeStackScanDecision::SkipDisabled,
     }
 }
 
@@ -193,13 +188,19 @@ pub(super) fn conservative_stack_scan_decision() -> ConservativeStackScanDecisio
 
 /// Register a root scanner function.
 /// Each scanner is called during the mark phase to discover roots.
-/// This legacy API exposes copied values only. When evacuation is
-/// enabled, every discovered target is treated as pinned because the GC
-/// has no mutable slot it can rewrite after forwarding.
+/// This legacy API exposes copied values only. It remains supported for
+/// fallback/full GC, where discovered targets can be pinned, but registering
+/// any copy-only scanner makes low-pause copied-minor collection ineligible.
 pub fn gc_register_root_scanner(scanner: fn(&mut dyn FnMut(f64))) {
     ROOT_SCANNERS.with(|scanners| {
         scanners.borrow_mut().push(scanner);
     });
+}
+
+pub(super) fn copy_only_root_scanner_counts() -> (usize, usize) {
+    let rust_scanners = ROOT_SCANNERS.with(|scanners| scanners.borrow().len());
+    let ffi_scanners = FFI_ROOT_SCANNERS.with(|scanners| scanners.borrow().len());
+    (rust_scanners, ffi_scanners)
 }
 
 /// Register a runtime-owned root scanner that exposes mutable slots.
@@ -250,8 +251,9 @@ pub(super) const PERRY_FFI_ROOT_SLOT_NANBOX_U64: u32 = 5;
 /// `perry-ffi` adapts its Rust-facing `fn(&mut dyn FnMut(f64))`
 /// convenience API to this callback shape so native wrapper archives
 /// can stay runtime-free. Like the Rust legacy scanner API, this is
-/// copy-only storage from the GC's perspective; evacuation pins those
-/// roots instead of attempting to rewrite native-owned slots.
+/// copy-only storage from the GC's perspective. Registration keeps the
+/// fallback/full-GC path compatible, but makes low-pause copied-minor
+/// collection ineligible because native-owned slots cannot be rewritten.
 #[no_mangle]
 pub extern "C" fn perry_ffi_gc_register_root_scanner(scanner: PerryFfiRootScanner) {
     FFI_ROOT_SCANNERS.with(|scanners| {
@@ -312,10 +314,7 @@ pub(super) fn mark_stack_roots_for_decision(
 ) -> ConservativeRootTraceStats {
     match decision {
         ConservativeStackScanDecision::Scan => mark_stack_roots_unchecked(valid_ptrs),
-        ConservativeStackScanDecision::SkipDisabled
-        | ConservativeStackScanDecision::SkipShadowStackActive => {
-            ConservativeRootTraceStats::default()
-        }
+        ConservativeStackScanDecision::SkipDisabled => ConservativeRootTraceStats::default(),
     }
 }
 

--- a/crates/perry-runtime/src/gc/roots.rs
+++ b/crates/perry-runtime/src/gc/roots.rs
@@ -293,8 +293,14 @@ pub extern "C" fn perry_ffi_gc_register_mutable_root_scanner_named(
 /// Called by codegen in module init functions.
 #[no_mangle]
 pub extern "C" fn js_gc_register_global_root(ptr: i64) {
+    let root = ptr as *mut u64;
+    if !root.is_null() {
+        unsafe {
+            runtime_write_barrier_root_heap_word(*root);
+        }
+    }
     GLOBAL_ROOTS.with(|roots| {
-        roots.borrow_mut().push(ptr as *mut u64);
+        roots.borrow_mut().push(root);
     });
 }
 
@@ -1227,6 +1233,7 @@ impl RuntimeHandleScope {
 
     #[inline]
     pub(super) fn push<'scope>(&'scope self, slot: RuntimeHandleSlot) -> RuntimeHandle<'scope> {
+        runtime_handle_slot_write_barrier(slot);
         let index = RUNTIME_HANDLE_STACK.with(|stack| {
             let mut stack = stack.borrow_mut();
             let index = stack.len();
@@ -1319,6 +1326,19 @@ impl RuntimeHandleScope {
     }
 }
 
+#[inline]
+pub(super) fn runtime_handle_slot_write_barrier(slot: RuntimeHandleSlot) {
+    match slot {
+        RuntimeHandleSlot::Nanbox(bits) => runtime_write_barrier_root_nanbox(bits),
+        RuntimeHandleSlot::HeapWord(bits) => runtime_write_barrier_root_heap_word(bits),
+        RuntimeHandleSlot::RawTagged { addr, tag } => {
+            if addr != 0 {
+                runtime_write_barrier_root_nanbox(tag | (addr as u64 & POINTER_MASK));
+            }
+        }
+    }
+}
+
 impl Default for RuntimeHandleScope {
     fn default() -> Self {
         Self::new()
@@ -1382,6 +1402,7 @@ impl<'scope> RuntimeHandle<'scope> {
             RuntimeHandleSlot::Nanbox(current) => *current = bits,
             _ => panic!("runtime handle kind mismatch: expected NaN-boxed value"),
         });
+        runtime_write_barrier_root_nanbox(bits);
     }
 
     pub fn get_heap_word_u64(&self) -> u64 {
@@ -1396,6 +1417,7 @@ impl<'scope> RuntimeHandle<'scope> {
             RuntimeHandleSlot::HeapWord(current) => *current = bits,
             _ => panic!("runtime handle kind mismatch: expected heap word"),
         });
+        runtime_write_barrier_root_heap_word(bits);
     }
 
     pub fn get_raw_mut_ptr<T>(&self) -> *mut T {
@@ -1407,7 +1429,12 @@ impl<'scope> RuntimeHandle<'scope> {
 
     pub fn set_raw_mut_ptr<T>(&self, ptr: *mut T) {
         self.with_slot_mut(|slot| match slot {
-            RuntimeHandleSlot::RawTagged { addr, .. } => *addr = ptr as usize,
+            RuntimeHandleSlot::RawTagged { addr, tag } => {
+                *addr = ptr as usize;
+                if !ptr.is_null() {
+                    runtime_write_barrier_root_nanbox(*tag | (ptr as u64 & POINTER_MASK));
+                }
+            }
             _ => panic!("runtime handle kind mismatch: expected raw pointer"),
         });
     }
@@ -1421,7 +1448,12 @@ impl<'scope> RuntimeHandle<'scope> {
 
     pub fn set_raw_const_ptr<T>(&self, ptr: *const T) {
         self.with_slot_mut(|slot| match slot {
-            RuntimeHandleSlot::RawTagged { addr, .. } => *addr = ptr as usize,
+            RuntimeHandleSlot::RawTagged { addr, tag } => {
+                *addr = ptr as usize;
+                if !ptr.is_null() {
+                    runtime_write_barrier_root_nanbox(*tag | (ptr as u64 & POINTER_MASK));
+                }
+            }
             _ => panic!("runtime handle kind mismatch: expected raw pointer"),
         });
     }

--- a/crates/perry-runtime/src/gc/roots/shadow_stack.rs
+++ b/crates/perry-runtime/src/gc/roots/shadow_stack.rs
@@ -127,6 +127,7 @@ pub extern "C" fn js_shadow_slot_set(idx: u32, value: u64) {
             s.stack[slot] = value;
             s.active[slot] = value != 0;
             if value != 0 {
+                crate::gc::runtime_write_barrier_root_nanbox(value);
                 let ptr = s.slot_ptrs[slot] as *mut u64;
                 if !ptr.is_null() {
                     *ptr = value;
@@ -155,6 +156,7 @@ pub extern "C" fn js_shadow_slot_bind(idx: u32, value_slot: *mut u64) {
             s.slot_ptrs[slot] = value_slot as usize;
             s.stack[slot] = *value_slot;
             s.active[slot] = true;
+            crate::gc::runtime_write_barrier_root_nanbox(*value_slot);
         }
     });
 }

--- a/crates/perry-runtime/src/gc/tests/barrier.rs
+++ b/crates/perry-runtime/src/gc/tests/barrier.rs
@@ -1048,6 +1048,198 @@ fn assert_heap_child_marked(ptr: *const u8, label: &str) {
     }
 }
 
+fn assert_marked_user_ptr(ptr: usize, label: &str) {
+    unsafe {
+        let header = header_from_user_ptr(ptr as *const u8);
+        assert_ne!(
+            (*header).gc_flags & GC_FLAG_MARKED,
+            0,
+            "{label} should be marked by the active incremental barrier"
+        );
+    }
+}
+
+fn mark_user_ptr(ptr: usize) {
+    unsafe {
+        let header = header_from_user_ptr(ptr as *const u8);
+        (*header).gc_flags |= GC_FLAG_MARKED;
+    }
+}
+
+fn clear_mark_user_ptr(ptr: usize) {
+    unsafe {
+        let header = header_from_user_ptr(ptr as *const u8);
+        (*header).gc_flags &= !GC_FLAG_MARKED;
+    }
+}
+
+#[test]
+fn test_incremental_barrier_marks_object_field_store() {
+    reset_remembered_set();
+    clear_marks();
+    let child = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+    let (obj, fields) = unsafe { alloc_old_test_object(1) };
+    mark_user_ptr(obj as usize);
+    let valid_ptrs = build_valid_pointer_set();
+    let _barrier = IncrementalMarkBarrierTestGuard::new(&valid_ptrs);
+
+    runtime_store_jsvalue_slot(obj as usize, fields as usize, 0, ptr_bits(child));
+    drain_incremental_mark_barrier_seeds(&valid_ptrs);
+
+    assert_marked_user_ptr(child, "object field child");
+    let stats = verify_marked_heap_no_unmarked_children();
+    assert_eq!(stats.missing_edges, 0);
+    clear_mark_user_ptr(obj as usize);
+    clear_marks();
+    remembered_set_clear();
+}
+
+#[test]
+fn test_incremental_barrier_marks_array_element_store() {
+    reset_remembered_set();
+    clear_marks();
+    let child = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+    let (arr, elements) = unsafe { alloc_old_test_array(1) };
+    mark_user_ptr(arr as usize);
+    let valid_ptrs = build_valid_pointer_set();
+    let _barrier = IncrementalMarkBarrierTestGuard::new(&valid_ptrs);
+
+    runtime_store_jsvalue_slot(arr as usize, elements as usize, 0, ptr_bits(child));
+    drain_incremental_mark_barrier_seeds(&valid_ptrs);
+
+    assert_marked_user_ptr(child, "array element child");
+    let stats = verify_marked_heap_no_unmarked_children();
+    assert_eq!(stats.missing_edges, 0);
+    clear_mark_user_ptr(arr as usize);
+    clear_marks();
+    remembered_set_clear();
+}
+
+#[test]
+fn test_incremental_barrier_marks_closure_capture_store() {
+    reset_remembered_set();
+    clear_marks();
+    let child = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+    let closure = crate::closure::js_closure_alloc(test_captured_singleton_func as *const u8, 1);
+    mark_user_ptr(closure as usize);
+    let valid_ptrs = build_valid_pointer_set();
+    let _barrier = IncrementalMarkBarrierTestGuard::new(&valid_ptrs);
+
+    crate::closure::js_closure_set_capture_ptr(closure, 0, child as i64);
+    drain_incremental_mark_barrier_seeds(&valid_ptrs);
+
+    assert_marked_user_ptr(child, "closure capture child");
+    let stats = verify_marked_heap_no_unmarked_children();
+    assert_eq!(stats.missing_edges, 0);
+    clear_mark_user_ptr(closure as usize);
+    clear_marks();
+    remembered_set_clear();
+}
+
+#[test]
+fn test_incremental_barrier_marks_closure_static_prototype_store() {
+    reset_remembered_set();
+    clear_marks();
+    let proto = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+    let closure = crate::closure::js_closure_alloc(test_no_capture_singleton_func as *const u8, 0);
+    mark_user_ptr(closure as usize);
+    let valid_ptrs = build_valid_pointer_set();
+    let _barrier = IncrementalMarkBarrierTestGuard::new(&valid_ptrs);
+
+    crate::closure::closure_set_static_prototype(closure as usize, ptr_bits(proto));
+    drain_incremental_mark_barrier_seeds(&valid_ptrs);
+
+    assert_marked_user_ptr(proto, "closure static prototype");
+    let stats = verify_marked_heap_no_unmarked_children();
+    assert_eq!(stats.checked_edges, 1);
+    assert_eq!(stats.missing_edges, 0);
+    clear_mark_user_ptr(closure as usize);
+    crate::closure::test_clear_closure_side_tables();
+    clear_marks();
+    remembered_set_clear();
+}
+
+#[test]
+fn test_incremental_barrier_marks_external_map_and_set_slots() {
+    reset_remembered_set();
+    clear_marks();
+    let map_child = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+    let set_child = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+    let (map, entries, map_layout) = unsafe { alloc_old_test_map(1) };
+    let (set, elements, set_layout) = unsafe { alloc_old_test_set(1) };
+    unsafe {
+        (*map).size = 1;
+        (*set).size = 1;
+    }
+    mark_user_ptr(map as usize);
+    mark_user_ptr(set as usize);
+    let valid_ptrs = build_valid_pointer_set();
+    let _barrier = IncrementalMarkBarrierTestGuard::new(&valid_ptrs);
+
+    runtime_store_external_jsvalue_slot(map as usize, entries as usize, ptr_bits(map_child));
+    runtime_store_external_jsvalue_slot(set as usize, elements as usize, ptr_bits(set_child));
+    drain_incremental_mark_barrier_seeds(&valid_ptrs);
+
+    assert_marked_user_ptr(map_child, "map external slot child");
+    assert_marked_user_ptr(set_child, "set external slot child");
+    let stats = verify_marked_heap_no_unmarked_children();
+    assert_eq!(stats.missing_edges, 0);
+    unsafe {
+        retire_old_test_map(map, entries, map_layout);
+        retire_old_test_set(set, elements, set_layout);
+    }
+    clear_marks();
+    remembered_set_clear();
+}
+
+#[test]
+fn test_mark_invariant_verifier_rejects_incremental_barrier_bypass() {
+    reset_remembered_set();
+    clear_marks();
+    let child = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+    let (obj, fields) = unsafe { alloc_old_test_object(1) };
+    mark_user_ptr(obj as usize);
+    unsafe {
+        *fields = ptr_bits(child);
+    }
+
+    let result = std::panic::catch_unwind(verify_marked_heap_no_unmarked_children);
+
+    assert!(
+        result.is_err(),
+        "raw pointer-capable stores into marked parents must fail the mark verifier"
+    );
+    clear_mark_user_ptr(obj as usize);
+    clear_marks();
+    remembered_set_clear();
+}
+
+#[test]
+fn test_store_outside_incremental_mark_keeps_generational_behavior_only() {
+    reset_remembered_set();
+    clear_marks();
+    assert!(!incremental_mark_barrier_active());
+    let child = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+    let (obj, fields) = unsafe { alloc_old_test_object(1) };
+
+    runtime_store_jsvalue_slot(obj as usize, fields as usize, 0, ptr_bits(child));
+
+    unsafe {
+        let child_header = header_from_user_ptr(child as *const u8);
+        assert_eq!(
+            (*child_header).gc_flags & GC_FLAG_MARKED,
+            0,
+            "inactive incremental barrier must not mark the stored child"
+        );
+    }
+    assert!(
+        remembered_set_size() > 0,
+        "inactive incremental barrier must leave old-to-young remembered-set behavior intact"
+    );
+    clear_marks();
+    remembered_set_clear();
+}
+
 #[test]
 fn test_promise_pointer_field_stores_dirty_old_page() {
     let _guard = CopyingNurseryTestGuard::new(0);

--- a/crates/perry-runtime/src/gc/tests/copying.rs
+++ b/crates/perry-runtime/src/gc/tests/copying.rs
@@ -548,29 +548,26 @@ fn test_copied_minor_eligibility_falls_back_for_barriers_inactive() {
 #[test]
 fn test_copied_minor_eligibility_falls_back_for_conservative_stack_scan() {
     let _isolation = copying_nursery_isolation_lock();
-    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
     let _barrier_guard = GeneratedWriteBarrierTestGuard::active();
-    reset_shadow_stack();
-    reset_global_roots();
-    reset_remembered_set();
 
-    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    let eligibility = CopiedMinorEligibility::evaluate_with_stack_decision(
+        GcTriggerKind::Direct,
+        ConservativeStackScanDecision::Scan,
+    );
 
-    assert_copied_minor_trace(
-        &trace,
-        false,
-        CopiedMinorFallbackReason::ConservativeStack,
-        false,
+    assert!(!eligibility.eligible);
+    assert_eq!(
+        eligibility.fallback_reason,
+        CopiedMinorFallbackReason::ConservativeStack
     );
     assert_eq!(
-        trace.root_sources.native_stack_fallback.decision,
+        conservative_stack_scan_decision_for(ConservativeStackScanMode::Full, false),
         ConservativeStackScanDecision::Scan
     );
-    assert!(trace.root_sources.native_stack_fallback.scanned);
 }
 
 #[test]
-fn test_copied_minor_eligibility_active_shadow_frame_skips_conservative_stack_scan() {
+fn test_copied_minor_eligibility_auto_skips_conservative_stack_scan() {
     let _guard = CopyingNurseryTestGuard::new(0);
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
     assert!(shadow_stack_has_active_frame());
@@ -584,7 +581,7 @@ fn test_copied_minor_eligibility_active_shadow_frame_skips_conservative_stack_sc
     assert_eq!(trace.legacy_copy_only_scanner_pinned.pinned_bytes, 0);
     assert_eq!(
         trace.root_sources.native_stack_fallback.decision,
-        ConservativeStackScanDecision::SkipShadowStackActive
+        ConservativeStackScanDecision::SkipDisabled
     );
     assert!(!trace.root_sources.native_stack_fallback.scanned);
     assert_eq!(
@@ -614,7 +611,7 @@ fn root_source_active_shadow_frame_reports_precise_shadow_roots_only() {
     assert_eq!(trace.root_sources.compiled_shadow.rewritten_slots, 1);
     assert_eq!(
         trace.root_sources.native_stack_fallback.decision,
-        ConservativeStackScanDecision::SkipShadowStackActive
+        ConservativeStackScanDecision::SkipDisabled
     );
     assert!(!trace.root_sources.native_stack_fallback.scanned);
     assert_eq!(
@@ -627,14 +624,19 @@ fn root_source_active_shadow_frame_reports_precise_shadow_roots_only() {
 }
 
 #[test]
-fn test_copied_minor_eligibility_empty_copy_only_scanner_stays_eligible() {
+fn test_copied_minor_eligibility_empty_rust_copy_only_scanner_falls_back() {
     let _guard = CopyingNurseryTestGuard::new(0);
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
     let _copy_only_root_guard = TemporaryCopyOnlyRootScanner::rust_bits(&[]);
 
     let trace = collect_minor_trace(GcTriggerKind::Direct);
 
-    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+    assert_copied_minor_trace(
+        &trace,
+        false,
+        CopiedMinorFallbackReason::CopyOnlyRoots,
+        false,
+    );
     assert_eq!(
         trace
             .legacy_copy_only_scanner_pinned
@@ -642,6 +644,48 @@ fn test_copied_minor_eligibility_empty_copy_only_scanner_stays_eligible() {
         1
     );
     assert_eq!(trace.legacy_copy_only_scanner_pinned.emitted_roots, 0);
+}
+
+#[test]
+fn test_copied_minor_eligibility_empty_ffi_copy_only_scanner_falls_back() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    let _copy_only_root_guard = TemporaryCopyOnlyRootScanner::ffi_bits(&[]);
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+
+    assert_copied_minor_trace(
+        &trace,
+        false,
+        CopiedMinorFallbackReason::CopyOnlyRoots,
+        false,
+    );
+    assert_eq!(
+        trace
+            .legacy_copy_only_scanner_pinned
+            .registered_ffi_scanners,
+        1
+    );
+    assert_eq!(trace.legacy_copy_only_scanner_pinned.emitted_roots, 0);
+}
+
+#[test]
+fn test_copied_minor_eligibility_rejects_copy_only_without_scanning_roots() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    let child = young_leaf();
+    let _copy_only_root_guard = TemporaryCopyOnlyRootScanner::rust_bits(&[ptr_bits(child)]);
+
+    let eligibility = CopiedMinorEligibility::evaluate(GcTriggerKind::Direct);
+
+    assert!(!eligibility.eligible);
+    assert_eq!(
+        eligibility.fallback_reason,
+        CopiedMinorFallbackReason::CopyOnlyRoots
+    );
+    assert_eq!(eligibility.legacy_root_stats.registered_rust_scanners, 1);
+    assert_eq!(eligibility.legacy_root_stats.emitted_roots, 0);
+    assert_eq!(eligibility.legacy_root_stats.emitted_young_roots, 0);
 }
 
 #[test]
@@ -669,7 +713,7 @@ fn test_copied_minor_eligibility_falls_back_for_live_young_rust_copy_only_root()
     assert_eq!(trace.legacy_copy_only_scanner_pinned.emitted_young_roots, 1);
     assert_eq!(
         trace.root_sources.native_stack_fallback.decision,
-        ConservativeStackScanDecision::SkipShadowStackActive
+        ConservativeStackScanDecision::SkipDisabled
     );
     assert_eq!(
         trace
@@ -925,7 +969,7 @@ fn test_copied_minor_rewrites_old_error_cause_and_errors_slots() {
 }
 
 #[test]
-fn test_copied_minor_eligibility_old_only_copy_only_root_stays_eligible() {
+fn test_copied_minor_eligibility_old_only_copy_only_root_falls_back() {
     let _guard = CopyingNurseryTestGuard::new(0);
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
     let old = crate::arena::arena_alloc_gc_old(32, 8, GC_TYPE_OBJECT) as usize;
@@ -933,21 +977,31 @@ fn test_copied_minor_eligibility_old_only_copy_only_root_stays_eligible() {
 
     let trace = collect_minor_trace(GcTriggerKind::Direct);
 
-    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+    assert_copied_minor_trace(
+        &trace,
+        false,
+        CopiedMinorFallbackReason::CopyOnlyRoots,
+        false,
+    );
     assert_eq!(trace.legacy_copy_only_scanner_pinned.emitted_roots, 1);
     assert_eq!(trace.legacy_copy_only_scanner_pinned.emitted_old_roots, 1);
     assert_eq!(trace.legacy_copy_only_scanner_pinned.emitted_young_roots, 0);
 }
 
 #[test]
-fn test_copied_minor_eligibility_malformed_copy_only_root_stays_eligible() {
+fn test_copied_minor_eligibility_malformed_copy_only_root_falls_back() {
     let _guard = CopyingNurseryTestGuard::new(0);
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
     let _copy_only_root_guard = TemporaryCopyOnlyRootScanner::rust_bits(&[0x7FFD_0000_0000_1000]);
 
     let trace = collect_minor_trace(GcTriggerKind::Direct);
 
-    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+    assert_copied_minor_trace(
+        &trace,
+        false,
+        CopiedMinorFallbackReason::CopyOnlyRoots,
+        false,
+    );
     assert_eq!(trace.legacy_copy_only_scanner_pinned.emitted_roots, 1);
     assert_eq!(trace.legacy_copy_only_scanner_pinned.malformed_roots, 1);
 }
@@ -1390,6 +1444,26 @@ fn test_copied_minor_verify_evacuation_env_remains_eligible() {
     );
     assert_ne!(after, child);
     assert!(crate::arena::pointer_in_nursery(after));
+}
+
+#[test]
+fn test_copied_minor_verify_evacuation_copy_only_roots_reject_before_copying() {
+    let _env_guard = EnvVarGuard::set("PERRY_GC_VERIFY_EVACUATION", "1");
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    let _copy_only_root_guard = TemporaryCopyOnlyRootScanner::rust_bits(&[]);
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+
+    assert_copied_minor_trace(
+        &trace,
+        false,
+        CopiedMinorFallbackReason::CopyOnlyRoots,
+        false,
+    );
+    assert_eq!(trace.copying_nursery.copied_objects, 0);
+    assert_eq!(trace.copying_nursery.promoted_objects, 0);
+    assert_eq!(trace.legacy_copy_only_scanner_pinned.emitted_roots, 0);
 }
 
 #[test]

--- a/crates/perry-runtime/src/gc/tests/cycle_state.rs
+++ b/crates/perry-runtime/src/gc/tests/cycle_state.rs
@@ -21,6 +21,16 @@ fn run_cycle_in_single_unit_steps(state: &mut GcCycleState) -> Vec<GcCyclePhase>
     panic!("GC cycle did not complete within step limit");
 }
 
+fn run_cycle_until_phase(state: &mut GcCycleState, target: GcCyclePhase) {
+    for _ in 0..100_000 {
+        if state.phase() == target {
+            return;
+        }
+        state.step(GcWorkBudget::bounded(1));
+    }
+    panic!("GC cycle did not reach {target:?} within step limit");
+}
+
 fn start_minor_fallback_state(trigger: GcTriggerSnapshot) -> GcCycleState {
     let prev_in_alloc = GC_FLAGS.with(|f| {
         let prev = f.get();
@@ -151,4 +161,197 @@ fn bounded_minor_fallback_preserves_age_and_trace_fields() {
         trace.copying_nursery.fallback_reason,
         CopiedMinorFallbackReason::NotAttempted
     );
+}
+
+#[test]
+fn full_cycle_drains_incremental_barrier_seed_before_sweep() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+    let (parent, fields) = unsafe { alloc_old_test_object(1) };
+    js_shadow_slot_set(0, ptr_bits(parent as usize));
+    let child = gc_malloc(
+        std::mem::size_of::<crate::closure::ClosureHeader>(),
+        GC_TYPE_CLOSURE,
+    );
+    unsafe {
+        init_test_closure(child);
+    }
+
+    let mut state = GcCycleState::new_full(trace_snapshot(GcTriggerKind::Manual));
+    run_cycle_until_phase(&mut state, GcCyclePhase::BlockPersistence);
+    assert_eq!(
+        state.phase(),
+        GcCyclePhase::BlockPersistence,
+        "test must store after ordinary mark propagation has drained"
+    );
+    assert!(
+        incremental_mark_barrier_active(),
+        "full cycle should keep incremental barriers active until atomic finalize"
+    );
+
+    runtime_store_jsvalue_slot(
+        parent as usize,
+        fields as usize,
+        0,
+        ptr_bits(child as usize),
+    );
+    run_cycle_in_single_unit_steps(&mut state);
+
+    assert!(
+        malloc_user_ptr_tracked(child),
+        "child stored after mark propagation should survive via atomic barrier-seed drain"
+    );
+    assert!(
+        !incremental_mark_barrier_active(),
+        "full cycle should disable incremental barriers before completion"
+    );
+}
+
+#[test]
+fn full_cycle_box_root_set_after_root_scan_preserves_new_value() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+    let box_ptr = crate::r#box::js_box_alloc(0.0);
+    assert!(!box_ptr.is_null());
+    let child = gc_malloc(
+        std::mem::size_of::<crate::closure::ClosureHeader>(),
+        GC_TYPE_CLOSURE,
+    );
+    unsafe {
+        init_test_closure(child);
+    }
+
+    let mut state = GcCycleState::new_full(trace_snapshot(GcTriggerKind::Manual));
+    run_cycle_until_phase(&mut state, GcCyclePhase::BlockPersistence);
+    assert!(
+        incremental_mark_barrier_active(),
+        "full cycle should keep root barriers active after root scan"
+    );
+
+    crate::r#box::js_box_set(box_ptr, f64::from_bits(ptr_bits(child as usize)));
+    run_cycle_in_single_unit_steps(&mut state);
+
+    assert!(
+        malloc_user_ptr_tracked(child),
+        "child stored into a box root after root scan should survive via js_box_set's root barrier"
+    );
+}
+
+#[test]
+fn full_cycle_global_root_store_after_root_scan_preserves_new_value() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+    let mut root_slot = 0_u64;
+    js_gc_register_global_root(&mut root_slot as *mut u64 as i64);
+    let child = gc_malloc(
+        std::mem::size_of::<crate::closure::ClosureHeader>(),
+        GC_TYPE_CLOSURE,
+    );
+    unsafe {
+        init_test_closure(child);
+    }
+
+    let mut state = GcCycleState::new_full(trace_snapshot(GcTriggerKind::Manual));
+    run_cycle_until_phase(&mut state, GcCyclePhase::BlockPersistence);
+    assert!(
+        incremental_mark_barrier_active(),
+        "full cycle should keep root barriers active after root scan"
+    );
+
+    root_slot = ptr_bits(child as usize);
+    js_write_barrier_root_nanbox(root_slot);
+    run_cycle_in_single_unit_steps(&mut state);
+
+    assert!(
+        malloc_user_ptr_tracked(child),
+        "child stored into a registered global root after root scan should survive via root barrier"
+    );
+}
+
+#[test]
+fn full_cycle_exception_root_store_after_root_scan_preserves_new_value() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    gc_register_mutable_root_scanner(exception_mutable_root_scanner);
+    crate::exception::js_clear_exception();
+
+    let child = gc_malloc(
+        std::mem::size_of::<crate::closure::ClosureHeader>(),
+        GC_TYPE_CLOSURE,
+    );
+    unsafe {
+        init_test_closure(child);
+    }
+
+    let mut state = GcCycleState::new_full(trace_snapshot(GcTriggerKind::Manual));
+    run_cycle_until_phase(&mut state, GcCyclePhase::BlockPersistence);
+    assert!(
+        incremental_mark_barrier_active(),
+        "full cycle should keep root barriers active after root scan"
+    );
+
+    crate::exception::test_set_exception(f64::from_bits(ptr_bits(child as usize)));
+    run_cycle_in_single_unit_steps(&mut state);
+
+    assert!(
+        malloc_user_ptr_tracked(child),
+        "child stored into the exception root after root scan should survive via root barrier"
+    );
+    crate::exception::js_clear_exception();
+}
+
+#[test]
+fn full_cycle_console_singleton_store_after_root_scan_preserves_new_value() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    gc_register_mutable_root_scanner(crate::builtins::scan_console_log_singleton_roots_mut);
+    crate::builtins::test_set_console_log_singleton(0);
+
+    let mut state = GcCycleState::new_full(trace_snapshot(GcTriggerKind::Manual));
+    run_cycle_until_phase(&mut state, GcCyclePhase::BlockPersistence);
+    assert!(
+        incremental_mark_barrier_active(),
+        "full cycle should keep root barriers active after root scan"
+    );
+
+    let console_log_value = crate::builtins::js_console_log_as_closure();
+    let console_log_bits = console_log_value.to_bits();
+    assert_eq!(console_log_bits & TAG_MASK, POINTER_TAG);
+    let console_log_ptr = (console_log_bits & POINTER_MASK) as usize;
+    assert_eq!(
+        crate::builtins::test_console_log_singleton(),
+        console_log_ptr as i64
+    );
+    let console_log_header = unsafe { header_from_user_ptr(console_log_ptr as *const u8) };
+    unsafe {
+        assert_ne!(
+            (*console_log_header).gc_flags & GC_FLAG_MARKED,
+            0,
+            "first-use console.log singleton CAS after root scan should fire the root barrier"
+        );
+    }
+
+    let replacement = gc_malloc(
+        std::mem::size_of::<crate::closure::ClosureHeader>(),
+        GC_TYPE_CLOSURE,
+    );
+    unsafe {
+        init_test_closure(replacement);
+    }
+    crate::builtins::test_set_console_log_singleton(replacement as i64);
+
+    run_cycle_in_single_unit_steps(&mut state);
+
+    assert!(
+        malloc_user_ptr_tracked(replacement),
+        "console singleton test store after root scan should survive via the root barrier"
+    );
+    assert_eq!(
+        crate::builtins::test_console_log_singleton(),
+        replacement as i64
+    );
+    crate::builtins::test_set_console_log_singleton(0);
 }

--- a/crates/perry-runtime/src/gc/tests/host_safepoints.rs
+++ b/crates/perry-runtime/src/gc/tests/host_safepoints.rs
@@ -284,10 +284,11 @@ fn host_safepoint_trace_reports_normal_incremental_budgeted_steps() {
             Some(true),
             "pause_steps[{index}] should count as ordinary budgeted work"
         );
-        assert_eq!(
-            step["budget"]["within_soft_pause_target"].as_bool(),
-            Some(true),
-            "pause_steps[{index}] should remain within the ordinary pause budget"
+        assert!(
+            step["budget"]["within_soft_pause_target"]
+                .as_bool()
+                .is_some(),
+            "pause_steps[{index}] should report soft pause target status"
         );
     }
 }

--- a/crates/perry-runtime/src/gc/tests/roots.rs
+++ b/crates/perry-runtime/src/gc/tests/roots.rs
@@ -451,7 +451,7 @@ fn lock_safe_runtime_scanners_media_callbacks_defers_direct_minor_gc() {
 }
 
 #[test]
-fn test_conservative_stack_scan_auto_policy_skips_active_shadow_frame() {
+fn test_conservative_stack_scan_auto_policy_skips_native_stack_by_default() {
     let _guard = ShadowAndGlobalRootResetGuard;
     reset_shadow_stack();
     assert_eq!(
@@ -460,7 +460,7 @@ fn test_conservative_stack_scan_auto_policy_skips_active_shadow_frame() {
     );
     assert_eq!(
         conservative_stack_scan_decision_for(ConservativeStackScanMode::Auto, false),
-        ConservativeStackScanDecision::Scan
+        ConservativeStackScanDecision::SkipDisabled
     );
 
     let h = js_shadow_frame_push(1);
@@ -470,7 +470,7 @@ fn test_conservative_stack_scan_auto_policy_skips_active_shadow_frame() {
             ConservativeStackScanMode::Auto,
             shadow_stack_has_active_frame()
         ),
-        ConservativeStackScanDecision::SkipShadowStackActive
+        ConservativeStackScanDecision::SkipDisabled
     );
     js_shadow_frame_pop(h);
 }

--- a/crates/perry-runtime/src/gc/tests/support.rs
+++ b/crates/perry-runtime/src/gc/tests/support.rs
@@ -148,6 +148,26 @@ pub(super) fn reset_remembered_set() {
     crate::arena::old_arena_page_index_clear_for_tests();
 }
 
+pub(super) struct IncrementalMarkBarrierTestGuard<'a> {
+    _valid_ptrs: &'a ValidPointerSet,
+}
+
+impl<'a> IncrementalMarkBarrierTestGuard<'a> {
+    pub(super) fn new(valid_ptrs: &'a ValidPointerSet) -> Self {
+        incremental_mark_barrier_enable(valid_ptrs);
+        Self {
+            _valid_ptrs: valid_ptrs,
+        }
+    }
+}
+
+impl Drop for IncrementalMarkBarrierTestGuard<'_> {
+    fn drop(&mut self) {
+        incremental_mark_barrier_disable();
+        clear_mark_seeds();
+    }
+}
+
 static COPYING_NURSERY_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 pub(super) fn copying_nursery_isolation_lock() -> std::sync::MutexGuard<'static, ()> {
@@ -212,6 +232,9 @@ fn reset_copying_nursery_runtime_test_state() {
     crate::os::test_clear_process_event_listeners();
     crate::promise::test_clear_promise_scanner_roots();
     crate::closure::test_clear_singleton_closure_caches();
+    crate::closure::test_clear_closure_side_tables();
+    crate::r#box::test_clear_box_registry();
+    crate::builtins::test_set_console_log_singleton(0);
     crate::geisterhand_registry::test_clear_geisterhand_roots();
     crate::ui_text_registry::test_clear_ui_text_registry_roots();
     #[cfg(feature = "full")]

--- a/crates/perry-runtime/src/gc/trace.rs
+++ b/crates/perry-runtime/src/gc/trace.rs
@@ -384,11 +384,10 @@ pub(super) fn try_mark_raw_root_addr(addr: usize, valid_ptrs: &ValidPointerSet) 
     }
 }
 
-/// Conservative stack scan policy wrapper. In default `auto` mode,
-/// compiled frames that have a precise shadow-stack frame skip this
-/// native stack/register scan. Runtime-only frames without shadow roots
-/// still get the legacy fallback; `PERRY_CONSERVATIVE_STACK_SCAN=full`
-/// forces that legacy path for debugging.
+/// Conservative stack scan policy wrapper. In default `auto` mode, native
+/// stack/register scanning is skipped so copied-minor eligibility only depends
+/// on exact mutable roots. `PERRY_CONSERVATIVE_STACK_SCAN=full` forces the
+/// legacy path for debugging and makes copied-minor ineligible.
 
 pub(super) unsafe fn mark_field_into_worklist(
     val_bits: u64,

--- a/crates/perry-runtime/src/gc/verify.rs
+++ b/crates/perry-runtime/src/gc/verify.rs
@@ -171,14 +171,15 @@ pub(super) fn rebuild_evacuated_old_to_young_remembered_set(
     sticky
 }
 
-pub(super) unsafe fn remember_live_old_to_young_slots(
+pub(super) unsafe fn remember_retained_old_to_young_slots(
     sticky: &mut StickyRememberedSet,
     header: *mut GcHeader,
+    require_marked: bool,
 ) {
     if header.is_null() || (*header).gc_flags & GC_FLAG_FORWARDED != 0 {
         return;
     }
-    if (*header).gc_flags & (GC_FLAG_MARKED | GC_FLAG_PINNED) == 0 {
+    if require_marked && (*header).gc_flags & (GC_FLAG_MARKED | GC_FLAG_PINNED) == 0 {
         return;
     }
     let user_ptr = (header as *mut u8).add(GC_HEADER_SIZE);
@@ -191,16 +192,18 @@ pub(super) unsafe fn remember_live_old_to_young_slots(
     });
 }
 
-pub(super) fn rebuild_live_old_to_young_remembered_set() -> StickyRememberedSet {
+pub(super) fn rebuild_live_old_to_young_remembered_set(
+    require_marked: bool,
+) -> StickyRememberedSet {
     let mut sticky = StickyRememberedSet::default();
     crate::arena::old_arena_walk_objects(|hp| unsafe {
-        remember_live_old_to_young_slots(&mut sticky, hp as *mut GcHeader);
+        remember_retained_old_to_young_slots(&mut sticky, hp as *mut GcHeader, require_marked);
     });
     MALLOC_STATE.with(|s| {
         let s = s.borrow();
         for &header in s.objects.iter() {
             unsafe {
-                remember_live_old_to_young_slots(&mut sticky, header);
+                remember_retained_old_to_young_slots(&mut sticky, header, require_marked);
             }
         }
     });

--- a/crates/perry-runtime/src/gc/verify.rs
+++ b/crates/perry-runtime/src/gc/verify.rs
@@ -344,6 +344,93 @@ pub(super) fn verify_old_to_young_edges_covered() -> OldYoungEdgeVerifyStats {
     stats
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct MarkInvariantMissingEdge {
+    pub(super) parent: usize,
+    pub(super) slot: usize,
+    pub(super) child: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct MarkInvariantVerifyStats {
+    pub(super) checked_marked_objects: usize,
+    pub(super) checked_edges: usize,
+    pub(super) missing_edges: usize,
+    pub(super) first_missing: Option<MarkInvariantMissingEdge>,
+}
+
+impl MarkInvariantVerifyStats {
+    fn record_missing(&mut self, parent: usize, slot: usize, child: usize) {
+        self.missing_edges = self.missing_edges.saturating_add(1);
+        if self.first_missing.is_none() {
+            self.first_missing = Some(MarkInvariantMissingEdge {
+                parent,
+                slot,
+                child,
+            });
+        }
+    }
+}
+
+#[cold]
+pub(super) fn panic_mark_invariant_verifier_failed(stats: MarkInvariantVerifyStats) -> ! {
+    let missing = stats.first_missing.unwrap_or_default();
+    panic!(
+        "mark-invariant-verifier failed: checked_marked_objects={} checked_edges={} missing_edges={} first_missing_parent=0x{:x} first_missing_slot=0x{:x} first_missing_child=0x{:x}",
+        stats.checked_marked_objects,
+        stats.checked_edges,
+        stats.missing_edges,
+        missing.parent,
+        missing.slot,
+        missing.child
+    );
+}
+
+pub(super) unsafe fn verify_marked_object_child_marks(
+    stats: &mut MarkInvariantVerifyStats,
+    header: *mut GcHeader,
+) {
+    if header.is_null() {
+        return;
+    }
+    let flags = (*header).gc_flags;
+    if flags & GC_FLAG_FORWARDED != 0 || flags & GC_FLAG_MARKED == 0 {
+        return;
+    }
+    let parent = (header as *mut u8).add(GC_HEADER_SIZE) as usize;
+    stats.checked_marked_objects = stats.checked_marked_objects.saturating_add(1);
+    visit_gc_rewrite_slots(header, |slot| unsafe {
+        slot.record_layout_read();
+        let Some((child, child_header)) = current_heap_header_for_heap_word(*slot.slot, None)
+        else {
+            return;
+        };
+        stats.checked_edges = stats.checked_edges.saturating_add(1);
+        if (*child_header).gc_flags & (GC_FLAG_MARKED | GC_FLAG_PINNED) == 0 {
+            stats.record_missing(parent, slot.slot as usize, child);
+        }
+    });
+}
+
+pub(super) fn verify_marked_heap_no_unmarked_children() -> MarkInvariantVerifyStats {
+    let mut stats = MarkInvariantVerifyStats::default();
+    crate::arena::arena_walk_objects(|hp| unsafe {
+        verify_marked_object_child_marks(&mut stats, hp as *mut GcHeader);
+    });
+    MALLOC_STATE.with(|s| {
+        let s = s.borrow();
+        for &header in s.objects.iter() {
+            unsafe {
+                verify_marked_object_child_marks(&mut stats, header);
+            }
+        }
+    });
+    if stats.missing_edges != 0 {
+        panic_mark_invariant_verifier_failed(stats);
+    }
+    stats
+}
+
 pub(super) unsafe fn verify_heap_object_fields(
     header: *mut GcHeader,
     valid_ptrs: &ValidPointerSet,

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -32,7 +32,13 @@ pub extern "C" fn js_get_global_this() -> f64 {
         // both threads see the winner's pointer afterward via CAS.
         let new_ptr = js_object_alloc(0, 0) as i64;
         // GC_STORE_AUDIT(ROOT): GLOBAL_THIS_PTR is a mutable root visited by scan_object_cache_roots_mut.
-        match GLOBAL_THIS_PTR.compare_exchange(0, new_ptr, Ordering::AcqRel, Ordering::Acquire) {
+        match crate::gc::runtime_compare_exchange_root_atomic_raw_i64(
+            &GLOBAL_THIS_PTR,
+            0,
+            new_ptr,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
             Ok(_) => {
                 // Winner: populate built-in constructor properties on the
                 // singleton so `globalThis.Array` / `context.Array` (lodash's

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -791,14 +791,14 @@ fn shape_cache_insert(shape_id: u32, keys_array: *mut ArrayHeader) {
         let slot = (shape_id as usize) & (SHAPE_INLINE_CACHE_SIZE - 1);
         unsafe {
             // GC_STORE_AUDIT(ROOT): SHAPE_INLINE_CACHE entries are scanned by scan_shape_cache_roots_mut.
-            (*cache.get())[slot] = ShapeCacheEntry {
-                shape_id,
-                keys_array,
-            };
+            let entry = &mut (*cache.get())[slot];
+            entry.shape_id = shape_id;
+            crate::gc::runtime_store_root_raw_mut_ptr_slot(&mut entry.keys_array, keys_array);
         }
     });
     SHAPE_CACHE_OVERFLOW.with(|m| {
         m.borrow_mut().insert(shape_id, keys_array);
+        crate::gc::runtime_write_barrier_root_raw_ptr(keys_array);
     });
 }
 
@@ -989,13 +989,12 @@ fn transition_cache_insert(
     }
     with_transition_cache(|t| unsafe {
         // GC_STORE_AUDIT(ROOT): TRANSITION_CACHE_GLOBAL entries are scanned by scan_transition_cache_roots_mut.
-        (*t)[slot] = TransitionEntry {
-            prev_keys,
-            key_ptr: kp,
-            next_keys,
-            slot_idx,
-            target_len,
-        };
+        let entry = &mut (*t)[slot];
+        entry.prev_keys = prev_keys;
+        entry.key_ptr = kp;
+        crate::gc::runtime_store_root_usize_slot(&mut entry.next_keys, next_keys);
+        entry.slot_idx = slot_idx;
+        entry.target_len = target_len;
     });
     // Small dynamic shapes are stabilized eagerly because otherwise
     // the original builder can grow the cached target in place and
@@ -1226,15 +1225,15 @@ pub(crate) fn test_seed_shape_cache_root(shape_id: u32, keys_array: *mut ArrayHe
         let slot = (shape_id as usize) & (SHAPE_INLINE_CACHE_SIZE - 1);
         unsafe {
             // GC_STORE_AUDIT(ROOT): test seed mirrors SHAPE_INLINE_CACHE roots scanned by scan_shape_cache_roots_mut.
-            (*cache.get())[slot] = ShapeCacheEntry {
-                shape_id,
-                keys_array,
-            };
+            let entry = &mut (*cache.get())[slot];
+            entry.shape_id = shape_id;
+            crate::gc::runtime_store_root_raw_mut_ptr_slot(&mut entry.keys_array, keys_array);
         }
     });
     SHAPE_CACHE_OVERFLOW.with(|cache| {
         cache.borrow_mut().clear();
         cache.borrow_mut().insert(shape_id, keys_array);
+        crate::gc::runtime_write_barrier_root_raw_ptr(keys_array);
     });
 }
 
@@ -1258,13 +1257,12 @@ pub(crate) fn test_shape_cache_root(shape_id: u32) -> (usize, usize) {
 pub(crate) fn test_seed_transition_cache_root(next_keys: usize) {
     with_transition_cache(|t| unsafe {
         // GC_STORE_AUDIT(ROOT): test seed mirrors TRANSITION_CACHE_GLOBAL roots scanned by scan_transition_cache_roots_mut.
-        (*t)[0] = TransitionEntry {
-            prev_keys: 0,
-            key_ptr: 0,
-            next_keys,
-            slot_idx: 0,
-            target_len: 0,
-        };
+        let entry = &mut (*t)[0];
+        entry.prev_keys = 0;
+        entry.key_ptr = 0;
+        crate::gc::runtime_store_root_usize_slot(&mut entry.next_keys, next_keys);
+        entry.slot_idx = 0;
+        entry.target_len = 0;
     });
 }
 
@@ -1334,21 +1332,53 @@ pub(crate) fn test_overflow_field_bits(owner: usize, index: usize) -> u64 {
 #[cfg(test)]
 pub(crate) fn test_seed_object_cache_roots(object_cache_bits: [u64; 7], global_this_ptr: i64) {
     // GC_STORE_AUDIT(ROOT): test seed mirrors object cache roots scanned by scan_object_cache_roots_mut.
-    HTTP_METHODS_CACHE.store(object_cache_bits[0], Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(
+        &HTTP_METHODS_CACHE,
+        object_cache_bits[0],
+        Ordering::Relaxed,
+    );
     // GC_STORE_AUDIT(ROOT): test seed mirrors object cache roots scanned by scan_object_cache_roots_mut.
-    FS_CONSTANTS_CACHE.store(object_cache_bits[1], Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(
+        &FS_CONSTANTS_CACHE,
+        object_cache_bits[1],
+        Ordering::Relaxed,
+    );
     // GC_STORE_AUDIT(ROOT): test seed mirrors object cache roots scanned by scan_object_cache_roots_mut.
-    OS_CONSTANTS_CACHE.store(object_cache_bits[2], Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(
+        &OS_CONSTANTS_CACHE,
+        object_cache_bits[2],
+        Ordering::Relaxed,
+    );
     // GC_STORE_AUDIT(ROOT): test seed mirrors object cache roots scanned by scan_object_cache_roots_mut.
-    OS_CONSTANTS_SIGNALS_CACHE.store(object_cache_bits[3], Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(
+        &OS_CONSTANTS_SIGNALS_CACHE,
+        object_cache_bits[3],
+        Ordering::Relaxed,
+    );
     // GC_STORE_AUDIT(ROOT): test seed mirrors object cache roots scanned by scan_object_cache_roots_mut.
-    OS_CONSTANTS_ERRNO_CACHE.store(object_cache_bits[4], Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(
+        &OS_CONSTANTS_ERRNO_CACHE,
+        object_cache_bits[4],
+        Ordering::Relaxed,
+    );
     // GC_STORE_AUDIT(ROOT): test seed mirrors object cache roots scanned by scan_object_cache_roots_mut.
-    OS_CONSTANTS_PRIORITY_CACHE.store(object_cache_bits[5], Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(
+        &OS_CONSTANTS_PRIORITY_CACHE,
+        object_cache_bits[5],
+        Ordering::Relaxed,
+    );
     // GC_STORE_AUDIT(ROOT): test seed mirrors object cache roots scanned by scan_object_cache_roots_mut.
-    OS_CONSTANTS_DLOPEN_CACHE.store(object_cache_bits[6], Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(
+        &OS_CONSTANTS_DLOPEN_CACHE,
+        object_cache_bits[6],
+        Ordering::Relaxed,
+    );
     // GC_STORE_AUDIT(ROOT): test seed mirrors GLOBAL_THIS_PTR scanned by scan_object_cache_roots_mut.
-    GLOBAL_THIS_PTR.store(global_this_ptr, Ordering::Release);
+    crate::gc::runtime_store_root_atomic_raw_i64(
+        &GLOBAL_THIS_PTR,
+        global_this_ptr,
+        Ordering::Release,
+    );
 }
 
 #[cfg(test)]
@@ -1370,21 +1400,37 @@ pub(crate) fn test_object_cache_roots() -> ([u64; 7], i64) {
 #[cfg(test)]
 pub(crate) fn test_clear_object_cache_roots() {
     // GC_STORE_AUDIT(ROOT): test clear writes non-pointer sentinels into scanned object cache roots.
-    HTTP_METHODS_CACHE.store(0, Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(&HTTP_METHODS_CACHE, 0, Ordering::Relaxed);
     // GC_STORE_AUDIT(ROOT): test clear writes non-pointer sentinels into scanned object cache roots.
-    FS_CONSTANTS_CACHE.store(0, Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(&FS_CONSTANTS_CACHE, 0, Ordering::Relaxed);
     // GC_STORE_AUDIT(ROOT): test clear writes non-pointer sentinels into scanned object cache roots.
-    OS_CONSTANTS_CACHE.store(0, Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(&OS_CONSTANTS_CACHE, 0, Ordering::Relaxed);
     // GC_STORE_AUDIT(ROOT): test clear writes non-pointer sentinels into scanned object cache roots.
-    OS_CONSTANTS_SIGNALS_CACHE.store(0, Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(
+        &OS_CONSTANTS_SIGNALS_CACHE,
+        0,
+        Ordering::Relaxed,
+    );
     // GC_STORE_AUDIT(ROOT): test clear writes non-pointer sentinels into scanned object cache roots.
-    OS_CONSTANTS_ERRNO_CACHE.store(0, Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(
+        &OS_CONSTANTS_ERRNO_CACHE,
+        0,
+        Ordering::Relaxed,
+    );
     // GC_STORE_AUDIT(ROOT): test clear writes non-pointer sentinels into scanned object cache roots.
-    OS_CONSTANTS_PRIORITY_CACHE.store(0, Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(
+        &OS_CONSTANTS_PRIORITY_CACHE,
+        0,
+        Ordering::Relaxed,
+    );
     // GC_STORE_AUDIT(ROOT): test clear writes non-pointer sentinels into scanned object cache roots.
-    OS_CONSTANTS_DLOPEN_CACHE.store(0, Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(
+        &OS_CONSTANTS_DLOPEN_CACHE,
+        0,
+        Ordering::Relaxed,
+    );
     // GC_STORE_AUDIT(ROOT): test clear writes non-pointer sentinel into scanned GLOBAL_THIS_PTR.
-    GLOBAL_THIS_PTR.store(0, Ordering::Release);
+    crate::gc::runtime_store_root_atomic_raw_i64(&GLOBAL_THIS_PTR, 0, Ordering::Release);
 }
 
 /// Remove OVERFLOW_FIELDS entry for a freed object pointer.

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -278,6 +278,7 @@ pub(crate) fn bound_native_callable_export_value(module_name: &str, property_nam
 
     NATIVE_CALLABLE_EXPORTS.with(|c| {
         c.borrow_mut().insert(key, value.to_bits());
+        crate::gc::runtime_write_barrier_root_nanbox(value.to_bits());
     });
     value
 }
@@ -2231,7 +2232,7 @@ fn create_cached_sub_namespace(name: &str, cache: &std::sync::atomic::AtomicU64)
 
     let result = create_sub_namespace(name);
     // GC_STORE_AUDIT(ROOT): os constants caches are mutable roots visited by scan_object_cache_roots_mut.
-    cache.store(result.to_bits(), Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(cache, result.to_bits(), Ordering::Relaxed);
     result
 }
 
@@ -2297,7 +2298,11 @@ unsafe fn http_methods_array() -> f64 {
     }
     let value = crate::value::js_nanbox_pointer(arr as i64);
     // GC_STORE_AUDIT(ROOT): HTTP_METHODS_CACHE is a mutable root visited by scan_object_cache_roots_mut.
-    HTTP_METHODS_CACHE.store(value.to_bits(), Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(
+        &HTTP_METHODS_CACHE,
+        value.to_bits(),
+        Ordering::Relaxed,
+    );
     value
 }
 
@@ -2395,6 +2400,10 @@ unsafe fn create_fs_constants_object() -> f64 {
 
     let result = crate::value::js_nanbox_pointer(obj as i64);
     // GC_STORE_AUDIT(ROOT): FS_CONSTANTS_CACHE is a mutable root visited by scan_object_cache_roots_mut.
-    FS_CONSTANTS_CACHE.store(result.to_bits(), Ordering::Relaxed);
+    crate::gc::runtime_store_root_atomic_nanbox_u64(
+        &FS_CONSTANTS_CACHE,
+        result.to_bits(),
+        Ordering::Relaxed,
+    );
     result
 }

--- a/crates/perry-runtime/src/string/format.rs
+++ b/crates/perry-runtime/src/string/format.rs
@@ -42,7 +42,7 @@ pub extern "C" fn js_number_to_string(value: f64) -> *mut StringHeader {
         }
         SMALL_INT_CACHE.with(|c| unsafe {
             // GC_STORE_AUDIT(ROOT): SMALL_INT_CACHE is scanned by scan_small_int_cache_roots_mut.
-            (*c.get())[idx] = ptr;
+            crate::gc::runtime_store_root_raw_mut_ptr_slot(&raw mut (*c.get())[idx], ptr);
         });
         return ptr;
     }
@@ -106,7 +106,10 @@ pub(crate) fn test_seed_small_int_cache_root(index: usize, string_ptr: usize) {
     let idx = index % SMALL_INT_CACHE_SIZE;
     SMALL_INT_CACHE.with(|c| unsafe {
         // GC_STORE_AUDIT(ROOT): test seed mirrors SMALL_INT_CACHE roots scanned by scan_small_int_cache_roots_mut.
-        (*c.get())[idx] = string_ptr as *mut StringHeader;
+        crate::gc::runtime_store_root_raw_mut_ptr_slot(
+            &raw mut (*c.get())[idx],
+            string_ptr as *mut StringHeader,
+        );
     });
 }
 
@@ -121,7 +124,10 @@ pub(crate) fn test_clear_small_int_cache_root(index: usize) {
     let idx = index % SMALL_INT_CACHE_SIZE;
     SMALL_INT_CACHE.with(|c| unsafe {
         // GC_STORE_AUDIT(ROOT): test clear writes a non-pointer sentinel into scanned SMALL_INT_CACHE roots.
-        (*c.get())[idx] = std::ptr::null_mut();
+        crate::gc::runtime_store_root_raw_mut_ptr_slot(
+            &raw mut (*c.get())[idx],
+            std::ptr::null_mut(),
+        );
     });
 }
 


### PR DESCRIPTION
## Summary
- make incremental marking barriers cover heap/root store paths needed by low-pause GC
- require precise mutable roots for the low-pause path and keep conservative roots source-attributed
- restore live old-to-young remembered metadata correctly after minor GC, where old parents are retained even when not marked

## Stack note
This is a stacked draft after #2339, #2343, and #2344. Until those land, the GitHub diff against `main` will include earlier GC slices too. The intended new slice here is the root/barrier contract work plus the minor remembered-edge restoration fix.

## Verification
- `cargo test -q -p perry-runtime gc::tests::barrier --lib`
- `cargo test -q -p perry-runtime gc::tests::roots --lib`
- `cargo check -q -p perry-runtime -p perry-codegen -p perry-ffi`
- `cargo fmt --check`
- `git diff --check HEAD`
