### PR TITLE
fix(runtime): Error.prototype.toString returns 'name: message' not '[object Object]' (#2135)

### DIFF
--- a/crates/perry-runtime/src/error.rs
+++ b/crates/perry-runtime/src/error.rs
@@ -254,6 +254,39 @@ pub extern "C" fn js_error_get_stack(error: *mut ErrorHeader) -> *mut StringHead
     }
 }
 
+/// Read a `StringHeader`'s UTF-8 bytes into an owned `String` (lossy on
+/// invalid UTF-8). Empty on null.
+unsafe fn read_string_header_owned(ptr: *const StringHeader) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    let len = (*ptr).byte_len as usize;
+    let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+    let bytes = std::slice::from_raw_parts(data, len);
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+/// `Error.prototype.toString()` — ECMAScript §20.5.3.4. Returns `name` when
+/// `message` is empty, `message` when `name` is empty, otherwise
+/// `"{name}: {message}"`. Previously errors fell back to `Object.prototype`'s
+/// `"[object Object]"` for both explicit `e.toString()` and string coercion
+/// (`String(e)`, template literals), diverging from Node byte-for-byte (#2135).
+#[no_mangle]
+pub extern "C" fn js_error_to_string(error: *mut ErrorHeader) -> *mut StringHeader {
+    unsafe {
+        let name = read_string_header_owned(js_error_get_name(error));
+        let message = read_string_header_owned(js_error_get_message(error));
+        let result = if name.is_empty() {
+            message
+        } else if message.is_empty() {
+            name
+        } else {
+            format!("{name}: {message}")
+        };
+        js_string_from_bytes(result.as_ptr(), result.len() as u32)
+    }
+}
+
 /// Get the cause property of an Error (raw f64 NaN-boxed value)
 #[no_mangle]
 pub extern "C" fn js_error_get_cause(error: *mut ErrorHeader) -> f64 {
@@ -440,4 +473,34 @@ pub extern "C" fn js_throw_type_error_immutable_write(
 /// `#[no_mangle]` because callers are runtime modules, not codegen.
 pub(crate) fn throw_immutable_write(kind: u32, key: &str) -> ! {
     js_throw_type_error_immutable_write(kind, key.as_ptr(), key.len())
+}
+
+#[cfg(test)]
+mod tostring_tests {
+    use super::*;
+
+    fn s(bytes: &[u8]) -> *mut StringHeader {
+        js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
+    }
+
+    #[test]
+    fn error_to_string_name_and_message() {
+        let e = js_error_new_with_message(s(b"boom"));
+        let out = unsafe { read_string_header_owned(js_error_to_string(e)) };
+        assert_eq!(out, "Error: boom");
+    }
+
+    #[test]
+    fn error_to_string_no_message_is_just_name() {
+        let e = js_error_new_with_message(s(b""));
+        let out = unsafe { read_string_header_owned(js_error_to_string(e)) };
+        assert_eq!(out, "Error");
+    }
+
+    #[test]
+    fn typed_error_to_string_uses_subclass_name() {
+        let e = js_error_new_with_name_message(b"TypeError", s(b"bad"));
+        let out = unsafe { read_string_header_owned(js_error_to_string(e)) };
+        assert_eq!(out, "TypeError: bad");
+    }
 }

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -256,6 +256,15 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
                     return js_jsvalue_to_string(primitive);
                 }
             }
+            // #2135: a built-in Error with no user-overridden `toString`
+            // resolves here. `Error.prototype.toString` is `name`/`message`/
+            // `"name: message"`, not Object.prototype's `"[object Object]"`.
+            unsafe {
+                let gc_header = ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+                if (*gc_header).obj_type == crate::gc::GC_TYPE_ERROR {
+                    return crate::error::js_error_to_string(ptr as *mut crate::error::ErrorHeader);
+                }
+            }
         }
         crate::string::js_string_from_bytes(b"[object Object]".as_ptr(), 15)
     } else {


### PR DESCRIPTION
## Summary

Surfaced while investigating #2135: **`Error.prototype.toString()` returned `"[object Object]"`** for every built-in error, both for explicit `e.toString()` and for string coercion (`String(e)`, template literals, `"" + e`), diverging from Node byte-for-byte.

```ts
new Error("boom").toString()      // Perry: "[object Object]"  Node: "Error: boom"
String(new TypeError("bad"))      // Perry: "[object Object]"  Node: "TypeError: bad"
`${new Error("x")}`               // Perry: "[object Object]"  Node: "Error: x"
```

`js_jsvalue_to_string` already documented this as a gap ("Built-in Error/Date prototype `toString`s are not discoverable as object fields in Perry's model, so they still hit the fallback").

## How

- New centralized `js_error_to_string` (`error.rs`) implementing ECMAScript §20.5.3.4: returns `name` when message is empty, `message` when name is empty, otherwise `"{name}: {message}"`.
- `js_jsvalue_to_string` routes `GC_TYPE_ERROR` objects through it — placed **after** `OrdinaryToPrimitive` so a user-overridden `toString` on an error still wins, and before the `"[object Object]"` fallback. This single chokepoint fixes explicit `.toString()`, `String()`, template literals, and concatenation together.

## Test plan

- 3 new unit tests in `error.rs` (`name: message`, name-only when message empty, subclass-name via `TypeError`).
- End-to-end vs Node v25: `Error`/`TypeError`/`RangeError` `.toString()`, `String(e)`, template literals, and concatenation now all match.
- `console.log(error)` is unaffected (it uses the separate inspect path, verified — still prints the error, not `[object Object]`).

## Scope / follow-ups

Covers built-in errors. Two related gaps remain as follow-ups (noted in the commit):
- **Error subclasses** (`class X extends Error`) are plain class instances (not `GC_TYPE_ERROR`); resolving their `toString` needs an Error-subclass class-chain check + field reads.
- **`Array.prototype.join`** has its own per-element stringify that doesn't route through `js_jsvalue_to_string`.

This does not fully close #2135 (other process output diffs remain) but removes a broad, cross-cutting error-output divergence that affects process error tests and the wider #800 sweep.
