### PR TITLE
fix(querystring): stringify enumerable keys only

### DIFF
--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -32,8 +32,8 @@ use perry_runtime::array::{js_array_alloc, js_array_length, js_array_push_f64};
 use perry_runtime::closure::{is_closure_ptr, js_closure_call1, ClosureHeader};
 use perry_runtime::{
     js_object_alloc_null_proto, js_object_get_field_by_name, js_object_get_own_field_or_undef,
-    js_object_set_field_by_name, js_string_from_bytes, ArrayHeader, JSValue, ObjectHeader,
-    StringHeader,
+    js_object_keys, js_object_set_field_by_name, js_string_from_bytes, ArrayHeader, JSValue,
+    ObjectHeader, StringHeader,
 };
 
 // Suppress unused — `Handle` is re-exported for symmetry with other modules.
@@ -423,7 +423,7 @@ pub unsafe extern "C" fn js_querystring_stringify(
     }
     let obj = addr as *mut ObjectHeader;
 
-    let keys = (*obj).keys_array;
+    let keys = js_object_keys(obj as *const ObjectHeader);
     if keys.is_null() {
         return nanbox_string(intern_string(""));
     }


### PR DESCRIPTION
## Summary
- make `querystring.stringify` iterate Perry's `js_object_keys` result instead of the raw object key array
- skip non-enumerable own string properties when serializing query strings, matching Node's own-property enumeration behavior

## DeepWiki
- `reference/deepwiki/node-querystring-stringify-enumerable-keys.md` (local reference; not staged)

## Tests
- Baseline full `node-suite/querystring`: 53 PASS / 2 FAIL, with `stringify/symbol-keys-extra` failing
- Baseline exact `./run_parity_tests.sh --suite node-suite --filter node-suite/querystring/stringify/symbol-keys-extra` failed: Perry emitted `a=1&hidden=3`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/querystring/stringify/symbol-keys-extra`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/querystring` (54 PASS / 1 FAIL; remaining residual is `parse/custom-decoder-errors`)
- `cargo check -p perry-stdlib`
- `cargo fmt --check`
- `git diff --check`

## Non-goals
- no custom decoder error swallowing
- no querystring parser changes
- no object descriptor model rewrite