### PR TITLE
fix(querystring): fall back on decoder throws

### DIFF
--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -27,6 +27,7 @@
 
 use crate::common::handle::Handle;
 use std::borrow::Cow;
+use std::os::raw::c_int;
 
 use perry_runtime::array::{js_array_alloc, js_array_length, js_array_push_f64};
 use perry_runtime::closure::{is_closure_ptr, js_closure_call1, ClosureHeader};
@@ -232,20 +233,8 @@ pub unsafe extern "C" fn js_querystring_parse(
                 None => (pair, ""),
             }
         };
-        let key = match decode {
-            Some(cb) => {
-                let normalized = normalize_decode_component_input(key_raw);
-                apply_codec(cb, normalized.as_ref())
-            }
-            None => percent_decode(key_raw, true),
-        };
-        let value = match decode {
-            Some(cb) => {
-                let normalized = normalize_decode_component_input(val_raw);
-                apply_codec(cb, normalized.as_ref())
-            }
-            None => percent_decode(val_raw, true),
-        };
+        let key = decode_parse_component(key_raw, decode);
+        let value = decode_parse_component(val_raw, decode);
         push_parsed_pair(obj, &key, &value);
         parsed += 1;
     }
@@ -285,6 +274,27 @@ fn normalize_decode_component_input(input: &str) -> Cow<'_, str> {
     } else {
         Cow::Borrowed(input)
     }
+}
+
+unsafe fn decode_parse_component(raw: &str, decode: Option<*const ClosureHeader>) -> String {
+    let Some(callback) = decode else {
+        return percent_decode(raw, true);
+    };
+    let normalized = normalize_decode_component_input(raw);
+    apply_decode_codec(callback, normalized.as_ref()).unwrap_or_else(|| percent_decode(raw, true))
+}
+
+unsafe fn apply_decode_codec(callback: *const ClosureHeader, raw: &str) -> Option<String> {
+    let trap_buf = perry_runtime::exception::js_try_push();
+    let jumped = unsafe { perry_runtime::ffi::setjmp::setjmp(trap_buf as *mut c_int) };
+    let result = if jumped == 0 {
+        Some(apply_codec(callback, raw))
+    } else {
+        perry_runtime::exception::js_clear_exception();
+        None
+    };
+    perry_runtime::exception::js_try_end();
+    result
 }
 
 /// Call a user-supplied codec closure with `raw` and decode the return.


### PR DESCRIPTION
## Summary
- wrap `querystring.parse` custom decode callbacks in a runtime try frame
- fall back to the built-in percent decoder per component when the custom decoder throws
- keep successful custom decoder results and `querystring.stringify` custom encoder errors unchanged

## Verification
- `./run_parity_tests.sh --suite node-suite --filter node-suite/querystring/parse/custom-decoder-errors` PASS, report `test-parity/reports/parity_report_20260528_180001.json`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/querystring` 54 PASS / 1 parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260528_180019.json`; remaining failure is `querystring/stringify/symbol-keys-extra`, covered by #2350
- `cargo check -p perry-stdlib` PASS with existing warnings
- `cargo fmt --check` PASS
- `git diff --check` PASS

## Notes
- DeepWiki saved at `reference/deepwiki/node-querystring-parse-custom-decoder-errors.md`; its prose claimed custom decoder exceptions propagate, but local Node 25 output and the parity fixture showed parse catches decoder throws and falls back, so direct Node behavior was used as authoritative.

## Non-goals
- no `querystring.stringify` enumerable-key change in this branch
- no custom encoder exception swallowing
- no broad querystring parser rewrite