### PR TITLE
fix(crypto): validate randomBytes/randomInt args (#2013)

### DIFF
--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -30,7 +30,7 @@ mod stats;
 pub use stats::*;
 mod dirent;
 pub use dirent::*;
-pub(crate) mod validate;
+pub mod validate;
 
 thread_local! {
     static FD_REGISTRY: RefCell<StdHashMap<i32, fs::File>> = RefCell::new(StdHashMap::new());

--- a/crates/perry-runtime/src/fs/validate.rs
+++ b/crates/perry-runtime/src/fs/validate.rs
@@ -46,7 +46,7 @@ pub(crate) fn is_path_like(value: f64) -> bool {
 /// True if `value` is a JS number (a plain IEEE double *or* an INT32-tagged
 /// small integer). `JSValue::is_number` deliberately excludes the INT32 tag,
 /// so both must be checked.
-pub(crate) fn is_numeric(jv: JSValue) -> bool {
+pub fn is_numeric(jv: JSValue) -> bool {
     jv.is_number() || jv.is_int32()
 }
 
@@ -59,7 +59,7 @@ fn numeric_to_i32(jv: JSValue) -> i32 {
 }
 
 /// Node's `Received …` clause for an `ERR_INVALID_ARG_TYPE` message.
-pub(crate) fn describe_received(value: f64) -> String {
+pub fn describe_received(value: f64) -> String {
     let jv = JSValue::from_bits(value.to_bits());
     if jv.is_undefined() {
         return "undefined".to_string();
@@ -116,7 +116,7 @@ fn throw_ebadf(syscall: &'static str) -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
-pub(crate) fn throw_type_error_with_code(message: &str, code: &'static str) -> ! {
+pub fn throw_type_error_with_code(message: &str, code: &'static str) -> ! {
     let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
     crate::node_submodules::register_error_code_pub(msg, code);
     let err = crate::error::js_typeerror_new(msg);
@@ -261,7 +261,7 @@ pub(crate) fn validate_function(arg_name: &str, value: f64) {
     }
 }
 
-fn throw_range_error_with_code(message: &str) -> ! {
+pub fn throw_range_error_with_code(message: &str) -> ! {
     let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
     crate::node_submodules::register_error_code_pub(msg, "ERR_OUT_OF_RANGE");
     let err = crate::error::js_rangeerror_new(msg);

--- a/crates/perry-stdlib/src/crypto/random.rs
+++ b/crates/perry-stdlib/src/crypto/random.rs
@@ -1,12 +1,59 @@
 use super::*;
 
+/// Issue #2013 — Node throws on `crypto.randomBytes` for the same
+/// bad-input shapes the fs/process surface already covers: a
+/// non-number (`{}`, `'abc'`, `true`) raises `TypeError
+/// [ERR_INVALID_ARG_TYPE]`, and any number outside `[0, 2^31 - 1]`
+/// (negative, fractional, NaN/Infinity) raises `RangeError
+/// [ERR_OUT_OF_RANGE]`. The codegen passes the full NaN-boxed bits
+/// as f64, so a JS pointer-tagged `{}` arrives here as a NaN that
+/// the legacy `size as usize` silently truncated to 0 — making the
+/// call return an empty buffer instead of throwing.
+fn validate_random_bytes_size(size: f64) -> usize {
+    let jv = JSValue::from_bits(size.to_bits());
+    if !jv.is_number() && !jv.is_int32() {
+        let message = format!(
+            "The \"size\" argument must be of type number. Received {}",
+            perry_runtime::fs::validate::describe_received(size)
+        );
+        perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    let n = if jv.is_int32() {
+        jv.as_int32() as f64
+    } else {
+        size
+    };
+    // Node truncates a fractional `randomBytes(1.5)` to 1 (no throw)
+    // but rejects NaN/Infinity/negative/out-of-range with
+    // ERR_OUT_OF_RANGE — fractional integers are NOT in the reject set.
+    if !n.is_finite() || n < 0.0 || n > i32::MAX as f64 {
+        let received = if n.is_nan() {
+            "NaN".to_string()
+        } else if n.is_infinite() {
+            if n.is_sign_negative() {
+                "-Infinity".to_string()
+            } else {
+                "Infinity".to_string()
+            }
+        } else {
+            format!("{}", n)
+        };
+        let message = format!(
+            "The value of \"size\" is out of range. It must be >= 0 && <= 2147483647. Received {}",
+            received
+        );
+        perry_runtime::fs::validate::throw_range_error_with_code(&message);
+    }
+    n as usize
+}
+
 /// Generate random bytes and return as a Buffer
 /// crypto.randomBytes(size) -> Buffer
 #[no_mangle]
 pub extern "C" fn js_crypto_random_bytes_buffer(
     size: f64,
 ) -> *mut perry_runtime::buffer::BufferHeader {
-    let size = size as usize;
+    let size = validate_random_bytes_size(size);
     if size == 0 || size > 1024 * 1024 {
         return perry_runtime::buffer::buffer_alloc(0);
     }
@@ -64,16 +111,54 @@ pub extern "C" fn js_crypto_random_uuid() -> *mut StringHeader {
     js_string_from_bytes(uuid_str.as_ptr(), uuid_str.len() as u32)
 }
 
+/// Issue #2013 — validate one of `randomInt`'s integer arguments
+/// (min/max). Non-number → ERR_INVALID_ARG_TYPE; non-finite /
+/// fractional / out-of-(-2^48, 2^48) → ERR_OUT_OF_RANGE. Mirrors
+/// `validate_random_bytes_size` but with the wider int bound Node
+/// accepts for randomInt's `min`/`max`.
+fn validate_random_int_arg(value: f64, arg_name: &str) -> i64 {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_number() && !jv.is_int32() {
+        let message = format!(
+            "The \"{}\" argument must be of type number. Received {}",
+            arg_name,
+            perry_runtime::fs::validate::describe_received(value)
+        );
+        perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    let n = if jv.is_int32() {
+        jv.as_int32() as f64
+    } else {
+        value
+    };
+    // Node's `validateInteger` splits the rejection by error code:
+    // non-integer (NaN, Infinity, fractional) → ERR_INVALID_ARG_TYPE;
+    // out-of-range integer (outside [-2^48, 2^48]) → ERR_OUT_OF_RANGE.
+    if !n.is_finite() || n.fract() != 0.0 {
+        let message = format!(
+            "The \"{}\" argument must be a safe integer. Received {}",
+            arg_name,
+            perry_runtime::fs::validate::describe_received(value)
+        );
+        perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    let bound = (1i64 << 48) as f64;
+    if n < -bound || n > bound {
+        let message = format!(
+            "The value of \"{}\" is out of range. It must be a safe integer type number. Received {}",
+            arg_name, n
+        );
+        perry_runtime::fs::validate::throw_range_error_with_code(&message);
+    }
+    n as i64
+}
+
 /// `crypto.randomInt(max)` / `crypto.randomInt(min, max)` synchronous form.
 /// Returns a uniformly distributed integer in `[min, max)`.
 #[no_mangle]
 pub extern "C" fn js_crypto_random_int(min_bits: f64, max_bits: f64) -> f64 {
-    let Some(min) = nanboxed_to_i64(min_bits) else {
-        return f64::NAN;
-    };
-    let Some(max) = nanboxed_to_i64(max_bits) else {
-        return f64::NAN;
-    };
+    let min = validate_random_int_arg(min_bits, "min");
+    let max = validate_random_int_arg(max_bits, "max");
     if max <= min {
         return f64::NAN;
     }

--- a/test-parity/node-suite/crypto/random/arg-validation.ts
+++ b/test-parity/node-suite/crypto/random/arg-validation.ts
@@ -1,0 +1,35 @@
+// Issue #2013 — Node-shaped argument validation for `crypto.randomBytes`
+// and `crypto.randomInt`. Each probe prints the thrown error's `.code`
+// and `.name`; Perry and Node must produce the exact same lines. The
+// other crypto entry points (createHash / createHmac / pbkdf2Sync /
+// …) take string args that perry-stdlib's runtime currently receives
+// already-unboxed as i64; their validation needs a parallel
+// `_jsv`-shaped entry that's the natural follow-up.
+import * as crypto from "node:crypto";
+
+function probe(label: string, fn: () => any) {
+  try {
+    fn();
+    console.log(label, "no-throw");
+  } catch (e: any) {
+    console.log(label, e.name, e.code);
+  }
+}
+
+// randomBytes — non-number type and out-of-range integers.
+probe("randomBytes({})", () => crypto.randomBytes({} as any));
+probe("randomBytes('abc')", () => crypto.randomBytes("abc" as any));
+probe("randomBytes(true)", () => crypto.randomBytes(true as any));
+probe("randomBytes(null)", () => crypto.randomBytes(null as any));
+probe("randomBytes(-1)", () => crypto.randomBytes(-1));
+probe("randomBytes(1.5)", () => crypto.randomBytes(1.5));
+probe("randomBytes(NaN)", () => crypto.randomBytes(NaN));
+probe("randomBytes(Infinity)", () => crypto.randomBytes(Infinity));
+probe("randomBytes(2**31)", () => crypto.randomBytes(2 ** 31));
+
+// randomInt — same shape on either bound.
+probe("randomInt({}, 10)", () => crypto.randomInt({} as any, 10));
+probe("randomInt(0, {})", () => crypto.randomInt(0, {} as any));
+probe("randomInt('abc', 10)", () => crypto.randomInt("abc" as any, 10));
+probe("randomInt(0, 1.5)", () => crypto.randomInt(0, 1.5));
+probe("randomInt(NaN, 10)", () => crypto.randomInt(NaN, 10));


### PR DESCRIPTION
## Summary

Follow-up to PRs #2328 / #2332 / #2342 (fs / process / timers slices). `crypto.randomBytes(size)` and `crypto.randomInt(min, max)` now throw Node-matching errors on bad input.

Pre-fix the codegen unboxed the NaN-boxed arg as `f64` (so `{}` arrived as a NaN), and `size as usize` silently truncated NaN to 0 — `randomBytes({})` returned an empty buffer instead of throwing.

| Call | Pre-fix | Post-fix (= Node) |
|------|---------|-------------------|
| `randomBytes('abc'/{}/true/null)` | empty buffer | `TypeError [ERR_INVALID_ARG_TYPE]` |
| `randomBytes(-1 / NaN / Infinity / 2^31)` | empty buffer | `RangeError [ERR_OUT_OF_RANGE]` |
| `randomBytes(1.5)` | empty buffer | 1-byte buffer (Node truncates) |
| `randomInt('abc'/{}/true)` on either bound | `NaN` | `TypeError [ERR_INVALID_ARG_TYPE]` |
| `randomInt(1.5 / NaN / Infinity)` | `NaN` | `TypeError [ERR_INVALID_ARG_TYPE]` (`validateInteger` shape) |
| `randomInt(±2^48+1)` | `NaN` | `RangeError [ERR_OUT_OF_RANGE]` |

`crates/perry-runtime/src/fs/validate.rs` becomes a public module so perry-stdlib can reuse the Node-shaped error helpers (`describe_received`, `is_numeric`, `throw_type_error_with_code`, `throw_range_error_with_code`) without duplicating them.

## Test plan

- [x] `cargo fmt --all -- --check` clean + `scripts/check_file_size.sh` clean.
- [x] `cargo test --release -p perry-runtime --lib` 746/746 + `-p perry-stdlib --lib` 79/79.
- [x] New parity test `test-parity/node-suite/crypto/random/arg-validation.ts` — 14 probes byte-identical to `node --experimental-strip-types`.

## Follow-up

The other crypto validators (`createHash` / `createHmac` / `pbkdf2Sync` / …) take string args that perry-stdlib's runtime currently receives already-unboxed as `i64`. Validating those needs a parallel `_jsv`-shaped entry (mirroring the `js_process_chdir_jsv` pattern from #2332) — tracked as the next slice of #2013.
