### PR TITLE
fix(node:process): chdir error path/dest/errno match Node (#2135)

### DIFF
--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -1062,67 +1062,10 @@ pub extern "C" fn js_process_next_tick(callback: *const crate::closure::ClosureH
     crate::builtins::js_queue_next_tick(callback as i64);
 }
 
-/// process.chdir(directory) — change working directory. Throws a Node-shaped
-/// `Error` (`code`/`syscall`/`path` populated) when the target can't be entered,
-/// matching `ENOENT: no such file or directory, chdir '<cwd>' -> '<target>'`.
-/// Refs #2135 (process parity, chdir error message gap).
-#[no_mangle]
-pub extern "C" fn js_process_chdir(dir_ptr: *const StringHeader) {
-    unsafe {
-        if dir_ptr.is_null() {
-            return;
-        }
-        let len = (*dir_ptr).byte_len as usize;
-        let data = (dir_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-        let bytes = std::slice::from_raw_parts(data, len);
-        let Ok(target) = std::str::from_utf8(bytes) else {
-            return;
-        };
-        if let Err(err) = std::env::set_current_dir(target) {
-            throw_chdir_error(&err, target);
-        }
-    }
-}
-
-/// libuv-style POSIX `ERR_*` for an `io::Error`, scoped to the kinds
-/// `chdir(2)` can return.
-fn chdir_error_code(err: &std::io::Error) -> &'static str {
-    use std::io::ErrorKind;
-    match err.kind() {
-        ErrorKind::NotFound => "ENOENT",
-        ErrorKind::PermissionDenied => "EACCES",
-        ErrorKind::NotADirectory => "ENOTDIR",
-        _ => "EIO",
-    }
-}
-
-/// Human-readable description matching Node's libuv `chdir` error strings.
-/// Node hardcodes these in its libuv error table; `io::Error::to_string()`
-/// uses Rust's text (e.g. "entity not found"), which would diverge from
-/// Node's output byte-for-byte.
-fn chdir_error_description(code: &str) -> &'static str {
-    match code {
-        "ENOENT" => "no such file or directory",
-        "EACCES" => "permission denied",
-        "ENOTDIR" => "not a directory",
-        _ => "i/o error",
-    }
-}
-
-unsafe fn throw_chdir_error(err: &std::io::Error, target: &str) -> ! {
-    let code = chdir_error_code(err);
-    let desc = chdir_error_description(code);
-    let cwd = std::env::current_dir()
-        .map(|p| p.display().to_string())
-        .unwrap_or_default();
-    let message = format!("{code}: {desc}, chdir '{cwd}' -> '{target}'");
-    let msg_ptr = js_string_from_bytes(message.as_ptr(), message.len() as u32);
-    crate::node_submodules::register_error_code_pub(msg_ptr, code);
-    crate::node_submodules::register_error_syscall(msg_ptr, "chdir");
-    crate::node_submodules::register_error_path(msg_ptr, target.to_string());
-    let err_ptr = crate::error::js_error_new_with_message(msg_ptr);
-    crate::exception::js_throw(crate::value::js_nanbox_pointer(err_ptr as i64));
-}
+// `process.chdir()` + its Node-shaped error live in the `chdir` submodule
+// (#2135); split out to keep this file under the 2000-line gate.
+mod chdir;
+pub use chdir::js_process_chdir;
 
 /// process.kill(pid, signal?) — send signal to process. signal=0 means existence check.
 #[no_mangle]

--- a/crates/perry-runtime/src/os/chdir.rs
+++ b/crates/perry-runtime/src/os/chdir.rs
@@ -1,0 +1,106 @@
+//! `process.chdir()` and its Node-shaped error construction (#2135).
+//!
+//! Split out of `os.rs` to keep that file under the 2000-line gate. The
+//! thrown error mirrors libuv's `chdir` shape:
+//! `ENOENT: no such file or directory, chdir '<cwd>' -> '<target>'` with
+//! `code` / `syscall` / `path` (= cwd, the *source*) / `dest` (= target) /
+//! `errno` (negative libuv code) populated.
+
+use crate::string::{js_string_from_bytes, StringHeader};
+
+/// process.chdir(directory) — change working directory. Throws a Node-shaped
+/// `Error` when the target can't be entered.
+#[no_mangle]
+pub extern "C" fn js_process_chdir(dir_ptr: *const StringHeader) {
+    unsafe {
+        if dir_ptr.is_null() {
+            return;
+        }
+        let len = (*dir_ptr).byte_len as usize;
+        let data = (dir_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        let bytes = std::slice::from_raw_parts(data, len);
+        let Ok(target) = std::str::from_utf8(bytes) else {
+            return;
+        };
+        if let Err(err) = std::env::set_current_dir(target) {
+            throw_chdir_error(&err, target);
+        }
+    }
+}
+
+/// libuv-style POSIX `ERR_*` for an `io::Error`, scoped to the kinds
+/// `chdir(2)` can return.
+fn chdir_error_code(err: &std::io::Error) -> &'static str {
+    use std::io::ErrorKind;
+    match err.kind() {
+        ErrorKind::NotFound => "ENOENT",
+        ErrorKind::PermissionDenied => "EACCES",
+        ErrorKind::NotADirectory => "ENOTDIR",
+        _ => "EIO",
+    }
+}
+
+/// Human-readable description matching Node's libuv `chdir` error strings.
+/// Node hardcodes these in its libuv error table; `io::Error::to_string()`
+/// uses Rust's text (e.g. "entity not found"), which would diverge from
+/// Node's output byte-for-byte.
+fn chdir_error_description(code: &str) -> &'static str {
+    match code {
+        "ENOENT" => "no such file or directory",
+        "EACCES" => "permission denied",
+        "ENOTDIR" => "not a directory",
+        _ => "i/o error",
+    }
+}
+
+/// libuv `errno` (negative) for a `chdir` error code, matching the value Node
+/// exposes on `err.errno`. libuv reports `-<system errno>`.
+fn chdir_error_errno(code: &str) -> i32 {
+    match code {
+        "ENOENT" => -2,
+        "EACCES" => -13,
+        "ENOTDIR" => -20,
+        _ => -5, // EIO
+    }
+}
+
+unsafe fn throw_chdir_error(err: &std::io::Error, target: &str) -> ! {
+    let code = chdir_error_code(err);
+    let desc = chdir_error_description(code);
+    let cwd = std::env::current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    let message = format!("{code}: {desc}, chdir '{cwd}' -> '{target}'");
+    let msg_ptr = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    crate::node_submodules::register_error_code_pub(msg_ptr, code);
+    crate::node_submodules::register_error_syscall(msg_ptr, "chdir");
+    // #2135: match Node's uv `chdir` error shape — `path` is the *source*
+    // (cwd), `dest` is the failed target, and `errno` is the negative libuv
+    // code. Previously `path` was set to the target and `dest`/`errno` were
+    // absent.
+    crate::node_submodules::register_error_path(msg_ptr, cwd);
+    let err_ptr = crate::error::js_error_new_with_message(msg_ptr);
+    let err_addr = err_ptr as usize;
+    let dest_ptr = js_string_from_bytes(target.as_ptr(), target.len() as u32);
+    crate::node_submodules::set_error_user_prop(
+        err_addr,
+        "dest",
+        crate::value::js_nanbox_string(dest_ptr as i64),
+    );
+    crate::node_submodules::set_error_user_prop(err_addr, "errno", chdir_error_errno(code) as f64);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err_ptr as i64));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chdir_error_errno_matches_libuv() {
+        // #2135: Node exposes libuv's negative errno on chdir errors.
+        assert_eq!(chdir_error_errno("ENOENT"), -2);
+        assert_eq!(chdir_error_errno("EACCES"), -13);
+        assert_eq!(chdir_error_errno("ENOTDIR"), -20);
+        assert_eq!(chdir_error_errno("EIO"), -5);
+    }
+}


### PR DESCRIPTION
## Summary

`process.chdir()` to a missing/invalid directory threw an error whose properties diverged from Node:

```ts
try { process.chdir("/nope"); } catch (e) { /* e.path, e.dest, e.errno */ }
//        Node                         Perry (before)
// path:  <cwd>                        "/nope"   (wrong — was the target)
// dest:  "/nope"                      undefined
// errno: -2                           undefined
```

Node's libuv `chdir` error sets `path` to the **source** (cwd), `dest` to the failed **target**, and `errno` to the negative libuv code.

## How

In `throw_chdir_error` (`os.rs`): set `path` = cwd (was the target), and attach `dest` (target) and `errno` (negative libuv code: ENOENT=-2, EACCES=-13, ENOTDIR=-20, else EIO=-5) via the per-error user-prop side table (`set_error_user_prop`, the same mechanism `.code`/`.errno` already read). The error `message` already matched Node and is unchanged.

## Test plan

- New unit test `chdir_error_errno_matches_libuv`.
- End-to-end vs Node v25: `process.chdir("/nonexistent")` now matches on `message`, `code`, `syscall`, `path` (=cwd), `dest` (=target), `errno` (=-2), `name`, and `toString`.

Backs `test-process-chdir-errormessage.js` from #2135. (The remaining #2135 process clusters — `process.abort()` stderr framing, exit/beforeExit ordering — are separate follow-ups.)
