### PR TITLE
fix(node:timers): accept promise resolver callbacks

### DIFF
--- a/crates/perry-runtime/src/timer.rs
+++ b/crates/perry-runtime/src/timer.rs
@@ -330,6 +330,15 @@ pub unsafe extern "C" fn js_timer_validate_callback(value: f64, fn_name_idx: i32
             return ptr as i64;
         }
     }
+    // Promise executor resolve/reject callbacks are passed through this runtime
+    // as raw closure pointer bits rather than NaN-boxed pointers. They are still
+    // callable JS functions, so accept them after proving the candidate is a
+    // Perry-managed closure. Do not call `is_closure_ptr` on arbitrary JS bits:
+    // short strings and doubles can otherwise look pointer-ish enough to
+    // segfault during validation.
+    if let Some(ptr) = raw_closure_pointer(bits) {
+        return ptr as i64;
+    }
     // 0 = setTimeout, 1 = setInterval, 2 = setImmediate, anything
     // else falls back to the generic "callback" wording.
     let fn_name: &str = match fn_name_idx {
@@ -347,6 +356,45 @@ pub unsafe extern "C" fn js_timer_validate_callback(value: f64, fn_name_idx: i32
     // varies a touch but the code does not.
     let _ = fn_name;
     crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn raw_closure_pointer(bits: u64) -> Option<usize> {
+    const RAW_PTR_MAX: u64 = 0x0000_FFFF_FFFF_FFFF;
+    if !(0x10000..=RAW_PTR_MAX).contains(&bits) || bits & 0x7 != 0 {
+        return None;
+    }
+    let ptr = bits as usize;
+    if ptr < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return None;
+    }
+    let header_addr = ptr - crate::gc::GC_HEADER_SIZE;
+    let header = header_addr as *const crate::gc::GcHeader;
+    let tracked_malloc = crate::gc::gc_malloc_header_is_tracked(header);
+    let arena_payload = !matches!(
+        crate::arena::classify_heap_space(ptr),
+        crate::arena::HeapSpace::Unknown
+    );
+    let arena_header = !matches!(
+        crate::arena::classify_heap_space(header_addr),
+        crate::arena::HeapSpace::Unknown
+    );
+    if !tracked_malloc && !(arena_payload && arena_header) {
+        return None;
+    }
+    unsafe {
+        if (*header).obj_type != crate::gc::GC_TYPE_CLOSURE {
+            return None;
+        }
+        let size = (*header).size as usize;
+        if size < crate::gc::GC_HEADER_SIZE || size > (1usize << 34) {
+            return None;
+        }
+        let is_arena = (*header).gc_flags & crate::gc::GC_FLAG_ARENA != 0;
+        if tracked_malloc == is_arena {
+            return None;
+        }
+    }
+    crate::closure::is_closure_ptr(ptr).then_some(ptr)
 }
 
 /// JS-style setTimeout that takes a callback function and delay


### PR DESCRIPTION
## Summary
- Accept raw Perry closure-pointer callback values in `node:timers` callback validation after proving they are Perry-managed closures.
- Preserve the existing `ERR_INVALID_ARG_TYPE` path for invalid callback values.
- Unblock `new Promise(resolve => setTimeout(resolve, ms))` patterns used by timer wait helpers and npm workloads.

## Verification
- Baseline exact failure: `./run_parity_tests.sh --suite node-suite --filter node-suite/timers/timeout/zero-delay`, report `test-parity/reports/parity_report_20260528_182240.json`.
- Final exact pass: `./run_parity_tests.sh --suite node-suite --filter node-suite/timers/timeout/zero-delay`, report `test-parity/reports/parity_report_20260528_183939.json`.
- Invalid-callback guardrail: `./run_parity_tests.sh --suite node-suite --filter node-suite/timers/arg-validation`, report `test-parity/reports/parity_report_20260528_184022.json`.
- Full timers suite: `./run_parity_tests.sh --suite node-suite --filter node-suite/timers`, `73 PASS / 5 parity FAIL / 0 compile FAIL`, report `test-parity/reports/parity_report_20260528_184031.json`; remaining failures are `immediate/cross-clear-noop`, `interval/nan-delay`, `interval/negative-delay`, `timeout/negative-delay`, and `timeout/zero-negative-delay`.
- `cargo check -p perry-runtime` passes with existing warnings.
- `cargo fmt --check` passes.
- `git diff --check` passes.

## DeepWiki
- Saved locally at `reference/deepwiki/node-timers-promise-resolve-callback.md`.
- Invariant used: Node validates timer callbacks as functions; a Promise executor `resolve` is a JS function, so `setTimeout(resolve, ms)` is valid and stores/invokes that callback later.

## Non-goals
- No delay warning or negative-delay timer semantics.
- No `clearTimeout(immediate)` cross-clear behavior.
- No timer queue rewrite.
- No timer warning output emulation.
