### PR TITLE
feat(dynamic-import): directory-glob template specifiers (#1674 sub-B)

### DIFF
--- a/crates/perry-hir/src/dynamic_import.rs
+++ b/crates/perry-hir/src/dynamic_import.rs
@@ -734,6 +734,81 @@ pub fn resolve_import_path(arg: &Expr) -> Resolution {
 /// per-call cycle-breaker — a const initializer that references its
 /// own id (impossible in well-formed TS, but defensive) returns
 /// Unresolved instead of recursing infinitely.
+/// #1674 sub-part B (glob): when a template-literal specifier has a fixed,
+/// relative, directory-anchored `prefix`, a fixed `suffix`, and a
+/// non-statically-resolvable middle (`import(`./plugins/${name}.ts`)`),
+/// return `(prefix, suffix)` so the driver can glob `<prefix>*<suffix>`
+/// against the importing module's directory and enumerate the candidates.
+///
+/// Returns `None` for anything that isn't this shape — fully-resolvable
+/// templates (handled by [`resolve_import_path_with_consts`]) and patterns
+/// with no fixed, directory-bearing prefix (too broad to glob safely). The
+/// resolver itself performs no filesystem I/O; the driver owns the readdir.
+pub fn dynamic_import_glob_pattern(
+    arg: &Expr,
+    consts: &std::collections::HashMap<u32, Expr>,
+) -> Option<(String, String)> {
+    // Only template-literal concatenations (`Binary(Add, …)`) can glob.
+    if !matches!(
+        arg,
+        Expr::Binary {
+            op: BinaryOp::Add,
+            ..
+        }
+    ) {
+        return None;
+    }
+    let mut parts: Vec<&Expr> = Vec::new();
+    flatten_concat(arg, &mut parts);
+    if parts.len() < 2 {
+        return None;
+    }
+
+    // A part resolves to a single fixed string, or it doesn't (wildcard).
+    let single = |p: &Expr| -> Option<String> {
+        let mut visiting = std::collections::HashSet::new();
+        match resolve_import_path_with_consts(p, consts, &mut visiting) {
+            Resolution::Set(v) if v.len() == 1 => Some(v.into_iter().next().unwrap()),
+            _ => None,
+        }
+    };
+
+    // Leading fixed parts → prefix.
+    let mut prefix = String::new();
+    let mut i = 0;
+    while i < parts.len() {
+        match single(parts[i]) {
+            Some(s) => {
+                prefix.push_str(&s);
+                i += 1;
+            }
+            None => break,
+        }
+    }
+    // Trailing fixed parts → suffix.
+    let mut suffix = String::new();
+    let mut j = parts.len();
+    while j > i {
+        match single(parts[j - 1]) {
+            Some(s) => {
+                suffix.insert_str(0, &s);
+                j -= 1;
+            }
+            None => break,
+        }
+    }
+    // Need at least one non-fixed (wildcard) part between prefix and suffix.
+    if i >= j {
+        return None;
+    }
+    // The prefix must be a relative specifier with a directory component so
+    // the glob is scoped to one folder (never the whole project / node_modules).
+    if !(prefix.starts_with("./") || prefix.starts_with("../")) || !prefix.contains('/') {
+        return None;
+    }
+    Some((prefix, suffix))
+}
+
 pub fn resolve_import_path_with_consts(
     arg: &Expr,
     consts: &std::collections::HashMap<u32, Expr>,
@@ -1361,5 +1436,56 @@ mod tests {
         m.init.push(Stmt::Expr(closure));
         detect_top_level_await(&mut m);
         assert!(!m.has_top_level_await);
+    }
+
+    // #1674 sub-B: `("./plugins/" + name) + ".ts"` where `name` is a
+    // non-resolvable local — the HIR shape of `` `./plugins/${name}.ts` ``.
+    fn glob_chain(prefix: &str, suffix: &str, wild_id: u32) -> Expr {
+        Expr::Binary {
+            op: BinaryOp::Add,
+            left: Box::new(Expr::Binary {
+                op: BinaryOp::Add,
+                left: Box::new(Expr::String(prefix.into())),
+                right: Box::new(Expr::LocalGet(wild_id)),
+            }),
+            right: Box::new(Expr::String(suffix.into())),
+        }
+    }
+
+    #[test]
+    fn glob_pattern_extracts_relative_prefix_and_suffix() {
+        let consts = std::collections::HashMap::new();
+        let arg = glob_chain("./plugins/", ".ts", 1);
+        assert_eq!(
+            dynamic_import_glob_pattern(&arg, &consts),
+            Some(("./plugins/".to_string(), ".ts".to_string()))
+        );
+    }
+
+    #[test]
+    fn glob_pattern_rejects_non_relative_or_dirless_prefix() {
+        let consts = std::collections::HashMap::new();
+        // bare prefix with no directory component — too broad to glob.
+        assert_eq!(
+            dynamic_import_glob_pattern(&glob_chain("locale_", ".ts", 1), &consts),
+            None
+        );
+        // absolute / package prefix — not a relative directory glob.
+        assert_eq!(
+            dynamic_import_glob_pattern(&glob_chain("@scope/", ".ts", 1), &consts),
+            None
+        );
+    }
+
+    #[test]
+    fn glob_pattern_none_when_fully_resolvable() {
+        // No wildcard part — the normal resolver handles this, not the glob.
+        let consts = std::collections::HashMap::new();
+        let arg = Expr::Binary {
+            op: BinaryOp::Add,
+            left: Box::new(Expr::String("./a".into())),
+            right: Box::new(Expr::String(".ts".into())),
+        };
+        assert_eq!(dynamic_import_glob_pattern(&arg, &consts), None);
     }
 }

--- a/crates/perry-hir/src/lib.rs
+++ b/crates/perry-hir/src/lib.rs
@@ -28,9 +28,9 @@ pub use analysis::{collect_local_refs_expr, collect_local_refs_stmt};
 pub use audit::{audit_module, AuditManifest, ModuleAudit};
 pub use capability::{audit_module_capabilities, CapabilityPolicy, CapabilityViolation};
 pub use dynamic_import::{
-    collect_module_const_locals, detect_top_level_await, flatten_exports,
-    for_each_dynamic_import_mut, resolve_import_path, resolve_import_path_with_consts, FlatExport,
-    Resolution, DYNAMIC_IMPORT_PATH_CAP,
+    collect_module_const_locals, detect_top_level_await, dynamic_import_glob_pattern,
+    flatten_exports, for_each_dynamic_import_mut, resolve_import_path,
+    resolve_import_path_with_consts, FlatExport, Resolution, DYNAMIC_IMPORT_PATH_CAP,
 };
 pub use egress::{audit_module_egress, EgressRefusalReason, EgressViolation};
 pub use enums::fix_imported_enums;

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -172,6 +172,61 @@ pub(super) fn known_node_submodule_key(source: &str) -> Option<&'static str> {
     }
 }
 
+/// #1674 sub-part B: expand a dynamic-`import()` glob pattern
+/// (`<prefix>*<suffix>`, where `prefix` is a relative, directory-anchored
+/// path) into concrete relative specifiers by reading the importing module's
+/// directory. Each returned specifier equals the string the runtime template
+/// produces (`prefix_dir + filename`), so the compile-time candidate keys match
+/// the runtime dispatch arg exactly. Returns specifiers sorted for determinism.
+fn expand_dynamic_import_glob(
+    importing_file: &str,
+    prefix: &str,
+    suffix: &str,
+    cap: usize,
+) -> Vec<String> {
+    // Split the prefix into its directory part (through the last '/') and the
+    // leading filename fragment that survivors must start with.
+    let last_slash = match prefix.rfind('/') {
+        Some(i) => i,
+        None => return Vec::new(),
+    };
+    let prefix_dir = &prefix[..=last_slash]; // e.g. "./plugins/" or "./"
+    let file_prefix = &prefix[last_slash + 1..]; // e.g. "" or "locale_"
+
+    let importing_dir = std::path::Path::new(importing_file)
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."));
+    let glob_dir = importing_dir.join(prefix_dir);
+
+    let entries = match std::fs::read_dir(&glob_dir) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+    let min_len = file_prefix.len() + suffix.len();
+    let mut out: Vec<String> = Vec::new();
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            continue;
+        }
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        // The wildcard must match a non-empty middle: `name` strictly longer
+        // than `file_prefix + suffix`, and bracketed by them.
+        if name.len() <= min_len || !name.starts_with(file_prefix) || !name.ends_with(suffix) {
+            continue;
+        }
+        let candidate = format!("{prefix_dir}{name}");
+        if !out.contains(&candidate) {
+            out.push(candidate);
+        }
+        if out.len() > cap {
+            break;
+        }
+    }
+    out.sort();
+    out
+}
+
 /// Collect all modules to compile (transitive closure of imports)
 pub(super) fn collect_modules(
     entry_path: &PathBuf,
@@ -543,6 +598,41 @@ pub(super) fn collect_modules(
                     *paths = set;
                 }
                 perry_hir::Resolution::Unresolved(reason) => {
+                    // #1674 sub-part B: a non-resolvable template specifier with
+                    // a fixed relative-directory prefix/suffix
+                    // (`import(`./plugins/${name}.ts`)`) globs the importing
+                    // module's directory for matching files instead of erroring.
+                    if let Some((prefix, suffix)) =
+                        perry_hir::dynamic_import_glob_pattern(arg, &module_const_locals)
+                    {
+                        let matches = expand_dynamic_import_glob(
+                            &source_file_path,
+                            &prefix,
+                            &suffix,
+                            perry_hir::DYNAMIC_IMPORT_PATH_CAP,
+                        );
+                        if matches.len() > perry_hir::DYNAMIC_IMPORT_PATH_CAP {
+                            dyn_errors.push(format!(
+                                "dynamic import() in module {}: glob '{}*{}' matched {} files \
+                                 (limit: {})",
+                                module_name,
+                                prefix,
+                                suffix,
+                                matches.len(),
+                                perry_hir::DYNAMIC_IMPORT_PATH_CAP
+                            ));
+                            return;
+                        }
+                        if !matches.is_empty() {
+                            for p in &matches {
+                                if !new_dyn_imports.contains(p) {
+                                    new_dyn_imports.push(p.clone());
+                                }
+                            }
+                            *paths = matches;
+                            return;
+                        }
+                    }
                     dyn_errors.push(format!(
                         "dynamic import() in module {}: {}",
                         module_name, reason
@@ -1418,5 +1508,40 @@ fn excerpt_around_offset(source: &str, lo: usize) -> Option<String> {
         None
     } else {
         Some(out)
+    }
+}
+
+#[cfg(test)]
+mod glob_expand_tests {
+    use super::expand_dynamic_import_glob;
+
+    #[test]
+    fn expands_directory_files_matching_suffix() {
+        // #1674 sub-B: glob `./plugins/*.ts` against the importing module's dir.
+        let base = std::env::temp_dir().join(format!("perry_glob_test_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let plugins = base.join("plugins");
+        std::fs::create_dir_all(&plugins).unwrap();
+        std::fs::write(plugins.join("alpha.ts"), "export const x=1;").unwrap();
+        std::fs::write(plugins.join("beta.ts"), "export const x=2;").unwrap();
+        std::fs::write(plugins.join("notes.md"), "ignored: wrong suffix").unwrap();
+        let importing = base.join("main.ts");
+        std::fs::write(&importing, "").unwrap();
+
+        let got = expand_dynamic_import_glob(importing.to_str().unwrap(), "./plugins/", ".ts", 64);
+        assert_eq!(
+            got,
+            vec![
+                "./plugins/alpha.ts".to_string(),
+                "./plugins/beta.ts".to_string()
+            ]
+        );
+
+        // A directory with no matches yields nothing (→ rejected promise).
+        let none =
+            expand_dynamic_import_glob(importing.to_str().unwrap(), "./plugins/", ".mjs", 64);
+        assert!(none.is_empty());
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 }


### PR DESCRIPTION
## Summary

Implements **sub-part B (directory glob)** of #1674. A dynamic `import()` whose specifier is a template literal with a fixed relative-directory prefix/suffix and a runtime-variable middle now resolves by globbing the importing module's directory, rather than erroring:

```ts
const which = pickPlugin();                 // runtime value
const mod = await import(`./plugins/${which}.ts`);   // ✅ compiles all ./plugins/*.ts
```

Builds on sub-part A (#2338, merged). Together they cover the type/flow-narrowing and glob axes of #1674.

## How

- **perry-hir** — new `dynamic_import_glob_pattern(arg, consts) -> Option<(prefix, suffix)>` recognizes a `Binary(Add, …)` template whose leading/trailing parts fold to fixed strings around a non-resolvable middle. It is **additive**: the existing `resolve_import_path_with_consts` is untouched; the driver only consults the glob detector on the `Unresolved` fallthrough. The prefix must be **relative and directory-bearing** (`./`/`../` + a `/`) so a glob can never escape one folder into `node_modules` or the whole project.
- **driver** (`collect_modules`) — `expand_dynamic_import_glob` reads `<prefix-dir>` resolved relative to the importing module and keeps files matching `<file-prefix>*<suffix>` with a non-empty wildcard middle. The candidate specifier is `prefix_dir + filename`, which **equals the string the runtime template produces**, so the compile-time keys match the runtime dispatch arg exactly. Candidates feed the existing `Set` path → each is compiled and wired into the N-way `js_string_equals` dispatch. Bounded by `DYNAMIC_IMPORT_PATH_CAP` (64; over-cap → compile error); no match → rejected promise (Node miss semantics).

## Test plan

- Unit: `dynamic_import_glob_pattern` (accepts `./plugins/`+`.ts`; rejects dirless `locale_`, package `@scope/`, and fully-resolvable templates) + `expand_dynamic_import_glob` (suffix filter, wrong-suffix ignored, no-match empty).
- 20 existing dynamic_import tests still green.
- End-to-end vs Node v25: a runtime-selected `` `./plugins/${which}.ts` `` dispatches to the correct plugin for both branches; a non-existent name → rejected promise (matches Node).

## Scope

Single-directory glob (non-recursive), which covers the common Vite/Rollup `import.meta.glob`-style adapter-by-name and config-loader cases. Recursive `**` globbing is a possible future extension.
