### PR TITLE
fix(runtime): Array.prototype.join uses ToString for object elements (#800)

### DIFF
--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -612,15 +612,40 @@ pub extern "C" fn js_array_join(
                 let s = std::str::from_utf8_unchecked(&scratch[..n]);
                 result.push_str(s);
             } else if jsvalue.is_pointer() {
-                // POINTER_TAG — may be a string stored with the wrong tag (cross-module)
-                let ptr = (element_bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
-                if !ptr.is_null() && (ptr as usize) >= 0x1000 {
-                    let str_len = (*ptr).byte_len as usize;
-                    let str_data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-                    let s = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-                        str_data, str_len,
-                    ));
-                    result.push_str(s);
+                // POINTER_TAG. Two cases:
+                //  1. A genuine string NaN-boxed with POINTER_TAG instead of
+                //     STRING_TAG (a cross-module mis-tag) — read its bytes.
+                //  2. A real heap object/array/error/buffer — these must go
+                //     through the spec `ToString` (`js_jsvalue_to_string`):
+                //     Array→nested join, Error→"name: message" (#2135), an
+                //     object with a custom `toString`→that result, buffers,
+                //     etc. The old code read *every* pointer as a
+                //     `StringHeader`, so a non-string's garbage `byte_len`
+                //     produced corrupted output (`[err].join()` → empty).
+                //     Distinguish via the GcHeader type tag, excluding the
+                //     headerless buffer/symbol pointers first.
+                let ptr_addr = (element_bits & 0x0000_FFFF_FFFF_FFFF) as usize;
+                if ptr_addr >= 0x1000 {
+                    let is_string_obj = !crate::buffer::is_registered_buffer(ptr_addr)
+                        && !crate::symbol::is_registered_symbol(ptr_addr)
+                        && {
+                            let gc_header = (ptr_addr as *const u8).sub(crate::gc::GC_HEADER_SIZE)
+                                as *const crate::gc::GcHeader;
+                            (*gc_header).obj_type == crate::gc::GC_TYPE_STRING
+                        };
+                    let s_ptr = if is_string_obj {
+                        ptr_addr as *const StringHeader
+                    } else {
+                        crate::value::js_jsvalue_to_string(f64::from_bits(element_bits))
+                    };
+                    if !s_ptr.is_null() {
+                        let str_len = (*s_ptr).byte_len as usize;
+                        let str_data =
+                            (s_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+                        result.push_str(std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+                            str_data, str_len,
+                        )));
+                    }
                 } else {
                     result.push_str("[object Object]");
                 }

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -935,3 +935,26 @@ fn test_array_splice_grow_realloc() {
     }
     assert_eq!(js_array_get_f64(out_arr, 11), 2.0);
 }
+
+#[test]
+fn join_routes_objects_and_nested_arrays_through_tostring() {
+    // #800/#2135: a POINTER_TAG element that is an object/array (not a string)
+    // must go through the spec ToString — a nested array joins recursively, a
+    // plain object becomes "[object Object]" — instead of being mis-read as a
+    // StringHeader (which produced corrupted/empty output).
+    unsafe {
+        let inner = js_array_push_f64(js_array_push_f64(js_array_alloc(2), 1.0), 2.0);
+        let inner_v = f64::from_bits(crate::value::JSValue::pointer(inner as *const u8).bits());
+        let obj = crate::object::js_object_alloc(0, 0);
+        let obj_v = f64::from_bits(crate::value::JSValue::pointer(obj as *const u8).bits());
+        let mut arr = js_array_alloc(2);
+        arr = js_array_push_f64(arr, inner_v);
+        arr = js_array_push_f64(arr, obj_v);
+        let sep = crate::string::js_string_from_bytes(b";".as_ptr(), 1);
+        let out = js_array_join(arr, sep);
+        let len = (*out).byte_len as usize;
+        let data = (out as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+        let s = std::str::from_utf8(std::slice::from_raw_parts(data, len)).unwrap();
+        assert_eq!(s, "1,2;[object Object]");
+    }
+}


### PR DESCRIPTION
## Summary

`Array.prototype.join` read **every** `POINTER_TAG` element as a `StringHeader`, so a non-string element (object / array / error / buffer) had its garbage `byte_len` read — producing corrupted or empty output that diverged from Node:

```ts
[new Error("boom")].join(", ")          // before: "" (corrupt)   Node: "Error: boom"
[{toString(){return "A"}}].join("-")    // before: ""             Node: "A"
[[1,2],[3,4]].join(";")                 // before: garbage        Node: "1,2;3,4"
```

Discovered while verifying error stringification (#2135); advances the #800 node-core parity sweep (Array tests).

## How

In the `is_pointer()` arm of `js_array_join`, route **non-string** pointer elements through the spec `ToString` (`js_jsvalue_to_string`), which already handles each kind correctly (Array→nested join, Error→`"name: message"`, object-with-custom-`toString`→that result, buffers, JSX, …). A genuine string NaN-boxed with `POINTER_TAG` (the documented cross-module mis-tag) is still read directly as a string — detected via the `GcHeader` type tag (`GC_TYPE_STRING`) after first excluding the headerless buffer/symbol pointers (checked via their registries) so the tag read is always safe.

Behavior preserved: plain objects still join as `"[object Object]"`; strings, `SHORT_STRING`, numbers, booleans, null/undefined, holes (`Array(n).join`), and the raw-pointer-string fallback are all unchanged.

## Test plan

- New unit test: `[ [1,2], {} ].join(";")` → `"1,2;[object Object]"` (nested array recurses, plain object via ToString).
- 86 existing array tests green; `cargo fmt` + file-size gate clean.
- End-to-end vs Node v25: errors, `class X extends Error`, custom `toString`, nested arrays, plain objects, mixed primitives (`[1,"two",true,null,undefined,3.5]`), and `Array(3).join("0")` all match byte-for-byte.
