### PR TITLE
fix(console): inspect Map/Set/RegExp instead of [object Object]/{} (#800)

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -10,6 +10,7 @@ use super::println;
 use super::*;
 
 mod boxed_primitives;
+mod collections;
 
 /// Returns true if the f64 value is negative zero (-0.0).
 /// Uses bit pattern comparison so +0.0 and -0.0 are distinguished
@@ -657,6 +658,13 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                 // would read garbage one word before the BufferHeader).
                 let buf_ptr = ptr as *const crate::buffer::BufferHeader;
                 format_buffer_value(buf_ptr)
+            } else if crate::regex::is_registered_regex(ptr as usize) {
+                // RegExp literals are GC_TYPE_OBJECT allocations with no
+                // enumerable string keys, so the generic object formatter
+                // prints `{}`. Render the literal form `/source/flags`
+                // instead (registry-gated; #800). This check sits with the
+                // other registry pre-checks, before the GC-header read.
+                collections::format_regexp(ptr as *const crate::regex::RegExpHeader)
             } else if crate::proxy::js_proxy_is_proxy(value) != 0 {
                 let target = crate::proxy::js_proxy_target(value);
                 format_jsvalue(target, depth)
@@ -826,7 +834,9 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                     let body_str = format_object_as_json(obj_ptr, depth);
                     inspect_finish_circular(ptr as usize, body_str)
                 } else if gc_type == crate::gc::GC_TYPE_MAP {
-                    "Map {}".to_string()
+                    collections::format_map_with_cycle(ptr, depth)
+                } else if gc_type == crate::gc::GC_TYPE_SET {
+                    collections::format_set_with_cycle(ptr, depth)
                 } else if gc_type == crate::gc::GC_TYPE_CLOSURE {
                     format_function_for_console(ptr as *const crate::closure::ClosureHeader)
                 } else if gc_type == crate::gc::GC_TYPE_PROMISE {
@@ -1286,6 +1296,18 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
                     format_jsvalue_for_json(target, depth)
                 } else if (ptr as usize) < 0x100000 {
                     "[object Object]".to_string()
+                } else if crate::symbol::is_registered_symbol(ptr as usize)
+                    || crate::regex::is_registered_regex(ptr as usize)
+                    || crate::buffer::is_registered_buffer(ptr as usize)
+                    || crate::typedarray::lookup_typed_array_kind(ptr as usize).is_some()
+                {
+                    // Symbol / RegExp / Buffer / TypedArray field values need
+                    // type-specific rendering this JSON-ish formatter never
+                    // implemented — they collapsed to `[object Object]` / `{}`
+                    // (#800). Delegate to `format_jsvalue`, which gates these
+                    // on the same registries BEFORE any GC-header read (Buffers
+                    // carry no GC header, so the read below would be garbage).
+                    format_jsvalue(value, depth)
                 } else {
                     let gc_header = (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE)
                         as *const crate::gc::GcHeader;
@@ -1371,15 +1393,14 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
                             "[object Object]".to_string()
                         };
                         inspect_finish_circular(ptr as usize, body_str)
+                    } else if gc_type == crate::gc::GC_TYPE_MAP {
+                        collections::format_map_with_cycle(ptr, depth)
+                    } else if gc_type == crate::gc::GC_TYPE_SET {
+                        collections::format_set_with_cycle(ptr, depth)
                     } else if gc_type == crate::gc::GC_TYPE_CLOSURE {
-                        // Function-valued object fields used to fall through
-                        // to the `[object Object]` catch-all below, hiding
-                        // both the function name and any user-attached own
-                        // properties (e.g. `console.log({ handler: myFn })`
-                        // collapsed `myFn` to `[object Object]`). Route
-                        // through the same display path `format_jsvalue`'s
-                        // own GC_TYPE_CLOSURE branch uses so the registered
-                        // function name flows out.
+                        // Function-valued field: route through the same display
+                        // path as `format_jsvalue` so the registered function
+                        // name flows out instead of `[object Object]`.
                         format_function_for_console(ptr as *const crate::closure::ClosureHeader)
                     } else {
                         "[object Object]".to_string()
@@ -1389,6 +1410,11 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
         } else if jsval.is_int32() {
             jsval.as_int32().to_string()
         } else {
+            // A TypedArray field is a RAW (non-NaN-boxed) heap pointer, so it
+            // lands here, not in the pointer branch; redirect it (#800).
+            if let Some(s) = collections::raw_heap_pointer_display(value, depth) {
+                return s;
+            }
             let n = value;
             if n.is_nan() {
                 "NaN".to_string()

--- a/crates/perry-runtime/src/builtins/formatting/collections.rs
+++ b/crates/perry-runtime/src/builtins/formatting/collections.rs
@@ -1,0 +1,236 @@
+//! `util.inspect` / `console.log` formatting for the collection types that
+//! the generic object/array formatter can't render from a keys array: `Map`,
+//! `Set`, and `RegExp`. Node prints these as `Map(2) { 'a' => 1 }`,
+//! `Set(3) { 1, 2, 3 }`, and `/ab+c/gi` respectively — see #800.
+//!
+//! Kept in a sibling submodule so the (already ~2000-line) parent
+//! `formatting.rs` stays under the file-size gate. Reaches back into the
+//! parent for `format_jsvalue` and the circular-reference bookkeeping via
+//! `super::`.
+
+use super::{format_jsvalue, inspect_compact_enabled, inspect_depth_limit};
+use crate::string::StringHeader;
+use crate::value::JSValue;
+
+/// Format a single Map key/value or Set element the way Node's `util.inspect`
+/// does *inside* a container: strings are quoted (`'hello'`), everything else
+/// uses the normal `format_jsvalue` rendering.
+fn format_member(value: f64, depth: usize) -> String {
+    let jsval = JSValue::from_bits(value.to_bits());
+    let rendered = format_jsvalue(value, depth + 1);
+    if jsval.is_any_string() {
+        format!("'{}'", rendered)
+    } else {
+        rendered
+    }
+}
+
+/// Wrap `parts` as `TypeName(count) { ... }`, breaking onto multiple lines
+/// the same way the array/object formatters do (Node uses one line until the
+/// content is long or the entry count is high).
+fn wrap(label: &str, count: usize, parts: &[String]) -> String {
+    if count == 0 {
+        return format!("{}(0) {{}}", label);
+    }
+    let inner = parts.join(", ");
+    let use_multiline =
+        !inspect_compact_enabled() || count > 6 || inner.len() + label.len() + 8 > 76;
+    if !use_multiline {
+        format!("{}({}) {{ {} }}", label, count, inner)
+    } else {
+        let body = parts
+            .iter()
+            .map(|p| format!("  {}", p))
+            .collect::<Vec<_>>()
+            .join(",\n");
+        format!("{}({}) {{\n{}\n}}", label, count, body)
+    }
+}
+
+/// Render a `Map` as `Map(size) { key => value, ... }`.
+///
+/// # Safety
+/// `map` must be a live `MapHeader` (callers gate on `GC_TYPE_MAP`).
+pub(super) unsafe fn format_map(map: *const crate::map::MapHeader, depth: usize) -> String {
+    if map.is_null() {
+        return "Map(0) {}".to_string();
+    }
+    if depth > inspect_depth_limit() {
+        return "[Map]".to_string();
+    }
+    let size = (*map).size as usize;
+    let entries = (*map).entries;
+    if size == 0 || entries.is_null() {
+        return "Map(0) {}".to_string();
+    }
+    let mut parts: Vec<String> = Vec::with_capacity(size);
+    for i in 0..size {
+        let key = *entries.add(i * 2);
+        let val = *entries.add(i * 2 + 1);
+        parts.push(format!(
+            "{} => {}",
+            format_member(key, depth),
+            format_member(val, depth)
+        ));
+    }
+    wrap("Map", size, &parts)
+}
+
+/// Render a `Set` as `Set(size) { value, ... }`.
+///
+/// # Safety
+/// `set` must be a live `SetHeader` (callers gate on `GC_TYPE_SET`).
+pub(super) unsafe fn format_set(set: *const crate::set::SetHeader, depth: usize) -> String {
+    if set.is_null() {
+        return "Set(0) {}".to_string();
+    }
+    if depth > inspect_depth_limit() {
+        return "[Set]".to_string();
+    }
+    let size = (*set).size as usize;
+    let elements = (*set).elements;
+    if size == 0 || elements.is_null() {
+        return "Set(0) {}".to_string();
+    }
+    let mut parts: Vec<String> = Vec::with_capacity(size);
+    for i in 0..size {
+        parts.push(format_member(*elements.add(i), depth));
+    }
+    wrap("Set", size, &parts)
+}
+
+/// `format_map` wrapped in the parent's circular-reference bookkeeping so a
+/// self-referential Map prints `[Circular *N]` instead of recursing forever.
+///
+/// # Safety
+/// `ptr` must point at a live `MapHeader` (callers gate on `GC_TYPE_MAP`).
+pub(super) unsafe fn format_map_with_cycle(
+    ptr: *const crate::array::ArrayHeader,
+    depth: usize,
+) -> String {
+    match super::inspect_enter_circular(ptr as usize) {
+        Err(id) => format!("[Circular *{}]", id),
+        Ok(()) => {
+            let body = format_map(ptr as *const crate::map::MapHeader, depth);
+            super::inspect_finish_circular(ptr as usize, body)
+        }
+    }
+}
+
+/// `format_set` wrapped in the parent's circular-reference bookkeeping.
+///
+/// # Safety
+/// `ptr` must point at a live `SetHeader` (callers gate on `GC_TYPE_SET`).
+pub(super) unsafe fn format_set_with_cycle(
+    ptr: *const crate::array::ArrayHeader,
+    depth: usize,
+) -> String {
+    match super::inspect_enter_circular(ptr as usize) {
+        Err(id) => format!("[Circular *{}]", id),
+        Ok(()) => {
+            let body = format_set(ptr as *const crate::set::SetHeader, depth);
+            super::inspect_finish_circular(ptr as usize, body)
+        }
+    }
+}
+
+/// If `value` is a RAW (non-NaN-boxed) heap pointer to a TypedArray or
+/// Buffer — the bit pattern Perry uses for those object fields — render it
+/// via the main `format_jsvalue` and return `Some`. Returns `None` for an
+/// ordinary number. Mirrors `format_jsvalue`'s own raw-pointer probe so the
+/// JSON-ish field formatter doesn't print the pointer bits as a float.
+pub(super) fn raw_heap_pointer_display(value: f64, depth: usize) -> Option<String> {
+    let raw_bits = value.to_bits();
+    if raw_bits > 0x1000
+        && (raw_bits >> 48) == 0
+        && (crate::typedarray::lookup_typed_array_kind(raw_bits as usize).is_some()
+            || crate::buffer::is_registered_buffer(raw_bits as usize))
+    {
+        Some(super::format_jsvalue(value, depth))
+    } else {
+        None
+    }
+}
+
+/// Read a `StringHeader` into an owned `String` (empty on null).
+unsafe fn read_string_header(s: *const StringHeader) -> String {
+    if s.is_null() {
+        return String::new();
+    }
+    let len = (*s).byte_len as usize;
+    let data = (s as *const u8).add(std::mem::size_of::<StringHeader>());
+    let bytes = std::slice::from_raw_parts(data, len);
+    std::str::from_utf8(bytes).unwrap_or("").to_string()
+}
+
+/// Render a `RegExp` literal as `/source/flags` (Node prints an empty source
+/// as `/(?:)/` so the result always re-parses as a regex).
+///
+/// # Safety
+/// `re` must be a registered `RegExpHeader` (callers gate on
+/// `crate::regex::is_registered_regex`).
+pub(super) unsafe fn format_regexp(re: *const crate::regex::RegExpHeader) -> String {
+    let source = read_string_header(crate::regex::js_regexp_get_source(re));
+    let flags = read_string_header(crate::regex::js_regexp_get_flags(re));
+    let source = if source.is_empty() {
+        "(?:)".to_string()
+    } else {
+        source
+    };
+    format!("/{}/{}", source, flags)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_formats_entries_with_size_prefix() {
+        unsafe {
+            let mut m = crate::map::js_map_alloc(4);
+            m = crate::map::js_map_set(m, 1.0, 2.0);
+            m = crate::map::js_map_set(m, 3.0, 4.0);
+            let out = format_map(m as *const crate::map::MapHeader, 1);
+            assert_eq!(out, "Map(2) { 1 => 2, 3 => 4 }");
+        }
+    }
+
+    #[test]
+    fn empty_map_and_set_use_zero_prefix() {
+        unsafe {
+            let m = crate::map::js_map_alloc(0);
+            assert_eq!(
+                format_map(m as *const crate::map::MapHeader, 1),
+                "Map(0) {}"
+            );
+            let s = crate::set::js_set_alloc(0);
+            assert_eq!(
+                format_set(s as *const crate::set::SetHeader, 1),
+                "Set(0) {}"
+            );
+        }
+    }
+
+    #[test]
+    fn set_formats_elements_with_size_prefix() {
+        unsafe {
+            let mut s = crate::set::js_set_alloc(4);
+            s = crate::set::js_set_add(s, 1.0);
+            s = crate::set::js_set_add(s, 2.0);
+            s = crate::set::js_set_add(s, 3.0);
+            let out = format_set(s as *const crate::set::SetHeader, 1);
+            assert_eq!(out, "Set(3) { 1, 2, 3 }");
+        }
+    }
+
+    #[test]
+    fn deep_nesting_collapses_to_type_label() {
+        unsafe {
+            let m = crate::map::js_map_alloc(0);
+            // Past the inspect depth limit, Node prints `[Map]` / `[Set]`.
+            assert_eq!(format_map(m as *const crate::map::MapHeader, 99), "[Map]");
+            let s = crate::set::js_set_alloc(0);
+            assert_eq!(format_set(s as *const crate::set::SetHeader, 99), "[Set]");
+        }
+    }
+}

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -148,6 +148,15 @@ fn is_valid_regex_ptr(p: *const RegExpHeader) -> bool {
     REGEX_POINTERS.with(|s| s.borrow().contains(&(p as usize)))
 }
 
+/// Public: is `addr` a RegExpHeader we allocated via `js_regexp_new`?
+/// Used by the console/`util.inspect` formatter to print regex literals
+/// as `/source/flags` instead of `{}` (they're GC_TYPE_OBJECT allocations
+/// with no enumerable string keys). Registry-gated so a generic object
+/// is never mis-read as a RegExpHeader.
+pub fn is_registered_regex(addr: usize) -> bool {
+    REGEX_POINTERS.with(|s| s.borrow().contains(&addr))
+}
+
 /// Internal helper: Get string data from StringHeader
 fn string_as_str<'a>(s: *const StringHeader) -> &'a str {
     unsafe {


### PR DESCRIPTION
## Problem

`console.log` / `util.inspect` rendered the collection types wrong — both at top level and as object fields:

| value | before | Node (and now) |
|-------|--------|------|
| `new Map([["a",1],["b",2]])` | `Map {}` | `Map(2) { 'a' => 1, 'b' => 2 }` |
| `new Set([1,2,3])` | `[object Object]` | `Set(3) { 1, 2, 3 }` |
| `/ab+c/gi` | `{}` | `/ab+c/gi` |
| `{ sym: Symbol("s") }` | `{ sym: [object Object] }` | `{ sym: Symbol(s) }` |
| `{ re: /x/g }` | `{ re: {} }` | `{ re: /x/g }` |
| `{ ta: new Int32Array([10,20]) }` | `{ ta: 2.26e-311 }` | `{ ta: Int32Array(2) [ 10, 20 ] }` |

The Map branch was hardcoded to `"Map {}"`, there was no `GC_TYPE_SET` branch (Sets fell to the `[object Object]` catch-all), and the object-field formatter (`format_jsvalue_for_json`) never implemented the Symbol/RegExp/Buffer/TypedArray pointer cases that the top-level `format_jsvalue` already handled.

## Fix

New `builtins/formatting/collections.rs` submodule (keeps the ~2000-line `formatting.rs` under the file-size gate):

- `format_map` / `format_set` — `Type(size) { ... }`, matching Node's single-vs-multi-line break heuristics. Empty → `Map(0) {}` / `Set(0) {}`; past the inspect depth limit → `[Map]` / `[Set]`.
- `format_regexp` — `/source/flags` (empty source → `/(?:)/`).
- cyclic wrappers so a self-referential Map/Set prints `<ref *1> ... [Circular *1]`.
- `raw_heap_pointer_display` — TypedArray fields are stored as raw (non-NaN-boxed) heap pointers, so they land in the number branch; redirect them through `format_jsvalue`.

Wired into **both** `format_jsvalue` and `format_jsvalue_for_json`. The object-field path now delegates Symbol/RegExp/Buffer/TypedArray to `format_jsvalue`, which gates these on their registries **before** any GC-header read — incidentally fixing a latent Buffer-in-object misread (Buffers carry no GC header). Adds a `regex::is_registered_regex` accessor.

## Tests

- 4 unit tests in `collections::tests` (entries, empty, multi-element, depth collapse).
- Verified byte-for-byte against `node` across: top-level + nested + in-array Map/Set/RegExp, mixed objects, depth limits, multi-line (8-entry Map), self-reference, empty collections, Buffer/TypedArray fields.

Part of #800 (Node-core parity). Addresses the CLAUDE.md "known categorical gap: `console.dir`/`console.group*` formatting".

> Note: discovered a **separate** pre-existing SIGSEGV in `JSON.stringify(new Set()/new Map())` (`json/stringify.rs` reads a Set/Map header as an ObjectHeader). Out of scope here — filed separately.
