### PR TITLE
fix(json): JSON.stringify of Map/Set/Error → {} instead of SIGSEGV (#2364)

### DIFF
--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -551,6 +551,32 @@ mod tests {
     }
 
     #[test]
+    fn stringify_set_serializes_as_empty_object() {
+        // Regression: a Set/Map header is NOT an ObjectHeader, so the old
+        // catch-all object path read its internals as a `keys_array` and
+        // segfaulted. Node serializes both as "{}".
+        unsafe {
+            let mut s = crate::set::js_set_alloc(4);
+            s = crate::set::js_set_add(s, 1.0);
+            s = crate::set::js_set_add(s, 2.0);
+            let boxed = f64::from_bits(POINTER_TAG | (s as u64 & POINTER_MASK));
+            let output = js_json_stringify(boxed, TYPE_UNKNOWN);
+            assert_eq!(str_from_header(output).unwrap(), "{}");
+        }
+    }
+
+    #[test]
+    fn stringify_map_serializes_as_empty_object() {
+        unsafe {
+            let mut m = crate::map::js_map_alloc(4);
+            m = crate::map::js_map_set(m, 1.0, 2.0);
+            let boxed = f64::from_bits(POINTER_TAG | (m as u64 & POINTER_MASK));
+            let output = js_json_stringify(boxed, TYPE_UNKNOWN);
+            assert_eq!(str_from_header(output).unwrap(), "{}");
+        }
+    }
+
+    #[test]
     fn direct_parse_shared_shape_roundtrips_array_records() {
         let input = br#"[{"id":1,"name":"item_1","nested":{"x":1,"y":2}},{"id":2,"name":"item_2","nested":{"x":2,"y":4}}]"#;
         let text = js_string_from_bytes(input.as_ptr(), input.len() as u32);

--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -150,6 +150,12 @@ unsafe fn dispatch_pointer_with_replacer(
             // Error objects have a dedicated layout; Node emits "{}" (#928).
             buf.push_str("{}");
         }
+        crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET => {
+            // Map/Set have a non-ObjectHeader layout; Node serializes both
+            // as "{}". Must not reach the catch-all (segfault) — same fix as
+            // the plain-stringify paths in `stringify.rs`.
+            buf.push_str("{}");
+        }
         _ => {
             // Untagged pointer: structural fallback (no replacer recursion is
             // safe here — we don't know the layout). Defer to plain stringify.
@@ -476,6 +482,21 @@ pub(crate) unsafe fn stringify_value_pretty(
     }
 
     if let Some(ptr) = extract_pointer(bits) {
+        // Map / Set / Error have non-ObjectHeader layouts; detect them before
+        // the `is_object_pointer` probes below, which would deref their
+        // internals as a `keys_array` and segfault. Node serializes all three
+        // as "{}" (no enumerable own props). Buffers are excluded from the
+        // `gc_obj_type` read (they carry no GcHeader) and left to fall through
+        // to the existing path, which pretty-prints their `toJSON` form.
+        if !crate::buffer::is_registered_buffer(ptr as usize)
+            && matches!(
+                gc_obj_type(ptr),
+                crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET | crate::gc::GC_TYPE_ERROR
+            )
+        {
+            buf.push_str("{}");
+            return;
+        }
         if type_hint == TYPE_OBJECT || (type_hint == TYPE_UNKNOWN && is_object_pointer(ptr)) {
             stringify_object_pretty(ptr, buf, indent, depth);
         } else if type_hint == TYPE_ARRAY {

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -508,6 +508,14 @@ pub(crate) unsafe fn stringify_value(value: f64, type_hint: u32, buf: &mut Strin
                 // `stack`) are non-enumerable; mirror that.
                 buf.push_str("{}");
             }
+            crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET => {
+                // Map/Set have a `{size, capacity, entries/elements}` header,
+                // NOT the JSObject keys/values layout — routing them through
+                // the catch-all `is_object_pointer` path derefs their internals
+                // as a `keys_array` pointer and segfaults. Node serializes both
+                // as "{}" (their contents aren't enumerable own props).
+                buf.push_str("{}");
+            }
             _ => {
                 // Unknown/untagged pointer: fall back to the structural
                 // heuristics for safety (e.g. pointers to non-GC-tracked
@@ -629,6 +637,11 @@ pub(crate) unsafe fn stringify_value_depth(
             }
             crate::gc::GC_TYPE_ERROR => {
                 // Issue #928: see the matching branch in `stringify_value`.
+                buf.push_str("{}");
+            }
+            crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET => {
+                // See the matching branch in `stringify_value` — Map/Set
+                // serialize as "{}" and must not reach the object catch-all.
                 buf.push_str("{}");
             }
             _ => {
@@ -1321,6 +1334,11 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
                     } else {
                         buf.push_str("null");
                     }
+                }
+                crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET => {
+                    // See `stringify_value` — Map/Set serialize as "{}" and
+                    // must not reach the object catch-all (segfault).
+                    buf.push_str("{}");
                 }
                 _ => {
                     if is_object_pointer(elem_ptr) {


### PR DESCRIPTION
Fixes #2364.

## Problem

`JSON.stringify(new Set(...))` and `JSON.stringify(new Map(...))` SIGSEGV (exit 139). A `SetHeader { size, capacity, elements }` / `MapHeader { size, capacity, entries }` is **not** an `ObjectHeader`, so the serializer's catch-all object path dereferenced their internals as a `keys_array` pointer and crashed. Node returns `{}` for both (their contents are not enumerable own properties).

```ts
JSON.stringify(new Set([1, 2]))           // SIGSEGV → "{}"
JSON.stringify(new Map([["a", 1]]))       // SIGSEGV → "{}"
JSON.stringify({ a: new Set([1, 2]) })    // SIGSEGV → {"a":{}}
JSON.stringify({ s: new Set([9]) }, null, 2)  // SIGSEGV → pretty {}
```

## Fix

Add explicit `GC_TYPE_MAP | GC_TYPE_SET => "{}"` arms (mirroring the existing `GC_TYPE_ERROR` arm) to every serialization dispatch site:

- `stringify_value`, `stringify_value_depth`, and the array-element loop in `json/stringify.rs`
- `stringify_value_with_replacer_pretty` and `stringify_value_pretty` in `json/replacer.rs`

The no-replacer pretty path (`stringify_value_pretty`) used `is_object_pointer` directly with no tag guard; it now checks `gc_obj_type` first (buffers excluded from that read since they carry no `GcHeader`). This also adds the `GC_TYPE_ERROR` guard the plain path already had, so `JSON.stringify(new Error(), null, 2)` no longer crashes either.

## Validation

Verified byte-for-byte against `node` across top-level / nested / in-array / pretty-print / replacer-function forms, plus a no-regression sweep over plain objects, arrays, errors, buffers, and dates. + 2 unit tests (`json::tests::stringify_{set,map}_serializes_as_empty_object`).

> Discovered a **separate** pre-existing SIGSEGV: `JSON.stringify(buf, null, 2)` (a Buffer in pretty-print mode) crashes on `main` independent of this change — filed separately. This PR leaves the Buffer pretty path untouched.
