### PR TITLE
fix(node:diagnostics_channel): recognize Channel instances

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -67,6 +67,30 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     &[(DOUBLE, &v), (DOUBLE, &ty_v)],
                 ));
             }
+            if let Some((submod_key, exported_name)) = ctx.import_function_node_submodule.get(ty) {
+                if submod_key == "diagnostics_channel" && exported_name == "Channel" {
+                    let submod_label = emit_string_literal_global(ctx, submod_key);
+                    let name_label = emit_string_literal_global(ctx, exported_name);
+                    let submod_len = submod_key.len();
+                    let name_len = exported_name.len();
+                    let blk = ctx.block();
+                    let ty_v = blk.call(
+                        DOUBLE,
+                        "js_node_submodule_export_as_function",
+                        &[
+                            (PTR, &submod_label),
+                            (I32, &submod_len.to_string()),
+                            (PTR, &name_label),
+                            (I32, &name_len.to_string()),
+                        ],
+                    );
+                    return Ok(blk.call(
+                        DOUBLE,
+                        "js_instanceof_dynamic",
+                        &[(DOUBLE, &v), (DOUBLE, &ty_v)],
+                    ));
+                }
+            }
             // Built-in Error subclasses have reserved CLASS_ID_* constants
             // in the runtime (see crates/perry-runtime/src/error.rs). Map
             // them by name here so `e instanceof TypeError` works even

--- a/crates/perry-runtime/src/node_submodules/diagnostics.rs
+++ b/crates/perry-runtime/src/node_submodules/diagnostics.rs
@@ -309,6 +309,20 @@ pub(crate) fn channel_key(name: f64) -> Option<DiagChannelKey> {
     None
 }
 
+pub(crate) fn diagnostics_channel_is_channel_instance_value(value: f64) -> bool {
+    let js_value = JSValue::from_bits(value.to_bits());
+    if !js_value.is_pointer() {
+        return false;
+    }
+    let ptr = js_value.as_pointer::<ObjectHeader>();
+    DIAG_CHANNELS.with(|channels| {
+        channels
+            .borrow()
+            .values()
+            .any(|channel| std::ptr::eq(channel.obj, ptr))
+    })
+}
+
 thread_local! {
     /// Side table keyed on an ErrorHeader's `message` string pointer (which
     /// is allocated fresh per throw via `js_string_from_bytes`). The

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -704,6 +704,22 @@ fn ensure_export_singleton(
     allocated
 }
 
+pub(crate) fn is_diagnostics_channel_constructor_value(value: f64) -> bool {
+    let js_value = JSValue::from_bits(value.to_bits());
+    if !js_value.is_pointer() {
+        return false;
+    }
+    let ptr = js_value.as_pointer::<ClosureHeader>() as *mut ClosureHeader;
+    let Some(submod) = find_submodule("diagnostics_channel") else {
+        return false;
+    };
+    let Some(export) = find_export(submod, "Channel") else {
+        return false;
+    };
+    let key = (submod.key.as_ptr() as usize, export.name.as_ptr() as usize);
+    EXPORT_SINGLETONS.with(|m| m.borrow().get(&key).copied() == Some(ptr))
+}
+
 fn ensure_namespace_singleton(submod: &'static SubmoduleSpec) -> *mut ObjectHeader {
     let key = submod.key.as_ptr() as usize;
     if let Some(cached) = NAMESPACE_SINGLETONS.with(|m| m.borrow().get(&key).copied()) {

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -51,6 +51,13 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
             return f64::from_bits(crate::value::TAG_TRUE);
         }
     }
+    if crate::node_submodules::is_diagnostics_channel_constructor_value(type_ref) {
+        return if crate::node_submodules::diagnostics_channel_is_channel_instance_value(value) {
+            f64::from_bits(crate::value::TAG_TRUE)
+        } else {
+            f64::from_bits(TAG_FALSE)
+        };
+    }
     f64::from_bits(TAG_FALSE)
 }
 


### PR DESCRIPTION
## Summary
- route imported `node:diagnostics_channel` `Channel` instanceof checks through the dynamic runtime helper
- recognize registered diagnostics-channel objects as instances of the exported Channel singleton
- keep subscriber error-order and tracing callback ordering outside this slice

## Verification
- Baseline `./run_parity_tests.sh --suite node-suite --filter node-suite/diagnostics_channel`: 56 pass / 4 parity fail / 0 compile fail, report `test-parity/reports/parity_report_20260528_204339.json`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/diagnostics_channel/channel/identity-instanceof`: pass, report `test-parity/reports/parity_report_20260528_205425.json`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/diagnostics_channel/channel/pub-sub-channel-methods`: pass, report `test-parity/reports/parity_report_20260528_205435.json`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/diagnostics_channel`: 58 pass / 2 parity fail / 0 compile fail, report `test-parity/reports/parity_report_20260528_205444.json`
- `cargo check -p perry-api-manifest -p perry-codegen -p perry-runtime`
- `cargo fmt --check`
- `git diff --check && git diff --cached --check`

DeepWiki reference saved locally: `reference/deepwiki/nodejs-node-diagnostics-channel-channel-instanceof.md`.