### PR TITLE
fix(json): JSON.stringify(buffer, null, n) pretty-prints instead of SIGSEGV (#2367)

### DIFF
--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -65,9 +65,9 @@ pub(crate) use simd::find_string_terminator;
 pub(crate) use stringify::{
     arm_to_json_result_guard, build_shape_prefix_template, estimate_json_size, is_closure_value,
     is_object_pointer, object_get_to_json, shape_template_for, stringify_array,
-    stringify_array_depth, stringify_buffer, stringify_object, stringify_object_inner,
-    stringify_value, stringify_value_depth, try_emit_shape_element, write_escaped_string,
-    write_number, ShapeTemplate,
+    stringify_array_depth, stringify_buffer, stringify_buffer_pretty, stringify_object,
+    stringify_object_inner, stringify_value, stringify_value_depth, try_emit_shape_element,
+    write_escaped_string, write_number, ShapeTemplate,
 };
 #[allow(unused_imports)]
 pub(crate) use stringify_api::{
@@ -573,6 +573,25 @@ mod tests {
             let boxed = f64::from_bits(POINTER_TAG | (m as u64 & POINTER_MASK));
             let output = js_json_stringify(boxed, TYPE_UNKNOWN);
             assert_eq!(str_from_header(output).unwrap(), "{}");
+        }
+    }
+
+    #[test]
+    fn stringify_buffer_pretty_indents_type_and_data() {
+        // Regression (#2367): a Buffer in pretty-print mode used to reach
+        // `is_object_pointer` (no buffer guard in the pretty path) and SIGSEGV.
+        unsafe {
+            let b = crate::buffer::js_buffer_alloc(3, 0);
+            let data = (b as *mut u8).add(std::mem::size_of::<crate::buffer::BufferHeader>());
+            *data = 1;
+            *data.add(1) = 2;
+            *data.add(2) = 3;
+            let mut out = String::new();
+            stringify_buffer_pretty(b as *const u8, &mut out, "  ", 0);
+            assert_eq!(
+                out,
+                "{\n  \"type\": \"Buffer\",\n  \"data\": [\n    1,\n    2,\n    3\n  ]\n}"
+            );
         }
     }
 

--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -119,9 +119,15 @@ unsafe fn dispatch_pointer_with_replacer(
     depth: usize,
 ) {
     // Buffer / Uint8Array have no GcHeader — detect before gc_obj_type so the
-    // tag read doesn't deref unrelated memory (issue #639 pattern).
+    // tag read doesn't deref unrelated memory (issue #639 pattern). This
+    // dispatch serves both compact (indent == "") and pretty replacer walks,
+    // so pick the matching buffer serializer.
     if crate::buffer::is_registered_buffer(ptr as usize) {
-        stringify_buffer(ptr, buf);
+        if indent.is_empty() {
+            stringify_buffer(ptr, buf);
+        } else {
+            stringify_buffer_pretty(ptr, buf, indent, depth);
+        }
         return;
     }
     match gc_obj_type(ptr) {
@@ -482,18 +488,19 @@ pub(crate) unsafe fn stringify_value_pretty(
     }
 
     if let Some(ptr) = extract_pointer(bits) {
-        // Map / Set / Error have non-ObjectHeader layouts; detect them before
-        // the `is_object_pointer` probes below, which would deref their
-        // internals as a `keys_array` and segfault. Node serializes all three
-        // as "{}" (no enumerable own props). Buffers are excluded from the
-        // `gc_obj_type` read (they carry no GcHeader) and left to fall through
-        // to the existing path, which pretty-prints their `toJSON` form.
-        if !crate::buffer::is_registered_buffer(ptr as usize)
-            && matches!(
-                gc_obj_type(ptr),
-                crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET | crate::gc::GC_TYPE_ERROR
-            )
-        {
+        // Buffer / Map / Set / Error have non-ObjectHeader layouts; detect them
+        // before the `is_object_pointer` probes below, which would deref their
+        // internals as a `keys_array` and segfault. Buffers (no GcHeader, so
+        // checked first) pretty-print their `{type,data}` / index form; Map/
+        // Set/Error serialize as "{}" in Node (no enumerable own props).
+        if crate::buffer::is_registered_buffer(ptr as usize) {
+            stringify_buffer_pretty(ptr, buf, indent, depth);
+            return;
+        }
+        if matches!(
+            gc_obj_type(ptr),
+            crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET | crate::gc::GC_TYPE_ERROR
+        ) {
             buf.push_str("{}");
             return;
         }

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -60,6 +60,90 @@ pub(crate) unsafe fn stringify_buffer(ptr: *const u8, buf: &mut String) {
     }
 }
 
+/// Pretty-printed (`space`-indented) form of `stringify_buffer`. Emits the
+/// same `{type,data}` (Buffer) / `{index:byte}` (plain Uint8Array) shape as
+/// the compact version but with newlines + indentation, matching Node's
+/// `JSON.stringify(buf, null, n)`. `depth` is the indent level of the value
+/// itself (content sits at `depth + 1`, the closing brace at `depth`),
+/// mirroring `stringify_object_pretty`.
+pub(crate) unsafe fn stringify_buffer_pretty(
+    ptr: *const u8,
+    buf: &mut String,
+    indent: &str,
+    depth: usize,
+) {
+    let buf_ptr = ptr as *const crate::buffer::BufferHeader;
+    if buf_ptr.is_null() {
+        buf.push_str("null");
+        return;
+    }
+    let len = (*buf_ptr).length as usize;
+    let data = (buf_ptr as *const u8).add(std::mem::size_of::<crate::buffer::BufferHeader>());
+    let bytes = std::slice::from_raw_parts(data, len);
+
+    let push_indent = |buf: &mut String, levels: usize| {
+        for _ in 0..levels {
+            buf.push_str(indent);
+        }
+    };
+
+    if len == 0 {
+        // Empty Uint8Array -> "{}"; empty Buffer -> {"type":"Buffer","data":[]}.
+        if crate::buffer::is_uint8array_buffer(ptr as usize) {
+            buf.push_str("{}");
+        } else {
+            buf.push_str("{\n");
+            push_indent(buf, depth + 1);
+            buf.push_str("\"type\": \"Buffer\",\n");
+            push_indent(buf, depth + 1);
+            buf.push_str("\"data\": []\n");
+            push_indent(buf, depth);
+            buf.push('}');
+        }
+        return;
+    }
+
+    if crate::buffer::is_uint8array_buffer(ptr as usize) {
+        // Plain Uint8Array: { "0": b0, "1": b1, ... }
+        buf.push_str("{\n");
+        for (i, b) in bytes.iter().enumerate() {
+            push_indent(buf, depth + 1);
+            let mut idx_buf = itoa::Buffer::new();
+            buf.push('"');
+            buf.push_str(idx_buf.format(i));
+            buf.push_str("\": ");
+            let mut byte_buf = itoa::Buffer::new();
+            buf.push_str(byte_buf.format(*b));
+            if i + 1 < len {
+                buf.push(',');
+            }
+            buf.push('\n');
+        }
+        push_indent(buf, depth);
+        buf.push('}');
+    } else {
+        // Buffer: { "type": "Buffer", "data": [ b0, b1, ... ] }
+        buf.push_str("{\n");
+        push_indent(buf, depth + 1);
+        buf.push_str("\"type\": \"Buffer\",\n");
+        push_indent(buf, depth + 1);
+        buf.push_str("\"data\": [\n");
+        for (i, b) in bytes.iter().enumerate() {
+            push_indent(buf, depth + 2);
+            let mut byte_buf = itoa::Buffer::new();
+            buf.push_str(byte_buf.format(*b));
+            if i + 1 < len {
+                buf.push(',');
+            }
+            buf.push('\n');
+        }
+        push_indent(buf, depth + 1);
+        buf.push_str("]\n");
+        push_indent(buf, depth);
+        buf.push('}');
+    }
+}
+
 #[inline]
 pub(crate) unsafe fn is_object_pointer(ptr: *const u8) -> bool {
     let obj = ptr as *const crate::ObjectHeader;


### PR DESCRIPTION
Fixes #2367.

## Problem

`JSON.stringify(buffer, null, n)` — a Buffer/Uint8Array in **pretty-print** mode — SIGSEGV. The compact form already worked.

```ts
JSON.stringify({ buf: Buffer.from([1,2,3]) })           // OK: {"buf":{"type":"Buffer","data":[1,2,3]}}
JSON.stringify({ buf: Buffer.from([1,2,3]) }, null, 2)  // SIGSEGV
```

The pretty serializer (`stringify_value_pretty` / `dispatch_pointer_with_replacer` in `json/replacer.rs`) had no buffer detection — a buffer field reached `is_object_pointer`, which dereferenced the `BufferHeader` bytes as an `ObjectHeader` `keys_array` and crashed. (The compact path checks `is_registered_buffer` first and routes to `stringify_buffer`.)

## Fix

- New `stringify_buffer_pretty` (in `json/stringify.rs`): indented `{type,data}` for Buffer, indexed `{ "0": b0, ... }` for plain Uint8Array, matching Node's whitespace at any indent/depth. Handles the empty-buffer cases.
- Detect `is_registered_buffer` before the `gc_obj_type` read in both pretty paths. `dispatch_pointer_with_replacer` serves both compact (`indent == ""`) and pretty replacer walks, so it picks the compact vs. pretty serializer based on `indent`.

## Validation

Byte-for-byte against `node`: Buffer & Uint8Array at various indents, nested in objects/arrays, with a replacer function, and empty buffers — plus a no-regression sweep over the compact forms. + a unit test (`json::tests::stringify_buffer_pretty_indents_type_and_data`).

Follow-up to #2366 (#2364) — same family of non-ObjectHeader-layout crashes in `JSON.stringify`.
