### PR TITLE
fix(console): inspect Date as ISO + WeakMap/WeakSet without leaking internals (#800)

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -651,33 +651,24 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                 let ta = ptr as *const crate::typedarray::TypedArrayHeader;
                 crate::typedarray::format_typed_array(ta)
             } else if crate::buffer::is_registered_buffer(ptr as usize) {
-                // Buffer/Uint8Array — Node prints as `<Buffer xx xx xx ...>`
-                // (lowercase hex bytes separated by single spaces). Buffer
-                // headers don't carry a GC header, so this check must happen
-                // BEFORE the GC_HEADER_SIZE pointer arithmetic below (which
+                // Buffer/Uint8Array — `<Buffer xx xx ...>`. No GC header, so
+                // this must precede the GC_HEADER_SIZE arithmetic below (which
                 // would read garbage one word before the BufferHeader).
                 let buf_ptr = ptr as *const crate::buffer::BufferHeader;
                 format_buffer_value(buf_ptr)
             } else if crate::regex::is_registered_regex(ptr as usize) {
-                // RegExp literals are GC_TYPE_OBJECT allocations with no
-                // enumerable string keys, so the generic object formatter
-                // prints `{}`. Render the literal form `/source/flags`
-                // instead (registry-gated; #800). This check sits with the
-                // other registry pre-checks, before the GC-header read.
+                // RegExp literals are GC_TYPE_OBJECT with no enumerable keys
+                // (generic formatter prints `{}`); render `/source/flags`
+                // instead (registry-gated, before the GC-header read; #800).
                 collections::format_regexp(ptr as *const crate::regex::RegExpHeader)
             } else if crate::proxy::js_proxy_is_proxy(value) != 0 {
                 let target = crate::proxy::js_proxy_target(value);
                 format_jsvalue(target, depth)
             } else if (ptr as usize) < 0x100000 {
                 // Refs #421: Web Fetch (and other) handles are NaN-boxed
-                // POINTER_TAG values whose unboxed payload is a small
-                // registry id (1, 2, 3, ...) — NOT a real heap pointer.
-                // Reading the GC header at `ptr - 8` would deref unmapped
-                // memory and SIGSEGV. Print a placeholder that distinguishes
-                // the value from "{}". A future enhancement can look up the
-                // specific registry (Request / Response / Headers / Blob /
-                // sockets / DB connections / etc.) and format with the type
-                // name and key fields the way Node does for those classes.
+                // POINTER_TAG values whose payload is a small registry id, NOT
+                // a heap pointer — reading the GC header at `ptr - 8` would
+                // SIGSEGV. Placeholder distinguishes it from "{}".
                 "{}".to_string()
             } else {
                 // Use GC header to determine the actual type of the object.
@@ -812,8 +803,8 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                     // `[Object]` (#1204). The depth cap is overridable via
                     // INSPECT_DEPTH_LIMIT for `%o` / `console.dir(v, { depth })`.
                     let obj_ptr = ptr as *const crate::object::ObjectHeader;
-                    if let Some(label) = crate::weakref::weak_wrapper_inspect_label(obj_ptr) {
-                        return format!("{label} {{}}");
+                    if let Some(body) = crate::weakref::weak_wrapper_inspect_label(obj_ptr) {
+                        return body.to_string();
                     }
                     if let Err(id) = inspect_enter_circular(ptr as usize) {
                         return format!("[Circular *{}]", id);
@@ -851,6 +842,10 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
         } else if jsval.is_int32() {
             jsval.as_int32().to_string()
         } else {
+            // Date → unquoted ISO string / `Invalid Date` (before is_nan).
+            if let Some(s) = collections::date_inspect(value) {
+                return s;
+            }
             // Regular number — but first check for raw (non-NaN-boxed) heap
             // pointers. The codegen sometimes returns a raw
             // i64 buffer pointer bitcast directly to f64 (no POINTER_TAG), so
@@ -1374,8 +1369,8 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
                         // depth cap is overridable via INSPECT_DEPTH_LIMIT
                         // for `%o` / `console.dir(v, { depth })`.
                         let obj_ptr = ptr as *const crate::object::ObjectHeader;
-                        if let Some(label) = crate::weakref::weak_wrapper_inspect_label(obj_ptr) {
-                            return format!("{label} {{}}");
+                        if let Some(body) = crate::weakref::weak_wrapper_inspect_label(obj_ptr) {
+                            return body.to_string();
                         }
                         if let Err(id) = inspect_enter_circular(ptr as usize) {
                             return format!("[Circular *{}]", id);
@@ -1410,6 +1405,10 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
         } else if jsval.is_int32() {
             jsval.as_int32().to_string()
         } else {
+            // Date field → unquoted ISO string / `Invalid Date`.
+            if let Some(s) = collections::date_inspect(value) {
+                return s;
+            }
             // A TypedArray field is a RAW (non-NaN-boxed) heap pointer, so it
             // lands here, not in the pointer branch; redirect it (#800).
             if let Some(s) = collections::raw_heap_pointer_display(value, depth) {

--- a/crates/perry-runtime/src/builtins/formatting/collections.rs
+++ b/crates/perry-runtime/src/builtins/formatting/collections.rs
@@ -152,6 +152,23 @@ pub(super) fn raw_heap_pointer_display(value: f64, depth: usize) -> Option<Strin
     }
 }
 
+/// If `value` is a Date (a raw f64 timestamp registered in `DATE_REGISTRY`),
+/// return its `util.inspect` rendering — the ISO string unquoted
+/// (`1970-01-01T00:00:00.000Z`) or `Invalid Date` for a NaN time. Returns
+/// `None` for an ordinary number so callers fall through to numeric output.
+pub(super) fn date_inspect(value: f64) -> Option<String> {
+    if !crate::date::is_registered_date_bits(value.to_bits()) {
+        return None;
+    }
+    let s = crate::date::js_date_to_iso_string(value);
+    let out = unsafe { read_string_header(s) };
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
 /// Read a `StringHeader` into an owned `String` (empty on null).
 unsafe fn read_string_header(s: *const StringHeader) -> String {
     if s.is_null() {
@@ -183,6 +200,17 @@ pub(super) unsafe fn format_regexp(re: *const crate::regex::RegExpHeader) -> Str
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn date_inspect_returns_iso_string_for_registered_date() {
+        let date_val = crate::date::js_date_new_from_timestamp(0.0);
+        assert_eq!(
+            date_inspect(date_val),
+            Some("1970-01-01T00:00:00.000Z".to_string())
+        );
+        // A plain number is not a Date — falls through to numeric formatting.
+        assert_eq!(date_inspect(42.0), None);
+    }
 
     #[test]
     fn map_formats_entries_with_size_prefix() {

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -28,13 +28,21 @@ const FINREG_SHAPE_ID: u32 = 0x7FFF_FE11;
 pub const CLASS_ID_WEAKREF: u32 = 0xFFFF_0029;
 pub const CLASS_ID_FINALIZATION_REGISTRY: u32 = 0xFFFF_002A;
 
+/// The full `util.inspect` body for a weak-collection wrapper, or `None` if
+/// `obj` isn't one. Returning the complete string (not just the class name)
+/// lets WeakMap/WeakSet print Node's `{ <items unknown> }` placeholder — their
+/// contents are intentionally not enumerable — while WeakRef /
+/// FinalizationRegistry stay `{}`. Without this, WeakMap/WeakSet leaked their
+/// `__perry_wk_entries` storage field (e.g. `{ __perry_wk_entries: [] }`).
 pub(crate) fn weak_wrapper_inspect_label(obj: *const ObjectHeader) -> Option<&'static str> {
     if obj.is_null() {
         return None;
     }
     match unsafe { (*obj).class_id } {
-        CLASS_ID_WEAKREF => Some("WeakRef"),
-        CLASS_ID_FINALIZATION_REGISTRY => Some("FinalizationRegistry"),
+        CLASS_ID_WEAKREF => Some("WeakRef {}"),
+        CLASS_ID_FINALIZATION_REGISTRY => Some("FinalizationRegistry {}"),
+        CLASS_ID_WEAKMAP => Some("WeakMap { <items unknown> }"),
+        CLASS_ID_WEAKSET => Some("WeakSet { <items unknown> }"),
         _ => None,
     }
 }
@@ -417,4 +425,28 @@ pub extern "C" fn js_weak_throw_primitive() -> f64 {
     let err = crate::error::js_error_new_with_message(msg_str);
     let err_val = JSValue::pointer(err as *const u8);
     crate::exception::js_throw(f64::from_bits(err_val.bits()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn weak_collections_inspect_with_items_unknown() {
+        // WeakMap/WeakSet contents aren't enumerable, so Node prints the
+        // `<items unknown>` placeholder rather than leaking storage fields.
+        let wm = js_weakmap_new();
+        assert_eq!(
+            weak_wrapper_inspect_label(wm),
+            Some("WeakMap { <items unknown> }")
+        );
+        let ws = js_weakset_new();
+        assert_eq!(
+            weak_wrapper_inspect_label(ws),
+            Some("WeakSet { <items unknown> }")
+        );
+        // WeakRef / FinalizationRegistry have no items placeholder.
+        let wr = js_weakref_new(f64::from_bits(TAG_UNDEFINED));
+        assert_eq!(weak_wrapper_inspect_label(wr), Some("WeakRef {}"));
+    }
 }


### PR DESCRIPTION
Part of #800 (Node core parity); addresses the CLAUDE.md "known categorical gap: console formatting".

## Problem

`console.log` / `util.inspect` rendered two very common types incorrectly — both at top level and as object fields:

| value | before | Node (and now) |
|-------|--------|------|
| `new Date(0)` | `0` | `1970-01-01T00:00:00.000Z` |
| `{ d: new Date(0) }` | `{ d: 0 }` | `{ d: 1970-01-01T00:00:00.000Z }` |
| `new WeakMap()` | `{ __perry_wk_entries: [] }` | `WeakMap { <items unknown> }` |
| `new WeakSet()` | `{ __perry_wk_entries: [] }` | `WeakSet { <items unknown> }` |

A Date is a raw f64 timestamp registered in `DATE_REGISTRY`, so it reached the formatter's number branch and printed the raw millisecond value. WeakMap/WeakSet leaked their internal `__perry_wk_entries` storage field because `weak_wrapper_inspect_label` only handled WeakRef/FinalizationRegistry.

## Fix

- **Date** → new `collections::date_inspect(value)` helper: if the f64 is a registered date, return its ISO string unquoted (or `Invalid Date`). Wired into both console number branches (`format_jsvalue` + `format_jsvalue_for_json`). `JSON.stringify(date)` uses a separate path and is unchanged.
- **WeakMap/WeakSet** → `weak_wrapper_inspect_label` now returns the full inspect body, so WeakMap/WeakSet print the `{ <items unknown> }` placeholder (their contents aren't enumerable) while WeakRef / FinalizationRegistry keep `{}`.

## Validation

Byte-for-byte vs `node`: valid dates (top-level / nested / in-array), all four weak types, mixed objects, and a `JSON.stringify(date)` no-regression check. + 2 unit tests (`date_inspect_returns_iso_string_for_registered_date`, `weak_collections_inspect_with_items_unknown`).

> Known gap (pre-existing, **not** regressed): `new Date(NaN)` still prints `NaN` instead of `Invalid Date` — the `DATE_NAN_BITS` sentinel payload is lost in the codegen value round-trip, so the formatter can't distinguish it from a plain `NaN`. Filed as #2371.
