### PR TITLE
fix(symbol): well-known symbols report qualified description "Symbol.iterator" (#800)

### DIFF
--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -134,7 +134,13 @@ pub fn well_known_symbol(short_name: &str) -> *mut SymbolHeader {
     // `Symbol.toString()` / `is_symbol` can transiently return wrong
     // results. Lock order matches `js_symbol_for` below: cache → side
     // tables, never the reverse.
-    record_registered_symbol_description(sym_ptr as usize, short_name);
+    // Spec: a well-known symbol's `[[Description]]` is the qualified name
+    // `"Symbol.iterator"`, not the bare `"iterator"`. This is what
+    // `Symbol.iterator.description`, `.toString()`, `String(sym)`, and
+    // `console.log` all report. The cache key stays the short name so callers
+    // (`well_known_symbol("iterator")`) and pointer-identity property lookups
+    // are unaffected.
+    record_registered_symbol_description(sym_ptr as usize, &format!("Symbol.{short_name}"));
     register_symbol_pointer(sym_ptr as usize);
     cache.insert(short_name.to_string(), sym_ptr as usize);
     drop(guard);
@@ -1175,5 +1181,25 @@ pub unsafe extern "C" fn js_symbol_equals(a: f64, b: f64) -> i32 {
         1
     } else {
         0
+    }
+}
+
+#[cfg(test)]
+mod wellknown_desc_tests {
+    use super::*;
+
+    #[test]
+    fn well_known_symbols_use_qualified_description() {
+        // Spec: `Symbol.iterator.description === "Symbol.iterator"` (qualified),
+        // which is also what `console.log` / `String(sym)` report.
+        for short in ["iterator", "asyncIterator", "hasInstance", "toPrimitive"] {
+            let ptr = well_known_symbol(short) as usize;
+            let desc = registered_symbol_description(ptr);
+            assert_eq!(
+                desc.as_deref(),
+                Some(format!("Symbol.{short}").as_str()),
+                "well-known symbol {short} should have qualified description"
+            );
+        }
     }
 }


### PR DESCRIPTION
Part of #800 (Node core parity).

## Problem

Well-known symbols reported the bare short name as their description instead of the spec-qualified name:

```ts
Symbol.iterator.description   // 'iterator'        → should be 'Symbol.iterator'
String(Symbol.iterator)       // 'Symbol(iterator)' → 'Symbol(Symbol.iterator)'
console.log(Symbol.iterator)  // Symbol(iterator)   → Symbol(Symbol.iterator)
Symbol.iterator.toString()    // 'Symbol(iterator)' → 'Symbol(Symbol.iterator)'
```

Per ECMA-262, a well-known symbol's `[[Description]]` is the qualified `"Symbol.iterator"`. This affected every well-known symbol (`iterator`, `asyncIterator`, `hasInstance`, `toPrimitive`, `toStringTag`, `dispose`, ...).

## Fix

`well_known_symbol()` now records the description as `format!("Symbol.{short_name}")`. The cache key remains the short name, so callers (`well_known_symbol("iterator")`) and **pointer-identity** property lookups are unaffected — `for-of`, `[...obj]`, `obj[Symbol.iterator]`, `Symbol.iterator in obj`, `instanceof` via `@@hasInstance`, and `Map`/`Set` iteration all still work (verified byte-for-byte vs node). The `@@`-mangled method keys derive from the short name, not the description, so dispatch is untouched.

## Validation

`console.log` / `String()` / `.toString()` / `.description` for `iterator`, `asyncIterator`, `hasInstance` now match `node` byte-for-byte; custom `Symbol("x")` and `Symbol.for(...)` unchanged. + unit test.

> Note: spotted a **separate** pre-existing gap — `Symbol.toPrimitive` isn't invoked by `+`/template-literal coercion on class instances (`+new T()` → `NaN`). Description-independent; filed separately.
