### PR TITLE
fix(node:perf_hooks): recognize performance entry instances

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -105,6 +105,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // `rs.pipeThrough(ts) instanceof ReadableStream`, …).
                 "ReadableStream" => 0xFFFF0060u32,
                 "WritableStream" => 0xFFFF0061u32,
+                // node:perf_hooks entry classes. Runtime classifies the
+                // shaped entry objects returned by performance.mark/measure.
+                "PerformanceEntry" => 0xFFFF0080u32,
+                "PerformanceMark" => 0xFFFF0081u32,
+                "PerformanceMeasure" => 0xFFFF0082u32,
                 // `Object` — every non-primitive matches per ECMAScript;
                 // reserved id mapped in the runtime. Pre-#585 this fell
                 // into the `cid = 0` fallback and matched accidentally

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -50,6 +50,17 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
         {
             return f64::from_bits(crate::value::TAG_TRUE);
         }
+        if module == "perf_hooks" {
+            let class_id = match method.as_str() {
+                "PerformanceEntry" => crate::perf_hooks::CLASS_ID_PERFORMANCE_ENTRY,
+                "PerformanceMark" => crate::perf_hooks::CLASS_ID_PERFORMANCE_MARK,
+                "PerformanceMeasure" => crate::perf_hooks::CLASS_ID_PERFORMANCE_MEASURE,
+                _ => 0,
+            };
+            if class_id != 0 {
+                return js_instanceof(value, class_id);
+            }
+        }
     }
     f64::from_bits(TAG_FALSE)
 }
@@ -396,6 +407,14 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
                 }
                 _ => false_val,
             };
+        }
+
+        if gc_type == crate::gc::GC_TYPE_OBJECT {
+            if let Some(matches) =
+                crate::perf_hooks::is_perf_entry_object_instance_of(obj_ptr, class_id)
+            {
+                return if matches { true_val } else { false_val };
+            }
         }
 
         // For user-defined classes that extend Error: `myErr instanceof Error` should be true.

--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -30,6 +30,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 const ENTRY_TYPE_MARK: u8 = 0;
 const ENTRY_TYPE_MEASURE: u8 = 1;
 
+pub(crate) const CLASS_ID_PERFORMANCE_ENTRY: u32 = 0xFFFF_0080;
+pub(crate) const CLASS_ID_PERFORMANCE_MARK: u32 = 0xFFFF_0081;
+pub(crate) const CLASS_ID_PERFORMANCE_MEASURE: u32 = 0xFFFF_0082;
+
 /// Shape id for the `{ name, entryType, startTime, duration, detail }` object
 /// returned by mark/measure and the getEntries* arrays.
 const PERF_ENTRY_SHAPE: u32 = 0x7FFF_FF40;
@@ -90,6 +94,34 @@ pub(crate) unsafe fn is_perf_entry_object(obj: *const crate::object::ObjectHeade
     }
     let recorded = PERF_ENTRY_KEYS_ARRAY.with(|c| c.get());
     recorded != 0 && (*obj).keys_array as usize == recorded
+}
+
+unsafe fn perf_entry_type(obj: *const crate::object::ObjectHeader) -> Option<u8> {
+    let entry_type = string_of(js_object_get_field(obj, 1))?;
+    match entry_type.as_str() {
+        "mark" => Some(ENTRY_TYPE_MARK),
+        "measure" => Some(ENTRY_TYPE_MEASURE),
+        _ => None,
+    }
+}
+
+pub(crate) unsafe fn is_perf_entry_object_instance_of(
+    obj: *const crate::object::ObjectHeader,
+    class_id: u32,
+) -> Option<bool> {
+    let want = match class_id {
+        CLASS_ID_PERFORMANCE_ENTRY => None,
+        CLASS_ID_PERFORMANCE_MARK => Some(ENTRY_TYPE_MARK),
+        CLASS_ID_PERFORMANCE_MEASURE => Some(ENTRY_TYPE_MEASURE),
+        _ => return None,
+    };
+    if !is_perf_entry_object(obj) {
+        return Some(false);
+    }
+    Some(match want {
+        None => true,
+        Some(kind) => perf_entry_type(obj) == Some(kind),
+    })
 }
 
 /// Build the plain object returned by `PerformanceEntry#toJSON()` — a copy of


### PR DESCRIPTION
## Summary
- classify Perry's existing perf entry-shaped objects for `PerformanceEntry`, `PerformanceMark`, and `PerformanceMeasure` `instanceof` checks
- route both static class-id lowering and dynamic perf_hooks constructor exports through reserved perf entry class ids
- keep mark/measure storage unchanged; concrete class checks derive from the existing `entryType` field

Refs #793.

## Proof
- Baseline full `node-suite/perf_hooks` failed 69 PASS / 2 parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260528_213404.json`; failures were `mark/instanceof` and `measure/instanceof` with `PerformanceEntry: false` in Perry.
- Baseline exact `node-suite/perf_hooks/mark/instanceof` failed, report `test-parity/reports/parity_report_20260528_213637.json`.
- DeepWiki reference: `reference/deepwiki/nodejs-node-perf-hooks-performance-entry-instanceof.md` saved locally, not staged.

## Verification
- `./run_parity_tests.sh --suite node-suite --filter node-suite/perf_hooks/mark/instanceof` PASS, report `test-parity/reports/parity_report_20260528_214002.json`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/perf_hooks/measure/instanceof` PASS, report `test-parity/reports/parity_report_20260528_214101.json`
- `./run_parity_tests.sh --suite node-suite --module perf_hooks` PASS 71/0, report `test-parity/reports/parity_report_20260528_214117.json`
- `cargo check -p perry-codegen -p perry-runtime` PASS with existing warnings
- `cargo fmt --check` PASS
- `git diff --check` PASS
- `git diff --cached --check` PASS

## Non-goals
- no direct `new PerformanceEntry` / `new PerformanceMark` / `new PerformanceMeasure` constructor semantics
- no `PerformanceResourceTiming` or broader resource timing class hierarchy
- no changes to perf entry allocation, timeline ordering, or observer behavior
- no generic native-module class hierarchy rewrite
