### PR TITLE
fix(node:string_decoder): normalize empty encoding

### DIFF
--- a/crates/perry-stdlib/src/string_decoder.rs
+++ b/crates/perry-stdlib/src/string_decoder.rs
@@ -104,7 +104,7 @@ impl StringDecoderHandle {
 fn parse_encoding(name: &str) -> Option<DecodingMode> {
     let lower = name.to_ascii_lowercase();
     Some(match lower.as_str() {
-        "utf8" | "utf-8" => DecodingMode::Utf8,
+        "" | "utf8" | "utf-8" => DecodingMode::Utf8,
         "utf16le" | "utf-16le" | "ucs2" | "ucs-2" => DecodingMode::Utf16Le,
         "base64" => DecodingMode::Base64,
         "base64url" => DecodingMode::Base64Url,
@@ -139,7 +139,10 @@ unsafe fn encoding_name_from_bits(bits: i64) -> Option<String> {
     // remaining 48 bits, length in bits 44..47 of the top 16.
     if top16 == 0x7FFA {
         let len = ((u >> 44) & 0xF) as usize;
-        if len == 0 || len > 6 {
+        if len == 0 {
+            return Some(String::new());
+        }
+        if len > 6 {
             return None;
         }
         let mut bytes = [0u8; 6];
@@ -156,7 +159,10 @@ unsafe fn encoding_name_from_bits(bits: i64) -> Option<String> {
     }
     let hdr = addr as *const StringHeader;
     let len = (*hdr).byte_len as usize;
-    if len == 0 || len > 32 {
+    if len == 0 {
+        return Some(String::new());
+    }
+    if len > 32 {
         return None;
     }
     let data = (hdr as *const u8).add(std::mem::size_of::<StringHeader>());


### PR DESCRIPTION
## Summary
- treat `new StringDecoder("")` like Node's encoding normalization path and default it to `utf8`
- preserve empty heap and short-string encoding arguments instead of turning them into an unknown encoding sentinel
- keep invalid non-empty encodings throwing through the existing path

Refs #793.

## Proof
- Baseline full `node-suite/string_decoder` failed 33 PASS / 1 parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260528_214529.json`; `constructor/normalization-extra` showed Node returning `enc:  => utf8` while Perry threw `TypeError no-code`.
- DeepWiki reference: `reference/deepwiki/nodejs-node-string-decoder-empty-encoding-normalization.md` saved locally, not staged.

## Verification
- `./run_parity_tests.sh --suite node-suite --filter node-suite/string_decoder/constructor/normalization-extra` PASS, report `test-parity/reports/parity_report_20260528_214812.json`
- `./run_parity_tests.sh --suite node-suite --module string_decoder` PASS 34/0, report `test-parity/reports/parity_report_20260528_214832.json`
- `cargo check -p perry-stdlib` PASS with existing warnings
- `cargo fmt --check` PASS
- `git diff --check` PASS
- `git diff --cached --check` PASS

## Non-goals
- no broader StringDecoder encoding matrix changes
- no change to invalid non-empty encoding errors
- no write/end incremental decoding changes
- no Buffer encoding normalization refactor
