### PR TITLE
fix(array): implement Array.prototype.lastIndexOf (was returning the receiver) (#800)

### DIFF
--- a/crates/perry-codegen/src/lower_array_method.rs
+++ b/crates/perry-codegen/src/lower_array_method.rs
@@ -470,6 +470,36 @@ pub(crate) fn lower_array_method(
             );
             Ok(blk.sitofp(I32, &i32_v, DOUBLE))
         }
+        "lastIndexOf" => {
+            if args.is_empty() || args.len() > 2 {
+                bail!(
+                    "perry-codegen: Array.lastIndexOf expects 1-2 args, got {}",
+                    args.len()
+                );
+            }
+            let val_box = lower_expr(ctx, &args[0])?;
+            // Optional fromIndex: with has_from=1 pass the lowered index;
+            // when absent pass has_from=0 (runtime defaults to length-1) and
+            // reuse `val_box` as an ignored placeholder DOUBLE operand.
+            let (from_box, has_from) = if args.len() == 2 {
+                (lower_expr(ctx, &args[1])?, "1")
+            } else {
+                (val_box.clone(), "0")
+            };
+            let blk = ctx.block();
+            let recv_handle = unbox_to_i64(blk, &recv_box);
+            let i32_v = blk.call(
+                I32,
+                "js_array_last_index_of_jsvalue",
+                &[
+                    (I64, &recv_handle),
+                    (DOUBLE, &val_box),
+                    (DOUBLE, &from_box),
+                    (I32, has_from),
+                ],
+            );
+            Ok(blk.sitofp(I32, &i32_v, DOUBLE))
+        }
         "at" => {
             if args.len() != 1 {
                 bail!("perry-codegen: Array.at expects 1 arg, got {}", args.len());

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -690,6 +690,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_date_new_from_value", DOUBLE, &[DOUBLE]);
     module.declare_function("js_array_indexOf_f64", I32, &[I64, DOUBLE]);
     module.declare_function("js_array_indexOf_jsvalue", I32, &[I64, DOUBLE]);
+    module.declare_function(
+        "js_array_last_index_of_jsvalue",
+        I32,
+        &[I64, DOUBLE, DOUBLE, I32],
+    );
     module.declare_function("js_array_includes_f64", I32, &[I64, DOUBLE]);
     module.declare_function("js_array_includes_jsvalue", I32, &[I64, DOUBLE]);
     module.declare_function("js_map_size", I32, &[I64]);

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -75,7 +75,7 @@ pub use self::push_pop::{
 pub use self::reduce_right::js_array_reduce_right;
 pub use self::search::{
     js_array_includes_f64, js_array_includes_jsvalue, js_array_indexOf_f64,
-    js_array_indexOf_jsvalue,
+    js_array_indexOf_jsvalue, js_array_last_index_of_jsvalue,
 };
 pub use self::sort::{js_array_sort_default, js_array_sort_with_comparator};
 pub use self::splice_slice::{js_array_slice, js_array_splice};

--- a/crates/perry-runtime/src/array/search.rs
+++ b/crates/perry-runtime/src/array/search.rs
@@ -40,6 +40,63 @@ pub extern "C" fn js_array_indexOf_jsvalue(arr: *const ArrayHeader, value: f64) 
     }
 }
 
+/// `Array.prototype.lastIndexOf` (ECMA-262 §23.1.3.20): search backward for
+/// `value`, returning the highest matching index or -1. `has_from == 0` means
+/// no `fromIndex` argument (default: `length - 1`); otherwise `from_index` is
+/// the caller's `fromIndex` with the spec's clamping. Uses `jsvalue` equality
+/// so SSO/heap string elements compare by content (mirrors `indexOf`).
+#[no_mangle]
+pub extern "C" fn js_array_last_index_of_jsvalue(
+    arr: *const ArrayHeader,
+    value: f64,
+    from_index: f64,
+    has_from: i32,
+) -> i32 {
+    let arr = clean_arr_ptr(arr);
+    if arr.is_null() {
+        return -1;
+    }
+    unsafe {
+        let length = (*arr).length as i64;
+        if length == 0 {
+            return -1;
+        }
+        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+
+        // Determine the start index. Without an explicit fromIndex, start at
+        // the last element. With one, apply ToIntegerOrInfinity + clamping
+        // while avoiding i64 overflow for ±Infinity / out-of-range values.
+        let start: i64 = if has_from == 0 {
+            length - 1
+        } else {
+            let n = if from_index.is_nan() {
+                0.0
+            } else {
+                from_index.trunc()
+            };
+            if n >= length as f64 {
+                length - 1
+            } else if n >= 0.0 {
+                n as i64
+            } else if n >= -(length as f64) {
+                length + (n as i64) // n negative: count from the end
+            } else {
+                return -1; // fromIndex < -length: nothing to search
+            }
+        };
+
+        let mut i = start;
+        while i >= 0 {
+            let element = *elements_ptr.add(i as usize);
+            if crate::value::js_jsvalue_equals(element, value) == 1 {
+                return i as i32;
+            }
+            i -= 1;
+        }
+        -1
+    }
+}
+
 /// Check if an array includes a value
 /// Returns 1 if found, 0 if not
 #[no_mangle]

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -793,6 +793,27 @@ fn test_array_includes() {
 }
 
 #[test]
+fn test_array_last_index_of() {
+    let arr = js_array_alloc(8);
+    for v in [1.0, 2.0, 3.0, 2.0, 1.0] {
+        js_array_push_f64(arr, v);
+    }
+    // No fromIndex (has_from == 0) → search from the last element.
+    assert_eq!(js_array_last_index_of_jsvalue(arr, 2.0, 0.0, 0), 3);
+    assert_eq!(js_array_last_index_of_jsvalue(arr, 1.0, 0.0, 0), 4);
+    assert_eq!(js_array_last_index_of_jsvalue(arr, 9.0, 0.0, 0), -1);
+    // Explicit fromIndex (has_from == 1), including the spec's clamping.
+    assert_eq!(js_array_last_index_of_jsvalue(arr, 2.0, 2.0, 1), 1);
+    assert_eq!(js_array_last_index_of_jsvalue(arr, 2.0, -2.0, 1), 3); // 5 + (-2) = 3
+    assert_eq!(js_array_last_index_of_jsvalue(arr, 2.0, -10.0, 1), -1); // < -length
+    assert_eq!(js_array_last_index_of_jsvalue(arr, 2.0, 100.0, 1), 3); // clamp to len-1
+    assert_eq!(js_array_last_index_of_jsvalue(arr, 2.0, 0.0, 1), -1); // only index 0
+                                                                      // Empty array.
+    let empty = js_array_alloc(1);
+    assert_eq!(js_array_last_index_of_jsvalue(empty, 1.0, 0.0, 0), -1);
+}
+
+#[test]
 fn test_array_from_f64_and_length() {
     let values = [5.0, 10.0, 15.0];
     let arr = js_array_from_f64(values.as_ptr(), 3);

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1255,6 +1255,19 @@ pub unsafe extern "C" fn js_native_call_method(
                         let r = crate::array::js_array_includes_jsvalue(arr, value);
                         return f64::from_bits(JSValue::bool(r != 0).bits());
                     }
+                    "lastIndexOf" if args_len >= 1 && !args_ptr.is_null() => {
+                        let arr = raw_ptr as *const crate::array::ArrayHeader;
+                        let value = *args_ptr;
+                        // Optional fromIndex (2nd arg); absent → has_from=0.
+                        let (from_index, has_from) = if args_len >= 2 {
+                            (*args_ptr.add(1), 1)
+                        } else {
+                            (0.0, 0)
+                        };
+                        return crate::array::js_array_last_index_of_jsvalue(
+                            arr, value, from_index, has_from,
+                        ) as f64;
+                    }
                     "at" if args_len >= 1 && !args_ptr.is_null() => {
                         let arr = raw_ptr as *const crate::array::ArrayHeader;
                         return crate::array::js_array_at(arr, *args_ptr);


### PR DESCRIPTION
Part of #800 (Node core parity).

## Problem

`Array.prototype.lastIndexOf` returned the **receiver array** instead of the index:

```ts
[1,2,3,2,1].lastIndexOf(2)   // Perry: [ 1, 2, 3, 2, 1 ]   Node: 3
[1,2,3].lastIndexOf(9)       // Perry: [ 1, 2, 3 ]         Node: -1
```

`lastIndexOf` had no arm in `lower_array_method`, so the best-effort fallback lowered the args and returned `recv_box`. The runtime variable-method dispatch (`obj[nameVar]()`) was also missing it (only `indexOf`/`includes` were wired), yielding `[object Object]`. (String `lastIndexOf` was unaffected.)

## Fix

- **Runtime** `js_array_last_index_of_jsvalue` (`array/search.rs`): backward scan using `jsvalue` equality (SSO/heap strings compare by content, mirroring `indexOf`), with full ECMA-262 §23.1.3.20 `fromIndex` handling — default `length-1`, negative counts from the end, out-of-range clamped without `i64` overflow.
- **Codegen** `lastIndexOf` arm in `lower_array_method` (1–2 args) + extern declaration.
- **Runtime dynamic dispatch** arm in `native_call_method` so the computed / variable-method-name path works too.

## Validation

Byte-for-byte vs `node` across **all** receiver forms — static array, typed param, `any`, literal computed key `["lastIndexOf"]`, and variable method name `[m]` — plus `fromIndex` edge cases (positive / negative / out-of-range), `NaN`, and empty arrays. + a runtime unit test (`test_array_last_index_of`).
