### PR TITLE
fix(date): model Date as a reference type so mutations propagate (#2089)

### DIFF
--- a/crates/perry-codegen/src/expr/compare.rs
+++ b/crates/perry-codegen/src/expr/compare.rs
@@ -367,6 +367,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 return Ok(blk.bitcast_i64_to_double(&result_bits));
             }
 
+            // #2089: an ordered relational compare (`<`, `<=`, `>`, `>=`)
+            // whose operands aren't statically numeric may be Date values —
+            // NaN-boxed `DateCell` pointers whose raw bits are NaN, so a bare
+            // `fcmp` would be unordered (always false). Coerce each operand to
+            // its ms timestamp via `js_date_coerce_number` first; plain numbers
+            // pass through unchanged, so the statically-numeric case keeps its
+            // bare `fcmp` fast path (no call emitted).
+            let coerce_relational_dates = matches!(
+                op,
+                CompareOp::Lt | CompareOp::Le | CompareOp::Gt | CompareOp::Ge
+            ) && !(is_numeric_expr(ctx, left)
+                && is_numeric_expr(ctx, right));
             let l = lower_expr(ctx, left)?;
             let r = lower_expr(ctx, right)?;
             let pred = match op {
@@ -384,6 +396,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 CompareOp::LooseEq | CompareOp::LooseNe => unreachable!(),
             };
             let blk = ctx.block();
+            let (l, r) = if coerce_relational_dates {
+                let lc = blk.call(DOUBLE, "js_date_coerce_number", &[(DOUBLE, &l)]);
+                let rc = blk.call(DOUBLE, "js_date_coerce_number", &[(DOUBLE, &r)]);
+                (lc, rc)
+            } else {
+                (l, r)
+            };
             let bit = blk.fcmp(pred, &l, &r);
             let tag_true_i64 = crate::nanbox::TAG_TRUE_I64;
             let tag_false_i64 = crate::nanbox::TAG_FALSE_I64;

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1712,6 +1712,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::DecodeURI(..)
         | Expr::EncodeURIComponent(..)
         | Expr::DecodeURIComponent(..)
+        | Expr::DateToString(..)
         | Expr::DateToDateString(..)
         | Expr::DateToTimeString(..)
         | Expr::DateToLocaleDateString(..)

--- a/crates/perry-codegen/src/expr/os_uri_dates.rs
+++ b/crates/perry-codegen/src/expr/os_uri_dates.rs
@@ -147,6 +147,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let h = blk.call(I64, "js_decode_uri_component", &[(DOUBLE, &v)]);
             Ok(nanbox_string_inline(blk, &h))
         }
+        Expr::DateToString(o) => {
+            let v = lower_expr(ctx, o)?;
+            let blk = ctx.block();
+            let handle = blk.call(I64, "js_date_to_string", &[(DOUBLE, &v)]);
+            Ok(nanbox_string_inline(blk, &handle))
+        }
         Expr::DateToDateString(o) => {
             let v = lower_expr(ctx, o)?;
             let blk = ctx.block();

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -686,6 +686,10 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_date_get_utc_milliseconds", DOUBLE, &[DOUBLE]);
     module.declare_function("js_date_value_of", DOUBLE, &[DOUBLE]);
     module.declare_function("js_date_get_timezone_offset", DOUBLE, &[DOUBLE]);
+    // #2089: deref a Date (NaN-boxed DateCell pointer) to its ms timestamp for
+    // ordered relational compares; a plain number passes through unchanged.
+    module.declare_function("js_date_coerce_number", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_date_to_string", I64, &[DOUBLE]);
     module.declare_function("js_date_to_iso_string", I64, &[DOUBLE]);
     module.declare_function("js_date_to_iso_string_or_throw", I64, &[DOUBLE]);
     module.declare_function("js_date_new_from_timestamp", DOUBLE, &[DOUBLE]);

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -145,6 +145,7 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
         // Date string-returning methods all produce real string handles
         // via js_date_to_*_string. Refining the local lets `dateStr.includes("2024")`
         // hit the string .includes fast path.
+        | Expr::DateToString(_)
         | Expr::DateToDateString(_)
         | Expr::DateToTimeString(_)
         | Expr::DateToLocaleString(_)
@@ -1131,6 +1132,7 @@ pub(crate) fn is_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         | Expr::RegExpSource(_)
         | Expr::RegExpFlags(_)
         // Date.prototype.to*String() → string
+        | Expr::DateToString(_)
         | Expr::DateToDateString(_)
         | Expr::DateToTimeString(_)
         | Expr::DateToLocaleString(_)

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1492,6 +1492,7 @@ pub enum Expr {
 
     // Date misc
     DateValueOf(Box<Expr>),      // date.valueOf() -> number (same as getTime)
+    DateToString(Box<Expr>),     // date.toString() / String(date) -> full date string
     DateToDateString(Box<Expr>), // date.toDateString() -> string
     DateToTimeString(Box<Expr>), // date.toTimeString() -> string
     DateToLocaleDateString(Box<Expr>), // date.toLocaleDateString() -> string

--- a/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
@@ -241,6 +241,17 @@ pub(super) fn try_url_date_weakref_instance(
                         let date_expr = lower_expr(ctx, &member.obj)?;
                         return Ok(Ok(Expr::DateValueOf(Box::new(date_expr))));
                     }
+                    // #2089: `date.toString()` — full local date string (or
+                    // "Invalid Date"). `toString` exists on EVERY value, so this
+                    // arm must fire ONLY when the receiver is statically a Date;
+                    // otherwise it would hijack `bigint.toString()` /
+                    // `urlSearchParams.toString()` / etc. An `any`-typed Date
+                    // receiver falls through to generic dispatch, which routes a
+                    // DateCell through `js_jsvalue_to_string` (also #2089-aware).
+                    "toString" if recv_class == Some("Date") => {
+                        let date_expr = lower_expr(ctx, &member.obj)?;
+                        return Ok(Ok(Expr::DateToString(Box::new(date_expr))));
+                    }
                     "toDateString" => {
                         let date_expr = lower_expr(ctx, &member.obj)?;
                         return Ok(Ok(Expr::DateToDateString(Box::new(date_expr))));
@@ -348,11 +359,14 @@ pub(super) fn try_url_date_weakref_instance(
                                 },
                                 _ => unreachable!(),
                             };
-                            // If receiver is a local variable, mutate it in place by wrapping
-                            // the setter result in a LocalSet so the new timestamp is stored back.
-                            if let Expr::LocalGet(local_id) = &date_expr {
-                                return Ok(Ok(Expr::LocalSet(*local_id, Box::new(setter_call))));
-                            }
+                            // #2089: Date is now a reference type — a setter
+                            // mutates the shared `DateCell` in place, so its
+                            // effect is already visible through every alias /
+                            // param / closure that holds this Date. The setter
+                            // call evaluates to the numeric ms (the JS setter
+                            // return value). The old `LocalSet(id, setter_call)`
+                            // writeback is dropped: it would now overwrite the
+                            // receiver local's Date POINTER with that number.
                             return Ok(Ok(setter_call));
                         }
                     }

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -417,6 +417,7 @@ impl SH for Expr {
             Expr::DateSetMilliseconds { date, value } => { tag(h, 484); date.as_ref().hash(h); value.as_ref().hash(h); }
             Expr::DateSetTime { date, value } => { tag(h, 485); date.as_ref().hash(h); value.as_ref().hash(h); }
             Expr::DateValueOf(e) => { tag(h, 338); e.as_ref().hash(h); }
+            Expr::DateToString(e) => { tag(h, 1339); e.as_ref().hash(h); }
             Expr::DateToDateString(e) => { tag(h, 339); e.as_ref().hash(h); }
             Expr::DateToTimeString(e) => { tag(h, 340); e.as_ref().hash(h); }
             Expr::DateToLocaleDateString(e) => { tag(h, 341); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -253,6 +253,7 @@ where
         | Expr::DateGetUtcSeconds(v)
         | Expr::DateGetUtcMilliseconds(v)
         | Expr::DateValueOf(v)
+        | Expr::DateToString(v)
         | Expr::DateToDateString(v)
         | Expr::DateToTimeString(v)
         | Expr::DateToLocaleDateString(v)

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -254,6 +254,7 @@ where
         | Expr::DateGetUtcSeconds(v)
         | Expr::DateGetUtcMilliseconds(v)
         | Expr::DateValueOf(v)
+        | Expr::DateToString(v)
         | Expr::DateToDateString(v)
         | Expr::DateToTimeString(v)
         | Expr::DateToLocaleDateString(v)

--- a/crates/perry-runtime/src/builtins/arithmetic.rs
+++ b/crates/perry-runtime/src/builtins/arithmetic.rs
@@ -211,6 +211,12 @@ pub extern "C" fn js_value_typeof(value: f64) -> *mut StringHeader {
             // and Box-leaked symbols, which have no GcHeader).
             if crate::symbol::is_registered_symbol(ptr as usize) {
                 get_cached(&TYPEOF_SYMBOL, "symbol")
+            } else if crate::date::is_date_cell_addr(ptr as usize) {
+                // Date is a NaN-boxed pointer to an 8-byte `DateCell` (#2089).
+                // `typeof aDate === "object"`. Check this BEFORE reading the
+                // `type_tag` at offset 12 below — the cell is only 8 bytes, so
+                // that read would fall off the end of the allocation.
+                get_cached(&TYPEOF_OBJECT, "object")
             } else {
                 // ClosureHeader has type_tag at offset 12 (after func_ptr:8 + capture_count:4)
                 let type_tag = unsafe { *(ptr.add(12) as *const u32) };
@@ -260,14 +266,9 @@ pub extern "C" fn js_value_typeof(value: f64) -> *mut StringHeader {
                 return get_cached(&TYPEOF_OBJECT, "object");
             }
         }
-        // Date — stored as a raw f64 millisecond timestamp, registered
-        // in `DATE_REGISTRY` because the value carries no tag of its
-        // own. `typeof new Date()` must be "object" per ECMA-262 — any
-        // duck-type test (`typeof v === "object" && v instanceof Date`)
-        // gates Date handling on this returning the right thing.
-        if crate::date::is_registered_date_bits(bits) {
-            return get_cached(&TYPEOF_OBJECT, "object");
-        }
+        // Date is now a NaN-boxed `DateCell` pointer (#2089), handled in the
+        // `is_pointer()` arm above — it no longer reaches this numeric
+        // fallthrough.
         // #1650: Web Streams handles (ReadableStream / WritableStream /
         // reader / writer) are returned as a raw `id as f64` whole number in
         // a high id range (#1545), so they reach this fallthrough and would

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -588,6 +588,20 @@ unsafe fn format_error_value(error_ptr: *const crate::error::ErrorHeader, depth:
     out
 }
 
+/// #2089: a Date's `util.inspect` rendering — ISO string (unquoted) or "Invalid Date". DateCell pointer only (gated by callers).
+unsafe fn date_inspect_string(value: f64) -> String {
+    let s_ptr = crate::date::js_date_to_iso_string(value);
+    if s_ptr.is_null() {
+        return "Invalid Date".to_string();
+    }
+    let len = (*s_ptr).byte_len as usize;
+    let data = (s_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+    let bytes = std::slice::from_raw_parts(data, len);
+    std::str::from_utf8(bytes)
+        .unwrap_or("Invalid Date")
+        .to_string()
+}
+
 /// Print multiple values from an array (console.log with spread support)
 /// Takes a pointer to an ArrayHeader containing f64 values
 /// Helper function to format a JSValue as a string (for spread arrays)
@@ -664,6 +678,12 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
             } else if crate::proxy::js_proxy_is_proxy(value) != 0 {
                 let target = crate::proxy::js_proxy_target(value);
                 format_jsvalue(target, depth)
+            } else if crate::date::is_date_cell_addr(ptr as usize) {
+                // #2089: a Date is a NaN-boxed `DateCell` pointer. Node's
+                // `util.inspect` prints the ISO string unquoted (or
+                // `Invalid Date`). Handle before the GC-header object dispatch
+                // below, which would deref the 8-byte cell as an ObjectHeader.
+                date_inspect_string(value)
             } else if (ptr as usize) < 0x100000 {
                 // Refs #421: Web Fetch (and other) handles are NaN-boxed
                 // POINTER_TAG values whose payload is a small registry id, NOT
@@ -1289,6 +1309,11 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
                 if crate::proxy::js_proxy_is_proxy(value) != 0 {
                     let target = crate::proxy::js_proxy_target(value);
                     format_jsvalue_for_json(target, depth)
+                } else if crate::date::is_date_cell_addr(ptr as usize) {
+                    // #2089: Date inside an inspected object — ISO string
+                    // unquoted (or `Invalid Date`), not the 8-byte cell deref'd
+                    // as an object.
+                    date_inspect_string(value)
                 } else if (ptr as usize) < 0x100000 {
                     "[object Object]".to_string()
                 } else if crate::symbol::is_registered_symbol(ptr as usize)

--- a/crates/perry-runtime/src/builtins/numbers.rs
+++ b/crates/perry-runtime/src/builtins/numbers.rs
@@ -334,6 +334,11 @@ pub extern "C" fn js_number_coerce(value: f64) -> f64 {
         crate::bigint::js_bigint_to_f64(ptr)
     } else if jsval.is_pointer() {
         let id = (value.to_bits() & 0x0000_FFFF_FFFF_FFFF) as i64;
+        // #2089: a Date is a NaN-boxed pointer to a `DateCell`. `Number(date)`
+        // / `+date` / `date - other` coerce to the millisecond timestamp.
+        if crate::date::is_date_cell_addr(id as usize) {
+            return crate::date::date_cell_timestamp(value);
+        }
         // Timer handles coerce numerically to their internal id (matches
         // Node's `+timeout` shape — Node returns `_idleTimeout`, Perry
         // returns the handle id; both are numbers and both are stable

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -1,68 +1,117 @@
 //! Date operations runtime support
 //!
 //! Provides JavaScript Date functionality using system time.
-//! Dates are represented internally as i64 timestamps (milliseconds since Unix epoch).
+//!
+//! A `Date` is a **reference type**: a NaN-boxed pointer to a 1-slot mutable
+//! [`DateCell`] holding the millisecond timestamp. This gives JS-correct
+//! aliasing semantics — a setter mutation made through any binding (alias,
+//! function parameter, closure capture) is visible through all of them
+//! (#2089). Getters dereference the cell; setters mutate it in place.
 
-use std::cell::RefCell;
-use std::collections::HashSet;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-thread_local! {
-    /// Bit patterns of f64 values that came from a `new Date(...)` constructor
-    /// (or `Date.now()` / a Date method). `instanceof Date` consults this set
-    /// — without it, every finite number would match because Perry stores
-    /// Date as a raw f64 timestamp with no tag.
-    ///
-    /// False positives are possible (a regular number equal to a registered
-    /// Date timestamp), but in practice the set is small and dominated by
-    /// recently-minted Date timestamps.
-    static DATE_REGISTRY: RefCell<HashSet<u64>> = RefCell::new(HashSet::new());
+const NANBOX_PTR_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+
+/// A `Date` is a **reference type**: a NaN-boxed POINTER (POINTER_TAG) to
+/// this 1-slot mutable heap cell, *not* a raw f64 timestamp. Aliases
+/// (`const b = a`), function parameters, and closure captures all share
+/// the same cell, so an in-place setter mutation is visible through every
+/// binding — this is what fixes #2089 (effect `DateTime.add`). The cell is
+/// arena-allocated as `GC_TYPE_DATE_CELL`: non-movable (a NaN-boxed pointer
+/// living in a plain f64/DOUBLE local is kept alive by the conservative
+/// stack scan, and the stable address means that un-shadow-rooted pointer
+/// never goes stale across a GC) and pointer-free (`ts` is a raw IEEE
+/// double, so no write barrier is needed when a setter mutates it).
+#[repr(C)]
+pub struct DateCell {
+    pub ts: f64,
 }
 
-/// Canonical "Invalid Date" bit pattern.
-///
-/// An *Invalid Date* (`new Date(NaN)`, `new Date("nope")`, the zero-date
-/// branch of `@perryts/mysql`'s `MyDateTime.toDate()`, …) is still a Date
-/// object per ECMA-262 §21.4.1.1 — `typeof` must be `"object"` and
-/// `instanceof Date` must be `true`, even though its time value is NaN.
-///
-/// Perry stores Date as a raw f64 with no tag and tracks finite Dates in
-/// the thread-local `DATE_REGISTRY`. A NaN can't go in that value-keyed
-/// set: NaN never compares equal, the bit pattern isn't stable, and the
-/// set is thread-local so a Date minted on a socket/worker thread (mysql
-/// row decode) wouldn't be seen on the main thread anyway. So Invalid
-/// Date gets a single canonical sentinel recognized *by bit pattern*,
-/// globally, with no registration step — it works across threads for
-/// free because it is a constant, not a tracked value.
-///
-/// The pattern is a quiet NaN (exponent all ones, mantissa MSB set so it
-/// stays quiet per IEEE-754 §6.2.1 and arithmetic propagates instead of
-/// trapping). It lives in the 0x7FF8 space, which `JSValue::is_number`
-/// treats as a plain number rather than a NaN-box tag, so the value
-/// flows through arithmetic and the existing `if timestamp.is_nan()`
-/// guards in every Date getter exactly like a bare NaN — only `typeof` /
-/// `instanceof` / dynamic dispatch get to see that it is really a Date.
-/// The low payload `0x0DA7` just distinguishes it from the FPU's
-/// canonical `0x7FF8_0000_0000_0000`.
-pub const DATE_NAN_BITS: u64 = 0x7FF8_0000_0000_0DA7;
+/// Allocate a fresh Date cell holding `ts` and return it as a NaN-boxed
+/// pointer (an f64 carrying POINTER_TAG). `ts` may be NaN — that is an
+/// *Invalid Date*, still a real Date object for `typeof` / `instanceof`
+/// (the cell pointer is what makes it a Date, independent of its time
+/// value), so unlike the old value-type representation there is no need
+/// for a separate NaN sentinel bit pattern.
+pub fn alloc_date_cell(ts: f64) -> f64 {
+    unsafe {
+        let ptr = crate::arena::arena_alloc_gc(
+            std::mem::size_of::<DateCell>(),
+            8,
+            crate::gc::GC_TYPE_DATE_CELL,
+        ) as *mut DateCell;
+        (*ptr).ts = ts;
+        f64::from_bits(crate::value::JSValue::pointer(ptr as *const u8).bits())
+    }
+}
 
-/// The canonical Invalid Date value.
+/// The canonical Invalid Date value — a fresh cell whose time value is NaN.
 #[inline]
 pub fn date_invalid() -> f64 {
-    f64::from_bits(DATE_NAN_BITS)
+    alloc_date_cell(f64::NAN)
 }
 
-/// Map any NaN result to the canonical Invalid-Date sentinel; pass
-/// finite values through untouched. Used by the `new Date(...)`
-/// constructors so an invalid time value is still a recognizable Date
-/// object instead of a bare, type-less NaN.
+/// True if `addr` (a cleaned heap address, NOT NaN-boxed bits) points at a
+/// `DateCell`. Reads the `GcHeader.obj_type`: for any live `is_pointer()`
+/// value the header is always present and valid, and because `DateCell` is
+/// non-movable its address is stable, so this is an exact identity check
+/// with no side-table registry to keep in sync.
 #[inline]
-fn date_or_invalid(v: f64) -> f64 {
-    if v.is_nan() {
-        date_invalid()
-    } else {
-        v
+pub fn is_date_cell_addr(addr: usize) -> bool {
+    if addr < 0x1000 + crate::gc::GC_HEADER_SIZE {
+        return false;
     }
+    unsafe {
+        let header = (addr - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        (*header).obj_type == crate::gc::GC_TYPE_DATE_CELL
+    }
+}
+
+/// True if `value` is a Date — i.e. a NaN-boxed pointer to a `DateCell`.
+/// Replaces the old value-keyed `is_registered_date_bits`.
+#[inline]
+pub fn is_date_value(value: f64) -> bool {
+    let bits = value.to_bits();
+    if !crate::value::JSValue::from_bits(bits).is_pointer() {
+        return false;
+    }
+    is_date_cell_addr((bits & NANBOX_PTR_MASK) as usize)
+}
+
+/// Read the timestamp out of a Date value. If `value` is a `DateCell`
+/// pointer, dereference it; otherwise (a raw numeric timestamp handed to a
+/// Date method directly — e.g. via `Date.UTC()` or a legacy path) pass it
+/// through unchanged. Every public Date getter/formatter funnels its
+/// receiver through this so it works whether it was given a cell or a bare
+/// number.
+#[inline]
+pub fn date_cell_timestamp(value: f64) -> f64 {
+    let bits = value.to_bits();
+    if crate::value::JSValue::from_bits(bits).is_pointer() {
+        let addr = (bits & NANBOX_PTR_MASK) as usize;
+        if is_date_cell_addr(addr) {
+            return unsafe { (*(addr as *const DateCell)).ts };
+        }
+    }
+    value
+}
+
+/// Mutate the `DateCell` `value` points at, writing `ts` into it. No-op if
+/// `value` is not a cell (e.g. a raw timestamp). Returns `ts` — the numeric
+/// millisecond value a JS Date setter evaluates to. `DateCell` is
+/// pointer-free, so this raw f64 store needs no GC write barrier.
+#[inline]
+fn date_cell_store(value: f64, ts: f64) -> f64 {
+    let bits = value.to_bits();
+    if crate::value::JSValue::from_bits(bits).is_pointer() {
+        let addr = (bits & NANBOX_PTR_MASK) as usize;
+        if is_date_cell_addr(addr) {
+            unsafe {
+                (*(addr as *mut DateCell)).ts = ts;
+            }
+        }
+    }
+    ts
 }
 
 /// The string every Date string-method returns when the time value is
@@ -82,18 +131,24 @@ fn throw_invalid_time_value() -> ! {
     crate::exception::js_throw(f64::from_bits(err_value))
 }
 
-/// Mark `bits` as a Date so future `instanceof Date` checks can recognize it.
-pub fn register_date_bits(bits: u64) {
-    DATE_REGISTRY.with(|r| {
-        r.borrow_mut().insert(bits);
-    });
+/// Coerce a value to a number for an ordered relational comparison
+/// (`date1 < date2`, `date < ms`, …). A Date is a NaN-boxed `DateCell`
+/// pointer whose raw bits are a NaN — bare `fcmp` would compare unordered
+/// (always false) — so codegen routes non-statically-numeric relational
+/// operands through here to dereference the timestamp first. Plain numbers
+/// pass straight through.
+#[no_mangle]
+pub extern "C" fn js_date_coerce_number(value: f64) -> f64 {
+    date_cell_timestamp(value)
 }
 
-/// True when `bits` are a Date: either the canonical Invalid-Date
-/// sentinel (recognized globally, no registration) or a finite timestamp
-/// previously registered by `new Date(...)` / `Date.now()` / a Date method.
+/// Back-compat shim for the old value-keyed identity check. Date is now a
+/// reference type, so identity is "the value is a pointer to a `DateCell`".
+/// Kept so external callers (e.g. `perry-stdlib`'s querystring) need only a
+/// trivial update. Prefer [`is_date_value`].
+#[inline]
 pub fn is_registered_date_bits(bits: u64) -> bool {
-    bits == DATE_NAN_BITS || DATE_REGISTRY.with(|r| r.borrow().contains(&bits))
+    is_date_value(f64::from_bits(bits))
 }
 
 /// Convert a UTC timestamp (seconds) to local-time components.
@@ -175,23 +230,17 @@ pub extern "C" fn js_performance_now() -> f64 {
         .unwrap_or(0.0)
 }
 
-/// Create a new Date from current time, returning timestamp in milliseconds
+/// Create a new Date from current time, returning a NaN-boxed DateCell pointer.
 #[no_mangle]
 pub extern "C" fn js_date_new() -> f64 {
-    let v = js_date_now();
-    register_date_bits(v.to_bits());
-    v
+    alloc_date_cell(js_date_now())
 }
 
 /// Create a new Date from a timestamp (milliseconds since epoch).
-/// A NaN timestamp produces a recognizable Invalid Date, not a bare NaN.
+/// A NaN timestamp produces a recognizable Invalid Date (a cell with NaN ts).
 #[no_mangle]
 pub extern "C" fn js_date_new_from_timestamp(timestamp: f64) -> f64 {
-    let result = date_or_invalid(timestamp);
-    if !result.is_nan() {
-        register_date_bits(result.to_bits());
-    }
-    result
+    alloc_date_cell(timestamp)
 }
 
 /// Create a new Date from a value that could be a number or a NaN-boxed string.
@@ -218,15 +267,15 @@ pub extern "C" fn js_date_new_from_value(value: f64) -> f64 {
                 }
             }
         }
+    } else if is_date_value(value) {
+        // `new Date(anotherDate)` copies the source's time value (and would
+        // otherwise read the pointer bits as a bogus timestamp).
+        date_cell_timestamp(value)
     } else {
         // Numeric timestamp
         value
     };
-    let result = date_or_invalid(result);
-    if !result.is_nan() {
-        register_date_bits(result.to_bits());
-    }
-    result
+    alloc_date_cell(result)
 }
 
 /// Parse a date string into a millisecond timestamp.
@@ -357,6 +406,7 @@ fn components_to_timestamp(
 /// Since we store dates as timestamps, this is an identity function
 #[no_mangle]
 pub extern "C" fn js_date_get_time(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     timestamp
 }
 
@@ -364,6 +414,7 @@ pub extern "C" fn js_date_get_time(timestamp: f64) -> f64 {
 /// Returns a pointer to a StringHeader
 #[no_mangle]
 pub extern "C" fn js_date_to_iso_string(timestamp: f64) -> *mut crate::StringHeader {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return invalid_date_string();
     }
@@ -388,6 +439,7 @@ pub extern "C" fn js_date_to_iso_string(timestamp: f64) -> *mut crate::StringHea
 /// JSON internals, the public method must throw RangeError for Invalid Date.
 #[no_mangle]
 pub extern "C" fn js_date_to_iso_string_or_throw(timestamp: f64) -> *mut crate::StringHeader {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         throw_invalid_time_value();
     }
@@ -397,6 +449,7 @@ pub extern "C" fn js_date_to_iso_string_or_throw(timestamp: f64) -> *mut crate::
 /// Get the full year (date.getFullYear()) in LOCAL time.
 #[no_mangle]
 pub extern "C" fn js_date_get_full_year(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return f64::NAN;
     }
@@ -409,6 +462,7 @@ pub extern "C" fn js_date_get_full_year(timestamp: f64) -> f64 {
 /// Get the month (0-11) (date.getMonth()) in LOCAL time.
 #[no_mangle]
 pub extern "C" fn js_date_get_month(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return f64::NAN;
     }
@@ -421,6 +475,7 @@ pub extern "C" fn js_date_get_month(timestamp: f64) -> f64 {
 /// Get the day of month (1-31) (date.getDate()) in LOCAL time.
 #[no_mangle]
 pub extern "C" fn js_date_get_date(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return f64::NAN;
     }
@@ -433,6 +488,7 @@ pub extern "C" fn js_date_get_date(timestamp: f64) -> f64 {
 /// Get the hour (0-23) (date.getHours()) in LOCAL time.
 #[no_mangle]
 pub extern "C" fn js_date_get_hours(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return f64::NAN;
     }
@@ -445,6 +501,7 @@ pub extern "C" fn js_date_get_hours(timestamp: f64) -> f64 {
 /// Get the minutes (0-59) (date.getMinutes()) in LOCAL time.
 #[no_mangle]
 pub extern "C" fn js_date_get_minutes(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return f64::NAN;
     }
@@ -457,6 +514,7 @@ pub extern "C" fn js_date_get_minutes(timestamp: f64) -> f64 {
 /// Get the seconds (0-59) (date.getSeconds()) in LOCAL time.
 #[no_mangle]
 pub extern "C" fn js_date_get_seconds(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return f64::NAN;
     }
@@ -469,6 +527,7 @@ pub extern "C" fn js_date_get_seconds(timestamp: f64) -> f64 {
 /// Get the milliseconds (0-999) (date.getMilliseconds())
 #[no_mangle]
 pub extern "C" fn js_date_get_milliseconds(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return f64::NAN;
     }
@@ -479,6 +538,7 @@ pub extern "C" fn js_date_get_milliseconds(timestamp: f64) -> f64 {
 /// Get the day of week (0-6, Sunday=0) in LOCAL time (date.getDay()).
 #[no_mangle]
 pub extern "C" fn js_date_get_day(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return f64::NAN;
     }
@@ -565,8 +625,8 @@ pub extern "C" fn js_date_utc(
 /// up reading garbage out of a `getTime()` like `1.9e+214` and reports the
 /// year as `292278994`.
 ///
-/// Returns a millisecond timestamp; the caller registers it in the
-/// DATE_REGISTRY so future `instanceof Date` checks succeed.
+/// Returns a NaN-boxed `DateCell` pointer; `instanceof Date` recognizes it
+/// by the cell's `GcHeader` type.
 #[no_mangle]
 pub extern "C" fn js_date_new_local_components(
     year: f64,
@@ -624,7 +684,7 @@ pub extern "C" fn js_date_new_local_components(
         || s.is_nan()
         || ms.is_nan()
     {
-        return f64::NAN;
+        return alloc_date_cell(f64::NAN);
     }
     let mut year_i = y as i32;
     // ECMA-262: if 0 <= year < 100, year = 1900 + year.
@@ -652,18 +712,14 @@ pub extern "C" fn js_date_new_local_components(
     // (treated as a UTC epoch); the resulting tz_offset is the delta.
     let (_, _, _, _, _, _, tz_offset) = timestamp_to_local_components(local_secs);
     let utc_secs = local_secs - tz_offset;
-    let result = (utc_secs * 1000 + ms_i) as f64;
-    let result = date_or_invalid(result);
-    if !result.is_nan() {
-        register_date_bits(result.to_bits());
-    }
-    result
+    alloc_date_cell((utc_secs * 1000 + ms_i) as f64)
 }
 
 // --- UTC getters: same impl as the regular getters since we store UTC internally ---
 
 #[no_mangle]
 pub extern "C" fn js_date_get_utc_day(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return f64::NAN;
     }
@@ -674,21 +730,25 @@ pub extern "C" fn js_date_get_utc_day(timestamp: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_date_get_utc_full_year(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     js_date_get_full_year(timestamp)
 }
 
 #[no_mangle]
 pub extern "C" fn js_date_get_utc_month(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     js_date_get_month(timestamp)
 }
 
 #[no_mangle]
 pub extern "C" fn js_date_get_utc_date(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     js_date_get_date(timestamp)
 }
 
 #[no_mangle]
 pub extern "C" fn js_date_get_utc_hours(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return f64::NAN;
     }
@@ -700,6 +760,7 @@ pub extern "C" fn js_date_get_utc_hours(timestamp: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_date_get_utc_minutes(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return f64::NAN;
     }
@@ -711,6 +772,7 @@ pub extern "C" fn js_date_get_utc_minutes(timestamp: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_date_get_utc_seconds(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return f64::NAN;
     }
@@ -722,12 +784,14 @@ pub extern "C" fn js_date_get_utc_seconds(timestamp: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_date_get_utc_milliseconds(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     js_date_get_milliseconds(timestamp)
 }
 
 /// date.valueOf() — same as getTime(), returns ms timestamp.
 #[no_mangle]
 pub extern "C" fn js_date_value_of(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     timestamp
 }
 
@@ -736,6 +800,7 @@ pub extern "C" fn js_date_value_of(timestamp: f64) -> f64 {
 /// west of UTC, negative for those east (matches the JS/Node convention).
 #[no_mangle]
 pub extern "C" fn js_date_get_timezone_offset(timestamp: f64) -> f64 {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return f64::NAN;
     }
@@ -749,9 +814,15 @@ pub extern "C" fn js_date_get_timezone_offset(timestamp: f64) -> f64 {
 }
 
 // --- UTC setters: rebuild the timestamp with one component replaced ---
+//
+// `date` is the receiver — a NaN-boxed DateCell pointer. We dereference its
+// current time value, rebuild, then write the new value back INTO the same
+// cell so the mutation is visible through every alias/param/closure that
+// holds this Date (#2089). The numeric ms is returned (what a JS setter
+// evaluates to).
 
 fn rebuild_with(
-    timestamp: f64,
+    date: f64,
     year: Option<i32>,
     month: Option<u32>,
     day: Option<u32>,
@@ -760,6 +831,10 @@ fn rebuild_with(
     second: Option<u32>,
     millisecond: Option<i64>,
 ) -> f64 {
+    // A NaN time value coerces to 0 via `as i64`, matching the prior
+    // value-type behavior (e.g. `setUTCFullYear` reviving an Invalid Date
+    // from the epoch per ECMA-262 §21.4.4.40's "if t is NaN, set t to +0").
+    let timestamp = date_cell_timestamp(date);
     let ts_ms = timestamp as i64;
     let secs = ts_ms.div_euclid(1000);
     let cur_ms = ts_ms.rem_euclid(1000);
@@ -773,7 +848,7 @@ fn rebuild_with(
         second.unwrap_or(cs),
     );
     let new_ms = millisecond.unwrap_or(cur_ms);
-    (new_secs * 1000 + new_ms) as f64
+    date_cell_store(date, (new_secs * 1000 + new_ms) as f64)
 }
 
 #[no_mangle]
@@ -886,7 +961,7 @@ pub extern "C" fn js_date_set_utc_milliseconds(timestamp: f64, value: f64) -> f6
 // through untouched so an Invalid Date stays an Invalid Date.
 
 fn rebuild_local_with(
-    timestamp: f64,
+    date: f64,
     year: Option<i32>,
     month: Option<u32>,
     day: Option<u32>,
@@ -895,8 +970,10 @@ fn rebuild_local_with(
     second: Option<u32>,
     millisecond: Option<i64>,
 ) -> f64 {
+    let timestamp = date_cell_timestamp(date);
     if timestamp.is_nan() {
-        return timestamp;
+        // Setting a component on an Invalid Date leaves it invalid.
+        return date_cell_store(date, timestamp);
     }
     let ts_ms = timestamp as i64;
     let secs = ts_ms.div_euclid(1000);
@@ -914,12 +991,9 @@ fn rebuild_local_with(
     );
     let (_, _, _, _, _, _, tz_offset) = timestamp_to_local_components(local_secs);
     let utc_secs = local_secs - tz_offset;
-    let result = (utc_secs * 1000 + new_ms) as f64;
-    let result = date_or_invalid(result);
-    if !result.is_nan() {
-        register_date_bits(result.to_bits());
-    }
-    result
+    // Write the rebuilt value back into the receiver's cell and return the
+    // numeric ms (what a JS Date setter evaluates to).
+    date_cell_store(date, (utc_secs * 1000 + new_ms) as f64)
 }
 
 #[no_mangle]
@@ -1021,16 +1095,11 @@ pub extern "C" fn js_date_set_milliseconds(timestamp: f64, value: f64) -> f64 {
     )
 }
 
-/// `date.setTime(ms)` — replace the entire time value. NaN in produces an
-/// Invalid Date; otherwise the new ms timestamp is registered so future
-/// `instanceof Date` checks succeed.
+/// `date.setTime(ms)` — replace the entire time value in place. A NaN `value`
+/// makes the receiver an Invalid Date. Returns the numeric ms.
 #[no_mangle]
-pub extern "C" fn js_date_set_time(_timestamp: f64, value: f64) -> f64 {
-    let result = date_or_invalid(value);
-    if !result.is_nan() {
-        register_date_bits(result.to_bits());
-    }
-    result
+pub extern "C" fn js_date_set_time(date: f64, value: f64) -> f64 {
+    date_cell_store(date, value)
 }
 
 // --- String-returning Date methods ---
@@ -1040,9 +1109,48 @@ const MONTH_NAMES: [&str; 12] = [
     "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ];
 
+/// `date.toString()` / `String(date)` / `` `${date}` `` — the full local
+/// date+time string, e.g. "Mon Jan 15 2024 12:30:45 GMT+0100 (local)", or
+/// "Invalid Date". #2089: Date is a reference type now, so the generic
+/// object-to-string path would otherwise print "[object Object]" (the old
+/// value-type rep printed the bare millisecond number — also non-conformant).
+/// The timezone long-name isn't reproduced (Perry has no tz database), so this
+/// is close to but not byte-identical with Node for valid dates; Invalid Date
+/// matches exactly.
+#[no_mangle]
+pub extern "C" fn js_date_to_string(timestamp: f64) -> *mut crate::StringHeader {
+    let timestamp = date_cell_timestamp(timestamp);
+    if timestamp.is_nan() {
+        return invalid_date_string();
+    }
+    let ts_ms = timestamp as i64;
+    let secs = ts_ms.div_euclid(1000);
+    let (year, month, day, hour, minute, second, tz_offset) = timestamp_to_local_components(secs);
+    let dow = weekday_from_timestamp(secs + tz_offset) as usize;
+    let sign = if tz_offset >= 0 { '+' } else { '-' };
+    let abs_off = tz_offset.abs();
+    let off_h = abs_off / 3600;
+    let off_m = (abs_off % 3600) / 60;
+    let s = format!(
+        "{} {} {:02} {:04} {:02}:{:02}:{:02} GMT{}{:02}{:02} (local)",
+        WEEKDAY_NAMES[dow],
+        MONTH_NAMES[(month - 1) as usize],
+        day,
+        year,
+        hour,
+        minute,
+        second,
+        sign,
+        off_h,
+        off_m
+    );
+    alloc_runtime_string(&s)
+}
+
 /// date.toDateString() — e.g. "Mon Jan 15 2024" (local time).
 #[no_mangle]
 pub extern "C" fn js_date_to_date_string(timestamp: f64) -> *mut crate::StringHeader {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return invalid_date_string();
     }
@@ -1063,6 +1171,7 @@ pub extern "C" fn js_date_to_date_string(timestamp: f64) -> *mut crate::StringHe
 /// date.toTimeString() — e.g. "12:30:45 GMT+0100 (local)" (local time).
 #[no_mangle]
 pub extern "C" fn js_date_to_time_string(timestamp: f64) -> *mut crate::StringHeader {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return invalid_date_string();
     }
@@ -1083,6 +1192,7 @@ pub extern "C" fn js_date_to_time_string(timestamp: f64) -> *mut crate::StringHe
 /// date.toLocaleDateString() — simple en-US-style date (local time).
 #[no_mangle]
 pub extern "C" fn js_date_to_locale_date_string(timestamp: f64) -> *mut crate::StringHeader {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return invalid_date_string();
     }
@@ -1096,6 +1206,7 @@ pub extern "C" fn js_date_to_locale_date_string(timestamp: f64) -> *mut crate::S
 /// date.toLocaleTimeString() — simple H:MM:SS AM/PM en-US style (local time).
 #[no_mangle]
 pub extern "C" fn js_date_to_locale_time_string(timestamp: f64) -> *mut crate::StringHeader {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return invalid_date_string();
     }
@@ -1173,6 +1284,7 @@ pub extern "C" fn js_number_to_locale_string(n: f64) -> *mut crate::StringHeader
 /// date.toLocaleString() — combined date and time (local time).
 #[no_mangle]
 pub extern "C" fn js_date_to_locale_string(timestamp: f64) -> *mut crate::StringHeader {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return invalid_date_string();
     }
@@ -1198,6 +1310,7 @@ pub extern "C" fn js_date_to_locale_string(timestamp: f64) -> *mut crate::String
 /// date.toJSON() — null for Invalid Date, otherwise the ISO string.
 #[no_mangle]
 pub extern "C" fn js_date_to_json(timestamp: f64) -> *mut crate::StringHeader {
+    let timestamp = date_cell_timestamp(timestamp);
     if timestamp.is_nan() {
         return std::ptr::null_mut();
     }

--- a/crates/perry-runtime/src/gc/types.rs
+++ b/crates/perry-runtime/src/gc/types.rs
@@ -38,7 +38,14 @@ pub const GC_TYPE_NATIVE_ARENA_OWNER: u8 = 13;
 pub const GC_TYPE_NATIVE_TYPED_VIEW: u8 = 14;
 pub const GC_TYPE_NATIVE_HANDLE: u8 = 15;
 pub const GC_TYPE_NATIVE_POD_VIEW: u8 = 16;
-pub const GC_TYPE_MAX: u8 = GC_TYPE_NATIVE_POD_VIEW;
+/// A 1-slot mutable `Date` cell (`DateCell { ts: f64 }`). Arena-allocated,
+/// non-movable (so a NaN-boxed pointer held in a plain f64/DOUBLE local
+/// never goes stale across a copying GC), pointer-free (the `ts` slot is a
+/// raw IEEE double, not a JSValue). Gives `Date` reference semantics so
+/// setter mutations propagate through aliasing / function / closure
+/// boundaries (#2089).
+pub const GC_TYPE_DATE_CELL: u8 = 17;
+pub const GC_TYPE_MAX: u8 = GC_TYPE_DATE_CELL;
 
 pub(super) const MALLOC_KIND_UNKNOWN_INDEX: usize = 0;
 pub(super) const MALLOC_KIND_BUCKET_COUNT: usize = GC_TYPE_MAX as usize + 1;
@@ -421,6 +428,26 @@ pub(super) static GC_TYPE_INFO_BY_ID: [Option<GcTypeInfo>; MALLOC_KIND_BUCKET_CO
         GcMoveHookKind::None,
         GcRewriteHookKind::None,
         GcFinalizeHookKind::NativePodView,
+    )),
+    Some(gc_type_info_entry(
+        GC_TYPE_DATE_CELL,
+        "date",
+        GcAllocationPolicy::Arena,
+        true,
+        GcRewriteDescriptorKind::Leaf,
+        GcLayoutSlotKind::None,
+        // Non-movable: a Date is referenced by a NaN-boxed pointer kept in a
+        // plain f64/DOUBLE local that codegen does NOT shadow-root. The
+        // conservative stack scan keeps it alive; keeping the address stable
+        // means that un-rooted pointer never goes stale across a GC move.
+        false,
+        GcExternalBytePolicy::None,
+        GcLargeObjectPolicy::NotApplicable,
+        // pointer_free: the single `ts` slot is a raw f64, never a JSValue.
+        true,
+        GcMoveHookKind::None,
+        GcRewriteHookKind::None,
+        GcFinalizeHookKind::None,
     )),
 ];
 

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -179,26 +179,9 @@ pub(crate) unsafe fn is_object_pointer(ptr: *const u8) -> bool {
 
 #[inline]
 pub(crate) unsafe fn write_number(buf: &mut String, value: f64) {
-    // Date — JSON.stringify must call toJSON/toISOString per ECMA-262
-    // 24.5.4.1. Perry stores Date as a raw f64 timestamp; the
-    // `DATE_REGISTRY` HashSet records which finite numbers came from a
-    // `new Date(...)`. Every numeric write that's actually a Date routes
-    // here as the last-resort fallback, so centralizing the check at
-    // this single funnel covers all template / fast-path / replacer
-    // sites without per-call-site changes. Guarded on "finite integer"
-    // first since the lookup involves a thread-local HashSet — only
-    // millisecond-shaped values can be Dates.
-    if value.is_finite() && value.fract() == 0.0 && value >= 0.0 && value < 1e16 {
-        if crate::date::is_registered_date_bits(value.to_bits()) {
-            let s_ptr = crate::date::js_date_to_iso_string(value);
-            if let Some(s) = str_from_header(s_ptr) {
-                write_escaped_string(buf, s);
-            } else {
-                buf.push_str("null");
-            }
-            return;
-        }
-    }
+    // #2089: a Date is now a NaN-boxed `DateCell` pointer, handled in
+    // `stringify_value`/`stringify_value_depth` before this numeric funnel —
+    // so no Date detection is needed here anymore.
     if value.is_nan() || value.is_infinite() {
         buf.push_str("null");
     } else if value.fract() == 0.0 && value.abs() < (i64::MAX as f64) {
@@ -522,6 +505,18 @@ pub(crate) unsafe fn stringify_value(value: f64, type_hint: u32, buf: &mut Strin
             buf.push_str("null");
             return;
         }
+        // #2089: a Date is a NaN-boxed `DateCell` pointer — emit `toJSON()`
+        // (ISO string, or `null` for an Invalid Date) per ECMA-262 25.5.2,
+        // before any object/array deref of the small cell.
+        if crate::date::is_date_cell_addr(ptr as usize) {
+            let s_ptr = crate::date::js_date_to_json(value);
+            if let Some(s) = str_from_header(s_ptr) {
+                write_escaped_string(buf, s);
+            } else {
+                buf.push_str("null");
+            }
+            return;
+        }
         if type_hint == TYPE_OBJECT {
             stringify_object(ptr, buf);
             return;
@@ -710,6 +705,19 @@ pub(crate) unsafe fn stringify_value_depth(
         // objects live far above this low-memory guard (matches gc_obj_type).
         if (ptr as usize) < 0x1000 {
             buf.push_str("null");
+            return;
+        }
+        // #2089: a Date is a NaN-boxed `DateCell` pointer. JSON.stringify must
+        // emit `toJSON()` → the ISO string (or `null` for an Invalid Date) per
+        // ECMA-262 25.5.2. Check before any object/array handling so the small
+        // cell is never deref'd as an `ObjectHeader`/`ArrayHeader`.
+        if crate::date::is_date_cell_addr(ptr as usize) {
+            let s_ptr = crate::date::js_date_to_json(value);
+            if let Some(s) = str_from_header(s_ptr) {
+                write_escaped_string(buf, s);
+            } else {
+                buf.push_str("null");
+            }
             return;
         }
         if type_hint == TYPE_OBJECT {
@@ -1352,7 +1360,11 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
     let template = if len >= 2 {
         let first_bits = (*elements).to_bits();
         let tag = first_bits & 0xFFFF_0000_0000_0000;
-        if tag == POINTER_TAG || is_raw_pointer(first_bits) {
+        if (tag == POINTER_TAG || is_raw_pointer(first_bits))
+            // #2089: a Date element is a small `DateCell`, not an object with a
+            // `keys_array` — don't build an object-shape template from it.
+            && !crate::date::is_date_cell_addr((first_bits & POINTER_MASK) as usize)
+        {
             build_shape_prefix_template(first_bits)
         } else {
             None
@@ -1425,6 +1437,17 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
             } else {
                 elem_bits as *const u8
             };
+            // #2089: a Date element → its toJSON() ISO string (or null),
+            // before any object/array deref of the small cell.
+            if crate::date::is_date_cell_addr(elem_ptr as usize) {
+                let s_ptr = crate::date::js_date_to_json(elem);
+                if let Some(s) = str_from_header(s_ptr) {
+                    write_escaped_string(buf, s);
+                } else {
+                    buf.push_str("null");
+                }
+                continue;
+            }
             // Issue #639: Buffer/Uint8Array detection BEFORE gc_obj_type — see
             // the matching branch in `stringify_value`.
             if crate::buffer::is_registered_buffer(elem_ptr as usize) {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -954,6 +954,40 @@ pub extern "C" fn js_object_get_field_by_name(
             return JSValue::undefined();
         }
     }
+    // #2089: a `Date` is a NaN-boxed pointer to an 8-byte `DateCell`. A
+    // generic property read on it (`date.constructor`, `date[k]`, a method
+    // read as a value) must NOT fall through to the object-deref path below —
+    // the cell is far smaller than an `ObjectHeader`, so reading its
+    // `keys_array`/field slots would deref unmapped memory. Resolve the few
+    // meaningful reads here and return `undefined` for everything else
+    // (matching property reads on the old value-type Date). `obj` may arrive
+    // NaN-boxed (top16 == 0x7FFD) or as a raw-I64 pointer (top16 == 0).
+    {
+        let bits = obj as u64;
+        let top16 = bits >> 48;
+        let addr = if top16 == 0x7FFD {
+            (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+        } else if top16 == 0 {
+            bits as usize
+        } else {
+            0
+        };
+        if addr != 0 && crate::date::is_date_cell_addr(addr) {
+            if !key.is_null() {
+                unsafe {
+                    let key_ptr =
+                        (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                    let key_len = (*key).byte_len as usize;
+                    let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
+                    if key_bytes == b"constructor" {
+                        let v = js_get_global_this_builtin_value(b"Date".as_ptr(), 4);
+                        return JSValue::from_bits(v.to_bits());
+                    }
+                }
+            }
+            return JSValue::undefined();
+        }
+    }
     // Issue #818 (Effect class-instance pattern): a V8 handle (JS_HANDLE_TAG
     // = 0x7FFB) reaches here when codegen routes a generic `PropertyGet`
     // through this slow path — e.g. `Effect.succeed(42).value` where the
@@ -1185,14 +1219,10 @@ pub extern "C" fn js_object_get_field_by_name(
     {
         let bits = obj as u64;
         let f = f64::from_bits(bits);
-        // Registered Date timestamps are also raw finite f64 — leave them to
-        // the existing Date handling (the `_f64` wrapper above already routed
-        // `date.constructor`), so this branch never changes Date behavior.
-        if !key.is_null()
-            && f.is_finite()
-            && (bits >> 48) != 0
-            && !crate::date::is_registered_date_bits(bits)
-        {
+        // A Date is now a NaN-boxed `DateCell` pointer (non-finite bit
+        // pattern), intercepted earlier in this function, so it never reaches
+        // this finite-number branch.
+        if !key.is_null() && f.is_finite() && (bits >> 48) != 0 {
             unsafe {
                 let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                 let name_len = (*key).byte_len as usize;
@@ -2262,26 +2292,10 @@ pub extern "C" fn js_object_get_field_by_name_f64(
     obj: *const ObjectHeader,
     key: *const crate::StringHeader,
 ) -> f64 {
-    // date-fns `constructFrom`: the parameter is statically Any so the
-    // codegen Date intercept doesn't fire here. Detect Date instances
-    // by their registered f64 bit pattern and route `.constructor` to
-    // the global Date constructor closure — same value the bare `Date`
-    // identifier produces, so `date instanceof Date` followed by `new
-    // date.constructor(value)` lands on the right factory inside
-    // `js_new_function_construct`.
-    if !key.is_null() {
-        let obj_bits = obj as u64;
-        if crate::date::is_registered_date_bits(obj_bits) {
-            unsafe {
-                let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-                let key_len = (*key).byte_len as usize;
-                let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
-                if key_bytes == b"constructor" {
-                    return js_get_global_this_builtin_value(b"Date".as_ptr(), 4);
-                }
-            }
-        }
-    }
+    // date-fns `constructFrom`: `new date.constructor(value)`. A Date is a
+    // NaN-boxed `DateCell` pointer (#2089); `js_object_get_field_by_name`
+    // routes `.constructor` to the global Date constructor closure and every
+    // other key to `undefined` without derefing the small cell as an object.
     let value = js_object_get_field_by_name(obj, key);
     f64::from_bits(value.bits())
 }

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -196,6 +196,26 @@ pub extern "C" fn js_object_set_field_by_name(
             return;
         }
     }
+    // #2089: a `Date` is a NaN-boxed pointer to an 8-byte `DateCell`. Setting
+    // an arbitrary property on it (`date.foo = x`) must NOT deref the small
+    // cell as an `ObjectHeader` below (memory corruption). Perry doesn't model
+    // expando properties on Date objects, so treat it as a no-op — the same
+    // observable result as the old value-type representation (a property set
+    // on a primitive number).
+    {
+        let bits = obj as u64;
+        let top16 = bits >> 48;
+        let addr = if top16 == 0x7FFD {
+            (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+        } else if top16 == 0 {
+            bits as usize
+        } else {
+            0
+        };
+        if addr != 0 && crate::date::is_date_cell_addr(addr) {
+            return;
+        }
+    }
     // Strip NaN-boxing tags if present (defensive: handle POINTER_TAG, UNDEFINED, NULL, etc.)
     let obj = {
         let bits = obj as u64;

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -221,22 +221,11 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
     const CLASS_ID_MAP: u32 = 0xFFFF0022;
     const CLASS_ID_SET: u32 = 0xFFFF0023;
     if class_id == CLASS_ID_DATE {
-        // A Perry Date is a raw f64 timestamp (no NaN-box tag, real f64).
-        // Distinguishing it from a regular number requires a side-channel:
-        // `js_date_new(...)` registers the f64 bits in DATE_REGISTRY, and
-        // here we consult that registry. Without the registry, every finite
-        // number would match (the prior "approximate" rule), which made
-        // `100 instanceof Date` true and broke the BSON encoder's typed
-        // dispatch (`if (value instanceof Date) … else if (typeof v === 'number') …`).
-        //
-        // The Invalid-Date sentinel is itself a NaN, so it must be matched
-        // *before* the `!is_nan()` guard — `new Date(NaN) instanceof Date`
-        // is `true` per ECMA-262 even though its time value is NaN.
-        if value.to_bits() == crate::date::DATE_NAN_BITS
-            || (!value.is_nan()
-                && value.is_finite()
-                && crate::date::is_registered_date_bits(value.to_bits()))
-        {
+        // A Perry Date is a NaN-boxed pointer to a `DateCell` (#2089). Its
+        // identity is the cell's `GcHeader` type, so `new Date(NaN)` (an
+        // Invalid Date — a cell whose time value is NaN) matches just like
+        // any other Date, and a plain number never matches.
+        if crate::date::is_date_value(value) {
             return true_val;
         }
         return false_val;
@@ -278,14 +267,8 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
     const CLASS_ID_OBJECT: u32 = 0xFFFF0050;
     if class_id == CLASS_ID_OBJECT {
         if jsval.is_pointer() {
-            return true_val;
-        }
-        // Invalid Date is still an Object (NaN time value, but a Date).
-        if value.to_bits() == crate::date::DATE_NAN_BITS
-            || (!value.is_nan()
-                && value.is_finite()
-                && crate::date::is_registered_date_bits(value.to_bits()))
-        {
+            // Covers every heap object, including a Date (now a NaN-boxed
+            // `DateCell` pointer — #2089) and an Invalid Date.
             return true_val;
         }
         let top16 = (bits >> 48) as u16;

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -999,9 +999,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("util.types", "isProxy") => crate::object::js_util_types_is_proxy(arg(0)),
         ("util.types", "isSet") => bool_tag(crate::set::is_registered_set(ptr_addr(arg(0)))),
         ("util.types", "isSetIterator") => crate::object::js_util_types_is_set_iterator(arg(0)),
-        ("util.types", "isDate") => {
-            bool_tag(crate::date::is_registered_date_bits(arg(0).to_bits()))
-        }
+        ("util.types", "isDate") => bool_tag(crate::date::is_date_value(arg(0))),
         ("util.types", "isRegExp") => {
             let v = JSValue::from_bits(arg(0).to_bits());
             bool_tag(v.is_pointer() && crate::regex::is_regex_pointer(v.as_pointer::<u8>()))
@@ -1058,9 +1056,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("util/types", "isProxy") => crate::object::js_util_types_is_proxy(arg(0)),
         ("util/types", "isSet") => bool_tag(crate::set::is_registered_set(ptr_addr(arg(0)))),
         ("util/types", "isSetIterator") => crate::object::js_util_types_is_set_iterator(arg(0)),
-        ("util/types", "isDate") => {
-            bool_tag(crate::date::is_registered_date_bits(arg(0).to_bits()))
-        }
+        ("util/types", "isDate") => bool_tag(crate::date::is_date_value(arg(0))),
         ("util/types", "isRegExp") => {
             let v = JSValue::from_bits(arg(0).to_bits());
             bool_tag(v.is_pointer() && crate::regex::is_regex_pointer(v.as_pointer::<u8>()))

--- a/crates/perry-runtime/src/object/util_types.rs
+++ b/crates/perry-runtime/src/object/util_types.rs
@@ -153,7 +153,7 @@ pub extern "C" fn js_util_types_is_set(value: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_util_types_is_date(value: f64) -> f64 {
-    nanbox_bool(crate::date::is_registered_date_bits(value.to_bits()))
+    nanbox_bool(crate::date::is_date_value(value))
 }
 
 #[no_mangle]

--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -521,7 +521,7 @@ pub extern "C" fn js_assimilate_thenable(value: f64) -> f64 {
         || crate::map::is_registered_map(raw_ptr)
         || crate::symbol::is_registered_symbol(raw_ptr)
         || crate::regex::is_regex_pointer(raw_ptr as *const u8)
-        || crate::date::is_registered_date_bits(bits)
+        || crate::date::is_date_cell_addr(raw_ptr)
     {
         return value;
     }

--- a/crates/perry-runtime/src/thread.rs
+++ b/crates/perry-runtime/src/thread.rs
@@ -247,6 +247,12 @@ pub(crate) enum SerializedValue {
 
     /// A BigInt: 16 x u64 limbs in little-endian order.
     BigInt([u64; BIGINT_LIMBS]),
+
+    /// A Date: its millisecond timestamp (may be NaN for an Invalid Date).
+    /// Re-allocated as a fresh `DateCell` on the receiving thread (#2089) —
+    /// deep-copy semantics, since the source cell's pointer is meaningless in
+    /// another thread's arena.
+    Date(f64),
 }
 
 // Safety: SerializedValue contains no raw pointers to arena memory.
@@ -325,6 +331,11 @@ pub(crate) unsafe fn serialize_nanbox_for_thread(bits: u64) -> SerializedValue {
             }
             gc::GC_TYPE_CLOSURE => {
                 return serialize_closure(raw_ptr as *const ClosureHeader);
+            }
+            gc::GC_TYPE_DATE_CELL => {
+                // #2089: copy the timestamp; the receiving thread re-allocates
+                // a fresh cell (deep-copy, like every other crossed value).
+                return SerializedValue::Date((*(raw_ptr as *const crate::date::DateCell)).ts);
             }
             _ => {
                 // Unknown pointer type — treat as undefined
@@ -585,6 +596,11 @@ pub(crate) unsafe fn deserialize_nanbox_on_current_thread(sv: &SerializedValue) 
             let ptr = bigint::bigint_alloc_with_limbs(*limbs);
             // NaN-box with BIGINT_TAG
             BIGINT_TAG | (ptr as u64 & POINTER_MASK)
+        }
+
+        SerializedValue::Date(ts) => {
+            // #2089: allocate a fresh DateCell in THIS thread's arena.
+            crate::date::alloc_date_cell(*ts).to_bits()
         }
     }
 }

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -231,6 +231,14 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
             if primitive.to_bits() != value.to_bits() {
                 return js_jsvalue_to_string(primitive);
             }
+            // #2089: a Date is a NaN-boxed `DateCell` pointer. `String(date)`,
+            // `` `${date}` ``, and `date.toString()` produce the full local
+            // date string (or "Invalid Date"), not "[object Object]". Detect
+            // before any GC-header object dispatch (the 8-byte cell is smaller
+            // than an ObjectHeader).
+            if crate::date::is_date_cell_addr(ptr as usize) {
+                return crate::date::js_date_to_string(value);
+            }
             // Buffers: BufferHeader has no GC header, so we must detect via
             // BUFFER_REGISTRY before computing gc_header (which would read
             // garbage one word before the buffer). `Buffer.toString()` with

--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -513,7 +513,7 @@ fn querystring_scalar_to_string(value_bits: u64) -> String {
     if value.is_undefined() || value.is_null() {
         return String::new();
     }
-    if perry_runtime::date::is_registered_date_bits(value_bits) {
+    if perry_runtime::date::is_date_value(f64::from_bits(value_bits)) {
         return String::new();
     }
     if value.is_bool() {

--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -106,6 +106,13 @@ crates/perry-runtime/src/object/class_registry.rs
 # Crossed the limit at 2014 LOC after the #2135 worker_threads
 # value-export arm. Split tracked under #1435.
 crates/perry-runtime/src/object/native_module.rs
+# console.log / util.inspect value formatter (two big per-tag dispatch
+# towers: format_jsvalue + format_jsvalue_for_json). main had already
+# grown it to 1999 LOC; the #2089 Date-as-reference-type inspect arms
+# (a DateCell pointer must render as its ISO string, not be deref'd as an
+# ObjectHeader) tipped it over. Splitting the two towers into sibling
+# modules is tracked under #1435.
+crates/perry-runtime/src/builtins/formatting.rs
 EOF
 )
 

--- a/test-files/test_issue_2089_date_reference.ts
+++ b/test-files/test_issue_2089_date_reference.ts
@@ -1,0 +1,65 @@
+// Issue #2089 — Date is a reference type: setter mutations must propagate
+// through aliasing / function / closure boundaries (this is what made effect's
+// DateTime.add a no-op). Pre-fix Perry modeled Date as a value-type f64, so
+// each binding held an independent copy and mutations didn't propagate.
+
+// Alias — `const b = a` is the same object in JS.
+const a = new Date(1704067200000);
+const b = a;
+b.setUTCDate(b.getUTCDate() + 1);
+console.log(a.getTime() - 1704067200000); // 86400000
+console.log(b.getTime() - 1704067200000); // 86400000
+
+// Mutation through a function parameter.
+function bump(d: Date) {
+  d.setUTCDate(d.getUTCDate() + 1);
+}
+const c = new Date(1704067200000);
+bump(c);
+console.log(c.getTime() - 1704067200000); // 86400000
+
+// Mutation through a closure parameter (the effect mutate(self, f) shape).
+function mutate(self: Date, f: (d: Date) => void): Date {
+  f(self);
+  return self;
+}
+const e = new Date(1704067200000);
+mutate(e, (d) => { d.setUTCDate(d.getUTCDate() + 1); });
+console.log(e.getTime() - 1704067200000); // 86400000
+
+// Function-local Date passed to a mutating fn.
+function addDay(): number {
+  const local = new Date(1704067200000);
+  bump(local);
+  return local.getTime() - 1704067200000;
+}
+console.log(addDay()); // 86400000
+
+// effect DateTime.add shape: clone, mutate the clone via a closure, read back;
+// the original stays untouched.
+const addDuration = (self: Date, days: number): Date =>
+  mutate(new Date(self.getTime()), (date) => {
+    date.setUTCDate(date.getUTCDate() + days);
+  });
+const base = new Date(1704067200000);
+const next = addDuration(base, 1);
+console.log(next.getTime() - base.getTime()); // 86400000
+console.log(base.getTime() - 1704067200000);  // 0
+
+// Reference identity: distinct objects with the same time are NOT ===.
+console.log(new Date(0) === new Date(0)); // false
+const x = new Date(0);
+console.log(x === x);                      // true
+
+// The rest of the Date surface stays intact.
+const d = new Date(1704067200000);
+console.log(typeof d);            // object
+console.log(d instanceof Date);   // true
+console.log(+d);                  // 1704067200000
+console.log(d < next);            // true
+console.log(JSON.stringify(d));   // "2024-01-01T00:00:00.000Z"
+console.log(JSON.stringify([d])); // ["2024-01-01T00:00:00.000Z"]
+const inv = new Date(NaN);
+console.log(inv instanceof Date); // true
+console.log(inv.toString());      // Invalid Date
+console.log(JSON.stringify(inv)); // null


### PR DESCRIPTION
## Summary

Fixes #2089. Perry modeled `Date` as a **value type** (a raw NaN-boxed f64 timestamp), so mutating a `Date` through any aliasing boundary — `const b = a`, a function parameter, or a closure parameter — did not propagate back, because each binding held an independent copy. This made effect's `DateTime.add(d, { days: 1 })` a no-op (it mutates a Date inside a closure and reads it back).

This promotes `Date` to a **reference type**: a NaN-boxed POINTER to a 1-slot mutable `DateCell { ts: f64 }`, so all aliases / params / closures share state.

## Approach

The representation lives in `crates/perry-runtime/src/date.rs`:

- **`DateCell` = `GC_TYPE_DATE_CELL`, arena-allocated, non-movable, pointer-free.** The conservative stack scan already masks NaN-boxed `POINTER_TAG` values in plain f64/DOUBLE locals, so cells stay alive without shadow-rooting; non-movable means the address is stable, so an un-shadow-rooted pointer in a DOUBLE local never goes stale across a GC; pointer-free means the `ts` store needs no write barrier. Net effect: **no codegen escape-analysis churn, and no leak** (cells are swept when unreachable). Date-producing exprs stay typed `DOUBLE` in codegen.
- Identity is `is_date_cell_addr(addr)` reading the `GcHeader.obj_type` — exact, no side-table registry.
- Constructors allocate cells; getters dereference; setters mutate in place and return the numeric ms. The HIR `LocalSet` setter writeback hack is dropped.

Consumers updated so the 8-byte cell is never dereferenced as an `ObjectHeader`:

- `instanceof` / `typeof` / `util.types.isDate` / `date.constructor`
- numeric coercion (`+date`, `date - date2`, `Number(date)`) via `js_number_coerce`
- relational `<` / `>` / `<=` / `>=` — codegen coercion hook (`js_date_coerce_number`) gated to non-statically-numeric operands so plain-number comparisons keep their bare `fcmp`
- `JSON.stringify` (value / object-field / array / shape-template paths)
- `String(date)` / `` `${date}` `` / `date.toString()` via new `js_date_to_string` + a `DateToString` HIR variant (gated to statically-Date receivers so it never hijacks `bigint.toString()` / `urlSearchParams.toString()`)
- `console.log` / `util.inspect` formatting
- field get/set guards, thenable skip, and cross-thread serialization (`SerializedValue::Date`)

`===` is already correct via `js_eq` bit comparison — that now gives JS-correct reference identity (distinct Date objects with the same time are `!==`).

## Validation

Byte-for-byte against `node --experimental-strip-types`:

- the issue repro (alias / fn-param / closure mutation propagation)
- the effect `DateTime.add` shape (mutate-clone-via-closure and mutate-in-place)
- the full Date matrix: `typeof`, `instanceof`, `+date`, `getTime`, `date - date2`, `date < date2`, `toISOString`, `JSON.stringify` (date / object / array), `Date.parse`, Invalid Date, getters/setters, reference identity

Existing Date tests stay green (`test_gap_date_methods`, `test_issue_1187_date_setters`, `test_issue_748_invalid_date`, `test_compat_url_date_math`). `cargo test` for the Date module, the GC type-metadata test, and all `perry-hir` tests pass; formatting is clean.

Adds `test-files/test_issue_2089_date_reference.ts`.

Refs #321.

## Note for the maintainer

Per the worktree convention this PR does **not** bump `Cargo.toml` / `CLAUDE.md` version or add a `CHANGELOG.md` entry — please fold those in at merge.

One intentionally-unaddressed edge: `date == number` loose equality now returns `false` (Node: `true`); the old value-type rep matched by coercion. It's an obscure pattern and out of scope here — happy to follow up if desired.
