### PR TITLE
Fix fs.promises FileHandle path-like operations

### DIFF
--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -12,7 +12,7 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::closure::ClosureHeader;
 use crate::string::{js_string_from_bytes, StringHeader};
-use crate::value::POINTER_MASK;
+use crate::value::{POINTER_MASK, POINTER_TAG};
 
 mod callbacks;
 pub use callbacks::*;
@@ -52,6 +52,18 @@ pub(crate) fn fd_is_registered(fd: i32) -> bool {
     FD_REGISTRY.with(|r| r.borrow().contains_key(&fd))
 }
 
+pub(crate) fn filehandle_object_fd(value: f64) -> Option<i32> {
+    let bits = value.to_bits();
+    if (bits & !POINTER_MASK) != POINTER_TAG {
+        return None;
+    }
+    let addr = (bits & POINTER_MASK) as usize;
+    if addr < 0x1000 {
+        return None;
+    }
+    FILEHANDLE_OBJECT_FDS.with(|fds| fds.borrow().get(&addr).copied())
+}
+
 struct DirState {
     entries: Vec<f64>,
     index: usize,
@@ -80,6 +92,9 @@ fn numeric_fd_value(value: f64) -> Option<i32> {
     if value.is_finite() && value >= 0.0 && value <= i32::MAX as f64 {
         Some(value as i32)
     } else {
+        if let Some(fd) = filehandle_object_fd(value) {
+            return Some(fd);
+        }
         unsafe {
             let bits = value.to_bits();
             let addr = if (bits >> 48) >= 0x7FF8 {
@@ -87,9 +102,6 @@ fn numeric_fd_value(value: f64) -> Option<i32> {
             } else {
                 bits as usize
             };
-            if let Some(fd) = FILEHANDLE_OBJECT_FDS.with(|fds| fds.borrow().get(&addr).copied()) {
-                return Some(fd);
-            }
             if crate::buffer::js_buffer_is_buffer(value.to_bits() as i64) == 1
                 || !extract_string_ptr(value).is_null()
             {

--- a/crates/perry-runtime/src/fs/validate.rs
+++ b/crates/perry-runtime/src/fs/validate.rs
@@ -142,6 +142,12 @@ pub(crate) fn validate_path_or_fd(arg_name: &str, value: f64, syscall: &'static 
     if is_path_like(value) {
         return;
     }
+    if let Some(fd) = crate::fs::filehandle_object_fd(value) {
+        if !crate::fs::fd_is_registered(fd) {
+            throw_ebadf(syscall);
+        }
+        return;
+    }
     let jv = JSValue::from_bits(value.to_bits());
     if is_numeric(jv) {
         // A numeric first argument is a file descriptor. Perry's readers and


### PR DESCRIPTION
## Summary
- Accept Perry fs.promises FileHandle objects in fs path-or-fd validation by resolving the registered FileHandle object pointer to its fd.
- Reuse that explicit FileHandle registry lookup in fd extraction while keeping arbitrary objects rejected by validation.

## DeepWiki
- Attempted DeepWiki for Node fs.promises FileHandle path-like behavior, but the MCP request timed out after 60s. Used official Node fs docs/source behavior as fallback: readFile, writeFile, and appendFile accept FileHandle objects.

## Verification
- Baseline exact `node-suite/fs-promises/basic/filehandle-as-pathlike` failed, report `test-parity/reports/parity_report_20260528_221927.json`.
- `./run_parity_tests.sh --suite node-suite --module fs-promises --filter filehandle-as-pathlike` PASS, report `test-parity/reports/parity_report_20260528_222146.json`.
- `./run_parity_tests.sh --suite node-suite --module fs-promises` PASS 57/0, report `test-parity/reports/parity_report_20260528_222232.json`.
- `cargo check -p perry-runtime` PASS with existing warnings.
- `cargo fmt --check` PASS.
- `git diff --check` PASS.
- `git diff --cached --check` PASS.