### PR TITLE
fix(string): String.prototype.lastIndexOf accepts optional position arg (was a compile error) (#800)

### DIFF
--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -344,21 +344,42 @@ pub(crate) fn lower_string_method(
             ))
         }
         "lastIndexOf" => {
-            if args.len() != 1 {
+            if args.is_empty() || args.len() > 2 {
                 bail!(
-                    "perry-codegen: String.lastIndexOf expects 1 arg, got {}",
+                    "perry-codegen: String.lastIndexOf expects 1 or 2 args, got {}",
                     args.len()
                 );
             }
             let needle_box = lower_expr(ctx, &args[0])?;
+            // Optional `position` (2nd arg). Without it, use the plain
+            // last-index-of (search to the end); with it, the position-aware
+            // variant. Mirrors the `indexOf` arm.
+            let pos_double = if args.len() == 2 {
+                Some(lower_expr(ctx, &args[1])?)
+            } else {
+                None
+            };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
             let needle_handle = unbox_str_handle(blk, &needle_box);
-            let i32_v = blk.call(
-                I32,
-                "js_string_last_index_of",
-                &[(I64, &recv_handle), (I64, &needle_handle)],
-            );
+            let i32_v = if let Some(pos_d) = pos_double {
+                blk.call(
+                    I32,
+                    "js_string_last_index_of_from",
+                    &[
+                        (I64, &recv_handle),
+                        (I64, &needle_handle),
+                        (DOUBLE, &pos_d),
+                        (I32, "1"),
+                    ],
+                )
+            } else {
+                blk.call(
+                    I32,
+                    "js_string_last_index_of",
+                    &[(I64, &recv_handle), (I64, &needle_handle)],
+                )
+            };
             Ok(blk.sitofp(I32, &i32_v, DOUBLE))
         }
         "padStart" | "padEnd" => {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1167,6 +1167,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_string_from_char_code", I64, &[I32]);
     module.declare_function("js_string_char_code_at", DOUBLE, &[I64, I32]);
     module.declare_function("js_string_last_index_of", I32, &[I64, I64]);
+    module.declare_function(
+        "js_string_last_index_of_from",
+        I32,
+        &[I64, I64, DOUBLE, I32],
+    );
     module.declare_function("js_string_locale_compare", DOUBLE, &[I64, I64]);
     module.declare_function("js_string_normalize", I64, &[I64, I64]);
     module.declare_function("js_string_pad_start", I64, &[I64, DOUBLE, I64]);

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -793,7 +793,13 @@ pub unsafe extern "C" fn js_native_call_method(
                             f64::from_bits(JSValue::bool(i >= 0).bits())
                         }
                         "lastIndexOf" => {
-                            crate::string::js_string_last_index_of(s_ptr, needle) as f64
+                            if args_len >= 2 {
+                                let pos = unsafe { *args_ptr.add(1) };
+                                crate::string::js_string_last_index_of_from(s_ptr, needle, pos, 1)
+                                    as f64
+                            } else {
+                                crate::string::js_string_last_index_of(s_ptr, needle) as f64
+                            }
                         }
                         "startsWith" => {
                             let at = if args_len >= 2 { arg_i32(1) } else { 0 };

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -69,9 +69,9 @@ pub use intern::{js_string_intern, scan_intern_table_roots, scan_intern_table_ro
 pub use io::{js_string_error, js_string_print, js_string_warn};
 pub use pad::{js_string_alloc_space, js_string_pad_end, js_string_pad_start, js_string_repeat};
 pub use slice_ops::{
-    js_string_index_of, js_string_index_of_from, js_string_last_index_of, js_string_slice,
-    js_string_substring, js_string_to_lower_case, js_string_to_upper_case, js_string_trim,
-    js_string_trim_end, js_string_trim_start,
+    js_string_index_of, js_string_index_of_from, js_string_last_index_of,
+    js_string_last_index_of_from, js_string_slice, js_string_substring, js_string_to_lower_case,
+    js_string_to_upper_case, js_string_trim, js_string_trim_end, js_string_trim_start,
 };
 pub use split::{js_string_split, js_string_split_n};
 

--- a/crates/perry-runtime/src/string/slice_ops.rs
+++ b/crates/perry-runtime/src/string/slice_ops.rs
@@ -268,3 +268,49 @@ pub extern "C" fn js_string_last_index_of(
         None => -1,
     }
 }
+
+/// `String.prototype.lastIndexOf(searchString, position)` (ECMA-262 §22.1.3.9):
+/// the highest match-start index `<= position` (UTF-16 units), or -1.
+/// `has_pos == 0` means no `position` argument (defaults to +Infinity, i.e.
+/// search the whole string) and delegates to the fast `js_string_last_index_of`.
+/// `position` is `ToIntegerOrInfinity`-clamped to `[0, length]`; `NaN` → end.
+#[no_mangle]
+pub extern "C" fn js_string_last_index_of_from(
+    haystack: *const StringHeader,
+    needle: *const StringHeader,
+    position: f64,
+    has_pos: i32,
+) -> i32 {
+    if has_pos == 0 {
+        return js_string_last_index_of(haystack, needle);
+    }
+    if !is_valid_string_ptr(haystack) {
+        return -1;
+    }
+    let hlen16 = unsafe { (*haystack).utf16_len as i64 };
+    // ToIntegerOrInfinity(position), clamped to [0, length]. NaN → search end.
+    let pos16: i64 = if position.is_nan() || position >= hlen16 as f64 {
+        hlen16
+    } else if position <= 0.0 {
+        0
+    } else {
+        position as i64
+    };
+    if !is_valid_string_ptr(needle) || unsafe { (*needle).byte_len } == 0 {
+        // Empty needle matches at every position; the answer is min(pos, len).
+        return pos16 as i32;
+    }
+    // Walk matches in ascending UTF-16 order; keep the highest start <= pos16.
+    let h = string_as_str(haystack);
+    let n = string_as_str(needle);
+    let mut best: i32 = -1;
+    for (byte_pos, _) in h.match_indices(n) {
+        let u16idx = byte_offset_to_utf16_index(h, byte_pos) as i64;
+        if u16idx <= pos16 {
+            best = u16idx as i32;
+        } else {
+            break; // ascending — no later match can satisfy <= pos16
+        }
+    }
+    best
+}

--- a/crates/perry-runtime/src/string/tests.rs
+++ b/crates/perry-runtime/src/string/tests.rs
@@ -150,6 +150,26 @@ fn test_string_index_of() {
 }
 
 #[test]
+fn test_string_last_index_of_from() {
+    let s = js_string_from_bytes(b"abcabc".as_ptr(), 6);
+    let c = js_string_from_bytes(b"c".as_ptr(), 1);
+    // has_pos == 0 → search to the end (same as plain lastIndexOf).
+    assert_eq!(js_string_last_index_of_from(s, c, 0.0, 0), 5);
+    // Explicit position bounds the match start.
+    assert_eq!(js_string_last_index_of_from(s, c, 3.0, 1), 2);
+    assert_eq!(js_string_last_index_of_from(s, c, 0.0, 1), -1); // no 'c' at/before 0
+    assert_eq!(js_string_last_index_of_from(s, c, 100.0, 1), 5); // clamp to end
+    assert_eq!(js_string_last_index_of_from(s, c, -5.0, 1), -1); // negative → 0
+                                                                 // Not found.
+    let z = js_string_from_bytes(b"z".as_ptr(), 1);
+    assert_eq!(js_string_last_index_of_from(s, z, 100.0, 1), -1);
+    // Empty needle → min(position, length).
+    let empty = js_string_from_bytes(b"".as_ptr(), 0);
+    assert_eq!(js_string_last_index_of_from(s, empty, 2.0, 1), 2);
+    assert_eq!(js_string_last_index_of_from(s, empty, 100.0, 1), 6);
+}
+
+#[test]
 fn test_string_split() {
     use crate::array::{js_array_get_f64, js_array_length};
 


### PR DESCRIPTION
Part of #800 (Node core parity).

## Problem

`"abcabc".lastIndexOf("c", 3)` — the 2-argument form of `String.prototype.lastIndexOf` — **failed to compile**:

```
perry-codegen: String.lastIndexOf expects 1 arg, got 2
```

The codegen arm hard-rejected a 2nd argument (so any program using `str.lastIndexOf(x, position)` wouldn't build), and the runtime had no position-aware variant. (The 1-arg form worked.)

## Fix

- **Runtime** `js_string_last_index_of_from(haystack, needle, position, has_pos)` (`string/slice_ops.rs`): returns the highest match-start index `<= position` in UTF-16 units. ECMA-262 §22.1.3.9 `ToIntegerOrInfinity` clamping — `NaN`/absent → search to end, negative → 0, out-of-range → length; empty needle → `min(position, length)`. Handles ASCII and non-ASCII. `has_pos == 0` delegates to the fast `js_string_last_index_of`.
- **Codegen**: the `lastIndexOf` arm now lowers 1–2 args (mirrors `indexOf`) + extern declaration.
- **Runtime dynamic dispatch** (`native_call_method`) honors `position` for the variable-method-name path.

## Validation

Byte-for-byte vs `node`: position in-range / `0` / negative / out-of-range, not-found, empty needle (with/without position), non-ASCII (`"café".lastIndexOf("é")`), and the dynamic `(s as any)[m]("c", 3)` receiver. + a runtime unit test (`test_string_last_index_of_from`).
