### PR TITLE
Fix crypto secureHeapUsed disabled defaults

### DIFF
--- a/crates/perry-stdlib/src/crypto/kdf.rs
+++ b/crates/perry-stdlib/src/crypto/kdf.rs
@@ -403,8 +403,8 @@ pub unsafe extern "C" fn js_crypto_secure_heap_used() -> *mut ObjectHeader {
     }
     set_object_value_field(obj, b"total", 0.0);
     set_object_value_field(obj, b"used", 0.0);
-    set_object_value_field(obj, b"utilization", 0.0);
-    set_object_value_field(obj, b"min", 0.0);
+    set_object_value_field(obj, b"utilization", f64::NAN);
+    set_object_value_field(obj, b"min", 2.0);
     obj
 }
 


### PR DESCRIPTION
## Summary
- Align `crypto.secureHeapUsed()` with Node's disabled secure-heap observable shape.
- Keep `total` and `used` at `0`, but return `utilization: NaN` and `min: 2` like Node when no secure heap is enabled.

## DeepWiki
- Attempted DeepWiki for Node `crypto.secureHeapUsed()` defaults, but the MCP request timed out after 90s and produced no markdown file.
- Fallback: direct Node fixture output plus official Node docs for `crypto.secureHeapUsed()` and `--secure-heap-min` behavior.

## Verification
- Baseline full `node-suite/crypto`: 197 PASS / 1 parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260528_222736.json`.
- Baseline exact `node-suite/crypto/inventory/secure-heap-used` FAIL, report `test-parity/reports/parity_report_20260528_223200.json`.
- `./run_parity_tests.sh --suite node-suite --module crypto --filter secure-heap-used` PASS, report `test-parity/reports/parity_report_20260528_223634.json`.
- `./run_parity_tests.sh --suite node-suite --module crypto` PASS 198/0, report `test-parity/reports/parity_report_20260528_223655.json`.
- `cargo check -p perry-stdlib` PASS with existing warnings.
- `cargo fmt --check` PASS.
- `git diff --check` PASS.
- `git diff --cached --check` PASS.

## Non-goals
- No secure heap allocation implementation.
- No crypto API inventory expansion.
- No OpenSSL secure heap flag parsing changes.