### PR TITLE
test(date): regression coverage for console.log(new Date(NaN)) (#2371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1035 — regression test: console.log(new Date(NaN)) → `Invalid Date` (#2371)
+
+Adds `test-files/test_gap_2371_console_invalid_date.ts`, locking in correct
+output for `console.log(new Date(NaN))` (`Invalid Date`, not `NaN`) across
+top-level inline/variable forms, invalid-via-string, nested array/object,
+a genuine numeric `NaN` (must still print `NaN`), and valid dates. Output is
+byte-identical to `node --experimental-strip-types`.
+
+`#2371` was the last symptom of the old f64-timestamp Date model: the
+Invalid-Date sentinel was a quiet NaN (`0x7FF8_0000_0000_0DA7`) whose payload
+got canonicalized to `f64::NAN` when `console.log` bundled its argument into a
+fresh `RawF64`-numeric array (`js_array_push_f64` → `canonical_raw_f64`),
+leaving the formatter unable to tell a Date-NaN from a bare numeric NaN. The
+reference-type Date rework in `#2089` (Date is now a NaN-boxed pointer to a
+`GC_TYPE_DATE_CELL`, never a raw numeric slot) removed that path and fixed the
+behavior; this commit adds the regression coverage so it can't silently
+return.
+
 ## v0.5.1034 — Number()/unary-+ applies ToPrimitive→ToString to arrays/objects (#2378)
 
 `Number(value)` (and unary `+`) returned `NaN` for every array and object

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1034
+**Current Version:** 0.5.1035
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4880,7 +4880,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "anyhow",
  "base64",
@@ -4935,14 +4935,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "cc",
  "libc",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "anyhow",
  "log",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "anyhow",
  "base64",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "serde",
  "serde_json",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1034"
+version = "0.5.1035"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "anyhow",
  "clap",
@@ -5056,14 +5056,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "chrono",
  "cron",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5162,14 +5162,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "base64",
  "image",
@@ -5354,14 +5354,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5388,7 +5388,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "brotli",
  "flate2",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "anyhow",
  "base64",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5571,14 +5571,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "base64",
  "itoa",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "base64",
  "block2",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "base64",
  "block2",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1034"
+version = "0.5.1035"
 
 [[package]]
 name = "perry-ui-test"
@@ -5667,11 +5667,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1034"
+version = "0.5.1035"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "base64",
  "block2",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "base64",
  "block2",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "block2",
  "libc",
@@ -5716,7 +5716,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "base64",
  "libc",
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1034"
+version = "0.5.1035"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1034"
+version = "0.5.1035"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/test-files/test_gap_2371_console_invalid_date.ts
+++ b/test-files/test_gap_2371_console_invalid_date.ts
@@ -1,0 +1,27 @@
+// Issue #2371 — `console.log(new Date(NaN))` must print `Invalid Date`, not
+// `NaN`. The Invalid-Date sentinel is a quiet NaN carrying a payload that
+// marks it as a Date; bundling the value into console.log's argument array
+// used to canonicalize the NaN (stripping the payload) so the formatter could
+// no longer tell it apart from a bare numeric NaN. These all compare
+// byte-for-byte against `node --experimental-strip-types`.
+
+// top-level, inline
+console.log(new Date(NaN));
+// top-level, via a variable (same value path as instanceof, which already worked)
+const d = new Date(NaN);
+console.log(d);
+// invalid via unparseable string
+console.log(new Date("not a date"));
+
+// nested forms (already correct — guard against regression)
+console.log([new Date(NaN)]);
+console.log({ d: new Date(NaN) });
+
+// a real numeric NaN must still print NaN
+console.log(NaN);
+console.log([NaN]);
+
+// valid dates must be unaffected
+console.log(new Date(0));
+const v = new Date(0);
+console.log(v);


### PR DESCRIPTION
## Summary

Regression coverage for #2371 — `console.log(new Date(NaN))` printing `NaN` instead of `Invalid Date`.

**The underlying bug is already fixed on `main` by #2089** (Date modeled as a reference type — a NaN-boxed pointer to a `GC_TYPE_DATE_CELL`, never a raw numeric slot). This PR lands the regression test so the behavior can't silently return.

## Why it was broken (old model)

Under the old f64-timestamp Date model, the Invalid-Date sentinel was a quiet NaN (`0x7FF8_0000_0000_0DA7`) whose mantissa payload marked it as a Date. `console.log` bundles its argument into a fresh array, which `js_array_alloc` marks `RawF64`-numeric, so `js_array_push_f64` → `canonical_raw_f64` collapsed the NaN to `f64::NAN` and stripped the payload — leaving `format_jsvalue`/`date_inspect` unable to distinguish a Date-NaN from a bare numeric NaN. (Nested `new Date(NaN)` in arrays/objects already worked because those slots hold a pointer.) The reference-type rework in #2089 removed the raw-numeric path entirely.

## Test

`test-files/test_gap_2371_console_invalid_date.ts` — byte-identical to `node --experimental-strip-types`, covering:
- top-level inline + variable `console.log(new Date(NaN))` → `Invalid Date`
- invalid-via-string `new Date("not a date")`
- nested array / object forms
- a genuine numeric `NaN` (must still print `NaN`) and `[NaN]`
- valid dates (`new Date(0)`) unaffected

Verified locally on the rebased base; `cargo fmt --all -- --check` clean.
