### PR TITLE
fix(ci): repair main drift — fmt, stream.unshift manifest row, regen API docs

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2571,6 +2571,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // #1539: push() backpressure return + readable/writableHighWaterMark
     // property getters on typed stream instances.
     method("stream", "push", true, None),
+    method("stream", "unshift", true, None),
     method("stream", "readableFlowing", true, None),
     method("stream", "readableHighWaterMark", true, None),
     method("stream", "readableLength", true, None),

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -40,9 +40,8 @@ pub use from::{
     js_array_buffer_new, js_buffer_alloc, js_buffer_alloc_fill_value, js_buffer_alloc_unsafe,
     js_buffer_concat, js_buffer_concat_with_length, js_buffer_fill, js_buffer_fill_range,
     js_buffer_fill_value_range, js_buffer_from_array, js_buffer_from_arraybuffer_slice,
-    js_buffer_from_string,
-    js_buffer_from_value, js_data_view_new, js_encoding_tag_from_value, js_shared_array_buffer_new,
-    js_uint8array_alloc, js_uint8array_from_array, js_uint8array_new,
+    js_buffer_from_string, js_buffer_from_value, js_data_view_new, js_encoding_tag_from_value,
+    js_shared_array_buffer_new, js_uint8array_alloc, js_uint8array_from_array, js_uint8array_new,
 };
 
 // ---- Re-exports: predicates / byteLength (FFI) ----

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1489 entries across 82 modules
+// Coverage: 1491 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1489 entries across 82 modules.
+Total: 1491 entries across 82 modules.
 
 ## Modules
 
@@ -1855,6 +1855,7 @@ Total: 1489 entries across 82 modules.
 - `toWeb` — module
 - `uncork` — instance
 - `unpipe` — instance
+- `unshift` — instance
 - `writable` — instance
 - `writableCorked` — instance
 - `writableEnded` — instance


### PR DESCRIPTION
## Summary

Three required CI gates are currently red on `main`, blocking every open PR (e.g. #2389). All three are pre-existing drift from recent merges, not from any feature work:

- **`lint`** — `cargo fmt --all -- --check` flags `crates/perry-runtime/src/buffer/mod.rs:40` (a `use`-group wrapping drift). Fixed by `cargo fmt --all` (only that file changes).
- **`cargo-test`** — `perry-codegen` `manifest_consistency::every_dispatch_entry_has_manifest_counterpart` fails: `NATIVE_MODULE_TABLE` has `stream::unshift` (`js_node_stream_method_unshift`, `has_receiver=true`) but `API_MANIFEST` lacked the row. Added `method("stream", "unshift", true, None)` to `crates/perry-api-manifest/src/entries.rs`.
- **`api-docs-drift`** — regenerated `docs/src/api/reference.md` + `docs/api/perry.d.ts` from the manifest (now picks up `stream.unshift` plus the previously-unsynced `buffer.atob`/`buffer.btoa`).

No behavioral change — formatting, a manifest row for an already-dispatched method, and generated-doc sync.

Verified locally: `cargo test -p perry-codegen --test manifest_consistency` passes 4/4 and `cargo fmt --all -- --check` is clean.
