### PR TITLE
fix(node:stream): propagate iterator helper rejections

### DIFF
--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -40,9 +40,8 @@ pub use from::{
     js_array_buffer_new, js_buffer_alloc, js_buffer_alloc_fill_value, js_buffer_alloc_unsafe,
     js_buffer_concat, js_buffer_concat_with_length, js_buffer_fill, js_buffer_fill_range,
     js_buffer_fill_value_range, js_buffer_from_array, js_buffer_from_arraybuffer_slice,
-    js_buffer_from_string,
-    js_buffer_from_value, js_data_view_new, js_encoding_tag_from_value, js_shared_array_buffer_new,
-    js_uint8array_alloc, js_uint8array_from_array, js_uint8array_new,
+    js_buffer_from_string, js_buffer_from_value, js_data_view_new, js_encoding_tag_from_value,
+    js_shared_array_buffer_new, js_uint8array_alloc, js_uint8array_from_array, js_uint8array_new,
 };
 
 // ---- Re-exports: predicates / byteLength (FFI) ----

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -1322,17 +1322,29 @@ fn propagate_stream_state(this: f64, opts: f64, result: f64) {
     }
 }
 
+fn drain_iter_helper_microtasks() {
+    for _ in 0..10_000 {
+        if crate::promise::js_promise_run_microtasks() == 0 {
+            break;
+        }
+    }
+}
+
+fn prepare_readable_for_iteration(stream: f64) {
+    invoke_read_once(stream);
+    drain_iter_helper_microtasks();
+}
+
 /// Resolve a callback result that may be a Promise (an async mapper /
 /// predicate) by draining microtasks until it settles, then reading the
-/// fulfilled value. Bounded so a never-settling promise can't hang the
-/// stub; an unresolved or rejected promise yields the original value.
-fn settle(value: f64) -> f64 {
+/// fulfilled value or preserving the rejection reason.
+fn settle_result(value: f64) -> Result<f64, f64> {
     if crate::promise::js_value_is_promise(value) == 0 {
-        return value;
+        return Ok(value);
     }
     let p = crate::value::js_nanbox_get_pointer(value) as *mut crate::promise::Promise;
     if p.is_null() {
-        return value;
+        return Ok(value);
     }
     for _ in 0..10_000 {
         if unsafe { (*p).state } != crate::promise::PromiseState::Pending {
@@ -1343,18 +1355,18 @@ fn settle(value: f64) -> f64 {
         }
     }
     unsafe {
-        if (*p).state == crate::promise::PromiseState::Fulfilled {
-            (*p).value
-        } else {
-            value
+        match (*p).state {
+            crate::promise::PromiseState::Fulfilled => Ok((*p).value),
+            crate::promise::PromiseState::Rejected => Err((*p).reason),
+            crate::promise::PromiseState::Pending => Ok(value),
         }
     }
 }
 
 /// Invoke a single-argument stream callback and settle an async result.
 #[inline]
-fn call_settled(cb: *const ClosureHeader, arg: f64) -> f64 {
-    settle(crate::closure::js_closure_call1(cb, arg))
+fn call_settled_result(cb: *const ClosureHeader, arg: f64) -> Result<f64, f64> {
+    settle_result(crate::closure::js_closure_call1(cb, arg))
 }
 
 /// Coerce a `take(n)` / `drop(n)` count argument to a clamped element
@@ -1387,50 +1399,77 @@ fn extend_with_array(
 
 extern "C" fn ns_iter_to_array(closure: *const ClosureHeader, opts: f64) -> f64 {
     let this = this_value(closure);
+    prepare_readable_for_iteration(this);
     let arr = readable_chunks_array(this);
     let mut out = crate::array::js_array_alloc(0);
     if !arr.is_null() {
         out = extend_with_array(out, arr);
     }
-    mark_stream_ended(this);
-    clear_readable_buffer(this);
-    destroy_stream(this, f64::from_bits(TAG_UNDEFINED));
-    settle_consuming(this, opts, box_pointer(out as *const u8))
+    let result = settle_consuming(this, opts, box_pointer(out as *const u8));
+    if readable_hidden_error(this).is_none() {
+        mark_stream_ended(this);
+        clear_readable_buffer(this);
+        destroy_stream(this, f64::from_bits(TAG_UNDEFINED));
+    }
+    result
 }
 
 extern "C" fn ns_iter_map(closure: *const ClosureHeader, mapper: f64, opts: f64) -> f64 {
     let this = this_value(closure);
+    prepare_readable_for_iteration(this);
     let arr = readable_chunks_array(this);
     let cb = callback_closure(mapper);
     let mut out = crate::array::js_array_alloc(0);
-    if !arr.is_null() && !cb.is_null() {
+    let mut callback_error = None;
+    if readable_hidden_error(this).is_none() && !arr.is_null() && !cb.is_null() {
         let len = crate::array::js_array_length(arr);
         for i in 0..len {
             let el = crate::array::js_array_get_f64(arr, i);
-            out = crate::array::js_array_push_f64(out, call_settled(cb, el));
-        }
-    }
-    let result = readable_from_chunks(out);
-    propagate_stream_state(this, opts, result);
-    result
-}
-
-extern "C" fn ns_iter_filter(closure: *const ClosureHeader, predicate: f64, opts: f64) -> f64 {
-    let this = this_value(closure);
-    let arr = readable_chunks_array(this);
-    let cb = callback_closure(predicate);
-    let mut out = crate::array::js_array_alloc(0);
-    if !arr.is_null() && !cb.is_null() {
-        let len = crate::array::js_array_length(arr);
-        for i in 0..len {
-            let el = crate::array::js_array_get_f64(arr, i);
-            if crate::value::js_is_truthy(call_settled(cb, el)) != 0 {
-                out = crate::array::js_array_push_f64(out, el);
+            match call_settled_result(cb, el) {
+                Ok(mapped) => out = crate::array::js_array_push_f64(out, mapped),
+                Err(err) => {
+                    callback_error = Some(err);
+                    break;
+                }
             }
         }
     }
     let result = readable_from_chunks(out);
     propagate_stream_state(this, opts, result);
+    if let Some(err) = callback_error {
+        set_hidden_value(result, hidden_error_key(), err);
+    }
+    result
+}
+
+extern "C" fn ns_iter_filter(closure: *const ClosureHeader, predicate: f64, opts: f64) -> f64 {
+    let this = this_value(closure);
+    prepare_readable_for_iteration(this);
+    let arr = readable_chunks_array(this);
+    let cb = callback_closure(predicate);
+    let mut out = crate::array::js_array_alloc(0);
+    let mut callback_error = None;
+    if readable_hidden_error(this).is_none() && !arr.is_null() && !cb.is_null() {
+        let len = crate::array::js_array_length(arr);
+        for i in 0..len {
+            let el = crate::array::js_array_get_f64(arr, i);
+            match call_settled_result(cb, el) {
+                Ok(value) if crate::value::js_is_truthy(value) != 0 => {
+                    out = crate::array::js_array_push_f64(out, el);
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    callback_error = Some(err);
+                    break;
+                }
+            }
+        }
+    }
+    let result = readable_from_chunks(out);
+    propagate_stream_state(this, opts, result);
+    if let Some(err) = callback_error {
+        set_hidden_value(result, hidden_error_key(), err);
+    }
     result
 }
 
@@ -1441,6 +1480,7 @@ extern "C" fn ns_iter_reduce(
     opts: f64,
 ) -> f64 {
     let this = this_value(closure);
+    prepare_readable_for_iteration(this);
     let arr = readable_chunks_array(this);
     let cb = callback_closure(reducer);
     let len = if arr.is_null() {
@@ -1458,11 +1498,14 @@ extern "C" fn ns_iter_reduce(
         // the stub resolves undefined rather than crash.
         return settle_consuming(this, opts, f64::from_bits(TAG_UNDEFINED));
     };
-    if !cb.is_null() {
+    if readable_hidden_error(this).is_none() && !cb.is_null() {
         for i in start..len {
             let el = crate::array::js_array_get_f64(arr, i);
             // Node's stream reducer is (accumulator, current) — no index.
-            acc = settle(crate::closure::js_closure_call2(cb, acc, el));
+            match settle_result(crate::closure::js_closure_call2(cb, acc, el)) {
+                Ok(value) => acc = value,
+                Err(err) => return rejected_promise(err),
+            }
         }
     }
     settle_consuming(this, opts, acc)
@@ -1470,13 +1513,16 @@ extern "C" fn ns_iter_reduce(
 
 extern "C" fn ns_iter_for_each(closure: *const ClosureHeader, action: f64, opts: f64) -> f64 {
     let this = this_value(closure);
+    prepare_readable_for_iteration(this);
     let arr = readable_chunks_array(this);
     let cb = callback_closure(action);
-    if !arr.is_null() && !cb.is_null() {
+    if readable_hidden_error(this).is_none() && !arr.is_null() && !cb.is_null() {
         let len = crate::array::js_array_length(arr);
         for i in 0..len {
             let el = crate::array::js_array_get_f64(arr, i);
-            let _ = call_settled(cb, el);
+            if let Err(err) = call_settled_result(cb, el) {
+                return rejected_promise(err);
+            }
         }
     }
     settle_consuming(this, opts, f64::from_bits(TAG_UNDEFINED))
@@ -1484,16 +1530,21 @@ extern "C" fn ns_iter_for_each(closure: *const ClosureHeader, action: f64, opts:
 
 extern "C" fn ns_iter_find(closure: *const ClosureHeader, predicate: f64, opts: f64) -> f64 {
     let this = this_value(closure);
+    prepare_readable_for_iteration(this);
     let arr = readable_chunks_array(this);
     let cb = callback_closure(predicate);
     let mut found = f64::from_bits(TAG_UNDEFINED);
-    if !arr.is_null() && !cb.is_null() {
+    if readable_hidden_error(this).is_none() && !arr.is_null() && !cb.is_null() {
         let len = crate::array::js_array_length(arr);
         for i in 0..len {
             let el = crate::array::js_array_get_f64(arr, i);
-            if crate::value::js_is_truthy(call_settled(cb, el)) != 0 {
-                found = el;
-                break;
+            match call_settled_result(cb, el) {
+                Ok(value) if crate::value::js_is_truthy(value) != 0 => {
+                    found = el;
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => return rejected_promise(err),
             }
         }
     }
@@ -1502,16 +1553,21 @@ extern "C" fn ns_iter_find(closure: *const ClosureHeader, predicate: f64, opts: 
 
 extern "C" fn ns_iter_some(closure: *const ClosureHeader, predicate: f64, opts: f64) -> f64 {
     let this = this_value(closure);
+    prepare_readable_for_iteration(this);
     let arr = readable_chunks_array(this);
     let cb = callback_closure(predicate);
     let mut result = f64::from_bits(TAG_FALSE);
-    if !arr.is_null() && !cb.is_null() {
+    if readable_hidden_error(this).is_none() && !arr.is_null() && !cb.is_null() {
         let len = crate::array::js_array_length(arr);
         for i in 0..len {
             let el = crate::array::js_array_get_f64(arr, i);
-            if crate::value::js_is_truthy(call_settled(cb, el)) != 0 {
-                result = f64::from_bits(TAG_TRUE);
-                break;
+            match call_settled_result(cb, el) {
+                Ok(value) if crate::value::js_is_truthy(value) != 0 => {
+                    result = f64::from_bits(TAG_TRUE);
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => return rejected_promise(err),
             }
         }
     }
@@ -1520,16 +1576,21 @@ extern "C" fn ns_iter_some(closure: *const ClosureHeader, predicate: f64, opts: 
 
 extern "C" fn ns_iter_every(closure: *const ClosureHeader, predicate: f64, opts: f64) -> f64 {
     let this = this_value(closure);
+    prepare_readable_for_iteration(this);
     let arr = readable_chunks_array(this);
     let cb = callback_closure(predicate);
     let mut result = f64::from_bits(TAG_TRUE);
-    if !arr.is_null() && !cb.is_null() {
+    if readable_hidden_error(this).is_none() && !arr.is_null() && !cb.is_null() {
         let len = crate::array::js_array_length(arr);
         for i in 0..len {
             let el = crate::array::js_array_get_f64(arr, i);
-            if crate::value::js_is_truthy(call_settled(cb, el)) == 0 {
-                result = f64::from_bits(TAG_FALSE);
-                break;
+            match call_settled_result(cb, el) {
+                Ok(value) if crate::value::js_is_truthy(value) == 0 => {
+                    result = f64::from_bits(TAG_FALSE);
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => return rejected_promise(err),
             }
         }
     }
@@ -1538,14 +1599,22 @@ extern "C" fn ns_iter_every(closure: *const ClosureHeader, predicate: f64, opts:
 
 extern "C" fn ns_iter_flat_map(closure: *const ClosureHeader, mapper: f64, opts: f64) -> f64 {
     let this = this_value(closure);
+    prepare_readable_for_iteration(this);
     let arr = readable_chunks_array(this);
     let cb = callback_closure(mapper);
     let mut out = crate::array::js_array_alloc(0);
-    if !arr.is_null() && !cb.is_null() {
+    let mut callback_error = None;
+    if readable_hidden_error(this).is_none() && !arr.is_null() && !cb.is_null() {
         let len = crate::array::js_array_length(arr);
         for i in 0..len {
             let el = crate::array::js_array_get_f64(arr, i);
-            let mapped = call_settled(cb, el);
+            let mapped = match call_settled_result(cb, el) {
+                Ok(value) => value,
+                Err(err) => {
+                    callback_error = Some(err);
+                    break;
+                }
+            };
             // flatMap flattens one level: an array result is spread, a
             // Readable result contributes its retained chunks, an
             // async-iterable (e.g. an `async function*` mapper return —
@@ -1569,6 +1638,9 @@ extern "C" fn ns_iter_flat_map(closure: *const ClosureHeader, mapper: f64, opts:
     }
     let result = readable_from_chunks(out);
     propagate_stream_state(this, opts, result);
+    if let Some(err) = callback_error {
+        set_hidden_value(result, hidden_error_key(), err);
+    }
     result
 }
 
@@ -1617,6 +1689,7 @@ fn flatten_async_iterable_value(value: f64) -> Option<*mut crate::array::ArrayHe
 
 extern "C" fn ns_iter_take(closure: *const ClosureHeader, count: f64) -> f64 {
     let this = this_value(closure);
+    prepare_readable_for_iteration(this);
     let arr = readable_chunks_array(this);
     let mut out = crate::array::js_array_alloc(0);
     if !arr.is_null() {
@@ -1633,6 +1706,7 @@ extern "C" fn ns_iter_take(closure: *const ClosureHeader, count: f64) -> f64 {
 
 extern "C" fn ns_iter_drop(closure: *const ClosureHeader, count: f64) -> f64 {
     let this = this_value(closure);
+    prepare_readable_for_iteration(this);
     let arr = readable_chunks_array(this);
     let mut out = crate::array::js_array_alloc(0);
     if !arr.is_null() {
@@ -1762,6 +1836,17 @@ fn register_stub_arities() {
     register(ns_is_paused0 as *const u8, 0);
     register(ns_unpipe1 as *const u8, 1);
     register(ns_readable_resume_microtask as *const u8, 0);
+    register(ns_iter_to_array as *const u8, 1);
+    register(ns_iter_map as *const u8, 2);
+    register(ns_iter_filter as *const u8, 2);
+    register(ns_iter_reduce as *const u8, 3);
+    register(ns_iter_for_each as *const u8, 2);
+    register(ns_iter_find as *const u8, 2);
+    register(ns_iter_some as *const u8, 2);
+    register(ns_iter_every as *const u8, 2);
+    register(ns_iter_flat_map as *const u8, 2);
+    register(ns_iter_take as *const u8, 1);
+    register(ns_iter_drop as *const u8, 1);
     async_iterator::register_arities();
 }
 

--- a/crates/perry-runtime/src/node_stream/async_iterator.rs
+++ b/crates/perry-runtime/src/node_stream/async_iterator.rs
@@ -75,15 +75,20 @@ extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
     let Some(stream) = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_STREAM_KEY)) else {
         return readable_iterator_done();
     };
-    if stream_destroyed(stream) {
+    prepare_readable_for_iteration(stream);
+    let arr = readable_chunks_array(stream);
+    let index = stream_consume_index(stream);
+    if !arr.is_null() && index < crate::array::js_array_length(arr) {
+        let value = crate::array::js_array_get_f64(arr, index);
+        set_stream_consume_index(stream, index + 1);
         set_hidden_value(
             iterator,
-            hidden_key(READABLE_ITERATOR_DONE_KEY),
-            f64::from_bits(TAG_TRUE),
+            hidden_key(READABLE_ITERATOR_INDEX_KEY),
+            (iterator_local_index(iterator) + 1) as f64,
         );
-        return readable_iterator_done();
+        mark_disturbed(stream);
+        return resolved_promise(iterator_result(value, false));
     }
-    invoke_read_once(stream);
     if let Some(err) = readable_hidden_error(stream) {
         set_hidden_value(
             iterator,
@@ -92,8 +97,14 @@ extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
         );
         return rejected_promise(err);
     }
-    let arr = readable_chunks_array(stream);
-    let index = stream_consume_index(stream);
+    if stream_destroyed(stream) {
+        set_hidden_value(
+            iterator,
+            hidden_key(READABLE_ITERATOR_DONE_KEY),
+            f64::from_bits(TAG_TRUE),
+        );
+        return readable_iterator_done();
+    }
     if arr.is_null() || index >= crate::array::js_array_length(arr) {
         set_hidden_value(
             iterator,
@@ -104,15 +115,7 @@ extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
         destroy_stream(stream, f64::from_bits(TAG_UNDEFINED));
         return readable_iterator_done();
     }
-    let value = crate::array::js_array_get_f64(arr, index);
-    set_stream_consume_index(stream, index + 1);
-    set_hidden_value(
-        iterator,
-        hidden_key(READABLE_ITERATOR_INDEX_KEY),
-        (iterator_local_index(iterator) + 1) as f64,
-    );
-    mark_disturbed(stream);
-    resolved_promise(iterator_result(value, false))
+    readable_iterator_done()
 }
 
 extern "C" fn ns_readable_iterator_return(closure: *const ClosureHeader) -> f64 {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -518,12 +518,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose() \u2014 error in middle transform does not propagate to composite 'error' event. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/iter-helpers/to-array-erroring": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: toArray() on an erroring stream does not reject its Promise with the error. Flips to PASS when #1558 lands."
-  },
   "node-suite/stream/readable/read-after-end": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -547,18 +541,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: objectMode Readable.read() does not return single object per call. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/iter-helpers/map-async-rejection": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: readable.map(asyncFn) \u2014 rejection in fn does not abort iteration / propagate as throw. Flips to PASS when #1558 lands."
-  },
-  "node-suite/stream/iter-helpers/reduce-no-initial": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: reduce(fn) without initial \u2014 first item not used as accumulator. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/pipeline/async-fn-sink": {
     "issue": "1532",
@@ -662,12 +644,6 @@
     "category": "bug-open",
     "reason": "node:stream: pause() inside 'data' listener \u2014 does not stop further synchronous emits. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/iter-helpers/find-returns-promise": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: find() \u2014 return value is not a Promise<value|undefined>. Flips to PASS when #1558 lands."
-  },
   "node-suite/stream/web/transform-stream-with-strategies": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -734,12 +710,6 @@
     "category": "bug-open",
     "reason": "node:stream: pipeline async-fn throwing \u2014 cb does not receive the error. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/iter-helpers/filter-then-toarray": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: filter(fn).toArray() \u2014 chain produces wrong result. Flips to PASS when #1558 lands."
-  },
   "node-suite/stream/readable/from-async-iter-mixed-values": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -776,18 +746,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.from(array with one Promise.reject) \u2014 error not emitted at the right point. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/iter-helpers/every-async-rejection": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: every(asyncFn) \u2014 fn rejection does not propagate as Promise reject. Flips to PASS when #1558 lands."
-  },
-  "node-suite/stream/iter-helpers/find-async-fn": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: find(asyncFn) \u2014 returns wrong value. Flips to PASS when #1558 lands."
-  },
   "node-suite/stream/readable/from-gen-yield-order": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -811,12 +769,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Readable.from(iter that throws on next) \u2014 'error' event not emitted. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/iter-helpers/some-async-rejection": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: some(asyncFn) \u2014 rejection in fn does not propagate. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/web/transform-readable-cancel-propagates": {
     "issue": "1545",
@@ -847,12 +799,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pipe() does not add 'unpipe' listener on destination. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/iter-helpers/map-then-toarray": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: map(fn).toArray() \u2014 chain returns non-Array or wrong values. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/readable/readable-mode-only": {
     "issue": "1532",
@@ -938,12 +884,6 @@
     "category": "bug-open",
     "reason": "node:stream: for-await break \u2014 custom iterator.return() not invoked. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/iter-helpers/some-finds-match": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: some() \u2014 does not short-circuit at first match (calls > N). Flips to PASS when #1558 lands."
-  },
   "node-suite/stream/pipeline/async-iter-source": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -1027,12 +967,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: TransformStream instance \u2014 fails instanceof checks vs RS/WS for readable/writable sides. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/iter-helpers/reduce-with-initial": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: reduce(fn, initial) \u2014 initial value not used or wrong sum. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/readable/readable-stream-id-properties": {
     "issue": "1532",


### PR DESCRIPTION
## Summary

- drain queued readable work before iterator helper consumption and async iterator `next()` checks
- preserve real source-stream and async-callback rejection reasons for `Readable` iterator helpers
- remove the #1558 known-failure rows proven passing by the focused stream parity run
- refresh generated API docs after the manifest coverage count changed

## Verification

- `./run_parity_tests.sh --suite node-suite --module stream --filter iter-helpers/to-array-erroring` passes
- `./run_parity_tests.sh --suite node-suite --module stream --filter iter-helpers/some-async-rejection` passes
- `./run_parity_tests.sh --suite node-suite --module stream --filter iter-helpers/map-async-rejection` passes
- `./run_parity_tests.sh --suite node-suite --module stream --filter iter-helpers` is 43 pass / 3 fail; remaining failures are `compose-then-toarray`, `for-each-await-each`, and `map-async-with-concurrency`
- `./run_parity_tests.sh --suite node-suite --module stream --filter readable/from-infinite-take` still fails and remains in `known_failures.json`
- `./run_parity_tests.sh --suite node-suite --module stream` was attempted; it reached the iterator-helper section with the fixed cases passing, then hung later in unrelated `stream/web/byte-length-queuing-strategy` because the local runner lacks the optional `timeout`/`gtimeout` guard
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `./scripts/check_file_size.sh`
- `git diff --check origin/main...HEAD`
- `cargo check -p perry-runtime`
- `cargo test -p perry-runtime node_stream --lib -- --nocapture`
- `./scripts/regen_api_docs.sh`

## Limitations / non-goals

- does not fix stream `compose()` helper chaining or `compose().toArray()` parity
- does not fix timer-backed async callback sequencing/concurrency in `forEach()` or `map()`
- does not fix async-generator source driving for `Readable.from(...).take(...)`
- does not cover the broader stream lifecycle, pipe, pipeline, or compose gaps already represented by other open stream work
