### PR TITLE
fix(console): revert Date-as-ISO inspect — it regressed Date.getTime()/valueOf()

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -880,10 +880,6 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
         } else if jsval.is_int32() {
             jsval.as_int32().to_string()
         } else {
-            // Date → unquoted ISO string / `Invalid Date` (before is_nan).
-            if let Some(s) = collections::date_inspect(value) {
-                return s;
-            }
             // Regular number — but first check for raw (non-NaN-boxed) heap
             // pointers. The codegen sometimes returns a raw
             // i64 buffer pointer bitcast directly to f64 (no POINTER_TAG), so
@@ -1453,10 +1449,6 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
         } else if jsval.is_int32() {
             jsval.as_int32().to_string()
         } else {
-            // Date field → unquoted ISO string / `Invalid Date`.
-            if let Some(s) = collections::date_inspect(value) {
-                return s;
-            }
             // A TypedArray field is a RAW (non-NaN-boxed) heap pointer, so it
             // lands here, not in the pointer branch; redirect it (#800).
             if let Some(s) = collections::raw_heap_pointer_display(value, depth) {

--- a/crates/perry-runtime/src/builtins/formatting/collections.rs
+++ b/crates/perry-runtime/src/builtins/formatting/collections.rs
@@ -152,23 +152,6 @@ pub(super) fn raw_heap_pointer_display(value: f64, depth: usize) -> Option<Strin
     }
 }
 
-/// If `value` is a Date (a raw f64 timestamp registered in `DATE_REGISTRY`),
-/// return its `util.inspect` rendering — the ISO string unquoted
-/// (`1970-01-01T00:00:00.000Z`) or `Invalid Date` for a NaN time. Returns
-/// `None` for an ordinary number so callers fall through to numeric output.
-pub(super) fn date_inspect(value: f64) -> Option<String> {
-    if !crate::date::is_registered_date_bits(value.to_bits()) {
-        return None;
-    }
-    let s = crate::date::js_date_to_iso_string(value);
-    let out = unsafe { read_string_header(s) };
-    if out.is_empty() {
-        None
-    } else {
-        Some(out)
-    }
-}
-
 /// Read a `StringHeader` into an owned `String` (empty on null).
 unsafe fn read_string_header(s: *const StringHeader) -> String {
     if s.is_null() {
@@ -200,17 +183,6 @@ pub(super) unsafe fn format_regexp(re: *const crate::regex::RegExpHeader) -> Str
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn date_inspect_returns_iso_string_for_registered_date() {
-        let date_val = crate::date::js_date_new_from_timestamp(0.0);
-        assert_eq!(
-            date_inspect(date_val),
-            Some("1970-01-01T00:00:00.000Z".to_string())
-        );
-        // A plain number is not a Date — falls through to numeric formatting.
-        assert_eq!(date_inspect(42.0), None);
-    }
 
     #[test]
     fn map_formats_entries_with_size_prefix() {


### PR DESCRIPTION
## Problem (regression from #2372)

#2372 added `console.log` / `util.inspect` rendering of `Date` values as their ISO string. But in Perry a `Date` and its numeric timestamp are the **same f64 bits** (Date is a value type — #2089), registered together in `DATE_REGISTRY`. So the change also made the *numeric* timestamp print as ISO:

```ts
const d = new Date(1700000000000);
d.getTime();          // Perry printed 2023-11-14T22:13:20.000Z — should be 1700000000000
+d;                   // same
console.log(1700000000000); // also ISO, if a Date with that ms is live
```

`typeof d.getTime()` is already `"object"` in Perry (pre-existing), confirming there's **no formatter-level way** to tell a Date from its timestamp number. Logging `getTime()`/timestamps is common, so this is a net parity regression.

## Fix

Revert the two `collections::date_inspect()` call sites (in `format_jsvalue` + `format_jsvalue_for_json`) and the helper. Numbers (including `getTime()` results) once again print as numbers — matching Node for the common case. The WeakMap/WeakSet inspect change from #2372 is **kept** (unaffected).

## Validation

Byte-for-byte vs `node`: `d.getTime()` / timestamp literals → numbers; `new WeakMap()`/`new WeakSet()`/`Set`/`Map`/`RegExp`/`Symbol.iterator` inspect all still correct.

> Correct `console.log(new Date(0))` → ISO requires a distinguishable Date representation (heap object or distinct tag) and is blocked on #2089 (Date-as-value). Tracking the deferred display separately.
