### PR TITLE
docs: regenerate API reference + .d.ts (repair recurring api-docs-drift)

### DIFF
--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1491 entries across 82 modules
+// Coverage: 1496 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -2075,9 +2075,15 @@ declare module "util/types" {
   /** stdlib */
   export function isDate(...args: any[]): any;
   /** stdlib */
+  export function isFloat32Array(...args: any[]): any;
+  /** stdlib */
   export function isFloat64Array(...args: any[]): any;
   /** stdlib */
+  export function isInt16Array(...args: any[]): any;
+  /** stdlib */
   export function isInt32Array(...args: any[]): any;
+  /** stdlib */
+  export function isInt8Array(...args: any[]): any;
   /** stdlib */
   export function isMap(...args: any[]): any;
   /** stdlib */
@@ -2103,7 +2109,11 @@ declare module "util/types" {
   /** stdlib */
   export function isUint16Array(...args: any[]): any;
   /** stdlib */
+  export function isUint32Array(...args: any[]): any;
+  /** stdlib */
   export function isUint8Array(...args: any[]): any;
+  /** stdlib */
+  export function isUint8ClampedArray(...args: any[]): any;
 }
 
 declare module "uuid" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1491 entries across 82 modules.
+Total: 1496 entries across 82 modules.
 
 ## Modules
 
@@ -1996,8 +1996,11 @@ Total: 1491 entries across 82 modules.
 - `isBooleanObject` — module
 - `isBoxedPrimitive` — module
 - `isDate` — module
+- `isFloat32Array` — module
 - `isFloat64Array` — module
+- `isInt16Array` — module
 - `isInt32Array` — module
+- `isInt8Array` — module
 - `isMap` — module
 - `isMapIterator` — module
 - `isNumberObject` — module
@@ -2010,7 +2013,9 @@ Total: 1491 entries across 82 modules.
 - `isStringObject` — module
 - `isTypedArray` — module
 - `isUint16Array` — module
+- `isUint32Array` — module
 - `isUint8Array` — module
+- `isUint8ClampedArray` — module
 
 ## `uuid`
 


### PR DESCRIPTION
Manifest grew to 1496 entries (util.types numeric-array predicates) without a docs regen, so api-docs-drift fails for every PR on current main. Regenerate docs/api/perry.d.ts + docs/src/api/reference.md via scripts/regen_api_docs.sh. No source change.

This is the 2nd api-docs drift repair in ~1h (#2393 was the 1st) — bypass merges keep skipping the regen step. Worth automating regen in the merge/release flow.