### PR TITLE
fix(json): JSON.stringify crash on arrays grown past inline capacity (#2021)

### DIFF
--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -1346,7 +1346,23 @@ pub(crate) unsafe fn try_emit_shape_element(
 
 /// Depth-aware variant of stringify_array for recursive calls.
 pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, depth: u32) {
-    let arr = ptr as *const crate::ArrayHeader;
+    // Issue #2021: an array that has grown past its initial inline capacity
+    // (16) was reallocated to a new block, leaving a GC_FLAG_FORWARDED stub
+    // at the old address. Callers (and element decoders) hand us whatever
+    // pointer the NaN-boxed value held, which for a grown array is that
+    // stale stub — reading its first 8 bytes as (length, capacity) yields
+    // the forwarding pointer reinterpreted as a huge length and walks off
+    // into garbage (Bus error in stringify, the original #2021 crash).
+    // `clean_arr_ptr` follows the forwarding chain exactly as every other
+    // array accessor does (#233); element reads via js_array_get already do
+    // this, which is why field access worked while whole-array stringify
+    // crashed. Resolving here is the single chokepoint for the top-level,
+    // nested-array, and object-field-array paths.
+    let arr = crate::array::clean_arr_ptr(ptr as *const crate::ArrayHeader);
+    if arr.is_null() {
+        buf.push_str("[]");
+        return;
+    }
     let len = (*arr).length;
     let elements = (arr as *const u8).add(std::mem::size_of::<crate::ArrayHeader>()) as *const f64;
 

--- a/test-files/test_gap_2021_json_stringify_grown_array.ts
+++ b/test-files/test_gap_2021_json_stringify_grown_array.ts
@@ -1,0 +1,30 @@
+// #2021 — JSON.stringify over an array that has grown past its initial inline
+// capacity (16) crashed with a Bus error. Array growth reallocates the
+// header+inline-elements block and leaves a GC_FLAG_FORWARDED stub at the old
+// address; element accessors resolve that forwarding (clean_arr_ptr, #233) but
+// stringify_array_depth read length/elements straight off the stale stub.
+// Fix: resolve forwarding at the stringify chokepoint. Output is byte-for-byte
+// vs `node --experimental-strip-types`.
+
+function build(n: number): Array<{ id: number; name: string; tags: string[] }> {
+  const out: Array<{ id: number; name: string; tags: string[] }> = [];
+  for (let i = 0; i < n; i++) {
+    out.push({ id: i, name: "rec-" + i, tags: ["t" + i, "x"] });
+  }
+  return out;
+}
+
+// 16 stays inline (no growth); 17 forces the first reallocation; 40 forces a
+// second. All three must stringify correctly, not just the small inline case.
+console.log(JSON.stringify(build(16)).length);
+console.log(JSON.stringify(build(17)));
+console.log(JSON.stringify(build(40)).length);
+
+// nested grown array inside an object field (object-field-array stringify path)
+const wrapper = { items: build(20), count: 20 };
+console.log(JSON.stringify(wrapper).length);
+
+// array of primitives grown past 16 (non-object-shape path)
+const nums: number[] = [];
+for (let i = 0; i < 50; i++) nums.push(i * 3);
+console.log(JSON.stringify(nums));


### PR DESCRIPTION
## Summary

Fixes #2021. `JSON.stringify` over an array that has grown past its initial inline capacity (16 elements) crashed with a Bus error / SIGSEGV.

Reported against the large JSON pipeline in #2021 (read → `JSON.parse` → transform → `JSON.stringify` over a 500k-record fixture), but it reproduces with **any** array of ≥17 elements — e.g. `JSON.stringify(buildArrayOf(17, ...))`. It is **not** a GC/remembered-set issue (it crashes under `PERRY_GEN_GC=0` too), despite the original born-in-old-large-array hypothesis on the issue.

## Root cause

Perry arrays are a contiguous `ArrayHeader` + inline-elements block. When an array grows beyond capacity it is reallocated to a larger block, leaving a `GC_FLAG_FORWARDED` stub at the old address (the forwarding chain `clean_arr_ptr` follows, #233).

Every normal array accessor (`arr[i]`, `js_array_get`, …) resolves that forwarding — which is why field access and per-element `JSON.stringify(arr[i])` worked fine. But `stringify_array_depth` cast the raw value pointer straight to `*const ArrayHeader` and read `length`/elements from it. For a grown array that pointer is the stale stub, whose first 8 bytes are the forwarding pointer reinterpreted as a gigantic `length`, so stringify walked off into freed memory and faulted reading an element's type tag.

## Fix

Resolve forwarding via `crate::array::clean_arr_ptr` at the `stringify_array_depth` entry — the single chokepoint for the top-level, nested-array, and object-field-array stringify paths.

## Verification

- Crash threshold bisected to exactly 16 (works) → 17 (crashed) pre-fix; all sizes pass post-fix.
- Output **byte-identical with `node --experimental-strip-types`** (boundary, nested arrays, primitive arrays, object-field arrays).
- The full 500k-record parse→transform→stringify pipeline from #2021 now completes cleanly.
- `cargo test -p perry-runtime` json (37) + array (99) subsets pass; `cargo fmt --check` clean.
- Added regression test `test-files/test_gap_2021_json_stringify_grown_array.ts` (auto-run + byte-compared by the parity harness).
