### PR TITLE
fix(node:util): inspect symbol-only objects

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -1076,14 +1076,11 @@ unsafe fn format_object_as_json(
     };
 
     let keys_array = (*obj_ptr).keys_array;
-    if keys_array.is_null() {
-        return empty_object();
-    }
-
-    let key_count = crate::array::js_array_length(keys_array) as usize;
-    if key_count == 0 {
-        return empty_object();
-    }
+    let key_count = if keys_array.is_null() {
+        0
+    } else {
+        crate::array::js_array_length(keys_array) as usize
+    };
 
     // Honor `Object.defineProperty(..., { enumerable: false })`. By default
     // we include every key in the `keys_array` (enumerability is rarely

--- a/test-parity/node-suite/util/inspect/symbol-only.ts
+++ b/test-parity/node-suite/util/inspect/symbol-only.ts
@@ -1,0 +1,7 @@
+import { inspect } from "node:util";
+
+const sym = Symbol("only");
+const obj: any = {};
+obj[sym] = 42;
+
+console.log(inspect(obj));


### PR DESCRIPTION
## Summary
- add a parity fixture for util.inspect on an object whose only enumerable own key is a symbol
- let object formatting continue into existing symbol-property collection even when there are no string keys

## Verification
- Baseline exact `./run_parity_tests.sh --suite node-suite --module util --filter symbol-only`: FAIL, report `test-parity/reports/parity_report_20260529_001416.json` (Node `{ Symbol(only): 42 }`, Perry `{}`)
- `cargo check -p perry-runtime`: PASS with existing warnings
- Final exact `./run_parity_tests.sh --suite node-suite --module util --filter symbol-only`: PASS, report `test-parity/reports/parity_report_20260529_002146.json`
- Final `./run_parity_tests.sh --suite node-suite --module util --filter inspect`: 10 PASS / 4 known parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260529_002237.json`; `symbol-only` passed
- Final `./run_parity_tests.sh --suite node-suite --module util`: 49 PASS / 6 known parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260529_002333.json`; `symbol-only` passed
- `rustfmt --check crates/perry-runtime/src/builtins/formatting.rs`: PASS
- `git diff --check`: PASS
- `git diff --cached --check`: PASS

## Notes
- DeepWiki for Node util.inspect symbol-property rendering timed out after 120s and wrote no markdown output, so this slice used direct Node parity output and Perry local formatter inspection as fallback evidence.
- The remaining util failures are out of scope here: `formatWithOptions/getters-and-custominspect` is covered by open PR #2399, plus existing `inspect/boxed-and-symbols`, `inspect/proxy-getters-weak`, `inspect/typed-arrays-arraybuffer`, `types/boxed-and-typedarrays-extra`, and `types/more-builtins`.
- Non-goals: no custom inspect function-name inference changes, no ArrayBuffer inspect rendering, no proxy/getter inspect option cleanup, no boxed-symbol cleanup, and no util.types predicate expansion.