### PR TITLE
fix(node:stream): await async iterator helper callbacks

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -1336,29 +1336,51 @@ fn prepare_readable_for_iteration(stream: f64) {
 }
 
 /// Resolve a callback result that may be a Promise (an async mapper /
-/// predicate) by draining microtasks until it settles, then reading the
-/// fulfilled value or preserving the rejection reason.
+/// predicate) by driving Perry's await pump until it settles, then
+/// reading the fulfilled value or preserving the rejection reason.
 fn settle_result(value: f64) -> Result<f64, f64> {
     if crate::promise::js_value_is_promise(value) == 0 {
         return Ok(value);
     }
-    let p = crate::value::js_nanbox_get_pointer(value) as *mut crate::promise::Promise;
-    if p.is_null() {
-        return Ok(value);
-    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value_handle = scope.root_nanbox_f64(value);
     for _ in 0..10_000 {
-        if unsafe { (*p).state } != crate::promise::PromiseState::Pending {
+        let current = value_handle.get_nanbox_f64();
+        if crate::promise::js_value_is_promise(current) == 0 {
+            return Ok(current);
+        }
+        let p = crate::value::js_nanbox_get_pointer(current) as *mut crate::promise::Promise;
+        if p.is_null() {
+            return Ok(current);
+        }
+        unsafe {
+            match (*p).state {
+                crate::promise::PromiseState::Fulfilled => return Ok((*p).value),
+                crate::promise::PromiseState::Rejected => return Err((*p).reason),
+                crate::promise::PromiseState::Pending => {}
+            }
+        }
+
+        crate::event_pump::perry_poll();
+        let _ = crate::timer::js_timer_tick();
+        let _ = crate::timer::js_callback_timer_tick();
+        let _ = crate::timer::js_interval_timer_tick();
+        if crate::event_pump::perry_has_work() == 0 {
             break;
         }
-        if crate::promise::js_promise_run_microtasks() == 0 {
-            break;
-        }
+        crate::event_pump::js_wait_for_event();
+    }
+
+    let current = value_handle.get_nanbox_f64();
+    let p = crate::value::js_nanbox_get_pointer(current) as *mut crate::promise::Promise;
+    if p.is_null() {
+        return Ok(current);
     }
     unsafe {
         match (*p).state {
             crate::promise::PromiseState::Fulfilled => Ok((*p).value),
             crate::promise::PromiseState::Rejected => Err((*p).reason),
-            crate::promise::PromiseState::Pending => Ok(value),
+            crate::promise::PromiseState::Pending => Ok(current),
         }
     }
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -776,12 +776,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: TS readable.cancel \u2014 writable.write does not reject after. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/iter-helpers/for-each-await-each": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: forEach(asyncFn) \u2014 does not await each call sequentially. Flips to PASS when #1558 lands."
-  },
   "node-suite/stream/readable/from-async-iter-nested": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -991,12 +985,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: compose(src) \u2014 only source given, Duplex output empty. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/iter-helpers/map-async-with-concurrency": {
-    "issue": "1558",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: map(asyncFn, {concurrency}) \u2014 toArray output wrong. Flips to PASS when #1558 lands."
   },
   "node-suite/stream/readable/from-gen-with-early-return": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- Drive stream iterator-helper callback Promise settlement through Perry's await pump so timer/native-async-backed callbacks can finish before helper results are consumed.
- Fix Readable.forEach(asyncFn) sequencing so each async callback completes before the next call starts.
- Fix Readable.map(asyncFn, { concurrency }).toArray() output so fulfilled mapper values are emitted in order instead of Promise objects.
- Rebased onto current main and included the tiny URL helper block close plus regenerated API-doc counts required by the PR checks.

## Tests
- Existing focused fixtures now pass; no new fixture was needed because the failing node-suite cases already covered this behavior.
- Removed the proven passing known-failure entries for `node-suite/stream/iter-helpers/for-each-await-each` and `node-suite/stream/iter-helpers/map-async-with-concurrency`.
- Verified the current-main repair path locally after the rebase.

## Commands Run
- `./run_parity_tests.sh --suite node-suite --module stream --filter iter-helpers/for-each-await-each`
- `./run_parity_tests.sh --suite node-suite --module stream --filter iter-helpers/map-async-with-concurrency`
- `./run_parity_tests.sh --suite node-suite --module stream --filter iter-helpers` (45 pass / 1 existing known failure: `compose-then-toarray`)
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `./scripts/check_file_size.sh`
- `git diff --check origin/main...HEAD`
- `cargo test -p perry-runtime node_stream`
- `RUST_TEST_THREADS=1 cargo test -p perry-runtime`
- `./scripts/regen_api_docs.sh`

## Limitations / Non-goals
- Does not address the existing `compose-then-toarray` stream helper gap.
- Does not redesign broader stream lifecycle, pipeline, backpressure, or full lazy/concurrency scheduling behavior.
