### PR TITLE
fix(stream/web): instanceof TransformStream (#1545)

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -129,6 +129,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // `rs.pipeThrough(ts) instanceof ReadableStream`, …).
                 "ReadableStream" => 0xFFFF0060u32,
                 "WritableStream" => 0xFFFF0061u32,
+                "TransformStream" => 0xFFFF0062u32,
                 // node:perf_hooks entry classes. Runtime classifies the
                 // shaped entry objects returned by performance.mark/measure.
                 "PerformanceEntry" => 0xFFFF0080u32,

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -211,16 +211,22 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
     // stdlib kind-probe (1 = readable, 2 = writable) rather than the class
     // chain. Covers `ts.readable instanceof ReadableStream`,
     // `rs.pipeThrough(ts) instanceof ReadableStream`, etc.
+    // kind probe values: 1 = readable, 2 = writable, 5 = transform
+    // (3 = reader, 4 = writer — not user-facing instanceof targets here).
     const CLASS_ID_READABLE_STREAM: u32 = 0xFFFF0060;
     const CLASS_ID_WRITABLE_STREAM: u32 = 0xFFFF0061;
-    if class_id == CLASS_ID_READABLE_STREAM || class_id == CLASS_ID_WRITABLE_STREAM {
+    const CLASS_ID_TRANSFORM_STREAM: u32 = 0xFFFF0062;
+    if class_id == CLASS_ID_READABLE_STREAM
+        || class_id == CLASS_ID_WRITABLE_STREAM
+        || class_id == CLASS_ID_TRANSFORM_STREAM
+    {
         if value.is_finite() && value > 0.0 && value.fract() == 0.0 {
             if let Some(probe) = crate::object::stream_handle_kind_probe() {
                 let kind = unsafe { probe(value as usize) };
-                let want = if class_id == CLASS_ID_READABLE_STREAM {
-                    1
-                } else {
-                    2
+                let want = match class_id {
+                    CLASS_ID_READABLE_STREAM => 1,
+                    CLASS_ID_WRITABLE_STREAM => 2,
+                    _ => 5, // CLASS_ID_TRANSFORM_STREAM
                 };
                 if kind == want {
                     return true_val;

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -644,12 +644,6 @@
     "category": "bug-open",
     "reason": "node:stream: pause() inside 'data' listener \u2014 does not stop further synchronous emits. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/web/transform-stream-with-strategies": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: TransformStream(t, writableStrategy, readableStrategy) \u2014 3-arg constructor form not honored. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/readable/compose-multi-async-fn": {
     "issue": "1531",
     "added": "2026-05-24",
@@ -961,12 +955,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pipeline(array, dst, cb) \u2014 sync iterable source not wired. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/web/transform-stream-instanceof-check": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: TransformStream instance \u2014 fails instanceof checks vs RS/WS for readable/writable sides. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/readable/readable-stream-id-properties": {
     "issue": "1532",


### PR DESCRIPTION
## What

Fixes `instanceof TransformStream` for `node:stream/web` (#1545).

`new TransformStream()` handles are numeric ids resolved via the stdlib stream-kind probe (`js_stream_handle_kind`), but only `ReadableStream` (`0xFFFF0060`) and `WritableStream` (`0xFFFF0061`) had reserved class ids in the codegen instanceof path — `TransformStream` had none, so `ts instanceof TransformStream` always returned false even though the probe returns kind `5` for transform handles.

- `perry-codegen/src/expr/instance_misc1.rs`: add `TransformStream => 0xFFFF0062`.
- `perry-runtime/src/object/instanceof.rs`: extend the stream-handle branch to map `0xFFFF0062` → kind `5`.

## Result

Two node-suite tests flip to PASS (byte-for-byte vs Node):
- `stream/web/transform-stream-instanceof-check`
- `stream/web/transform-stream-with-strategies` (its `constructed:` assertion is just `ts instanceof TransformStream`)

Removed both from `known_failures.json`. Runtime instanceof unit tests green; `cargo fmt` clean.

## Context — remaining #1545 tail

Current stream/web node-suite state: **105 PASS / 31 FAIL / 15 SKIP**. The granular structural follow-ups (#1642–#1646) all closed; the remaining 31 are behavioral edge cases that cluster as (filing/owning separately is fine):

- **Chained `pipeThrough().pipeThrough().getReader()`** → `(number).getReader is not a function` (2: double-pipe-through, transform-piped-twice) — chained pipeThrough result isn't typed `ReadableStream`, so the second hop loses static dispatch.
- **`setTimeout(resolve,…)` inside async sink/pull methods** → "callback argument must be of type function, received number" (3: cancel-during-pull, close-during-pending-writes, writable-close-async) — a stream handle bit-cast reaches a callback slot; async-sink-closure machinery bug.
- **Cancel/abort propagation** (5: transform[-readable]-cancel-propagates, abort-during-pipeto, pipe-to-with-pre-aborted-signal, pipe-to-with-options preventClose).
- **Throw-on-bad-input validation** (5: byob-on-non-byte → TypeError, NaN/non-number strategy size → RangeError, byte-stream non-buffer enqueue, writable type:'bytes'); note `getReader` FFI doesn't currently take the options arg, so byob validation needs an ABI change.
- **Compile errors** (7: desired-size-backpressure, from-async-generator-function, pull-promise-controls-pace, readable-stream-bytes-pull, writable-stream-start-hook, writer-desired-size, from-async-gen-throws-mid).
- **desiredSize/backpressure accounting, from-* iterable variants** (remainder).

Refs #1545
