### PR TITLE
fix(array): entries()/keys()/values() return a real iterator object, not a materialized array (#2384)

### DIFF
--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -942,26 +942,31 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(len_f64)
         }
 
-        // -------- arr.entries() / .keys() / .values() (eager) --------
+        // -------- arr.entries() / .keys() / .values() --------
+        // #2384: build a real `.next()`-bearing iterator OBJECT (not an eager
+        // materialized array) so `const e = arr.entries(); e.next().value`
+        // matches Node. Spread / for-of / Array.from already detect the
+        // iterator class id (`js_array_clone`, `js_for_of_to_array`) and drive
+        // `.next()`, so those paths keep working.
         Expr::ArrayEntries(arr) => {
             let arr_box = lower_expr(ctx, arr)?;
             let blk = ctx.block();
             let arr_handle = unbox_to_i64(blk, &arr_box);
-            let result = blk.call(I64, "js_array_entries", &[(I64, &arr_handle)]);
+            let result = blk.call(I64, "js_array_entries_iter_obj", &[(I64, &arr_handle)]);
             Ok(nanbox_pointer_inline(blk, &result))
         }
         Expr::ArrayKeys(arr) => {
             let arr_box = lower_expr(ctx, arr)?;
             let blk = ctx.block();
             let arr_handle = unbox_to_i64(blk, &arr_box);
-            let result = blk.call(I64, "js_array_keys", &[(I64, &arr_handle)]);
+            let result = blk.call(I64, "js_array_keys_iter_obj", &[(I64, &arr_handle)]);
             Ok(nanbox_pointer_inline(blk, &result))
         }
         Expr::ArrayValues(arr) => {
             let arr_box = lower_expr(ctx, arr)?;
             let blk = ctx.block();
             let arr_handle = unbox_to_i64(blk, &arr_box);
-            let result = blk.call(I64, "js_array_values", &[(I64, &arr_handle)]);
+            let result = blk.call(I64, "js_array_values_iter_obj", &[(I64, &arr_handle)]);
             Ok(nanbox_pointer_inline(blk, &result))
         }
 

--- a/crates/perry-codegen/src/lower_array_method.rs
+++ b/crates/perry-codegen/src/lower_array_method.rs
@@ -706,13 +706,16 @@ pub(crate) fn lower_array_method(
             }
             Ok(nanbox_pointer_inline(ctx.block(), &deleted_handle))
         }
+        // #2384: build a real `.next()`-bearing iterator OBJECT (not an eager
+        // materialized array) so manual `.next().value` matches Node; spread /
+        // for-of / Array.from already drive `.next()` on the iterator class id.
         "entries" => {
             for a in args {
                 let _ = lower_expr(ctx, a)?;
             }
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let result = blk.call(I64, "js_array_entries", &[(I64, &recv_handle)]);
+            let result = blk.call(I64, "js_array_entries_iter_obj", &[(I64, &recv_handle)]);
             Ok(nanbox_pointer_inline(blk, &result))
         }
         "keys" => {
@@ -721,7 +724,7 @@ pub(crate) fn lower_array_method(
             }
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let result = blk.call(I64, "js_array_keys", &[(I64, &recv_handle)]);
+            let result = blk.call(I64, "js_array_keys_iter_obj", &[(I64, &recv_handle)]);
             Ok(nanbox_pointer_inline(blk, &result))
         }
         "values" => {
@@ -730,7 +733,7 @@ pub(crate) fn lower_array_method(
             }
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let result = blk.call(I64, "js_array_values", &[(I64, &recv_handle)]);
+            let result = blk.call(I64, "js_array_values_iter_obj", &[(I64, &recv_handle)]);
             Ok(nanbox_pointer_inline(blk, &result))
         }
         // Issue #515 followup: `arr.with(idx, val)` reaches here when the
@@ -750,6 +753,54 @@ pub(crate) fn lower_array_method(
                 &[(I64, &recv_handle), (DOUBLE, &idx_d), (DOUBLE, &val_d)],
             );
             Ok(nanbox_pointer_inline(blk, &result))
+        }
+        // #2384: iterator-protocol methods. A value-level `arr.entries()` /
+        // `.keys()` / `.values()` now yields a real iterator OBJECT, but
+        // `is_array_expr` still classifies the binding as an array (the static
+        // type is `Array<…>`), so `e.next()` routes here. Returning `recv_box`
+        // (the old catch-all) handed back the iterator object itself —
+        // `.next().value` was then `undefined` (same class of bug as #800's
+        // `lastIndexOf`). Route through the runtime's generic dispatch so the
+        // `ARRAY_ITERATOR_CLASS_ID` check reaches `dispatch_array_iterator_method`.
+        "next" | "return" | "throw" => {
+            let mut lowered_args = Vec::with_capacity(args.len());
+            for a in args {
+                lowered_args.push(lower_expr(ctx, a)?);
+            }
+            let key_idx = ctx.strings.intern(property);
+            let entry = ctx.strings.entry(key_idx);
+            let bytes_global = format!("@{}", entry.bytes_global);
+            let name_len_str = entry.byte_len.to_string();
+            let (args_ptr, args_len) = if lowered_args.is_empty() {
+                ("null".to_string(), "0".to_string())
+            } else {
+                let n = lowered_args.len();
+                let buf_reg = ctx.func.alloca_entry_array(DOUBLE, n);
+                for (i, a_val) in lowered_args.iter().enumerate() {
+                    let slot = ctx
+                        .block()
+                        .gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", i))]);
+                    ctx.block().store(DOUBLE, a_val, &slot);
+                }
+                let ptr_reg = ctx.block().next_reg();
+                ctx.block().emit_raw(format!(
+                    "{} = getelementptr [{} x double], ptr {}, i64 0, i64 0",
+                    ptr_reg, n, buf_reg
+                ));
+                (ptr_reg, n.to_string())
+            };
+            let result = ctx.block().call(
+                DOUBLE,
+                "js_native_call_method",
+                &[
+                    (DOUBLE, &recv_box),
+                    (PTR, &bytes_global),
+                    (I64, &name_len_str),
+                    (PTR, &args_ptr),
+                    (I64, &args_len),
+                ],
+            );
+            Ok(result)
         }
         // Best-effort fallback: lower args for side effects, return
         // the receiver.

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1653,6 +1653,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_array_entries", I64, &[I64]);
     module.declare_function("js_array_keys", I64, &[I64]);
     module.declare_function("js_array_values", I64, &[I64]);
+    // #2384: iterator-OBJECT variants (real `.next()`-bearing iterator, not an
+    // eager materialized array) backing codegen's `Expr::ArrayValues`/etc.
+    module.declare_function("js_array_entries_iter_obj", I64, &[I64]);
+    module.declare_function("js_array_keys_iter_obj", I64, &[I64]);
+    module.declare_function("js_array_values_iter_obj", I64, &[I64]);
 
     // ──────────────────────────────────────────────────────────────────
     // Web Fetch API: Response / Headers / Request / Blob constructors +

--- a/crates/perry-runtime/src/array/iter_object.rs
+++ b/crates/perry-runtime/src/array/iter_object.rs
@@ -86,6 +86,68 @@ pub fn array_entries_iter(arr_f64: f64) -> f64 {
     unsafe { alloc_iterator(arr_ptr, KIND_ENTRIES) }
 }
 
+// ---------------------------------------------------------------------------
+// #2384: C-ABI entry points for codegen's `Expr::ArrayValues`/`ArrayKeys`/
+// `ArrayEntries` fast path. These build a real `.next()`-bearing iterator
+// OBJECT (not an eager materialized array), so a value-level
+// `const e = arr.entries(); e.next().value` matches Node. Spread
+// (`js_array_clone`) and the runtime default-iterator (`js_for_of_to_array`)
+// already detect `ARRAY_ITERATOR_CLASS_ID` and drive `.next()`, so
+// `[...arr.entries()]` / `for...of` / `Array.from(arr.entries())` keep working.
+//
+// They take a RAW array pointer (codegen passes the handle through
+// `unbox_to_i64`) and return the RAW iterator-object pointer as i64; the
+// caller NaN-boxes it via `nanbox_pointer_inline`.
+
+/// GcHeader `obj_type` byte for a receiver, or 0 if the pointer is too low to
+/// carry a header. Mirrors `flat_clone::receiver_gc_type` (that fn is private).
+unsafe fn receiver_obj_type(arr: *const ArrayHeader) -> u8 {
+    let addr = arr as usize;
+    if addr < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return 0;
+    }
+    let gc_header = (addr - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    (*gc_header).obj_type
+}
+
+unsafe fn array_iter_obj_raw(arr: *const ArrayHeader, kind: i32) -> i64 {
+    let cleaned = clean_arr_ptr(arr);
+    // #2384's iterator OBJECT is Array-scoped. A Map or Set reaches the codegen
+    // `.entries()`/`.keys()`/`.values()` catch-all when its static type is lost
+    // (`any`-typed Map/Set — effect's `FiberRefs.diff`, #321). Those keep the
+    // existing eager materialization, which `js_array_{entries,keys,values}`
+    // route to the correct Map/Set iterator — building an array-iterator over a
+    // Map/Set buffer would reinterpret it as `[index, value]` garbage. Genuine
+    // arrays (incl. `GC_TYPE_LAZY_ARRAY`) and everything else get the real
+    // iterator object.
+    let t = receiver_obj_type(cleaned);
+    if t == crate::gc::GC_TYPE_MAP || t == crate::gc::GC_TYPE_SET {
+        let materialized = match kind {
+            KIND_KEYS => crate::array::js_array_keys(arr),
+            KIND_VALUES => crate::array::js_array_values(arr),
+            _ => crate::array::js_array_entries(arr),
+        };
+        return materialized as i64;
+    }
+    let nanboxed = alloc_iterator(cleaned as *mut ArrayHeader, kind);
+    js_nanbox_get_pointer(nanboxed)
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_values_iter_obj(arr: *const ArrayHeader) -> i64 {
+    unsafe { array_iter_obj_raw(arr, KIND_VALUES) }
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_keys_iter_obj(arr: *const ArrayHeader) -> i64 {
+    unsafe { array_iter_obj_raw(arr, KIND_KEYS) }
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_entries_iter_obj(arr: *const ArrayHeader) -> i64 {
+    unsafe { array_iter_obj_raw(arr, KIND_ENTRIES) }
+}
+
 /// Build the `{ value, done }` iterator-result object. `value` arrives as
 /// a NaN-boxed JSValue; `done` is a JS boolean.
 unsafe fn make_iter_result(value: JSValue, done: bool) -> f64 {

--- a/test-files/test_gap_array_iterator_manual_next.ts
+++ b/test-files/test_gap_array_iterator_manual_next.ts
@@ -1,0 +1,61 @@
+// #2384: a value-level `Array.prototype.entries()`/`.keys()`/`.values()` must
+// return a real `.next()`-bearing iterator OBJECT, not an eagerly materialized
+// array. Before the fix, codegen's `Expr::ArrayEntries`/`ArrayKeys`/
+// `ArrayValues` fast path lowered to `js_array_{entries,keys,values}` (a
+// materialized array), so manual `e.next()` fell through the array-method
+// catch-all that returns the receiver — `.next().value` was `undefined`.
+// `for-of` and spread happened to work because they walk the materialized
+// array directly.
+//
+// Fix: route the fast path to iterator-OBJECT constructors and route the
+// `.next()`/`.return()`/`.throw()` array-method dispatch to the runtime's
+// generic dispatcher (which reaches `dispatch_array_iterator_method`). Spread /
+// for-of / Array.from keep working because `js_array_clone` /
+// `js_for_of_to_array` already detect the iterator class id and drive `.next()`.
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+// (1) manual .next() on entries() yields { value: [i, x], done }.
+const e = [10, 20, 30].entries();
+console.log(JSON.stringify(e.next())); // {"value":[0,10],"done":false}
+console.log(JSON.stringify(e.next())); // {"value":[1,20],"done":false}
+console.log(JSON.stringify(e.next())); // {"value":[2,30],"done":false}
+console.log(JSON.stringify(e.next())); // {"done":true}
+console.log(e.next().value === undefined); // true (past end)
+
+// (2) .keys() / .values() iterators advance independently.
+const k = [10, 20, 30].keys();
+console.log(JSON.stringify(k.next())); // {"value":0,"done":false}
+console.log(k.next().value); // 1
+
+const v = ["a", "b"].values();
+console.log(v.next().value); // a
+console.log(v.next().value); // b
+
+// (3) the iterator is itself iterable, and spread / for-of / Array.from still
+//     consume it correctly (regression guard for the materialized paths).
+console.log(JSON.stringify([...[10, 20].entries()])); // [[0,10],[1,20]]
+console.log(JSON.stringify([...[10, 20].keys()])); // [0,1]
+console.log(JSON.stringify([...["a", "b"].values()])); // ["a","b"]
+
+const out: string[] = [];
+for (const [i, x] of ["a", "b"].entries()) {
+  out.push(`${i}:${x}`);
+}
+console.log(out.join(",")); // 0:a,1:b
+
+console.log(JSON.stringify(Array.from([10, 20].entries()))); // [[0,10],[1,20]]
+
+// (4) early break out of a for-of over an iterator (exercises .return()).
+for (const [i, x] of [9, 8, 7].entries()) {
+  if (i === 1) break;
+  console.log("brk", i, x); // brk 0 9
+}
+
+// (5) empty array iterator is immediately done.
+console.log(JSON.stringify([].values().next())); // {"done":true}
+
+// (6) chained: destructure the pair straight off .next().value.
+const e2 = [100, 200].entries();
+const [, first] = e2.next().value;
+console.log(first); // 100


### PR DESCRIPTION
## Summary

Fixes #2384. A value-level `Array.prototype.entries()` / `.keys()` / `.values()` now returns a real `.next()`-bearing **iterator object** (matching Node) instead of an eagerly materialized array.

```ts
const e = [10, 20, 30].entries();
e.next();         // before: [[0,10],[1,20],[2,30]]   now: { value: [0,10], done: false }
e.next().value;   // before: undefined                now: [0,10]
```

## Root cause

Codegen's `Expr::ArrayEntries`/`ArrayKeys`/`ArrayValues` fast path lowered to `js_array_{entries,keys,values}` — a materialized array. Manual `.next()` on that array then fell through the array-method dispatch's best-effort catch-all that **returns the receiver**, so `.next().value` was `undefined` (same class of bug as #800's `lastIndexOf`). `for-of` and spread worked only because they walk the materialized array directly.

## Fix

- **perry-runtime**: add C-ABI iterator-object constructors `js_array_{entries,keys,values}_iter_obj` that build the existing `ARRAY_ITERATOR_CLASS_ID` object (advanced by `dispatch_array_iterator_method`). A Map/Set reaching the same `any`-typed catch-all keeps the eager materialization (delegated to `js_array_{entries,keys,values}`, which route to the correct Map/Set iterator — #321), so a Map buffer is never reinterpreted as `[index, value]` garbage.
- **perry-codegen**: route the `Expr::Array{Entries,Keys,Values}` fast path (in `arrays_finds.rs` and `lower_array_method.rs`) to the new iterator-object wrappers, and route the `next`/`return`/`throw` array-method arms to the runtime's generic `js_native_call_method` dispatch instead of returning the receiver, so the iterator-object class-id check reaches `dispatch_array_iterator_method`.

Spread / `for-of` / `Array.from` keep working unchanged: `js_array_clone` and `js_for_of_to_array` already detect `ARRAY_ITERATOR_CLASS_ID` and drive `.next()`.

## Validation

- New gap test `test-files/test_gap_array_iterator_manual_next.ts` — byte-identical to `node --experimental-strip-types` (manual `.next()`, `.keys()`/`.values()`, spread, for-of, `Array.from`, early-break `.return()`, empty array, chained destructure).
- Full `test_gap_*.ts` sweep: **103/106**; the 3 non-passing are pre-existing and unrelated (`console_methods` is a known categorical gap; `derived_param_props` / `param_prop_array_index` use TS parameter properties that `--strip-types` can't run — `param_prop_array_index` matches its stored expected `.txt`).
- `test_gap_map_set_entries_dispatch.ts` (the `any`-typed Map/Set dispatch, #321) still passes — confirms no regression to the Map/Set path.
- `cargo fmt --all -- --check` clean.
