### PR TITLE
fix(node:url): close credentials helper delimiter

### DIFF
--- a/crates/perry-runtime/src/url/url_class.rs
+++ b/crates/perry-runtime/src/url/url_class.rs
@@ -73,6 +73,8 @@ fn url_can_have_credentials(url: *mut ObjectHeader) -> bool {
     let host = get_string_content(crate::object::js_object_get_field_f64(url, URL_HOST));
     let protocol = get_string_content(crate::object::js_object_get_field_f64(url, URL_PROTOCOL));
     !host.is_empty() && protocol != "file:"
+}
+
 fn normalize_hostname_value(raw: &str) -> Option<String> {
     if raw.is_empty()
         || raw.chars().any(|c| {


### PR DESCRIPTION
## Summary
- restore the missing closing brace after `url_can_have_credentials` in `url_class.rs`
- unblocks current `main` from compiling after the URL userinfo setter changes

## Verification
- `cargo check -p perry-runtime`: PASS with existing warnings
- `rustfmt --check crates/perry-runtime/src/url/url_class.rs`: PASS
- `git diff --check` and `git diff --cached --check`: PASS