### PR TITLE
fix(ci): restore main URL/API docs checks

### DIFF
--- a/crates/perry-runtime/src/url/url_class.rs
+++ b/crates/perry-runtime/src/url/url_class.rs
@@ -73,6 +73,8 @@ fn url_can_have_credentials(url: *mut ObjectHeader) -> bool {
     let host = get_string_content(crate::object::js_object_get_field_f64(url, URL_HOST));
     let protocol = get_string_content(crate::object::js_object_get_field_f64(url, URL_PROTOCOL));
     !host.is_empty() && protocol != "file:"
+}
+
 fn normalize_hostname_value(raw: &str) -> Option<String> {
     if raw.is_empty()
         || raw.chars().any(|c| {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1498 entries across 82 modules
+// Coverage: 1501 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -2096,6 +2096,8 @@ declare module "util/types" {
   export function isMap(...args: any[]): any;
   /** stdlib */
   export function isMapIterator(...args: any[]): any;
+  /** stdlib */
+  export function isNativeError(...args: any[]): any;
   /** stdlib */
   export function isNumberObject(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1498 entries across 82 modules.
+Total: 1501 entries across 82 modules.
 
 ## Modules
 
@@ -2007,6 +2007,7 @@ Total: 1498 entries across 82 modules.
 - `isInt8Array` — module
 - `isMap` — module
 - `isMapIterator` — module
+- `isNativeError` — module
 - `isNumberObject` — module
 - `isPromise` — module
 - `isProxy` — module


### PR DESCRIPTION
## Summary
- Close the missing `url_can_have_credentials` block so `url_class.rs` parses again on current `main`.
- Regenerate API docs so `util/types.isNativeError` and the manifest totals match the current API manifest.

## Context
- Follow-up to #2405 after its check run failed in `lint`, `cargo-test`, `api-docs-drift`, and `compiler-output-regression`.

## Commands Run
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `./scripts/check_file_size.sh`
- `git diff --check origin/main...HEAD`
- `./scripts/regen_api_docs.sh` (rerun after amendment; clean diff)
- `RUST_TEST_THREADS=1 cargo test -p perry-runtime` (785 passed)
