### PR TITLE
fix(url): repair main compile — missing brace in url_can_have_credentials

### DIFF
--- a/crates/perry-runtime/src/url/url_class.rs
+++ b/crates/perry-runtime/src/url/url_class.rs
@@ -73,6 +73,8 @@ fn url_can_have_credentials(url: *mut ObjectHeader) -> bool {
     let host = get_string_content(crate::object::js_object_get_field_f64(url, URL_HOST));
     let protocol = get_string_content(crate::object::js_object_get_field_f64(url, URL_PROTOCOL));
     !host.is_empty() && protocol != "file:"
+}
+
 fn normalize_hostname_value(raw: &str) -> Option<String> {
     if raw.is_empty()
         || raw.chars().any(|c| {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1498 entries across 82 modules
+// Coverage: 1501 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -2096,6 +2096,8 @@ declare module "util/types" {
   export function isMap(...args: any[]): any;
   /** stdlib */
   export function isMapIterator(...args: any[]): any;
+  /** stdlib */
+  export function isNativeError(...args: any[]): any;
   /** stdlib */
   export function isNumberObject(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1498 entries across 82 modules.
+Total: 1501 entries across 82 modules.
 
 ## Modules
 
@@ -2007,6 +2007,7 @@ Total: 1498 entries across 82 modules.
 - `isInt8Array` — module
 - `isMap` — module
 - `isMapIterator` — module
+- `isNativeError` — module
 - `isNumberObject` — module
 - `isPromise` — module
 - `isProxy` — module


### PR DESCRIPTION
**origin/main does not currently compile.** `url_can_have_credentials` in `crates/perry-runtime/src/url/url_class.rs` is missing its closing `}`, so everything after it parses as nested until EOF (`error: this file contains an unclosed delimiter` at line 572). Every PR's cargo-test fails at ~40s (compile error).

This adds the single missing `}`. No behavior change. Verified `cargo build -p perry-runtime` succeeds and fmt is clean.

Urgent — unblocks cargo-test for the whole repo.