### PR TITLE
test(#2398): lock in console.log/util.inspect Date-as-ISO parity

### DIFF
--- a/test-files/test_issue_2398_console_date.ts
+++ b/test-files/test_issue_2398_console_date.ts
@@ -1,0 +1,39 @@
+// Issue #2398: console.log / util.inspect must render a Date as Node's ISO
+// string, while its numeric timestamp (getTime() / valueOf() / a literal)
+// keeps printing as a plain number. This works because #2089/#2380 made a
+// Date a distinguishable heap reference — guarding against a regression of
+// the kind PR #2397 (now obsolete) was reverting.
+import util from "node:util";
+
+// Direct constructor argument.
+console.log(new Date(0));
+
+// Inferred Date local.
+const d = new Date(1700000000000);
+console.log(d);
+
+// Explicitly-annotated Date local.
+const annotated: Date = new Date(0);
+console.log(annotated);
+
+// The numeric timestamp must still print as a number — not ISO.
+console.log(d.getTime());
+console.log(+d);
+console.log(1700000000000);
+
+// Mixed multi-arg: string + Date + string.
+console.log("at", new Date(0), "done");
+
+// Invalid Date.
+console.log(new Date(NaN));
+
+// Date arithmetic is unaffected.
+console.log(d.getTime() - 1700000000000);
+
+// Nested in an object/array: Date renders ISO, the timestamp stays numeric.
+console.log({ when: new Date(0), ts: d.getTime() });
+console.log([new Date(0), new Date(1700000000000)]);
+
+// util.inspect returns the ISO string.
+console.log(util.inspect(new Date(0)));
+console.log(util.inspect({ when: new Date(0) }));


### PR DESCRIPTION
## Summary

Closes #2398.

`console.log(new Date(0))` / `util.inspect(date)` rendering the raw timestamp instead of Node's ISO string was **resolved on `main` by #2380** ("model Date as a reference type", closing #2089). Now that a Date is a distinguishable heap reference — not the same f64 bits as its `getTime()` number — #2372's runtime ISO formatting is correct and the `getTime()`-prints-as-ISO regression that prompted the (still-open, now obsolete) revert PR #2397 no longer exists.

This PR adds a byte-for-byte parity regression test so a future #2397-style revert can't silently re-break the behavior. **No runtime/codegen changes** — the behavior already matches Node.

## Test

`test-files/test_issue_2398_console_date.ts` (auto-discovered by `run_parity_tests.sh`) covers, all verified byte-identical to `node`:

- `console.log(new Date(0))` → `1970-01-01T00:00:00.000Z`
- inferred and `: Date`-annotated Date locals → ISO
- `getTime()` / `+d` / timestamp literal → plain number (the discrimination guard)
- multi-arg, Invalid Date, Date arithmetic
- nested object/array: `{ when: 1970-01-01T00:00:00.000Z, ts: 1700000000000 }` (Date → ISO, timestamp → number)
- `util.inspect(date)` returns the ISO string

## Note

Revert PR #2397 is now obsolete and should be closed without merging — merging it would re-break #2398.
