### PR TITLE
fix(android): global-dynamic TLS model + bundle companion .so into APK (#1529, #1527)

### DIFF
--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -1299,6 +1299,14 @@ pub(super) fn build_geisterhand_libs(target: Option<&str>, format: OutputFormat)
         cargo_cmd.arg("--target").arg(triple);
     }
 
+    // #1529 — the geisterhand runtime/stdlib also land in the dlopen'd
+    // `libperry_app.so` on Android; force global-dynamic TLS so the IE
+    // model doesn't crash at load. (RUSTFLAGS scopes to the cross target,
+    // so host build-scripts/proc-macros are unaffected.)
+    if matches!(target, Some("android") | Some("android-x86_64")) {
+        cargo_cmd.env("RUSTFLAGS", "-C tls-model=global-dynamic");
+    }
+
     let status = cargo_cmd
         .status()
         .map_err(|e| anyhow!("Failed to run cargo: {}", e))?;

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -1177,7 +1177,8 @@ pub(super) fn build_and_run_link(
             } else if is_android {
                 (
                     "libperry_ui_android.a",
-                    "cargo build --release -p perry-ui-android --target aarch64-linux-android",
+                    // #1529 — TLS model must be global-dynamic for the dlopen'd cdylib.
+                    "RUSTFLAGS=\"-C tls-model=global-dynamic\" cargo build --release -p perry-ui-android --target aarch64-linux-android",
                 )
             } else if is_linux {
                 (
@@ -1353,11 +1354,14 @@ pub(super) fn build_and_run_link(
                         cargo_cmd.arg("-Zbuild-std=std,panic_abort");
                     }
 
-                    // For Android, ensure 16 KB page size alignment (required by Google Play)
+                    // For Android, ensure 16 KB page size alignment (required by Google Play),
+                    // and force the global-dynamic TLS model (#1529): the native lib's TLS
+                    // relocations are baked into the dlopen'd `libperry_app.so`, so an
+                    // Initial-Executable model (rustc's android default) crashes at load.
                     if is_android {
                         cargo_cmd.env(
                             "CARGO_TARGET_AARCH64_LINUX_ANDROID_RUSTFLAGS",
-                            "-C link-arg=-Wl,-z,max-page-size=16384",
+                            "-C link-arg=-Wl,-z,max-page-size=16384 -C tls-model=global-dynamic",
                         );
                     }
 

--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -611,14 +611,30 @@ pub(super) fn build_optimized_libs(
             }
         }
     }
+    // RUSTFLAGS is the only path that works without a custom cargo profile,
+    // and cargo correctly reuses incremental artifacts that were built with
+    // the same RUSTFLAGS. The hash-keyed CARGO_TARGET_DIR keeps builds with
+    // distinct flag sets from clobbering each other's cache.
+    let mut rustflags: Vec<&str> = Vec::new();
     if panic_abort_safe {
         // Override the workspace profile's `panic = "unwind"` for the
-        // duration of this invocation. RUSTFLAGS is the only path that
-        // works without a custom cargo profile, and cargo correctly
-        // reuses incremental artifacts that were built with the same
-        // RUSTFLAGS. The hash-keyed CARGO_TARGET_DIR keeps the abort
-        // and unwind builds from clobbering each other's cache.
-        cargo_cmd.env("RUSTFLAGS", "-C panic=abort");
+        // duration of this invocation.
+        rustflags.push("-C panic=abort");
+    }
+    // #1529 — Android loads `libperry_app.so` via `dlopen` at runtime
+    // (PerryActivity's System.loadLibrary), but Rust's default TLS model for
+    // the aarch64-linux-android target is Initial-Executable, which is only
+    // valid for libraries present at process startup. A dlopen'd library
+    // crashes with `TLS symbol "(null)" ... using IE access model`. The
+    // runtime/stdlib use `thread_local!` heavily (per-thread arena, GC state,
+    // shadow stack), so those IE TLS relocations get baked into the final
+    // cdylib. Force global-dynamic so the dynamic linker can resolve TLS
+    // slots after the process has started.
+    if matches!(target, Some("android") | Some("android-x86_64")) {
+        rustflags.push("-C tls-model=global-dynamic");
+    }
+    if !rustflags.is_empty() {
+        cargo_cmd.env("RUSTFLAGS", rustflags.join(" "));
     }
 
     // Closes #25 (the v0.5.384 NJOBS 6→3 retreat): serialize parallel

--- a/crates/perry/src/commands/run/android.rs
+++ b/crates/perry/src/commands/run/android.rs
@@ -48,6 +48,62 @@ pub fn build_and_run_android(
     std::fs::copy(so_path, jni_dir.join("libperry_app.so"))
         .map_err(|e| anyhow!("Failed to copy .so to jniLibs: {}", e))?;
 
+    // #1527 — bundle companion shared libraries. The compile step copies
+    // third-party `crate-android` cdylib outputs (e.g. `libperry_play_billing.so`
+    // from @perryts/play-billing) next to the main binary in the staging dir
+    // (the "Copied companion library" log line). `libperry_app.so` records them
+    // in DT_NEEDED, so the dynamic linker must find them in the same `lib/<abi>/`
+    // dir inside the APK — Gradle bundles whatever lives in jniLibs/<abi>/.
+    // Without this, the app crashes on launch with `UnsatisfiedLinkError:
+    // dlopen failed: library "lib….so" not found`. Static-lib companions link
+    // directly into libperry_app.so and have no `.so` here, so nothing to copy.
+    let staging_dir = so_path.parent().unwrap_or(Path::new("."));
+    if let Ok(entries) = std::fs::read_dir(staging_dir) {
+        let mut bundled = 0usize;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            // Only sibling `.so` files; the main output was already copied as
+            // libperry_app.so above (and it carries no `.so` extension itself,
+            // so it can't match here and won't be double-copied).
+            let is_so = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(|e| e == "so")
+                .unwrap_or(false);
+            if !is_so || path == *so_path {
+                continue;
+            }
+            let Some(name) = path.file_name() else {
+                continue;
+            };
+            match std::fs::copy(&path, jni_dir.join(name)) {
+                Ok(_) => {
+                    bundled += 1;
+                    if let OutputFormat::Text = format {
+                        println!("  Bundled companion library: {}", name.to_string_lossy());
+                    }
+                }
+                Err(e) => {
+                    if let OutputFormat::Text = format {
+                        println!(
+                            "Warning: failed to bundle companion library {}: {}",
+                            name.to_string_lossy(),
+                            e
+                        );
+                    }
+                }
+            }
+        }
+        if bundled > 0 {
+            if let OutputFormat::Text = format {
+                println!(
+                    "  Bundled {} companion .so into jniLibs/arm64-v8a (#1527)",
+                    bundled
+                );
+            }
+        }
+    }
+
     // Copy resource directories (assets/, logo/, etc.) into APK assets
     // Android loads ImageFile('assets/foo.png') from the APK's assets/ directory,
     // so we need 'assets/' inside 'app/src/main/assets/' → accessible as 'assets/foo.png'


### PR DESCRIPTION
## Summary

Two Android packaging fixes that together unblock the local build path (`perry run --local android`), which today produces an APK that installs but crashes on launch.

### #1529 — TLS Initial-Executable model crashes at dlopen

`perry compile --target android` built `libperry_app.so` with the IE TLS access model (rustc's default for `aarch64-linux-android`). That model is only valid for libraries present at process startup, but `PerryActivity` `dlopen`s the lib at runtime, so it crashed with:

```
dlopen failed: TLS symbol "(null)" in dlopened "…/libperry_app.so"
  referenced from "…/libperry_app.so" using IE access model
```

The runtime/stdlib use `thread_local!` heavily (per-thread arena, GC state, shadow stack), so those IE relocations get baked into the cdylib. Fix forces `-C tls-model=global-dynamic` for **every** Rust crate compiled for the android target:

- `optimized_libs.rs` — runtime/stdlib auto-optimize cross-build (combined with the existing `-C panic=abort` when applicable)
- `link/mod.rs` — third-party `perry.nativeLibrary` crate builds (appended to the existing `max-page-size` RUSTFLAGS)
- `library_search.rs` — geisterhand runtime/stdlib/ui cross-build
- the printed `perry-ui-android` manual build instruction

`RUSTFLAGS` scopes to the cross target on a cross-compile, so host build-scripts/proc-macros are unaffected.

### #1527 — companion `.so` deps not bundled into the APK

When an app depends on a `crate-android` cdylib (e.g. `libperry_play_billing.so` from `@perryts/play-billing`), the compile step copied the `.so` next to the output binary ("Copied companion library: …") but it never reached the APK, so launch failed with:

```
java.lang.UnsatisfiedLinkError: dlopen failed:
  library "libperry_play_billing.so" not found: needed by …/libperry_app.so
```

`build_and_run_android` now copies every sibling `.so` from the staging dir into `app/src/main/jniLibs/arm64-v8a/` so Gradle bundles them alongside `libperry_app.so`. The main binary carries no `.so` extension, so it can't be double-copied. Static-lib companions (e.g. `@perryts/google-auth`) link directly into `libperry_app.so` and have no `.so` to bundle, so they're correctly skipped.

## Testing

- `cargo build --release -p perry` — clean (only pre-existing warnings)
- `cargo fmt --all -- --check` — clean

Closes #1529
Closes #1527
