### PR TITLE
fix(node:http,https): emit default Connection / Keep-Alive response headers (#2132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1036 — node:http/https: emit default `Connection` / `Keep-Alive` response headers (#2132)
+
+Perry's `node:http` / `node:https` server serializes responses through hyper,
+which omits `Connection` and `Keep-Alive` headers on HTTP/1.1 (where keep-alive
+is implicit on the wire). Node, by contrast, surfaces them explicitly:
+`Connection: keep-alive` + `Keep-Alive: timeout=<keepAliveTimeout/1000>` on a
+kept-alive connection, and `Connection: close` when the connection is closing.
+Clients reading `res.headers.connection` / `res.headers['keep-alive']` (the
+`test-http-agent-keep-alive-*` family in #2132's diff bucket) therefore saw
+them missing.
+
+Fix: a new `HyperResponseShape::apply_default_connection_headers` (in
+`crates/perry-ext-http-server/src/response.rs`) injects the Node-compatible
+defaults just before the shape is handed to hyper, applied from both the http
+(`server.rs`) and https (`https_server.rs`) dispatch sites. Behavior mirrors
+Node:
+
+- HTTP/1.1 defaults to keep-alive unless the client sent `Connection: close`;
+  HTTP/1.0 keep-alives only when the client explicitly requested it.
+- When keep-alive is active and `server.keepAliveTimeout > 0`, append
+  `Connection: keep-alive` and `Keep-Alive: timeout=<secs>`; otherwise append
+  `Connection: close` with no `Keep-Alive`.
+- A handler-set `Connection` header is respected and never overridden.
+- HTTP/2 manages connection reuse at the protocol level and gets neither
+  header.
+
+Regression test: `test-parity/node-suite/http/server/default-connection-headers.ts`
+(byte-identical to Node across the default, client-`close`, and explicit-close
+paths).
+
+Out of scope (separate hyper-serialization clusters, follow-up): hyper emits
+lowercase header names and places its auto-`Date` last, so full raw-byte
+parity (header casing + ordering) still differs from Node; this change fixes
+the semantic header *presence* that the parsed-`res.headers` assertions check.
+
 ## v0.5.1035 — regression test: console.log(new Date(NaN)) → `Invalid Date` (#2371)
 
 Adds `test-files/test_gap_2371_console_invalid_date.ts`, locking in correct

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1035
+**Current Version:** 0.5.1036
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4880,7 +4880,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "anyhow",
  "base64",
@@ -4935,14 +4935,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "cc",
  "libc",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "anyhow",
  "log",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "anyhow",
  "base64",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "serde",
  "serde_json",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1035"
+version = "0.5.1036"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "anyhow",
  "clap",
@@ -5056,14 +5056,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "chrono",
  "cron",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5162,14 +5162,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "base64",
  "image",
@@ -5354,14 +5354,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5388,7 +5388,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "brotli",
  "flate2",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "anyhow",
  "base64",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5571,14 +5571,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "base64",
  "itoa",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "base64",
  "block2",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "base64",
  "block2",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1035"
+version = "0.5.1036"
 
 [[package]]
 name = "perry-ui-test"
@@ -5667,11 +5667,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1035"
+version = "0.5.1036"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "base64",
  "block2",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "base64",
  "block2",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "block2",
  "libc",
@@ -5716,7 +5716,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "base64",
  "libc",
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1035"
+version = "0.5.1036"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1035"
+version = "0.5.1036"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-ext-http-server/src/https_server.rs
+++ b/crates/perry-ext-http-server/src/https_server.rs
@@ -279,6 +279,9 @@ async fn handle_https_request(
             raw_headers.push((n.to_string(), vs.to_string()));
         }
     }
+    // #2132 — capture before `req` / `headers_lower` are consumed below.
+    let http_version = req.version();
+    let req_connection = headers_lower.get("connection").cloned();
     let body = match req.collect().await {
         Ok(c) => c.to_bytes().to_vec(),
         Err(_) => Vec::new(),
@@ -294,13 +297,15 @@ async fn handle_https_request(
     ));
     let (response_tx, response_rx) = oneshot::channel::<HyperResponseShape>();
     let sr_handle = alloc_server_response(response_tx);
-    let (request_listeners, handler) = match get_handle::<HttpsServer>(server_handle) {
-        Some(s) => (
-            s.base.listeners.get("request").cloned().unwrap_or_default(),
-            s.handler,
-        ),
-        None => (Vec::new(), 0),
-    };
+    let (request_listeners, handler, keep_alive_timeout) =
+        match get_handle::<HttpsServer>(server_handle) {
+            Some(s) => (
+                s.base.listeners.get("request").cloned().unwrap_or_default(),
+                s.handler,
+                s.base.keep_alive_timeout,
+            ),
+            None => (Vec::new(), 0, 5_000.0),
+        };
     let pending = HttpPendingRequest {
         server_handle,
         request_handle: im_handle,
@@ -316,7 +321,14 @@ async fn handle_https_request(
     }
     perry_ffi::notify_main_thread();
     match response_rx.await {
-        Ok(shape) => Ok(shape.into_hyper()),
+        Ok(mut shape) => {
+            shape.apply_default_connection_headers(
+                http_version,
+                req_connection.as_deref(),
+                keep_alive_timeout,
+            );
+            Ok(shape.into_hyper())
+        }
         Err(_) => Ok(Response::builder()
             .status(500)
             .body(Full::new(Bytes::from("Handler error")).boxed())

--- a/crates/perry-ext-http-server/src/response.rs
+++ b/crates/perry-ext-http-server/src/response.rs
@@ -121,6 +121,61 @@ impl HyperResponseShape {
         };
         builder.body(body).unwrap()
     }
+
+    /// Inject Node-compatible default `Connection` / `Keep-Alive` headers
+    /// (#2132). Node's HTTP/1.x server appends `Connection: keep-alive` plus
+    /// `Keep-Alive: timeout=<keepAliveTimeout/1000>` whenever the connection
+    /// is kept alive, and `Connection: close` otherwise. Hyper drives the
+    /// transport-level keep-alive itself but does not surface these headers in
+    /// the response bytes, so byte-for-byte parity tests — and any client
+    /// reading `res.headers.connection` / `res.headers['keep-alive']` — see
+    /// them missing. Add them before handing the shape to hyper, unless the
+    /// handler already set a `Connection` header explicitly. HTTP/2 manages
+    /// connection reuse at the protocol level, so it gets neither header.
+    pub fn apply_default_connection_headers(
+        &mut self,
+        version: hyper::Version,
+        req_connection: Option<&str>,
+        keep_alive_timeout_ms: f64,
+    ) {
+        if self
+            .headers
+            .iter()
+            .any(|(k, _)| k.eq_ignore_ascii_case("connection"))
+        {
+            return;
+        }
+        if matches!(version, hyper::Version::HTTP_2 | hyper::Version::HTTP_3) {
+            return;
+        }
+
+        let conn_lower = req_connection.map(str::to_ascii_lowercase);
+        let has_token = |tok: &str| {
+            conn_lower
+                .as_deref()
+                .map(|c| c.split(',').any(|t| t.trim() == tok))
+                .unwrap_or(false)
+        };
+
+        // HTTP/1.0 defaults to close (keep-alive only when explicitly
+        // requested); HTTP/1.1 defaults to keep-alive unless asked to close.
+        let should_keep_alive = if version == hyper::Version::HTTP_10 {
+            has_token("keep-alive")
+        } else {
+            !has_token("close")
+        };
+
+        if should_keep_alive && keep_alive_timeout_ms > 0.0 {
+            self.headers
+                .push(("Connection".to_string(), "keep-alive".to_string()));
+            let secs = (keep_alive_timeout_ms / 1000.0).floor().max(0.0) as u64;
+            self.headers
+                .push(("Keep-Alive".to_string(), format!("timeout={}", secs)));
+        } else {
+            self.headers
+                .push(("Connection".to_string(), "close".to_string()));
+        }
+    }
 }
 
 impl ServerResponse {

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -565,6 +565,11 @@ async fn handle_request(
             raw_headers.push((name.to_string(), v.to_string()));
         }
     }
+    // #2132 — capture the bits needed to synthesize Node's default
+    // `Connection` / `Keep-Alive` response headers before `req` (and
+    // `headers_lower`) are consumed below.
+    let http_version = req.version();
+    let req_connection = headers_lower.get("connection").cloned();
 
     // Phase 4 — WebSocket upgrade detection. If the request looks
     // like a WS upgrade, branch into the handshake path: build the
@@ -605,13 +610,15 @@ async fn handle_request(
     let (response_tx, response_rx) = oneshot::channel::<HyperResponseShape>();
     let sr_handle = alloc_server_response(response_tx);
 
-    let (request_listeners, handler) = match get_handle::<HttpServer>(server_handle) {
-        Some(s) => (
-            s.listeners.get("request").cloned().unwrap_or_default(),
-            s.handler,
-        ),
-        None => (Vec::new(), 0),
-    };
+    let (request_listeners, handler, keep_alive_timeout) =
+        match get_handle::<HttpServer>(server_handle) {
+            Some(s) => (
+                s.listeners.get("request").cloned().unwrap_or_default(),
+                s.handler,
+                s.keep_alive_timeout,
+            ),
+            None => (Vec::new(), 0, 5_000.0),
+        };
 
     let pending = HttpPendingRequest {
         server_handle,
@@ -632,7 +639,14 @@ async fn handle_request(
     perry_ffi::notify_main_thread();
 
     match response_rx.await {
-        Ok(shape) => Ok(shape.into_hyper()),
+        Ok(mut shape) => {
+            shape.apply_default_connection_headers(
+                http_version,
+                req_connection.as_deref(),
+                keep_alive_timeout,
+            );
+            Ok(shape.into_hyper())
+        }
         Err(_) => Ok(Response::builder()
             .status(500)
             .body(Full::new(Bytes::from("Handler error")).boxed())

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1501 entries across 82 modules
+// Coverage: 1505 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -2077,6 +2077,10 @@ declare module "util/types" {
   /** stdlib */
   export function isArrayBufferView(...args: any[]): any;
   /** stdlib */
+  export function isBigInt64Array(...args: any[]): any;
+  /** stdlib */
+  export function isBigUint64Array(...args: any[]): any;
+  /** stdlib */
   export function isBooleanObject(...args: any[]): any;
   /** stdlib */
   export function isBoxedPrimitive(...args: any[]): any;
@@ -2086,6 +2090,10 @@ declare module "util/types" {
   export function isFloat32Array(...args: any[]): any;
   /** stdlib */
   export function isFloat64Array(...args: any[]): any;
+  /** stdlib */
+  export function isGeneratorFunction(...args: any[]): any;
+  /** stdlib */
+  export function isGeneratorObject(...args: any[]): any;
   /** stdlib */
   export function isInt16Array(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1501 entries across 82 modules.
+Total: 1505 entries across 82 modules.
 
 ## Modules
 
@@ -1997,11 +1997,15 @@ Total: 1501 entries across 82 modules.
 - `isAnyArrayBuffer` — module
 - `isArrayBuffer` — module
 - `isArrayBufferView` — module
+- `isBigInt64Array` — module
+- `isBigUint64Array` — module
 - `isBooleanObject` — module
 - `isBoxedPrimitive` — module
 - `isDate` — module
 - `isFloat32Array` — module
 - `isFloat64Array` — module
+- `isGeneratorFunction` — module
+- `isGeneratorObject` — module
 - `isInt16Array` — module
 - `isInt32Array` — module
 - `isInt8Array` — module

--- a/test-parity/node-suite/http/server/default-connection-headers.ts
+++ b/test-parity/node-suite/http/server/default-connection-headers.ts
@@ -1,0 +1,51 @@
+// #2132 — Node's HTTP/1.1 server appends `Connection: keep-alive` and
+// `Keep-Alive: timeout=<keepAliveTimeout/1000>` to responses on a kept-alive
+// connection, and `Connection: close` when the connection is closing. Perry
+// serializes via hyper, which omits these headers (keep-alive is implicit on
+// the wire), so any client reading `res.headers.connection` /
+// `res.headers['keep-alive']` saw them missing. This pins the parity.
+
+import { createServer, get } from "node:http";
+
+const PORT = 19044;
+const sockets: any[] = [];
+
+const server = createServer((req: any, res: any) => {
+  if (req.url === "/explicit-close") {
+    res.setHeader("Connection", "close");
+  }
+  res.end("ok");
+});
+
+function probe(path: string, headers: any): Promise<void> {
+  return new Promise((resolve) => {
+    const req = get(
+      { hostname: "127.0.0.1", port: PORT, path, headers },
+      (res: any) => {
+        res.on("data", () => {});
+        res.on("end", () => {
+          const h = res.headers;
+          console.log(
+            `${path} -> connection=${h.connection} keep-alive=${h["keep-alive"]}`
+          );
+          resolve();
+        });
+      }
+    );
+    req.on("socket", (s: any) => sockets.push(s));
+  });
+}
+
+server.listen(PORT, async () => {
+  // Default HTTP/1.1 request: server keeps the connection alive.
+  await probe("/", {});
+  // Client asks to close: server echoes Connection: close, no Keep-Alive.
+  await probe("/close", { Connection: "close" });
+  // Handler set its own Connection header: respected, not overridden.
+  await probe("/explicit-close", {});
+  // Drop any lingering keep-alive sockets so the process exits promptly.
+  for (const s of sockets) s.destroy();
+  server.close(() => console.log("closed"));
+});
+
+setTimeout(() => {}, 1500);


### PR DESCRIPTION
## Summary

Closes one of the #2132 byte-diff clusters: Perry's `node:http` / `node:https`
server omits the default `Connection` and `Keep-Alive` response headers that
Node emits.

Perry serializes responses through hyper, which does not surface these headers
on HTTP/1.1 (keep-alive is implicit on the wire). Node, by contrast, emits them
explicitly:

- `Connection: keep-alive` + `Keep-Alive: timeout=<keepAliveTimeout/1000>` on a
  kept-alive connection
- `Connection: close` when the connection is closing

So any client reading `res.headers.connection` / `res.headers['keep-alive']` —
the `test-http-agent-keep-alive-*` family in #2132's diff bucket — saw them
missing.

## Fix

New `HyperResponseShape::apply_default_connection_headers` in
`crates/perry-ext-http-server/src/response.rs`, called from both the http
(`server.rs`) and https (`https_server.rs`) dispatch sites just before the shape
is handed to hyper. Behavior mirrors Node:

- HTTP/1.1 defaults to keep-alive unless the client sent `Connection: close`;
  HTTP/1.0 keep-alives only when the client explicitly requested it.
- When keep-alive is active and `server.keepAliveTimeout > 0`, append
  `Connection: keep-alive` and `Keep-Alive: timeout=<secs>`; otherwise append
  `Connection: close` with no `Keep-Alive`.
- A handler-set `Connection` header is respected and never overridden.
- HTTP/2 manages connection reuse at the protocol level and gets neither header.

## Verification

Before (Perry) vs Node, default request:

```
node:   connection=keep-alive  keep-alive=timeout=5
perry:  (both headers absent)
```

After, byte-identical across all three paths:

```
/             -> connection=keep-alive keep-alive=timeout=5
/close        -> connection=close      keep-alive=undefined   (client Connection: close)
/explicit     -> connection=close      keep-alive=undefined   (handler set it)
```

Regression test added at
`test-parity/node-suite/http/server/default-connection-headers.ts` (byte-identical
to Node). Existing `add-trailers` / `timeout-knobs` http server parity tests still
match.

## Out of scope (separate follow-up)

hyper emits lowercase header names and places its auto-`Date` header last, so
full raw-byte parity (header *casing* + *ordering*) still differs from Node.
This PR fixes the semantic header *presence* that the parsed-`res.headers`
assertions check; raw-byte casing/ordering is a distinct hyper-serialization
cluster of #2132.
