### PR TITLE
fix(node:util): inspect proxies and weakmap entries

### DIFF
--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -949,26 +949,41 @@ pub(super) fn lower_builtin_new(
             Ok(Some(nanbox_pointer_inline(blk, &p)))
         }
         "WeakMap" => {
-            // Lower init iterable args for side effects; the runtime's
-            // js_weakmap_new takes no args and the HIR lowering of
-            // `.set(k,v)` calls dispatch on the resulting handle.
-            for a in args {
-                let _ = lower_expr(ctx, a)?;
-            }
+            let lowered_args = args
+                .iter()
+                .map(|a| lower_expr(ctx, a))
+                .collect::<Result<Vec<_>>>()?;
             let handle = ctx.block().call(I64, "js_weakmap_new", &[]);
             // js_weakmap_new returns a raw `*mut ObjectHeader` — NaN-box
             // with POINTER_TAG so subsequent `js_weakmap_*` calls can
             // `js_nanbox_get_pointer` on the f64.
             let boxed = nanbox_pointer_inline(ctx.block(), &handle);
-            Ok(Some(boxed))
+            if let Some(iterable) = lowered_args.first() {
+                Ok(Some(ctx.block().call(
+                    DOUBLE,
+                    "js_weakmap_init_iterable",
+                    &[(DOUBLE, &boxed), (DOUBLE, iterable)],
+                )))
+            } else {
+                Ok(Some(boxed))
+            }
         }
         "WeakSet" => {
-            for a in args {
-                let _ = lower_expr(ctx, a)?;
-            }
+            let lowered_args = args
+                .iter()
+                .map(|a| lower_expr(ctx, a))
+                .collect::<Result<Vec<_>>>()?;
             let handle = ctx.block().call(I64, "js_weakset_new", &[]);
             let boxed = nanbox_pointer_inline(ctx.block(), &handle);
-            Ok(Some(boxed))
+            if let Some(iterable) = lowered_args.first() {
+                Ok(Some(ctx.block().call(
+                    DOUBLE,
+                    "js_weakset_init_iterable",
+                    &[(DOUBLE, &boxed), (DOUBLE, iterable)],
+                )))
+            } else {
+                Ok(Some(boxed))
+            }
         }
         "AbortController" => {
             // Lower any incidental args for side effects (shouldn't have any).

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -895,6 +895,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // generic extern-call path at lower_call.rs:149.
     module.declare_function("js_weakmap_new", I64, &[]);
     module.declare_function("js_weakset_new", I64, &[]);
+    module.declare_function("js_weakmap_init_iterable", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_weakset_init_iterable", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_weakmap_set", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_weakmap_get", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_weakmap_has", DOUBLE, &[DOUBLE, DOUBLE]);

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -376,10 +376,15 @@ pub fn function_name_for_ptr(func_ptr: usize) -> Option<String> {
 /// surface in `[bracketed]` form. See #1200.
 thread_local! {
     static INSPECT_SHOW_HIDDEN: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static INSPECT_SHOW_PROXY: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 pub(crate) fn inspect_show_hidden() -> bool {
     INSPECT_SHOW_HIDDEN.with(|c| c.get())
+}
+
+fn inspect_show_proxy() -> bool {
+    INSPECT_SHOW_PROXY.with(|c| c.get())
 }
 
 /// RAII guard for `INSPECT_SHOW_HIDDEN`; restores the previous value on
@@ -396,6 +401,21 @@ impl InspectShowHiddenGuard {
 impl Drop for InspectShowHiddenGuard {
     fn drop(&mut self) {
         INSPECT_SHOW_HIDDEN.with(|c| c.set(self.0));
+    }
+}
+
+pub(crate) struct InspectShowProxyGuard(bool);
+
+impl InspectShowProxyGuard {
+    pub(crate) fn new(show: bool) -> Self {
+        let prev = INSPECT_SHOW_PROXY.with(|c| c.replace(show));
+        Self(prev)
+    }
+}
+
+impl Drop for InspectShowProxyGuard {
+    fn drop(&mut self) {
+        INSPECT_SHOW_PROXY.with(|c| c.set(self.0));
     }
 }
 
@@ -695,8 +715,7 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                 // instead (registry-gated, before the GC-header read; #800).
                 collections::format_regexp(ptr as *const crate::regex::RegExpHeader)
             } else if crate::proxy::js_proxy_is_proxy(value) != 0 {
-                let target = crate::proxy::js_proxy_target(value);
-                format_jsvalue(target, depth)
+                format_proxy_value(value, depth, false)
             } else if crate::date::is_date_cell_addr(ptr as usize) {
                 // #2089: a Date is a NaN-boxed `DateCell` pointer. Node's
                 // `util.inspect` prints the ISO string unquoted (or
@@ -842,8 +861,8 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                     // `[Object]` (#1204). The depth cap is overridable via
                     // INSPECT_DEPTH_LIMIT for `%o` / `console.dir(v, { depth })`.
                     let obj_ptr = ptr as *const crate::object::ObjectHeader;
-                    if let Some(body) = crate::weakref::weak_wrapper_inspect_label(obj_ptr) {
-                        return body.to_string();
+                    if let Some(body) = format_weak_wrapper(obj_ptr, depth) {
+                        return body;
                     }
                     if let Err(id) = inspect_enter_circular(ptr as usize) {
                         return format!("[Circular *{}]", id);
@@ -966,6 +985,66 @@ unsafe fn format_buffer_value(buf_ptr: *const crate::buffer::BufferHeader) -> St
     }
     out.push('>');
     out
+}
+
+fn format_proxy_value(value: f64, depth: usize, json: bool) -> String {
+    let target = crate::proxy::js_proxy_target(value);
+    if !inspect_show_proxy() {
+        return if json {
+            format_jsvalue_for_json(target, depth)
+        } else {
+            format_jsvalue(target, depth)
+        };
+    }
+
+    let handler = crate::proxy::js_proxy_handler(value);
+    let target_str = if json {
+        format_jsvalue_for_json(target, depth + 1)
+    } else {
+        format_jsvalue(target, depth + 1)
+    };
+    let handler_str = if json {
+        format_jsvalue_for_json(handler, depth + 1)
+    } else {
+        format_jsvalue(handler, depth + 1)
+    };
+    format!("Proxy [ {}, {} ]", target_str, handler_str)
+}
+
+fn format_weak_wrapper(
+    obj_ptr: *const crate::object::ObjectHeader,
+    depth: usize,
+) -> Option<String> {
+    use crate::weakref::WeakWrapperKind;
+
+    match crate::weakref::weak_wrapper_kind(obj_ptr)? {
+        WeakWrapperKind::WeakRef | WeakWrapperKind::FinalizationRegistry => {
+            crate::weakref::weak_wrapper_inspect_label(obj_ptr).map(str::to_string)
+        }
+        WeakWrapperKind::WeakMap | WeakWrapperKind::WeakSet if !inspect_show_hidden() => {
+            crate::weakref::weak_wrapper_inspect_label(obj_ptr).map(str::to_string)
+        }
+        WeakWrapperKind::WeakMap => {
+            let parts = crate::weakref::weak_collection_entries(obj_ptr)
+                .into_iter()
+                .map(|(key, value)| {
+                    format!(
+                        "{} => {}",
+                        format_jsvalue(key, depth + 1),
+                        format_jsvalue_for_json(value, depth + 1)
+                    )
+                })
+                .collect::<Vec<_>>();
+            Some(format!("WeakMap {{ {} }}", parts.join(", ")))
+        }
+        WeakWrapperKind::WeakSet => {
+            let parts = crate::weakref::weak_collection_entries(obj_ptr)
+                .into_iter()
+                .map(|(key, _)| format_jsvalue(key, depth + 1))
+                .collect::<Vec<_>>();
+            Some(format!("WeakSet {{ {} }}", parts.join(", ")))
+        }
+    }
 }
 
 /// Format an object as JSON-like string
@@ -1331,8 +1410,7 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
                 // Request) carries no GC header, so reading `ptr - 8` would
                 // deref unmapped memory — print a placeholder instead.
                 if crate::proxy::js_proxy_is_proxy(value) != 0 {
-                    let target = crate::proxy::js_proxy_target(value);
-                    format_jsvalue_for_json(target, depth)
+                    format_proxy_value(value, depth, true)
                 } else if crate::date::is_date_cell_addr(ptr as usize) {
                     // #2089: Date inside an inspected object — ISO string
                     // unquoted (or `Invalid Date`), not the 8-byte cell deref'd
@@ -1418,8 +1496,8 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
                         // depth cap is overridable via INSPECT_DEPTH_LIMIT
                         // for `%o` / `console.dir(v, { depth })`.
                         let obj_ptr = ptr as *const crate::object::ObjectHeader;
-                        if let Some(body) = crate::weakref::weak_wrapper_inspect_label(obj_ptr) {
-                            return body.to_string();
+                        if let Some(body) = format_weak_wrapper(obj_ptr, depth) {
+                            return body;
                         }
                         if let Err(id) = inspect_enter_circular(ptr as usize) {
                             return format!("[Circular *{}]", id);
@@ -1807,11 +1885,10 @@ pub extern "C" fn js_util_format(arr_ptr: *const crate::array::ArrayHeader) -> f
                 }
                 b'o' => {
                     // Node's `%o` overlays util.inspect options with
-                    // showHidden/showProxy and depth: 4. Perry does not expose
-                    // showProxy yet, but showHidden and the depth budget are
-                    // observable in current parity fixtures.
+                    // showHidden/showProxy and depth: 4.
                     let _depth_guard = InspectDepthLimitGuard::new(4);
                     let _hidden_guard = InspectShowHiddenGuard::new(true);
+                    let _proxy_guard = InspectShowProxyGuard::new(true);
                     out.push_str(&format_jsvalue(val, 0));
                 }
                 b'O' => {
@@ -1862,6 +1939,8 @@ pub extern "C" fn js_util_format_with_options(
     let max_depth = unsafe { super::console::decode_dir_depth_option(options) }.unwrap_or(2);
     let show_hidden =
         unsafe { super::console::decode_dir_bool_option(options, "showHidden") }.unwrap_or(false);
+    let show_proxy =
+        unsafe { super::console::decode_dir_bool_option(options, "showProxy") }.unwrap_or(false);
     let custom_inspect =
         unsafe { super::console::decode_dir_bool_option(options, "customInspect") }.unwrap_or(true);
     let getters =
@@ -1872,6 +1951,7 @@ pub extern "C" fn js_util_format_with_options(
         unsafe { super::console::decode_dir_bool_option(options, "compact") }.unwrap_or(true);
     let _depth_guard = InspectDepthLimitGuard::new(max_depth);
     let _hidden_guard = InspectShowHiddenGuard::new(show_hidden);
+    let _proxy_guard = InspectShowProxyGuard::new(show_proxy);
     let _custom_guard = InspectCustomInspectGuard::new(custom_inspect);
     let _getters_guard = InspectGettersGuard::new(getters);
     let _sorted_guard = InspectSortedGuard::new(sorted);
@@ -1884,6 +1964,8 @@ pub extern "C" fn js_util_inspect(value: f64, options: f64) -> f64 {
     let max_depth = unsafe { super::console::decode_dir_depth_option(options) }.unwrap_or(2);
     let show_hidden =
         unsafe { super::console::decode_dir_bool_option(options, "showHidden") }.unwrap_or(false);
+    let show_proxy =
+        unsafe { super::console::decode_dir_bool_option(options, "showProxy") }.unwrap_or(false);
     // `util.inspect` defaults to `customInspect: true`; an explicit
     // `{ customInspect: false }` opts out and surfaces the hook as a
     // symbol property. Refs #1201.
@@ -1897,6 +1979,7 @@ pub extern "C" fn js_util_inspect(value: f64, options: f64) -> f64 {
         unsafe { super::console::decode_dir_bool_option(options, "compact") }.unwrap_or(true);
     let _depth_guard = InspectDepthLimitGuard::new(max_depth);
     let _hidden_guard = InspectShowHiddenGuard::new(show_hidden);
+    let _proxy_guard = InspectShowProxyGuard::new(show_proxy);
     let _custom_guard = InspectCustomInspectGuard::new(custom_inspect);
     let _getters_guard = InspectGettersGuard::new(getters);
     let _sorted_guard = InspectSortedGuard::new(sorted);

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -183,6 +183,21 @@ pub extern "C" fn js_proxy_target(proxy_boxed: f64) -> f64 {
     f64::from_bits(TAG_UNDEFINED)
 }
 
+/// Return the proxy's handler for `util.inspect(..., { showProxy: true })`.
+#[no_mangle]
+pub extern "C" fn js_proxy_handler(proxy_boxed: f64) -> f64 {
+    if let Some(id) = lookup(proxy_boxed) {
+        return PROXIES.with(|p| {
+            p.borrow()
+                .get(id as usize)
+                .and_then(|o| o.as_ref())
+                .map(|e| e.handler)
+                .unwrap_or(f64::from_bits(TAG_UNDEFINED))
+        });
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
 /// Helper: fetch the trap closure from the handler object by name. Returns
 /// TAG_UNDEFINED if the handler has no such trap.
 fn handler_trap(handler: f64, trap_name: &str) -> f64 {

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -28,6 +28,27 @@ const FINREG_SHAPE_ID: u32 = 0x7FFF_FE11;
 pub const CLASS_ID_WEAKREF: u32 = 0xFFFF_0029;
 pub const CLASS_ID_FINALIZATION_REGISTRY: u32 = 0xFFFF_002A;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum WeakWrapperKind {
+    WeakRef,
+    FinalizationRegistry,
+    WeakMap,
+    WeakSet,
+}
+
+pub(crate) fn weak_wrapper_kind(obj: *const ObjectHeader) -> Option<WeakWrapperKind> {
+    if obj.is_null() {
+        return None;
+    }
+    match unsafe { (*obj).class_id } {
+        CLASS_ID_WEAKREF => Some(WeakWrapperKind::WeakRef),
+        CLASS_ID_FINALIZATION_REGISTRY => Some(WeakWrapperKind::FinalizationRegistry),
+        CLASS_ID_WEAKMAP => Some(WeakWrapperKind::WeakMap),
+        CLASS_ID_WEAKSET => Some(WeakWrapperKind::WeakSet),
+        _ => None,
+    }
+}
+
 /// The full `util.inspect` body for a weak-collection wrapper, or `None` if
 /// `obj` isn't one. Returning the complete string (not just the class name)
 /// lets WeakMap/WeakSet print Node's `{ <items unknown> }` placeholder — their
@@ -35,15 +56,36 @@ pub const CLASS_ID_FINALIZATION_REGISTRY: u32 = 0xFFFF_002A;
 /// FinalizationRegistry stay `{}`. Without this, WeakMap/WeakSet leaked their
 /// `__perry_wk_entries` storage field (e.g. `{ __perry_wk_entries: [] }`).
 pub(crate) fn weak_wrapper_inspect_label(obj: *const ObjectHeader) -> Option<&'static str> {
-    if obj.is_null() {
-        return None;
+    match weak_wrapper_kind(obj)? {
+        WeakWrapperKind::WeakRef => Some("WeakRef {}"),
+        WeakWrapperKind::FinalizationRegistry => Some("FinalizationRegistry {}"),
+        WeakWrapperKind::WeakMap => Some("WeakMap { <items unknown> }"),
+        WeakWrapperKind::WeakSet => Some("WeakSet { <items unknown> }"),
     }
-    match unsafe { (*obj).class_id } {
-        CLASS_ID_WEAKREF => Some("WeakRef {}"),
-        CLASS_ID_FINALIZATION_REGISTRY => Some("FinalizationRegistry {}"),
-        CLASS_ID_WEAKMAP => Some("WeakMap { <items unknown> }"),
-        CLASS_ID_WEAKSET => Some("WeakSet { <items unknown> }"),
-        _ => None,
+}
+
+pub(crate) fn weak_collection_entries(obj: *const ObjectHeader) -> Vec<(f64, f64)> {
+    match weak_wrapper_kind(obj) {
+        Some(WeakWrapperKind::WeakMap | WeakWrapperKind::WeakSet) => {}
+        _ => return Vec::new(),
+    }
+
+    unsafe {
+        let entries_ptr = entries_array(obj as *mut ObjectHeader);
+        if entries_ptr.is_null() {
+            return Vec::new();
+        }
+        let len = js_array_length(entries_ptr) as usize;
+        let mut entries = Vec::with_capacity(len);
+        for i in 0..len {
+            let pair_val_f = js_array_get_f64(entries_ptr, i as u32);
+            let pair_ptr = (pair_val_f.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ArrayHeader;
+            if pair_ptr.is_null() {
+                continue;
+            }
+            entries.push((js_array_get_f64(pair_ptr, 0), js_array_get_f64(pair_ptr, 1)));
+        }
+        entries
     }
 }
 
@@ -256,6 +298,36 @@ pub extern "C" fn js_weakmap_new() -> *mut ObjectHeader {
 }
 
 #[no_mangle]
+pub extern "C" fn js_weakmap_init_iterable(map: f64, iterable: f64) -> f64 {
+    if crate::array::js_array_is_array(iterable).to_bits() != TAG_TRUE {
+        return map;
+    }
+    let arr_ptr = js_nanbox_get_pointer(iterable) as *const ArrayHeader;
+    if arr_ptr.is_null() {
+        return map;
+    }
+    unsafe {
+        let len = js_array_length(arr_ptr) as usize;
+        for i in 0..len {
+            let pair = js_array_get_f64(arr_ptr, i as u32);
+            if crate::array::js_array_is_array(pair).to_bits() != TAG_TRUE {
+                continue;
+            }
+            let pair_ptr = js_nanbox_get_pointer(pair) as *const ArrayHeader;
+            if pair_ptr.is_null() {
+                continue;
+            }
+            js_weakmap_set(
+                map,
+                js_array_get_f64(pair_ptr, 0),
+                js_array_get_f64(pair_ptr, 1),
+            );
+        }
+    }
+    map
+}
+
+#[no_mangle]
 pub extern "C" fn js_weakmap_set(map: f64, key: f64, value: f64) -> f64 {
     let map_ptr = js_nanbox_get_pointer(map) as *mut ObjectHeader;
     if map_ptr.is_null() {
@@ -393,6 +465,24 @@ pub extern "C" fn js_weakset_new() -> *mut ObjectHeader {
         (*obj).class_id = CLASS_ID_WEAKSET;
     }
     obj
+}
+
+#[no_mangle]
+pub extern "C" fn js_weakset_init_iterable(set: f64, iterable: f64) -> f64 {
+    if crate::array::js_array_is_array(iterable).to_bits() != TAG_TRUE {
+        return set;
+    }
+    let arr_ptr = js_nanbox_get_pointer(iterable) as *const ArrayHeader;
+    if arr_ptr.is_null() {
+        return set;
+    }
+    unsafe {
+        let len = js_array_length(arr_ptr) as usize;
+        for i in 0..len {
+            js_weakset_add(set, js_array_get_f64(arr_ptr, i as u32));
+        }
+    }
+    set
 }
 
 #[no_mangle]


### PR DESCRIPTION
## Summary
- honor `util.inspect(..., { showProxy: true })` and `%o` by printing `Proxy [ target, handler ]`
- render WeakMap/WeakSet stored entries under `showHidden: true` while preserving the default opaque weak-collection output
- initialize WeakMap/WeakSet from array-backed constructor iterable arguments so inspect can see focused fixture entries

## Verification
- Baseline exact `node-suite/util/inspect/proxy-getters-weak`: FAIL, `test-parity/reports/parity_report_20260529_020246.json`
- Rebased exact `node-suite/util/inspect/proxy-getters-weak`: PASS, `test-parity/reports/parity_report_20260529_023152.json`
- Rebased inspect guardrail `./run_parity_tests.sh --suite node-suite --module util --filter inspect`: 13 PASS / 1 parity FAIL / 0 compile FAIL, `test-parity/reports/parity_report_20260529_023245.json` (`formatWithOptions/getters-and-custominspect`, open #2399)
- Rebased full util `./run_parity_tests.sh --suite node-suite --module util`: 55 PASS / 2 parity FAIL / 0 compile FAIL, `test-parity/reports/parity_report_20260529_023317.json` (`formatWithOptions/getters-and-custominspect`, `types/more-builtins` from open #2408)
- `cargo check -p perry-codegen -p perry-runtime`
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `cargo fmt --check -- crates/perry-runtime/src/builtins/formatting.rs crates/perry-runtime/src/proxy.rs crates/perry-runtime/src/weakref.rs crates/perry-codegen/src/runtime_decls/strings.rs crates/perry-codegen/src/lower_call/builtin.rs`
- `git diff --check -- crates/perry-runtime/src/builtins/formatting.rs crates/perry-runtime/src/proxy.rs crates/perry-runtime/src/weakref.rs crates/perry-codegen/src/runtime_decls/strings.rs crates/perry-codegen/src/lower_call/builtin.rs`
- `git diff --cached --check`

## DeepWiki / fallback evidence
- DeepWiki query for Node `util.inspect` Proxy/getters/WeakMap invariants timed out after 120s with no markdown output.
- Fallback direct Node output confirmed `proxy default: { a: 1 }`, `proxy shown: Proxy [ { a: 1 }, {} ]`, and `weakmap: WeakMap { {} => 1 }`.

## Non-goals
- no invalid WeakMap/WeakSet constructor iterable TypeError shaping
- no non-array iterable materialization for weak collections
- no broader util.inspect residual cleanup
- no async util.types predicate implementation on this branch
- no assigned custom-inspect hook changes beyond open #2399
