### PR TITLE
fix(node:console): write Console instances to custom streams

### DIFF
--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -194,6 +194,21 @@ pub(super) fn lower_builtin_new(
             let handle = blk.call(I64, "js_event_target_new", &[]);
             Ok(Some(nanbox_pointer_inline(blk, &handle)))
         }
+        "Console" => {
+            let opts = if let Some(a) = args.first() {
+                lower_expr(ctx, a)?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            for a in args.iter().skip(1) {
+                let _ = lower_expr(ctx, a)?;
+            }
+            Ok(Some(ctx.block().call(
+                DOUBLE,
+                "js_console_new",
+                &[(DOUBLE, &opts)],
+            )))
+        }
         // node:perf_hooks — `new PerformanceObserver(cb)` registers the
         // observer and returns its `perf_observer` namespace object (already
         // NaN-boxed). `cb` is passed through so the runtime can invoke it on

--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -27,7 +27,7 @@ use perry_hir::Expr;
 
 use crate::expr::{lower_expr, nanbox_pointer_inline, unbox_to_i64, FnCtx};
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
-use crate::types::{DOUBLE, I32, I64};
+use crate::types::{DOUBLE, I32, I64, PTR};
 
 // Re-export parent items so siblings can pick them up via `use super::*;`.
 // `pub(super)` is the visibility-tightest form that still lets the glob
@@ -1657,6 +1657,52 @@ pub(crate) fn lower_native_method_call(
             blk.call(DOUBLE, "js_util_format", &[(I64, &current_arr)])
         };
         return Ok(result);
+    }
+
+    // `new Console({ stdout, stderr }).log(...)` reaches HIR as an instance
+    // `NativeMethodCall` on module "console" / class "Console", not as a
+    // generic `PropertyGet` call. Preserve the receiver and route through the
+    // runtime's method dispatcher so per-instance streams, indentation, and
+    // counters are used instead of the process-global console helpers.
+    if module == "console" && class_name == Some("Console") {
+        if let Some(recv) = object {
+            let recv_box = lower_expr(ctx, recv)?;
+            let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());
+            for arg in args {
+                lowered_args.push(lower_expr(ctx, arg)?);
+            }
+
+            let (args_ptr, args_len) = if lowered_args.is_empty() {
+                ("null".to_string(), "0".to_string())
+            } else {
+                let n = lowered_args.len();
+                let buf = ctx.func.alloca_entry_array(DOUBLE, n);
+                {
+                    let blk = ctx.block();
+                    for (i, value) in lowered_args.iter().enumerate() {
+                        let slot = blk.gep(DOUBLE, &buf, &[(I64, &i.to_string())]);
+                        blk.store(DOUBLE, value, &slot);
+                    }
+                }
+                (buf, n.to_string())
+            };
+
+            let method_idx = ctx.strings.intern(method);
+            let entry = ctx.strings.entry(method_idx);
+            let bytes_global = format!("@{}", entry.bytes_global);
+            let name_len = entry.byte_len.to_string();
+            return Ok(ctx.block().call(
+                DOUBLE,
+                "js_native_call_method",
+                &[
+                    (DOUBLE, &recv_box),
+                    (PTR, &bytes_global),
+                    (I64, &name_len),
+                    (PTR, &args_ptr),
+                    (I64, &args_len),
+                ],
+            ));
+        }
     }
 
     // Receiver-less native method calls (e.g. plugin::setConfig(...)

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1599,6 +1599,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_console_count_reset", VOID, &[I64]);
     module.declare_function("js_console_count_value", VOID, &[DOUBLE]);
     module.declare_function("js_console_count_reset_value", VOID, &[DOUBLE]);
+    module.declare_function("js_console_new", DOUBLE, &[DOUBLE]);
     module.declare_function("js_console_group_begin", VOID, &[]);
     module.declare_function("js_console_group_end", VOID, &[]);
     module.declare_function("js_console_clear", VOID, &[]);

--- a/crates/perry-runtime/src/builtins/console.rs
+++ b/crates/perry-runtime/src/builtins/console.rs
@@ -165,6 +165,23 @@ pub fn scan_console_log_singleton_roots(mark: &mut dyn FnMut(f64)) {
 
 pub fn scan_console_log_singleton_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     visitor.visit_atomic_i64_slot(&CONSOLE_LOG_SINGLETON, Ordering::Acquire, Ordering::Release);
+    let mut moved = Vec::new();
+    CONSOLE_INSTANCES.with(|instances| {
+        let mut instances = instances.borrow_mut();
+        for (&owner, state) in instances.iter_mut() {
+            let mut new_owner = owner;
+            if visitor.visit_metadata_usize_slot(&mut new_owner) {
+                moved.push((owner, new_owner));
+            }
+            visitor.visit_nanbox_f64_slot(&mut state.stdout);
+            visitor.visit_nanbox_f64_slot(&mut state.stderr);
+        }
+        for (old_owner, new_owner) in moved.drain(..) {
+            if let Some(state) = instances.remove(&old_owner) {
+                instances.insert(new_owner, state);
+            }
+        }
+    });
 }
 
 /// Print a number to stdout (optimized path for known numbers)
@@ -426,6 +443,17 @@ use std::time::Instant;
 thread_local! {
     static CONSOLE_TIMERS: RefCell<HashMap<String, Instant>> = RefCell::new(HashMap::new());
     static CONSOLE_COUNTERS: RefCell<HashMap<String, u64>> = RefCell::new(HashMap::new());
+    static CONSOLE_INSTANCES: RefCell<HashMap<usize, ConsoleInstanceState>> = RefCell::new(HashMap::new());
+}
+
+pub(crate) const CONSOLE_INSTANCE_CLASS_ID: u32 = 0xFFFF_0081;
+
+struct ConsoleInstanceState {
+    stdout: f64,
+    stderr: f64,
+    counters: HashMap<String, u64>,
+    indent: usize,
+    _ignore_errors: bool,
 }
 
 unsafe fn label_from_str_ptr(ptr: *const StringHeader) -> String {
@@ -488,6 +516,207 @@ fn console_label_from_value(value: f64) -> *const StringHeader {
         }
     }
     js_string_coerce(value) as *const StringHeader
+}
+
+fn undefined_value() -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+fn null_or_undefined(value: f64) -> bool {
+    matches!(
+        value.to_bits(),
+        crate::value::TAG_NULL | crate::value::TAG_UNDEFINED
+    )
+}
+
+fn object_property(value: f64, name: &[u8]) -> f64 {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if !jsval.is_pointer() {
+        return undefined_value();
+    }
+    let obj = jsval.as_pointer::<crate::object::ObjectHeader>();
+    if obj.is_null() {
+        return undefined_value();
+    }
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    f64::from_bits(crate::object::js_object_get_field_by_name(obj, key).bits())
+}
+
+#[cold]
+fn throw_console_writable_stream() -> ! {
+    let msg = b"Console expects a writable stream instance";
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    crate::node_submodules::register_error_code_pub(s, "ERR_CONSOLE_WRITABLE_STREAM");
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+#[no_mangle]
+pub extern "C" fn js_console_new(options: f64) -> f64 {
+    let stdout = object_property(options, b"stdout");
+    if null_or_undefined(stdout) {
+        throw_console_writable_stream();
+    }
+    let stderr_candidate = object_property(options, b"stderr");
+    let stderr = if null_or_undefined(stderr_candidate) {
+        stdout
+    } else {
+        stderr_candidate
+    };
+    let ignore_errors = unsafe { decode_dir_bool_option(options, "ignoreErrors") }.unwrap_or(true);
+
+    let obj = crate::object::js_object_alloc(CONSOLE_INSTANCE_CLASS_ID, 0);
+    let value = crate::value::js_nanbox_pointer(obj as i64);
+    CONSOLE_INSTANCES.with(|instances| {
+        instances.borrow_mut().insert(
+            obj as usize,
+            ConsoleInstanceState {
+                stdout,
+                stderr,
+                counters: HashMap::new(),
+                indent: 0,
+                _ignore_errors: ignore_errors,
+            },
+        );
+    });
+    value
+}
+
+enum ConsoleInstanceAction {
+    Write {
+        stream: f64,
+        line: String,
+        stderr: bool,
+    },
+    Noop,
+}
+
+fn format_console_instance_args(args: &[f64]) -> String {
+    let arr = crate::array::js_array_alloc(args.len() as u32);
+    for arg in args {
+        crate::array::js_array_push_f64(arr, *arg);
+    }
+    jsvalue_string_content(js_util_format(arr)).unwrap_or_default()
+}
+
+fn console_instance_label(args: &[f64]) -> String {
+    let label_value = args.first().copied().unwrap_or_else(undefined_value);
+    unsafe { label_from_str_ptr(console_label_from_value(label_value)) }
+}
+
+fn console_instance_write(stream: f64, line: &str, stderr: bool) {
+    if null_or_undefined(stream) {
+        if stderr {
+            eprintln!("{line}");
+        } else {
+            println!("{line}");
+        }
+        return;
+    }
+
+    let mut chunk = String::with_capacity(line.len() + 1);
+    chunk.push_str(line);
+    chunk.push('\n');
+    let chunk_ptr = crate::string::js_string_from_bytes(chunk.as_ptr(), chunk.len() as u32);
+    let chunk_value = f64::from_bits(JSValue::string_ptr(chunk_ptr).bits());
+    let args = [chunk_value];
+    unsafe {
+        let _ = crate::object::js_native_call_method(
+            stream,
+            b"write".as_ptr() as *const i8,
+            5,
+            args.as_ptr(),
+            args.len(),
+        );
+    }
+}
+
+pub(crate) unsafe fn try_console_instance_method_dispatch(
+    obj: *const crate::object::ObjectHeader,
+    method_name: &str,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> Option<f64> {
+    if obj.is_null() || (*obj).class_id != CONSOLE_INSTANCE_CLASS_ID {
+        return None;
+    }
+    let args = if args_ptr.is_null() || args_len == 0 {
+        &[][..]
+    } else {
+        std::slice::from_raw_parts(args_ptr, args_len)
+    };
+
+    let action = CONSOLE_INSTANCES.with(|instances| {
+        let mut instances = instances.borrow_mut();
+        let state = instances.get_mut(&(obj as usize))?;
+        let indent = "  ".repeat(state.indent);
+        match method_name {
+            "log" | "info" | "debug" | "dir" | "dirxml" => Some(ConsoleInstanceAction::Write {
+                stream: state.stdout,
+                line: format!("{indent}{}", format_console_instance_args(args)),
+                stderr: false,
+            }),
+            "error" | "warn" => Some(ConsoleInstanceAction::Write {
+                stream: state.stderr,
+                line: format!("{indent}{}", format_console_instance_args(args)),
+                stderr: true,
+            }),
+            "count" => {
+                let label = console_instance_label(args);
+                let count = state.counters.entry(label.clone()).or_insert(0);
+                *count += 1;
+                Some(ConsoleInstanceAction::Write {
+                    stream: state.stdout,
+                    line: format!("{indent}{label}: {count}"),
+                    stderr: false,
+                })
+            }
+            "countReset" => {
+                let label = console_instance_label(args);
+                if state.counters.remove(&label).is_none() {
+                    Some(ConsoleInstanceAction::Write {
+                        stream: state.stderr,
+                        line: format!("Warning: Count for '{label}' does not exist"),
+                        stderr: true,
+                    })
+                } else {
+                    Some(ConsoleInstanceAction::Noop)
+                }
+            }
+            "group" | "groupCollapsed" => {
+                let line = if args.is_empty() {
+                    None
+                } else {
+                    Some(format!("{indent}{}", format_console_instance_args(args)))
+                };
+                state.indent += 1;
+                line.map(|line| ConsoleInstanceAction::Write {
+                    stream: state.stdout,
+                    line,
+                    stderr: false,
+                })
+                .or(Some(ConsoleInstanceAction::Noop))
+            }
+            "groupEnd" => {
+                if state.indent > 0 {
+                    state.indent -= 1;
+                }
+                Some(ConsoleInstanceAction::Noop)
+            }
+            "clear" | "profile" | "profileEnd" | "timeStamp" => Some(ConsoleInstanceAction::Noop),
+            _ => None,
+        }
+    })?;
+
+    match action {
+        ConsoleInstanceAction::Write {
+            stream,
+            line,
+            stderr,
+        } => console_instance_write(stream, &line, stderr),
+        ConsoleInstanceAction::Noop => {}
+    }
+    Some(undefined_value())
 }
 
 #[no_mangle]

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -61,13 +61,15 @@ pub use console::{
     js_console_error_number, js_console_error_spread, js_console_group, js_console_group_begin,
     js_console_group_end, js_console_log, js_console_log_as_closure, js_console_log_dynamic,
     js_console_log_i32, js_console_log_i64, js_console_log_number, js_console_log_spread,
-    js_console_noop, js_console_time, js_console_time_end, js_console_time_end_value,
-    js_console_time_log, js_console_time_log_spread, js_console_time_log_value,
-    js_console_time_value, js_console_trace, js_console_trace_spread, js_console_warn_dynamic,
-    js_console_warn_i32, js_console_warn_number, js_console_warn_spread, perry_debug_trace_init,
-    perry_debug_trace_init_done, scan_console_log_singleton_roots,
+    js_console_new, js_console_noop, js_console_time, js_console_time_end,
+    js_console_time_end_value, js_console_time_log, js_console_time_log_spread,
+    js_console_time_log_value, js_console_time_value, js_console_trace, js_console_trace_spread,
+    js_console_warn_dynamic, js_console_warn_i32, js_console_warn_number, js_console_warn_spread,
+    perry_debug_trace_init, perry_debug_trace_init_done, scan_console_log_singleton_roots,
     scan_console_log_singleton_roots_mut,
 };
+
+pub(crate) use console::try_console_instance_method_dispatch;
 
 pub use formatting::{
     function_name_for_ptr, js_array_print, js_register_function_name, js_util_format,

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -2049,6 +2049,15 @@ pub unsafe extern "C" fn js_native_call_method(
             return f64::from_bits(JSValue::pointer(null_obj_ptr).bits());
         }
 
+        if let Some(r) = crate::builtins::try_console_instance_method_dispatch(
+            obj,
+            method_name,
+            args_ptr,
+            args_len,
+        ) {
+            return r;
+        }
+
         // #1387: synthesized `PerformanceEntry#toJSON()`. Entry objects are
         // plain shaped objects with no stored `toJSON` field, so the
         // field-scan dispatch below would miss it. A bound-method read (from


### PR DESCRIPTION
Summary:
- construct runtime-backed `Console` instances with configured stdout/stderr
- route receiver `Console` native calls through method dispatch instead of no-op fallback
- add per-instance count/group state and newline stream writes, plus GC scanning for instance stream roots and side-table owner rewrites

Evidence:
- DeepWiki saved at `reference/deepwiki/nodejs-node-console-class-custom-stream-group-count-2026-05-29.md`
- Baseline count 10/1: `test-parity/reports/parity_report_20260529_024107.json`
- Baseline console-class 9/2: `test-parity/reports/parity_report_20260529_024519.json`
- Exact final PASS: `test-parity/reports/parity_report_20260529_030655.json`
- Console-class guardrail 10/1 with residual `stream-errors`: `test-parity/reports/parity_report_20260529_025817.json`
- Count guardrail 11/0: `test-parity/reports/parity_report_20260529_025904.json`
- `cargo check -p perry-codegen -p perry-runtime`
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- targeted `cargo fmt --check`, `git diff --check`, `git diff --cached --check`

Non-goals:
- stream subclass/EventEmitter initialization residual (`console-class/stream-errors`)
- old positional `new Console(stdout, stderr)` constructor
- full Console color/inspect option matrix beyond current passing fixtures
- broad writable stream error semantics