### PR TITLE
fix(node:assert): return bool for typed array equality

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -2021,7 +2021,7 @@ fn js_util_deep_strict_equal_bool(left: f64, right: f64, depth: usize) -> bool {
         return equal;
     }
     if let Some(equal) = typed_array_equality::deep_strict_typed_array_equal(left, right) {
-        return f64::from_bits(crate::value::JSValue::bool(equal).bits());
+        return equal;
     }
     if identity_equality::is_identity_only_deep_equal_value(left)
         || identity_equality::is_identity_only_deep_equal_value(right)


### PR DESCRIPTION
Summary:
- fix `js_util_deep_strict_equal_bool` to return the typed-array equality `bool` directly
- unblock current `main` after the typed-array deep equality merge introduced a boxed JS boolean return in a Rust `bool` helper

Evidence:
- Baseline `cargo build --release -p perry` on `origin/main` failed with `E0308` at `crates/perry-runtime/src/builtins/formatting.rs:2024`
- `cargo check -p perry-runtime`
- `cargo build --release -p perry`
- `cargo fmt --check -- crates/perry-runtime/src/builtins/formatting.rs`
- `git diff --check -- crates/perry-runtime/src/builtins/formatting.rs`
- `git diff --cached --check`

Non-goals:
- no assertion behavior changes beyond restoring the intended bool return
- no warning cleanup