### PR TITLE
fix(compile): hint missing compilePackages deps

### DIFF
--- a/crates/perry/src/commands/compile/audit_manifest.rs
+++ b/crates/perry/src/commands/compile/audit_manifest.rs
@@ -20,8 +20,9 @@ use super::CompilationContext;
 /// `node_modules/@scope/pkg/...` returns `@scope/pkg`. Returns `None`
 /// for user-source files outside `node_modules/`.
 pub(super) fn package_name_for_path(source_path: &str) -> Option<String> {
-    let idx = source_path.rfind("node_modules/")?;
-    let after = &source_path[idx + "node_modules/".len()..];
+    let normalized = source_path.replace('\\', "/");
+    let idx = normalized.rfind("node_modules/")?;
+    let after = &normalized[idx + "node_modules/".len()..];
     if let Some(stripped) = after.strip_prefix('@') {
         let mut parts = stripped.splitn(3, '/');
         let scope = parts.next().unwrap_or("");
@@ -152,6 +153,14 @@ mod js_runtime_gate_tests {
         assert_eq!(
             package_name_for_path("/repo/node_modules/outer/node_modules/inner/lib/index.js"),
             Some("inner".to_string())
+        );
+    }
+
+    #[test]
+    fn windows_path_under_node_modules() {
+        assert_eq!(
+            package_name_for_path(r"C:\repo\node_modules\connected-domain\index.js"),
+            Some("connected-domain".to_string())
         );
     }
 

--- a/crates/perry/src/commands/compile/bootstrap.rs
+++ b/crates/perry/src/commands/compile/bootstrap.rs
@@ -246,6 +246,25 @@ pub(super) fn enforce_js_runtime_gate(ctx: &CompilationContext) -> Result<()> {
     if importers.len() > limit {
         detail.push_str(&format!("\n  ... and {} more", importers.len() - limit));
     }
+    let mut packages: Vec<String> = importers
+        .iter()
+        .filter_map(|path| super::audit_manifest::package_name_for_path(&path.to_string_lossy()))
+        .filter(|pkg| !ctx.compile_packages.contains(pkg))
+        .collect();
+    packages.sort();
+    packages.dedup();
+    let package_hint = if packages.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "\n\nPackage hint: the following npm package(s) are still routed \
+             to runtime JavaScript because they are not in \
+             `perry.compilePackages`: {}. If you have reviewed and trust \
+             them, add them to both `perry.compilePackages` and \
+             `perry.allow.compilePackages`.",
+            packages.join(", ")
+        )
+    };
     anyhow::bail!(
         "JavaScript runtime (V8) support has been removed. This build of \
          Perry compiles TypeScript ahead-of-time only and cannot evaluate \
@@ -254,8 +273,47 @@ pub(super) fn enforce_js_runtime_gate(ctx: &CompilationContext) -> Result<()> {
          \n\
          Port the offending module(s) to TypeScript, add the owning package \
          to `perry.compilePackages` so it is compiled natively, or replace \
-         it with a native Perry stdlib equivalent."
+         it with a native Perry stdlib equivalent.{package_hint}"
     );
+}
+
+#[cfg(test)]
+mod js_runtime_gate_tests {
+    use std::path::PathBuf;
+
+    use super::{enforce_js_runtime_gate, CompilationContext};
+
+    #[test]
+    fn diagnostic_suggests_missing_compile_package_on_windows_paths() {
+        let mut ctx = CompilationContext::new(PathBuf::from(r"C:\repo"));
+        ctx.compile_packages.insert("ps-node".to_string());
+        ctx.compile_packages.insert("table-parser".to_string());
+        ctx.js_runtime_importers.push(PathBuf::from(
+            r"C:\repo\node_modules\connected-domain\index.js",
+        ));
+
+        let message = enforce_js_runtime_gate(&ctx)
+            .expect_err("runtime JS importer must fail the V8-free gate")
+            .to_string();
+
+        assert!(message.contains("connected-domain"));
+        assert!(message.contains("perry.compilePackages"));
+        assert!(message.contains("perry.allow.compilePackages"));
+    }
+
+    #[test]
+    fn diagnostic_does_not_suggest_already_opted_in_packages() {
+        let mut ctx = CompilationContext::new(PathBuf::from("/repo"));
+        ctx.compile_packages.insert("already-native".to_string());
+        ctx.js_runtime_importers
+            .push(PathBuf::from("/repo/node_modules/already-native/index.js"));
+
+        let message = enforce_js_runtime_gate(&ctx)
+            .expect_err("runtime JS importer must fail the V8-free gate")
+            .to_string();
+
+        assert!(!message.contains("Package hint:"));
+    }
 }
 
 /// Recompute project_root as the common ancestor of all module paths.


### PR DESCRIPTION
## Summary

- normalize Windows path separators when attributing JS-runtime fallback files to npm packages
- include a package hint in the V8-free compile error for npm packages missing from `perry.compilePackages`
- cover both behaviors with focused unit tests

## Validation

- `cargo fmt --check`
- `cargo test -p perry js_runtime_gate_tests` currently fails before reaching these tests because upstream `main` does not compile on this Windows checkout:
  `crates/perry-runtime/src/builtins/formatting.rs:2024` returns `f64` from a function declared `bool`

## Context

This came up while probing `ps-node` on Windows. `ps-node` compiles natively when its transitive JS dependencies are explicitly trusted (`ps-node`, `table-parser`, `connected-domain`), but when `connected-domain` is omitted the existing error can be hard to act on. This change keeps the trust model unchanged and only makes the missing package explicit.
