### PR TITLE
fix(node:stream): preserve compose output for iterator helpers

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -534,10 +534,14 @@ extern "C" fn ns_unshift1(closure: *const ClosureHeader, chunk: f64) -> f64 {
 }
 
 /// `readable.compose(stream)` (#1539): the instance-method form of
-/// `stream.compose`. Returns a fresh Duplex stub so shape checks
-/// (`typeof composed.on === "function"`) hold; real data composition is
-/// tracked separately.
-extern "C" fn ns_compose1(_closure: *const ClosureHeader, _arg: f64) -> f64 {
+/// `stream.compose`. Retained-chunk Readables can eagerly compose through a
+/// single Transform/PassThrough so downstream iterator helpers still see a
+/// readable chunk snapshot; unsupported forms keep the historical shape stub.
+extern "C" fn ns_compose1(closure: *const ClosureHeader, arg: f64) -> f64 {
+    let source = this_value(closure);
+    if let Some(composed) = compose_readable_snapshot(source, arg) {
+        return composed;
+    }
     js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
 }
 
@@ -2280,6 +2284,66 @@ fn drain_iter_helper_microtasks() {
 fn prepare_readable_for_iteration(stream: f64) {
     invoke_read_once(stream);
     drain_iter_helper_microtasks();
+}
+
+fn extend_compose_output_chunks(
+    mut out: *mut crate::array::ArrayHeader,
+    stage: f64,
+    chunks: f64,
+) -> *mut crate::array::ArrayHeader {
+    if !readable_object_mode(stage) {
+        let mut bytes = Vec::new();
+        append_chunk_bytes(chunks, &mut bytes, 0);
+        if !bytes.is_empty() {
+            out = crate::array::js_array_push_f64(out, buffer_value_from_bytes(&bytes));
+        }
+        return out;
+    }
+
+    if is_array_like_value(chunks) {
+        extend_with_array(out, raw_ptr_from_value(chunks) as *const _)
+    } else {
+        crate::array::js_array_push_f64(out, chunks)
+    }
+}
+
+fn compose_readable_snapshot(source: f64, stage: f64) -> Option<f64> {
+    prepare_readable_for_iteration(source);
+    let arr = readable_chunks_array(source);
+    if arr.is_null() || !is_transform_stream(stage) {
+        return None;
+    }
+
+    let mut out = crate::array::js_array_alloc(0);
+    if has_truthy_hidden(stage, hidden_transform_passthrough_key()) {
+        out = extend_compose_output_chunks(out, stage, box_pointer(arr as *const u8));
+    } else {
+        transform_hidden_callback(stage)?;
+        clear_readable_buffer(stage);
+        let len = crate::array::js_array_length(arr);
+        for i in 0..len {
+            let chunk = crate::array::js_array_get_f64(arr, i);
+            let _ = write_writable_chunk(
+                stage,
+                chunk,
+                f64::from_bits(TAG_UNDEFINED),
+                f64::from_bits(TAG_UNDEFINED),
+            );
+            if let Some(err) = readable_hidden_error(stage) {
+                let result = readable_from_chunks(out);
+                propagate_stream_state(source, f64::from_bits(TAG_UNDEFINED), result);
+                set_hidden_value(result, hidden_error_key(), err);
+                return Some(result);
+            }
+        }
+        if let Some(chunks) = readable_hidden_chunks(stage) {
+            out = extend_compose_output_chunks(out, stage, chunks);
+        }
+    }
+
+    let result = readable_from_chunks(out);
+    propagate_stream_state(source, f64::from_bits(TAG_UNDEFINED), result);
+    Some(result)
 }
 
 /// Resolve a callback result that may be a Promise (an async mapper /

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -662,12 +662,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: writer.write() Promise resolution timing \u2014 resolves before sink processes chunk. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/iter-helpers/compose-then-toarray": {
-    "issue": "1558",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: compose(transform).toArray() \u2014 chain produces wrong result. Flips to PASS when #1558 lands."
-  },
   "node-suite/stream/destroy/_destroy-user-impl": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- make retained-chunk `Readable.from(...).compose(single Transform/PassThrough)` produce a readable snapshot instead of the historical Duplex-only fallback
- drive retained source chunks through the transform callback, collect buffered output, and keep iterator helpers like `toArray()` available on the composed result
- coalesce byte-mode transform output into one Buffer chunk so `Readable.from(['a','b','c']).compose(uppercase).toArray()` matches Node's `ABC` shape
- remove the proven `node-suite/stream/iter-helpers/compose-then-toarray` known-failure entry

## Verification
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `./run_parity_tests.sh --suite node-suite --module stream --filter iter-helpers/compose-then-toarray` => 1 pass / 0 fail / 0 compile fail (`parity_report_20260529_035403.json`)
- `./run_parity_tests.sh --suite node-suite --module stream --filter iter-helpers` => 46 pass / 0 fail / 0 compile fail (`parity_report_20260529_035455.json`)
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module stream` => 644 pass / 97 existing parity fail / 0 compile fail (`parity_report_20260529_035609.json`)
- `cargo test -p perry-runtime node_stream` => 62 passed / 0 failed
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `./scripts/check_file_size.sh`
- `git diff --check origin/main...HEAD`

## Non-goals
- does not implement general multi-stage `stream.compose` dataflow
- does not handle async generator/function compose forms, full error propagation, lifecycle/backpressure parity, or broader stream/web stream gaps
