### PR TITLE
fix(node:stream): initialize Writable subclasses

### DIFF
--- a/crates/perry-codegen/src/codegen/method.rs
+++ b/crates/perry-codegen/src/codegen/method.rs
@@ -265,7 +265,15 @@ pub(super) fn compile_method(
         // args. The walk skips empty-bodied parents (matching the JS spec
         // chain semantics).
         if class.constructor.is_none() && class.extends_name.is_some() {
-            let mut effective_parent: Option<&str> = class.extends_name.as_deref();
+            let builtin_parent_runtime = match class.extends_name.as_deref() {
+                Some("Writable") => Some("js_node_stream_writable_subclass_init"),
+                _ => None,
+            };
+            let mut effective_parent: Option<&str> = if builtin_parent_runtime.is_some() {
+                None
+            } else {
+                class.extends_name.as_deref()
+            };
             while let Some(pname) = effective_parent {
                 let Some(pc) = ctx.classes.get(pname).copied() else {
                     break;
@@ -381,6 +389,24 @@ pub(super) fn compile_method(
                     class.name
                 )
             })?;
+            if let Some(runtime_fn) = builtin_parent_runtime {
+                let undef_lit =
+                    crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+                let opts = method
+                    .params
+                    .first()
+                    .and_then(|param| ctx.locals.get(&param.id).cloned())
+                    .map(|slot| ctx.block().load(DOUBLE, &slot))
+                    .unwrap_or_else(|| undef_lit.clone());
+                let this_box = ctx
+                    .this_stack
+                    .last()
+                    .cloned()
+                    .map(|slot| ctx.block().load(DOUBLE, &slot))
+                    .unwrap_or_else(|| undef_lit.clone());
+                ctx.block()
+                    .call(DOUBLE, runtime_fn, &[(DOUBLE, &this_box), (DOUBLE, &opts)]);
+            }
         }
     }
 

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -118,7 +118,7 @@ pub(crate) use v8_interop::{
 pub(crate) use write_barrier::{
     emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
     emit_layout_note_slot_on_block, emit_write_barrier, emit_write_barrier_slot_on_block,
-    lower_stream_super_init,
+    lower_node_stream_super_init, lower_stream_super_init,
 };
 
 /// Per-function codegen context. Held briefly during lowering, never stored.

--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -38,8 +38,8 @@ use super::{
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
     lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
+    lower_index_set_fast, lower_js_args_array, lower_node_stream_super_init, lower_object_literal,
+    lower_stream_super_init, lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
     nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
     try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
     unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
@@ -129,6 +129,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             | "URIError"
                             | "EvalError"
                             | "AggregateError"
+                            | "Writable"
                             | "ReadableStream"
                             | "WritableStream"
                             | "TransformStream"
@@ -220,6 +221,21 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                 crate::nanbox::TAG_UNDEFINED,
                             )));
                         }
+                    }
+                    let node_stream_kind = match parent_name.as_str() {
+                        "Writable" => Some("writable"),
+                        _ => None,
+                    };
+                    if let Some(kind) = node_stream_kind {
+                        let result = lower_node_stream_super_init(ctx, kind, super_args)?;
+                        let current_class_name =
+                            ctx.class_stack.last().cloned().unwrap_or_default();
+                        crate::lower_call::apply_field_initializers_recursive(
+                            ctx,
+                            &current_class_name,
+                            crate::lower_call::FieldInitMode::SelfOnly,
+                        )?;
+                        return Ok(result);
                     }
                     // Issue #562: `class X extends WritableStream/ReadableStream/TransformStream`
                     // — `super({ ... })` allocates an underlying stream registry handle and

--- a/crates/perry-codegen/src/expr/write_barrier.rs
+++ b/crates/perry-codegen/src/expr/write_barrier.rs
@@ -229,3 +229,39 @@ pub(crate) fn lower_stream_super_init(
 
     Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
 }
+
+/// Initialize Node's classic `stream.Writable` base class on an existing
+/// subclass instance. Unlike `new Writable(opts)`, `super(opts)` must keep the
+/// object identity allocated for the derived class and attach stream state to it.
+pub(crate) fn lower_node_stream_super_init(
+    ctx: &mut FnCtx<'_>,
+    kind: &str,
+    super_args: &[Expr],
+) -> Result<String> {
+    let undef_lit = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+    let opts = if let Some(first) = super_args.first() {
+        lower_expr(ctx, first)?
+    } else {
+        undef_lit.clone()
+    };
+    for arg in super_args.iter().skip(1) {
+        let _ = lower_expr(ctx, arg)?;
+    }
+
+    let this_box = match ctx.this_stack.last().cloned() {
+        Some(slot) => ctx.block().load(DOUBLE, &slot),
+        None => undef_lit.clone(),
+    };
+
+    let runtime_fn = match kind {
+        "writable" => "js_node_stream_writable_subclass_init",
+        _ => unreachable!(
+            "lower_node_stream_super_init: unexpected Node stream kind {}",
+            kind
+        ),
+    };
+    ctx.block()
+        .call(DOUBLE, runtime_fn, &[(DOUBLE, &this_box), (DOUBLE, &opts)]);
+
+    Ok(undef_lit)
+}

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -432,6 +432,15 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
     // depends on Column's body running `this.config = config` first).
     let has_own_ctor = class.constructor.is_some();
     let has_extends = class.extends_name.is_some();
+    let has_imported_ctor = ctx.imported_class_ctors.contains_key(class_name);
+    let builtin_parent_runtime = if !has_own_ctor && !has_imported_ctor {
+        match class.extends_name.as_deref() {
+            Some("Writable") => Some("js_node_stream_writable_subclass_init"),
+            _ => None,
+        }
+    } else {
+        None
+    };
     let inherited_ctor_class: Option<String> = if !has_own_ctor && has_extends {
         // Walk the inheritance chain to find the closest ancestor with
         // an explicit ctor — same logic as the body-inlining loop below.
@@ -655,6 +664,9 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
                 found_inherited_ctor = true; // skip the imported-ctor fallback below
             }
         }
+        if builtin_parent_runtime.is_some() {
+            found_inherited_ctor = true;
+        }
         // If no parent constructor was found (imported class with no
         // inlineable constructor body), call the cross-module constructor.
         // Refs #420: walk past empty-bodied ancestors with param_count==0
@@ -787,7 +799,6 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
     // super + applies SelfOnly) or has an explicit body. Drizzle's
     // `BetterSQLiteSession` (explicit ctor) and arrow-field cross-
     // module classes are both load-bearing. Refs #420 / #618 followup.
-    let has_imported_ctor = ctx.imported_class_ctors.contains_key(class_name);
     if !has_own_ctor && has_extends && !has_imported_ctor {
         if let Some(stop_at) = inherited_ctor_class {
             apply_field_initializers_recursive(
@@ -798,6 +809,21 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
         } else {
             apply_field_initializers_recursive(ctx, class_name, FieldInitMode::SelfOnly)?;
         }
+    }
+    if let Some(runtime_fn) = builtin_parent_runtime {
+        let undef_lit = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+        let opts = lowered_args
+            .first()
+            .cloned()
+            .unwrap_or_else(|| undef_lit.clone());
+        let this_box = ctx
+            .this_stack
+            .last()
+            .cloned()
+            .map(|slot| ctx.block().load(DOUBLE, &slot))
+            .unwrap_or_else(|| undef_lit.clone());
+        ctx.block()
+            .call(DOUBLE, runtime_fn, &[(DOUBLE, &this_box), (DOUBLE, &opts)]);
     }
 
     if let Some(keys_global_name) = ctx.class_keys_globals.get(class_name).cloned() {

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -887,6 +887,11 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // ========== node:stream stubs (issue #631) ==========
     module.declare_function("js_node_stream_readable_new", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_writable_new", DOUBLE, &[DOUBLE]);
+    module.declare_function(
+        "js_node_stream_writable_subclass_init",
+        DOUBLE,
+        &[DOUBLE, DOUBLE],
+    );
     module.declare_function("js_node_stream_duplex_new", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_transform_new", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_passthrough_new", DOUBLE, &[DOUBLE]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -2754,6 +2754,35 @@ fn build_object(methods: &[(&str, StubFn)], shape_id: u32) -> *mut ObjectHeader 
     obj
 }
 
+fn install_methods_on_existing_object(
+    obj: *mut ObjectHeader,
+    this_value: f64,
+    methods: &[(&str, StubFn)],
+    skip_names: &[&str],
+) {
+    register_stub_arities();
+    let this_bits = this_value.to_bits();
+    let mut on_method: Option<f64> = None;
+    for (name, func) in methods {
+        if skip_names.iter().any(|skip| skip == name) {
+            continue;
+        }
+        if *name == "addListener" {
+            if let Some(val) = on_method {
+                js_object_set_field_by_name(obj, hidden_key(name.as_bytes()), val);
+                continue;
+            }
+        }
+        let closure = js_closure_alloc(*func as *const u8, 1);
+        crate::closure::js_closure_set_capture_ptr(closure, 0, this_bits as i64);
+        let val = f64::from_bits(JSValue::pointer(closure as *const u8).bits());
+        if *name == "on" {
+            on_method = Some(val);
+        }
+        js_object_set_field_by_name(obj, hidden_key(name.as_bytes()), val);
+    }
+}
+
 fn register_stub_arities() {
     let register = |func: *const u8, arity: u32| {
         crate::closure::js_register_closure_arity(func, arity);
@@ -5307,6 +5336,61 @@ pub extern "C" fn js_node_stream_writable_new(opts: f64) -> f64 {
     install_stream_async_dispose_symbol(writable);
     invoke_construct_callback(writable, opts);
     writable
+}
+
+#[no_mangle]
+pub extern "C" fn js_node_stream_writable_subclass_init(this: f64, opts: f64) -> f64 {
+    let obj = {
+        let bits = this.to_bits();
+        let top16 = bits >> 48;
+        let raw = if top16 >= 0x7FF8 {
+            if top16 == 0x7FFC {
+                return f64::from_bits(TAG_UNDEFINED);
+            }
+            (bits & crate::value::POINTER_MASK) as usize
+        } else {
+            bits as usize
+        };
+        if raw < crate::gc::GC_HEADER_SIZE + 0x1000 {
+            return f64::from_bits(TAG_UNDEFINED);
+        }
+        raw as *mut ObjectHeader
+    };
+    let this = f64::from_bits(JSValue::pointer(obj as *const u8).bits());
+    unsafe {
+        if gc_type_for_ptr(obj as usize) != Some(crate::gc::GC_TYPE_OBJECT) {
+            return f64::from_bits(TAG_UNDEFINED);
+        }
+    }
+    if obj.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+
+    let subclass_write = js_object_get_field_by_name_f64(obj, hidden_key(b"_write"));
+    let subclass_writev = js_object_get_field_by_name_f64(obj, hidden_key(b"_writev"));
+    let methods = writable_methods();
+    install_methods_on_existing_object(obj, this, &methods, &["_write"]);
+
+    if let Some(write) = write_callback_from_options(opts) {
+        js_object_set_field_by_name(obj, hidden_write_key(), rebind_callback_this(write, this));
+    } else if is_callable_value(subclass_write) {
+        js_object_set_field_by_name(obj, hidden_write_key(), subclass_write);
+    }
+    if let Some(writev) = writev_callback_from_options(opts) {
+        js_object_set_field_by_name(obj, hidden_writev_key(), rebind_callback_this(writev, this));
+    } else if is_callable_value(subclass_writev) {
+        js_object_set_field_by_name(obj, hidden_writev_key(), subclass_writev);
+    }
+
+    init_lifecycle_state(this, opts);
+    init_constructor(this, "Writable");
+    init_writable_state(this, opts);
+    install_common_lifecycle_callbacks(this, opts);
+    install_writable_lifecycle_callbacks(this, opts);
+    init_abort_signal_state(this, opts);
+    install_stream_async_dispose_symbol(this);
+    invoke_construct_callback(this, opts);
+    this
 }
 
 #[no_mangle]


### PR DESCRIPTION
## Summary
- initialize classic node:stream Writable base methods/state on derived class instances
- route explicit super(opts), default same-module new Subclass(opts), and standalone constructors through the subclass initializer
- preserve subclass _write/_writev callbacks while installing Writable/EventEmitter methods on the existing object

## Verification
- cargo fmt --check
- cargo check -p perry-codegen -p perry-runtime
- git diff --check
- git diff --cached --check
- ./run_parity_tests.sh --suite node-suite --module stream --filter subclass/extends-writable (PASS 1/0/0, report test-parity/reports/parity_report_20260529_041123.json)
- ./run_parity_tests.sh --suite node-suite --module console --filter console-class (PASS 11/0/0, report test-parity/reports/parity_report_20260529_041143.json)
- ./run_parity_tests.sh --suite node-suite --module stream --filter subclass (expected residuals: extends-readable, extends-duplex, extends-transform; report test-parity/reports/parity_report_20260529_040722.json)