### PR TITLE
fix(number): toFixed rounds genuine halves away from zero; exponential for >=1e21 (#2418)

### DIFF
--- a/crates/perry-runtime/src/string/format.rs
+++ b/crates/perry-runtime/src/string/format.rs
@@ -147,6 +147,14 @@ pub(crate) fn test_clear_small_int_cache_root(index: usize) {
 pub extern "C" fn js_number_to_fixed(value: f64, decimals: f64) -> *mut StringHeader {
     let dp = decimals as usize;
 
+    // ECMA-262 §21.1.3.3 step 9: if |x| >= 10^21, the result is ToString(x)
+    // (which switches to exponential form), NOT a zero-padded fixed string.
+    // `format!("{:.prec$}", 1e21)` would emit "1000000000000000000000.00";
+    // Node emits "1e+21".
+    if !value.is_nan() && !value.is_infinite() && value.abs() >= 1e21 {
+        return js_number_to_string(value);
+    }
+
     // Fast path: pure integer arithmetic + manual digit emission.
     // Conditions: finite, magnitude < 1e15 (so value * 10^dp fits safely
     // in i64), dp <= 6 (limits 10^dp to 1_000_000 — `value * 10^dp` then
@@ -174,22 +182,41 @@ fn fmt_fixed_int(value: f64, dp: usize) -> Option<*mut StringHeader> {
     static POW10: [u64; 7] = [1, 10, 100, 1_000, 10_000, 100_000, 1_000_000];
     let scale = POW10[dp];
 
-    // The multiplication `value * scale` can lose precision when the
-    // true result is near a half-integer — e.g. `0.015 * 100` rounds
-    // to exactly 1.5 in f64 (the original value is 0.01499999...), so
-    // a naïve `.round()` produces "0.02" while Node's Grisu-based
-    // formatter produces "0.01" (the spec-correct value for the actual
-    // IEEE 754 representation). Detect this by checking whether the
-    // scaled value's fractional part is suspiciously close to 0.5; if
-    // so, fall back to Rust's `format!` (which uses the same Grisu
-    // algorithm Node does and produces the spec-correct answer).
-    let scaled_raw = value * scale as f64;
+    // The multiplication `value * scale` can land on a half-integer in
+    // two very different ways, which `toFixed` must round oppositely:
+    //
+    //   * Genuine half (e.g. `2.5`, `1234.5`, `0.5`): the exact real
+    //     product `value * scale` IS k + 0.5. ECMA-262 §21.1.3.3 picks
+    //     the larger n on a tie — i.e. round half away from zero — so
+    //     `(2.5).toFixed(0)` is "3", not "2".
+    //   * Precision artifact (e.g. `0.015 * 100`): the f64 product
+    //     rounds to exactly 1.5, but the true value is 1.499999… (the
+    //     IEEE-754 value of 0.015 is 0.01499999…). Here Node's Grisu
+    //     formatter rounds the *true* value down to "0.01".
+    //
+    // Rust's `f64::round` is round-half-away-from-zero, so the genuine
+    // case is handled by `scaled_raw.round()` below. Only the artifact
+    // case must defer to `format!` (Grisu, operating on the true value).
+    //
+    // Distinguish them by testing whether the multiply was *exact*: an
+    // FMA computes `value*scale - scaled_raw` at infinite precision, so
+    // a zero error means `scaled_raw` is the exact product and a 0.5
+    // fractional part is a genuine tie. A non-zero error means the half
+    // is a rounding artifact — let `format!` decide on the true value.
+    let s = scale as f64;
+    let scaled_raw = value * s;
     let frac = scaled_raw - scaled_raw.floor();
     // 1e-9 catches any plausible f64-precision artifact: the relative
     // error of one f64 mul on values < 1e15 is bounded by ~1e-15, and
     // we're working with values whose fractional part is in [0, 1).
     if (frac - 0.5).abs() < 1e-9 {
-        return None;
+        let err = value.mul_add(s, -scaled_raw);
+        if err != 0.0 {
+            // Inexact product → artifact half. Defer to Grisu.
+            return None;
+        }
+        // Exact product → genuine half. Fall through; `round()` rounds
+        // away from zero, matching V8 / the spec's larger-n tiebreak.
     }
     let scaled = scaled_raw.round();
     if !scaled.is_finite() {

--- a/test-files/test_gap_2418_tofixed_rounding.ts
+++ b/test-files/test_gap_2418_tofixed_rounding.ts
@@ -1,0 +1,48 @@
+// Issue #2418 — Number.prototype.toFixed must round genuine half values
+// AWAY FROM ZERO (ECMA-262 §21.1.3.3 picks the larger n on a tie), not
+// half-to-even like Rust's `format!`. It must also emit exponential form
+// for |x| >= 1e21 (the result is ToString(x), per spec step 9).
+//
+// The tricky part: precision-artifact halves (e.g. 0.015*100 == 1.5 in f64,
+// but 0.015 is really 0.01499…) must STILL round on the true value, so those
+// stay byte-identical to Node's Grisu formatter. All lines compare
+// byte-for-byte against `node --experimental-strip-types`.
+
+// Genuine halves — round away from zero.
+console.log((1234.5).toFixed(0)); // 1235
+console.log((2.5).toFixed(0)); // 3
+console.log((0.5).toFixed(0)); // 1
+console.log((1.5).toFixed(0)); // 2
+console.log((3.5).toFixed(0)); // 4
+console.log((255.5).toFixed(0)); // 256
+
+// Negative genuine halves — magnitude rounds away from zero.
+console.log((-1234.5).toFixed(0)); // -1235
+console.log((-2.5).toFixed(0)); // -3
+console.log((-0.5).toFixed(0)); // -1
+
+// Genuine halves at higher precision.
+console.log((0.125).toFixed(2)); // 0.13
+console.log((2.45).toFixed(1)); // 2.5
+console.log((1.45).toFixed(1)); // 1.5
+
+// Precision-artifact halves — round on the true (sub-half) value.
+console.log((0.015).toFixed(2)); // 0.01
+console.log((8.575).toFixed(2)); // 8.57
+console.log((1.005).toFixed(2)); // 1.00
+console.log((1.255).toFixed(2)); // 1.25
+console.log((0.135).toFixed(2)); // 0.14
+console.log((9.95).toFixed(1)); // 9.9
+
+// >= 1e21 — exponential form, not zero-padded decimals.
+console.log((1e21).toFixed(2)); // 1e+21
+console.log((1e21).toFixed(0)); // 1e+21
+console.log((-1e21).toFixed(2)); // -1e+21
+console.log((5e20).toFixed(2)); // 500000000000000000000.00 (still < 1e21)
+
+// Non-half ordinary cases — unaffected.
+console.log((123.456).toFixed(2)); // 123.46
+console.log((1.999).toFixed(2)); // 2.00
+console.log((1.23456789).toFixed(5)); // 1.23457
+console.log((100).toFixed(2)); // 100.00
+console.log((0).toFixed(2)); // 0.00


### PR DESCRIPTION
## Summary

Fixes #2418. `Number.prototype.toFixed` had two spec deviations:

1. **Half rounding** — genuine half values (`2.5`, `1234.5`, `0.5`, …) rounded **half-to-even** (Rust `format!`) instead of JS's **away-from-zero**. `(2.5).toFixed(0)` gave `"2"` instead of `"3"`.
2. **No exponential for `|x| >= 1e21`** — `(1e21).toFixed(2)` produced `"1000000000000000000000.00"` instead of `"1e+21"`.

## Root cause

In `fmt_fixed_int` (the `toFixed` integer fast path), any scaled value within `1e-9` of a half-integer returned `None`, sending it to `format!("{:.prec$}", value)` — which rounds half-to-even. That guard was added to handle **precision-artifact** halves (`0.015 * 100 == 1.5` in f64, though `0.015` is really `0.01499…`), where Grisu/`format!` is correct. But it also caught **genuine** halves, which the spec rounds away from zero.

## Fix

- Distinguish the two with an FMA exactness check: `value.mul_add(scale, -scaled_raw)`. A **zero** error means the multiply was exact, so the `0.5` fractional part is a genuine tie → fall through to `scaled_raw.round()` (Rust's `f64::round` is round-half-away-from-zero, matching V8 / ECMA-262 §21.1.3.3's larger-`n` tiebreak). A **non-zero** error means the half is a rounding artifact → keep deferring to `format!` (Grisu, on the true value).
- Add a `|x| >= 1e21` guard at the top of `js_number_to_fixed` that returns `js_number_to_string(value)` (already emits exponential form), per spec step 9.

## Validation

New gap test `test-files/test_gap_2418_tofixed_rounding.ts` — 27 cases (genuine halves, negatives, higher-precision halves, precision artifacts `0.015`/`8.575`/`1.005`/`1.255`, `1e21`/`5e20`, ordinary values) — byte-identical to `node --experimental-strip-types`.
