### PR TITLE
fix(array): expose queue method property values

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1710,6 +1710,19 @@ pub extern "C" fn js_object_get_field_by_name(
                     let v = js_get_global_this_builtin_value(b"Array".as_ptr(), 5);
                     return JSValue::from_bits(v.to_bits());
                 }
+                if is_array_method_value_name(key_bytes) {
+                    let heap_name = {
+                        let layout =
+                            std::alloc::Layout::from_size_align(key_bytes.len().max(1), 1).unwrap();
+                        let ptr = std::alloc::alloc(layout);
+                        std::ptr::copy_nonoverlapping(key_bytes.as_ptr(), ptr, key_bytes.len());
+                        ptr
+                    };
+                    let this_f64 =
+                        f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+                    let result = js_class_method_bind(this_f64, heap_name, key_bytes.len());
+                    return JSValue::from_bits(result.to_bits());
+                }
             }
             return JSValue::undefined();
         }
@@ -2317,6 +2330,13 @@ fn is_primitive_proto_method(key: &[u8]) -> bool {
             | b"isPrototypeOf"
             | b"propertyIsEnumerable"
             | b"toLocaleString"
+    )
+}
+
+fn is_array_method_value_name(key: &[u8]) -> bool {
+    matches!(
+        key,
+        b"pop" | b"push" | b"shift" | b"unshift" | b"splice" | b"slice"
     )
 }
 

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1115,6 +1115,15 @@ pub unsafe extern "C" fn js_native_call_method(
                         );
                         return f64::from_bits(JSValue::pointer(deleted as *mut u8).bits());
                     }
+                    "shift" => {
+                        let arr = raw_ptr as *mut crate::array::ArrayHeader;
+                        return crate::array::js_array_shift_f64(arr);
+                    }
+                    "unshift" if args_len >= 1 && !args_ptr.is_null() => {
+                        let arr = raw_ptr as *mut crate::array::ArrayHeader;
+                        let result = crate::array::js_array_unshift_f64(arr, *args_ptr);
+                        return crate::array::js_array_length(result) as f64;
+                    }
                     // Issue #515 followup: defensive `with` arm for arrays that
                     // reach the generic dispatch tower because the HIR fold
                     // bailed (untyped receiver, chained call returning Array,

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -8,12 +8,6 @@
       "reason": "Free-text explanation. Keep the most-actionable signal first \u2014 what changes the verdict (a fixture, a Perry fix, a Node spec change)."
     }
   },
-  "issue_655_repro": {
-    "issue": "655",
-    "added": "2026-05-24",
-    "category": "bug-stale",
-    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #655 is closed. Deliberate failing repro/harness \u2014 kept as a regression canary. Canonical regression-catcher for issue #655. Flips to PASS when the underlying fix lands. Keep regardless of CI verdict \u2014 it's a deliberate failing repro."
-  },
   "test_gap_regexp_advanced": {
     "issue": null,
     "added": "2026-05-15",


### PR DESCRIPTION
## Summary
- Return function values for array queue-style methods when arrays reach generic runtime property lookup.
- Add dynamic array `shift`/`unshift` dispatch so those bound method values are callable through the existing method path.
- Remove `issue_655_repro` from known failures now that it passes.

## Tests
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `./scripts/check_file_size.sh`
- `git diff --check origin/main...HEAD`
- `cargo check -p perry-runtime` (passes with existing warnings)
- `./run_parity_tests.sh --filter issue_655_repro`