### PR TITLE
fix(stream): initialize Readable subclasses

### DIFF
--- a/crates/perry-codegen/src/codegen/method.rs
+++ b/crates/perry-codegen/src/codegen/method.rs
@@ -15,6 +15,29 @@ use crate::types::{LlvmType, DOUBLE, I64};
 use super::helpers::sanitize;
 use super::opts::CrossModuleCtx;
 
+fn node_stream_parent_kind(
+    classes: &HashMap<String, &perry_hir::Class>,
+    class: &perry_hir::Class,
+) -> Option<&'static str> {
+    let mut cur = class.extends_name.as_deref();
+    let mut depth = 0usize;
+    while let Some(name) = cur {
+        match name {
+            "Readable" => return Some("readable"),
+            _ => {}
+        }
+        cur = classes
+            .get(name)
+            .copied()
+            .and_then(|parent| parent.extends_name.as_deref());
+        depth += 1;
+        if depth > 32 {
+            break;
+        }
+    }
+    None
+}
+
 /// Compile a class instance method as a top-level LLVM function with the
 /// signature `perry_method_<class>_<name>(this_box: double, args: double…)
 /// -> double`. The first parameter (`this`) is stored in a slot whose
@@ -287,91 +310,123 @@ pub(super) fn compile_method(
             }
             if let Some(pname) = effective_parent {
                 let pname_owned = pname.to_string();
-                // Resolve the standalone-ctor symbol name. Prefer the
-                // local class table (same module) for an inline call;
-                // fall back to imported_class_ctors for cross-module.
-                let (ctor_sym, param_count) = if let Some(pclass) =
-                    ctx.classes.get(&pname_owned).copied()
-                {
-                    if pclass.constructor.is_some() {
-                        // Local class with own ctor — use the per-module-prefix
-                        // standalone symbol, same one compile_method emits.
-                        let module_prefix = ctx.strings.module_prefix().to_string();
-                        let sym = format!("{}__{}_constructor", module_prefix, pname_owned);
-                        let pcount = pclass
-                            .constructor
-                            .as_ref()
-                            .map(|c| c.params.len())
-                            .unwrap_or(0);
-                        (sym, pcount)
+                let node_stream_kind = if pname_owned == "Readable" {
+                    node_stream_parent_kind(ctx.classes, class)
+                } else {
+                    None
+                };
+                if let Some(kind) = node_stream_kind {
+                    let undef_lit =
+                        crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+                    let opts_box = method
+                        .params
+                        .first()
+                        .and_then(|param| ctx.locals.get(&param.id).cloned())
+                        .map(|slot| ctx.block().load(DOUBLE, &slot))
+                        .unwrap_or_else(|| undef_lit.clone());
+                    let this_box = match ctx.this_stack.last().cloned() {
+                        Some(slot) => ctx.block().load(DOUBLE, &slot),
+                        None => undef_lit.clone(),
+                    };
+                    let runtime_fn = match kind {
+                        "readable" => "js_node_stream_readable_subclass_init",
+                        _ => unreachable!("node stream parent kind {}", kind),
+                    };
+                    ctx.block().call(
+                        DOUBLE,
+                        runtime_fn,
+                        &[(DOUBLE, &this_box), (DOUBLE, &opts_box)],
+                    );
+                } else {
+                    // Resolve the standalone-ctor symbol name. Prefer the
+                    // local class table (same module) for an inline call;
+                    // fall back to imported_class_ctors for cross-module.
+                    let (ctor_sym, param_count) = if let Some(pclass) =
+                        ctx.classes.get(&pname_owned).copied()
+                    {
+                        if pclass.constructor.is_some() {
+                            // Local class with own ctor — use the per-module-prefix
+                            // standalone symbol, same one compile_method emits.
+                            let module_prefix = ctx.strings.module_prefix().to_string();
+                            let sym = format!("{}__{}_constructor", module_prefix, pname_owned);
+                            let pcount = pclass
+                                .constructor
+                                .as_ref()
+                                .map(|c| c.params.len())
+                                .unwrap_or(0);
+                            (sym, pcount)
+                        } else if let Some((sym, n)) =
+                            ctx.imported_class_ctors.get(&pname_owned).cloned()
+                        {
+                            (sym, n)
+                        } else {
+                            // No callable ctor symbol — bail.
+                            stmt::lower_stmts(&mut ctx, &method.body).with_context(|| {
+                                format!("lowering body of method '{}::{}'", class.name, method.name)
+                            })?;
+                            // Fall through to the default ret at end.
+                            if !ctx.block().is_terminated() {
+                                let undef = crate::nanbox::double_literal(f64::from_bits(
+                                    crate::nanbox::TAG_UNDEFINED,
+                                ));
+                                ctx.block().ret(DOUBLE, &undef);
+                            }
+                            let _ = std::mem::take(&mut ctx.ic_globals);
+                            let _ = std::mem::take(&mut ctx.typed_parse_rodata);
+                            let _ = std::mem::take(&mut ctx.pending_declares);
+                            return Ok(());
+                        }
                     } else if let Some((sym, n)) =
                         ctx.imported_class_ctors.get(&pname_owned).cloned()
                     {
                         (sym, n)
                     } else {
-                        // No callable ctor symbol — bail.
-                        stmt::lower_stmts(&mut ctx, &method.body).with_context(|| {
-                            format!("lowering body of method '{}::{}'", class.name, method.name)
-                        })?;
-                        // Fall through to the default ret at end.
-                        if !ctx.block().is_terminated() {
-                            let undef = crate::nanbox::double_literal(f64::from_bits(
-                                crate::nanbox::TAG_UNDEFINED,
-                            ));
-                            ctx.block().ret(DOUBLE, &undef);
+                        ("".to_string(), 0)
+                    };
+                    if !ctor_sym.is_empty() {
+                        let undef_lit = crate::nanbox::double_literal(f64::from_bits(
+                            crate::nanbox::TAG_UNDEFINED,
+                        ));
+                        // Forward this method's params, padding with undefined if
+                        // the parent expects more.
+                        let mut forwarded: Vec<String> = Vec::with_capacity(param_count);
+                        for (i, p) in method.params.iter().enumerate() {
+                            if i >= param_count {
+                                break;
+                            }
+                            let slot = ctx.locals.get(&p.id).cloned();
+                            if let Some(slot) = slot {
+                                forwarded.push(ctx.block().load(DOUBLE, &slot));
+                            } else {
+                                forwarded.push(undef_lit.clone());
+                            }
                         }
-                        let _ = std::mem::take(&mut ctx.ic_globals);
-                        let _ = std::mem::take(&mut ctx.typed_parse_rodata);
-                        let _ = std::mem::take(&mut ctx.pending_declares);
-                        return Ok(());
-                    }
-                } else if let Some((sym, n)) = ctx.imported_class_ctors.get(&pname_owned).cloned() {
-                    (sym, n)
-                } else {
-                    ("".to_string(), 0)
-                };
-                if !ctor_sym.is_empty() {
-                    let undef_lit =
-                        crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
-                    // Forward this method's params, padding with undefined if
-                    // the parent expects more.
-                    let mut forwarded: Vec<String> = Vec::with_capacity(param_count);
-                    for (i, p) in method.params.iter().enumerate() {
-                        if i >= param_count {
-                            break;
-                        }
-                        let slot = ctx.locals.get(&p.id).cloned();
-                        if let Some(slot) = slot {
-                            forwarded.push(ctx.block().load(DOUBLE, &slot));
-                        } else {
+                        while forwarded.len() < param_count {
                             forwarded.push(undef_lit.clone());
                         }
+                        // Load `this` from the this_stack.
+                        let this_slot = ctx.this_stack.last().cloned();
+                        let this_box = if let Some(slot) = this_slot {
+                            ctx.block().load(DOUBLE, &slot)
+                        } else {
+                            undef_lit.clone()
+                        };
+                        let ctor_param_types: Vec<crate::types::LlvmType> = std::iter::once(DOUBLE)
+                            .chain(forwarded.iter().map(|_| DOUBLE))
+                            .collect();
+                        let mut ctor_args: Vec<(crate::types::LlvmType, &str)> =
+                            Vec::with_capacity(1 + forwarded.len());
+                        ctor_args.push((DOUBLE, &this_box));
+                        for la in &forwarded {
+                            ctor_args.push((DOUBLE, la.as_str()));
+                        }
+                        ctx.pending_declares.push((
+                            ctor_sym.clone(),
+                            crate::types::VOID,
+                            ctor_param_types,
+                        ));
+                        ctx.block().call_void(&ctor_sym, &ctor_args);
                     }
-                    while forwarded.len() < param_count {
-                        forwarded.push(undef_lit.clone());
-                    }
-                    // Load `this` from the this_stack.
-                    let this_slot = ctx.this_stack.last().cloned();
-                    let this_box = if let Some(slot) = this_slot {
-                        ctx.block().load(DOUBLE, &slot)
-                    } else {
-                        undef_lit.clone()
-                    };
-                    let ctor_param_types: Vec<crate::types::LlvmType> = std::iter::once(DOUBLE)
-                        .chain(forwarded.iter().map(|_| DOUBLE))
-                        .collect();
-                    let mut ctor_args: Vec<(crate::types::LlvmType, &str)> =
-                        Vec::with_capacity(1 + forwarded.len());
-                    ctor_args.push((DOUBLE, &this_box));
-                    for la in &forwarded {
-                        ctor_args.push((DOUBLE, la.as_str()));
-                    }
-                    ctx.pending_declares.push((
-                        ctor_sym.clone(),
-                        crate::types::VOID,
-                        ctor_param_types,
-                    ));
-                    ctx.block().call_void(&ctor_sym, &ctor_args);
                 }
             }
             // Apply self field initializers AFTER the parent body chain has

--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -129,6 +129,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             | "URIError"
                             | "EvalError"
                             | "AggregateError"
+                            | "Readable"
                             | "Writable"
                             | "ReadableStream"
                             | "WritableStream"
@@ -257,6 +258,21 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         // see uninitialized slots. Mirrors the equivalent
                         // call in the user-class super branch below
                         // (line ~4521). Refs #562.
+                        let current_class_name =
+                            ctx.class_stack.last().cloned().unwrap_or_default();
+                        crate::lower_call::apply_field_initializers_recursive(
+                            ctx,
+                            &current_class_name,
+                            crate::lower_call::FieldInitMode::SelfOnly,
+                        )?;
+                        return Ok(result);
+                    }
+                    let node_stream_kind = match parent_name.as_str() {
+                        "Readable" => Some("readable"),
+                        _ => None,
+                    };
+                    if let Some(kind) = node_stream_kind {
+                        let result = lower_node_stream_super_init(ctx, kind, super_args)?;
                         let current_class_name =
                             ctx.class_stack.last().cloned().unwrap_or_default();
                         crate::lower_call::apply_field_initializers_recursive(

--- a/crates/perry-codegen/src/expr/write_barrier.rs
+++ b/crates/perry-codegen/src/expr/write_barrier.rs
@@ -230,8 +230,8 @@ pub(crate) fn lower_stream_super_init(
     Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
 }
 
-/// Initialize Node's classic `stream.Writable` base class on an existing
-/// subclass instance. Unlike `new Writable(opts)`, `super(opts)` must keep the
+/// Initialize Node's classic stream base class on an existing subclass
+/// instance. Unlike `new Readable/Writable(opts)`, `super(opts)` must keep the
 /// object identity allocated for the derived class and attach stream state to it.
 pub(crate) fn lower_node_stream_super_init(
     ctx: &mut FnCtx<'_>,
@@ -254,6 +254,7 @@ pub(crate) fn lower_node_stream_super_init(
     };
 
     let runtime_fn = match kind {
+        "readable" => "js_node_stream_readable_subclass_init",
         "writable" => "js_node_stream_writable_subclass_init",
         _ => unreachable!(
             "lower_node_stream_super_init: unexpected Node stream kind {}",

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -13,6 +13,32 @@ use crate::expr::{lower_expr, nanbox_pointer_inline, FnCtx};
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
 use crate::types::{DOUBLE, I32, I64, I8, PTR};
 
+fn node_stream_parent_kind(ctx: &FnCtx<'_>, class: &perry_hir::Class) -> Option<&'static str> {
+    let mut cur = class.extends_name.as_deref();
+    let mut depth = 0usize;
+    while let Some(name) = cur {
+        match name {
+            "Readable" => return Some("readable"),
+            _ => {}
+        }
+        if ctx.imported_class_ctors.contains_key(name) {
+            return None;
+        }
+        let Some(parent) = ctx.classes.get(name).copied() else {
+            return None;
+        };
+        if parent.constructor.is_some() {
+            return None;
+        }
+        cur = parent.extends_name.as_deref();
+        depth += 1;
+        if depth > 32 {
+            break;
+        }
+    }
+    None
+}
+
 /// Lower `new ClassName(args…)` — Phase C.1.
 ///
 /// Strategy: allocate an anonymous object via `js_object_alloc(0, N)`
@@ -563,6 +589,26 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
                 parent_name = parent_class.extends_name.as_deref();
             } else {
                 break;
+            }
+        }
+        if !found_inherited_ctor {
+            if let Some(kind) = node_stream_parent_kind(ctx, class) {
+                let undef_lit =
+                    crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+                let opts_box = lowered_args
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| undef_lit.clone());
+                let runtime_fn = match kind {
+                    "readable" => "js_node_stream_readable_subclass_init",
+                    _ => unreachable!("node stream parent kind {}", kind),
+                };
+                ctx.block().call(
+                    DOUBLE,
+                    runtime_fn,
+                    &[(DOUBLE, &obj_box), (DOUBLE, &opts_box)],
+                );
+                found_inherited_ctor = true;
             }
         }
         // Issue #573: if the parent walk reached an Error-like built-in

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -886,6 +886,11 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
 
     // ========== node:stream stubs (issue #631) ==========
     module.declare_function("js_node_stream_readable_new", DOUBLE, &[DOUBLE]);
+    module.declare_function(
+        "js_node_stream_readable_subclass_init",
+        DOUBLE,
+        &[DOUBLE, DOUBLE],
+    );
     module.declare_function("js_node_stream_writable_new", DOUBLE, &[DOUBLE]);
     module.declare_function(
         "js_node_stream_writable_subclass_init",

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -5404,6 +5404,41 @@ pub extern "C" fn js_node_stream_readable_new(opts: f64) -> f64 {
 }
 
 #[no_mangle]
+pub extern "C" fn js_node_stream_readable_subclass_init(this: f64, opts: f64) -> f64 {
+    register_iter_helper_arities();
+    let raw = raw_ptr_from_value(this);
+    if raw == 0 {
+        return this;
+    }
+    if unsafe { gc_type_for_ptr(raw) } != Some(crate::gc::GC_TYPE_OBJECT) {
+        return this;
+    }
+
+    let obj = raw as *mut ObjectHeader;
+    let subclass_read =
+        js_object_get_field_by_name_f64(obj as *const ObjectHeader, hidden_key(b"_read"));
+
+    let methods = readable_methods();
+    install_methods_on_existing_object(obj, this, &methods, &[]);
+
+    if let Some(read) = read_callback_from_options(opts) {
+        js_object_set_field_by_name(obj, hidden_read_key(), rebind_callback_this(read, this));
+    } else if is_callable_value(subclass_read) {
+        js_object_set_field_by_name(obj, hidden_read_key(), subclass_read);
+    }
+
+    init_lifecycle_state(this, opts);
+    init_constructor(this, "Readable");
+    init_readable_state(this, opts);
+    install_common_lifecycle_callbacks(this, opts);
+    init_abort_signal_state(this, opts);
+    async_iterator::install_readable_async_iterator_symbol(this);
+    install_stream_async_dispose_symbol(this);
+    invoke_construct_callback(this, opts);
+    this
+}
+
+#[no_mangle]
 pub extern "C" fn js_node_stream_writable_new(opts: f64) -> f64 {
     let methods = writable_methods();
     let obj = build_object(&methods, WRITABLE_SHAPE_ID + methods.len() as u32);


### PR DESCRIPTION
## Summary
- Initialize existing `Readable` subclass instances with classic stream methods/state during `super()` and default constructor paths.
- Preserve subclass `_read` as the readable callback and invoke it when `data` listeners enter flowing mode.
- Add runtime FFI/codegen wiring for explicit, default, and standalone constructor paths.
- Rebased after #2430 merged; `Writable` subclass coverage is now green on `main`, leaving Duplex/Transform as separate follow-up slices.

## Tests
- `cargo fmt --check`
- `cargo check -p perry-codegen -p perry-runtime`
- `./run_parity_tests.sh --suite node-suite --module stream --filter subclass/extends-readable` (PASS, report `test-parity/reports/parity_report_20260529_045844.json` after rebase)
- `./run_parity_tests.sh --suite node-suite --module stream --filter subclass` (2 PASS / 2 expected residual parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260529_045945.json`; residuals: Duplex/Transform)
- `./run_parity_tests.sh --suite node-suite --module stream --filter events/data-listener-auto-resume`
- `./run_parity_tests.sh --suite node-suite --module stream --filter flow/pause-resume-cycle`
- `./run_parity_tests.sh --suite node-suite --module stream --filter readable/set-encoding`
- `git diff --check`
- `git diff --cached --check`
