### PR TITLE
fix(publish): project-relative framework_dir for vendored optional frameworks (#1303)

### DIFF
--- a/crates/perry/src/commands/compile/host_config.rs
+++ b/crates/perry/src/commands/compile/host_config.rs
@@ -663,6 +663,11 @@ pub(super) fn apply_pkg_and_toml_config(
                 }
                 warn_non_string("ios_client_id", ga);
                 warn_non_string("android_client_id", ga);
+                // #1303 — project-relative search dir for the vendored
+                // optional framework (GoogleSignIn SDK). Consumed by the link
+                // step (`link/mod.rs::resolve_optional_framework_dir`) and the
+                // `perry publish` tarball; validated here only for type.
+                warn_non_string("framework_dir", ga);
                 warn_non_string("server_client_id", ga);
 
                 if let Some(scopes) = ga.get("default_scopes") {

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -159,6 +159,56 @@ mod native_package_selection_tests {
     }
 }
 
+/// Walk up from the entry `.ts` to the directory holding `perry.toml`.
+/// Mirrors `widget_build::project_root_for` — kept local so the link
+/// module doesn't reach across sibling modules for one path lookup.
+fn find_project_root_for(input: &Path) -> Option<PathBuf> {
+    let mut dir = input.canonicalize().ok()?;
+    for _ in 0..8 {
+        dir = dir.parent()?.to_path_buf();
+        if dir.join("perry.toml").exists() {
+            return Some(dir);
+        }
+    }
+    None
+}
+
+/// Resolve the vendored optional-framework search directory for a native
+/// library that gates an SDK on `frameworks_env` (issue #1303 — e.g.
+/// `@perryts/google-auth`'s `PERRY_GOOGLE_SIGN_IN_FRAMEWORK_DIR`).
+///
+/// Precedence (matches the issue's contract):
+///   1. The `frameworks_env` env var, when set in the process environment
+///      — today's local `perry compile` behavior. Returned verbatim.
+///   2. `perry.toml [google_auth].framework_dir`, resolved relative to the
+///      project root → absolute. This is what survives the `perry publish`
+///      worker round-trip: the dev's shell env doesn't transfer and an
+///      absolute local path wouldn't exist on the worker, but perry.toml +
+///      the project-relative dir are both uploaded with `--project`, so the
+///      worker's `perry compile` re-resolves the same dir.
+///
+/// Returns `None` when neither source yields a path. Callers still check
+/// `is_dir()` before linking, so a stale/misspelled path skips silently
+/// (the wrapper's `#if canImport(...)` fallback keeps the link valid).
+fn resolve_optional_framework_dir(env_name: &str, args_input: &Path) -> Option<PathBuf> {
+    // 1. Explicit env var wins (today's behavior).
+    if let Some(dir) = std::env::var_os(env_name) {
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir));
+        }
+    }
+    // 2. Project-relative `perry.toml [google_auth].framework_dir`.
+    let project_root = find_project_root_for(args_input)?;
+    let content = fs::read_to_string(project_root.join("perry.toml")).ok()?;
+    let doc = content.parse::<toml::Table>().ok()?;
+    let rel = doc
+        .get("google_auth")?
+        .as_table()?
+        .get("framework_dir")?
+        .as_str()?;
+    Some(project_root.join(rel))
+}
+
 /// Construct the platform-specific linker command, append every required
 /// argument (object files, libraries, frameworks, system libs, native libs,
 /// geisterhand libs), invoke it, and bail on non-zero status.
@@ -1388,6 +1438,23 @@ pub(super) fn build_and_run_link(
                         }
                     }
 
+                    // #1303 — when the wrapper crate's `build.rs` gates an
+                    // optional vendored SDK on an env var (`frameworks_env`)
+                    // and the dev declared a project-relative `framework_dir`
+                    // in `perry.toml [google_auth]`, export the resolved
+                    // absolute path so `build.rs` opts the real SDK in. This
+                    // fires on the local machine AND on the `perry publish`
+                    // worker (where the dev's shell env doesn't transfer, but
+                    // the uploaded perry.toml + dir do). If the env var is
+                    // already set we re-export the same value — idempotent.
+                    if let Some(env_name) = target_config.frameworks_env.as_deref() {
+                        if let Some(dir) = resolve_optional_framework_dir(env_name, args_input) {
+                            if dir.is_dir() {
+                                cargo_cmd.env(env_name, &dir);
+                            }
+                        }
+                    }
+
                     let cargo_status = cargo_cmd.status()?;
                     if !cargo_status.success() {
                         return Err(anyhow!(
@@ -1477,34 +1544,40 @@ pub(super) fn build_and_run_link(
             //
             // Contract is static frameworks only — `-framework` links the
             // archive directly with no `.app/Frameworks/` embed + rpath.
+            //
+            // #1303 — the search dir resolves from the `frameworks_env` env
+            // var (local) or, when unset, the project-relative
+            // `perry.toml [google_auth].framework_dir` (so a `perry publish`
+            // worker build links the real SDK instead of the stub).
             if let Some(env_name) = target_config.frameworks_env.as_deref() {
                 if !target_config.optional_frameworks.is_empty() {
-                    match std::env::var(env_name) {
-                        Ok(dir) if Path::new(&dir).is_dir() => {
+                    match resolve_optional_framework_dir(env_name, args_input) {
+                        Some(dir) if dir.is_dir() => {
                             cmd.arg("-F").arg(&dir);
                             for framework in &target_config.optional_frameworks {
                                 cmd.arg("-framework").arg(framework);
                             }
                             if let OutputFormat::Text = format {
                                 println!(
-                                    "Linking {} optional framework(s) for {} from ${} ({})",
+                                    "Linking {} optional framework(s) for {} ({})",
                                     target_config.optional_frameworks.len(),
                                     native_lib.module,
-                                    env_name,
-                                    dir
+                                    dir.display()
                                 );
                             }
                         }
-                        Ok(dir) => {
+                        Some(dir) => {
                             if let OutputFormat::Text = format {
                                 println!(
-                                    "Skipping optional frameworks for {}: ${} = {:?} is not a directory",
-                                    native_lib.module, env_name, dir
+                                    "Skipping optional frameworks for {}: {:?} is not a directory",
+                                    native_lib.module,
+                                    dir.display()
                                 );
                             }
                         }
-                        Err(_) => {
-                            // env var unset → silent skip (canImport fallback).
+                        None => {
+                            // Neither env var nor framework_dir → silent skip
+                            // (the wrapper's canImport fallback keeps linking).
                         }
                     }
                 }
@@ -1798,4 +1871,59 @@ pub(super) fn build_and_run_link(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod optional_framework_dir_tests {
+    use super::*;
+
+    /// Lay out a temp project: `<root>/perry.toml` + `<root>/src/main.ts`,
+    /// with the perry.toml `[google_auth]` table set to `toml_body`.
+    /// Returns (tempdir, entry-ts-path).
+    fn scaffold(toml_body: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("perry.toml"), toml_body).unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        let entry = src.join("main.ts");
+        fs::write(&entry, "export {}\n").unwrap();
+        (dir, entry)
+    }
+
+    #[test]
+    fn resolves_framework_dir_relative_to_project_root() {
+        let (dir, entry) =
+            scaffold("[google_auth]\nframework_dir = \"vendor/google-sign-in/frameworks\"\n");
+        // Use a uniquely-named env var that is guaranteed unset.
+        let env_name = "PERRY_TEST_GA_FRAMEWORK_DIR_UNSET_A";
+        let resolved = resolve_optional_framework_dir(env_name, &entry).unwrap();
+        // Compare against the canonicalized root — `find_project_root_for`
+        // canonicalizes the entry, so the resolved path is symlink-resolved
+        // (e.g. /var/folders → /private/var on macOS).
+        assert_eq!(
+            resolved,
+            dir.path()
+                .canonicalize()
+                .unwrap()
+                .join("vendor/google-sign-in/frameworks")
+        );
+    }
+
+    #[test]
+    fn returns_none_when_no_framework_dir_key() {
+        let (_dir, entry) = scaffold("[google_auth]\nios_client_id = \"abc\"\n");
+        let env_name = "PERRY_TEST_GA_FRAMEWORK_DIR_UNSET_B";
+        assert!(resolve_optional_framework_dir(env_name, &entry).is_none());
+    }
+
+    #[test]
+    fn env_var_takes_precedence_over_perry_toml() {
+        let (_dir, entry) = scaffold("[google_auth]\nframework_dir = \"vendor/from-toml\"\n");
+        // Unique name so we don't race other tests sharing process env.
+        let env_name = "PERRY_TEST_GA_FRAMEWORK_DIR_SET_C";
+        std::env::set_var(env_name, "/absolute/from/env");
+        let resolved = resolve_optional_framework_dir(env_name, &entry).unwrap();
+        std::env::remove_var(env_name);
+        assert_eq!(resolved, PathBuf::from("/absolute/from/env"));
+    }
 }

--- a/crates/perry/src/commands/publish/config_types.rs
+++ b/crates/perry/src/commands/publish/config_types.rs
@@ -21,6 +21,19 @@ pub(super) struct PerryToml {
     pub(super) audit: Option<AuditConfig>,
     pub(super) verify: Option<VerifyConfig>,
     pub(super) release_notes: Option<std::collections::HashMap<String, String>>,
+    pub(super) google_auth: Option<GoogleAuthConfig>,
+}
+
+/// `[google_auth]` block (#1138 / #1303). Only `framework_dir` matters to
+/// `perry publish` — the client-id keys are consumed at compile time
+/// (`host_config.rs` / `apple_info_plist.rs`). `framework_dir` is a
+/// project-relative path to the vendored optional-framework search dir
+/// (e.g. the GoogleSignIn SDK); publish must force it into the upload
+/// tarball so the worker can link the real SDK. See issue #1303.
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+pub(super) struct GoogleAuthConfig {
+    pub(super) framework_dir: Option<String>,
 }
 
 // #854: deserialized [project] table; not every key is read.

--- a/crates/perry/src/commands/publish/mod.rs
+++ b/crates/perry/src/commands/publish/mod.rs
@@ -35,7 +35,7 @@ pub(crate) use saved_config::{
     save_config, AndroidSavedConfig, AppleSavedConfig, BetaConfig, HarmonyosSavedConfig,
     IosSavedConfig, PerryConfig,
 };
-pub(crate) use tarball::create_project_tarball_with_excludes;
+pub(crate) use tarball::{create_project_tarball, create_project_tarball_with_excludes};
 
 // Sibling-only items used by run_async and tests.
 use config_types::PerryToml;
@@ -1356,7 +1356,21 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
         .as_ref()
         .and_then(|p| p.exclude.clone())
         .unwrap_or_default();
-    let tarball = create_project_tarball_with_excludes(&project_dir, &publish_excludes)
+
+    // #1303 — force the vendored optional-framework dir
+    // (`[google_auth].framework_dir`, project-relative) into the upload set
+    // so the remote worker has the SDK binaries. Without this, the static
+    // archive (extension-less, usually >1 MB) is dropped by the default
+    // binary-artifact exclusion and the worker links the no-SDK stub.
+    let force_include_dirs: Vec<PathBuf> = config
+        .google_auth
+        .as_ref()
+        .and_then(|ga| ga.framework_dir.as_deref())
+        .map(|rel| project_dir.join(rel))
+        .filter(|p| p.is_dir())
+        .into_iter()
+        .collect();
+    let tarball = create_project_tarball(&project_dir, &publish_excludes, &force_include_dirs)
         .context("Failed to create project tarball")?;
 
     let tarball_size = tarball.len();

--- a/crates/perry/src/commands/publish/tarball.rs
+++ b/crates/perry/src/commands/publish/tarball.rs
@@ -67,6 +67,34 @@ pub(crate) fn create_project_tarball_with_excludes(
     project_dir: &Path,
     extra_excludes: &[String],
 ) -> Result<Vec<u8>> {
+    create_project_tarball(project_dir, extra_excludes, &[])
+}
+
+/// As [`create_project_tarball_with_excludes`], but `force_include_dirs`
+/// (absolute paths) are packed verbatim — files under them bypass
+/// [`should_exclude_file`]. Issue #1303: a vendored optional-framework dir
+/// (e.g. the GoogleSignIn SDK declared via `perry.toml [google_auth]
+/// framework_dir`) contains the static archive binary (extension-less, often
+/// >1 MB) and would otherwise be dropped, leaving the worker to link the
+/// no-SDK stub.
+pub(crate) fn create_project_tarball(
+    project_dir: &Path,
+    extra_excludes: &[String],
+    force_include_dirs: &[PathBuf],
+) -> Result<Vec<u8>> {
+    // Force-include dirs are matched by absolute-path prefix; canonicalize
+    // so a relative/`./`-prefixed input still matches the walked paths.
+    let force_roots: Vec<PathBuf> = force_include_dirs
+        .iter()
+        .filter_map(|d| d.canonicalize().ok())
+        .collect();
+    let is_force_included = |path: &Path| -> bool {
+        path.canonicalize()
+            .ok()
+            .map(|abs| force_roots.iter().any(|r| abs.starts_with(r)))
+            .unwrap_or(false)
+    };
+
     let buf = Vec::new();
     let encoder = GzEncoder::new(buf, Compression::default());
     let mut ar = tar::Builder::new(encoder);
@@ -124,7 +152,7 @@ pub(crate) fn create_project_tarball_with_excludes(
         }
 
         if path.is_file() {
-            if should_exclude_file(path) {
+            if should_exclude_file(path) && !is_force_included(path) {
                 continue;
             }
             ar.append_path_with_name(path, relative)?;
@@ -183,4 +211,57 @@ pub(crate) fn create_project_tarball_with_excludes(
     ar.finish()?;
     let encoder = ar.into_inner()?;
     Ok(encoder.finish()?)
+}
+
+#[cfg(test)]
+mod force_include_tests {
+    use super::*;
+
+    /// Collect the relative paths packed into a gzipped tarball.
+    fn tar_entries(bytes: &[u8]) -> Vec<String> {
+        let dec = flate2::read::GzDecoder::new(bytes);
+        let mut ar = tar::Archive::new(dec);
+        ar.entries()
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path().unwrap().to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn force_include_keeps_otherwise_excluded_framework_binary() {
+        let proj = tempfile::tempdir().unwrap();
+        // A vendored static framework binary: extension-less and >1 MB,
+        // which `should_exclude_file` drops by default.
+        let fw = proj
+            .path()
+            .join("vendor/google-sign-in/frameworks/GoogleSignIn.framework");
+        fs::create_dir_all(&fw).unwrap();
+        let binary = fw.join("GoogleSignIn");
+        fs::write(&binary, vec![0u8; 2 * 1024 * 1024]).unwrap();
+        // A normal source file so the tarball is never empty.
+        fs::write(proj.path().join("index.ts"), "export {}\n").unwrap();
+
+        // Without force-include: the binary is dropped.
+        let plain = create_project_tarball(proj.path(), &[], &[]).unwrap();
+        let plain_entries = tar_entries(&plain);
+        assert!(
+            !plain_entries
+                .iter()
+                .any(|p| p.ends_with("GoogleSignIn.framework/GoogleSignIn")),
+            "binary should be excluded by default, got {plain_entries:?}"
+        );
+
+        // With force-include: the binary survives.
+        let fw_dir = proj.path().join("vendor/google-sign-in/frameworks");
+        let forced =
+            create_project_tarball(proj.path(), &[], std::slice::from_ref(&fw_dir)).unwrap();
+        let forced_entries = tar_entries(&forced);
+        assert!(
+            forced_entries
+                .iter()
+                .any(|p| p.ends_with("GoogleSignIn.framework/GoogleSignIn")),
+            "force-included framework binary should be packed, got {forced_entries:?}"
+        );
+    }
 }

--- a/docs/src/native-libraries/manifest-v1.md
+++ b/docs/src/native-libraries/manifest-v1.md
@@ -405,6 +405,26 @@ compiles and the binary still links, returning a runtime
 symbols. The same `build.rs` opt-in (`-F $DIR` to `swiftc`) must
 gate the bridge's compile so both halves agree.
 
+**Project-relative `framework_dir` (survives `perry publish`).** The
+env var works for local `perry compile`, but `perry publish` uploads
+the project to a remote build worker where the dev's shell env
+doesn't transfer and an absolute local path wouldn't exist anyway.
+For the round-trip, declare the framework search dir **relative to
+the project root** in `perry.toml`:
+
+```toml
+[google_auth]
+framework_dir = "vendor/google-sign-in/frameworks"   # relative to perry.toml
+```
+
+Perry resolves it to an absolute path and exports it as the
+package's `frameworksEnv` before building the wrapper crate — on the
+local machine **and** on the worker — and `perry publish` forces the
+directory into the upload tarball (even though it holds the static
+archive binary, which the default binary-artifact exclusion would
+otherwise drop). Precedence is **explicit env var > `framework_dir`**,
+so existing local setups are unchanged. Issue #1303.
+
 **Contract — static frameworks only.** `-framework` links the
 archive directly; Perry does **not** embed the `.framework` into
 `<app>.app/Frameworks/` or add an `@executable_path/Frameworks`


### PR DESCRIPTION
Fixes #1303.

## Problem

`perry publish` uploads the project to the remote build worker and runs the whole build there — including the native wrapper crate's `cargo build`, so its `build.rs` runs on the worker. The `@perryts/google-auth` wrapper opts the real GoogleSignIn SDK in by reading the `PERRY_GOOGLE_SIGN_IN_FRAMEWORK_DIR` env var (its declared `frameworksEnv`). On the worker that breaks down completely:

1. The dev's shell env var doesn't transfer.
2. Even if it did, it's an absolute local path that doesn't exist on the worker.
3. There was no `perry.toml` key for the framework dir.
4. The framework binaries weren't in the upload set.

Result: published iOS builds silently linked the `framework-not-linked` stub. The SDK worked on local device builds but was dead in the TestFlight/App Store artifact.

## Fix

Make the optional-framework search dir **project-relative and uploaded**, so it survives the worker round-trip:

- **`perry.toml [google_auth].framework_dir`** — a dir relative to the project root. `link/mod.rs::resolve_optional_framework_dir` resolves it to an absolute path. Precedence is **explicit `frameworksEnv` env var > `framework_dir`**, so existing local setups are unchanged.
- **Export before `cargo build`** — Perry sets the package's `frameworksEnv` to the resolved absolute path before building the wrapper crate, so `build.rs` opts the real SDK in on both the local machine and the worker (which re-reads the uploaded `perry.toml`). The link step uses the same resolution for `-F <dir>` / `-framework <name>`.
- **Force-include in the publish tarball** — `framework_dir` is packed even though it holds the static archive binary (extension-less, usually >1 MB), which the default binary-artifact exclusion would otherwise drop.

```toml
[google_auth]
framework_dir = "vendor/google-sign-in/frameworks"   # relative to perry.toml
```

No changes to the build worker / `BuildManifest` were needed: the whole mechanism flows through `perry.toml` being read at compile time on the worker.

## Tests

- `optional_framework_dir_tests` — env-var precedence, `perry.toml` fallback resolution, absent-key returns `None`.
- `tarball::force_include_tests` — a >1 MB extension-less framework binary is dropped by default but survives force-include.
- Manifest-v1 docs section + a type-validation warning for the new key.

All new tests pass; `cargo fmt --all -- --check` clean. Touches only the `perry` CLI crate (no runtime/stdlib changes).
