### PR TITLE
fix(hir): infer generic rest params as tuples

### DIFF
--- a/crates/perry-hir/src/monomorph/constraints.rs
+++ b/crates/perry-hir/src/monomorph/constraints.rs
@@ -57,6 +57,11 @@ fn check_constraint(
         Type::Array(elem_constraint) => {
             if let Type::Array(elem_type) = concrete_type {
                 check_constraint(type_param, elem_type, elem_constraint, module, idx)
+            } else if let Type::Tuple(elem_types) = concrete_type {
+                for elem_type in elem_types {
+                    check_constraint(type_param, elem_type, elem_constraint, module, idx)?;
+                }
+                Ok(())
             } else {
                 Err(ConstraintError::TypeMismatch {
                     type_param: type_param.to_string(),
@@ -259,6 +264,31 @@ fn types_satisfy(actual: &Type, expected: &Type) -> bool {
         (Type::Boolean, Type::Boolean) => true,
         (Type::BigInt, Type::BigInt) => true,
         (Type::Array(a), Type::Array(b)) => types_satisfy(a, b),
+        (Type::Array(elem), Type::Generic { base, type_args })
+            if super::is_array_like_generic(base) && type_args.len() == 1 =>
+        {
+            types_satisfy(elem, &type_args[0])
+        }
+        (Type::Tuple(elems), Type::Generic { base, type_args })
+            if super::is_array_like_generic(base) && type_args.len() == 1 =>
+        {
+            elems.iter().all(|elem| types_satisfy(elem, &type_args[0]))
+        }
+        (
+            Type::Generic {
+                base: actual_base,
+                type_args: actual_args,
+            },
+            Type::Generic {
+                base: expected_base,
+                type_args: expected_args,
+            },
+        ) if actual_base == expected_base && actual_args.len() == expected_args.len() => {
+            actual_args
+                .iter()
+                .zip(expected_args.iter())
+                .all(|(actual_arg, expected_arg)| types_satisfy(actual_arg, expected_arg))
+        }
         (Type::Named(a), Type::Named(b)) => a == b,
         _ => actual == expected,
     }

--- a/crates/perry-hir/src/monomorph/infer.rs
+++ b/crates/perry-hir/src/monomorph/infer.rs
@@ -235,26 +235,155 @@ pub(crate) fn infer_type_args(
 
     let mut bindings: HashMap<String, Type> = HashMap::new();
 
-    // Try to unify each parameter with its corresponding argument
-    for (param, arg) in func.params.iter().zip(args.iter()) {
+    // Try to unify each parameter with its corresponding argument. Rest
+    // parameters bind to the whole trailing argument list, not only the first
+    // trailing scalar.
+    for (param_idx, param) in func.params.iter().enumerate() {
         // Skip if parameter type doesn't contain type variables
         if !type_contains_type_var(&param.ty) {
             continue;
         }
 
-        // Try to infer the argument's type
-        if let Some(arg_ty) = infer_expr_type(arg, module, idx) {
-            // Unify parameter type with argument type
-            if !unify_types(&param.ty, &arg_ty, &mut bindings) {
-                // Unification failed - can't infer
-                return None;
+        if param.is_rest {
+            let arg_tys: Option<Vec<Type>> = args
+                .iter()
+                .skip(param_idx)
+                .map(|arg| infer_expr_type(arg, module, idx))
+                .collect();
+            if let Some(arg_tys) = arg_tys {
+                if !unify_rest_param_types(&param.ty, &arg_tys, &mut bindings) {
+                    return None;
+                }
             }
+            break;
+        }
+
+        if let Some(arg) = args.get(param_idx) {
+            // Try to infer the argument's type
+            if let Some(arg_ty) = infer_expr_type(arg, module, idx) {
+                // Unify parameter type with argument type
+                if !unify_types(&param.ty, &arg_ty, &mut bindings) {
+                    // Unification failed - can't infer
+                    return None;
+                }
+            }
+        } else {
+            break;
         }
     }
 
     // Check if all type parameters were inferred
     let mut inferred_args = Vec::new();
     for type_param in &func.type_params {
+        if let Some(ty) = bindings.get(&type_param.name) {
+            inferred_args.push(ty.clone());
+        } else if let Some(ref default) = type_param.default {
+            // Use default type if available
+            inferred_args.push((**default).clone());
+        } else {
+            // Could not infer this type parameter
+            return None;
+        }
+    }
+
+    Some(inferred_args)
+}
+
+/// Unify a rest parameter's declared type with the trailing call argument
+/// types. `...items: T[]` should infer `T` from each item, while
+/// `...params: Params` should infer `Params` as the whole rest tuple.
+pub(crate) fn unify_rest_param_types(
+    param_ty: &Type,
+    arg_tys: &[Type],
+    bindings: &mut HashMap<String, Type>,
+) -> bool {
+    match param_ty {
+        Type::Array(elem) => arg_tys
+            .iter()
+            .all(|arg_ty| unify_types(elem, arg_ty, bindings)),
+        Type::Generic { base, type_args }
+            if is_array_like_generic(base) && type_args.len() == 1 =>
+        {
+            arg_tys
+                .iter()
+                .all(|arg_ty| unify_types(&type_args[0], arg_ty, bindings))
+        }
+        Type::Tuple(elems) => {
+            elems.len() == arg_tys.len()
+                && elems
+                    .iter()
+                    .zip(arg_tys.iter())
+                    .all(|(param_elem, arg_ty)| unify_types(param_elem, arg_ty, bindings))
+        }
+        Type::TypeVar(_) => {
+            let rest_ty = Type::Tuple(arg_tys.to_vec());
+            unify_types(param_ty, &rest_ty, bindings)
+        }
+        _ => {
+            let rest_ty = Type::Tuple(arg_tys.to_vec());
+            unify_types(param_ty, &rest_ty, bindings)
+        }
+    }
+}
+
+pub(crate) fn is_array_like_generic(base: &str) -> bool {
+    matches!(base, "Array" | "ReadonlyArray")
+}
+
+/// Infer type arguments for a generic class instantiation from constructor args.
+/// Returns None if inference fails.
+pub(crate) fn infer_type_args_for_class(
+    class: &Class,
+    constructor: &Function,
+    args: &[Expr],
+    module: &Module,
+    idx: &ModuleIndex,
+) -> Option<Vec<Type>> {
+    if class.type_params.is_empty() {
+        return None; // Not a generic class
+    }
+
+    let mut bindings: HashMap<String, Type> = HashMap::new();
+
+    // Try to unify each constructor parameter with its corresponding argument.
+    // Rest parameters consume the whole trailing argument list.
+    for (param_idx, param) in constructor.params.iter().enumerate() {
+        // Skip if parameter type doesn't contain type variables
+        if !type_contains_type_var(&param.ty) {
+            continue;
+        }
+
+        if param.is_rest {
+            let arg_tys: Option<Vec<Type>> = args
+                .iter()
+                .skip(param_idx)
+                .map(|arg| infer_expr_type(arg, module, idx))
+                .collect();
+            if let Some(arg_tys) = arg_tys {
+                if !unify_rest_param_types(&param.ty, &arg_tys, &mut bindings) {
+                    return None;
+                }
+            }
+            break;
+        }
+
+        if let Some(arg) = args.get(param_idx) {
+            // Try to infer the argument's type
+            if let Some(arg_ty) = infer_expr_type(arg, module, idx) {
+                // Unify parameter type with argument type
+                if !unify_types(&param.ty, &arg_ty, &mut bindings) {
+                    // Unification failed - can't infer
+                    return None;
+                }
+            }
+        } else {
+            break;
+        }
+    }
+
+    // Check if all class type parameters were inferred
+    let mut inferred_args = Vec::new();
+    for type_param in &class.type_params {
         if let Some(ty) = bindings.get(&type_param.name) {
             inferred_args.push(ty.clone());
         } else if let Some(ref default) = type_param.default {
@@ -284,53 +413,4 @@ pub(crate) fn type_contains_type_var(ty: &Type) -> bool {
         }
         _ => false,
     }
-}
-
-/// Infer type arguments for a generic class instantiation from constructor args.
-/// Returns None if inference fails.
-pub(crate) fn infer_type_args_for_class(
-    class: &Class,
-    constructor: &Function,
-    args: &[Expr],
-    module: &Module,
-    idx: &ModuleIndex,
-) -> Option<Vec<Type>> {
-    if class.type_params.is_empty() {
-        return None; // Not a generic class
-    }
-
-    let mut bindings: HashMap<String, Type> = HashMap::new();
-
-    // Try to unify each constructor parameter with its corresponding argument
-    for (param, arg) in constructor.params.iter().zip(args.iter()) {
-        // Skip if parameter type doesn't contain type variables
-        if !type_contains_type_var(&param.ty) {
-            continue;
-        }
-
-        // Try to infer the argument's type
-        if let Some(arg_ty) = infer_expr_type(arg, module, idx) {
-            // Unify parameter type with argument type
-            if !unify_types(&param.ty, &arg_ty, &mut bindings) {
-                // Unification failed - can't infer
-                return None;
-            }
-        }
-    }
-
-    // Check if all class type parameters were inferred
-    let mut inferred_args = Vec::new();
-    for type_param in &class.type_params {
-        if let Some(ty) = bindings.get(&type_param.name) {
-            inferred_args.push(ty.clone());
-        } else if let Some(ref default) = type_param.default {
-            // Use default type if available
-            inferred_args.push((**default).clone());
-        } else {
-            // Could not infer this type parameter
-            return None;
-        }
-    }
-
-    Some(inferred_args)
 }

--- a/crates/perry-hir/src/monomorph/mod.rs
+++ b/crates/perry-hir/src/monomorph/mod.rs
@@ -42,7 +42,8 @@ pub(crate) use constraints::{check_class_constraints, check_function_constraints
 pub(crate) use context::ModuleIndex;
 pub(crate) use defaults::fill_default_arguments;
 pub(crate) use infer::{
-    infer_type_args, infer_type_args_for_class, type_contains_type_var, unify_types,
+    infer_type_args, infer_type_args_for_class, is_array_like_generic, type_contains_type_var,
+    unify_rest_param_types, unify_types,
 };
 pub(crate) use inference_lookup::{ClassInfo, FuncInfo, InferenceLookup};
 pub(crate) use mangle::{generate_specialized_name, mangle_type, mangle_type_args};

--- a/crates/perry-hir/src/monomorph/tests.rs
+++ b/crates/perry-hir/src/monomorph/tests.rs
@@ -338,3 +338,114 @@ fn test_type_inference_string() {
         "Return type should be String"
     );
 }
+
+#[test]
+fn test_type_inference_rest_type_var_binds_tuple() {
+    let collect_func = Function {
+        id: 1,
+        name: "collect".to_string(),
+        type_params: vec![TypeParam {
+            name: "Params".to_string(),
+            constraint: Some(Box::new(Type::Generic {
+                base: "ReadonlyArray".to_string(),
+                type_args: vec![Type::String],
+            })),
+            default: None,
+        }],
+        params: vec![Param {
+            id: 0,
+            name: "params".to_string(),
+            ty: Type::TypeVar("Params".to_string()),
+            default: None,
+            decorators: Vec::new(),
+            is_rest: true,
+        }],
+        return_type: Type::TypeVar("Params".to_string()),
+        body: vec![Stmt::Return(Some(Expr::LocalGet(0)))],
+        is_async: false,
+        is_generator: false,
+        was_plain_async: false,
+        was_unrolled: false,
+        is_exported: true,
+        captures: vec![],
+        decorators: vec![],
+    };
+
+    let mut module = Module::new("test");
+    module.functions.push(collect_func);
+    module.init.push(Stmt::Expr(Expr::Call {
+        callee: Box::new(Expr::FuncRef(1)),
+        args: vec![
+            Expr::String("a".to_string()),
+            Expr::String("b".to_string()),
+            Expr::String("c".to_string()),
+        ],
+        type_args: vec![],
+    }));
+
+    monomorphize_module(&mut module);
+
+    let specialized = module
+        .functions
+        .iter()
+        .find(|f| f.name == "collect$tup_str_str_str")
+        .expect("rest type variable should specialize as the trailing tuple");
+
+    assert!(specialized.params[0].is_rest);
+    assert_eq!(
+        specialized.params[0].ty,
+        Type::Tuple(vec![Type::String, Type::String, Type::String])
+    );
+}
+
+#[test]
+fn test_type_inference_rest_array_binds_element_type() {
+    let collect_func = Function {
+        id: 1,
+        name: "collect".to_string(),
+        type_params: vec![TypeParam {
+            name: "T".to_string(),
+            constraint: None,
+            default: None,
+        }],
+        params: vec![Param {
+            id: 0,
+            name: "items".to_string(),
+            ty: Type::Array(Box::new(Type::TypeVar("T".to_string()))),
+            default: None,
+            decorators: Vec::new(),
+            is_rest: true,
+        }],
+        return_type: Type::Array(Box::new(Type::TypeVar("T".to_string()))),
+        body: vec![Stmt::Return(Some(Expr::LocalGet(0)))],
+        is_async: false,
+        is_generator: false,
+        was_plain_async: false,
+        was_unrolled: false,
+        is_exported: true,
+        captures: vec![],
+        decorators: vec![],
+    };
+
+    let mut module = Module::new("test");
+    module.functions.push(collect_func);
+    module.init.push(Stmt::Expr(Expr::Call {
+        callee: Box::new(Expr::FuncRef(1)),
+        args: vec![Expr::String("a".to_string()), Expr::String("b".to_string())],
+        type_args: vec![],
+    }));
+
+    monomorphize_module(&mut module);
+
+    let specialized = module
+        .functions
+        .iter()
+        .find(|f| f.name == "collect$str")
+        .expect("rest array should specialize by element type");
+
+    assert!(specialized.params[0].is_rest);
+    assert_eq!(
+        specialized.params[0].ty,
+        Type::Array(Box::new(Type::String))
+    );
+}

--- a/crates/perry-hir/src/monomorph/update_call_sites.rs
+++ b/crates/perry-hir/src/monomorph/update_call_sites.rs
@@ -480,15 +480,33 @@ fn infer_type_args_from_lookup(
 
     let mut bindings: HashMap<String, Type> = HashMap::new();
 
-    for (param, arg) in func_info.params.iter().zip(args.iter()) {
+    for (param_idx, param) in func_info.params.iter().enumerate() {
         if !type_contains_type_var(&param.ty) {
             continue;
         }
 
-        if let Some(arg_ty) = infer_expr_type_from_lookup(arg, lookup) {
-            if !unify_types(&param.ty, &arg_ty, &mut bindings) {
-                return None;
+        if param.is_rest {
+            let arg_tys: Option<Vec<Type>> = args
+                .iter()
+                .skip(param_idx)
+                .map(|arg| infer_expr_type_from_lookup(arg, lookup))
+                .collect();
+            if let Some(arg_tys) = arg_tys {
+                if !unify_rest_param_types(&param.ty, &arg_tys, &mut bindings) {
+                    return None;
+                }
             }
+            break;
+        }
+
+        if let Some(arg) = args.get(param_idx) {
+            if let Some(arg_ty) = infer_expr_type_from_lookup(arg, lookup) {
+                if !unify_types(&param.ty, &arg_ty, &mut bindings) {
+                    return None;
+                }
+            }
+        } else {
+            break;
         }
     }
 
@@ -520,15 +538,33 @@ fn infer_type_args_for_class_from_lookup(
 
     let mut bindings: HashMap<String, Type> = HashMap::new();
 
-    for (param, arg) in ctor_params.iter().zip(args.iter()) {
+    for (param_idx, param) in ctor_params.iter().enumerate() {
         if !type_contains_type_var(&param.ty) {
             continue;
         }
 
-        if let Some(arg_ty) = infer_expr_type_from_lookup(arg, lookup) {
-            if !unify_types(&param.ty, &arg_ty, &mut bindings) {
-                return None;
+        if param.is_rest {
+            let arg_tys: Option<Vec<Type>> = args
+                .iter()
+                .skip(param_idx)
+                .map(|arg| infer_expr_type_from_lookup(arg, lookup))
+                .collect();
+            if let Some(arg_tys) = arg_tys {
+                if !unify_rest_param_types(&param.ty, &arg_tys, &mut bindings) {
+                    return None;
+                }
             }
+            break;
+        }
+
+        if let Some(arg) = args.get(param_idx) {
+            if let Some(arg_ty) = infer_expr_type_from_lookup(arg, lookup) {
+                if !unify_types(&param.ty, &arg_ty, &mut bindings) {
+                    return None;
+                }
+            }
+        } else {
+            break;
         }
     }
 

--- a/test-files/test_issue_685_nested_class_static_param.ts
+++ b/test-files/test_issue_685_nested_class_static_param.ts
@@ -1,11 +1,9 @@
 // Issue #685: a class expression returned from a factory function with
 // a static field initializer that references the factory's parameter.
-// Pre-fix, the static field init was lifted to module-init scope where
-// the factory's parameter is out of scope; codegen emitted
-// `(0.0).slice()` which threw `TypeError: (number).slice is not a function`
-// before any user code ran. Now the lift is skipped (the static field
-// stays uninitialized, which is wrong but harmless) and module init
-// completes; calling the factory works as expected at runtime.
+// Pre-fix, Perry either lifted this initializer out of the factory or
+// specialized the generic rest parameter as a scalar. The static field
+// must be initialized when the class expression is evaluated and see the
+// per-call rest array.
 
 function makeWrapper<const Params extends ReadonlyArray<string>>(...params: Params) {
   return class WrapperClass {
@@ -16,8 +14,8 @@ function makeWrapper<const Params extends ReadonlyArray<string>>(...params: Para
 console.log("[1] before makeWrapper");
 const W = makeWrapper("a", "b", "c");
 console.log("[2] after makeWrapper");
-// W.params is currently `undefined` post-fix (perry doesn't yet emit
-// the static init at the class-expression site inside the factory body
-// — tracked as a follow-up). The win here is that module init no
-// longer throws; the program runs into user code.
+// The static field must be a fresh array copy of the rest parameter, not
+// a scalar argument.
 console.log("[3] params type:", typeof W.params);
+console.log("[4] params isArray:", Array.isArray(W.params));
+console.log("[5] params json:", JSON.stringify(W.params));

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -32,12 +32,6 @@
     "category": "ci-env",
     "reason": "Tracked in #1634 (parity CI environment fixtures). #422 closed (net.Socket connect/error events + factory). The test passes locally with an echo server running but fails on Linux CI because no echo fixture server runs. Environmental \u2014 needs a CI-side fixture, not a Perry fix."
   },
-  "test_issue_685_nested_class_static_param": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "bug-stale",
-    "reason": "#685 (nested-class static-field init) closed in v0.5.814 on macOS; Linux CI still surfaces an adjacent shape (different sub-case). Targeted Linux-side bisect needed; file a Linux-specific issue once the sub-case is pinned."
-  },
   "test_issue_922_api_route_crash": {
     "issue": "922",
     "added": "2026-05-24",


### PR DESCRIPTION
## User-visible improvement

Perry now specializes generic rest parameters as the full trailing argument tuple when the rest parameter itself is a type variable. This fixes the issue #685/#793 shape where a class expression static field captures a factory rest parameter and should see the per-call rest array instead of a scalar-specialized local.

## Tests added

- Tightened `test_issue_685_nested_class_static_param.ts` to assert `Array.isArray(W.params)` and the JSON output.
- Added monomorph unit coverage for `...params: Params` binding to a tuple and `...items: T[]` binding by element type.
- Removed `test_issue_685_nested_class_static_param` from `test-parity/known_failures.json` after the focused parity repro passed.

## Commands run

- `./run_parity_tests.sh --filter test_issue_685_nested_class_static_param` PASS 1/1; report `test-parity/reports/parity_report_20260529_053946.json`
- `cargo test -p perry-hir monomorph -- --nocapture`
- `cargo check -p perry-hir`
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `./scripts/check_file_size.sh`
- `git diff --check`
- `git diff --check origin/main...HEAD`

## Limitations

- This is scoped to monomorph type inference and constraint checking for generic rest parameters.
- Existing unrelated `perry-hir` warnings remain.

## Non-goals

- No broad runtime rest-parameter rewrite.
- No unrelated Node parity or node-suite inventory changes.
