### PR TITLE
fix(object): Object.assign extends array length for integer-index keys (#2439)

### DIFF
--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -659,6 +659,18 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
     let target = tgt_raw as *mut ObjectHeader;
     let src = src_raw as *const ObjectHeader;
 
+    // #2439: When the target is an array, an integer-keyed source property
+    // (e.g. `Object.assign([1,2], {2:3})`) must grow the array's length, not
+    // land as an inert object expando. `js_array_set_string_key` parses the
+    // key as a canonical array index and routes through `js_array_set_f64_extend`
+    // (which extends length + fills holes); non-numeric keys fall back to the
+    // object-property path on the array's expando map. Detect array-ness once.
+    let target_is_array = {
+        let gc_header =
+            (target as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY
+    };
+
     // 1) Copy own string-keyed enumerable properties from source to target,
     //    in source insertion order. Mirrors `js_object_copy_own_fields`.
     let src_keys = (*src).keys_array;
@@ -688,7 +700,20 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
                 let v = js_object_get_field(src, i as u32);
                 f64::from_bits(v.bits())
             };
-            js_object_set_field_by_name(target, key_ptr, field_f64);
+            if target_is_array {
+                // Routes integer-index keys to array element-set (extending
+                // length); non-numeric keys fall back to the object setter.
+                // The array may reallocate on growth, but #233 forwarding
+                // means the original `target_f64` still resolves to the new
+                // head, so we keep returning it for object identity.
+                crate::array::js_array_set_string_key(
+                    target as *mut crate::array::ArrayHeader,
+                    key_ptr,
+                    field_f64,
+                );
+            } else {
+                js_object_set_field_by_name(target, key_ptr, field_f64);
+            }
         }
     }
 

--- a/test-parity/node-suite/object/assign-array-index.ts
+++ b/test-parity/node-suite/object/assign-array-index.ts
@@ -1,0 +1,33 @@
+// #2439: `Object.assign(targetArray, source)` with an integer-keyed source
+// must extend the array's length, treating a canonical array index >= length
+// as a new element (Node grows length; Perry previously wrote an inert object
+// expando and dropped the element from length/enumeration).
+//
+// Only the integer-index extension path is exercised here — named-key expandos
+// on arrays are a separate, orthogonal gap (reading `arr.foo` back).
+
+// Append a new trailing index.
+const a = Object.assign([1, 2], { 2: 3 });
+console.log("a:", JSON.stringify(a), "len", a.length);
+
+// Overwrite an in-bounds index without changing length.
+const b = Object.assign([1, 2, 3], { 1: 9 });
+console.log("b:", JSON.stringify(b), "len", b.length);
+
+// Index past the end leaves a hole (serializes to null per JSON.stringify).
+const c = Object.assign([1, 2], { 4: 5 });
+console.log("c:", JSON.stringify(c), "len", c.length);
+
+// Multiple index keys in one source.
+const d = Object.assign([0], { 1: 1, 2: 2, 3: 3 });
+console.log("d:", JSON.stringify(d), "len", d.length);
+
+// Plain-object target is unaffected by the array routing.
+const e = Object.assign({ x: 1 }, { y: 2 });
+console.log("e:", JSON.stringify(e));
+
+// for-of sees the newly-added element (it is a real array slot).
+const f = Object.assign([10, 20], { 2: 30 });
+const seen: number[] = [];
+for (const v of f) seen.push(v);
+console.log("f-iter:", JSON.stringify(seen));


### PR DESCRIPTION
## Summary

Fixes #2439. `Object.assign(targetArray, source)` with an integer-keyed source did not extend the array's length — `Object.assign([1,2], {2:3})` produced `[1,2]` where Node produces `[1,2,3]`.

The property was written through the object-field path (`js_object_set_field_by_name`), which lands an inert expando rather than updating the `ArrayHeader` length, so the element was dropped from `length` and enumeration.

## Fix

In `js_object_assign_one` (`crates/perry-runtime/src/object/alloc.rs`), detect a `GC_TYPE_ARRAY` target once and route each copied string key through `js_array_set_string_key`, which:
- parses canonical array indices (`>= length`) and extends via `js_array_set_f64_extend` (grows length, fills gaps with `TAG_HOLE` so they serialize to `null`), and
- falls back to the object-property path for non-numeric keys.

Array growth may reallocate, but #233 growth-forwarding keeps the original `target` pointer valid, so `Object.assign`'s return-target identity is preserved.

## Validation

Byte-for-byte parity with `node --experimental-strip-types`:

```
a: [1,2,3] len 3            # append new trailing index
b: [1,9,3] len 3            # in-bounds overwrite, length unchanged
c: [1,2,null,null,5] len 5  # index past end -> holes
d: [0,1,2,3] len 4          # multiple index keys
e: {"x":1,"y":2}            # plain-object target unaffected
f-iter: [10,20,30]          # for-of sees the new element
```

Added `test-parity/node-suite/object/assign-array-index.ts` covering all of the above.

Scope note: reading a *named* expando off an array (`arr.foo` after `arr.foo = "x"`) still returns `undefined` — that is a separate pre-existing gap in the array named-property read path, unrelated to this change (reproduces with plain direct assignment, no `Object.assign`).

Found via probe-vs-node (#800).
