### PR TITLE
fix(stream): handle finished error false close

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -860,6 +860,15 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "stream",
         has_receiver: false,
+        method: "finished",
+        class_filter: None,
+        runtime: "js_node_stream_finished",
+        args: &[NA_VARARGS],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: false,
         method: "duplexPair",
         class_filter: None,
         runtime: "js_node_stream_duplex_pair",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -914,6 +914,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // #1539: compose(...streams) -> new Duplex; duplexPair(opts) -> [Duplex, Duplex].
     module.declare_function("js_node_stream_compose", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_pipeline", DOUBLE, &[I64]);
+    module.declare_function("js_node_stream_finished", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_duplex_pair", DOUBLE, &[DOUBLE]);
     // #1540: Readable/Writable .toWeb / .fromWeb — return fresh Duplex stubs.
     module.declare_function("js_node_stream_to_web", DOUBLE, &[DOUBLE]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -220,6 +220,24 @@ extern "C" fn ns_readable_resume_microtask(closure: *const ClosureHeader) -> f64
     f64::from_bits(TAG_UNDEFINED)
 }
 
+extern "C" fn ns_finished_error_false_close(closure: *const ClosureHeader) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    if js_closure_get_capture_f64(closure, 2).to_bits() == TAG_TRUE {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    js_closure_set_capture_f64(closure as *mut ClosureHeader, 2, f64::from_bits(TAG_TRUE));
+    let stream = js_closure_get_capture_f64(closure, 0);
+    let callback = js_closure_get_capture_f64(closure, 1);
+    if let Some(err) = readable_hidden_error(stream) {
+        call_listener_args(stream, callback, &[err]);
+    } else {
+        call_listener_args(stream, callback, &[]);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
 extern "C" fn ns_writable_finish_microtask(closure: *const ClosureHeader) -> f64 {
     if closure.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
@@ -2911,6 +2929,7 @@ fn register_stub_arities() {
     register(ns_is_paused0 as *const u8, 0);
     register(ns_unpipe1 as *const u8, 1);
     register(ns_readable_resume_microtask as *const u8, 0);
+    register(ns_finished_error_false_close as *const u8, 0);
     register(ns_iter_to_array as *const u8, 1);
     register(ns_iter_map as *const u8, 2);
     register(ns_iter_filter as *const u8, 2);
@@ -5704,6 +5723,43 @@ pub extern "C" fn js_node_stream_add_abort_signal(signal: f64, stream: f64) -> f
 #[no_mangle]
 pub extern "C" fn js_node_stream_compose(_streams_array: f64) -> f64 {
     js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
+}
+
+fn add_finished_error_false_close_listener(stream: f64, callback: f64) {
+    let listener = js_closure_alloc(ns_finished_error_false_close as *const u8, 3);
+    js_closure_set_capture_f64(listener, 0, stream);
+    js_closure_set_capture_f64(listener, 1, callback);
+    js_closure_set_capture_f64(listener, 2, f64::from_bits(TAG_FALSE));
+    add_stream_listener_for_event(
+        stream,
+        string_value(b"close"),
+        box_pointer(listener as *const u8),
+    );
+}
+
+/// `stream.finished(stream, [options], cb)` callback form. This slice covers
+/// Node's `{ error: false }` path: there is no dedicated `error` listener, but
+/// `close` still observes the stream's stored error and calls the callback.
+#[no_mangle]
+pub extern "C" fn js_node_stream_finished(args: *const crate::array::ArrayHeader) -> f64 {
+    let args = pipeline_args(args);
+    if args.len() < 2 {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let stream = args[0];
+    let mut options = f64::from_bits(TAG_UNDEFINED);
+    let mut callback = args[1];
+    if args.len() >= 3 && is_pipeline_options_arg(args[1]) {
+        options = args[1];
+        callback = args[2];
+    }
+    if !is_callable_value(callback) {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    if get_hidden_value(options, hidden_key(b"error")).is_some_and(|v| v.to_bits() == TAG_FALSE) {
+        add_finished_error_false_close_listener(stream, callback);
+    }
+    f64::from_bits(TAG_UNDEFINED)
 }
 
 /// `stream.pipeline(...streams, cb)` wires classic streams end-to-end and

--- a/test-parity/node-suite/stream/finished/error-false-option.ts
+++ b/test-parity/node-suite/stream/finished/error-false-option.ts
@@ -1,6 +1,6 @@
 import { Readable, finished } from "node:stream";
-// finished(stream, { error: false }, cb) — should NOT fire the callback
-// when the stream emits an error (only on normal completion).
+// `{ error: false }` skips the extra error listener, but Node still calls the
+// callback from `close` with the stream's stored destroy error.
 const r = new Readable({ read() {} });
 r.on("error", () => {});
 let fired = false;


### PR DESCRIPTION
## Summary

- Add callback-form `stream.finished(...)` lowering to the stream native table.
- Handle the narrow `{ error: false }` path by installing a once-gated `close` listener that forwards the stream's stored destroy error to the callback.
- Update the focused parity fixture comment to match live Node 25: `{ error:false }` skips the extra error listener, but `close` still reports the stored error.

## Verification

- `cargo fmt --check`
- `cargo check -p perry-codegen -p perry-runtime`
- Baseline exact `node-suite/stream/finished/error-false-option`: FAIL, report `test-parity/reports/parity_report_20260529_052930.json`
- Exact `node-suite/stream/finished/error-false-option`: PASS, report `test-parity/reports/parity_report_20260529_054418.json`
- Guardrail `node-suite/stream/finished/options-config`: PASS, report `test-parity/reports/parity_report_20260529_054504.json`
- Focused `node-suite/stream --filter finished/`: 4 PASS / 3 parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260529_054620.json`
- `git diff --check`
- `git diff --cached --check`

## Notes

- DeepWiki reference: `reference/deepwiki/nodejs-node-stream-finished-error-false-2026-05-29.md`.
- DeepWiki contradicted live Node on this edge; direct Node 25 and parity baseline were used as authoritative.
- Remaining `finished/` residuals are `readable-false-option`, `with-cleanup-option`, and `with-options-signal`.
- Non-goals: full `stream.finished()` state machine, cleanup listener removal, AbortSignal support, readable/writable side option completion beyond this close path, and promises `stream.finished`.
