### PR TITLE
fix(stream/web): honor pipeTo preventClose

### DIFF
--- a/crates/perry-codegen/src/lower_call/options/fetch.rs
+++ b/crates/perry-codegen/src/lower_call/options/fetch.rs
@@ -520,6 +520,11 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                 } else {
                     double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
                 };
+                let options = if args.len() >= 2 {
+                    lower_expr(ctx, &args[1])?
+                } else {
+                    double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                };
                 // Issue #562: `dest` may be a subclass instance — unwrap.
                 let dest =
                     ctx.block()
@@ -528,7 +533,7 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                 let promise = blk.call(
                     I64,
                     "js_readable_stream_pipe_to",
-                    &[(DOUBLE, &recv_handle), (DOUBLE, &dest)],
+                    &[(DOUBLE, &recv_handle), (DOUBLE, &dest), (DOUBLE, &options)],
                 );
                 return Ok(Some(nanbox_pointer_inline(blk, &promise)));
             }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1775,7 +1775,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_readable_stream_locked", DOUBLE, &[DOUBLE]);
     module.declare_function("js_readable_stream_cancel", I64, &[DOUBLE, DOUBLE]);
     module.declare_function("js_readable_stream_tee", DOUBLE, &[DOUBLE]);
-    module.declare_function("js_readable_stream_pipe_to", I64, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_readable_stream_pipe_to", I64, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function(
         "js_readable_stream_pipe_through",
         DOUBLE,

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -1118,7 +1118,11 @@ pub unsafe extern "C" fn js_readable_stream_pipe_through(
     transform_writable_handle: f64,
     transform_readable_handle: f64,
 ) -> f64 {
-    let _ = js_readable_stream_pipe_to(readable_handle, transform_writable_handle);
+    let _ = js_readable_stream_pipe_to(
+        readable_handle,
+        transform_writable_handle,
+        f64::from_bits(TAG_UNDEFINED),
+    );
     transform_readable_handle
 }
 
@@ -1715,6 +1719,10 @@ pub(crate) unsafe fn dispatch_stream_method(
         .first()
         .copied()
         .unwrap_or(f64::from_bits(TAG_UNDEFINED));
+    let arg1 = args
+        .get(1)
+        .copied()
+        .unwrap_or(f64::from_bits(TAG_UNDEFINED));
 
     // Probe each registry for membership first (dropping the guard before we
     // call the FFI, which re-locks the same registry).
@@ -1744,7 +1752,7 @@ pub(crate) unsafe fn dispatch_stream_method(
             "values" | "@@asyncIterator" => return Some(js_readable_stream_values(handle)),
             "cancel" => return Some(box_promise(js_readable_stream_cancel(handle, arg0))),
             "tee" => return Some(js_readable_stream_tee(handle)),
-            "pipeTo" => return Some(box_promise(js_readable_stream_pipe_to(handle, arg0))),
+            "pipeTo" => return Some(box_promise(js_readable_stream_pipe_to(handle, arg0, arg1))),
             // #1644: a readable handle is also its own controller. The
             // start/transform/flush callbacks receive it as `controller`, so
             // `controller.enqueue/close/error/terminate` dispatch here when the

--- a/crates/perry-stdlib/src/streams/pipe.rs
+++ b/crates/perry-stdlib/src/streams/pipe.rs
@@ -92,7 +92,8 @@ extern "C" fn readable_stream_pipe_to_microtask(closure: *const ClosureHeader) -
             reader_id: capture_f64(closure, 3) as usize,
             writer_id: capture_f64(closure, 4) as usize,
         };
-        let result = run_readable_stream_pipe_to(r_id, w_id);
+        let prevent_close = perry_runtime::value::js_is_truthy(capture_f64(closure, 5)) != 0;
+        let result = run_readable_stream_pipe_to(r_id, w_id, prevent_close);
         release_pipe_locks(r_id, w_id, locks);
         match result {
             Ok(()) => js_promise_resolve(promise, f64::from_bits(TAG_UNDEFINED)),
@@ -102,7 +103,11 @@ extern "C" fn readable_stream_pipe_to_microtask(closure: *const ClosureHeader) -
     f64::from_bits(TAG_UNDEFINED)
 }
 
-unsafe fn run_readable_stream_pipe_to(readable_id: usize, writable_id: usize) -> Result<(), u64> {
+unsafe fn run_readable_stream_pipe_to(
+    readable_id: usize,
+    writable_id: usize,
+    prevent_close: bool,
+) -> Result<(), u64> {
     loop {
         let chunk_or_done: Result<u64, bool> = {
             let mut g = READABLE_STREAMS.lock().unwrap();
@@ -143,6 +148,10 @@ unsafe fn run_readable_stream_pipe_to(readable_id: usize, writable_id: usize) ->
         }
     }
 
+    if prevent_close {
+        return Ok(());
+    }
+
     if TRANSFORM_PAIRS.lock().unwrap().contains_key(&writable_id) {
         let _ = transform_close(writable_id);
     } else {
@@ -173,10 +182,12 @@ unsafe fn run_readable_stream_pipe_to(readable_id: usize, writable_id: usize) ->
 pub unsafe extern "C" fn js_readable_stream_pipe_to(
     readable_handle: f64,
     writable_handle: f64,
+    options: f64,
 ) -> *mut Promise {
     let promise = js_promise_new();
     let r_id = readable_handle as usize;
     let w_id = writable_handle as usize;
+    let prevent_close = pipe_option_truthy(options, b"preventClose");
 
     let locks = match acquire_pipe_locks(r_id, w_id) {
         Ok(locks) => locks,
@@ -187,7 +198,7 @@ pub unsafe extern "C" fn js_readable_stream_pipe_to(
     };
 
     let closure =
-        perry_runtime::closure::js_closure_alloc(readable_stream_pipe_to_microtask as *const u8, 5);
+        perry_runtime::closure::js_closure_alloc(readable_stream_pipe_to_microtask as *const u8, 6);
     perry_runtime::closure::js_register_closure_arity(
         readable_stream_pipe_to_microtask as *const u8,
         0,
@@ -209,7 +220,18 @@ pub unsafe extern "C" fn js_readable_stream_pipe_to(
         4,
         (locks.writer_id as f64).to_bits() as i64,
     );
+    perry_runtime::closure::js_closure_set_capture_ptr(
+        closure,
+        5,
+        (if prevent_close { 1.0 } else { 0.0f64 }).to_bits() as i64,
+    );
     perry_runtime::builtins::js_queue_microtask(closure as i64);
 
     promise
+}
+
+unsafe fn pipe_option_truthy(options: f64, name: &[u8]) -> bool {
+    let value =
+        perry_runtime::value::js_get_property(options, name.as_ptr() as i64, name.len() as i64);
+    perry_runtime::value::js_is_truthy(value) != 0
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -296,12 +296,6 @@
     "category": "bug-open",
     "reason": "node:stream: stream.compose(asyncIterable) doesn't drive the source / forward data. Reopened #1539 for pipeline execution."
   },
-  "node-suite/stream/web/pipe-to-with-options": {
-    "issue": "1545",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/web: pipeTo preventClose option not honored. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/finished/readable-false-option": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary

- Thread the `ReadableStream.pipeTo()` options object through codegen and dynamic stream-handle dispatch.
- Honor `preventClose` by skipping the destination writable close callback/state transition when the source readable finishes.
- Remove the now-stale known-failure entry for `node-suite/stream/web/pipe-to-with-options`.

## Verification

- `cargo fmt --check`
- `cargo check -p perry-codegen -p perry-stdlib`
- `jq empty test-parity/known_failures.json`
- Baseline exact `node-suite/stream/web/pipe-to-with-options`: FAIL, report `test-parity/reports/parity_report_20260529_060452.json`
- Exact `node-suite/stream/web/pipe-to-with-options`: PASS, report `test-parity/reports/parity_report_20260529_061115.json`
- Focused `node-suite/stream --filter web/pipe-to`: 6 PASS / 1 parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260529_061144.json`
- `git diff --check`
- `git diff --cached --check`

## Notes

- DeepWiki reference: `reference/deepwiki/nodejs-node-webstreams-pipeto-preventclose-2026-05-29.md`.
- Remaining focused residual: `node-suite/stream/web/pipe-to-with-pre-aborted-signal`.
- Non-goals: `preventAbort`, `preventCancel`, `AbortSignal` support, async/backpressure rewrites, and broader stream/web residual cleanup.
