### PR TITLE
Fix dynamic class factory mixin captures

### DIFF
--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -853,7 +853,7 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
                 FieldInitMode::BetweenExclusiveTo(stop_at),
             )?;
         } else {
-            apply_field_initializers_recursive(ctx, class_name, FieldInitMode::SelfOnly)?;
+            apply_field_initializers_recursive(ctx, class_name, FieldInitMode::AfterRoot)?;
         }
     }
     if let Some(runtime_fn) = builtin_parent_runtime {
@@ -944,6 +944,11 @@ pub(crate) enum FieldInitMode {
     /// `stop_at` itself because that class's SelfOnly fields are
     /// applied via the SuperCall site inside the inlined body.
     BetweenExclusiveTo(String),
+    /// Apply every class after the root ancestor through the leaf. Used
+    /// when a default-derived constructor chain has no explicit inherited
+    /// constructor body, so there is no SuperCall site to apply intermediate
+    /// class fields.
+    AfterRoot,
 }
 
 pub(crate) fn apply_field_initializers_recursive(
@@ -987,6 +992,7 @@ pub(crate) fn apply_field_initializers_recursive(
     //   SelfOnly: keep only the leaf
     //   UpToInclusive(stop_at): keep chain[0..=index_of(stop_at)]
     //   BetweenExclusiveTo(stop_at): keep chain[index_of(stop_at)+1..]
+    //   AfterRoot: keep chain[1..]
     let chain: Vec<String> = match &mode {
         FieldInitMode::All => chain,
         FieldInitMode::AncestorsOnly => {
@@ -1031,6 +1037,13 @@ pub(crate) fn apply_field_initializers_recursive(
                 } else {
                     Vec::new()
                 }
+            } else {
+                Vec::new()
+            }
+        }
+        FieldInitMode::AfterRoot => {
+            if chain.len() > 1 {
+                chain[1..].to_vec()
             } else {
                 Vec::new()
             }

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -217,6 +217,7 @@ extern "C" fn ns_readable_resume_microtask(closure: *const ClosureHeader) -> f64
         let _ = emit_stream_event(stream, string_value(b"resume"), &[]);
         flush_pending_readable_chunks(stream);
         schedule_readable_from_drain(stream);
+        invoke_read_once(stream);
     }
     f64::from_bits(TAG_UNDEFINED)
 }

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -335,7 +335,6 @@ pub(super) fn readable_data_listener_added(stream: f64) {
     }
     set_readable_flowing(stream, f64::from_bits(TAG_TRUE));
     schedule_readable_resume(stream);
-    invoke_read_once(stream);
 }
 
 pub(super) fn readable_listener_added(stream: f64) {
@@ -1774,8 +1773,17 @@ pub(crate) fn js_node_stream_hidden_error_after_read(stream: f64) -> Option<f64>
     readable_hidden_error(stream)
 }
 
+pub(crate) fn js_node_stream_hidden_error(stream: f64) -> Option<f64> {
+    readable_hidden_error(stream)
+}
+
+#[cfg(test)]
 pub(crate) fn js_node_stream_is_stub_ended_after_read(stream: f64) -> bool {
     probe_read_once(stream);
+    stream_hidden_ended(stream)
+}
+
+pub(crate) fn js_node_stream_is_stub_ended(stream: f64) -> bool {
     stream_hidden_ended(stream)
 }
 

--- a/crates/perry-runtime/src/node_submodules/stream_promises.rs
+++ b/crates/perry-runtime/src/node_submodules/stream_promises.rs
@@ -195,9 +195,9 @@ extern "C" fn stream_promises_finished_done_listener(closure: *const ClosureHead
 extern "C" fn stream_promises_finished_close_listener(closure: *const ClosureHeader) -> f64 {
     let promise = js_closure_get_capture_ptr(closure, 0) as *mut crate::promise::Promise;
     let stream = f64::from_bits(js_closure_get_capture_ptr(closure, 1) as u64);
-    if let Some(err) = crate::node_stream::js_node_stream_hidden_error_after_read(stream) {
+    if let Some(err) = crate::node_stream::js_node_stream_hidden_error(stream) {
         crate::promise::js_promise_reject(promise, err);
-    } else if crate::node_stream::js_node_stream_is_stub_ended_after_read(stream) {
+    } else if crate::node_stream::js_node_stream_is_stub_ended(stream) {
         crate::promise::js_promise_resolve(promise, undefined_value());
     } else {
         crate::promise::js_promise_reject(promise, premature_close_error_value());
@@ -389,18 +389,18 @@ pub(crate) extern "C" fn thunk_streamP_finished(
         if signal_aborted(signal) {
             return promise_rejected(signal_reason(signal));
         }
-        if let Some(err) = crate::node_stream::js_node_stream_hidden_error_after_read(stream) {
+        if let Some(err) = crate::node_stream::js_node_stream_hidden_error(stream) {
             return promise_rejected(err);
         }
-        if crate::node_stream::js_node_stream_is_stub_ended_after_read(stream) {
+        if crate::node_stream::js_node_stream_is_stub_ended(stream) {
             return promise_undefined();
         }
         return pending_finished_promise(stream, Some(signal));
     }
 
-    if let Some(err) = crate::node_stream::js_node_stream_hidden_error_after_read(stream) {
+    if let Some(err) = crate::node_stream::js_node_stream_hidden_error(stream) {
         promise_rejected(err)
-    } else if crate::node_stream::js_node_stream_is_stub_ended_after_read(stream) {
+    } else if crate::node_stream::js_node_stream_is_stub_ended(stream) {
         promise_undefined()
     } else {
         pending_finished_promise(stream, None)

--- a/crates/perry-transform/src/inline/factory_specialize.rs
+++ b/crates/perry-transform/src/inline/factory_specialize.rs
@@ -1,22 +1,29 @@
-use perry_hir::walker::{walk_expr_children, walk_expr_children_mut};
-use perry_hir::{BinaryOp, Class, Expr, Function, Module, Param, Stmt};
-use perry_types::{FuncId, LocalId, Type};
+use perry_hir::walker::walk_expr_children;
+use perry_hir::{Class, Expr, Module, Stmt};
+use perry_types::{FuncId, LocalId};
 use std::collections::{HashMap, HashSet};
 
 use super::*;
 
+#[derive(Clone, Debug)]
+struct FactoryTarget {
+    target_name: String,
+    param_ids: Vec<LocalId>,
+}
+
+#[derive(Clone, Debug)]
+struct CurriedFactoryTarget {
+    target_name: String,
+    outer_param_ids: Vec<LocalId>,
+    inner_param_ids: Vec<LocalId>,
+}
+
 pub fn specialize_captured_class_factories(module: &mut Module) {
-    // Build a map of factory functions: `func_id -> (target_class_name,
-    // function_param_ids)`. Eligible iff the function's body is exactly one
-    // `Return(Some(ClassRef(C)))` AND `C` exists in `module.classes` AND
-    // `C` has at least one `__perry_cap_*` ctor param. (We accept multiple
-    // body stmts as long as the final one is the qualifying return AND no
-    // earlier stmt has side effects — but for the minimal #740 fix we
-    // restrict to single-stmt bodies, which covers the Effect TaggedError
-    // shape and probe1.ts. More elaborate factory bodies fall through to
-    // the regular inliner path.)
-    use perry_types::LocalId;
-    let mut factory_targets: HashMap<FuncId, (String, Vec<LocalId>)> = HashMap::new();
+    // Build maps of class-returning factory functions. We specialize only
+    // factories whose returned class reads factory params through synthesized
+    // capture ctor params or a dynamic `extends` expression.
+    let mut factory_targets: HashMap<FuncId, FactoryTarget> = HashMap::new();
+    let mut curried_factory_targets: HashMap<FuncId, CurriedFactoryTarget> = HashMap::new();
     let class_index: HashMap<String, usize> = module
         .classes
         .iter()
@@ -42,8 +49,10 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
     // local (`x` / `o`). Statements that read it (e.g. `PropertySet` on
     // sub-properties for prototype mutation) are allowed.
     fn resolve_factory_return_class<'a>(body: &'a [Stmt], classes: &'a [Class]) -> Option<String> {
-        if let [Stmt::Return(Some(Expr::ClassRef(c)))] = body {
-            return Some(c.clone());
+        if let [Stmt::Return(Some(expr))] = body {
+            if let Some(c) = classref_name(expr) {
+                return Some(c);
+            }
         }
         if body.len() < 2 {
             return None;
@@ -70,7 +79,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
             }
         }
         match (init_expr, ret_expr) {
-            (Expr::ClassRef(c), Expr::LocalGet(x_ref)) if *x_ref == *bound_id => Some(c.clone()),
+            (init, Expr::LocalGet(x_ref)) if *x_ref == *bound_id => classref_name(init),
             (
                 Expr::New {
                     class_name: anon_name,
@@ -97,6 +106,25 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
             }
             _ => None,
         }
+    }
+
+    fn classref_name(expr: &Expr) -> Option<String> {
+        match expr {
+            Expr::ClassRef(c) => Some(c.clone()),
+            Expr::Sequence(parts) => parts.last().and_then(classref_name),
+            _ => None,
+        }
+    }
+
+    fn resolve_curried_factory_return_class<'a>(
+        body: &'a [Stmt],
+        classes: &'a [Class],
+    ) -> Option<(String, Vec<LocalId>)> {
+        let [Stmt::Return(Some(Expr::Closure { params, body, .. }))] = body else {
+            return None;
+        };
+        let target = resolve_factory_return_class(body, classes)?;
+        Some((target, params.iter().map(|p| p.id).collect()))
     }
 
     fn middle_stmt_is_safe(stmt: &Stmt, bound_id: LocalId) -> bool {
@@ -127,26 +155,83 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
         }
     }
 
-    for f in &module.functions {
-        let Some(target) = resolve_factory_return_class(&f.body, &module.classes) else {
-            continue;
-        };
-        let Some(&ci) = class_index.get(&target) else {
-            continue;
-        };
-        let class = &module.classes[ci];
-        let has_caps = class
+    fn class_needs_specialization(class: &Class, param_ids: &[LocalId]) -> bool {
+        let param_set: HashSet<LocalId> = param_ids.iter().copied().collect();
+        let has_capture_params = class
             .constructor
             .as_ref()
-            .map(|c| c.params.iter().any(|p| p.name.starts_with("__perry_cap_")))
+            .map(|c| {
+                c.params.iter().any(|p| {
+                    p.name
+                        .strip_prefix("__perry_cap_")
+                        .and_then(|suffix| suffix.parse::<LocalId>().ok())
+                        .map(|outer_id| param_set.contains(&outer_id))
+                        .unwrap_or(false)
+                })
+            })
             .unwrap_or(false);
-        if !has_caps {
-            continue;
+        if has_capture_params {
+            return true;
         }
-        let param_ids: Vec<LocalId> = f.params.iter().map(|p| p.id).collect();
-        factory_targets.insert(f.id, (target.clone(), param_ids));
+        class
+            .extends_expr
+            .as_deref()
+            .map(|expr| expr_reads_any_local(expr, &param_set))
+            .unwrap_or(false)
     }
-    if factory_targets.is_empty() {
+
+    fn expr_reads_any_local(expr: &Expr, ids: &HashSet<LocalId>) -> bool {
+        if let Expr::LocalGet(id) = expr {
+            return ids.contains(id);
+        }
+        let mut found = false;
+        walk_expr_children(expr, &mut |child| {
+            if !found && expr_reads_any_local(child, ids) {
+                found = true;
+            }
+        });
+        found
+    }
+
+    for f in &module.functions {
+        let param_ids: Vec<LocalId> = f.params.iter().map(|p| p.id).collect();
+
+        if let Some(target) = resolve_factory_return_class(&f.body, &module.classes) {
+            if let Some(&ci) = class_index.get(&target) {
+                let class = &module.classes[ci];
+                if class_needs_specialization(class, &param_ids) {
+                    factory_targets.insert(
+                        f.id,
+                        FactoryTarget {
+                            target_name: target,
+                            param_ids: param_ids.clone(),
+                        },
+                    );
+                }
+            }
+        }
+
+        if let Some((target, inner_param_ids)) =
+            resolve_curried_factory_return_class(&f.body, &module.classes)
+        {
+            if let Some(&ci) = class_index.get(&target) {
+                let class = &module.classes[ci];
+                let mut combined_param_ids = param_ids.clone();
+                combined_param_ids.extend(inner_param_ids.iter().copied());
+                if class_needs_specialization(class, &combined_param_ids) {
+                    curried_factory_targets.insert(
+                        f.id,
+                        CurriedFactoryTarget {
+                            target_name: target,
+                            outer_param_ids: param_ids,
+                            inner_param_ids,
+                        },
+                    );
+                }
+            }
+        }
+    }
+    if factory_targets.is_empty() && curried_factory_targets.is_empty() {
         return;
     }
 
@@ -161,7 +246,8 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
     // Helper: visit a slice of stmts and rewrite eligible Lets in place.
     fn visit_stmts(
         stmts: &mut [Stmt],
-        factory_targets: &HashMap<FuncId, (String, Vec<LocalId>)>,
+        factory_targets: &HashMap<FuncId, FactoryTarget>,
+        curried_factory_targets: &HashMap<FuncId, CurriedFactoryTarget>,
         classes: &[Class],
         new_classes: &mut Vec<Class>,
         next_class_counter: &mut usize,
@@ -173,6 +259,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                     rewrite_call_init(
                         e,
                         factory_targets,
+                        curried_factory_targets,
                         classes,
                         new_classes,
                         next_class_counter,
@@ -183,6 +270,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                     rewrite_call_init(
                         e,
                         factory_targets,
+                        curried_factory_targets,
                         classes,
                         new_classes,
                         next_class_counter,
@@ -197,6 +285,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                     rewrite_call_init(
                         condition,
                         factory_targets,
+                        curried_factory_targets,
                         classes,
                         new_classes,
                         next_class_counter,
@@ -205,6 +294,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                     visit_stmts(
                         then_branch,
                         factory_targets,
+                        curried_factory_targets,
                         classes,
                         new_classes,
                         next_class_counter,
@@ -214,6 +304,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                         visit_stmts(
                             eb,
                             factory_targets,
+                            curried_factory_targets,
                             classes,
                             new_classes,
                             next_class_counter,
@@ -225,6 +316,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                     rewrite_call_init(
                         condition,
                         factory_targets,
+                        curried_factory_targets,
                         classes,
                         new_classes,
                         next_class_counter,
@@ -233,6 +325,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                     visit_stmts(
                         body,
                         factory_targets,
+                        curried_factory_targets,
                         classes,
                         new_classes,
                         next_class_counter,
@@ -250,6 +343,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                         visit_stmts(
                             &mut tmp,
                             factory_targets,
+                            curried_factory_targets,
                             classes,
                             new_classes,
                             next_class_counter,
@@ -263,6 +357,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                         rewrite_call_init(
                             c,
                             factory_targets,
+                            curried_factory_targets,
                             classes,
                             new_classes,
                             next_class_counter,
@@ -273,6 +368,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                         rewrite_call_init(
                             u,
                             factory_targets,
+                            curried_factory_targets,
                             classes,
                             new_classes,
                             next_class_counter,
@@ -282,6 +378,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                     visit_stmts(
                         body,
                         factory_targets,
+                        curried_factory_targets,
                         classes,
                         new_classes,
                         next_class_counter,
@@ -296,6 +393,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                     visit_stmts(
                         body,
                         factory_targets,
+                        curried_factory_targets,
                         classes,
                         new_classes,
                         next_class_counter,
@@ -305,6 +403,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                         visit_stmts(
                             &mut c.body,
                             factory_targets,
+                            curried_factory_targets,
                             classes,
                             new_classes,
                             next_class_counter,
@@ -315,6 +414,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                         visit_stmts(
                             fin,
                             factory_targets,
+                            curried_factory_targets,
                             classes,
                             new_classes,
                             next_class_counter,
@@ -329,6 +429,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                     rewrite_call_init(
                         discriminant,
                         factory_targets,
+                        curried_factory_targets,
                         classes,
                         new_classes,
                         next_class_counter,
@@ -339,6 +440,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                             rewrite_call_init(
                                 t,
                                 factory_targets,
+                                curried_factory_targets,
                                 classes,
                                 new_classes,
                                 next_class_counter,
@@ -348,6 +450,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                         visit_stmts(
                             &mut case.body,
                             factory_targets,
+                            curried_factory_targets,
                             classes,
                             new_classes,
                             next_class_counter,
@@ -360,6 +463,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                     visit_stmts(
                         &mut tmp,
                         factory_targets,
+                        curried_factory_targets,
                         classes,
                         new_classes,
                         next_class_counter,
@@ -380,7 +484,8 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
     // an Array literal still get specialized.
     fn rewrite_call_init(
         expr: &mut Expr,
-        factory_targets: &HashMap<FuncId, (String, Vec<LocalId>)>,
+        factory_targets: &HashMap<FuncId, FactoryTarget>,
+        curried_factory_targets: &HashMap<FuncId, CurriedFactoryTarget>,
         classes: &[Class],
         new_classes: &mut Vec<Class>,
         next_class_counter: &mut usize,
@@ -396,6 +501,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                 rewrite_call_init(
                     callee,
                     factory_targets,
+                    curried_factory_targets,
                     classes,
                     new_classes,
                     next_class_counter,
@@ -405,6 +511,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                     rewrite_call_init(
                         a,
                         factory_targets,
+                        curried_factory_targets,
                         classes,
                         new_classes,
                         next_class_counter,
@@ -418,6 +525,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                 rewrite_call_init(
                     left,
                     factory_targets,
+                    curried_factory_targets,
                     classes,
                     new_classes,
                     next_class_counter,
@@ -426,6 +534,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                 rewrite_call_init(
                     right,
                     factory_targets,
+                    curried_factory_targets,
                     classes,
                     new_classes,
                     next_class_counter,
@@ -436,6 +545,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                 rewrite_call_init(
                     operand,
                     factory_targets,
+                    curried_factory_targets,
                     classes,
                     new_classes,
                     next_class_counter,
@@ -450,6 +560,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                 rewrite_call_init(
                     condition,
                     factory_targets,
+                    curried_factory_targets,
                     classes,
                     new_classes,
                     next_class_counter,
@@ -458,6 +569,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                 rewrite_call_init(
                     then_expr,
                     factory_targets,
+                    curried_factory_targets,
                     classes,
                     new_classes,
                     next_class_counter,
@@ -466,6 +578,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                 rewrite_call_init(
                     else_expr,
                     factory_targets,
+                    curried_factory_targets,
                     classes,
                     new_classes,
                     next_class_counter,
@@ -477,6 +590,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                     rewrite_call_init(
                         e,
                         factory_targets,
+                        curried_factory_targets,
                         classes,
                         new_classes,
                         next_class_counter,
@@ -488,6 +602,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                 rewrite_call_init(
                     parent_expr,
                     factory_targets,
+                    curried_factory_targets,
                     classes,
                     new_classes,
                     next_class_counter,
@@ -502,6 +617,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                 rewrite_call_init(
                     key_expr,
                     factory_targets,
+                    curried_factory_targets,
                     classes,
                     new_classes,
                     next_class_counter,
@@ -510,6 +626,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                 rewrite_call_init(
                     value_expr,
                     factory_targets,
+                    curried_factory_targets,
                     classes,
                     new_classes,
                     next_class_counter,
@@ -521,6 +638,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                     rewrite_call_init(
                         a,
                         factory_targets,
+                        curried_factory_targets,
                         classes,
                         new_classes,
                         next_class_counter,
@@ -532,6 +650,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                 rewrite_call_init(
                     object,
                     factory_targets,
+                    curried_factory_targets,
                     classes,
                     new_classes,
                     next_class_counter,
@@ -542,6 +661,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                 rewrite_call_init(
                     object,
                     factory_targets,
+                    curried_factory_targets,
                     classes,
                     new_classes,
                     next_class_counter,
@@ -550,6 +670,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                 rewrite_call_init(
                     value,
                     factory_targets,
+                    curried_factory_targets,
                     classes,
                     new_classes,
                     next_class_counter,
@@ -559,17 +680,86 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
             _ => {}
         }
         // Now detect the factory pattern at THIS level.
-        let Expr::Call { callee, args, .. } = expr else {
+        let curried_call = match expr {
+            Expr::Call { callee, args, .. } => {
+                if let Expr::Call {
+                    callee: outer_callee,
+                    args: outer_args,
+                    ..
+                } = callee.as_ref()
+                {
+                    if let Expr::FuncRef(fn_id) = outer_callee.as_ref() {
+                        Some((*fn_id, outer_args.clone(), args.clone()))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+            _ => return,
+        };
+        if let Some((fn_id, outer_args, inner_args)) = curried_call {
+            if let Some(target) = curried_factory_targets.get(&fn_id) {
+                let mut param_ids = target.outer_param_ids.clone();
+                param_ids.extend(target.inner_param_ids.iter().copied());
+                let mut call_args = outer_args;
+                call_args.extend(inner_args);
+                if rewrite_to_specialized_class(
+                    expr,
+                    &target.target_name,
+                    &param_ids,
+                    &call_args,
+                    classes,
+                    new_classes,
+                    next_class_counter,
+                    base_class_counter_seed,
+                ) {
+                    return;
+                }
+            }
+        }
+
+        let direct_call = match expr {
+            Expr::Call { callee, args, .. } => {
+                if let Expr::FuncRef(fn_id) = callee.as_ref() {
+                    Some((*fn_id, args.clone()))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        let Some((fn_id, call_args)) = direct_call else {
             return;
         };
-        let Expr::FuncRef(fn_id) = callee.as_ref() else {
+        let Some(target) = factory_targets.get(&fn_id) else {
             return;
         };
-        let Some((target_name, param_ids)) = factory_targets.get(fn_id) else {
-            return;
-        };
+        rewrite_to_specialized_class(
+            expr,
+            &target.target_name,
+            &target.param_ids,
+            &call_args,
+            classes,
+            new_classes,
+            next_class_counter,
+            base_class_counter_seed,
+        );
+    }
+
+    fn rewrite_to_specialized_class(
+        expr: &mut Expr,
+        target_name: &str,
+        param_ids: &[LocalId],
+        args: &[Expr],
+        classes: &[Class],
+        new_classes: &mut Vec<Class>,
+        next_class_counter: &mut usize,
+        base_class_counter_seed: &str,
+    ) -> bool {
         let Some(class) = classes.iter().find(|c| &c.name == target_name) else {
-            return;
+            return false;
         };
         // Snapshot the args, padding with Undefined if the call passes
         // fewer args than the function declared params (rare but legal).
@@ -584,6 +774,16 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
         // name. We translate via the param NAME (`__perry_cap_<outer_id>`)
         // → the index of `outer_id` in `param_ids` → `padded_args[index]`.
         let mut subst: HashMap<LocalId, Expr> = HashMap::new();
+        let param_subst: HashMap<LocalId, Expr> = param_ids
+            .iter()
+            .enumerate()
+            .map(|(idx, id)| {
+                (
+                    *id,
+                    padded_args.get(idx).cloned().unwrap_or(Expr::Undefined),
+                )
+            })
+            .collect();
         if let Some(ctor) = &class.constructor {
             for p in &ctor.params {
                 if let Some(suffix) = p.name.strip_prefix("__perry_cap_") {
@@ -599,14 +799,20 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                             // factory's own params; bail out of
                             // specialization in this case and leave the
                             // Call as-is so any later pass can handle it.
-                            return;
+                            return false;
                         }
                     }
                 }
             }
         }
-        if subst.is_empty() {
-            return;
+        let param_set: HashSet<LocalId> = param_ids.iter().copied().collect();
+        let extends_needs_subst = class
+            .extends_expr
+            .as_deref()
+            .map(|expr| expr_reads_any_local(expr, &param_set))
+            .unwrap_or(false);
+        if subst.is_empty() && !extends_needs_subst {
+            return false;
         }
         // Clone and specialize the class.
         let mut next_id_seed: LocalId = 0;
@@ -617,59 +823,77 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
         *next_class_counter += 1;
         let mut cloned = class.clone();
         cloned.name = cloned_name.clone();
+        if let Some(extends_expr) = cloned.extends_expr.as_mut() {
+            substitute_locals(extends_expr, &param_subst, &mut next_id_seed);
+            if let Expr::ClassRef(parent_name) = extends_expr.as_ref() {
+                cloned.extends_name = Some(parent_name.clone());
+                cloned.extends = classes
+                    .iter()
+                    .find(|c| &c.name == parent_name)
+                    .map(|c| c.id)
+                    .or_else(|| {
+                        new_classes
+                            .iter()
+                            .find(|c| &c.name == parent_name)
+                            .map(|c| c.id)
+                    });
+            }
+        }
         // Filter out the capture ctor params + matching synthetic fields +
         // ctor-body assignments. Substitute the captured-param LocalGets
         // with the bound arg expression throughout the class body.
-        if let Some(ctor) = cloned.constructor.as_mut() {
-            // Identify the synthetic ctor param ids and the names we need
-            // to drop from fields and ctor body.
-            let cap_param_ids: HashSet<LocalId> = ctor
-                .params
-                .iter()
-                .filter(|p| p.name.starts_with("__perry_cap_"))
-                .map(|p| p.id)
-                .collect();
-            let cap_field_names: HashSet<String> = ctor
-                .params
-                .iter()
-                .filter(|p| p.name.starts_with("__perry_cap_"))
-                .map(|p| p.name.clone())
-                .collect();
-            // Drop the capture ctor params.
-            ctor.params.retain(|p| !cap_param_ids.contains(&p.id));
-            // Substitute remaining body refs to those param ids.
-            substitute_locals_in_stmts(&mut ctor.body, &subst, &mut next_id_seed);
-            // Drop ctor body statements that were the synthesized
-            // assignment `this.__perry_cap_<outer> = LocalGet(...)`. After
-            // substitution above those LocalGets are gone, so the assign
-            // would write a useless value to a field we're about to
-            // remove — drop them to keep the ctor body minimal.
-            ctor.body.retain(|s| match s {
-                Stmt::Expr(Expr::PropertySet { property, .. }) => {
-                    !cap_field_names.contains(property)
+        if !subst.is_empty() {
+            if let Some(ctor) = cloned.constructor.as_mut() {
+                // Identify the synthetic ctor param ids and the names we need
+                // to drop from fields and ctor body.
+                let cap_param_ids: HashSet<LocalId> = ctor
+                    .params
+                    .iter()
+                    .filter(|p| p.name.starts_with("__perry_cap_"))
+                    .map(|p| p.id)
+                    .collect();
+                let cap_field_names: HashSet<String> = ctor
+                    .params
+                    .iter()
+                    .filter(|p| p.name.starts_with("__perry_cap_"))
+                    .map(|p| p.name.clone())
+                    .collect();
+                // Drop the capture ctor params.
+                ctor.params.retain(|p| !cap_param_ids.contains(&p.id));
+                // Substitute remaining body refs to those param ids.
+                substitute_locals_in_stmts(&mut ctor.body, &subst, &mut next_id_seed);
+                // Drop ctor body statements that were the synthesized
+                // assignment `this.__perry_cap_<outer> = LocalGet(...)`. After
+                // substitution above those LocalGets are gone, so the assign
+                // would write a useless value to a field we're about to
+                // remove — drop them to keep the ctor body minimal.
+                ctor.body.retain(|s| match s {
+                    Stmt::Expr(Expr::PropertySet { property, .. }) => {
+                        !cap_field_names.contains(property)
+                    }
+                    _ => true,
+                });
+                // Drop the synthetic capture fields.
+                cloned.fields.retain(|f| !cap_field_names.contains(&f.name));
+                // Substitute remaining field inits / key exprs.
+                for field in cloned.fields.iter_mut() {
+                    if let Some(init) = field.init.as_mut() {
+                        substitute_locals(init, &subst, &mut next_id_seed);
+                    }
+                    if let Some(key) = field.key_expr.as_mut() {
+                        substitute_locals(key, &subst, &mut next_id_seed);
+                    }
                 }
-                _ => true,
-            });
-            // Drop the synthetic capture fields.
-            cloned.fields.retain(|f| !cap_field_names.contains(&f.name));
-            // Substitute remaining field inits / key exprs.
-            for field in cloned.fields.iter_mut() {
-                if let Some(init) = field.init.as_mut() {
-                    substitute_locals(init, &subst, &mut next_id_seed);
+                // Substitute in methods/getters/setters.
+                for m in cloned.methods.iter_mut() {
+                    substitute_locals_in_stmts(&mut m.body, &subst, &mut next_id_seed);
                 }
-                if let Some(key) = field.key_expr.as_mut() {
-                    substitute_locals(key, &subst, &mut next_id_seed);
+                for (_, g) in cloned.getters.iter_mut() {
+                    substitute_locals_in_stmts(&mut g.body, &subst, &mut next_id_seed);
                 }
-            }
-            // Substitute in methods/getters/setters.
-            for m in cloned.methods.iter_mut() {
-                substitute_locals_in_stmts(&mut m.body, &subst, &mut next_id_seed);
-            }
-            for (_, g) in cloned.getters.iter_mut() {
-                substitute_locals_in_stmts(&mut g.body, &subst, &mut next_id_seed);
-            }
-            for (_, s) in cloned.setters.iter_mut() {
-                substitute_locals_in_stmts(&mut s.body, &subst, &mut next_id_seed);
+                for (_, s) in cloned.setters.iter_mut() {
+                    substitute_locals_in_stmts(&mut s.body, &subst, &mut next_id_seed);
+                }
             }
         }
         // Avoid `aliases` pointing at the original class — the clone is a
@@ -697,6 +921,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
         // specialized class via the existing `local_class_aliases`
         // mechanism in codegen.
         *expr = Expr::ClassRef(cloned_name);
+        true
     }
 
     // Visit module init.
@@ -704,18 +929,19 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
     visit_stmts(
         &mut module.init,
         &factory_targets,
+        &curried_factory_targets,
         &classes_snapshot,
         &mut new_classes,
         &mut next_class_counter,
         "init",
     );
-    // Issue #740: dynamic parent registration with a static class result —
-    // after `rewrite_call_init` replaces `RegisterClassParentDynamic {
+    // Dynamic parent registration with a now-static class result: after
+    // `rewrite_call_init` replaces `RegisterClassParentDynamic {
     // parent_expr: Call(...) }` with `parent_expr: ClassRef(<inline>)`,
-    // hoist the static parent into `class.extends_name` on the child. This
-    // lets `lower_new`'s parent-ctor walk find the specialized class and
-    // inline its constructor (which has the captures baked into field
-    // initializers), so `new Child()` properly initializes the fields.
+    // hoist that concrete parent into `class.extends_name` on the child. This
+    // lets `lower_new` walk through the specialized class for inherited
+    // constructors and field initializers instead of the unspecialized
+    // anonymous original.
     for stmt in &module.init {
         if let Stmt::Expr(Expr::RegisterClassParentDynamic {
             class_name,
@@ -724,23 +950,19 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
         {
             if let Expr::ClassRef(parent_name) = parent_expr.as_ref() {
                 if let Some(child) = module.classes.iter_mut().find(|c| &c.name == class_name) {
-                    if child.extends_name.is_none() {
-                        child.extends_name = Some(parent_name.clone());
-                    }
-                    if child.extends.is_none() {
-                        if let Some(parent_cls) = new_classes
-                            .iter()
-                            .find(|c| &c.name == parent_name)
-                            .map(|c| c.id)
-                            .or_else(|| {
-                                classes_snapshot
-                                    .iter()
-                                    .find(|c| &c.name == parent_name)
-                                    .map(|c| c.id)
-                            })
-                        {
-                            child.extends = Some(parent_cls);
-                        }
+                    child.extends_name = Some(parent_name.clone());
+                    if let Some(parent_cls) = new_classes
+                        .iter()
+                        .find(|c| &c.name == parent_name)
+                        .map(|c| c.id)
+                        .or_else(|| {
+                            classes_snapshot
+                                .iter()
+                                .find(|c| &c.name == parent_name)
+                                .map(|c| c.id)
+                        })
+                    {
+                        child.extends = Some(parent_cls);
                     }
                 }
             }
@@ -751,6 +973,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
         visit_stmts(
             &mut func.body,
             &factory_targets,
+            &curried_factory_targets,
             &classes_snapshot,
             &mut new_classes,
             &mut next_class_counter,
@@ -763,6 +986,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
             visit_stmts(
                 &mut ctor.body,
                 &factory_targets,
+                &curried_factory_targets,
                 &classes_snapshot,
                 &mut new_classes,
                 &mut next_class_counter,
@@ -773,6 +997,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
             visit_stmts(
                 &mut m.body,
                 &factory_targets,
+                &curried_factory_targets,
                 &classes_snapshot,
                 &mut new_classes,
                 &mut next_class_counter,
@@ -783,6 +1008,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
             visit_stmts(
                 &mut g.body,
                 &factory_targets,
+                &curried_factory_targets,
                 &classes_snapshot,
                 &mut new_classes,
                 &mut next_class_counter,
@@ -793,6 +1019,7 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
             visit_stmts(
                 &mut s.body,
                 &factory_targets,
+                &curried_factory_targets,
                 &classes_snapshot,
                 &mut new_classes,
                 &mut next_class_counter,

--- a/test-files/test_issue_806_curried_factory_extends_capture.ts
+++ b/test-files/test_issue_806_curried_factory_extends_capture.ts
@@ -1,0 +1,18 @@
+function TaggedError<_Self>() {
+  return <Tag extends string>(tag: Tag, schema: Record<string, string>) =>
+    class {
+      readonly _tag: Tag = tag;
+      readonly _schema = schema;
+    };
+}
+
+class MyError extends TaggedError<MyError>()("MyError", { code: "string" }) {
+  describe(): string {
+    return `${this._tag}(code:${this._schema.code})`;
+  }
+}
+
+const err = new MyError();
+console.log("effect._tag:", err._tag);
+console.log("effect._schema.code:", err._schema.code);
+console.log("effect.describe:", err.describe());

--- a/test-files/test_issue_806_curried_mixin_outer_capture.ts
+++ b/test-files/test_issue_806_curried_mixin_outer_capture.ts
@@ -1,0 +1,25 @@
+type Ctor<T = {}> = new (...args: any[]) => T;
+
+class CoreBase {
+  core(): string {
+    return "core";
+  }
+}
+
+function ParamMixin<T>(seed: T) {
+  return <TBase extends Ctor>(B: TBase) =>
+    class extends B {
+      seed: T = seed;
+
+      describeSeed(): string {
+        return "seed=" + String(this.seed);
+      }
+    };
+}
+
+class Combined extends ParamMixin<number>(42)(CoreBase) {}
+
+const combined = new Combined();
+console.log("combo.core:", combined.core());
+console.log("combo.seed:", combined.seed);
+console.log("combo.describeSeed:", combined.describeSeed());

--- a/test-files/test_issue_806_default_derived_constructor_forwarding.ts
+++ b/test-files/test_issue_806_default_derived_constructor_forwarding.ts
@@ -1,0 +1,22 @@
+class Logged {
+  log: string;
+
+  constructor(seed: string) {
+    this.log = "seed=" + seed;
+  }
+}
+
+type Ctor<T = {}> = new (...args: any[]) => T;
+
+function WithSuffix<TBase extends Ctor<Logged>>(B: TBase) {
+  return class extends B {
+    constructor(seed: string) {
+      super(seed);
+      this.log += ":wrapped";
+    }
+  };
+}
+
+class WrappedLogged extends WithSuffix(Logged) {}
+
+console.log("super-args.log:", new WrappedLogged("alpha").log);

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -14,12 +14,6 @@
     "category": "gap-categorical",
     "reason": "Lookbehind regex assertions \u2014 Rust's `regex` crate doesn't support `(?<=)` / `(?<!)`. Documented in CLAUDE.md as a known categorical gap. Unblocking requires swapping the regex backend or implementing a separate matcher for lookbehind."
   },
-  "test_harness_class_mixins": {
-    "issue": "806",
-    "added": "2026-05-24",
-    "category": "bug-stale",
-    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #806 is closed. Deliberate failing repro/harness \u2014 kept as a regression canary. #806 harness for `class X extends Fn(...)<...>` patterns. Two sub-cases surface real Perry gaps today: (1) bare-factory subclass loses the base's field initializer (`bare.kind: undefined` vs Node's `bare.kind: bare`); (2) chained mixin `WithA(WithB(WithC(Base)))` throws `TypeError: value is not a function` at construction. Captured-factory + Effect double-call shapes pass post-#740 \u2014 the harness verifies that survives. Linked to #321 umbrella; will flip to PASS as each sub-case lands."
-  },
   "test_issue_422_socket_connect": {
     "issue": "1634",
     "added": "2026-05-15",


### PR DESCRIPTION
## User-visible improvement

Perry now matches Node for dynamic class factory mixins used in `extends` clauses, including default-derived constructor forwarding and curried factory captures. This removes the stale `test_harness_class_mixins` known failure tied to #806/#321-style class factory patterns.

This branch also repairs the current PR's stream CI failure from recent `main`: default `Readable` `_read` is deferred until the flow tick instead of firing synchronously when a `data` listener is attached, and `stream/promises.finished()` now observes existing hidden stream state without forcing `_read`.

## Tests added / enabled

- Added `test_issue_806_default_derived_constructor_forwarding.ts`.
- Added `test_issue_806_curried_factory_extends_capture.ts`.
- Added `test_issue_806_curried_mixin_outer_capture.ts`.
- Removed `test_harness_class_mixins` from `test-parity/known_failures.json` after proving it passes.
- Removed `node-suite/stream/error/no-read-impl` from `test-parity/known_failures.json` after proving it passes.

## Commands run

- `CARGO_BUILD_JOBS=1 cargo check -p perry-transform -p perry-codegen -p perry-runtime`
- `RUST_TEST_THREADS=1 cargo test -p perry-runtime` (792 passed, doc-tests clean)
- `RUST_TEST_THREADS=1 cargo test -p perry-runtime node_stream -- --nocapture` (62 passed)
- `RUST_TEST_THREADS=1 cargo test -p perry-runtime node_submodules::tests::stream_promises -- --nocapture` (7 passed)
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `./scripts/check_file_size.sh`
- `git diff --check origin/main...HEAD`
- `./run_parity_tests.sh --filter test_issue_806` (3/3 pass)
- `./run_parity_tests.sh --filter test_harness_class_mixins` (pass)
- `./run_parity_tests.sh --suite node-suite --module stream --filter no-read-impl` (pass)
- `./run_parity_tests.sh --suite node-suite --module stream --filter error-false-option` (pass)

Note: an earlier local `cargo check` attempt hit a disk-full condition while writing Rust metadata; after `cargo clean`, the same check passed, and it passed again post-commit.

## Limitations

Class factory specialization remains conservative: it handles statically visible class-returning factory shapes where captured params or dynamic `extends` parents can be resolved safely.

The stream change is limited to default `Readable` `_read` scheduling and `stream/promises.finished()` state observation. It is not a broad stream lifecycle rewrite.

## Non-goals

No Object.assign, module-resolution, package-sweep, or broad stream-suite work is included.