### PR TITLE
fix(stream/web): reject reserved WritableStream type

### DIFF
--- a/crates/perry-codegen/src/ext_registry.rs
+++ b/crates/perry-codegen/src/ext_registry.rs
@@ -120,6 +120,7 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
     ("js_readable_stream_controller_error",         OwnerKind::Stdlib { feature: Some("bundled-streams") }),
     ("js_readable_stream_controller_desired_size",  OwnerKind::Stdlib { feature: Some("bundled-streams") }),
     ("js_writable_stream_new",                      OwnerKind::Stdlib { feature: Some("bundled-streams") }),
+    ("js_writable_stream_new_with_sink_type",       OwnerKind::Stdlib { feature: Some("bundled-streams") }),
     ("js_writable_stream_get_writer",               OwnerKind::Stdlib { feature: Some("bundled-streams") }),
     ("js_writable_stream_locked",                   OwnerKind::Stdlib { feature: Some("bundled-streams") }),
     ("js_writable_stream_close",                    OwnerKind::Stdlib { feature: Some("bundled-streams") }),

--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -816,6 +816,7 @@ pub(super) fn lower_builtin_new(
             let mut write = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
             let mut close = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
             let mut abort = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+            let mut sink_type = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
             let mut hwm = double_literal(1.0);
             if !args.is_empty() {
                 if let Some(props) = extract_options_fields(ctx, &args[0]) {
@@ -832,6 +833,9 @@ pub(super) fn lower_builtin_new(
                             }
                             "abort" => {
                                 abort = lower_expr(ctx, vexpr)?;
+                            }
+                            "type" => {
+                                sink_type = lower_expr(ctx, vexpr)?;
                             }
                             _ => {
                                 let _ = lower_expr(ctx, vexpr)?;
@@ -853,13 +857,14 @@ pub(super) fn lower_builtin_new(
             }
             let h = ctx.block().call(
                 DOUBLE,
-                "js_writable_stream_new",
+                "js_writable_stream_new_with_sink_type",
                 &[
                     (DOUBLE, &start),
                     (DOUBLE, &write),
                     (DOUBLE, &close),
                     (DOUBLE, &abort),
                     (DOUBLE, &hwm),
+                    (DOUBLE, &sink_type),
                 ],
             );
             Ok(Some(h))

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1808,6 +1808,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE],
     );
+    module.declare_function(
+        "js_writable_stream_new_with_sink_type",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE],
+    );
     module.declare_function("js_writable_stream_throw_invalid_sink", DOUBLE, &[]);
     module.declare_function("js_writable_stream_get_writer", DOUBLE, &[DOUBLE]);
     module.declare_function("js_writable_stream_locked", DOUBLE, &[DOUBLE]);

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -311,6 +311,13 @@ unsafe fn throw_type_error(message: &str) -> ! {
     perry_runtime::exception::js_throw(f64::from_bits(err))
 }
 
+unsafe fn throw_range_error_with_code(message: &str, code: &'static str) -> ! {
+    let s = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    perry_runtime::node_submodules::register_error_code_pub(s, code);
+    let err = perry_runtime::error::js_rangeerror_new(s);
+    perry_runtime::exception::js_throw(f64::from_bits(JSValue::pointer(err as *const u8).bits()))
+}
+
 unsafe fn reject_type_error(promise: *mut Promise, message: &str) {
     let err = make_type_error_with_message(message);
     js_promise_reject(promise, f64::from_bits(err));
@@ -1134,6 +1141,32 @@ pub unsafe extern "C" fn js_writable_stream_new(
     abort_bits: f64,
     hwm: f64,
 ) -> f64 {
+    js_writable_stream_new_with_sink_type(
+        start_bits,
+        write_bits,
+        close_bits,
+        abort_bits,
+        hwm,
+        f64::from_bits(TAG_UNDEFINED),
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_writable_stream_new_with_sink_type(
+    start_bits: f64,
+    write_bits: f64,
+    close_bits: f64,
+    abort_bits: f64,
+    hwm: f64,
+    sink_type: f64,
+) -> f64 {
+    if sink_type.to_bits() != TAG_UNDEFINED {
+        throw_range_error_with_code(
+            "The argument 'type' is invalid. Received a non-undefined value",
+            "ERR_INVALID_ARG_VALUE",
+        );
+    }
+
     ensure_gc_registered();
     let id = alloc_writable(
         closure_from_bits(write_bits.to_bits()),

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -614,12 +614,6 @@
     "category": "bug-open",
     "reason": "node:stream: 'readable' event with read() drain \u2014 chunk order or count wrong. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/web/writable-stream-bytes-type": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: WritableStream({type:'bytes'}) \u2014 handling differs from Node (accept-and-ignore or throw). Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/web/from-promise-iterable": {
     "issue": "1545",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- thread WritableStream sink type through constructor lowering
- throw RangeError / ERR_INVALID_ARG_VALUE when the sink type is not undefined
- keep the existing js_writable_stream_new symbol as the undefined-type wrapper and remove the stale known-failure entry

## Verification
- cargo fmt --check
- cargo check -p perry-codegen -p perry-stdlib
- jq empty test-parity/known_failures.json
- ./run_parity_tests.sh --suite node-suite --module stream --filter web/writable-stream-bytes-type (PASS, report test-parity/reports/parity_report_20260529_064342.json)
- ./run_parity_tests.sh --suite node-suite --module stream --filter web/writable-stream (PASS 8/0/0, report test-parity/reports/parity_report_20260529_064402.json)
- git diff --check
- git diff --cached --check