### PR TITLE
fix(stream): reject detached Readable push

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -513,7 +513,29 @@ fn push_chunk_backpressure_result(stream: f64, total: f64) -> f64 {
 
 /// `readable.push(chunk)` for the untyped/`as any` object-method path.
 extern "C" fn ns_push1(closure: *const ClosureHeader, chunk: f64) -> f64 {
-    push_chunk(this_value(closure), chunk)
+    let stream = readable_push_receiver(closure);
+    if get_hidden_value(stream, hidden_readable_flag_key()).is_none() {
+        throw_readable_push_invalid_receiver();
+    }
+    push_chunk(stream, chunk)
+}
+
+fn readable_push_receiver(closure: *const ClosureHeader) -> f64 {
+    let implicit = crate::object::js_implicit_this_get();
+    if implicit.to_bits() != TAG_UNDEFINED {
+        return implicit;
+    }
+    if closure.is_null() {
+        return this_value(closure);
+    }
+    throw_readable_push_invalid_receiver()
+}
+
+#[cold]
+fn throw_readable_push_invalid_receiver() -> ! {
+    crate::node_submodules::diagnostics::throw_type_error_no_code(
+        b"Cannot read properties of undefined (reading '_readableState')",
+    )
 }
 
 fn unshift_chunk(stream: f64, chunk: f64) -> f64 {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -674,12 +674,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: BYOB reader missing methods (read/releaseLock) or .closed prop. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/readable/instance-method-bind-this": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: detached instance method called without `this` \u2014 wrong behavior (Perry should throw). Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/compose/three-stages-order": {
     "issue": "1531",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- make the untyped classic Readable push closure require a method-call receiver instead of the captured stream
- throw a catchable TypeError for detached push calls with no readable receiver
- remove the stale known-failure entry for node-suite/stream/readable/instance-method-bind-this

## Verification
- ./run_parity_tests.sh --suite node-suite --filter stream/readable/instance-method-bind-this (PASS, report test-parity/reports/parity_report_20260529_070319.json)
- ./run_parity_tests.sh --suite node-suite --module stream --filter readable/ (target PASS; broader readable residuals remain, report test-parity/reports/parity_report_20260529_065915.json)
- cargo fmt --check
- cargo check -p perry-runtime
- jq empty test-parity/known_failures.json
- git diff --check