### PR TITLE
fix(stream): finish on writable side when readable false

### DIFF
--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -716,16 +716,23 @@ pub extern "C" fn js_node_stream_compose(_streams_array: f64) -> f64 {
     js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
 }
 
-pub(super) fn add_finished_error_false_close_listener(stream: f64, callback: f64) {
+pub(super) fn add_finished_once_listeners(
+    stream: f64,
+    callback: f64,
+    watch_finish: bool,
+    watch_close: bool,
+) {
     let listener = js_closure_alloc(ns_finished_error_false_close as *const u8, 3);
     js_closure_set_capture_f64(listener, 0, stream);
     js_closure_set_capture_f64(listener, 1, callback);
     js_closure_set_capture_f64(listener, 2, f64::from_bits(TAG_FALSE));
-    add_stream_listener_for_event(
-        stream,
-        string_value(b"close"),
-        box_pointer(listener as *const u8),
-    );
+    let listener_value = box_pointer(listener as *const u8);
+    if watch_finish {
+        add_stream_listener_for_event(stream, string_value(b"finish"), listener_value);
+    }
+    if watch_close {
+        add_stream_listener_for_event(stream, string_value(b"close"), listener_value);
+    }
 }
 
 pub(super) fn add_finished_signal_abort_listener(stream: f64, signal: f64, callback: f64) {
@@ -760,8 +767,12 @@ pub(super) fn add_finished_cleanup_completion_listener(stream: f64, callback: f6
 }
 
 /// `stream.finished(stream, [options], cb)` callback form. This slice covers
-/// Node's `{ error: false }` path: there is no dedicated `error` listener, but
-/// `close` still observes the stream's stored error and calls the callback.
+/// focused option paths:
+///
+/// - `{ error: false }`: do not install an error listener, but `close` still
+///   observes the stream's stored error and calls the callback.
+/// - `{ readable: false }`: ignore the readable side and call back when the
+///   writable side emits `finish`.
 #[no_mangle]
 pub extern "C" fn js_node_stream_finished(args: *const crate::array::ArrayHeader) -> f64 {
     let args = pipeline_args(args);
@@ -778,8 +789,12 @@ pub extern "C" fn js_node_stream_finished(args: *const crate::array::ArrayHeader
     if !is_callable_value(callback) {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    if get_hidden_value(options, hidden_key(b"error")).is_some_and(|v| v.to_bits() == TAG_FALSE) {
-        add_finished_error_false_close_listener(stream, callback);
+    let watch_close =
+        get_hidden_value(options, hidden_key(b"error")).is_some_and(|v| v.to_bits() == TAG_FALSE);
+    let watch_finish = get_hidden_value(options, hidden_key(b"readable"))
+        .is_some_and(|v| v.to_bits() == TAG_FALSE);
+    if watch_close || watch_finish {
+        add_finished_once_listeners(stream, callback, watch_finish, watch_close);
     }
     if let Some(signal) = options_signal(options) {
         add_finished_signal_abort_listener(stream, signal, callback);

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -260,12 +260,6 @@
     "category": "bug-open",
     "reason": "node:stream: stream.compose(asyncIterable) doesn't drive the source / forward data. Reopened #1539 for pipeline execution."
   },
-  "node-suite/stream/finished/readable-false-option": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: finished({readable:false}) does not fire callback on writable-only close. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/duplex-pair/wired-comms": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- make callback-style stream.finished watch writable finish when options.readable is false
- preserve the existing error:false close listener path using the same one-shot callback guard
- remove the stale known-failure entry for node-suite/stream/finished/readable-false-option

## Verification
- ./run_parity_tests.sh --suite node-suite --filter stream/finished/readable-false-option (PASS, report test-parity/reports/parity_report_20260529_071145.json)
- ./run_parity_tests.sh --suite node-suite --module stream --filter finished/ (target PASS; cleanup/signal residuals remain, report test-parity/reports/parity_report_20260529_071105.json)
- cargo fmt --check
- cargo check -p perry-runtime
- jq empty test-parity/known_failures.json
- git diff --check