### PR TITLE
fix(stream): pass readable read size hint

### DIFF
--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -1458,9 +1458,10 @@ fn invoke_read_once_inner(stream: f64, emit_default_error: bool) {
         return;
     }
     set_hidden_value(stream, hidden_read_invoked_key(), f64::from_bits(TAG_TRUE));
+    let size = get_hidden_value(stream, hidden_hwm_key()).unwrap_or_else(|| default_hwm(false));
     let prev_this = crate::object::js_implicit_this_set(stream);
     unsafe {
-        let _ = crate::closure::js_native_call_value(read, std::ptr::null(), 0);
+        let _ = crate::closure::js_native_call_value(read, [size].as_ptr(), 1);
     }
     crate::object::js_implicit_this_set(prev_this);
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -290,12 +290,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.prototype.compose(stream) instance method \u2014 not yet exposed (only free compose() works). Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/readable/read-size-passed-to-_read": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: user _read(size) not invoked with the size hint from the read scheduler. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/events/finish-end-close-order": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- pass the effective readable highWaterMark as the advisory size argument when invoking a user-supplied Readable read hook
- remove the now-passing known failure entry for stream/readable/read-size-passed-to-_read

## Verification
- ./run_parity_tests.sh --suite node-suite --filter stream/readable/read-size-passed-to-_read (PASS, report test-parity/reports/parity_report_20260529_071851.json)
- ./run_parity_tests.sh --suite node-suite --module stream --filter readable/read- (target PASS; 16 PASS / 3 residual parity FAIL / 0 compile FAIL, report test-parity/reports/parity_report_20260529_071945.json)
- cargo fmt --check
- cargo check -p perry-runtime
- jq empty test-parity/known_failures.json
- git diff --check
- git diff --cached --check

## Notes
- DeepWiki reference saved at reference/deepwiki/nodejs-node-stream-readable-read-size-hint-2026-05-29.md
- Adjacent residuals in the read-* guard are read-after-end, read-in-readable-listener, and read-multibyte-boundary; this slice leaves them unchanged.