### PR TITLE
fix(stream): consume readable data before end

### DIFF
--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -317,6 +317,7 @@ pub(super) fn flush_pending_readable_chunks(stream: f64) {
             buffer_pending_readable_chunk(stream, chunk);
             continue;
         }
+        consume_readable_buffered_front(stream, chunk);
         emit_readable_data_unchecked(stream, chunk);
     }
     if stream_hidden_ended(stream)
@@ -836,6 +837,32 @@ pub(super) fn clear_pending_readable_chunks(stream: f64) {
     );
 }
 
+fn consume_readable_buffered_front(stream: f64, chunk: f64) {
+    let Some(chunks) = readable_hidden_chunks(stream) else {
+        return;
+    };
+    if !is_array_like_value(chunks) {
+        clear_readable_buffer(stream);
+        return;
+    }
+    let arr = raw_ptr_from_value(chunks) as *mut crate::array::ArrayHeader;
+    let len = crate::array::js_array_length(arr);
+    if len == 0 {
+        clear_readable_buffer(stream);
+        return;
+    }
+    let _ = crate::array::js_array_shift_f64(arr);
+    if len == 1 {
+        clear_readable_buffer(stream);
+        return;
+    }
+    let consumed = chunk_byte_len(chunk) as f64;
+    let remaining =
+        (get_hidden_value(stream, hidden_buffered_key()).unwrap_or(0.0) - consumed).max(0.0);
+    set_hidden_value(stream, hidden_buffered_key(), remaining);
+    set_hidden_value(stream, hidden_key(b"readableLength"), remaining);
+}
+
 pub(super) fn read_stream_with_size_arg(stream: f64, size: f64) -> f64 {
     let size_value = JSValue::from_bits(size.to_bits());
     if size_value.is_undefined() || !size_value.is_number() {
@@ -1027,9 +1054,11 @@ pub(super) fn drain_readable_from_events(stream: f64) {
                 if !emit_destroyed_tail {
                     return;
                 }
+                consume_readable_buffered_front(stream, chunk);
                 emit_readable_data_unchecked(stream, chunk);
                 return;
             }
+            consume_readable_buffered_front(stream, chunk);
             emit_readable_data_unchecked(stream, chunk);
             if stream_destroyed(stream) {
                 emit_destroyed_tail = true;

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -314,12 +314,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose() \u2014 error in middle transform does not propagate to composite 'error' event. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/readable/read-after-end": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: read() after end \u2014 does not consistently return null. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/transform-cancel-propagates": {
     "issue": "1545",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- consume the retained readable-buffer front entry when pending/data-drain chunks are emitted
- prevent data already delivered in flowing mode from being returned by read() after end
- remove the now-passing known failure entry for stream/readable/read-after-end

## Verification
- ./run_parity_tests.sh --suite node-suite --filter stream/readable/read-after-end (PASS, report test-parity/reports/parity_report_20260529_072848.json)
- ./run_parity_tests.sh --suite node-suite --module stream --filter readable/read- (target PASS; 16 PASS / 3 residual parity FAIL / 0 compile FAIL, report test-parity/reports/parity_report_20260529_072939.json)
- cargo fmt --check
- cargo check -p perry-runtime
- jq empty test-parity/known_failures.json
- git diff --check
- git diff --cached --check

## Notes
- DeepWiki reference saved at reference/deepwiki/nodejs-node-stream-readable-read-after-end-null-2026-05-29.md
- Focused residuals are read-in-readable-listener, read-multibyte-boundary, and read-size-passed-to-_read; the read-size residual is covered by separate PR #2465 because this branch is based on current origin/main.