### PR TITLE
fix(stream): finished() must not destroy an idle bare Readable (#2462)

### DIFF
--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -1433,8 +1433,25 @@ pub(super) fn invoke_construct_callback(stream: f64, opts: f64) {
 }
 
 pub(super) fn invoke_read_once(stream: f64) {
+    invoke_read_once_inner(stream, true);
+}
+
+/// Like [`invoke_read_once`] but never synthesizes the default `_read`
+/// (`ERR_METHOD_NOT_IMPLEMENTED`) error for a bare `Readable`. Passive probes
+/// such as `finished()` must observe a stream's state without destroying it —
+/// in Node, attaching `finished()` listeners does not call `_read`. Triggering
+/// the default error here destroyed an idle stream before a later
+/// `destroy(err)` could run, so `finished()` rejected with the default read
+/// error instead of the caller's error (#2441 regression / #2462).
+pub(super) fn probe_read_once(stream: f64) {
+    invoke_read_once_inner(stream, false);
+}
+
+fn invoke_read_once_inner(stream: f64, emit_default_error: bool) {
     let Some(read) = get_hidden_value(stream, hidden_read_key()) else {
-        maybe_emit_default_read_error(stream);
+        if emit_default_error {
+            maybe_emit_default_read_error(stream);
+        }
         return;
     };
     if get_hidden_value(stream, hidden_read_invoked_key()).is_some() {
@@ -1749,12 +1766,12 @@ pub fn js_node_stream_collect_bytes_result(stream: f64) -> Result<Vec<u8>, f64> 
 }
 
 pub(crate) fn js_node_stream_hidden_error_after_read(stream: f64) -> Option<f64> {
-    invoke_read_once(stream);
+    probe_read_once(stream);
     readable_hidden_error(stream)
 }
 
 pub(crate) fn js_node_stream_is_stub_ended_after_read(stream: f64) -> bool {
-    invoke_read_once(stream);
+    probe_read_once(stream);
     stream_hidden_ended(stream)
 }
 


### PR DESCRIPTION
Fixes #2462 — `main` is red because #2441 ("emit default Readable `_read` error") left 5 `node_stream`/`node_submodules` unit tests failing, blocking every PR (`cargo-test` is a required check).

## Root cause (1 real production regression)
`#2441` made a **bare** `Readable` (no `_read`) destroy itself with `ERR_METHOD_NOT_IMPLEMENTED` on the first read. That is Node-correct for `read()` — but `finished()` probed stream state through `js_node_stream_hidden_error_after_read` / `js_node_stream_is_stub_ended_after_read`, both of which called `invoke_read_once`. On a bare stream that:

1. synchronously set `destroyed = true` and **queued** the default-read-error microtask, so
2. a later `destroy(new Error('later-error'))` hit `destroy_stream`'s `already-destroyed` guard and **early-returned**, dropping the caller's error, and
3. when microtasks ran, `finished()` rejected with the **default read error** instead of `later-error`.

In Node, attaching `finished()` listeners never calls `_read`, so an idle stream is not destroyed merely by observing it.

### Fix
Split `invoke_read_once` into a `probe_read_once` variant that still runs a real `_read` callback but **never synthesizes the default error**, and use it for the two `finished()` state probes. `read()`, flowing-mode (`'data'` listener) and pipeline consumers keep the Node-correct default-error behavior from #2441.

## Stale white-box tests (4)
Four unit tests hand-drive a bare `Readable` via `js_node_stream_readable_new(UNDEFINED)` + manual `push`/`read`, expecting pre-#2441 lenient behavior. Reconciled by giving them a no-op `_read` through a shared `readable_with_noop_read()` test helper, so the manual-push lifecycle stays valid:

- `node_stream::state_tests::readable_lifecycle_flags_reflect_ended_state`
- `node_stream::tests::readable_set_encoding_emits_buffer_chunks_as_strings`
- `node_stream::tests_extra::pause_resume_track_readable_flowing_and_events`
- `node_stream::tests_extra::readable_push_emits_data_with_stream_this_and_deferred_end`

## Validation
- `cargo test --release -p perry-runtime node_stream` → **62 passed, 0 failed**
- `cargo test --release -p perry-runtime node_submodules` → **19 passed, 0 failed** (incl. `stream_promises_finished_rejects_later_destroy_error`)
- `cargo fmt --all -- --check` clean

No version bump / CHANGELOG entry — left for the maintainer to fold in at merge (main is moving across parallel sessions; avoids patch-version collisions).
