### PR TITLE
fix(stream): end after readable listener drain

### DIFF
--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -875,8 +875,10 @@ pub(super) fn read_stream_available_default(stream: f64) -> f64 {
     }
     clear_readable_buffer(stream);
     mark_disturbed(stream);
+    clear_pending_readable_chunks(stream);
     if stream_hidden_ended(stream) {
         queue_readable_event(stream);
+        schedule_readable_end(stream);
     }
     let encoded = readable_encoding_tag(stream).is_some();
     if values.len() == 1 {
@@ -978,6 +980,7 @@ pub(super) fn read_stream_object_mode_chunk(stream: f64) -> f64 {
     mark_disturbed(stream);
     if stream_hidden_ended(stream) && remaining == 0.0 {
         clear_pending_readable_chunks(stream);
+        queue_readable_event(stream);
         schedule_readable_end(stream);
     }
     chunk

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -362,12 +362,6 @@
     "category": "bug-open",
     "reason": "node:stream: r.compose(t1).compose(t2) \u2014 chained compose() returns Duplex but pipeline breaks. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/readable/read-in-readable-listener": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: read() inside 'readable' listener \u2014 while-loop drain pattern produces wrong output. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/flow/sequential-reads": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- clear Perry's pending-flow readable queue when read() drains the retained readable buffer
- keep the follow-up null readable notification and also schedule end once the drained stream is ended
- remove the now-passing known failure entry for stream/readable/read-in-readable-listener

## Verification
- ./run_parity_tests.sh --suite node-suite --filter stream/readable/read-in-readable-listener (PASS, report test-parity/reports/parity_report_20260529_074520.json)
- ./run_parity_tests.sh --suite node-suite --module stream --filter readable/read- (target PASS; 16 PASS / 3 residual parity FAIL / 0 compile FAIL, report test-parity/reports/parity_report_20260529_074605.json)
- cargo fmt --check
- cargo check -p perry-runtime
- jq empty test-parity/known_failures.json
- git diff --check
- git diff --cached --check

## Notes
- DeepWiki reference saved at reference/deepwiki/nodejs-node-stream-readable-listener-drain-end-2026-05-29.md
- Focused residuals are read-after-end, read-multibyte-boundary, and read-size-passed-to-_read; read-after-end is covered by PR #2468 and read-size by PR #2465 because this branch is based on current origin/main.