### PR TITLE
fix(stream): wake object-mode readable listeners

### DIFF
--- a/crates/perry-runtime/src/node_stream_event_emitter.rs
+++ b/crates/perry-runtime/src/node_stream_event_emitter.rs
@@ -223,7 +223,7 @@ fn add_stream_listener_for_event_with_options(
     if super::string_value_eq(event, b"data") {
         super::readable_data_listener_added(stream);
     } else if super::string_value_eq(event, b"readable") {
-        super::schedule_readable_event(stream);
+        super::readable_listener_added(stream);
     }
 }
 

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -338,6 +338,16 @@ pub(super) fn readable_data_listener_added(stream: f64) {
     invoke_read_once(stream);
 }
 
+pub(super) fn readable_listener_added(stream: f64) {
+    if get_hidden_value(stream, hidden_readable_flag_key()).is_none() {
+        return;
+    }
+    if get_hidden_value(stream, hidden_read_key()).is_some() {
+        invoke_read_once(stream);
+    }
+    schedule_readable_event(stream);
+}
+
 pub(super) fn schedule_readable_resume(stream: f64) {
     if has_truthy_hidden(stream, hidden_readable_resume_scheduled_key()) {
         return;
@@ -818,6 +828,14 @@ pub(super) fn clear_readable_buffer(stream: f64) {
     set_hidden_value(stream, hidden_key(b"readableLength"), 0.0);
 }
 
+pub(super) fn clear_pending_readable_chunks(stream: f64) {
+    set_hidden_value(
+        stream,
+        hidden_readable_pending_key(),
+        box_pointer(crate::array::js_array_alloc(0) as *const u8),
+    );
+}
+
 pub(super) fn read_stream_with_size_arg(stream: f64, size: f64) -> f64 {
     let size_value = JSValue::from_bits(size.to_bits());
     if size_value.is_undefined() || !size_value.is_number() {
@@ -959,7 +977,8 @@ pub(super) fn read_stream_object_mode_chunk(stream: f64) -> f64 {
     set_hidden_value(stream, hidden_key(b"readableLength"), remaining);
     mark_disturbed(stream);
     if stream_hidden_ended(stream) && remaining == 0.0 {
-        queue_readable_event(stream);
+        clear_pending_readable_chunks(stream);
+        schedule_readable_end(stream);
     }
     chunk
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -404,12 +404,6 @@
     "category": "gap-categorical",
     "reason": "#1278: console.trace / Error.stack frame format diverges from Node (Perry prints native frame addresses like `0: __mh_execute_header` instead of `at <fn> (file:///\u2026:line:col)`). Requires source-position retention through HIR/transform + native-frame \u2192 TS-source mapping. The other two divergences in this fixture (#1276 spurious `Values` column on array-of-arrays, #1277 timer ms numbers) are not gating: #1276 was fixed in v0.5.1019+; #1277 is a misdiagnosis \u2014 Perry's `Instant::now()` is correct and the apparent 1000\u00d7 gap is just AOT-vs-interpreted speedup on the trivial loop workload. Flips to PASS when #1278 lands."
   },
-  "node-suite/stream/readable/object-mode-read-returns-object": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: objectMode Readable.read() does not return single object per call. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/unshift-after-end": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -613,12 +607,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: writer.write() Promise resolution timing \u2014 resolves before sink processes chunk. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/readable/readable-event-with-objectmode": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: objectMode 'readable' event \u2014 read() returns wrong object values. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/from-async-gen-throws-mid": {
     "issue": "1545",


### PR DESCRIPTION
## Summary
- invoke the stream read hook when a readable listener is attached so object-mode sources can produce queued objects
- clear pending readable chunks and schedule end after object-mode read() drains the final object, avoiding an extra empty readable callback
- remove the now-passing known failures for object-mode readable read/drain behavior

## Verification
- ./run_parity_tests.sh --suite node-suite --filter stream/readable/object-mode-read-returns-object (baseline FAIL report test-parity/reports/parity_report_20260529_080108.json; final PASS report test-parity/reports/parity_report_20260529_081358.json)
- ./run_parity_tests.sh --suite node-suite --filter stream/readable/readable-event-with-objectmode (baseline FAIL report test-parity/reports/parity_report_20260529_080243.json; final PASS report test-parity/reports/parity_report_20260529_081448.json)
- ./run_parity_tests.sh --suite node-suite --module stream --filter objectmode (PASS 6/0/0, report test-parity/reports/parity_report_20260529_081528.json)
- cargo fmt --check
- cargo check -p perry-runtime
- jq empty test-parity/known_failures.json
- git diff --check
- git diff --cached --check

## Notes
- DeepWiki reference saved at reference/deepwiki/nodejs-node-stream-readable-objectmode-read-drain-2026-05-29.md
- Non-goals: no broad readable event-order cleanup, no default _read error timing changes for streams without a read callback, and no async iterator / Readable.from object-mode expansion.