### PR TITLE
fix(hir+runtime): ES5 function constructors run their body and support instanceof

### DIFF
--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -807,6 +807,25 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                         args,
                     });
                 }
+                // ES5 function constructors: `function Foo(){ this.x = … }`
+                // used as `new Foo()`. A top-level `function` declaration is
+                // tracked as a func (not a local, not a class), so neither the
+                // local branch above nor the `lookup_class` path fires — it
+                // would otherwise fall through to `Expr::New { class_name }`,
+                // whose codegen finds no class named `Foo` and produces an
+                // empty placeholder object that never runs the constructor
+                // body (so `this.x = …` writes are lost and `new Foo().x` is
+                // `undefined`). Route through `NewDynamic { FuncRef }` instead,
+                // which reaches `js_new_function_construct`: it allocates the
+                // instance, binds `this` for the duration of the call, runs the
+                // body, and returns the populated object — the same helper the
+                // local-binding path above relies on.
+                if let Some(func_id) = ctx.lookup_func(&class_name) {
+                    return Ok(Expr::NewDynamic {
+                        callee: Box::new(Expr::FuncRef(func_id)),
+                        args,
+                    });
+                }
             }
             // Issue #212: classes nested in a function may capture
             // enclosing-scope locals. `lower_class_decl` extended the

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -391,7 +391,17 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                 // chain depends on this. Refs #420 / #618 followup.
                 let ty_expr = if let ast::Expr::Ident(ident) = bin.right.as_ref() {
                     let name = ident.sym.as_ref();
-                    if ctx.lookup_local(name).is_some() {
+                    // A local holding a class ref (drizzle's `is(value, type)`),
+                    // OR a top-level ES5 function constructor (`function Foo(){…}`
+                    // used as `x instanceof Foo`). The latter has no class entry,
+                    // so without a dynamic value codegen resolves `ty = "Foo"` to
+                    // class_id 0 and instanceof always returns false — which makes
+                    // the ubiquitous `if (!(this instanceof Foo)) return new Foo()`
+                    // guard recurse forever. Lower the function to its value and
+                    // route through `js_instanceof_dynamic`, which derives the same
+                    // `synthetic_class_id_for_function` that `new Foo()` stamps onto
+                    // the instance (see js_new_function_construct).
+                    if ctx.lookup_local(name).is_some() || ctx.lookup_func(name).is_some() {
                         match lower_expr(ctx, &bin.right) {
                             Ok(e) => Some(Box::new(e)),
                             Err(_) => None,

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -69,6 +69,17 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
             f64::from_bits(TAG_FALSE)
         };
     }
+    // ES5 function constructors: `x instanceof Foo` where `Foo` is a plain
+    // function used with `new`. `js_new_function_construct` stamps each
+    // instance with `synthetic_class_id_for_function(Foo)`; derive the same
+    // id from the function value here and walk the candidate's class chain
+    // against it. Mirrors the construct site so the common
+    // `if (!(this instanceof Foo)) return new Foo()` guard resolves to true
+    // inside a `new`-invoked body instead of recursing forever (#838 followup).
+    let synthetic_cid = synthetic_class_id_for_function(type_ref);
+    if synthetic_cid != 0 {
+        return js_instanceof(value, synthetic_cid);
+    }
     f64::from_bits(TAG_FALSE)
 }
 


### PR DESCRIPTION
## Summary

ES5 function constructors (`function Foo(){ this.x = … }; new Foo()`) were broken in two compounding ways. This fixes both.

1. **The constructor body never ran.** A top-level `function` declaration used with `new` lowered to `Expr::New { class_name: "Foo" }`, but no class named `Foo` exists, so codegen produced an empty placeholder object and never invoked the body. Result: `new Foo().x` was `undefined` and `Object.keys(new Foo())` was empty. Fixed in `expr_new.rs` by routing top-level-function constructors through `NewDynamic { FuncRef }` → `js_new_function_construct` (the same helper the existing `lookup_local` branch already uses for function-valued locals), which allocates the instance, binds `this`, runs the body, and stamps a synthetic class id.

2. **`x instanceof Foo` was always false** for those instances. `js_instanceof_dynamic` had no branch for a plain function/closure RHS, and the lowering only produced a dynamic RHS value for *locals*, not top-level functions. Fixed in `lower_expr.rs` (resolve a `lookup_func` RHS to its value) and `instanceof.rs` (add a callable-closure branch using `synthetic_class_id_for_function`, the same id `js_new_function_construct` stamps onto the instance).

### Why both halves are needed

The ubiquitous guard idiom

```js
function Foo(message) {
  if (!(this instanceof Foo)) return new Foo(message);
  this.message = message || "";
}
```

only works if `this instanceof Foo` is true inside a `new`-invoked body. Without fix #2, that guard recurses forever and **stack-overflow crashes** (`SIGSEGV`). This is exactly test262's own `Test262Error` harness — so before this change, every failing test262 assertion crashed with no output instead of throwing a readable error.

## Testing

- `new Foo()` now sets instance fields; `Object.keys` reflects them.
- `x instanceof Foo`, the guard pattern, and a previously-`SIGSEGV`ing `assert.sameValue(1, 2, "msg")` all behave correctly (clean throw, exit 1).
- No regression: `[] instanceof Array`, `({}) instanceof Object`, `new Error() instanceof Error`, `new Date() instanceof Date`, and `class`-inheritance `instanceof` chains all still correct.
- `perry-hir` test suite green; test262 radar A/B over 1000 cases (Object/Array/expressions/statements) shows zero regressions.

## Notes

- This is a correctness fix for ES5 / common npm constructor patterns. It does **not** by itself raise the test262 parity *score* (those tests fail on underlying builtin semantics), but it eliminates a large class of stack-overflow crashes and makes failures diagnosable.
- Version bump + CHANGELOG entry intentionally omitted — please fold in at merge to avoid patch-version collisions with fast-moving `main`.
