### PR TITLE
fix(stream): align readable unshift end handling

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -547,6 +547,7 @@ fn unshift_chunk(stream: f64, chunk: f64) -> f64 {
         return push_chunk(stream, chunk);
     }
     if has_truthy_hidden(stream, hidden_ended_key()) {
+        destroy_stream(stream, readable_unshift_after_end_error());
         return f64::from_bits(TAG_FALSE);
     }
     let added = chunk_byte_len(chunk) as f64;
@@ -570,6 +571,14 @@ fn unshift_chunk(stream: f64, chunk: f64) -> f64 {
     } else {
         f64::from_bits(TAG_FALSE)
     }
+}
+
+fn readable_unshift_after_end_error() -> f64 {
+    let msg = b"stream.unshift() after end event";
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    crate::node_submodules::register_error_code_pub(s, "ERR_STREAM_PUSH_AFTER_EOF");
+    let err = crate::error::js_error_new_with_message(s);
+    crate::value::js_nanbox_pointer(err as i64)
 }
 
 extern "C" fn ns_unshift1(closure: *const ClosureHeader, chunk: f64) -> f64 {

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -546,7 +546,7 @@ fn unshift_chunk(stream: f64, chunk: f64) -> f64 {
     if jsval.is_null() || jsval.is_undefined() {
         return push_chunk(stream, chunk);
     }
-    if has_truthy_hidden(stream, hidden_ended_key()) {
+    if has_truthy_hidden(stream, hidden_end_emitted_key()) {
         destroy_stream(stream, readable_unshift_after_end_error());
         return f64::from_bits(TAG_FALSE);
     }
@@ -576,7 +576,7 @@ fn unshift_chunk(stream: f64, chunk: f64) -> f64 {
 fn readable_unshift_after_end_error() -> f64 {
     let msg = b"stream.unshift() after end event";
     let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-    crate::node_submodules::register_error_code_pub(s, "ERR_STREAM_PUSH_AFTER_EOF");
+    crate::node_submodules::register_error_code_pub(s, "ERR_STREAM_UNSHIFT_AFTER_END_EVENT");
     let err = crate::error::js_error_new_with_message(s);
     crate::value::js_nanbox_pointer(err as i64)
 }

--- a/crates/perry-runtime/src/node_stream_tests_extra.rs
+++ b/crates/perry-runtime/src/node_stream_tests_extra.rs
@@ -481,6 +481,22 @@ fn readable_unshift_prepends_chunk_and_returns_hwm_signal() {
     );
 }
 
+#[test]
+fn readable_unshift_after_eof_before_end_prepends_chunk() {
+    let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let handle = raw_ptr_from_value(stream) as i64;
+
+    let _ = js_node_stream_method_push(handle, string_value("world"));
+    let _ = js_node_stream_method_push(handle, f64::from_bits(TAG_NULL));
+    assert_eq!(
+        js_node_stream_method_unshift(handle, string_value("hello ")).to_bits(),
+        TAG_TRUE
+    );
+
+    let joined = js_node_stream_method_read(handle, f64::from_bits(TAG_UNDEFINED));
+    assert_eq!(stream_test_buffer_bytes(joined), b"hello world");
+}
+
 fn stream_test_buffer_bytes(value: f64) -> Vec<u8> {
     let len = crate::buffer::js_native_buffer_byte_len(value);
     let data = crate::buffer::js_native_buffer_data_ptr(value);

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -410,12 +410,6 @@
     "category": "bug-open",
     "reason": "node:stream: objectMode Readable.read() does not return single object per call. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/unshift-after-end": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: unshift() after end \u2014 does not emit 'error' / ERR_STREAM_PUSH_AFTER_EOF. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/compose/async-handler-promise": {
     "issue": "1531",
     "added": "2026-05-24",

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -188,12 +188,6 @@
     "category": "bug-open",
     "reason": "node:stream EventEmitter wiring incomplete \u2014 re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS. Real Perry gap (not ci-env); rolled under the open stream-events tracker #1532."
   },
-  "node-suite/stream/readable/unshift-chunk": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: unshift+data chain doesn't deliver. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/from-async-iterable": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -266,12 +260,6 @@
     "category": "bug-open",
     "reason": "node:stream: class extends Writable + _write doesn't deliver finish. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/unshift-after-read": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: read + unshift + re-read sequence doesn't deliver chunks in the right order. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/compose/with-async-fn": {
     "issue": "1539",
     "added": "2026-05-24",
@@ -337,12 +325,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: user _read(size) not invoked with the size hint from the read scheduler. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/readable/unshift-with-encoding": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: readable.unshift(chunk, encoding) \u2014 second-arg encoding form not honored. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/events/finish-end-close-order": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- emit the Node-compatible `ERR_STREAM_UNSHIFT_AFTER_END_EVENT` error only after the readable `end` event has been emitted
- allow `Readable.unshift(chunk[, encoding])` after EOF has been signaled but before `end`, so pushed-back chunks drain before the stream ends
- remove stale known-failure entries for the now-green `readable/unshift` slice

## Verification
- `./run_parity_tests.sh --suite node-suite --filter stream/readable/unshift-after-end` PASS 1/0/0 (`test-parity/reports/parity_report_20260529_084325.json`)
- `./run_parity_tests.sh --suite node-suite --filter stream/readable/unshift-with-encoding` PASS 1/0/0 (`test-parity/reports/parity_report_20260529_084326.json`)
- `./run_parity_tests.sh --suite node-suite --module stream --filter readable/unshift` PASS 8/0/0 (`test-parity/reports/parity_report_20260529_084715.json`)
- `cargo test -p perry-runtime readable_unshift_after_eof_before_end_prepends_chunk`
- `cargo check -p perry-runtime`
- `cargo fmt --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`
- `git diff --cached --check`

## Notes
DeepWiki references:
- `reference/deepwiki/nodejs-node-stream-readable-unshift-after-end-2026-05-29.md`
- `reference/deepwiki/nodejs-node-stream-readable-unshift-encoding-2026-05-29.md`

The final branch tip is `fc7253ec9` after rebasing onto the updated PR branch.
