### PR TITLE
fix(runtime): TypedArray map/filter/every/some/forEach/find/findIndex read element-typed storage

### DIFF
--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -11,6 +11,13 @@ pub extern "C" fn js_array_forEach(arr: *const ArrayHeader, callback: *const Clo
     if arr.is_null() {
         return;
     }
+    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+        crate::typedarray::js_typed_array_for_each(
+            arr as *const crate::typedarray::TypedArrayHeader,
+            callback,
+        );
+        return;
+    }
     unsafe {
         let length = (*arr).length;
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
@@ -37,6 +44,14 @@ pub extern "C" fn js_array_map(
     let arr = clean_arr_ptr(arr);
     if arr.is_null() {
         return js_array_alloc(0);
+    }
+    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+        // Typed-array receiver: read elements per element-kind and return a
+        // same-kind TypedArray (mirrors the sort/at/findLast delegation).
+        return crate::typedarray::js_typed_array_map(
+            arr as *const crate::typedarray::TypedArrayHeader,
+            callback,
+        ) as *mut ArrayHeader;
     }
     unsafe {
         let length = (*arr).length;
@@ -127,6 +142,12 @@ pub extern "C" fn js_array_filter(
     if arr.is_null() {
         return js_array_alloc(0);
     }
+    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+        return crate::typedarray::js_typed_array_filter(
+            arr as *const crate::typedarray::TypedArrayHeader,
+            callback,
+        ) as *mut ArrayHeader;
+    }
     unsafe {
         let length = (*arr).length;
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
@@ -166,6 +187,12 @@ pub extern "C" fn js_array_find(arr: *const ArrayHeader, callback: *const Closur
     if arr.is_null() {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
+    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+        return crate::typedarray::js_typed_array_find(
+            arr as *const crate::typedarray::TypedArrayHeader,
+            callback,
+        );
+    }
     unsafe {
         let length = (*arr).length;
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
@@ -203,6 +230,12 @@ pub extern "C" fn js_array_findIndex(
     let arr = clean_arr_ptr(arr);
     if arr.is_null() {
         return -1;
+    }
+    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+        return crate::typedarray::js_typed_array_find_index(
+            arr as *const crate::typedarray::TypedArrayHeader,
+            callback,
+        ) as i32;
     }
     unsafe {
         let length = (*arr).length;
@@ -366,6 +399,12 @@ pub extern "C" fn js_array_some(arr: *const ArrayHeader, callback: *const Closur
     if arr.is_null() {
         return f64::from_bits(TAG_FALSE);
     }
+    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+        return crate::typedarray::js_typed_array_some(
+            arr as *const crate::typedarray::TypedArrayHeader,
+            callback,
+        );
+    }
     unsafe {
         let length = (*arr).length;
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
@@ -400,6 +439,12 @@ pub extern "C" fn js_array_every(arr: *const ArrayHeader, callback: *const Closu
     let arr = clean_arr_ptr(arr);
     if arr.is_null() {
         return f64::from_bits(TAG_TRUE);
+    }
+    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+        return crate::typedarray::js_typed_array_every(
+            arr as *const crate::typedarray::TypedArrayHeader,
+            callback,
+        );
     }
     unsafe {
         let length = (*arr).length;

--- a/crates/perry-runtime/src/typedarray.rs
+++ b/crates/perry-runtime/src/typedarray.rs
@@ -997,6 +997,180 @@ pub extern "C" fn js_typed_array_find_last_index(
     }
 }
 
+// %TypedArray%.prototype iteration methods. The generic `js_array_*` helpers
+// detect a TypedArray receiver via `lookup_typed_array_kind` and delegate
+// here (mirroring the existing sort / at / findLast delegation), so these
+// read elements through the element-typed `load_at` instead of reinterpreting
+// the raw int/float storage as NaN-boxed f64 (which produced garbage values).
+// The callback receives `(element, index)` — same 2-arg convention the rest of
+// this file and the generic array helpers use.
+
+/// `ta.map(cb)` — returns a NEW TypedArray of the SAME kind (per spec, not a
+/// plain Array). Each result is coerced back to the element type via the same
+/// `jsvalue_to_f64` path `ta[i] = v` uses.
+#[no_mangle]
+pub extern "C" fn js_typed_array_map(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+) -> *mut TypedArrayHeader {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return typed_array_alloc(KIND_FLOAT64, 0);
+    }
+    unsafe {
+        let kind = (*ta).kind;
+        let len = (*ta).length as usize;
+        let out = typed_array_alloc(kind, len as u32);
+        for i in 0..len {
+            let v = load_at(ta, i);
+            let r = crate::closure::js_closure_call2(callback, v, i as f64);
+            store_at(out, i, jsvalue_to_f64(r));
+        }
+        out
+    }
+}
+
+/// `ta.filter(cb)` — returns a NEW TypedArray of the SAME kind holding the
+/// elements for which `cb` returned truthy.
+#[no_mangle]
+pub extern "C" fn js_typed_array_filter(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+) -> *mut TypedArrayHeader {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return typed_array_alloc(KIND_FLOAT64, 0);
+    }
+    unsafe {
+        let kind = (*ta).kind;
+        let len = (*ta).length as usize;
+        let mut kept: Vec<f64> = Vec::new();
+        for i in 0..len {
+            let v = load_at(ta, i);
+            let r = crate::closure::js_closure_call2(callback, v, i as f64);
+            if crate::value::js_is_truthy(r) != 0 {
+                kept.push(v);
+            }
+        }
+        let out = typed_array_alloc(kind, kept.len() as u32);
+        for (i, v) in kept.into_iter().enumerate() {
+            store_at(out, i, v);
+        }
+        out
+    }
+}
+
+/// `ta.every(cb)` — NaN-boxed boolean.
+#[no_mangle]
+pub extern "C" fn js_typed_array_every(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return f64::from_bits(crate::value::TAG_TRUE);
+    }
+    unsafe {
+        let len = (*ta).length as usize;
+        for i in 0..len {
+            let v = load_at(ta, i);
+            let r = crate::closure::js_closure_call2(callback, v, i as f64);
+            if crate::value::js_is_truthy(r) == 0 {
+                return f64::from_bits(crate::value::TAG_FALSE);
+            }
+        }
+        f64::from_bits(crate::value::TAG_TRUE)
+    }
+}
+
+/// `ta.some(cb)` — NaN-boxed boolean.
+#[no_mangle]
+pub extern "C" fn js_typed_array_some(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return f64::from_bits(crate::value::TAG_FALSE);
+    }
+    unsafe {
+        let len = (*ta).length as usize;
+        for i in 0..len {
+            let v = load_at(ta, i);
+            let r = crate::closure::js_closure_call2(callback, v, i as f64);
+            if crate::value::js_is_truthy(r) != 0 {
+                return f64::from_bits(crate::value::TAG_TRUE);
+            }
+        }
+        f64::from_bits(crate::value::TAG_FALSE)
+    }
+}
+
+/// `ta.forEach(cb)` — returns undefined.
+#[no_mangle]
+pub extern "C" fn js_typed_array_for_each(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    if !ta.is_null() {
+        unsafe {
+            let len = (*ta).length as usize;
+            for i in 0..len {
+                let v = load_at(ta, i);
+                let _ = crate::closure::js_closure_call2(callback, v, i as f64);
+            }
+        }
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// `ta.find(cb)` — first element for which `cb` is truthy, else undefined.
+#[no_mangle]
+pub extern "C" fn js_typed_array_find(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    unsafe {
+        let len = (*ta).length as usize;
+        for i in 0..len {
+            let v = load_at(ta, i);
+            let r = crate::closure::js_closure_call2(callback, v, i as f64);
+            if crate::value::js_is_truthy(r) != 0 {
+                return v;
+            }
+        }
+        f64::from_bits(crate::value::TAG_UNDEFINED)
+    }
+}
+
+/// `ta.findIndex(cb)` — first matching index as plain f64, else -1.
+#[no_mangle]
+pub extern "C" fn js_typed_array_find_index(
+    ta: *const TypedArrayHeader,
+    callback: *const ClosureHeader,
+) -> f64 {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return -1.0;
+    }
+    unsafe {
+        let len = (*ta).length as usize;
+        for i in 0..len {
+            let v = load_at(ta, i);
+            let r = crate::closure::js_closure_call2(callback, v, i as f64);
+            if crate::value::js_is_truthy(r) != 0 {
+                return i as f64;
+            }
+        }
+        -1.0
+    }
+}
+
 /// Format a typed array Node-style: `Int32Array(N) [ a, b, c ]`. Used by
 /// `format_jsvalue` in builtins.rs.
 pub fn format_typed_array(ta: *const TypedArrayHeader) -> String {


### PR DESCRIPTION
## Summary

`%TypedArray%.prototype` iteration methods produced wrong results because they lowered to the **generic** `Expr::Array*` variants, whose `js_array_*` helpers read the receiver as a regular `ArrayHeader` of NaN-boxed `f64` — but a TypedArray's storage is raw `int`/`float`. So on a typed array:

- `map` returned garbage f64s (e.g. `Int32Array([1,2,3]).map(x=>x*2)` → `[1.016e-320, …]`)
- `filter` returned `[]`
- `every` / `some` returned the wrong boolean
- `find` / `findIndex` / `forEach` read garbage elements

## Fix

Add the **established** `lookup_typed_array_kind(...)` delegation guard — the same pattern `js_array_sort` / `js_array_at` / `js_array_find_last` already use — to `js_array_map` / `filter` / `every` / `some` / `forEach` / `find` / `findIndex`, and implement the element-typed `js_typed_array_*` equivalents (reading via the per-kind `load_at`, writing via `store_at`). `map` / `filter` return a **same-kind TypedArray** per spec.

The guard only fires for genuine TypedArray pointers, so the regular-array hot path is byte-for-byte unchanged.

## Testing

Byte-identical to Node for `Int32Array` and `Float64Array`:

```
map [ 2, 4, 6, 8, 10 ]      filter [ 3, 4, 5 ]      every true   some true
find 4   findIndex 3   forEach (value, index)   Float64Array.map [ 2, 3, 4 ]
```

Regular-array `map`/`filter`/`every`/`some`/`find`/`forEach` over numbers, objects, and strings are unaffected (verified byte-identical to Node). `cargo fmt` clean.

## Scope / follow-ups

This fixes **instance method-call** correctness (`ta.map(...)`), which is what real code uses. It does **not** by itself move the test262 `built-ins/TypedArray` conformance score, which is gated by the reflective/descriptor layer — `TypedArray.prototype.<m>` reified as a callable value, `.name`/`.length` own-property descriptors, `Symbol.species`, and spec-mandated throws (detached buffer, non-callable arg). Those, plus the still-unwired `fill`/`copyWithin`/`reduce`/`join`/`indexOf`/`includes`, are the follow-ups.

Version bump + CHANGELOG entry intentionally omitted — please fold in at merge to avoid patch-version collisions with fast-moving `main`.
