### PR TITLE
fix(runtime): TypedArray lastIndexOf routes to array path, not string (#2457)

### DIFF
--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -597,6 +597,17 @@ pub fn check_escapes_in_expr(
             check_escapes_in_expr(array, candidates, classes, escaped);
             check_escapes_in_expr(value, candidates, classes, escaped);
         }
+        Expr::ArrayLastIndexOf {
+            array,
+            value,
+            from_index,
+        } => {
+            check_escapes_in_expr(array, candidates, classes, escaped);
+            check_escapes_in_expr(value, candidates, classes, escaped);
+            if let Some(fi) = from_index {
+                check_escapes_in_expr(fi, candidates, classes, escaped);
+            }
+        }
         Expr::NewDynamic { callee, args } => {
             check_escapes_in_expr(callee, candidates, classes, escaped);
             for a in args {

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -457,6 +457,17 @@ fn collect_used_new_fields_in_expr(
             collect_used_new_fields_in_expr(array, non_escaping_news, used);
             collect_used_new_fields_in_expr(value, non_escaping_news, used);
         }
+        Expr::ArrayLastIndexOf {
+            array,
+            value,
+            from_index,
+        } => {
+            collect_used_new_fields_in_expr(array, non_escaping_news, used);
+            collect_used_new_fields_in_expr(value, non_escaping_news, used);
+            if let Some(fi) = from_index {
+                collect_used_new_fields_in_expr(fi, non_escaping_news, used);
+            }
+        }
         Expr::I18nString { params, .. } => {
             for (_, value) in params {
                 collect_used_new_fields_in_expr(value, non_escaping_news, used);

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -715,6 +715,17 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
             walk(array, out);
             walk(value, out);
         }
+        Expr::ArrayLastIndexOf {
+            array,
+            value,
+            from_index,
+        } => {
+            walk(array, out);
+            walk(value, out);
+            if let Some(fi) = from_index {
+                walk(fi, out);
+            }
+        }
         Expr::ArraySome { array, callback } | Expr::ArrayEvery { array, callback } => {
             walk(array, out);
             walk(callback, out);

--- a/crates/perry-codegen/src/expr/misc_methods.rs
+++ b/crates/perry-codegen/src/expr/misc_methods.rs
@@ -455,6 +455,38 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(blk.sitofp(I32, &i32_v, DOUBLE))
         }
 
+        // arr.lastIndexOf(value, fromIndex?) — mirrors ArrayIndexOf + the
+        // `lower_array_method::lastIndexOf` arm. Routed here (instead of the
+        // string `lastIndexOf`) for known-not-string / typed-array locals.
+        Expr::ArrayLastIndexOf {
+            array,
+            value,
+            from_index,
+        } => {
+            let arr_box = lower_expr(ctx, array)?;
+            let v = lower_expr(ctx, value)?;
+            // With a fromIndex, pass has_from=1 + the lowered index; without,
+            // pass has_from=0 and reuse `v` as an ignored placeholder DOUBLE
+            // operand (runtime defaults to length-1).
+            let (from_box, has_from) = match from_index {
+                Some(fi) => (lower_expr(ctx, fi)?, "1"),
+                None => (v.clone(), "0"),
+            };
+            let blk = ctx.block();
+            let arr_handle = unbox_to_i64(blk, &arr_box);
+            let i32_v = blk.call(
+                I32,
+                "js_array_last_index_of_jsvalue",
+                &[
+                    (I64, &arr_handle),
+                    (DOUBLE, &v),
+                    (DOUBLE, &from_box),
+                    (I32, has_from),
+                ],
+            );
+            Ok(blk.sitofp(I32, &i32_v, DOUBLE))
+        }
+
         // -------- arr.forEach(callback) — invoke callback for side effects --------
         // We don't actually iterate; just lower the callback for side
         // effects (so closures get auto-collected) and return undefined.

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1585,6 +1585,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::WebCryptoUnwrapKey { .. }
         | Expr::CryptoRandomFillSync { .. }
         | Expr::ArrayIndexOf { .. }
+        | Expr::ArrayLastIndexOf { .. }
         | Expr::ArrayForEach { .. }
         | Expr::ObjectGetOwnPropertyDescriptor(..)
         | Expr::ObjectGetOwnPropertyDescriptors(..)

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1197,6 +1197,11 @@ pub enum Expr {
         array: Box<Expr>,
         value: Box<Expr>,
     }, // arr.indexOf(value) -> index
+    ArrayLastIndexOf {
+        array: Box<Expr>,
+        value: Box<Expr>,
+        from_index: Option<Box<Expr>>,
+    }, // arr.lastIndexOf(value, fromIndex?) -> index
     ArrayIncludes {
         array: Box<Expr>,
         value: Box<Expr>,

--- a/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
@@ -117,7 +117,10 @@ pub(super) fn try_local_array_methods(
                     Some(Type::Named(n))
                         if n == "Uint8Array" || n == "Buffer" || n == "Uint8ClampedArray"
                 );
-                let is_ambiguous_method = matches!(method_name, "indexOf" | "includes" | "slice");
+                let is_ambiguous_method = matches!(
+                    method_name,
+                    "indexOf" | "includes" | "slice" | "lastIndexOf"
+                );
                 let is_not_string = if is_known_string {
                     false // definitely a string, skip array block
                 } else if is_user_class_instance {
@@ -205,6 +208,23 @@ pub(super) fn try_local_array_methods(
                                     return Ok(Ok(Expr::ArrayIncludes {
                                         array: Box::new(Expr::LocalGet(array_id)),
                                         value: Box::new(args.into_iter().next().unwrap()),
+                                    }));
+                                }
+                            }
+                            // arr.lastIndexOf(value, fromIndex?) — route to the
+                            // array runtime fn. Without this, a known-not-string
+                            // / typed-array local fell through to the *string*
+                            // lastIndexOf (#2457): `new Int32Array(...).lastIndexOf`
+                            // threw "(number).lastIndexOf is not a function".
+                            "lastIndexOf" => {
+                                if !args.is_empty() {
+                                    let mut it = args.into_iter();
+                                    let value = it.next().unwrap();
+                                    let from_index = it.next().map(Box::new);
+                                    return Ok(Ok(Expr::ArrayLastIndexOf {
+                                        array: Box::new(Expr::LocalGet(array_id)),
+                                        value: Box::new(value),
+                                        from_index,
                                     }));
                                 }
                             }

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -394,6 +394,17 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
             array: Box::new(substitute_expr(array, substitutions)),
             value: Box::new(substitute_expr(value, substitutions)),
         },
+        Expr::ArrayLastIndexOf {
+            array,
+            value,
+            from_index,
+        } => Expr::ArrayLastIndexOf {
+            array: Box::new(substitute_expr(array, substitutions)),
+            value: Box::new(substitute_expr(value, substitutions)),
+            from_index: from_index
+                .as_ref()
+                .map(|fi| Box::new(substitute_expr(fi, substitutions))),
+        },
         Expr::ArrayIncludes { array, value } => Expr::ArrayIncludes {
             array: Box::new(substitute_expr(array, substitutions)),
             value: Box::new(substitute_expr(value, substitutions)),

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -319,6 +319,7 @@ impl SH for Expr {
             Expr::ArrayShift(id) => { tag(h, 252); id.hash(h); }
             Expr::ArrayUnshift { array_id, value } => { tag(h, 253); array_id.hash(h); value.as_ref().hash(h); }
             Expr::ArrayIndexOf { array, value } => { tag(h, 254); array.as_ref().hash(h); value.as_ref().hash(h); }
+            Expr::ArrayLastIndexOf { array, value, from_index } => { tag(h, 11244); array.as_ref().hash(h); value.as_ref().hash(h); if let Some(fi) = from_index { tag(h, 1); fi.as_ref().hash(h); } else { tag(h, 0); } }
             Expr::ArrayIncludes { array, value } => { tag(h, 255); array.as_ref().hash(h); value.as_ref().hash(h); }
             Expr::ArraySlice { array, start, end } => { tag(h, 256); array.as_ref().hash(h); start.as_ref().hash(h); end.hash(h); }
             Expr::ArraySplice { array_id, start, delete_count, items, } => { tag(h, 257); array_id.hash(h); start.as_ref().hash(h); delete_count.hash(h); items.hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1324,6 +1324,17 @@ where
             f(array);
             f(value);
         }
+        Expr::ArrayLastIndexOf {
+            array,
+            value,
+            from_index,
+        } => {
+            f(array);
+            f(value);
+            if let Some(fi) = from_index {
+                f(fi);
+            }
+        }
         Expr::ArraySlice { array, start, end } => {
             f(array);
             f(start);

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1299,6 +1299,17 @@ where
             f(array);
             f(value);
         }
+        Expr::ArrayLastIndexOf {
+            array,
+            value,
+            from_index,
+        } => {
+            f(array);
+            f(value);
+            if let Some(fi) = from_index {
+                f(fi);
+            }
+        }
         Expr::ArraySlice { array, start, end } => {
             f(array);
             f(start);

--- a/crates/perry-runtime/src/array/search.rs
+++ b/crates/perry-runtime/src/array/search.rs
@@ -81,9 +81,41 @@ pub extern "C" fn js_array_last_index_of_jsvalue(
     if arr.is_null() {
         return -1;
     }
-    // NB: TypedArray `lastIndexOf` does NOT reach here — the HIR lowers it to
-    // the string `lastIndexOf` path (`js_string_last_index_of`), so a typed
-    // branch would be dead code. Tracked as a separate codegen-routing fix.
+    // TypedArray: backward strict-equality numeric search over the typed
+    // store (#2457 routes `Int32Array(..).lastIndexOf` here via the new
+    // `Expr::ArrayLastIndexOf` lowering). Mirrors the `indexOf` typed branch.
+    if let Some((ta, tlen)) = as_typed_array(arr) {
+        let length = tlen as i64;
+        if length == 0 {
+            return -1;
+        }
+        let start: i64 = if has_from == 0 {
+            length - 1
+        } else {
+            let n = if from_index.is_nan() {
+                0.0
+            } else {
+                from_index.trunc()
+            };
+            if n >= length as f64 {
+                length - 1
+            } else if n >= 0.0 {
+                n as i64
+            } else if n >= -(length as f64) {
+                length + (n as i64)
+            } else {
+                return -1;
+            }
+        };
+        let mut i = start;
+        while i >= 0 {
+            if crate::typedarray::js_typed_array_get(ta, i as i32) == value {
+                return i as i32;
+            }
+            i -= 1;
+        }
+        return -1;
+    }
     unsafe {
         let length = (*arr).length as i64;
         if length == 0 {
@@ -214,5 +246,25 @@ mod typed_search_tests {
         assert_eq!(js_array_includes_jsvalue(arr, f64::NAN), 1);
         assert_eq!(js_array_indexOf_jsvalue(arr, f64::NAN), -1);
         assert_eq!(js_array_indexOf_jsvalue(arr, 2.5), 2);
+    }
+
+    /// `lastIndexOf` on a registered TypedArray scans the typed backing store
+    /// backward (#2457). Without a fromIndex it starts at the last element;
+    /// with one it clamps like the array path.
+    #[test]
+    fn typed_array_last_index_of() {
+        // Int32Array([1, 2, 3, 2, 1])
+        let ta = js_typed_array_new_empty(KIND_INT32 as i32, 5);
+        for (i, v) in [1.0, 2.0, 3.0, 2.0, 1.0].iter().enumerate() {
+            js_typed_array_set(ta, i as i32, *v);
+        }
+        let arr = ta as *const ArrayHeader;
+        // no fromIndex (has_from = 0): highest match.
+        assert_eq!(js_array_last_index_of_jsvalue(arr, 2.0, 0.0, 0), 3);
+        assert_eq!(js_array_last_index_of_jsvalue(arr, 9.0, 0.0, 0), -1);
+        // fromIndex = 2: search backward from index 2.
+        assert_eq!(js_array_last_index_of_jsvalue(arr, 2.0, 2.0, 1), 1);
+        // strict equality → NaN never matches.
+        assert_eq!(js_array_last_index_of_jsvalue(arr, f64::NAN, 0.0, 0), -1);
     }
 }


### PR DESCRIPTION
Fixes #2457.

## Problem
`new Int32Array([1,2,3,2,1]).lastIndexOf(2)` threw `TypeError: (number).lastIndexOf is not a function`, while `.indexOf` / `.includes` worked (fixed in #2456).

A `--trace llvm` showed the divergence: `ta.indexOf` → `js_array_indexOf_jsvalue` (array path), but `ta.lastIndexOf` → **`js_string_last_index_of`** (string path). The HIR lowers `lastIndexOf` on a known-not-string / typed-array local to the *string* method; at runtime the typed-array pointer reads as a number, so the string dispatch throws. `indexOf`/`includes` avoided this via dedicated `Expr::ArrayIndexOf`/`ArrayIncludes` lowering — `lastIndexOf` had no equivalent.

## Fix
Add a parallel `Expr::ArrayLastIndexOf { array, value, from_index }`:
- **HIR** (`local_array_methods`): emit it for a known-not-string / typed-array local; add `lastIndexOf` to the ambiguous-method set so an *unknown*-typed local (possibly a string) still falls through to the string path.
- **Codegen** (`misc_methods`): lower to `js_array_last_index_of_jsvalue` (value + optional `fromIndex` with spec clamping), mirroring the `lower_array_method::lastIndexOf` arm.
- **Runtime** (`array/search`): re-add the typed-array branch to `js_array_last_index_of_jsvalue` (now reached) — backward strict-equality scan over the typed store via `js_typed_array_get`.
- Wire the new variant through the walkers, collectors, monomorph substitute, and stable-hash (exhaustive matches).

`Uint8Array`/`Buffer` keep their existing byte-level runtime dispatch (they skip the array block).

## Testing
- `cargo test -p perry-runtime --lib` → **795 passed, 0 failed** (adds `typed_array_last_index_of`).
- Byte-for-byte vs `node`, all match:
  - `Int32Array`/`Float64Array` `lastIndexOf` (incl. `fromIndex` and `NaN`),
  - regular-array, string, and `any`-typed-param `lastIndexOf` (unchanged — no mis-routing),
  - `Uint8Array` `lastIndexOf` (byte dispatch unchanged).

Follow-up to #2456 (TypedArray indexOf/includes); part of #2447.
