### PR TITLE
Implement FileHandle.readLines parity

### DIFF
--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -115,6 +115,26 @@ fn is_node_readable_for_await_target(ctx: &LoweringContext, expr: &ast::Expr) ->
     )
 }
 
+fn is_filehandle_readlines_for_await_target(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    matches!(
+        crate::lower_types::infer_type_from_expr(strip_for_of_expr_wrappers(expr), ctx),
+        Type::Named(name) if name == crate::lower_types::FILEHANDLE_READLINES_ITERATOR_TYPE
+    )
+}
+
+fn async_iterator_method_call(iterable: Expr) -> Expr {
+    Expr::Call {
+        callee: Box::new(Expr::IndexGet {
+            object: Box::new(iterable),
+            index: Box::new(Expr::SymbolFor(Box::new(Expr::String(
+                "@@__perry_wk_asyncIterator".to_string(),
+            )))),
+        }),
+        args: vec![],
+        type_args: vec![],
+    }
+}
+
 fn iterator_return_call(iter_id: LocalId, needs_await: bool) -> Expr {
     let call = Expr::Call {
         callee: Box::new(Expr::PropertyGet {
@@ -270,11 +290,14 @@ pub(crate) fn lower_stmt_for_of(
 
     let is_node_readable_for_await =
         for_of_stmt.is_await && is_node_readable_for_await_target(ctx, &for_of_stmt.right);
+    let is_filehandle_readlines_for_await =
+        for_of_stmt.is_await && is_filehandle_readlines_for_await_target(ctx, &for_of_stmt.right);
 
     if is_generator_call
         || iter_from_class.is_some()
         || is_timer_promises_interval_call
         || is_node_readable_for_await
+        || is_filehandle_readlines_for_await
     {
         // Lower to iterator protocol:
         //   let __iter = genFunc(...);                     // generator-fn path
@@ -293,6 +316,8 @@ pub(crate) fn lower_stmt_for_of(
                 args: vec![iter_expr],
                 type_args: vec![],
             }
+        } else if is_filehandle_readlines_for_await {
+            async_iterator_method_call(iter_expr)
         } else if is_node_readable_for_await {
             Expr::Call {
                 callee: Box::new(Expr::PropertyGet {
@@ -388,7 +413,7 @@ pub(crate) fn lower_stmt_for_of(
             lower_stmt(ctx, module, &for_of_stmt.body)?;
         }
         let mut user_body: Vec<Stmt> = module.init.drain(init_before..).collect();
-        if is_node_readable_for_await {
+        if is_node_readable_for_await || is_filehandle_readlines_for_await {
             insert_iterator_return_before_abrupts(&mut user_body, iter_id, needs_await);
         }
         body_stmts.append(&mut user_body);

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -11,6 +11,7 @@ use crate::lower::{
 use crate::lower_patterns::*;
 use crate::lower_types::*;
 
+use super::helpers::{async_iterator_method_call, is_filehandle_readlines_for_await_target};
 use super::*;
 
 fn unwrap_stream_expr(mut expr: &ast::Expr) -> &ast::Expr {
@@ -1082,11 +1083,14 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
 
             let is_node_readable_for_await =
                 for_of_stmt.is_await && is_node_readable_for_await_target(ctx, &for_of_stmt.right);
+            let is_filehandle_readlines_for_await = for_of_stmt.is_await
+                && is_filehandle_readlines_for_await_target(ctx, &for_of_stmt.right);
 
             if is_generator_call
                 || iter_from_class.is_some()
                 || is_timer_promises_interval_call
                 || is_node_readable_for_await
+                || is_filehandle_readlines_for_await
             {
                 let scope_mark = ctx.push_block_scope();
                 let iter_expr_raw = lower_expr(ctx, &for_of_stmt.right)?;
@@ -1096,6 +1100,8 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                         args: vec![iter_expr_raw],
                         type_args: vec![],
                     }
+                } else if is_filehandle_readlines_for_await {
+                    async_iterator_method_call(iter_expr_raw)
                 } else if is_node_readable_for_await {
                     Expr::Call {
                         callee: Box::new(Expr::PropertyGet {
@@ -1170,7 +1176,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     }),
                 });
                 let mut user_body = lower_body_stmt(ctx, &for_of_stmt.body)?;
-                if is_node_readable_for_await {
+                if is_node_readable_for_await || is_filehandle_readlines_for_await {
                     insert_iterator_return_before_abrupts(&mut user_body, iter_id, needs_await);
                 }
                 body_stmts.extend(user_body);

--- a/crates/perry-hir/src/lower_decl/helpers.rs
+++ b/crates/perry-hir/src/lower_decl/helpers.rs
@@ -17,6 +17,41 @@ use crate::lower::{
 use crate::lower_patterns::*;
 use crate::lower_types::*;
 
+fn strip_for_await_expr_wrappers(mut expr: &ast::Expr) -> &ast::Expr {
+    loop {
+        expr = match expr {
+            ast::Expr::TsAs(x) => &x.expr,
+            ast::Expr::TsNonNull(x) => &x.expr,
+            ast::Expr::TsConstAssertion(x) => &x.expr,
+            ast::Expr::Paren(x) => &x.expr,
+            _ => return expr,
+        };
+    }
+}
+
+pub(super) fn is_filehandle_readlines_for_await_target(
+    ctx: &LoweringContext,
+    expr: &ast::Expr,
+) -> bool {
+    matches!(
+        infer_type_from_expr(strip_for_await_expr_wrappers(expr), ctx),
+        Type::Named(name) if name == FILEHANDLE_READLINES_ITERATOR_TYPE
+    )
+}
+
+pub(super) fn async_iterator_method_call(iterable: Expr) -> Expr {
+    Expr::Call {
+        callee: Box::new(Expr::IndexGet {
+            object: Box::new(iterable),
+            index: Box::new(Expr::SymbolFor(Box::new(Expr::String(
+                "@@__perry_wk_asyncIterator".to_string(),
+            )))),
+        }),
+        args: vec![],
+        type_args: vec![],
+    }
+}
+
 /// Build `if (param === undefined) { param = default; }` stmts for every
 /// param with a default value. Prepended to function/constructor bodies so
 /// cross-module callers that pad missing args with `undefined` still observe

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -10,6 +10,8 @@ use crate::ir::*;
 use crate::lower::{lower_expr, LoweringContext};
 use crate::lower_patterns::{get_pat_name, lower_lit};
 
+pub(crate) const FILEHANDLE_READLINES_ITERATOR_TYPE: &str = "__PerryFileHandleReadLinesIterator";
+
 pub(crate) fn infer_type_from_expr(expr: &ast::Expr, ctx: &LoweringContext) -> Type {
     match expr {
         // Literals
@@ -610,6 +612,13 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                         }
                         _ => {}
                     }
+                }
+
+                // `FileHandle.readLines()` returns a readline interface whose
+                // async iterator lives behind `[Symbol.asyncIterator]()`, not
+                // as a public `.next()` method on the returned object.
+                if method_name == "readLines" {
+                    return Type::Named(FILEHANDLE_READLINES_ITERATOR_TYPE.to_string());
                 }
 
                 // String methods

--- a/crates/perry-runtime/src/fs/filehandle.rs
+++ b/crates/perry-runtime/src/fs/filehandle.rs
@@ -1,11 +1,25 @@
 //! `fs/promises.FileHandle` — per-method closures + object construction.
 
-use std::fs;
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom, Write};
 
 use crate::closure::ClosureHeader;
 
 use super::*;
+
+thread_local! {
+    static READ_LINES_REGISTRY: RefCell<HashMap<usize, ReadLinesState>> =
+        RefCell::new(HashMap::new());
+    static NEXT_READ_LINES_ID: RefCell<usize> = const { RefCell::new(1) };
+}
+
+struct ReadLinesState {
+    lines: Vec<String>,
+    index: usize,
+    fd: i32,
+    handle: f64,
+}
 
 pub(crate) unsafe fn build_file_io_result(
     count_name: &str,
@@ -29,12 +43,164 @@ pub(crate) fn make_filehandle_method(fd: i32, func: *const u8) -> f64 {
     f64::from_bits(crate::value::JSValue::pointer(closure as *const u8).bits())
 }
 
+pub(crate) fn make_filehandle_method_with_handle(fd: i32, handle: f64, func: *const u8) -> f64 {
+    let closure = crate::closure::js_closure_alloc(func, 2);
+    crate::closure::js_closure_set_capture_ptr(closure, 0, fd as i64);
+    crate::closure::js_closure_set_capture_f64(closure, 1, handle);
+    f64::from_bits(crate::value::JSValue::pointer(closure as *const u8).bits())
+}
+
 pub(crate) fn filehandle_fd(closure: *const ClosureHeader) -> i32 {
     crate::closure::js_closure_get_capture_ptr(closure, 0) as i32
 }
 
+fn filehandle_object(closure: *const ClosureHeader) -> Option<f64> {
+    if closure.is_null() {
+        return None;
+    }
+    let captures = crate::closure::real_capture_count(unsafe { (*closure).capture_count });
+    if captures < 2 {
+        return None;
+    }
+    Some(crate::closure::js_closure_get_capture_f64(closure, 1))
+}
+
+fn filehandle_field_fd(handle: f64) -> Option<i32> {
+    let ptr = crate::value::js_nanbox_get_pointer(handle);
+    if ptr < 0x1000 {
+        return None;
+    }
+    let key = crate::string::js_string_from_bytes(b"fd".as_ptr(), 2);
+    let value =
+        crate::object::js_object_get_field_by_name(ptr as *const crate::object::ObjectHeader, key);
+    let js = crate::value::JSValue::from_bits(value.bits());
+    if js.is_int32() {
+        Some(js.as_int32())
+    } else if js.is_number() {
+        Some(f64::from_bits(value.bits()) as i32)
+    } else {
+        None
+    }
+}
+
+fn set_filehandle_field_fd(handle: f64, fd: i32) {
+    let ptr = crate::value::js_nanbox_get_pointer(handle);
+    if ptr < 0x1000 {
+        return;
+    }
+    let key = crate::string::js_string_from_bytes(b"fd".as_ptr(), 2);
+    crate::object::js_object_set_field_by_name(
+        ptr as *mut crate::object::ObjectHeader,
+        key,
+        fd as f64,
+    );
+}
+
+fn close_filehandle_fd(fd: i32, handle: f64) {
+    if fd >= 0 && crate::fs::fd_is_registered(fd) {
+        let _ = js_fs_close_sync(fd as f64);
+    }
+    set_filehandle_field_fd(handle, -1);
+}
+
+fn make_read_lines_method(id: usize, func: *const u8) -> f64 {
+    let closure = crate::closure::js_closure_alloc(func, 1);
+    crate::closure::js_closure_set_capture_ptr(closure, 0, id as i64);
+    f64::from_bits(crate::value::JSValue::pointer(closure as *const u8).bits())
+}
+
+fn read_lines_id(closure: *const ClosureHeader) -> usize {
+    crate::closure::js_closure_get_capture_ptr(closure, 0) as usize
+}
+
+fn build_read_lines_step(value: f64, done: bool) -> f64 {
+    let obj = crate::object::js_object_alloc(0, 2);
+    let set = |name: &[u8], v: f64| {
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        crate::object::js_object_set_field_by_name(obj, key, v);
+    };
+    set(b"value", value);
+    set(
+        b"done",
+        f64::from_bits(if done {
+            crate::value::TAG_TRUE
+        } else {
+            crate::value::TAG_FALSE
+        }),
+    );
+    f64::from_bits(crate::value::JSValue::pointer(obj as *const u8).bits())
+}
+
+extern "C" fn read_lines_next_impl(closure: *const ClosureHeader, _arg: f64) -> f64 {
+    let id = read_lines_id(closure);
+    let next_line = READ_LINES_REGISTRY.with(|states| {
+        let mut states = states.borrow_mut();
+        let Some(state) = states.get_mut(&id) else {
+            return None;
+        };
+        if state.index >= state.lines.len() {
+            close_filehandle_fd(state.fd, state.handle);
+            states.remove(&id);
+            return None;
+        }
+        let line = state.lines[state.index].clone();
+        state.index += 1;
+        Some(line)
+    });
+    let Some(line) = next_line else {
+        return promise_value_fs(build_read_lines_step(
+            f64::from_bits(crate::value::TAG_UNDEFINED),
+            true,
+        ));
+    };
+    let s = js_string_from_bytes(line.as_ptr(), line.len() as u32);
+    let value = f64::from_bits(crate::value::JSValue::string_ptr(s).bits());
+    promise_value_fs(build_read_lines_step(value, false))
+}
+
+extern "C" fn read_lines_return_impl(closure: *const ClosureHeader, _arg: f64) -> f64 {
+    READ_LINES_REGISTRY.with(|states| {
+        states.borrow_mut().remove(&read_lines_id(closure));
+    });
+    promise_value_fs(build_read_lines_step(
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+        true,
+    ))
+}
+
+extern "C" fn read_lines_close_impl(closure: *const ClosureHeader) -> f64 {
+    READ_LINES_REGISTRY.with(|states| {
+        states.borrow_mut().remove(&read_lines_id(closure));
+    });
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+extern "C" fn read_lines_iterator_impl(closure: *const ClosureHeader) -> f64 {
+    f64::from_bits(crate::closure::js_closure_get_capture_ptr(closure, 0) as u64)
+}
+
+fn install_read_lines_async_iterator(target: f64, iterator: f64) {
+    let async_iterator = crate::symbol::well_known_symbol("asyncIterator");
+    if async_iterator.is_null() {
+        return;
+    }
+    let closure = crate::closure::js_closure_alloc(read_lines_iterator_impl as *const u8, 1);
+    crate::closure::js_closure_set_capture_ptr(closure, 0, iterator.to_bits() as i64);
+    let closure_value = f64::from_bits(crate::value::JSValue::pointer(closure as *const u8).bits());
+    let symbol_value =
+        f64::from_bits(crate::value::JSValue::pointer(async_iterator as *const u8).bits());
+    unsafe {
+        crate::symbol::js_object_set_symbol_property(target, symbol_value, closure_value);
+    }
+}
+
 pub(crate) extern "C" fn filehandle_close_impl(closure: *const ClosureHeader) -> f64 {
-    let _ = js_fs_close_sync(filehandle_fd(closure) as f64);
+    let fd = filehandle_fd(closure);
+    if let Some(handle) = filehandle_object(closure) {
+        close_filehandle_fd(filehandle_field_fd(handle).unwrap_or(fd), handle);
+        return promise_undefined_fs();
+    }
+    let _ = js_fs_close_sync(fd as f64);
     promise_undefined_fs()
 }
 
@@ -309,91 +475,187 @@ pub(crate) extern "C" fn filehandle_create_write_stream_impl(
     }
 }
 
+pub(crate) extern "C" fn filehandle_read_lines_impl(
+    closure: *const ClosureHeader,
+    options: f64,
+) -> f64 {
+    let fallback_fd = filehandle_fd(closure);
+    let handle = filehandle_object(closure).unwrap_or(f64::from_bits(crate::value::TAG_UNDEFINED));
+    let fd = filehandle_field_fd(handle).unwrap_or(fallback_fd);
+    if !fd_is_registered(fd) {
+        crate::fs::validate::throw_range_error_with_code(
+            "The value of \"fd\" is out of range. It must be >= 0 && <= 2147483647. Received -1",
+        );
+    }
+
+    let bytes = FD_REGISTRY.with(|r| {
+        let mut reg = r.borrow_mut();
+        let mut bytes = Vec::new();
+        let Some(file) = reg.get_mut(&fd) else {
+            return bytes;
+        };
+        let start = unsafe { options_number_field(options, b"start") }
+            .filter(|n| n.is_finite() && *n >= 0.0)
+            .map(|n| n as u64);
+        let end = unsafe { options_number_field(options, b"end") }
+            .filter(|n| n.is_finite() && *n >= 0.0)
+            .map(|n| n as u64);
+        if let Some(start) = start {
+            let _ = file.seek(SeekFrom::Start(start));
+        }
+        if let Some(end) = end {
+            let start_for_len = start.unwrap_or(0);
+            if end >= start_for_len {
+                let max_len = end.saturating_sub(start_for_len).saturating_add(1);
+                let _ = Read::by_ref(file).take(max_len).read_to_end(&mut bytes);
+            }
+        } else {
+            let _ = file.read_to_end(&mut bytes);
+        }
+        bytes
+    });
+    let text = String::from_utf8_lossy(&bytes);
+    let lines = text.lines().map(ToOwned::to_owned).collect::<Vec<_>>();
+    let id = NEXT_READ_LINES_ID.with(|next| {
+        let mut next = next.borrow_mut();
+        let id = *next;
+        *next = next.saturating_add(1);
+        id
+    });
+    READ_LINES_REGISTRY.with(|states| {
+        states.borrow_mut().insert(
+            id,
+            ReadLinesState {
+                lines,
+                index: 0,
+                fd,
+                handle,
+            },
+        );
+    });
+
+    let iterator_obj = crate::object::js_object_alloc(0, 2);
+    let set_iterator = |name: &str, v: f64| {
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        crate::object::js_object_set_field_by_name(iterator_obj, key, v);
+    };
+    set_iterator(
+        "next",
+        make_read_lines_method(id, read_lines_next_impl as *const u8),
+    );
+    set_iterator(
+        "return",
+        make_read_lines_method(id, read_lines_return_impl as *const u8),
+    );
+    let iterator = f64::from_bits(crate::value::JSValue::pointer(iterator_obj as *const u8).bits());
+    install_read_lines_async_iterator(iterator, iterator);
+
+    let interface_obj = crate::object::js_object_alloc(0, 1);
+    let close_key = crate::string::js_string_from_bytes(b"close".as_ptr(), 5);
+    crate::object::js_object_set_field_by_name(
+        interface_obj,
+        close_key,
+        make_read_lines_method(id, read_lines_close_impl as *const u8),
+    );
+    let interface =
+        f64::from_bits(crate::value::JSValue::pointer(interface_obj as *const u8).bits());
+    install_read_lines_async_iterator(interface, iterator);
+    interface
+}
+
 /// Build a minimal `fs.promises.FileHandle` object for deterministic parity.
 #[no_mangle]
 pub extern "C" fn js_fs_filehandle_open(path_value: f64, flags_value: f64) -> f64 {
     let fd = js_fs_open_sync(path_value, flags_value) as i32;
-    unsafe {
-        crate::closure::js_register_closure_arity(filehandle_stat_impl as *const u8, 1);
-        crate::closure::js_register_closure_arity(filehandle_read_impl as *const u8, 5);
-        crate::closure::js_register_closure_arity(filehandle_write_impl as *const u8, 5);
-        let obj = crate::object::js_object_alloc(0, 18);
-        let set = |name: &str, v: f64| {
-            let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-            crate::object::js_object_set_field_by_name(obj, key, v);
-        };
-        set("fd", fd as f64);
-        set(
-            "close",
-            make_filehandle_method(fd, filehandle_close_impl as *const u8),
-        );
-        set(
-            "sync",
-            make_filehandle_method(fd, filehandle_sync_impl as *const u8),
-        );
-        set(
-            "datasync",
-            make_filehandle_method(fd, filehandle_datasync_impl as *const u8),
-        );
-        set(
-            "stat",
-            make_filehandle_method(fd, filehandle_stat_impl as *const u8),
-        );
-        set(
-            "truncate",
-            make_filehandle_method(fd, filehandle_truncate_impl as *const u8),
-        );
-        set(
-            "utimes",
-            make_filehandle_method(fd, filehandle_utimes_impl as *const u8),
-        );
-        set(
-            "chmod",
-            make_filehandle_method(fd, filehandle_chmod_impl as *const u8),
-        );
-        set(
-            "chown",
-            make_filehandle_method(fd, filehandle_chown_impl as *const u8),
-        );
-        set(
-            "readFile",
-            make_filehandle_method(fd, filehandle_read_file_impl as *const u8),
-        );
-        set(
-            "writeFile",
-            make_filehandle_method(fd, filehandle_write_file_impl as *const u8),
-        );
-        set(
-            "appendFile",
-            make_filehandle_method(fd, filehandle_append_file_impl as *const u8),
-        );
-        set(
-            "read",
-            make_filehandle_method(fd, filehandle_read_impl as *const u8),
-        );
-        set(
-            "write",
-            make_filehandle_method(fd, filehandle_write_impl as *const u8),
-        );
-        set(
-            "readv",
-            make_filehandle_method(fd, filehandle_readv_impl as *const u8),
-        );
-        set(
-            "writev",
-            make_filehandle_method(fd, filehandle_writev_impl as *const u8),
-        );
-        set(
-            "createReadStream",
-            make_filehandle_method(fd, filehandle_create_read_stream_impl as *const u8),
-        );
-        set(
-            "createWriteStream",
-            make_filehandle_method(fd, filehandle_create_write_stream_impl as *const u8),
-        );
-        FILEHANDLE_OBJECT_FDS.with(|fds| {
-            fds.borrow_mut().insert(obj as usize, fd);
-        });
-        f64::from_bits(crate::value::JSValue::pointer(obj as *const u8).bits())
-    }
+    crate::closure::js_register_closure_arity(filehandle_stat_impl as *const u8, 1);
+    crate::closure::js_register_closure_arity(filehandle_read_impl as *const u8, 5);
+    crate::closure::js_register_closure_arity(filehandle_write_impl as *const u8, 5);
+    crate::closure::js_register_closure_arity(filehandle_read_lines_impl as *const u8, 1);
+    crate::closure::js_register_closure_arity(read_lines_next_impl as *const u8, 1);
+    crate::closure::js_register_closure_arity(read_lines_return_impl as *const u8, 1);
+    crate::closure::js_register_closure_arity(read_lines_close_impl as *const u8, 0);
+    crate::closure::js_register_closure_arity(read_lines_iterator_impl as *const u8, 0);
+    let obj = crate::object::js_object_alloc(0, 19);
+    let handle = f64::from_bits(crate::value::JSValue::pointer(obj as *const u8).bits());
+    let set = |name: &str, v: f64| {
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        crate::object::js_object_set_field_by_name(obj, key, v);
+    };
+    set("fd", fd as f64);
+    set(
+        "close",
+        make_filehandle_method_with_handle(fd, handle, filehandle_close_impl as *const u8),
+    );
+    set(
+        "sync",
+        make_filehandle_method(fd, filehandle_sync_impl as *const u8),
+    );
+    set(
+        "datasync",
+        make_filehandle_method(fd, filehandle_datasync_impl as *const u8),
+    );
+    set(
+        "stat",
+        make_filehandle_method(fd, filehandle_stat_impl as *const u8),
+    );
+    set(
+        "truncate",
+        make_filehandle_method(fd, filehandle_truncate_impl as *const u8),
+    );
+    set(
+        "utimes",
+        make_filehandle_method(fd, filehandle_utimes_impl as *const u8),
+    );
+    set(
+        "chmod",
+        make_filehandle_method(fd, filehandle_chmod_impl as *const u8),
+    );
+    set(
+        "chown",
+        make_filehandle_method(fd, filehandle_chown_impl as *const u8),
+    );
+    set(
+        "readFile",
+        make_filehandle_method(fd, filehandle_read_file_impl as *const u8),
+    );
+    set(
+        "writeFile",
+        make_filehandle_method(fd, filehandle_write_file_impl as *const u8),
+    );
+    set(
+        "appendFile",
+        make_filehandle_method(fd, filehandle_append_file_impl as *const u8),
+    );
+    set(
+        "read",
+        make_filehandle_method(fd, filehandle_read_impl as *const u8),
+    );
+    set(
+        "write",
+        make_filehandle_method(fd, filehandle_write_impl as *const u8),
+    );
+    set(
+        "readv",
+        make_filehandle_method(fd, filehandle_readv_impl as *const u8),
+    );
+    set(
+        "writev",
+        make_filehandle_method(fd, filehandle_writev_impl as *const u8),
+    );
+    set(
+        "createReadStream",
+        make_filehandle_method(fd, filehandle_create_read_stream_impl as *const u8),
+    );
+    set(
+        "createWriteStream",
+        make_filehandle_method(fd, filehandle_create_write_stream_impl as *const u8),
+    );
+    set(
+        "readLines",
+        make_filehandle_method_with_handle(fd, handle, filehandle_read_lines_impl as *const u8),
+    );
+    FILEHANDLE_OBJECT_FDS.with(|fds| {
+        fds.borrow_mut().insert(obj as usize, fd);
+    });
+    handle
 }

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -1396,7 +1396,7 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 
 ### node:fs/promises
 
-**Gap APIs: 47** · Already covered: 14
+**Gap APIs: 46** · Already covered: 15
 
 #### Missing from Perry
 
@@ -1436,7 +1436,6 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 - `filehandle.read([options])`
 - `filehandle.read(buffer[, options])`
 - `filehandle.readableWebStream([options])`
-- `filehandle.readLines([options])`
 - `filehandle.readv(buffers[, position])`
 - `filehandle.sync()`
 - `filehandle.truncate(len)`
@@ -1463,6 +1462,7 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 | `filehandle.appendFile(data[, options])` | `manifest:fs.appendFile` |
 | `filehandle.createReadStream([options])` | `manifest:fs.createReadStream` |
 | `filehandle.createWriteStream([options])` | `manifest:fs.createWriteStream` |
+| `filehandle.readLines([options])` | `ffi:js_fs_filehandle_open` |
 | `filehandle.readFile(options)` | `manifest:fs.readFile` |
 | `filehandle.stat([options])` | `manifest:fs.stat` |
 | `filehandle.writeFile(data, options)` | `manifest:fs.writeFile` |

--- a/test-parity/node-suite/fs-promises/README.md
+++ b/test-parity/node-suite/fs-promises/README.md
@@ -8,4 +8,4 @@ Current coverage includes deterministic import-shape parity plus functional
 Promise operations for read/write/append including Buffer data, directory mutation, recursive readdir, stats/lstat, chmod,
 copy/recursive copy, links/symlinks/readlink, truncate, mkdtemp, rm/rmdir/unlink,
 rename, access, statfs, glob/watch import surface, opendir/Dir, utimes/lutimes, and a first FileHandle subset (`open`, `readFile`,
-`writeFile`, `appendFile`, `read`, `write`, `readv`, `writev`, `stat`, `chmod`, `utimes`, `truncate`, `sync`, `close`). FileHandle stream behavior is covered for createReadStream/createWriteStream; readLines remains future work.
+`writeFile`, `appendFile`, `read`, `write`, `readv`, `writev`, `stat`, `chmod`, `utimes`, `truncate`, `sync`, `close`, `readLines`). FileHandle stream behavior is covered for createReadStream/createWriteStream; broader readline integration remains future work.

--- a/test-parity/node-suite/fs-promises/basic/filehandle-readlines.ts
+++ b/test-parity/node-suite/fs-promises/basic/filehandle-readlines.ts
@@ -1,0 +1,58 @@
+import * as fsp from "node:fs/promises";
+
+(process as any).emitWarning = () => {};
+
+const ROOT = "/tmp/perry_node_suite_fs_promises_filehandle_readlines";
+try { await fsp.rm(ROOT, { recursive: true, force: true }); } catch (_e) {}
+await fsp.mkdir(ROOT, { recursive: true });
+
+async function collect(path: string, options?: { encoding?: BufferEncoding; start?: number; end?: number }) {
+  const fh = await fsp.open(path, "r");
+  try {
+    const lines = fh.readLines(options);
+    console.log("fh readLines typeof:", typeof fh.readLines);
+    console.log("fh readLines next:", typeof (lines as any).next);
+    console.log("fh readLines close:", typeof (lines as any).close);
+    console.log("fh readLines asyncIterator:", typeof (lines as any)[Symbol.asyncIterator]);
+    const out: string[] = [];
+    for await (const line of lines) out.push(line);
+    return out;
+  } finally {
+    await fh.close();
+  }
+}
+
+const multi = ROOT + "/multi.txt";
+await fsp.writeFile(multi, "alpha\nbeta\n", "utf8");
+console.log("fh readLines multi:", JSON.stringify(await collect(multi, { encoding: "utf8" })));
+
+const empty = ROOT + "/empty.txt";
+await fsp.writeFile(empty, "", "utf8");
+console.log("fh readLines empty:", JSON.stringify(await collect(empty)));
+
+const final = ROOT + "/final.txt";
+await fsp.writeFile(final, "last-line", "utf8");
+console.log("fh readLines final:", JSON.stringify(await collect(final)));
+
+const range = ROOT + "/range.txt";
+await fsp.writeFile(range, "zero\none\ntwo\nthree", "utf8");
+console.log("fh readLines range:", JSON.stringify(await collect(range, { encoding: "utf8", start: 5, end: 11 })));
+
+const early = await fsp.open(multi, "r");
+const earlyLines: string[] = [];
+for await (const line of early.readLines()) {
+  earlyLines.push(line);
+  break;
+}
+console.log("fh readLines early break:", JSON.stringify(earlyLines), early.fd >= 0 ? "open" : "closed");
+await early.close();
+
+const closed = await fsp.open(multi, "r");
+await closed.close();
+try {
+  closed.readLines();
+  console.log("fh readLines closed:", "none");
+} catch (e) {
+  const err = e as NodeJS.ErrnoException;
+  console.log("fh readLines closed:", `${err.name}:${err.code}:${err.message.split("\n")[0]}`);
+}

--- a/test-parity/node-suite/fs/STATUS.md
+++ b/test-parity/node-suite/fs/STATUS.md
@@ -22,7 +22,7 @@ These areas are intentionally left as follow-up work because they require larger
 
 1. Real `fs.watch`, `fs.watchFile`, and `fs.promises.watch` event delivery, including recursive watching, abort signals, and async iterator behavior.
 2. Advanced `glob` semantics: async iterators, arrays of patterns, `exclude`, `withFileTypes`, brace/extglob edge cases, and broader cwd/pathlike validation.
-3. Full FileHandle coverage such as `readLines`, readline integration, and more stream lifecycle/error cases.
+3. Full FileHandle coverage such as readline integration and more stream lifecycle/error cases.
 4. `writeFile` and FileHandle write inputs from streams, async iterables, iterables, and abort signals.
 5. Node-perfect `cp` behavior for async filters, exact validation/errors, symlink cycles, subdirectory guards, mode/reflink semantics, and conflict handling.
 6. Node-perfect errors across fs APIs: exact error type, `code`, `errno`, `path`, `dest`, and `syscall` fields.


### PR DESCRIPTION
Closes #2478.

## Summary
- Add FileHandle.readLines runtime support with a readline-style async iterable interface, close method, range reads, and closed-fd validation.
- Teach for-await lowering to drive FileHandle.readLines through [Symbol.asyncIterator]() before calling next().
- Add fs/promises parity coverage and update parity gap docs.

## Verification
- cargo fmt --all -- --check
- ./scripts/check_file_size.sh
- git diff --check
- ./run_parity_tests.sh --suite node-suite --module fs-promises --filter filehandle-readlines (1/1 pass)
- ./run_parity_tests.sh --suite node-suite --module fs-promises --filter filehandle (14/14 pass)