### PR TITLE
fix(compile): canonicalize exe so a symlinked perry finds the workspace (#2531)

### DIFF
--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -46,34 +46,56 @@ pub(super) use native_library::{
 #[cfg(test)]
 use native_library::{split_module_spec, PERRY_FFI_ABI_VERSION};
 
+/// True when `dir` is the root of the Perry workspace (carries the
+/// marker crates the auto-optimize relink reaches for).
+fn is_perry_workspace_root(dir: &Path) -> bool {
+    dir.join("crates/perry-runtime").is_dir() && dir.join("crates/perry-ui-geisterhand").is_dir()
+}
+
+/// Locate the workspace root by walking up from the perry executable.
+///
+/// A `cargo`/dev install typically exposes `perry` as a **symlink**
+/// (e.g. `~/.cargo/bin/perry -> .../target/release/perry`).
+/// `std::env::current_exe()` returns that symlink path on macOS, so the
+/// `../../` walk would otherwise climb `~/.cargo/bin → ~/.cargo → ~` and
+/// never reach the workspace — silently dropping the per-feature
+/// `perry-ext-*` libs at link time (issue #2531; same class as #846,
+/// whose auto-optimize fix the symlink defeated). Canonicalize the exe
+/// first so the walk starts from the real `target/release/perry`.
+fn workspace_root_from_exe(exe: &Path) -> Option<PathBuf> {
+    let exe = std::fs::canonicalize(exe).unwrap_or_else(|_| exe.to_path_buf());
+    let dir = exe.parent()?;
+    // Binary in target/release/ → workspace is ../../
+    for ancestor in [
+        dir.to_path_buf(),
+        dir.join(".."),
+        dir.join("../.."),
+        dir.join("../../.."),
+    ] {
+        // A missing/uncanonicalizable ancestor must be skipped, not abort
+        // the whole search — otherwise the cwd fallback below never runs.
+        if let Ok(candidate) = std::fs::canonicalize(&ancestor) {
+            if is_perry_workspace_root(&candidate) {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
 /// Find the Perry workspace root by searching upward from the executable location.
 pub fn find_perry_workspace_root() -> Option<PathBuf> {
     // First try: relative to the perry executable
     if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            // Binary in target/release/ → workspace is ../../
-            for ancestor in [
-                dir,
-                &dir.join(".."),
-                &dir.join("../.."),
-                &dir.join("../../.."),
-            ] {
-                let candidate = std::fs::canonicalize(ancestor).ok()?;
-                if candidate.join("crates/perry-runtime").is_dir()
-                    && candidate.join("crates/perry-ui-geisterhand").is_dir()
-                {
-                    return Some(candidate);
-                }
-            }
+        if let Some(root) = workspace_root_from_exe(&exe) {
+            return Some(root);
         }
     }
     // Second try: current working directory or its ancestors
     if let Ok(cwd) = std::env::current_dir() {
         let mut dir = cwd.as_path();
         loop {
-            if dir.join("crates/perry-runtime").is_dir()
-                && dir.join("crates/perry-ui-geisterhand").is_dir()
-            {
+            if is_perry_workspace_root(dir) {
                 return Some(dir.to_path_buf());
             }
             dir = dir.parent()?;

--- a/crates/perry/src/commands/compile/resolve/tests.rs
+++ b/crates/perry/src/commands/compile/resolve/tests.rs
@@ -1,5 +1,64 @@
 use super::*;
 
+/// Issue #2531 — a symlinked `perry` (the `cargo`/dev-install default,
+/// e.g. `~/.cargo/bin/perry -> .../target/release/perry`) must still
+/// locate the workspace root. Without canonicalizing the exe first, the
+/// `../../` walk climbs the symlink's own ancestors and misses the
+/// workspace, silently dropping the per-feature `perry-ext-*` libs.
+#[cfg(unix)]
+mod workspace_root_symlink_tests {
+    use super::super::workspace_root_from_exe;
+
+    #[test]
+    fn symlinked_exe_resolves_to_workspace_root() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+
+        // Lay out a fake workspace: <root>/target/release/perry plus the
+        // two marker crates the detector keys off of.
+        let real_dir = root.join("target/release");
+        std::fs::create_dir_all(&real_dir).expect("mkdir target/release");
+        let real_exe = real_dir.join("perry");
+        std::fs::write(&real_exe, b"#!/bin/true\n").expect("write exe");
+        std::fs::create_dir_all(root.join("crates/perry-runtime")).expect("mkdir runtime");
+        std::fs::create_dir_all(root.join("crates/perry-ui-geisterhand")).expect("mkdir gh");
+
+        // Install perry as a symlink under a sibling "bin" dir whose
+        // ancestors contain no workspace markers (mimics ~/.cargo/bin).
+        let bin_dir = root.join("bin");
+        std::fs::create_dir_all(&bin_dir).expect("mkdir bin");
+        let link = bin_dir.join("perry");
+        std::os::unix::fs::symlink(&real_exe, &link).expect("symlink");
+
+        let found = workspace_root_from_exe(&link).expect("workspace root via symlink");
+        assert_eq!(
+            found,
+            std::fs::canonicalize(root).expect("canonicalize root")
+        );
+    }
+
+    #[test]
+    fn missing_ancestor_does_not_abort_before_match() {
+        // The real binary lives at <root>/target/release/perry; the
+        // deeper `../../../..` ancestor may climb above the tempdir but
+        // must not bail before the `../..` match at the workspace root.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let real_dir = root.join("target/release");
+        std::fs::create_dir_all(&real_dir).expect("mkdir target/release");
+        let real_exe = real_dir.join("perry");
+        std::fs::write(&real_exe, b"#!/bin/true\n").expect("write exe");
+        std::fs::create_dir_all(root.join("crates/perry-runtime")).expect("mkdir runtime");
+        std::fs::create_dir_all(root.join("crates/perry-ui-geisterhand")).expect("mkdir gh");
+
+        let found = workspace_root_from_exe(&real_exe).expect("workspace root");
+        assert_eq!(
+            found,
+            std::fs::canonicalize(root).expect("canonicalize root")
+        );
+    }
+}
+
 #[cfg(test)]
 mod abi_validation_tests {
     use super::*;


### PR DESCRIPTION
## Summary

Fixes #2531. When `perry` is installed as a **symlink** (the cargo/dev-install default, e.g. `~/.cargo/bin/perry -> .../target/release/perry`), `find_perry_workspace_root()` failed to locate the workspace. `std::env::current_exe()` returns the symlink path on macOS, so the `../../` walk climbed the symlink's own ancestors (`~/.cargo/bin → ~/.cargo → ~`), never reached the workspace, and the compiler silently fell back to linking **only** `libperry_runtime.a + libperry_stdlib.a` — dropping every per-feature `perry-ext-*` lib. Any program using a `perry-ext-*`-provided API (e.g. the `node:http` server) then failed to link.

This is the same class as #846, whose auto-optimize fix the symlink defeated.

## Fix

- Canonicalize the exe **before** taking `.parent()` so a symlinked install resolves to the real `target/release/perry` and the walk reaches the workspace root.
- Stop the per-ancestor canonicalize from aborting the whole search. It used `.ok()?`, which returned `None` from the entire function — skipping the cwd fallback — when any ancestor was missing/uncanonicalizable. Now a bad ancestor is skipped instead.
- Extracted `workspace_root_from_exe` / `is_perry_workspace_root` so the exe-walk is unit-testable without depending on the real `current_exe()`.

## Tests

New `workspace_root_symlink_tests` (unix-gated):
- `symlinked_exe_resolves_to_workspace_root` — a fake workspace with `perry` reached via a symlink under a marker-less `bin/` dir resolves to the real root.
- `missing_ancestor_does_not_abort_before_match` — a deep ancestor that climbs above the tempdir doesn't bail before the match.

Also verified end-to-end against the issue repro: compiling the `node:http` example through a symlinked `perry` now builds + links `libperry_ext_http.a` and produces the executable (previously: "workspace source not found" + undefined `_js_node_http_*` symbols).
