### PR TITLE
fix(hir): unwrap non-null/paren around update operand (#2530)

### DIFF
--- a/crates/perry-hir/src/lower/expr_misc.rs
+++ b/crates/perry-hir/src/lower/expr_misc.rs
@@ -88,7 +88,18 @@ pub(super) fn lower_update(ctx: &mut LoweringContext, update: &ast::UpdateExpr) 
         ast::UpdateOp::MinusMinus => BinaryOp::Sub,
     };
 
-    match update.arg.as_ref() {
+    // Unwrap compile-time-only wrappers: `obj.x!++` (TS non-null assertion) and
+    // `(obj.x)++` (parenthesized) are transparent to update-expression lowering.
+    let mut arg = update.arg.as_ref();
+    loop {
+        match arg {
+            ast::Expr::TsNonNull(inner) => arg = inner.expr.as_ref(),
+            ast::Expr::Paren(inner) => arg = inner.expr.as_ref(),
+            _ => break,
+        }
+    }
+
+    match arg {
         // Simple identifier: x++ or ++x
         ast::Expr::Ident(ident) => {
             let name = ident.sym.to_string();

--- a/test-files/test_gap_2530_nonnull_update.ts
+++ b/test-files/test_gap_2530_nonnull_update.ts
@@ -1,0 +1,33 @@
+// #2530 — update expression (`++`/`--`) on a non-null-asserted member.
+// `obj.x!++` is valid TS: the `!` (TSNonNullExpression) is a compile-time-only
+// assertion and must be transparent to update-expression lowering. Perry used
+// to reject it with U006 ("Update expression only supports identifiers and
+// member expressions") because the wrapper wasn't unwrapped before the
+// identifier/member check. Parenthesized operands `(obj.x)++` are the same case.
+// Output is byte-for-byte vs `node --experimental-strip-types`.
+
+const counts: Record<string, number> = { roles: 0 };
+counts.roles!++;
+console.log(counts.roles); // 1
+
+let obj = { count: 5 };
+obj.count!--;
+console.log(obj.count); // 4
+
+// Prefix form on a non-null-asserted member.
+++obj.count!;
+console.log(obj.count); // 5
+
+// Parenthesized operand.
+(obj.count)++;
+console.log(obj.count); // 6
+
+// Computed member with non-null assertion.
+const arr: number[] = [10];
+arr[0]!++;
+console.log(arr[0]); // 11
+
+// Plain identifier with non-null assertion still works.
+let n: number = 41;
+n!++;
+console.log(n); // 42


### PR DESCRIPTION
## Summary

Fixes #2530 — `perry check`/`compile` rejected an update expression (`++`/`--`) whose operand is a non-null assertion on a member, e.g. `counts.roles!++`, with **U006** ("Update expression only supports identifiers and member expressions"). This is valid TypeScript and common when bumping an optionally-typed counter.

## Root cause

`lower_update` (`crates/perry-hir/src/lower/expr_misc.rs`) matched directly on `update.arg`. The TS non-null assertion `!` parses as a `TSNonNullExpression` wrapping the member, so `counts.roles!` was neither a bare `Ident` nor a `Member` and fell through to the U006 error. Parenthesized operands `(obj.x)++` hit the same path.

## Fix

Unwrap the compile-time-only wrappers (`TsNonNull`, `Paren`) around the operand in a small loop before the identifier/member check, so the assertion is transparent to update-expression lowering — exactly matching `obj.x++`.

## Validation

Added `test-files/test_gap_2530_nonnull_update.ts` covering postfix/prefix, dotted/computed members, parenthesized, and plain-identifier non-null operands. Output is byte-for-byte identical to `node --experimental-strip-types`:

```
1
4
5
6
11
42
```

`cargo fmt --all -- --check` clean.
