### PR TITLE
Tighten FileHandle.readLines type inference

### DIFF
--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -259,6 +259,9 @@ pub(crate) fn lower_module_decl(
                         } else {
                             // Namespace import from JS module - register so calls resolve to ExternFuncRef
                             ctx.register_imported_func(local.clone(), local.clone());
+                            if source == "fs/promises" {
+                                ctx.register_builtin_module_alias(local.clone(), source.clone());
+                            }
                             // Record that `local` is a module namespace (not a
                             // class). `local.member(args)` must call the member,
                             // not lower to StaticMethodCall — see the heuristic

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -12,6 +12,14 @@ use crate::lower_patterns::{get_pat_name, lower_lit};
 
 pub(crate) const FILEHANDLE_READLINES_ITERATOR_TYPE: &str = "__PerryFileHandleReadLinesIterator";
 
+fn is_fs_promises_module(module: &str) -> bool {
+    module.strip_prefix("node:").unwrap_or(module) == "fs/promises"
+}
+
+fn filehandle_type() -> Type {
+    Type::Named("FileHandle".to_string())
+}
+
 pub(crate) fn infer_type_from_expr(expr: &ast::Expr, ctx: &LoweringContext) -> Type {
     match expr {
         // Literals
@@ -536,6 +544,12 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
         // Direct function call: foo()
         ast::Expr::Ident(ident) => {
             let name = ident.sym.as_ref();
+            if matches!(
+                ctx.lookup_native_module(name),
+                Some((module, Some("open"))) if is_fs_promises_module(module)
+            ) {
+                return Type::Promise(Box::new(filehandle_type()));
+            }
             // Check user-defined function return types
             if let Some(ty) = ctx.lookup_func_return_type(name) {
                 return ty.clone();
@@ -554,6 +568,19 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
         ast::Expr::Member(member) => {
             if let ast::MemberProp::Ident(method) = &member.prop {
                 let method_name = method.sym.as_ref();
+                if method_name == "open" {
+                    if let ast::Expr::Ident(obj) = member.obj.as_ref() {
+                        let namespace_is_fs_promises = matches!(
+                            ctx.lookup_native_module(obj.sym.as_ref()),
+                            Some((module, None)) if is_fs_promises_module(module)
+                        ) || ctx
+                            .lookup_builtin_module_alias(obj.sym.as_ref())
+                            .is_some_and(is_fs_promises_module);
+                        if namespace_is_fs_promises {
+                            return Type::Promise(Box::new(filehandle_type()));
+                        }
+                    }
+                }
                 let obj_ty = infer_type_from_expr(&member.obj, ctx);
 
                 // Phase 4.1: user class methods. When the receiver is typed
@@ -578,6 +605,9 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                     match (class_name.as_str(), method_name) {
                         ("TextEncoder", "encode") => return Type::Named("Uint8Array".into()),
                         ("TextDecoder", "decode") => return Type::String,
+                        ("FileHandle", "readLines") => {
+                            return Type::Named(FILEHANDLE_READLINES_ITERATOR_TYPE.to_string());
+                        }
                         (
                             "Readable",
                             "map" | "filter" | "flatMap" | "take" | "drop" | "compose",
@@ -612,13 +642,6 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                         }
                         _ => {}
                     }
-                }
-
-                // `FileHandle.readLines()` returns a readline interface whose
-                // async iterator lives behind `[Symbol.asyncIterator]()`, not
-                // as a public `.next()` method on the returned object.
-                if method_name == "readLines" {
-                    return Type::Named(FILEHANDLE_READLINES_ITERATOR_TYPE.to_string());
                 }
 
                 // String methods

--- a/test-parity/node-suite/fs-promises/basic/filehandle-readlines.ts
+++ b/test-parity/node-suite/fs-promises/basic/filehandle-readlines.ts
@@ -1,4 +1,5 @@
 import * as fsp from "node:fs/promises";
+import { open as openFile } from "node:fs/promises";
 
 (process as any).emitWarning = () => {};
 
@@ -46,6 +47,14 @@ for await (const line of early.readLines()) {
 }
 console.log("fh readLines early break:", JSON.stringify(earlyLines), early.fd >= 0 ? "open" : "closed");
 await early.close();
+
+const named = await openFile(multi, "r");
+const namedLines: string[] = [];
+for await (const line of named.readLines()) {
+  namedLines.push(line);
+}
+console.log("fh readLines named import:", JSON.stringify(namedLines));
+await named.close();
 
 const closed = await fsp.open(multi, "r");
 await closed.close();


### PR DESCRIPTION
Follow-up to #2526 / #2478.

## Summary
- infer `FileHandle` for `fs/promises` `open()` namespace and named imports
- scope the `readLines()` async-iterator marker to `FileHandle` receivers instead of every method named `readLines`
- extend `FileHandle.readLines` parity coverage for named `open` imports

## Verification
- `node --experimental-strip-types test-parity/node-suite/fs-promises/basic/filehandle-readlines.ts`
- `env RUSTC_WRAPPER= cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `git diff --check`
- `env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs-promises --filter filehandle-readlines`
- `env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs-promises --filter filehandle`
