### PR TITLE
fix(runtime): built-in prototype methods are non-enumerable (spec descriptor)

### DIFF
--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -628,6 +628,16 @@ fn install_proto_method(
     let key = crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
     let value = crate::value::js_nanbox_pointer(closure as i64);
     js_object_set_field_by_name(proto_obj, key, value);
+    // Built-in prototype methods are `{ writable: true, enumerable: false,
+    // configurable: true }` per spec. Record that descriptor (reflection-only,
+    // no hot-path gate flip) so `Object.getOwnPropertyDescriptor`, `Object.keys`
+    // and `for-in` all observe them as non-enumerable — Test262's `verifyProperty`
+    // checks every built-in method this way. See `set_builtin_property_attrs`.
+    super::set_builtin_property_attrs(
+        proto_obj as usize,
+        method_name.to_string(),
+        super::PropertyAttrs::new(true, false, true),
+    );
 }
 
 /// Install a list of `(method_name, arity)` pairs on a prototype object,

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -538,6 +538,27 @@ pub(crate) fn set_builtin_accessor_descriptor(
     });
 }
 
+/// Install a built-in *reflection-only* data-property descriptor for (obj, key)
+/// WITHOUT flipping the process-wide `GLOBAL_DESCRIPTORS_IN_USE` /
+/// `PROPERTY_ATTRS_IN_USE` hot-path gates — the data-property analogue of
+/// [`set_builtin_accessor_descriptor`].
+///
+/// Built-in prototype methods are spec'd as `{ writable: true,
+/// enumerable: false, configurable: true }`, but `install_proto_method`
+/// stores them via the ordinary field-set path (default all-true), so
+/// `Object.getOwnPropertyDescriptor(Array.prototype, "map").enumerable` and a
+/// `for (k in Array.prototype)` scan both reported them as enumerable —
+/// failing Test262's pervasive `verifyProperty` checks. Recording a
+/// non-enumerable descriptor here fixes all three observation paths
+/// (`getOwnPropertyDescriptor`, `Object.keys`, `for-in`), each of which reads
+/// `PROPERTY_DESCRIPTORS` per-object and unconditionally. The gate stays
+/// down, so the object get/set hot path is unaffected for every program.
+pub(crate) fn set_builtin_property_attrs(obj: usize, key: String, attrs: PropertyAttrs) {
+    PROPERTY_DESCRIPTORS.with(|m| {
+        m.borrow_mut().insert((obj, key), attrs);
+    });
+}
+
 /// Walk the keys array of `obj` and apply the given attribute mask AND filter to every existing key.
 /// Used by `Object.freeze` (drops `writable` + `configurable`) and `Object.seal` (drops `configurable`).
 unsafe fn mark_all_keys(


### PR DESCRIPTION
## Summary

Built-in prototype methods (`Array`/`String`/`Number`/`Object`/`TypedArray`/… `.prototype.*`) were installed via the ordinary field-set path, which defaults to `{ writable: true, enumerable: true, configurable: true }`. Per spec they are **non-enumerable**, so Perry disagreed with Node on all three observation paths:

```js
Object.getOwnPropertyDescriptor(Array.prototype, "map").enumerable  // Perry: true,  Node: false
for (const k in Array.prototype) { /* ... */ }                      // Perry: 42 methods, Node: 0
Object.keys(Array.prototype)                                        // Perry: listed them, Node: []
```

This fails Test262's pervasive `verifyProperty` checks (every built-in method test verifies the property is non-enumerable, via both `getOwnPropertyDescriptor` and a `for-in` scan).

## Fix

Record a non-enumerable data-property descriptor at install time, via a new `set_builtin_property_attrs` helper. Like the existing #2060 built-in **accessor** path, it inserts into `PROPERTY_DESCRIPTORS` **without** flipping the process-wide `GLOBAL_DESCRIPTORS_IN_USE` hot-path gate.

This works because `getOwnPropertyDescriptor`, `Object.keys`, and `for-in` (which lowers to `Object.keys`) each read `PROPERTY_DESCRIPTORS` **per-object and unconditionally** — so they now observe `enumerable:false` — while the object get/set **hot path** keeps skipping the descriptor table for every program (no perf regression).

## Testing

Now matches Node exactly:

```
for (k in Array.prototype) → 0 keys
Object.getOwnPropertyDescriptor(Array.prototype,"map") → { writable:true, enumerable:false, configurable:true }
```

User-object `for-in` / `Object.keys` unaffected (`{a,b,c}` → `['a','b','c']`). `cargo fmt` clean.

## Scope

Foundational spec-correctness for the reflective layer. On its own it moves the Test262 conformance % only marginally (each `verifyProperty` test also gates on `writable`-via-write, `configurable`-via-delete, exact `value`, and `.name`/`.length` own-properties — all of which must pass together), but the non-enumerable descriptor is a prerequisite that every built-in-method conformance test needs.

Version bump + CHANGELOG entry omitted — please fold in at merge.
