### PR TITLE
feat(node:url): implement fileURLToPathBuffer (#2541)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2708,6 +2708,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("buffer", "kStringMaxLength"),
     // --- url (additional helpers) ---
     method("url", "fileURLToPath", false, None),
+    method("url", "fileURLToPathBuffer", false, None),
     method("url", "pathToFileURL", false, None),
     method("url", "domainToASCII", false, None),
     method("url", "domainToUnicode", false, None),

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -264,6 +264,15 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "url",
         has_receiver: false,
+        method: "fileURLToPathBuffer",
+        class_filter: None,
+        runtime: "js_url_file_url_to_path_buffer",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "url",
+        has_receiver: false,
         method: "pathToFileURL",
         class_filter: None,
         runtime: "js_url_path_to_file_url",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -503,6 +503,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     //   js_url_search_params_get_all(*mut ObjectHeader, *mut StringHeader)
     //                                                          -> f64 (NaN-boxed array)
     module.declare_function("js_url_file_url_to_path", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_url_file_url_to_path_buffer", DOUBLE, &[DOUBLE]);
     module.declare_function("js_url_get_hash", DOUBLE, &[I64]);
     module.declare_function("js_url_get_host", DOUBLE, &[I64]);
     module.declare_function("js_url_get_hostname", DOUBLE, &[I64]);

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -733,6 +733,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("url", "URL")
             | ("url", "URLSearchParams")
             | ("url", "fileURLToPath")
+            | ("url", "fileURLToPathBuffer")
             | ("url", "pathToFileURL")
             | ("url", "domainToASCII")
             | ("url", "domainToUnicode")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1145,6 +1145,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         }
         // ── url module (module-level functions return NaN-boxed JS values) ──
         ("url", "fileURLToPath") => crate::url::js_url_file_url_to_path(arg(0)),
+        ("url", "fileURLToPathBuffer") => crate::url::js_url_file_url_to_path_buffer(arg(0)),
         ("url", "pathToFileURL") => crate::url::js_url_path_to_file_url(arg(0)),
         ("url", "domainToASCII") => crate::url::js_url_domain_to_ascii(arg(0)),
         ("url", "domainToUnicode") => crate::url::js_url_domain_to_unicode(arg(0)),

--- a/crates/perry-runtime/src/url/mod.rs
+++ b/crates/perry-runtime/src/url/mod.rs
@@ -23,8 +23,9 @@ pub use self::abort::{
     js_abort_signal_is_aborted, js_abort_signal_remove_listener, js_abort_signal_timeout,
 };
 pub use self::node_compat::{
-    js_url_domain_to_ascii, js_url_domain_to_unicode, js_url_file_url_to_path, js_url_format,
-    js_url_legacy_parse, js_url_legacy_resolve, js_url_path_to_file_url, js_url_to_http_options,
+    js_url_domain_to_ascii, js_url_domain_to_unicode, js_url_file_url_to_path,
+    js_url_file_url_to_path_buffer, js_url_format, js_url_legacy_parse, js_url_legacy_resolve,
+    js_url_path_to_file_url, js_url_to_http_options,
 };
 pub use self::search_params::{
     js_url_search_params_append, js_url_search_params_delete, js_url_search_params_delete2,

--- a/crates/perry-runtime/src/url/node_compat.rs
+++ b/crates/perry-runtime/src/url/node_compat.rs
@@ -59,7 +59,10 @@ fn hex_nibble(b: u8) -> Option<u8> {
     }
 }
 
-fn decode_file_url_pathname(pathname: &str) -> String {
+/// Percent-decode a file-URL pathname to its raw byte sequence. Bytes are
+/// returned verbatim (no UTF-8 validation) so `fileURLToPathBuffer` can
+/// preserve paths whose decoded bytes are not valid UTF-8.
+fn decode_file_url_pathname_bytes(pathname: &str) -> Vec<u8> {
     let bytes = pathname.as_bytes();
     let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
@@ -80,14 +83,17 @@ fn decode_file_url_pathname(pathname: &str) -> String {
         out.push(bytes[i]);
         i += 1;
     }
-    String::from_utf8_lossy(&out).into_owned()
+    out
 }
 
-/// Convert a file:// URL to a filesystem path
-/// Strips the "file://" prefix and percent-decodes the result
-/// js_url_file_url_to_path(url_f64: f64) -> f64 (NaN-boxed string)
-#[no_mangle]
-pub extern "C" fn js_url_file_url_to_path(url_f64: f64) -> f64 {
+fn decode_file_url_pathname(pathname: &str) -> String {
+    String::from_utf8_lossy(&decode_file_url_pathname_bytes(pathname)).into_owned()
+}
+
+/// Shared `file:` URL → path parsing for both `fileURLToPath` (UTF-8 string)
+/// and `fileURLToPathBuffer` (raw bytes). Returns the decoded path bytes,
+/// throwing the same scheme/host/encoded-slash errors as Node.
+fn file_url_to_path_bytes(url_f64: f64) -> Vec<u8> {
     let url_string = object_from_f64(url_f64)
         .map(|obj| object_prop_string(obj, "href"))
         .unwrap_or_else(|| {
@@ -116,9 +122,39 @@ pub extern "C" fn js_url_file_url_to_path(url_f64: f64) -> f64 {
         after_scheme
     };
     let pathname = pathname.split(['?', '#']).next().unwrap_or_default();
+    decode_file_url_pathname_bytes(pathname)
+}
 
-    let decoded = decode_file_url_pathname(pathname);
+/// Convert a file:// URL to a filesystem path
+/// Strips the "file://" prefix and percent-decodes the result
+/// js_url_file_url_to_path(url_f64: f64) -> f64 (NaN-boxed string)
+#[no_mangle]
+pub extern "C" fn js_url_file_url_to_path(url_f64: f64) -> f64 {
+    let decoded = String::from_utf8_lossy(&file_url_to_path_bytes(url_f64)).into_owned();
     create_string_f64(&decoded)
+}
+
+/// `url.fileURLToPathBuffer(url[, options])` (#2541) — the Buffer-returning
+/// counterpart to `fileURLToPath`. Returns the decoded path's raw bytes as a
+/// `Buffer`, preserving percent-encoded sequences that are not valid UTF-8
+/// (where the string form would lossily substitute U+FFFD). Same scheme/host
+/// validation as `fileURLToPath`.
+/// js_url_file_url_to_path_buffer(url_f64: f64) -> f64 (NaN-boxed Buffer ptr)
+#[no_mangle]
+pub extern "C" fn js_url_file_url_to_path_buffer(url_f64: f64) -> f64 {
+    let bytes = file_url_to_path_bytes(url_f64);
+    let buf = crate::buffer::buffer_alloc(bytes.len() as u32);
+    unsafe {
+        (*buf).length = bytes.len() as u32;
+        if !bytes.is_empty() {
+            std::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                crate::buffer::buffer_data_mut(buf),
+                bytes.len(),
+            );
+        }
+    }
+    crate::value::js_nanbox_pointer(buf as i64)
 }
 
 #[no_mangle]

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1506 entries across 82 modules
+// Coverage: 1507 entries across 82 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -2026,6 +2026,8 @@ declare module "url" {
   export function domainToUnicode(...args: any[]): any;
   /** stdlib */
   export function fileURLToPath(...args: any[]): any;
+  /** stdlib */
+  export function fileURLToPathBuffer(...args: any[]): any;
   /** stdlib */
   export function format(...args: any[]): any;
   /** stdlib */

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -1575,7 +1575,6 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 - `urlPattern.test(input[, baseURL])`
 - `url.domainToASCII(domain)`
 - `url.domainToUnicode(domain)`
-- `url.fileURLToPathBuffer(url[, options])`
 - `url.urlToHttpOptions(url)`
 - `url.resolve(from, to)`
 

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1506 entries across 82 modules.
+Total: 1507 entries across 82 modules.
 
 ## Modules
 
@@ -1959,6 +1959,7 @@ Total: 1506 entries across 82 modules.
 - `domainToASCII` — module
 - `domainToUnicode` — module
 - `fileURLToPath` — module
+- `fileURLToPathBuffer` — module
 - `format` — module
 - `parse` — module
 - `pathToFileURL` — module

--- a/test-parity/node-suite/url/file-url-to-path-buffer.ts
+++ b/test-parity/node-suite/url/file-url-to-path-buffer.ts
@@ -1,0 +1,14 @@
+// url.fileURLToPathBuffer(url[, options]) — Buffer-returning counterpart to
+// fileURLToPath (Node 22+). Regression cover for #2541.
+import { fileURLToPath, fileURLToPathBuffer } from "node:url";
+
+console.log("is function:", typeof fileURLToPathBuffer === "function");
+const b = fileURLToPathBuffer(new URL("file:///tmp/a%20b"));
+console.log("isBuffer:", Buffer.isBuffer(b));
+console.log("value:", b.toString());
+const u = "file:///home/user/file.txt";
+console.log(
+  "matches fileURLToPath:",
+  fileURLToPathBuffer(u).equals(Buffer.from(fileURLToPath(u))),
+);
+console.log("spaces:", fileURLToPathBuffer(new URL("file:///a%20b/c")).toString());


### PR DESCRIPTION
Fixes #2541.

## Summary
Implements `url.fileURLToPathBuffer(url[, options])` (Node 22+) — the Buffer-returning counterpart to `fileURLToPath`. It was unimplemented (no manifest/dispatch entry), so named/namespace imports couldn't bind or dispatch.

## Implementation
Reuses `fileURLToPath`'s `file:` URL parsing (scheme/host/encoded-slash validation), refactored into a shared `file_url_to_path_bytes` helper returning the percent-decoded path as **raw bytes**:
- the string variant lossily UTF-8-decodes them (unchanged behavior);
- the Buffer variant copies them verbatim into a `Buffer`, so paths whose decoded bytes aren't valid UTF-8 are preserved (the whole point of the API).

Wired the standard native-module sites: runtime fn + `url` re-export, codegen extern decl + `NativeModSig` row, runtime dispatch arm, native-module value gate, and the API manifest (docs regenerated via `regen_api_docs.sh`). Removed the gap from `docs/runtime-parity-gaps.md`.

## Testing
Byte-for-byte vs `node` (v25): `typeof` is `function`; `Buffer.isBuffer(...)` true; percent-decoded spaces resolve (`file:///a%20b/c` → `/a b/c`); `fileURLToPathBuffer(u).equals(Buffer.from(fileURLToPath(u)))` for valid UTF-8 paths. Adds `test-parity/node-suite/url/file-url-to-path-buffer.ts`. fmt + file-size + api-manifest + codegen native-table tests pass locally.
