### PR TITLE
fix(stream/web): validate byte stream enqueue chunks

### DIFF
--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -297,6 +297,28 @@ unsafe fn read_bytes_from_chunk(chunk_bits: u64) -> Option<Vec<u8>> {
     Some(std::slice::from_raw_parts(data, len).to_vec())
 }
 
+unsafe fn raw_pointer_addr(bits: u64) -> Option<usize> {
+    let top = bits >> 48;
+    if top == 0x7FFD || top == 0x7FFF {
+        Some((bits & POINTER_MASK) as usize)
+    } else if top == 0 && bits >= 0x10000 {
+        Some(bits as usize)
+    } else {
+        None
+    }
+}
+
+unsafe fn is_byte_stream_enqueue_chunk(chunk_bits: u64) -> bool {
+    let Some(addr) = raw_pointer_addr(chunk_bits) else {
+        return false;
+    };
+    perry_runtime::typedarray::lookup_typed_array_kind(addr).is_some()
+        || perry_runtime::buffer::is_data_view(addr)
+        || perry_runtime::buffer::is_uint8array_buffer(addr)
+        || (perry_runtime::buffer::is_registered_buffer(addr)
+            && !perry_runtime::buffer::is_any_array_buffer(addr))
+}
+
 unsafe fn make_error_with_message(msg: &str) -> u64 {
     let s = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
     let err = perry_runtime::error::js_error_new_with_message(s);
@@ -942,6 +964,15 @@ pub unsafe extern "C" fn js_readable_stream_controller_enqueue(
 ) -> f64 {
     let id = stream_handle as usize;
     let chunk_bits = chunk.to_bits();
+    let is_byte_stream = {
+        let g = READABLE_STREAMS.lock().unwrap();
+        g.get(&id).map(|s| s.is_byte_stream).unwrap_or(false)
+    };
+    if is_byte_stream && !is_byte_stream_enqueue_chunk(chunk_bits) {
+        throw_invalid_arg_type(
+            "The \"buffer\" argument must be an instance of Buffer, TypedArray, or DataView",
+        );
+    }
     let (popped, strategy_size_cb) = {
         let mut g = READABLE_STREAMS.lock().unwrap();
         match g.get_mut(&id) {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -494,12 +494,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose(src, PassThrough) \u2014 data not preserved through PT in composite. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/web/byte-stream-non-buffer-throws": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: bytes-typed RS \u2014 enqueue(string) does not throw TypeError. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/readable/from-async-iter-mixed-values": {
     "issue": "1532",
     "added": "2026-05-24",

--- a/test-parity/node-suite/stream/web/byte-stream-non-buffer-throws.ts
+++ b/test-parity/node-suite/stream/web/byte-stream-non-buffer-throws.ts
@@ -1,5 +1,5 @@
 import { ReadableStream } from "node:stream/web";
-// A type:"bytes" ReadableStream can only enqueue ArrayBuffer/views — string throws.
+// A type:"bytes" ReadableStream can only enqueue Buffer/TypedArray/DataView chunks.
 let caught: string | null = null;
 const rs = new ReadableStream({
   type: "bytes",
@@ -7,7 +7,7 @@ const rs = new ReadableStream({
     try {
       c.enqueue("not-a-buffer" as any);
     } catch (e: any) {
-      caught = e && e.name;
+      caught = e && `${e.name}:${e.code}`;
     }
   },
 } as any);


### PR DESCRIPTION
## Summary
- validate `ReadableByteStreamController.enqueue()` chunks for byte streams before queueing or resolving reads
- accept Buffer/Uint8Array-style buffers, typed arrays, and DataView; reject strings/plain objects/bare ArrayBuffer with `TypeError [ERR_INVALID_ARG_TYPE]`
- tighten the parity fixture to assert the Node error code and remove the stale known-failure entry

## Verification
- Baseline exact `node-suite/stream/web/byte-stream-non-buffer-throws`: FAIL on origin/main, report `test-parity/reports/parity_report_20260529_100734.json`
- DeepWiki reference: `reference/deepwiki/nodejs-node-webstreams-byte-enqueue-type-2026-05-29.md`
- `./run_parity_tests.sh --suite node-suite --filter stream/web/byte-stream-non-buffer-throws`: PASS, report `test-parity/reports/parity_report_20260529_102710.json`
- `./run_parity_tests.sh --suite node-suite --filter stream/web/byte-stream`: PASS 2/0/0, report `test-parity/reports/parity_report_20260529_102937.json`
- `cargo check -p perry-stdlib --features bundled-streams`: PASS with existing warnings
- `cargo fmt --all --check`: PASS
- `jq empty test-parity/known_failures.json test-parity/reports/parity_report_20260529_102710.json test-parity/reports/parity_report_20260529_102937.json`: PASS
- `git diff --check && git diff --cached --check`: PASS

## Notes
- Rebased onto `origin/main` after #2553 merged; this composes with the readable strategy-size validation path.
- A broader `--filter stream/web/byte` rerun had the target PASS but hit an existing reduced-runtime link error in `byte-length-queuing-strategy` (`_js_byte_length_queuing_strategy_new` missing), so the authoritative guard for this slice is the byte-stream focused filter.
- Non-goals: BYOB implementation, ByteLengthQueuingStrategy auto-linking, zero-length/detached buffer state validation, broader stream/web state-machine changes.