### PR TITLE
fix(node:http): bind aliased/indirect createServer to native dispatch (#2533)

### DIFF
--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -189,8 +189,8 @@ pub use value::{
 pub use value::{
     js_set_handle_array_get, js_set_handle_array_length, js_set_handle_call_method,
     js_set_handle_object_get_property, js_set_handle_to_string, js_set_handle_typeof,
-    js_set_native_crypto_dispatch, js_set_native_module_js_loader, js_set_native_zlib_dispatch,
-    js_set_new_from_handle_v8,
+    js_set_native_crypto_dispatch, js_set_native_http_dispatch, js_set_native_module_js_loader,
+    js_set_native_zlib_dispatch, js_set_new_from_handle_v8,
 };
 
 // Extension pump registration — allows extensions to register pump functions

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -863,6 +863,20 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("zlib", "Unzip")
             | ("zlib", "BrotliCompress")
             | ("zlib", "BrotliDecompress")
+            // #2533: node:http/https/http2 server factories read as callable
+            // values so `const createServer = createServerHTTP` (and
+            // `@hono/node-server`'s `options.createServer || createServerHTTP`)
+            // produce a bound-method closure instead of undefined. The closure
+            // routes back through dispatch_native_module_method → the stdlib
+            // http dispatcher (external-http-server-pump). The method-call form
+            // already lowers through the codegen NATIVE_MODULE_TABLE.
+            | ("http", "createServer")
+            | ("http", "Server")
+            | ("https", "createServer")
+            | ("https", "Server")
+            | ("http2", "createServer")
+            | ("http2", "createSecureServer")
+            | ("http2", "Server")
     )
 }
 

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1337,6 +1337,48 @@ pub(crate) unsafe fn dispatch_native_module_method(
             }
         }
 
+        // #2533: captured / aliased server factories
+        // (`const createServer = options.createServer || createServerHTTP;
+        // createServer(opts, handler)` — `@hono/node-server`'s `serve()`). The
+        // method-call form (`http.createServer(...)`) already lowers through a
+        // dedicated codegen NATIVE_MODULE_TABLE path; the value-read form yields
+        // a bound-method closure (see `is_native_module_callable_export`) that
+        // lands here when invoked. The impls live in perry-ext-http-server, so
+        // route through the dispatcher perry-stdlib registers at startup under
+        // `external-http-server-pump` (enabled whenever http/https/http2 is
+        // imported). Null when the http ext crate isn't linked → undefined. The
+        // dispatcher takes the module name so one callback serves all three.
+        ("http", "createServer")
+        | ("http", "Server")
+        | ("https", "createServer")
+        | ("https", "Server")
+        | ("http2", "createServer")
+        | ("http2", "createSecureServer")
+        | ("http2", "Server") => {
+            let ptr =
+                crate::value::JS_NATIVE_HTTP_DISPATCH.load(std::sync::atomic::Ordering::SeqCst);
+            if ptr.is_null() {
+                f64::from_bits(JSValue::undefined().bits())
+            } else {
+                let dispatch: unsafe extern "C" fn(
+                    *const u8,
+                    usize,
+                    *const u8,
+                    usize,
+                    *const f64,
+                    usize,
+                ) -> f64 = std::mem::transmute(ptr);
+                dispatch(
+                    module_name.as_ptr(),
+                    module_name.len(),
+                    method_name.as_ptr(),
+                    method_name.len(),
+                    args_ptr,
+                    args_len,
+                )
+            }
+        }
+
         _ => {
             // Method not found on native module — return undefined
             f64::from_bits(JSValue::undefined().bits())

--- a/crates/perry-runtime/src/value/handle.rs
+++ b/crates/perry-runtime/src/value/handle.rs
@@ -56,6 +56,15 @@ pub extern "C" fn js_set_native_zlib_dispatch(func: JsNativeZlibDispatchFn) {
     JS_NATIVE_ZLIB_DISPATCH.store(func as *mut (), Ordering::SeqCst);
 }
 
+/// Set the node:http/https/http2 server-factory dispatcher. Registered by
+/// perry-stdlib at startup (under `external-http-server-pump`) so a captured /
+/// aliased `createServer` reaches the perry-ext-http-server impls, which this
+/// crate can't call directly. Stays null when the http ext crate isn't linked. (#2533)
+#[no_mangle]
+pub extern "C" fn js_set_native_http_dispatch(func: JsNativeHttpDispatchFn) {
+    JS_NATIVE_HTTP_DISPATCH.store(func as *mut (), Ordering::SeqCst);
+}
+
 /// Set the native module JS property loader (called by perry-jsruntime)
 /// This callback loads a native module via V8 and gets a property from it.
 #[no_mangle]

--- a/crates/perry-runtime/src/value/mod.rs
+++ b/crates/perry-runtime/src/value/mod.rs
@@ -58,17 +58,18 @@ pub(crate) use tags::{
     STRING_TAG, TAG_FALSE, TAG_HOLE, TAG_MASK, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,
 };
 pub use tags::{
-    JS_HANDLE_CALL_METHOD, JS_HANDLE_TYPEOF, JS_NATIVE_CRYPTO_DISPATCH, JS_NATIVE_MODULE_JS_LOADER,
-    JS_NATIVE_ZLIB_DISPATCH, JS_NEW_FROM_HANDLE_V8, SHORT_STRING_MAX_LEN,
+    JS_HANDLE_CALL_METHOD, JS_HANDLE_TYPEOF, JS_NATIVE_CRYPTO_DISPATCH, JS_NATIVE_HTTP_DISPATCH,
+    JS_NATIVE_MODULE_JS_LOADER, JS_NATIVE_ZLIB_DISPATCH, JS_NEW_FROM_HANDLE_V8,
+    SHORT_STRING_MAX_LEN,
 };
 
 // Crate-internal handle dispatch atomics + callback type aliases (read by
 // every dispatcher that needs to call back into perry-jsruntime).
 pub(crate) use tags::{
     JsHandleArrayGetFn, JsHandleArrayLengthFn, JsHandleCallMethodFn, JsHandleObjectGetPropertyFn,
-    JsHandleToStringFn, JsHandleTypeofFn, JsNativeCryptoDispatchFn, JsNativeModuleJsLoaderFn,
-    JsNativeZlibDispatchFn, JsNewFromHandleV8Fn, JS_HANDLE_ARRAY_GET, JS_HANDLE_ARRAY_LENGTH,
-    JS_HANDLE_OBJECT_GET_PROPERTY, JS_HANDLE_TO_STRING,
+    JsHandleToStringFn, JsHandleTypeofFn, JsNativeCryptoDispatchFn, JsNativeHttpDispatchFn,
+    JsNativeModuleJsLoaderFn, JsNativeZlibDispatchFn, JsNewFromHandleV8Fn, JS_HANDLE_ARRAY_GET,
+    JS_HANDLE_ARRAY_LENGTH, JS_HANDLE_OBJECT_GET_PROPERTY, JS_HANDLE_TO_STRING,
 };
 
 // ----- JSValue type + impls -----
@@ -80,8 +81,8 @@ pub use handle::{
     is_js_handle, js_handle_array_get, js_handle_array_length, js_set_handle_array_get,
     js_set_handle_array_length, js_set_handle_call_method, js_set_handle_object_get_property,
     js_set_handle_to_string, js_set_handle_typeof, js_set_native_crypto_dispatch,
-    js_set_native_module_js_loader, js_set_native_zlib_dispatch, js_set_new_from_handle_v8,
-    native_module_try_js_property,
+    js_set_native_http_dispatch, js_set_native_module_js_loader, js_set_native_zlib_dispatch,
+    js_set_new_from_handle_v8, native_module_try_js_property,
 };
 
 // ----- Basic NaN-box pack / unpack FFI -----

--- a/crates/perry-runtime/src/value/tags.rs
+++ b/crates/perry-runtime/src/value/tags.rs
@@ -120,6 +120,16 @@ pub(crate) type JsNativeCryptoDispatchFn =
 /// stdlib zlib FFIs since this crate cannot call them directly.
 pub(crate) type JsNativeZlibDispatchFn =
     unsafe extern "C" fn(*const u8, usize, *const f64, usize) -> f64;
+/// node:http / node:https / node:http2 server-factory dispatcher (registered
+/// by perry-stdlib under the `external-http-server-pump` feature, which is
+/// enabled whenever a program imports one of those modules). Lets a captured /
+/// aliased `createServer` (`const cs = createServer; cs(handler)`, or
+/// `@hono/node-server`'s `const createServer = options.createServer ||
+/// createServerHTTP`) reach the perry-ext-http-server impls. Unlike crypto/zlib
+/// it also takes the module name so one callback can route http vs https vs
+/// http2. Stays null when the http ext crate isn't linked. (#2533)
+pub(crate) type JsNativeHttpDispatchFn =
+    unsafe extern "C" fn(*const u8, usize, *const u8, usize, *const f64, usize) -> f64;
 
 // ----- JS handle dispatch atomics (shared between handle.rs and consumers) -----
 
@@ -134,3 +144,4 @@ pub static JS_NEW_FROM_HANDLE_V8: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_
 pub static JS_HANDLE_TYPEOF: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
 pub static JS_NATIVE_CRYPTO_DISPATCH: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
 pub static JS_NATIVE_ZLIB_DISPATCH: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+pub static JS_NATIVE_HTTP_DISPATCH: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -1684,6 +1684,76 @@ pub unsafe extern "C" fn js_handle_property_set_dispatch(
     }
 }
 
+/// #2533: route a captured / aliased `http`/`https`/`http2` `createServer`
+/// (or the `Server` / `createSecureServer` aliases) back to the
+/// perry-ext-http-server factories. Registered with the runtime via
+/// `js_set_native_http_dispatch` under `external-http-server-pump` (enabled
+/// whenever the program imports one of those modules), so we can safely
+/// `extern "C"`-reference the ext-crate symbols — they're guaranteed linked.
+///
+/// The method-call form (`http.createServer(...)`) already lowers through the
+/// codegen NATIVE_MODULE_TABLE; this only serves the value-read form, where the
+/// factory reaches the runtime as a bound-method closure (see
+/// `is_native_module_callable_export`) and lands here when invoked.
+///
+/// Node's overloads are `createServer([options][, requestListener])`, while
+/// `@hono/node-server` calls `createServer(serverOptions, requestListener)`. We
+/// classify each arg by type rather than position — the function/closure arg is
+/// the handler, the remaining object arg is the options — so both orders work.
+#[cfg(feature = "external-http-server-pump")]
+unsafe extern "C" fn js_node_http_native_dispatch(
+    module_ptr: *const u8,
+    module_len: usize,
+    _method_ptr: *const u8,
+    _method_len: usize,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
+    use perry_runtime::JSValue;
+    extern "C" {
+        fn js_node_http_create_server_with_options(handler: i64, options_f64: f64) -> i64;
+        fn js_node_https_create_server(opts_f64: f64, handler: i64) -> i64;
+        fn js_node_http2_create_secure_server(opts_f64: f64, handler: i64) -> i64;
+        fn js_value_is_closure(value_bits: i64) -> i32;
+    }
+    let undefined = f64::from_bits(JSValue::undefined().bits());
+    let module = if module_ptr.is_null() || module_len == 0 {
+        ""
+    } else {
+        std::str::from_utf8(std::slice::from_raw_parts(module_ptr, module_len)).unwrap_or("")
+    };
+    let arg = |n: usize| -> f64 {
+        if n < args_len && !args_ptr.is_null() {
+            *args_ptr.add(n)
+        } else {
+            undefined
+        }
+    };
+    // Disambiguate handler (function/closure) from options (object),
+    // independent of argument order.
+    let mut handler_ptr: i64 = 0;
+    let mut options_f64 = undefined;
+    for n in 0..args_len.min(2) {
+        let a = arg(n);
+        if js_value_is_closure(a.to_bits() as i64) != 0 {
+            handler_ptr = perry_runtime::js_nanbox_get_pointer(a);
+        } else if JSValue::from_bits(a.to_bits()).is_pointer() {
+            options_f64 = a;
+        }
+    }
+    let handle = match module {
+        "http" => js_node_http_create_server_with_options(handler_ptr, options_f64),
+        "https" => js_node_https_create_server(options_f64, handler_ptr),
+        "http2" => js_node_http2_create_secure_server(options_f64, handler_ptr),
+        _ => return undefined,
+    };
+    if handle == 0 {
+        undefined
+    } else {
+        perry_runtime::js_nanbox_pointer(handle)
+    }
+}
+
 /// Initialize the handle method and property dispatch systems.
 /// This registers our dispatch functions with perry-runtime.
 /// Must be called before any user code runs.
@@ -1725,6 +1795,13 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
     // `const f = zlib.gzipSync; f(buf)` reach the FFIs.
     #[cfg(feature = "compression")]
     perry_runtime::js_set_native_zlib_dispatch(crate::zlib::js_zlib_native_dispatch);
+
+    // #2533: route captured / aliased http/https/http2 `createServer` back to
+    // the perry-ext-http-server factories. Only registered when the http ext
+    // crate is linked (its symbols are referenced by the dispatcher), so the
+    // runtime arm stays null-and-undefined for non-http programs.
+    #[cfg(feature = "external-http-server-pump")]
+    perry_runtime::js_set_native_http_dispatch(js_node_http_native_dispatch);
 
     // #1545: register the Web Streams numeric-handle probe so method calls on
     // stream handles whose static type the codegen lost route to the stream

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -2161,6 +2161,7 @@ mod tests {
                     pull_cb: 0,
                     cancel_cb: 0,
                     high_water_mark: 1.0,
+                    strategy_size_cb: 0,
                     is_byte_stream: false,
                     pulling: false,
                     started: false,

--- a/test-files/test_issue_2533_aliased_http_createserver.ts
+++ b/test-files/test_issue_2533_aliased_http_createserver.ts
@@ -1,0 +1,47 @@
+// Refs #2533: a `node:http` `createServer` reached INDIRECTLY through a local
+// binding — `@hono/node-server`'s `const createServer = options.createServer ||
+// createServerHTTP` — must still bind to native dispatch. Pre-fix the aliased
+// reference lowered to a value-read that resolved to a non-function, so calling
+// it threw `TypeError: value is not a function` at `serve()` bind time.
+//
+// The fix lists `("http"/"https"/"http2", "createServer"/"Server"/...)` in
+// `is_native_module_callable_export` so the value-read yields a bound-method
+// closure, and routes the closure's invocation through a new
+// `JS_NATIVE_HTTP_DISPATCH` hook (registered by perry-stdlib under
+// `external-http-server-pump`) to the perry-ext-http-server factories.
+//
+// Scope mirrors #2153 (HttpServer dynamic dispatch): this verifies the bind
+// path — `createServer` no longer throws and the returned server supports
+// listen / address / close. Full request serving through the aliased path
+// additionally needs runtime dynamic dispatch for IncomingMessage /
+// ServerResponse methods, tracked as a follow-up.
+
+import { createServer as createServerHTTP } from "node:http";
+
+// A bare value-read of the native import must read as a function.
+console.log("typeof createServerHTTP:", typeof createServerHTTP);
+
+// Direct alias: `const cs = createServerHTTP`.
+const cs = createServerHTTP;
+console.log("typeof cs:", typeof cs);
+
+// Indirect alias through `||` — the exact `@hono/node-server` shape.
+const opts: any = {};
+const createServer = opts.createServer || createServerHTTP;
+console.log("typeof createServer:", typeof createServer);
+
+const server: any = createServer((req: any, res: any) => {
+  res.end();
+});
+
+console.log("server typeof:", typeof server);
+console.log("listen returns server:", server.listen(0) === server);
+
+const addr = server.address();
+console.log("address typeof:", typeof addr);
+// `address.family` is omitted: it reflects the default bind family (Perry
+// binds IPv4 0.0.0.0, Node binds IPv6 ::) which is orthogonal to #2533.
+console.log("address.port typeof:", addr && typeof addr.port);
+
+const closeResult = server.close();
+console.log("close returns server:", closeResult === server);


### PR DESCRIPTION
## Summary

Fixes #2533. `@hono/node-server`'s `serve()` does:

```js
import { createServer as createServerHTTP } from "http";
const createServer = options.createServer || createServerHTTP;   // aliased/indirect
const server = createServer(options.serverOptions || {}, requestListener);
```

When a `node:http` factory is reached **indirectly** through a local binding (not a direct, statically-resolvable call), Perry lowered the value-read to a non-function, so invoking it threw `TypeError: value is not a function` at bind time — the precise blocker for the "`@hono/node-server` works unchanged" path (ref #1655).

## Root cause

A bare value-read of a native-module factory lowers to `Expr::PropertyGet { NativeModuleRef("http"), "createServer" }`. Two gaps:

1. `("http", "createServer")` wasn't on the `is_native_module_callable_export` whitelist, so the value-read resolved to `undefined` (hence "not a function").
2. Even once whitelisted (→ a bound-method closure), the closure's invocation had **no dispatch arm** reaching the `perry-ext-http-server` factories — those impls live in an ext crate that `perry-runtime` can't call directly.

## Fix

- **Whitelist** `("http"/"https"/"http2", "createServer"/"Server"/"createSecureServer")` in `is_native_module_callable_export` so the value-read yields a bound-method closure (`typeof === "function"`, matching Node).
- **Add a `JS_NATIVE_HTTP_DISPATCH` hook**, mirroring the existing crypto/zlib dispatchers: `perry-stdlib` registers `js_node_http_native_dispatch` under the `external-http-server-pump` feature (auto-activated whenever `http`/`https`/`http2` is imported), routing the bound-method invocation to the `perry-ext-http-server` `createServer` factories. The dispatcher classifies args by type (function ⇒ handler, object ⇒ options) so **both** `createServer(handler)` and `createServer(options, handler)` orders work. Stays null (→ `undefined`) when the http ext crate isn't linked, so non-http programs are unaffected.

## Scope

Mirrors #2153 (the HttpServer dynamic-dispatch PR): this resolves the **bind path** — `createServer` no longer throws and the returned server supports `listen` / `address` / `close`. Full *request serving* through the aliased path additionally requires runtime dynamic dispatch for `IncomingMessage` / `ServerResponse` methods+properties (an `any`-typed `res.end(...)` etc.), which #2153 likewise deferred for the typed path. That remains a follow-up.

## Test

`test-files/test_issue_2533_aliased_http_createserver.ts` — exercises the direct alias and the `options.createServer || createServerHTTP` shape, then `listen(0)`/`address()`/`close()`. Output is byte-identical to `node --experimental-strip-types`.

## Validation

- `cargo build --release -p perry-runtime -p perry-stdlib` (default) ✅
- `cargo build --release -p perry-stdlib --features external-http-server-pump` ✅
- `cargo fmt --all -- --check` clean ✅
- New test byte-identical to Node ✅
