### PR TITLE
test(stream/web): clear strategy size non-number failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -656,12 +656,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: pipeThrough().pipeThrough() \u2014 second transform output wrong. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/web/strategy-size-non-number": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: strategy.size returning non-number \u2014 doesn't throw on enqueue. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/compose/just-source-only": {
     "issue": "1531",
     "added": "2026-05-24",

--- a/test-parity/node-suite/stream/web/strategy-size-non-number.ts
+++ b/test-parity/node-suite/stream/web/strategy-size-non-number.ts
@@ -11,7 +11,7 @@ const rs = new ReadableStream(
       try {
         c.enqueue("x");
       } catch (e: any) {
-        enqueueErr = e && e.name;
+        enqueueErr = e && `${e.name}:${e.code}`;
       }
     },
   },


### PR DESCRIPTION
## Summary
- remove stale known-failure entry for `node-suite/stream/web/strategy-size-non-number`
- tighten the fixture to assert `RangeError:ERR_INVALID_ARG_VALUE` instead of only the error name

## Verification
- Baseline exact on current `origin/main`: `./run_parity_tests.sh --suite node-suite --filter stream/web/strategy-size-non-number` PASS, report `test-parity/reports/parity_report_20260529_104415.json` (proved the known failure was stale after #2553)
- DeepWiki reference: `reference/deepwiki/nodejs-node-webstreams-strategy-size-non-number-2026-05-29.md`; direct Node output was used for the final error shape because the DeepWiki summary predicted `TypeError`, while live Node returns `RangeError [ERR_INVALID_ARG_VALUE]`
- Tightened exact: `./run_parity_tests.sh --suite node-suite --filter stream/web/strategy-size-non-number` PASS, report `test-parity/reports/parity_report_20260529_104657.json`
- Narrow repeat: `./run_parity_tests.sh --suite node-suite --filter stream/web/strategy-size` PASS, report `test-parity/reports/parity_report_20260529_104724.json`
- Adjacent guard: `./run_parity_tests.sh --suite node-suite --filter stream/web/custom-strategy` PASS, report `test-parity/reports/parity_report_20260529_104953.json`
- `cargo fmt --all --check`: PASS
- `jq empty test-parity/known_failures.json test-parity/reports/parity_report_20260529_104657.json test-parity/reports/parity_report_20260529_104724.json test-parity/reports/parity_report_20260529_104953.json`: PASS
- `git diff --check && git diff --cached --check`: PASS

## Notes
- No Rust/runtime code changes in this slice; #2553 already fixed the behavior.
- Non-goals: desiredSize/backpressure accounting, broader strategy fixture cleanup, runtime strategy-size changes beyond #2553.