### PR TITLE
Implement Buffer.copyBytesFrom

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2685,6 +2685,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("buffer", "from", false, None),
     method("buffer", "of", false, None),
     method("buffer", "concat", false, None),
+    method("buffer", "copyBytesFrom", false, None),
     method("buffer", "isBuffer", false, None),
     method("buffer", "isEncoding", false, None),
     method("buffer", "byteLength", false, None),

--- a/crates/perry-codegen/src/boxed_vars.rs
+++ b/crates/perry-codegen/src/boxed_vars.rs
@@ -1401,6 +1401,14 @@ fn refine_type_from_init_simple(init: &perry_hir::Expr) -> Option<perry_types::T
             };
             Some(Type::Named(name.to_string()))
         }
+        Expr::NativeMethodCall {
+            module,
+            method,
+            object: None,
+            ..
+        } if module == "buffer" && method == "copyBytesFrom" => {
+            Some(Type::Named("Uint8Array".to_string()))
+        }
         _ => None,
     }
 }

--- a/crates/perry-codegen/src/collectors/hir_facts.rs
+++ b/crates/perry-codegen/src/collectors/hir_facts.rs
@@ -313,6 +313,12 @@ fn is_owned_u8_buffer_alloc(expr: &Expr) -> bool {
         Expr::TypedArrayNew {
             arg: Some(size), ..
         } => is_fresh_uint8array_length_literal(size),
+        Expr::NativeMethodCall {
+            module,
+            method,
+            object: None,
+            ..
+        } if module == "buffer" && method == "copyBytesFrom" => true,
         Expr::NativeArenaView { .. } => true,
         _ => false,
     }

--- a/crates/perry-codegen/src/collectors/pointer_locals.rs
+++ b/crates/perry-codegen/src/collectors/pointer_locals.rs
@@ -196,6 +196,14 @@ pub fn collect_pointer_typed_locals(
             | Expr::Uint8ArrayNew(_)
             | Expr::Uint8ArrayFrom(_)
             | Expr::TextEncoderEncode(_) => Some(Type::Named("Uint8Array".into())),
+            Expr::NativeMethodCall {
+                module,
+                method,
+                object: None,
+                ..
+            } if module == "buffer" && method == "copyBytesFrom" => {
+                Some(Type::Named("Uint8Array".into()))
+            }
             Expr::Void(_) => Some(Type::Void),
             _ => None,
         }

--- a/crates/perry-codegen/src/expr/buffer_views.rs
+++ b/crates/perry-codegen/src/expr/buffer_views.rs
@@ -248,10 +248,19 @@ pub(crate) fn update_buffer_view_for_assignment(
     value: &Expr,
     lowered_value: &str,
 ) {
-    if matches!(
+    let is_fresh_u8_buffer = matches!(
         value,
         Expr::BufferAlloc { .. } | Expr::BufferAllocUnsafe(_) | Expr::Uint8ArrayNew(_)
-    ) {
+    ) || matches!(
+        value,
+        Expr::NativeMethodCall {
+            module,
+            method,
+            object: None,
+            ..
+        } if module == "buffer" && method == "copyBytesFrom"
+    );
+    if is_fresh_u8_buffer {
         let blk = ctx.block();
         let handle = unbox_to_i64(blk, lowered_value);
         let handle_ptr = blk.inttoptr(I64, &handle);

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -1246,6 +1246,15 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "buffer",
         has_receiver: false,
+        method: "copyBytesFrom",
+        class_filter: None,
+        runtime: "js_buffer_copy_bytes_from",
+        args: &[NA_F64, NA_F64, NA_F64],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "buffer",
+        has_receiver: false,
         method: "isAscii",
         class_filter: None,
         runtime: "js_buffer_is_ascii",

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -1141,6 +1141,22 @@ fn register_noalias_buffer_view(
 
 fn buffer_view_init_for_expr(expr: &perry_hir::Expr) -> Option<BufferViewInit> {
     match expr {
+        perry_hir::Expr::NativeMethodCall {
+            module,
+            method,
+            object: None,
+            ..
+        } if module == "buffer" && method == "copyBytesFrom" => Some(BufferViewInit {
+            elem: BufferElem::U8,
+            element_width_bytes: 1,
+            index_unit: BufferIndexUnit::Byte,
+            data_offset_bytes: 8,
+            length_offset_from_data: -8,
+            length_source: buffer_alloc_length_source(expr),
+            native_owner_local_id: None,
+            native_byte_offset: None,
+            native_byte_length: None,
+        }),
         perry_hir::Expr::BufferAlloc { .. }
         | perry_hir::Expr::BufferAllocUnsafe(_)
         | perry_hir::Expr::Uint8ArrayNew(_) => Some(BufferViewInit {
@@ -1262,6 +1278,12 @@ fn buffer_alloc_length_source(expr: &perry_hir::Expr) -> LengthSource {
         perry_hir::Expr::TypedArrayNew { arg: None, .. } => {
             return LengthSource::Constant(0);
         }
+        perry_hir::Expr::NativeMethodCall {
+            module,
+            method,
+            object: None,
+            ..
+        } if module == "buffer" && method == "copyBytesFrom" => None,
         perry_hir::Expr::NativeArenaView { length, .. } => Some(length.as_ref()),
         _ => None,
     };

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -233,6 +233,14 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
         | Expr::BufferConcat(_)
         | Expr::BufferConcatWithLength { .. }
         | Expr::CryptoRandomBytes(_) => Some(HirType::Named("Uint8Array".into())),
+        Expr::NativeMethodCall {
+            module,
+            method,
+            object: None,
+            ..
+        } if module == "buffer" && method == "copyBytesFrom" => {
+            Some(HirType::Named("Uint8Array".into()))
+        }
         // Compare results are now NaN-boxed booleans (TAG_TRUE/FALSE).
         // Type-refining the local as Boolean lets is_numeric_expr
         // skip the fast path (which would emit fcmp/sitofp on a NaN

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -1049,6 +1049,15 @@ pub(super) fn try_module_static_methods(
                                 return Ok(Ok(Expr::BufferConcat(Box::new(list))));
                             }
                         }
+                        "copyBytesFrom" => {
+                            return Ok(Ok(Expr::NativeMethodCall {
+                                module: "buffer".to_string(),
+                                class_name: None,
+                                object: None,
+                                method: "copyBytesFrom".to_string(),
+                                args,
+                            }));
+                        }
                         "of" => {
                             return Ok(Ok(Expr::BufferFrom {
                                 data: Box::new(Expr::Array(args)),

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -510,6 +510,15 @@ pub(super) fn try_native_module_methods(
                             }
                             return Ok(Ok(Expr::BufferConcat(Box::new(list))));
                         }
+                        "copyBytesFrom" => {
+                            return Ok(Ok(Expr::NativeMethodCall {
+                                module: "buffer".to_string(),
+                                class_name: None,
+                                object: None,
+                                method: "copyBytesFrom".to_string(),
+                                args,
+                            }));
+                        }
                         "of" => {
                             return Ok(Ok(Expr::BufferFrom {
                                 data: Box::new(Expr::Array(args)),

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -741,7 +741,7 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                     // array path which reads f64 elements as JS values.
                     if obj_name == "Buffer" {
                         return match method_name {
-                            "from" | "alloc" | "allocUnsafe" | "concat" => {
+                            "from" | "alloc" | "allocUnsafe" | "concat" | "copyBytesFrom" => {
                                 Type::Named("Uint8Array".to_string())
                             }
                             "isBuffer" => Type::Boolean,

--- a/crates/perry-runtime/src/buffer/copy_bytes.rs
+++ b/crates/perry-runtime/src/buffer/copy_bytes.rs
@@ -1,0 +1,166 @@
+use super::*;
+
+use crate::value::JSValue;
+
+const MAX_SAFE_INTEGER: f64 = 9_007_199_254_740_991.0;
+
+fn value_addr(value: f64) -> usize {
+    let bits = value.to_bits();
+    if (bits >> 48) >= 0x7FF8 {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else {
+        bits as usize
+    }
+}
+
+fn format_received_number(n: f64) -> String {
+    if n.is_nan() {
+        "NaN".to_string()
+    } else if n.is_infinite() {
+        if n.is_sign_negative() {
+            "-Infinity".to_string()
+        } else {
+            "Infinity".to_string()
+        }
+    } else if n.fract() == 0.0 && n.abs() < 1e21 && n >= i64::MIN as f64 && n <= i64::MAX as f64 {
+        format!("{}", n as i64)
+    } else {
+        format!("{}", n)
+    }
+}
+
+fn optional_index(value: f64, name: &str) -> Option<usize> {
+    let js_value = JSValue::from_bits(value.to_bits());
+    if js_value.is_undefined() {
+        return None;
+    }
+    if !crate::fs::validate::is_numeric(js_value) {
+        let message = format!(
+            "The \"{}\" argument must be of type number. Received {}",
+            name,
+            crate::fs::validate::describe_received(value)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    let number = if js_value.is_int32() {
+        js_value.as_int32() as f64
+    } else {
+        js_value.as_number()
+    };
+    if !number.is_finite() || number.fract() != 0.0 {
+        let message = format!(
+            "The value of \"{}\" is out of range. It must be an integer. Received {}",
+            name,
+            format_received_number(number)
+        );
+        crate::fs::validate::throw_range_error_with_code(&message);
+    }
+    if !(0.0..=MAX_SAFE_INTEGER).contains(&number) {
+        let message = format!(
+            "The value of \"{}\" is out of range. It must be >= 0 && <= 9007199254740991. Received {}",
+            name,
+            format_received_number(number)
+        );
+        crate::fs::validate::throw_range_error_with_code(&message);
+    }
+    Some(number as usize)
+}
+
+fn throw_invalid_view(value: f64) -> ! {
+    let message = format!(
+        "The \"view\" argument must be an instance of TypedArray. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
+unsafe fn buffer_from_slice(bytes: &[u8]) -> *mut BufferHeader {
+    let len = bytes.len().min(u32::MAX as usize);
+    let buf = buffer_alloc(len as u32);
+    (*buf).length = len as u32;
+    if len > 0 {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), buffer_data_mut(buf), len);
+    }
+    buf
+}
+
+unsafe fn copy_registered_buffer(
+    source: *const BufferHeader,
+    offset_value: f64,
+    length_value: f64,
+) -> *mut BufferHeader {
+    let element_len = (*source).length as usize;
+    let offset = optional_index(offset_value, "offset").unwrap_or(0);
+    let start = offset.min(element_len);
+    let available = element_len.saturating_sub(start);
+    let requested = optional_index(length_value, "length").unwrap_or(available);
+    let take = requested.min(available);
+    let out = buffer_alloc(take as u32);
+    (*out).length = take as u32;
+    let dst = buffer_data_mut(out);
+    for i in 0..take {
+        *dst.add(i) = js_buffer_get(source, (start + i) as i32) as u8;
+    }
+    out
+}
+
+unsafe fn copy_typed_array(
+    source: *const crate::typedarray::TypedArrayHeader,
+    offset_value: f64,
+    length_value: f64,
+) -> *mut BufferHeader {
+    let source = crate::typedarray::clean_ta_ptr(source);
+    if source.is_null() {
+        throw_invalid_view(f64::from_bits(JSValue::undefined().bits()));
+    }
+    let element_len = (*source).length as usize;
+    let element_size = (*source).elem_size as usize;
+    let offset = optional_index(offset_value, "offset").unwrap_or(0);
+    let start = offset.min(element_len);
+    let available = element_len.saturating_sub(start);
+    let requested = optional_index(length_value, "length").unwrap_or(available);
+    let take = requested.min(available);
+    let Some(bytes) = crate::typedarray::typed_array_bytes(source) else {
+        return buffer_alloc(0);
+    };
+    let byte_start = start.saturating_mul(element_size).min(bytes.len());
+    let byte_len = take
+        .saturating_mul(element_size)
+        .min(bytes.len().saturating_sub(byte_start));
+    buffer_from_slice(&bytes[byte_start..byte_start + byte_len])
+}
+
+/// `Buffer.copyBytesFrom(view[, offset[, length]])`.
+///
+/// Node accepts TypedArray instances, including Buffer, and copies raw bytes
+/// from an element range. DataView and ArrayBuffer are intentionally rejected.
+#[no_mangle]
+pub extern "C" fn js_buffer_copy_bytes_from(
+    view: f64,
+    offset_value: f64,
+    length_value: f64,
+) -> *mut BufferHeader {
+    let addr = value_addr(view);
+    if addr < 0x1000 {
+        throw_invalid_view(view);
+    }
+
+    unsafe {
+        if is_registered_buffer(addr) {
+            if is_any_array_buffer(addr) || is_data_view(addr) {
+                throw_invalid_view(view);
+            }
+            return copy_registered_buffer(addr as *const BufferHeader, offset_value, length_value);
+        }
+
+        if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
+            return copy_typed_array(
+                addr as *const crate::typedarray::TypedArrayHeader,
+                offset_value,
+                length_value,
+            );
+        }
+    }
+
+    throw_invalid_view(view);
+}

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -11,6 +11,7 @@ use crate::string::{
 mod access;
 mod cmp;
 mod coding;
+mod copy_bytes;
 mod copy_write;
 mod encode;
 mod from;
@@ -64,6 +65,7 @@ pub use access::{
 };
 
 // ---- Re-exports: copy / write ----
+pub use copy_bytes::js_buffer_copy_bytes_from;
 pub use copy_write::{js_buffer_copy, js_buffer_write, js_buffer_write_len};
 
 // ---- Re-exports: compare / search ----

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -632,6 +632,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("cluster", "setupPrimary")
             | ("cluster", "setupMaster")
             | ("cluster", "Worker")
+            | ("buffer.Buffer", "copyBytesFrom")
             | ("buffer", "atob")
             | ("buffer", "btoa")
             | ("util", "format")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -290,6 +290,10 @@ pub(crate) unsafe fn dispatch_native_module_method(
             };
             ptr_to_f64(buf as *const u8)
         }
+        ("buffer.Buffer", "copyBytesFrom") => {
+            let buf = crate::buffer::js_buffer_copy_bytes_from(arg(0), arg(1), arg(2));
+            ptr_to_f64(buf as *const u8)
+        }
         ("buffer.Buffer", "of") => {
             let arr = pack_args();
             ptr_to_f64(crate::buffer::js_buffer_from_array(arr) as *const u8)

--- a/crates/perry-runtime/src/object/polymorphic_index.rs
+++ b/crates/perry-runtime/src/object/polymorphic_index.rs
@@ -44,6 +44,18 @@ pub extern "C" fn js_object_get_index_polymorphic(obj_handle: i64, idx: f64) -> 
         return f64::from_bits(v.bits());
     }
 
+    if crate::buffer::is_registered_buffer(raw as usize) {
+        let byte_val =
+            crate::buffer::js_buffer_get(raw as *const crate::buffer::BufferHeader, idx_i32);
+        return byte_val as f64;
+    }
+    if crate::typedarray::lookup_typed_array_kind(raw as usize).is_some() {
+        return crate::typedarray::js_typed_array_get(
+            raw as *const crate::typedarray::TypedArrayHeader,
+            idx_i32,
+        );
+    }
+
     let gc_type = unsafe {
         let gc_header_addr = raw.wrapping_sub(crate::gc::GC_HEADER_SIZE as u64) as usize;
         if gc_header_addr < 0x1000 {
@@ -117,6 +129,23 @@ pub extern "C" fn js_object_set_index_polymorphic(obj_handle: i64, idx: f64, val
         let s = idx_i32.to_string();
         let key = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
         js_object_set_field_by_name(raw as *mut ObjectHeader, key, value);
+        return;
+    }
+
+    if crate::buffer::is_registered_buffer(raw as usize) {
+        crate::buffer::js_buffer_set(
+            raw as *mut crate::buffer::BufferHeader,
+            idx_i32,
+            value as i32,
+        );
+        return;
+    }
+    if crate::typedarray::lookup_typed_array_kind(raw as usize).is_some() {
+        crate::typedarray::js_typed_array_set(
+            raw as *mut crate::typedarray::TypedArrayHeader,
+            idx_i32,
+            value,
+        );
         return;
     }
 

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1512 entries across 83 modules
+// Coverage: 1513 entries across 83 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -195,6 +195,8 @@ declare module "buffer" {
   export function byteLength(...args: any[]): any;
   /** stdlib */
   export function concat(...args: any[]): any;
+  /** stdlib */
+  export function copyBytesFrom(...args: any[]): any;
   /** stdlib */
   export function from(...args: any[]): any;
   /** stdlib */

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -1592,12 +1592,11 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 
 ### node:buffer
 
-**Gap APIs: 41** · Already covered: 67
+**Gap APIs: 40** · Already covered: 68
 
 #### Missing from Perry
 
 - `Buffer.allocUnsafeSlow(size)`
-- `Buffer.copyBytesFrom(view[, offset[, length]])`
 - `Buffer.isEncoding(encoding)`
 - `Buffer.poolSize`
 - `buf.readBigInt64BE([offset])`
@@ -1647,6 +1646,7 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 | `Buffer.byteLength(string[, encoding])` | `manifest:buffer.byteLength` |
 | `Buffer.compare(buf1, buf2)` | `ffi:js_buffer_compare` |
 | `Buffer.concat(list[, totalLength])` | `manifest:buffer.concat` |
+| `Buffer.copyBytesFrom(view[, offset[, length]])` | `ffi:js_buffer_copy_bytes_from` |
 | `Buffer.from(array)` | `manifest:buffer.from` |
 | `Buffer.from(arrayBuffer[, byteOffset[, length]])` | `manifest:buffer.from` |
 | `Buffer.from(buffer)` | `manifest:buffer.from` |

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1512 entries across 83 modules.
+Total: 1513 entries across 83 modules.
 
 ## Modules
 
@@ -258,6 +258,7 @@ Total: 1512 entries across 83 modules.
 - `btoa` — module
 - `byteLength` — module
 - `concat` — module
+- `copyBytesFrom` — module
 - `from` — module
 - `isAscii` — module
 - `isBuffer` — module

--- a/test-parity/node-suite/buffer/from/copy-bytes-from.ts
+++ b/test-parity/node-suite/buffer/from/copy-bytes-from.ts
@@ -1,0 +1,44 @@
+import { Buffer } from "node:buffer";
+
+function show(label: string, value: Buffer) {
+  console.log(`${label}:`, `${value.toString("hex")}/${value.length}`);
+}
+
+function showError(label: string, fn: () => unknown) {
+  try {
+    fn();
+    console.log(`${label}:`, "no throw");
+  } catch (err: any) {
+    console.log(`${label}:`, err?.name, err?.code || "no-code");
+  }
+}
+
+const bytes = new Uint8Array([1, 2, 3, 4]);
+const u8All = Buffer.copyBytesFrom(bytes);
+const u8Range = Buffer.copyBytesFrom(bytes, 1, 2);
+show("u8 all", u8All);
+show("u8 range", u8Range);
+const boundCopy = Buffer.copyBytesFrom;
+show("bound u8", boundCopy(bytes, 0, 2));
+const boundIndexed = boundCopy(bytes, 0, 1);
+console.log("bound index:", String(boundIndexed[0]));
+
+const wide = new Uint16Array([0x0102, 0x0304, 0x0506]);
+const u16All = Buffer.copyBytesFrom(wide);
+const u16Range = Buffer.copyBytesFrom(wide, 1, 1);
+show("u16 all", u16All);
+show("u16 range", u16Range);
+
+const copy = Buffer.copyBytesFrom(bytes);
+bytes[0] = 99;
+console.log("copy independent:", String(copy[0]), String(bytes[0]));
+
+const lengthClamp = Buffer.copyBytesFrom(bytes, 1, 99);
+show("length clamp", lengthClamp);
+
+showError("dataview", () => Buffer.copyBytesFrom(new DataView(new ArrayBuffer(2)) as any));
+showError("arraybuffer", () => Buffer.copyBytesFrom(new ArrayBuffer(2) as any));
+showError("negative offset", () => Buffer.copyBytesFrom(bytes, -1));
+showError("fractional offset", () => Buffer.copyBytesFrom(bytes, 1.5));
+showError("negative length", () => Buffer.copyBytesFrom(bytes, 0, -1));
+showError("fractional length", () => Buffer.copyBytesFrom(bytes, 0, 1.5));


### PR DESCRIPTION
Closes #2502

## Summary
- add Buffer.copyBytesFrom runtime support for Buffer and TypedArray inputs, copying raw bytes from an element offset/length range into an independent Buffer
- wire Buffer.copyBytesFrom through native dispatch, HIR/codegen lowering, manifest coverage, and returned Uint8Array typing for indexed reads
- add a focused node:buffer parity fixture and update the runtime parity gaps doc

## Notes
- Local Node v25.9.0 rejects DataView and ArrayBuffer with ERR_INVALID_ARG_TYPE, so this follows that observed behavior even though the issue body mentions DataView.
- The broader parity runner was attempted, but local release-build contention made it unreliable; the direct Node and Perry fixture runs matched exactly.

## Verification
- node --experimental-strip-types test-parity/node-suite/buffer/from/copy-bytes-from.ts
- PERRY_ALLOW_UNIMPLEMENTED=1 target/debug/perry compile --no-auto-optimize --no-cache test-parity/node-suite/buffer/from/copy-bytes-from.ts -o /tmp/perry_copy_bytes_from && /tmp/perry_copy_bytes_from
- cargo check -p perry-codegen -p perry-runtime
- cargo build -p perry
- cargo fmt --all -- --check
- ./scripts/check_file_size.sh
- git diff --check
- git diff --cached --check