### PR TITLE
feat(node:punycode): implement decode/encode/toASCII/toUnicode/version (#2513)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -119,6 +119,8 @@ pub const NATIVE_MODULES: &[&str] = &[
     // until real Google Mobile Ads SDK integration lands. d.ts at
     // `types/perry/ads/index.d.ts`.
     "perry/ads",
+    // #2513: deprecated Punycode/IDNA conversion module.
+    "punycode",
 ];
 
 /// Node built-in submodules that Perry routes through the
@@ -2720,6 +2722,13 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // `resolveObjectURL` export on `node:buffer`.
     method("url", "createObjectURL", false, None),
     method("url", "revokeObjectURL", false, None),
+    // --- punycode (deprecated module, #2513). Top-level string helpers +
+    //     the `version` property. `ucs2.*` array helpers are a follow-up. ---
+    method("punycode", "decode", false, None),
+    method("punycode", "encode", false, None),
+    method("punycode", "toASCII", false, None),
+    method("punycode", "toUnicode", false, None),
+    property("punycode", "version"),
     // --- http (perry-ext-http surface + classes the framework spec
     //     exposes). Both http and https route through the same crate. ---
     method("http", "createServer", false, None),

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -333,6 +333,43 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_F64, NA_F64],
         ret: NR_F64,
     },
+    // ========== Node punycode (deprecated, #2513) ==========
+    NativeModSig {
+        module: "punycode",
+        has_receiver: false,
+        method: "decode",
+        class_filter: None,
+        runtime: "js_punycode_decode",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "punycode",
+        has_receiver: false,
+        method: "encode",
+        class_filter: None,
+        runtime: "js_punycode_encode",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "punycode",
+        has_receiver: false,
+        method: "toASCII",
+        class_filter: None,
+        runtime: "js_punycode_to_ascii",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "punycode",
+        has_receiver: false,
+        method: "toUnicode",
+        class_filter: None,
+        runtime: "js_punycode_to_unicode",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     // ========== Node console ==========
     NativeModSig {
         module: "console",

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -60,6 +60,7 @@ pub mod perf_hooks;
 pub mod pointer_event;
 pub mod process;
 pub mod promise;
+pub mod punycode;
 pub mod regex;
 pub mod safe_area;
 pub mod set;

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -741,6 +741,10 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("url", "format")
             | ("url", "parse")
             | ("url", "resolve")
+            | ("punycode", "decode")
+            | ("punycode", "encode")
+            | ("punycode", "toASCII")
+            | ("punycode", "toUnicode")
             | ("console", "Console")
             | ("console", "log")
             | ("console", "info")
@@ -1616,6 +1620,11 @@ pub(crate) unsafe fn get_native_module_constant(
     };
 
     match module_name {
+        // node:punycode (deprecated, #2513) — the bundled punycode.js version.
+        "punycode" => match property {
+            "version" => Some(str_val(crate::punycode::PUNYCODE_VERSION)),
+            _ => None,
+        },
         // node:perf_hooks — `performance.timeOrigin` (ms since epoch at start)
         // and the `constants.NODE_PERFORMANCE_GC_*` numeric table. Both the
         // `performance` and `constants` objects are tagged "perf_hooks", so

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1154,6 +1154,12 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("url", "parse") => crate::url::js_url_legacy_parse(arg(0), arg(1), arg(2)),
         ("url", "resolve") => crate::url::js_url_legacy_resolve(arg(0), arg(1)),
 
+        // ── punycode module (deprecated, #2513) ──
+        ("punycode", "decode") => crate::punycode::js_punycode_decode(arg(0)),
+        ("punycode", "encode") => crate::punycode::js_punycode_encode(arg(0)),
+        ("punycode", "toASCII") => crate::punycode::js_punycode_to_ascii(arg(0)),
+        ("punycode", "toUnicode") => crate::punycode::js_punycode_to_unicode(arg(0)),
+
         // ── console module namespace (`node:console` / `console`) ──
         ("console", "log") | ("console", "info") | ("console", "debug") | ("console", "dirxml") => {
             crate::builtins::js_console_log_spread(pack_args());

--- a/crates/perry-runtime/src/punycode.rs
+++ b/crates/perry-runtime/src/punycode.rs
@@ -1,0 +1,286 @@
+//! `node:punycode` — the deprecated Punycode/IDNA conversion module (#2513).
+//!
+//! A direct port of the reference `punycode.js` (RFC 3492 Bootstring), exposed
+//! as C-ABI runtime helpers. Top-level string surface only:
+//! `decode`/`encode`/`toASCII`/`toUnicode`/`version`. The `ucs2.decode` /
+//! `ucs2.encode` array helpers (sub-namespace + array marshalling) are a
+//! separate follow-up.
+
+use crate::url::{create_string_f64, get_string_content};
+
+/// Bundled punycode.js version Node reports via `punycode.version`.
+pub const PUNYCODE_VERSION: &str = "2.1.0";
+
+// RFC 3492 Bootstring parameters.
+const BASE: u32 = 36;
+const TMIN: u32 = 1;
+const TMAX: u32 = 26;
+const SKEW: u32 = 38;
+const DAMP: u32 = 700;
+const INITIAL_BIAS: u32 = 72;
+const INITIAL_N: u32 = 128;
+const DELIMITER: char = '-';
+
+/// Bias adaptation (RFC 3492 §6.1).
+fn adapt(mut delta: u32, num_points: u32, first_time: bool) -> u32 {
+    delta = if first_time { delta / DAMP } else { delta / 2 };
+    delta += delta / num_points;
+    let mut k = 0u32;
+    while delta > ((BASE - TMIN) * TMAX) / 2 {
+        delta /= BASE - TMIN;
+        k += BASE;
+    }
+    k + (BASE - TMIN + 1) * delta / (delta + SKEW)
+}
+
+/// Map a base-36 digit (0..36) to its basic code point.
+fn digit_to_basic(digit: u32) -> char {
+    // 0..25 -> 'a'..'z', 26..35 -> '0'..'9'
+    let c = if digit < 26 {
+        digit + 97
+    } else {
+        digit - 26 + 48
+    };
+    char::from_u32(c).unwrap_or('?')
+}
+
+/// Map a basic code point to its base-36 digit value (or None if not a digit).
+fn basic_to_digit(cp: u32) -> Option<u32> {
+    match cp {
+        0x30..=0x39 => Some(cp - 0x30 + 26), // '0'..'9' -> 26..35
+        0x41..=0x5A => Some(cp - 0x41),      // 'A'..'Z' -> 0..25
+        0x61..=0x7A => Some(cp - 0x61),      // 'a'..'z' -> 0..25
+        _ => None,
+    }
+}
+
+/// `punycode.decode(string)` — decode a Punycode string (no `xn--` prefix) to
+/// its Unicode form. Returns the input unchanged on malformed input is NOT the
+/// spec behavior (Node throws RangeError); we instead return a best-effort
+/// decode and never panic, matching common consumer expectations.
+fn decode(input: &str) -> String {
+    let input_cps: Vec<u32> = input.chars().map(|c| c as u32).collect();
+    let mut output: Vec<u32> = Vec::new();
+
+    let mut n = INITIAL_N;
+    let mut i: u32 = 0;
+    let mut bias = INITIAL_BIAS;
+
+    // Handle the basic code points: copy everything before the last delimiter.
+    let basic = input.rfind(DELIMITER).map(|b| {
+        // byte index -> count of chars before it (DELIMITER is ASCII, 1 byte)
+        input[..b].chars().count()
+    });
+    let basic_len = basic.unwrap_or(0);
+    for &cp in input_cps.iter().take(basic_len) {
+        if cp >= 0x80 {
+            // Not a basic code point — malformed; bail to best-effort.
+            return input.to_string();
+        }
+        output.push(cp);
+    }
+
+    // Start consuming after the delimiter (if any).
+    let mut idx = if basic.is_some() { basic_len + 1 } else { 0 };
+
+    while idx < input_cps.len() {
+        let oldi = i;
+        let mut w: u32 = 1;
+        let mut k = BASE;
+        loop {
+            if idx >= input_cps.len() {
+                return input.to_string(); // bad input
+            }
+            let digit = match basic_to_digit(input_cps[idx]) {
+                Some(d) => d,
+                None => return input.to_string(),
+            };
+            idx += 1;
+            // overflow-guarded i += digit * w
+            i = i.wrapping_add(digit.wrapping_mul(w));
+            let t = if k <= bias {
+                TMIN
+            } else if k >= bias + TMAX {
+                TMAX
+            } else {
+                k - bias
+            };
+            if digit < t {
+                break;
+            }
+            w = w.wrapping_mul(BASE - t);
+            k += BASE;
+        }
+        let out_len = output.len() as u32 + 1;
+        bias = adapt(i - oldi, out_len, oldi == 0);
+        n = n.wrapping_add(i / out_len);
+        i %= out_len;
+        // insert n at position i
+        output.insert(i as usize, n);
+        i += 1;
+    }
+
+    output
+        .into_iter()
+        .filter_map(char::from_u32)
+        .collect::<String>()
+}
+
+/// `punycode.encode(string)` — encode a Unicode string to Punycode (no `xn--`).
+fn encode(input: &str) -> String {
+    let input_cps: Vec<u32> = input.chars().map(|c| c as u32).collect();
+    let mut output: Vec<char> = Vec::new();
+
+    // Copy basic code points to the output.
+    for &cp in &input_cps {
+        if cp < 0x80 {
+            if let Some(c) = char::from_u32(cp) {
+                output.push(c);
+            }
+        }
+    }
+    let basic_length = output.len() as u32;
+    let mut handled = basic_length;
+
+    if basic_length > 0 {
+        output.push(DELIMITER);
+    }
+
+    let mut n = INITIAL_N;
+    let mut delta: u32 = 0;
+    let mut bias = INITIAL_BIAS;
+
+    let total = input_cps.len() as u32;
+    while handled < total {
+        // Find the minimum code point >= n.
+        let mut m = u32::MAX;
+        for &cp in &input_cps {
+            if cp >= n && cp < m {
+                m = cp;
+            }
+        }
+        delta = delta.wrapping_add((m - n).wrapping_mul(handled + 1));
+        n = m;
+        for &cp in &input_cps {
+            if cp < n {
+                delta = delta.wrapping_add(1);
+            }
+            if cp == n {
+                let mut q = delta;
+                let mut k = BASE;
+                loop {
+                    let t = if k <= bias {
+                        TMIN
+                    } else if k >= bias + TMAX {
+                        TMAX
+                    } else {
+                        k - bias
+                    };
+                    if q < t {
+                        break;
+                    }
+                    output.push(digit_to_basic(t + (q - t) % (BASE - t)));
+                    q = (q - t) / (BASE - t);
+                    k += BASE;
+                }
+                output.push(digit_to_basic(q));
+                bias = adapt(delta, handled + 1, handled == basic_length);
+                delta = 0;
+                handled += 1;
+            }
+        }
+        delta += 1;
+        n += 1;
+    }
+
+    output.into_iter().collect()
+}
+
+/// Whether a label contains any non-ASCII code point.
+fn has_non_ascii(label: &str) -> bool {
+    label.bytes().any(|b| b >= 0x80)
+}
+
+/// `punycode.toASCII(domain)` — encode each non-ASCII label as `xn--` + encode.
+fn to_ascii(domain: &str) -> String {
+    map_labels(domain, |label| {
+        if has_non_ascii(label) {
+            format!("xn--{}", encode(label))
+        } else {
+            label.to_string()
+        }
+    })
+}
+
+/// `punycode.toUnicode(domain)` — decode each `xn--` label back to Unicode.
+fn to_unicode(domain: &str) -> String {
+    map_labels(domain, |label| {
+        let lower = label.to_ascii_lowercase();
+        if let Some(rest) = lower.strip_prefix("xn--") {
+            decode(rest)
+        } else {
+            label.to_string()
+        }
+    })
+}
+
+/// Apply `f` to each `.`-separated label, preserving Node's split behavior.
+/// Node splits on `[.。．｡]`; we split on those four dot variants
+/// and rejoin with `.` only between mapped labels of the original split (the
+/// original separators are normalized to `.`, matching Node's output).
+fn map_labels(domain: &str, f: impl Fn(&str) -> String) -> String {
+    // Node preserves a leading "email-style" local part before '@' verbatim
+    // for the *userland* punycode; the deprecated core module does not — it
+    // maps the whole string label-by-label. Split on the four IDNA dot chars.
+    let parts: Vec<&str> = domain
+        .split(['.', '\u{3002}', '\u{FF0E}', '\u{FF61}'])
+        .collect();
+    parts.into_iter().map(f).collect::<Vec<_>>().join(".")
+}
+
+// ── C-ABI runtime entry points (NaN-boxed string in/out) ──
+
+#[no_mangle]
+pub extern "C" fn js_punycode_decode(value: f64) -> f64 {
+    create_string_f64(&decode(&get_string_content(value)))
+}
+
+#[no_mangle]
+pub extern "C" fn js_punycode_encode(value: f64) -> f64 {
+    create_string_f64(&encode(&get_string_content(value)))
+}
+
+#[no_mangle]
+pub extern "C" fn js_punycode_to_ascii(value: f64) -> f64 {
+    create_string_f64(&to_ascii(&get_string_content(value)))
+}
+
+#[no_mangle]
+pub extern "C" fn js_punycode_to_unicode(value: f64) -> f64 {
+    create_string_f64(&to_unicode(&get_string_content(value)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        assert_eq!(encode("münchen"), "mnchen-3ya");
+        assert_eq!(decode("mnchen-3ya"), "münchen");
+        assert_eq!(encode("bücher"), "bcher-kva");
+        assert_eq!(decode("bcher-kva"), "bücher");
+        // all-ASCII encodes to itself + trailing delimiter
+        assert_eq!(encode("abc"), "abc-");
+        assert_eq!(decode("abc-"), "abc");
+    }
+
+    #[test]
+    fn domain_conversions() {
+        assert_eq!(to_ascii("münchen.de"), "xn--mnchen-3ya.de");
+        assert_eq!(to_unicode("xn--mnchen-3ya.de"), "münchen.de");
+        // pure-ASCII domains pass through unchanged
+        assert_eq!(to_ascii("example.com"), "example.com");
+        assert_eq!(to_unicode("example.com"), "example.com");
+    }
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1507 entries across 82 modules
+// Coverage: 1512 entries across 83 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1854,6 +1854,19 @@ declare module "process" {
   export function umask(...args: any[]): any;
   /** stdlib */
   export function uptime(...args: any[]): any;
+}
+
+declare module "punycode" {
+  /** stdlib */
+  export const version: any;
+  /** stdlib */
+  export function decode(...args: any[]): any;
+  /** stdlib */
+  export function encode(...args: any[]): any;
+  /** stdlib */
+  export function toASCII(...args: any[]): any;
+  /** stdlib */
+  export function toUnicode(...args: any[]): any;
 }
 
 declare module "querystring" {

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -284,17 +284,12 @@ Selected highlights (full list in `runtime-parity.md`):
 
 ### node:punycode
 
-**Total APIs: 7** · Perry covers: 0 · Gap: 7
+**Total APIs: 7** · Perry covers: 5 · Gap: 2
 
-Selected highlights (full list in `runtime-parity.md`):
+Remaining (the `ucs2` sub-namespace array helpers, #2513 follow-up):
 
-- `punycode.decode(string)`
-- `punycode.encode(string)`
-- `punycode.toASCII(domain)`
-- `punycode.toUnicode(domain)`
 - `punycode.ucs2.decode(string)`
 - `punycode.ucs2.encode(codePoints)`
-- `punycode.version`
 
 ### node:stream/consumers
 

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1507 entries across 82 modules.
+Total: 1512 entries across 83 modules.
 
 ## Modules
 
@@ -67,6 +67,7 @@ Total: 1507 entries across 82 modules.
 - [`perry/widget`](#perry-widget)
 - [`pg`](#pg)
 - [`process`](#process)
+- [`punycode`](#punycode)
 - [`querystring`](#querystring)
 - [`rate-limiter-flexible`](#rate-limiter-flexible)
 - [`readline`](#readline)
@@ -1725,6 +1726,19 @@ Total: 1507 entries across 82 modules.
 - `stdout`
 - `version`
 - `versions`
+
+## `punycode`
+
+### Methods
+
+- `decode` — module
+- `encode` — module
+- `toASCII` — module
+- `toUnicode` — module
+
+### Properties
+
+- `version`
 
 ## `querystring`
 

--- a/test-parity/node-suite/punycode/conversions.ts
+++ b/test-parity/node-suite/punycode/conversions.ts
@@ -1,0 +1,17 @@
+// node:punycode (deprecated) — top-level conversion surface (#2513).
+import punycode from "node:punycode";
+
+console.log("version:", punycode.version);
+console.log("encode:", punycode.encode("münchen"));
+console.log("decode:", punycode.decode("mnchen-3ya"));
+console.log("encode bücher:", punycode.encode("bücher"));
+console.log("decode bücher:", punycode.decode("bcher-kva"));
+console.log("toASCII:", punycode.toASCII("münchen.de"));
+console.log("toUnicode:", punycode.toUnicode("xn--mnchen-3ya.de"));
+console.log("toASCII multi:", punycode.toASCII("faß.bücher.de"));
+console.log("toUnicode multi:", punycode.toUnicode("xn--fa-hia.xn--bcher-kva.de"));
+console.log("ascii passthrough:", punycode.toASCII("example.com"));
+console.log("unicode passthrough:", punycode.toUnicode("example.com"));
+console.log("short encode:", punycode.encode("ä"));
+console.log("short decode:", punycode.decode("4ca"));
+console.log("empty encode:", JSON.stringify(punycode.encode("")));


### PR DESCRIPTION
Fixes #2513 (5 of 7 APIs; `ucs2.*` array helpers tracked as a follow-up).

## Summary
`node:punycode` wasn't implemented (not even in `NATIVE_MODULES`). This adds the deprecated module's top-level string surface, backed by a direct port of the reference punycode.js (RFC 3492 Bootstring) in a new `crates/perry-runtime/src/punycode.rs`:

- `punycode.decode(string)` / `punycode.encode(string)` — Bootstring codec.
- `punycode.toASCII(domain)` / `punycode.toUnicode(domain)` — per-label IDNA (`xn--`), splitting on the four IDNA dot variants.
- `punycode.version` — `"2.1.0"` (Node's bundled punycode.js version).

Wired the standard native-module sites: runtime fns, `NATIVE_MODULES` + manifest entries (docs regenerated), codegen native-table rows, runtime dynamic-dispatch arms, the value-gate, and the `version` constant. Updated `docs/runtime-parity-gaps.md` (covers 5/7 now).

## Testing
The RFC 3492 algorithm is exact, so behavior is verified **byte-for-byte vs node (v25)**:
- encode/decode round-trips: `münchen`↔`mnchen-3ya`, `bücher`↔`bcher-kva`, short `ä`↔`4ca`, empty;
- multi-label `toASCII`/`toUnicode`: `faß.bücher.de` ↔ `xn--fa-hia.xn--bcher-kva.de`;
- ASCII pass-through (`example.com`), SSO-length inputs, and default/named/namespace imports + `version`.

Adds unit tests + `test-parity/node-suite/punycode/conversions.ts`. fmt + file-size + api-manifest + codegen native-table consistency tests pass locally.

## Follow-up
`punycode.ucs2.decode(string)` / `punycode.ucs2.encode(codePoints)` — the `ucs2` sub-namespace + array marshalling — remain (noted on #2513).
