### PR TITLE
Expose fs Stats Date timestamp aliases

### DIFF
--- a/crates/perry-runtime/src/fs/stats.rs
+++ b/crates/perry-runtime/src/fs/stats.rs
@@ -52,14 +52,129 @@ pub(crate) fn bigint_i64_value(value: i64) -> f64 {
 //   - 0xFE5C: regular Stats (numeric fields)
 //   - 0xFE5D: bigint Stats (adds *Ns fields)
 //
-// Field order MUST match the order writes are emitted below.
+// Field order MUST match the order writes are emitted below. The Date aliases
+// live in hidden slots after the enumerable fields and are exposed through
+// class-level getters/setters below.
 pub(crate) const STATS_KEYS_REGULAR: &[u8] = b"isFile\0isDirectory\0isSymbolicLink\0size\0atimeMs\0mtimeMs\0ctimeMs\0birthtimeMs\0mode\0uid\0gid\0nlink\0dev\0rdev\0blksize\0ino\0blocks\0";
-pub(crate) const STATS_REGULAR_COUNT: u32 = 17;
+pub(crate) const STATS_REGULAR_COUNT: u32 = 21;
 pub(crate) const STATS_REGULAR_CLASS_ID: u32 = 0xFFFF_0070;
 
 pub(crate) const STATS_KEYS_BIGINT: &[u8] = b"isFile\0isDirectory\0isSymbolicLink\0size\0atimeMs\0mtimeMs\0ctimeMs\0birthtimeMs\0atimeNs\0mtimeNs\0ctimeNs\0birthtimeNs\0mode\0uid\0gid\0nlink\0dev\0rdev\0blksize\0ino\0blocks\0";
-pub(crate) const STATS_BIGINT_COUNT: u32 = 21;
+pub(crate) const STATS_BIGINT_COUNT: u32 = 25;
 pub(crate) const STATS_BIGINT_CLASS_ID: u32 = 0xFFFF_0071;
+
+const REGULAR_DATE_SLOT_BASE: u32 = 17;
+const BIGINT_DATE_SLOT_BASE: u32 = 21;
+
+fn stats_date_slot(
+    this_value: f64,
+    offset: u32,
+) -> Option<(*mut crate::object::ObjectHeader, u32)> {
+    let value = crate::value::JSValue::from_bits(this_value.to_bits());
+    if !value.is_pointer() {
+        return None;
+    }
+    let obj = value.as_pointer::<crate::object::ObjectHeader>() as *mut crate::object::ObjectHeader;
+    if obj.is_null() {
+        return None;
+    }
+    unsafe {
+        match (*obj).class_id {
+            STATS_REGULAR_CLASS_ID => Some((obj, REGULAR_DATE_SLOT_BASE + offset)),
+            STATS_BIGINT_CLASS_ID => Some((obj, BIGINT_DATE_SLOT_BASE + offset)),
+            _ => None,
+        }
+    }
+}
+
+fn stats_date_get(this_value: f64, offset: u32) -> f64 {
+    if let Some((obj, slot)) = stats_date_slot(this_value, offset) {
+        return f64::from_bits(crate::object::js_object_get_field(obj, slot).bits());
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+fn stats_date_set(this_value: f64, offset: u32, value: f64) -> f64 {
+    if let Some((obj, slot)) = stats_date_slot(this_value, offset) {
+        crate::object::js_object_set_field_f64(obj, slot, value);
+    }
+    value
+}
+
+extern "C" fn stats_atime_getter(this_value: f64) -> f64 {
+    stats_date_get(this_value, 0)
+}
+
+extern "C" fn stats_mtime_getter(this_value: f64) -> f64 {
+    stats_date_get(this_value, 1)
+}
+
+extern "C" fn stats_ctime_getter(this_value: f64) -> f64 {
+    stats_date_get(this_value, 2)
+}
+
+extern "C" fn stats_birthtime_getter(this_value: f64) -> f64 {
+    stats_date_get(this_value, 3)
+}
+
+extern "C" fn stats_atime_setter(this_value: f64, value: f64) -> f64 {
+    stats_date_set(this_value, 0, value)
+}
+
+extern "C" fn stats_mtime_setter(this_value: f64, value: f64) -> f64 {
+    stats_date_set(this_value, 1, value)
+}
+
+extern "C" fn stats_ctime_setter(this_value: f64, value: f64) -> f64 {
+    stats_date_set(this_value, 2, value)
+}
+
+extern "C" fn stats_birthtime_setter(this_value: f64, value: f64) -> f64 {
+    stats_date_set(this_value, 3, value)
+}
+
+fn ensure_stats_date_accessors_registered() {
+    static REGISTER: std::sync::Once = std::sync::Once::new();
+    REGISTER.call_once(|| unsafe {
+        for class_id in [STATS_REGULAR_CLASS_ID, STATS_BIGINT_CLASS_ID] {
+            for (name, getter, setter) in [
+                (
+                    "atime",
+                    stats_atime_getter as *const u8,
+                    stats_atime_setter as *const u8,
+                ),
+                (
+                    "mtime",
+                    stats_mtime_getter as *const u8,
+                    stats_mtime_setter as *const u8,
+                ),
+                (
+                    "ctime",
+                    stats_ctime_getter as *const u8,
+                    stats_ctime_setter as *const u8,
+                ),
+                (
+                    "birthtime",
+                    stats_birthtime_getter as *const u8,
+                    stats_birthtime_setter as *const u8,
+                ),
+            ] {
+                crate::object::js_register_class_getter(
+                    class_id as i64,
+                    name.as_ptr(),
+                    name.len() as i64,
+                    getter as i64,
+                );
+                crate::object::js_register_class_setter(
+                    class_id as i64,
+                    name.as_ptr(),
+                    name.len() as i64,
+                    setter as i64,
+                );
+            }
+        }
+    });
+}
 
 pub(crate) unsafe fn build_stats_object(
     is_file: bool,
@@ -81,6 +196,7 @@ pub(crate) unsafe fn build_stats_object(
     // Real nanosecond timestamps when we have a Metadata in hand; otherwise
     // fall back to the millisecond × 1e6 approximation below.
     let times_ns = meta_extra.map(metadata_times_ns);
+    ensure_stats_date_accessors_registered();
 
     let (obj, count) = if bigint {
         let o = crate::object::js_object_alloc_class_with_keys(
@@ -104,6 +220,12 @@ pub(crate) unsafe fn build_stats_object(
     let _ = count;
     let set = |idx: u32, v: f64| {
         crate::object::js_object_set_field_f64(obj, idx, v);
+    };
+    let set_date_aliases = |base: u32| {
+        set(base, crate::date::alloc_date_cell(atime_ms));
+        set(base + 1, crate::date::alloc_date_cell(mtime_ms));
+        set(base + 2, crate::date::alloc_date_cell(ctime_ms));
+        set(base + 3, crate::date::alloc_date_cell(birthtime_ms));
     };
     set(0, make_stats_predicate(is_file));
     set(1, make_stats_predicate(is_dir));
@@ -133,6 +255,7 @@ pub(crate) unsafe fn build_stats_object(
         set(18, bigint_u64_value(blksize));
         set(19, bigint_u64_value(ino));
         set(20, bigint_u64_value(blocks));
+        set_date_aliases(BIGINT_DATE_SLOT_BASE);
     } else {
         set(3, size as f64);
         set(4, atime_ms);
@@ -148,6 +271,7 @@ pub(crate) unsafe fn build_stats_object(
         set(14, blksize as f64);
         set(15, ino as f64);
         set(16, blocks as f64);
+        set_date_aliases(REGULAR_DATE_SLOT_BASE);
     }
     const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
     f64::from_bits(POINTER_TAG | (obj as u64 & 0x0000_FFFF_FFFF_FFFF))

--- a/test-parity/node-suite/fs-promises/stats/date-fields.ts
+++ b/test-parity/node-suite/fs-promises/stats/date-fields.ts
@@ -1,0 +1,60 @@
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+
+const ROOT = "/tmp/perry_node_suite_fs_promises_stats_date_fields";
+try { await fsp.rm(ROOT, { recursive: true, force: true }); } catch (_e) {}
+await fsp.mkdir(ROOT, { recursive: true });
+const file = ROOT + "/file.txt";
+const link = ROOT + "/link.txt";
+await fsp.writeFile(file, "date-fields");
+try { await fsp.symlink(file, link); } catch (_e) {}
+
+const oldMs = Date.parse("2005-06-07T08:09:10.000Z");
+fs.utimesSync(file, oldMs / 1000, oldMs / 1000);
+
+function show(label: string, st: any, expectedMtimeMs?: number) {
+  console.log(
+    `${label} date aliases:`,
+    `${st.atime instanceof Date},${st.mtime instanceof Date},${st.ctime instanceof Date},${st.birthtime instanceof Date}`,
+  );
+  if (expectedMtimeMs !== undefined) {
+    console.log(
+      `${label} mtime close:`,
+      st.mtime instanceof Date && Math.abs(st.mtime.getTime() - expectedMtimeMs) < 2000,
+    );
+  }
+}
+
+const st = await fsp.stat(file);
+console.log(
+  "promises Date aliases enumerable:",
+  ["atime", "mtime", "ctime", "birthtime"].map((key) => Object.keys(st).includes(key)).join(","),
+);
+console.log(
+  "promises Date aliases own:",
+  ["atime", "mtime", "ctime", "birthtime"].map((key) => Object.prototype.hasOwnProperty.call(st, key)).join(","),
+);
+show("promises stat", st, oldMs);
+
+const lst = await fsp.lstat(link);
+show("promises lstat", lst);
+
+const originalMtime = st.mtime;
+st.mtimeMs = 789;
+console.log(
+  "promises Date independent from mtimeMs:",
+  originalMtime instanceof Date && st.mtime === originalMtime && st.mtime.getTime() === oldMs && st.mtimeMs === 789,
+);
+st.mtime = new Date(654);
+console.log(
+  "promises mtimeMs independent from Date:",
+  st.mtime instanceof Date && st.mtime.getTime() === 654 && st.mtimeMs === 789,
+);
+
+const fh = await fsp.open(file, "r");
+const fhSt = await fh.stat();
+show("filehandle stat", fhSt, oldMs);
+const fhBig = await fh.stat({ bigint: true });
+show("filehandle bigint", fhBig, oldMs);
+console.log("filehandle bigint timestamp types:", `${typeof fhBig.mtimeMs},${typeof fhBig.mtimeNs}`);
+await fh.close();

--- a/test-parity/node-suite/fs/STATUS.md
+++ b/test-parity/node-suite/fs/STATUS.md
@@ -26,7 +26,7 @@ These areas are intentionally left as follow-up work because they require larger
 4. `writeFile` and FileHandle write inputs from streams, async iterables, iterables, and abort signals.
 5. Node-perfect `cp` behavior for async filters, exact validation/errors, symlink cycles, subdirectory guards, mode/reflink semantics, and conflict handling.
 6. Node-perfect errors across fs APIs: exact error type, `code`, `errno`, `path`, `dest`, and `syscall` fields.
-7. Stats `Date` fields (`atime`, `mtime`, `ctime`, `birthtime`) and related timestamp precision. The numeric and bigint timestamp fields are covered; Date object parity needs runtime Date representation work.
+7. Remaining Stats timestamp precision edge cases. Numeric, bigint, and Date-valued timestamp aliases are covered for the main stat/lstat/fstat paths.
 8. Stream edge cases: backpressure, `autoClose`, `emitClose`, destroy/error ordering, and fd lifecycle parity.
 9. URL/path edge cases, especially full compatibility with `pathToFileURL()`-generated objects.
 10. Additional platform- and permission-sensitive behavior once the parity runner can model those deterministically.

--- a/test-parity/node-suite/fs/stats/date-fields.ts
+++ b/test-parity/node-suite/fs/stats/date-fields.ts
@@ -1,0 +1,65 @@
+import * as fs from "node:fs";
+
+const ROOT = "/tmp/perry_node_suite_fs_stats_date_fields";
+try { fs.rmSync(ROOT, { recursive: true, force: true }); } catch (_e) {}
+fs.mkdirSync(ROOT, { recursive: true });
+const file = ROOT + "/file.txt";
+const link = ROOT + "/link.txt";
+fs.writeFileSync(file, "date-fields");
+try { fs.symlinkSync(file, link); } catch (_e) {}
+
+const oldMs = Date.parse("2004-05-06T07:08:09.000Z");
+fs.utimesSync(file, oldMs / 1000, oldMs / 1000);
+
+function show(label: string, st: any, expectedMtimeMs?: number) {
+  console.log(
+    `${label} date aliases:`,
+    `${st.atime instanceof Date},${st.mtime instanceof Date},${st.ctime instanceof Date},${st.birthtime instanceof Date}`,
+  );
+  if (expectedMtimeMs !== undefined) {
+    console.log(
+      `${label} mtime close:`,
+      st.mtime instanceof Date && Math.abs(st.mtime.getTime() - expectedMtimeMs) < 2000,
+    );
+  }
+}
+
+const st = fs.statSync(file);
+console.log(
+  "statSync Date aliases enumerable:",
+  ["atime", "mtime", "ctime", "birthtime"].map((key) => Object.keys(st).includes(key)).join(","),
+);
+console.log(
+  "statSync Date aliases own:",
+  ["atime", "mtime", "ctime", "birthtime"].map((key) => Object.prototype.hasOwnProperty.call(st, key)).join(","),
+);
+show("statSync", st, oldMs);
+
+const lst = fs.lstatSync(link);
+show("lstatSync", lst);
+
+const fd = fs.openSync(file, "r");
+const fst = fs.fstatSync(fd);
+show("fstatSync", fst, oldMs);
+fs.closeSync(fd);
+
+const originalMtime = st.mtime;
+st.mtimeMs = 123;
+console.log(
+  "statSync Date independent from mtimeMs:",
+  originalMtime instanceof Date && st.mtime === originalMtime && st.mtime.getTime() === oldMs && st.mtimeMs === 123,
+);
+st.mtime = new Date(456);
+console.log(
+  "statSync mtimeMs independent from Date:",
+  st.mtime instanceof Date && st.mtime.getTime() === 456 && st.mtimeMs === 123,
+);
+
+const big = fs.statSync(file, { bigint: true });
+show("statSync bigint", big, oldMs);
+console.log("statSync bigint timestamp types:", `${typeof big.mtimeMs},${typeof big.mtimeNs}`);
+
+fs.stat(file, (err, cbSt) => {
+  console.log("stat callback err:", err === null);
+  show("stat callback", cbSt, oldMs);
+});


### PR DESCRIPTION
Closes #2560

## Summary
- add Date-valued `atime`, `mtime`, `ctime`, and `birthtime` aliases to the shared fs Stats builder for regular and bigint stats objects
- expose the aliases through hidden slots plus class-level accessors so they are not own enumerable keys before access
- preserve numeric `*Ms`, bigint `*Ns`, and platform stat fields while covering sync/callback fs stats and fs/promises/FileHandle stats

## Verification
- `node test-parity/node-suite/fs/stats/date-fields.ts`
- `node test-parity/node-suite/fs-promises/stats/date-fields.ts`
- `RUSTC_WRAPPER= cargo check -p perry-runtime`
- `RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs --filter stats/` (8 pass, report `test-parity/reports/parity_report_20260529_111932.json`)
- `RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs-promises --filter stats/` (4 pass, report `test-parity/reports/parity_report_20260529_112052.json`)
- `RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs --filter date-fields` (1 pass, report `test-parity/reports/parity_report_20260529_112152.json`)
- `RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs-promises --filter date-fields` (1 pass, report `test-parity/reports/parity_report_20260529_112200.json`)
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `git diff --check && git diff --cached --check`
