### PR TITLE
fix(stream/web): reject pre-aborted pipeTo signal

### DIFF
--- a/crates/perry-stdlib/src/streams/pipe.rs
+++ b/crates/perry-stdlib/src/streams/pipe.rs
@@ -6,8 +6,8 @@ use super::{
     WRITABLE_STREAMS,
 };
 use perry_runtime::{
-    js_closure_call0, js_closure_call1, js_promise_new, js_promise_reject, js_promise_resolve,
-    ClosureHeader, Promise,
+    js_closure_call0, js_closure_call1, js_nanbox_get_pointer, js_promise_new, js_promise_reject,
+    js_promise_resolve, ClosureHeader, JSValue, ObjectHeader, Promise,
 };
 
 #[derive(Clone, Copy)]
@@ -188,6 +188,10 @@ pub unsafe extern "C" fn js_readable_stream_pipe_to(
     let r_id = readable_handle as usize;
     let w_id = writable_handle as usize;
     let prevent_close = pipe_option_truthy(options, b"preventClose");
+    if pipe_signal_is_aborted(options) {
+        js_promise_reject(promise, perry_runtime::url::js_abort_error_value());
+        return promise;
+    }
 
     let locks = match acquire_pipe_locks(r_id, w_id) {
         Ok(locks) => locks,
@@ -230,8 +234,24 @@ pub unsafe extern "C" fn js_readable_stream_pipe_to(
     promise
 }
 
+unsafe fn pipe_signal_is_aborted(options: f64) -> bool {
+    let signal = pipe_option_value(options, b"signal");
+    let jsval = JSValue::from_bits(signal.to_bits());
+    if !jsval.is_pointer() {
+        return false;
+    }
+    let signal_ptr = js_nanbox_get_pointer(signal) as *mut ObjectHeader;
+    if signal_ptr.is_null() {
+        return false;
+    }
+    perry_runtime::url::js_abort_signal_is_aborted(signal_ptr) != 0
+}
+
 unsafe fn pipe_option_truthy(options: f64, name: &[u8]) -> bool {
-    let value =
-        perry_runtime::value::js_get_property(options, name.as_ptr() as i64, name.len() as i64);
+    let value = pipe_option_value(options, name);
     perry_runtime::value::js_is_truthy(value) != 0
+}
+
+unsafe fn pipe_option_value(options: f64, name: &[u8]) -> f64 {
+    perry_runtime::value::js_get_property(options, name.as_ptr() as i64, name.len() as i64)
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -554,12 +554,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.from(asyncIter with awaits) \u2014 wrong collected output. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/web/pipe-to-with-pre-aborted-signal": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: pipeTo with pre-aborted signal \u2014 does not reject immediately. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/readable/readable-mode-only": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- reject `ReadableStream.pipeTo(..., { signal })` immediately when the supplied signal is already aborted
- return the rejected promise before acquiring readable/writable pipe locks so streams are left unlocked
- remove the stale known-failure entry for `node-suite/stream/web/pipe-to-with-pre-aborted-signal`

## Verification
- Baseline exact failure on `origin/main`: `test-parity/reports/parity_report_20260529_110014.json`
- Direct Node check: pre-aborted `pipeTo` rejects with `AbortError` and leaves both streams unlocked
- DeepWiki: `reference/deepwiki/nodejs-node-webstreams-pipeto-preaborted-signal-2026-05-29.md`
- PASS: `./run_parity_tests.sh --suite node-suite --filter stream/web/pipe-to-with-pre-aborted-signal` (`test-parity/reports/parity_report_20260529_110740.json`)
- PASS: `./run_parity_tests.sh --suite node-suite --filter stream/web/pipe-to` (`test-parity/reports/parity_report_20260529_111423.json`, 7/0/0; one Node-side skip)
- PASS: `cargo check -p perry-stdlib --features bundled-streams`
- PASS: `cargo fmt --all --check`
- PASS: `jq empty test-parity/known_failures.json test-parity/reports/parity_report_20260529_110740.json test-parity/reports/parity_report_20260529_111423.json`
- PASS: `git diff --check`