### PR TITLE
fix(compile): resolve CJS re-export targets consistently

### DIFF
--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -68,6 +68,7 @@ mod tests {
         extract_require_aliases_with_ranges, extract_require_specifiers,
     };
     use super::wrap::wrap_commonjs;
+    use std::fs;
     use std::path::PathBuf;
 
     #[test]
@@ -379,6 +380,28 @@ module.exports = inner;
         let src = "module.exports = { foo: 1, bar: 2 };";
         let wrapped = wrap_commonjs(src, &PathBuf::from("/tmp/test.js"));
         assert!(wrapped.contains("export default _cjs;"));
+    }
+
+    #[test]
+    fn wrap_copies_named_exports_from_extensionless_reexport_target() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let lib_dir = tmp.path().join("lib");
+        fs::create_dir_all(&lib_dir).expect("mkdir lib");
+        fs::write(
+            lib_dir.join("index.js"),
+            "module.exports.parse = function parse() {};",
+        )
+        .expect("write target");
+
+        let entry = tmp.path().join("index.js");
+        let src = "module.exports = require('./lib/index');";
+        let wrapped = wrap_commonjs(src, &entry);
+
+        assert!(
+            wrapped.contains("export const parse = _cjs.parse;"),
+            "expected named export copied through extensionless CJS re-export, got:\n{}",
+            wrapped
+        );
     }
 
     #[test]

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -144,18 +144,18 @@ pub(in crate::commands::compile) fn wrap_commonjs(source: &str, source_path: &Pa
     // react/index.js — which has zero `exports.X =` patterns of its own —
     // produces zero named exports and downstream `import { useState } from
     // "react"` link-fails.
-    let parent = source_path.parent();
-    if let Some(parent) = parent {
-        for spec in &require_specs {
-            if !spec.starts_with("./") && !spec.starts_with("../") {
-                continue;
-            }
-            let target = parent.join(spec);
-            if let Ok(target_source) = std::fs::read_to_string(&target) {
-                for name in extract_exports_from_source(&target_source) {
-                    if !named_exports.contains(&name) {
-                        named_exports.push(name);
-                    }
+    for spec in &require_specs {
+        if !spec.starts_with("./") && !spec.starts_with("../") {
+            continue;
+        }
+        let Some(target) = super::super::resolve::resolve_relative_import_path(spec, source_path)
+        else {
+            continue;
+        };
+        if let Ok(target_source) = std::fs::read_to_string(&target) {
+            for name in extract_exports_from_source(&target_source) {
+                if !named_exports.contains(&name) {
+                    named_exports.push(name);
                 }
             }
         }

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -532,6 +532,19 @@ pub(super) fn is_ts_file(path: &Path) -> bool {
     }
 }
 
+pub(super) fn resolve_relative_import_path(
+    import_source: &str,
+    importer_path: &Path,
+) -> Option<PathBuf> {
+    if !import_source.starts_with("./") && !import_source.starts_with("../") {
+        return None;
+    }
+    let parent = importer_path.parent()?;
+    let resolved = parent.join(import_source);
+    let path = resolve_with_extensions(&resolved)?;
+    path.canonicalize().ok()
+}
+
 /// Resolve an import specifier to a file path
 pub(super) fn resolve_import(
     import_source: &str,
@@ -554,10 +567,7 @@ pub(super) fn resolve_import(
 
     // Handle relative imports (./ or ../)
     if import_source.starts_with("./") || import_source.starts_with("../") {
-        let parent = importer_path.parent()?;
-        let resolved = parent.join(import_source);
-        if let Some(path) = resolve_with_extensions(&resolved) {
-            let canonical = path.canonicalize().ok()?;
+        if let Some(canonical) = resolve_relative_import_path(import_source, importer_path) {
             // Refs #486: a relative `import './foo.js'` from inside a compile
             // package must classify as NativeCompiled even when the resolved
             // file lives outside the literal `node_modules/<pkg>/` substring


### PR DESCRIPTION
## Summary
- reuse Perry's relative import resolver when cjs_wrap inspects trivial CommonJS re-export targets
- preserve named exports through extensionless requires like module.exports = require('./lib/index')
- add a regression test for copying named exports from ./lib/index.js

## Why
The normal module graph already resolves ./lib/index to ./lib/index.js, but cjs_wrap's named-export inspection used parent.join(spec) directly. That meant a package entry like table-parser/index.js compiled, but its namespace missed parse from lib/index.js.

## Verification
- cargo fmt --check
- cargo test -p perry cjs_wrap
- cargo build -p perry
- D:\\Projects\\perry\\target\\debug\\perry.exe compile D:\\tmp\\perry-ps-node-repro\\table-parser-smoke.ts --output D:\\tmp\\perry-table-parser-smoke.exe --no-auto-optimize
- D:\\tmp\\perry-table-parser-smoke.exe -> rows 1