### PR TITLE
Complete fs StatFs fields

### DIFF
--- a/crates/perry-runtime/src/fs/fd_ops.rs
+++ b/crates/perry-runtime/src/fs/fd_ops.rs
@@ -502,30 +502,74 @@ pub(crate) fn writev_sync_inner(fd: i32, buffers_value: f64, position_value: f64
     })
 }
 
-pub(crate) unsafe fn build_statfs_object(
-    bsize: f64,
-    blocks: f64,
-    bfree: f64,
-    bavail: f64,
-    bigint: bool,
-) -> f64 {
-    let obj = crate::object::js_object_alloc(0, 4);
+#[derive(Default, Clone, Copy)]
+struct StatFsFields {
+    fs_type: u64,
+    bsize: u64,
+    frsize: u64,
+    blocks: u64,
+    bfree: u64,
+    bavail: u64,
+    files: u64,
+    ffree: u64,
+}
+
+unsafe fn build_statfs_object(fields: StatFsFields, bigint: bool) -> f64 {
+    let obj = crate::object::js_object_alloc(0, 8);
     let set = |name: &str, v: f64| {
         let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
         crate::object::js_object_set_field_by_name(obj, key, v);
     };
-    if bigint {
-        set("bsize", bigint_u64_value(bsize as u64));
-        set("blocks", bigint_u64_value(blocks as u64));
-        set("bfree", bigint_u64_value(bfree as u64));
-        set("bavail", bigint_u64_value(bavail as u64));
-    } else {
-        set("bsize", bsize);
-        set("blocks", blocks);
-        set("bfree", bfree);
-        set("bavail", bavail);
+    for (name, value) in [
+        ("type", fields.fs_type),
+        ("bsize", fields.bsize),
+        ("frsize", fields.frsize),
+        ("blocks", fields.blocks),
+        ("bfree", fields.bfree),
+        ("bavail", fields.bavail),
+        ("files", fields.files),
+        ("ffree", fields.ffree),
+    ] {
+        if bigint {
+            set(name, bigint_u64_value(value));
+        } else {
+            set(name, value as f64);
+        }
     }
     f64::from_bits(crate::value::JSValue::pointer(obj as *const u8).bits())
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "tvos",
+    target_os = "watchos"
+))]
+unsafe fn statfs_type(c_path: *const libc::c_char) -> u64 {
+    let mut stat: libc::statfs = std::mem::zeroed();
+    if libc::statfs(c_path, &mut stat) == 0 {
+        stat.f_type as u64
+    } else {
+        0
+    }
+}
+
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "tvos",
+    target_os = "watchos"
+)))]
+unsafe fn statfs_type(_c_path: *const libc::c_char) -> u64 {
+    0
 }
 
 /// `fs.statfsSync(path)` — stable StatFs subset used by Node/Bun tests.
@@ -540,21 +584,27 @@ pub extern "C" fn js_fs_statfs_sync_options(path_value: f64, options_value: f64)
     unsafe {
         let path = match decode_path_value(path_value) {
             Some(s) => s,
-            None => return build_statfs_object(0.0, 0.0, 0.0, 0.0, bigint),
+            None => return build_statfs_object(StatFsFields::default(), bigint),
         };
         #[cfg(unix)]
         {
             let c_path = match std::ffi::CString::new(path) {
                 Ok(s) => s,
-                Err(_) => return build_statfs_object(0.0, 0.0, 0.0, 0.0, bigint),
+                Err(_) => return build_statfs_object(StatFsFields::default(), bigint),
             };
             let mut stat: libc::statvfs = std::mem::zeroed();
             if libc::statvfs(c_path.as_ptr(), &mut stat) == 0 {
                 return build_statfs_object(
-                    stat.f_bsize as f64,
-                    stat.f_blocks as f64,
-                    stat.f_bfree as f64,
-                    stat.f_bavail as f64,
+                    StatFsFields {
+                        fs_type: statfs_type(c_path.as_ptr()),
+                        bsize: stat.f_bsize as u64,
+                        frsize: stat.f_frsize as u64,
+                        blocks: stat.f_blocks as u64,
+                        bfree: stat.f_bfree as u64,
+                        bavail: stat.f_bavail as u64,
+                        files: stat.f_files as u64,
+                        ffree: stat.f_ffree as u64,
+                    },
                     bigint,
                 );
             }
@@ -563,7 +613,7 @@ pub extern "C" fn js_fs_statfs_sync_options(path_value: f64, options_value: f64)
         {
             let _ = path;
         }
-        build_statfs_object(0.0, 0.0, 0.0, 0.0, bigint)
+        build_statfs_object(StatFsFields::default(), bigint)
     }
 }
 

--- a/test-parity/node-suite/fs-promises/stats/statfs-bigint-options.ts
+++ b/test-parity/node-suite/fs-promises/stats/statfs-bigint-options.ts
@@ -4,7 +4,11 @@ const ROOT = "/tmp/perry_node_suite_fs_promises_statfs_bigint_options";
 try { await fsp.rm(ROOT, { recursive: true, force: true }); } catch (_e) {}
 await fsp.mkdir(ROOT, { recursive: true });
 
+const fields = ["type", "bsize", "blocks", "bfree", "bavail", "files", "ffree"];
+
+function show(label: string, st: any) {
+  console.log(`${label} types:`, fields.map((key) => typeof st[key]).join(","));
+}
+
 const st = await fsp.statfs(ROOT, { bigint: true });
-console.log("promises statfs bigint bsize type:", typeof st.bsize);
-console.log("promises statfs bigint blocks type:", typeof st.blocks);
-console.log("promises statfs bigint bfree type:", typeof st.bfree);
+show("promises statfs bigint", st);

--- a/test-parity/node-suite/fs-promises/stats/statfs-fields.ts
+++ b/test-parity/node-suite/fs-promises/stats/statfs-fields.ts
@@ -1,0 +1,18 @@
+import * as fsp from "node:fs/promises";
+
+const ROOT = "/tmp/perry_node_suite_fs_promises_statfs_fields";
+try { await fsp.rm(ROOT, { recursive: true, force: true }); } catch (_e) {}
+await fsp.mkdir(ROOT, { recursive: true });
+
+const fields = ["type", "bsize", "blocks", "bfree", "bavail", "files", "ffree"];
+
+const stats = await fsp.statfs(ROOT);
+console.log("promises statfs field types:", fields.map((key) => typeof (stats as any)[key]).join(","));
+console.log(
+  "promises statfs relationships:",
+  stats.type >= 0 &&
+    stats.bsize > 0 &&
+    stats.blocks >= stats.bfree &&
+    stats.bfree >= stats.bavail &&
+    stats.files >= stats.ffree,
+);

--- a/test-parity/node-suite/fs/stats/statfs-bigint-options.ts
+++ b/test-parity/node-suite/fs/stats/statfs-bigint-options.ts
@@ -4,12 +4,16 @@ const ROOT = "/tmp/perry_node_suite_fs_statfs_bigint_options";
 try { fs.rmSync(ROOT, { recursive: true, force: true }); } catch (_e) {}
 fs.mkdirSync(ROOT, { recursive: true });
 
+const fields = ["type", "bsize", "blocks", "bfree", "bavail", "files", "ffree"];
+
+function show(label: string, st: any) {
+  console.log(`${label} types:`, fields.map((key) => typeof st[key]).join(","));
+}
+
 const st = fs.statfsSync(ROOT, { bigint: true });
-console.log("statfsSync bigint bsize type:", typeof st.bsize);
-console.log("statfsSync bigint blocks type:", typeof st.blocks);
-console.log("statfsSync bigint bfree type:", typeof st.bfree);
+show("statfsSync bigint", st);
 
 fs.statfs(ROOT, { bigint: true }, (err, cst) => {
   console.log("statfs callback bigint err:", err === null);
-  console.log("statfs callback bigint bsize type:", typeof cst.bsize);
+  show("statfs callback bigint", cst);
 });

--- a/test-parity/node-suite/fs/stats/statfs.ts
+++ b/test-parity/node-suite/fs/stats/statfs.ts
@@ -1,7 +1,26 @@
 import * as fs from "node:fs";
 
-const stats = fs.statfsSync("/tmp");
-console.log("statfs bsize positive:", stats.bsize > 0);
-console.log("statfs blocks positive:", stats.blocks > 0);
-console.log("statfs bfree number:", typeof stats.bfree);
-console.log("statfs bavail number:", typeof stats.bavail);
+const ROOT = "/tmp/perry_node_suite_fs_statfs_fields";
+try { fs.rmSync(ROOT, { recursive: true, force: true }); } catch (_e) {}
+fs.mkdirSync(ROOT, { recursive: true });
+
+const fields = ["type", "bsize", "blocks", "bfree", "bavail", "files", "ffree"];
+
+function show(label: string, stats: any) {
+  console.log(`${label} field types:`, fields.map((key) => typeof stats[key]).join(","));
+  console.log(
+    `${label} relationships:`,
+    stats.type >= 0 &&
+      stats.bsize > 0 &&
+      stats.blocks >= stats.bfree &&
+      stats.bfree >= stats.bavail &&
+      stats.files >= stats.ffree,
+  );
+}
+
+show("statfsSync", fs.statfsSync(ROOT));
+
+fs.statfs(ROOT, (err, stats) => {
+  console.log("statfs callback err:", err === null);
+  show("statfs callback", stats);
+});


### PR DESCRIPTION
Closes #2561

## Summary
- expands the StatFs builder to return `type`, `bsize`, `frsize`, `blocks`, `bfree`, `bavail`, `files`, and `ffree`
- populates block and file counts from `statvfs`, and filesystem type from `statfs` where available
- keeps bigint mode returning bigint values for every StatFs field
- updates fs and fs/promises parity fixtures to cover the Node v25-comparable StatFs fields

Node v25.9.0 on this machine does not expose `frsize`, while the current Node docs list it as added in v26.1.0, so the parity fixtures assert the shared fields while the runtime still forwards `frsize`.

## Verification
- `cargo check -p perry-runtime`
- `cargo build -p perry`
- `env RUSTC_WRAPPER= cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs --filter stats/` (7 pass, 0 fail, 0 compile fail; report `test-parity/reports/parity_report_20260529_113632.json`)
- `env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs-promises --filter stats/` (4 pass, 0 fail, 0 compile fail; report `test-parity/reports/parity_report_20260529_113800.json`)
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `git diff --check && git diff --cached --check`