### PR TITLE
fix(stream): abort callback-form finished

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -239,6 +239,28 @@ extern "C" fn ns_finished_error_false_close(closure: *const ClosureHeader) -> f6
     f64::from_bits(TAG_UNDEFINED)
 }
 
+extern "C" fn ns_finished_signal_abort(closure: *const ClosureHeader) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    if js_closure_get_capture_f64(closure, 2).to_bits() == TAG_TRUE {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    js_closure_set_capture_f64(closure as *mut ClosureHeader, 2, f64::from_bits(TAG_TRUE));
+    let stream = js_closure_get_capture_f64(closure, 0);
+    let callback = js_closure_get_capture_f64(closure, 1);
+    let signal = js_closure_get_capture_f64(closure, 3);
+    if let Some(signal_obj) = object_ptr_from_value(signal) {
+        crate::url::js_abort_signal_remove_listener(
+            signal_obj,
+            string_value(b"abort"),
+            box_pointer(closure as *const u8),
+        );
+    }
+    call_listener_args(stream, callback, &[crate::url::js_abort_error_value()]);
+    f64::from_bits(TAG_UNDEFINED)
+}
+
 extern "C" fn ns_writable_finish_microtask(closure: *const ClosureHeader) -> f64 {
     if closure.is_null() {
         return f64::from_bits(TAG_UNDEFINED);

--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -728,6 +728,26 @@ pub(super) fn add_finished_error_false_close_listener(stream: f64, callback: f64
     );
 }
 
+pub(super) fn add_finished_signal_abort_listener(stream: f64, signal: f64, callback: f64) {
+    let listener = js_closure_alloc(ns_finished_signal_abort as *const u8, 4);
+    js_closure_set_capture_f64(listener, 0, stream);
+    js_closure_set_capture_f64(listener, 1, callback);
+    js_closure_set_capture_f64(listener, 2, f64::from_bits(TAG_FALSE));
+    js_closure_set_capture_f64(listener, 3, signal);
+    if signal_is_aborted(signal) {
+        crate::builtins::js_queue_microtask(listener as i64);
+        return;
+    }
+    let Some(signal_obj) = object_ptr_from_value(signal) else {
+        return;
+    };
+    crate::url::js_abort_signal_add_listener(
+        signal_obj,
+        string_value(b"abort"),
+        box_pointer(listener as *const u8),
+    );
+}
+
 /// `stream.finished(stream, [options], cb)` callback form. This slice covers
 /// Node's `{ error: false }` path: there is no dedicated `error` listener, but
 /// `close` still observes the stream's stored error and calls the callback.
@@ -749,6 +769,9 @@ pub extern "C" fn js_node_stream_finished(args: *const crate::array::ArrayHeader
     }
     if get_hidden_value(options, hidden_key(b"error")).is_some_and(|v| v.to_bits() == TAG_FALSE) {
         add_finished_error_false_close_listener(stream, callback);
+    }
+    if let Some(signal) = options_signal(options) {
+        add_finished_signal_abort_listener(stream, signal, callback);
     }
     f64::from_bits(TAG_UNDEFINED)
 }

--- a/crates/perry-runtime/src/node_stream_dispatch.rs
+++ b/crates/perry-runtime/src/node_stream_dispatch.rs
@@ -172,6 +172,7 @@ pub(super) fn register_stub_arities() {
     register(ns_unpipe1 as *const u8, 1);
     register(ns_readable_resume_microtask as *const u8, 0);
     register(ns_finished_error_false_close as *const u8, 0);
+    register(ns_finished_signal_abort as *const u8, 0);
     register(ns_iter_to_array as *const u8, 1);
     register(ns_iter_map as *const u8, 2);
     register(ns_iter_filter as *const u8, 2);

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -200,12 +200,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.from(generator) \u2192 data event chain doesn't deliver. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/finished/with-options-signal": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: finished(stream, {signal}, cb) abort path doesn't fire callback. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/error/no-read-impl": {
     "issue": "1532",
     "added": "2026-05-23",

--- a/test-parity/node-suite/stream/finished/with-options-signal.ts
+++ b/test-parity/node-suite/stream/finished/with-options-signal.ts
@@ -3,6 +3,6 @@ import { PassThrough, finished } from "node:stream";
 const p = new PassThrough();
 const ctrl = new AbortController();
 finished(p, { signal: ctrl.signal }, (err) => {
-  console.log("aborted err exists:", err !== null && err !== undefined);
+  console.log("aborted err:", `${err?.name}:${(err as any)?.code}`);
 });
 ctrl.abort();


### PR DESCRIPTION
## Summary
- wire callback-form `stream.finished(stream, { signal }, cb)` to the provided AbortSignal
- call the callback with a Node-shaped `AbortError` / `ABORT_ERR` without destroying the stream
- remove the abort listener once it fires and clear the stale known-failure entry

## Verification
- Baseline exact failure on `origin/main`: `test-parity/reports/parity_report_20260529_111813.json`
- DeepWiki: `reference/deepwiki/nodejs-node-stream-finished-callback-signal-2026-05-29.md`
- Direct Node check: callback gets `AbortError ABORT_ERR`; stream remains `destroyed false`
- PASS: exact `./run_parity_tests.sh --suite node-suite --filter stream/finished/with-options-signal` after fixture tightening (`test-parity/reports/parity_report_20260529_113948.json`)
- Guardrail: `./run_parity_tests.sh --suite node-suite --filter stream/finished/` -> target PASS, 5 PASS / 2 residual parity FAIL (`readable-false-option`, `with-cleanup-option`), report `test-parity/reports/parity_report_20260529_114119.json`
- Post-rebase PASS on `origin/main` `2364ad341`: exact `stream/finished/with-options-signal`, report `test-parity/reports/parity_report_20260529_114500.json`
- Post-rebase PASS on `origin/main` `f0cee9b07`: exact `stream/finished/with-options-signal`, report `test-parity/reports/parity_report_20260529_115506.json`
- PASS: `cargo build --release -p perry -p perry-runtime -p perry-stdlib` on `f0cee9b07` after a transient sccache build failure in the parity harness
- PASS: `cargo check -p perry-runtime`
- PASS: `cargo fmt --all --check`
- PASS: `jq empty test-parity/known_failures.json test-parity/reports/parity_report_20260529_115506.json`
- PASS: `git diff --check && git diff --cached --check`