### PR TITLE
fix(globals): expose callable globalThis functions

### DIFF
--- a/crates/perry-codegen/src/expr/helpers.rs
+++ b/crates/perry-codegen/src/expr/helpers.rs
@@ -251,9 +251,10 @@ pub(crate) fn unbox_to_i64(blk: &mut LlBlock, boxed: &str) -> String {
 /// `globalThis.<Name>` should route through `js_get_global_this`
 /// (returning the populated backing-object) or fall through to the `0.0`
 /// no-value placeholder. Keep this list in sync with
-/// `GLOBAL_THIS_BUILTIN_CONSTRUCTORS` + `GLOBAL_THIS_BUILTIN_NAMESPACES`
-/// in object.rs — the codegen check and the runtime population together
-/// implement the lodash `runInContext` blocker fix.
+/// `GLOBAL_THIS_BUILTIN_CONSTRUCTORS` + `GLOBAL_THIS_BUILTIN_FUNCTIONS`
+/// + `GLOBAL_THIS_BUILTIN_NAMESPACES` + the singleton `globalThis`
+/// self-reference in object.rs — the codegen check and the runtime
+/// population together implement the lodash `runInContext` blocker fix.
 pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
     matches!(
         name,
@@ -311,7 +312,12 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
             | "Request"
             | "Response"
             | "FinalizationRegistry"
+            // Global functions (typeof === "function" in spec).
+            | "structuredClone"
+            | "atob"
+            | "btoa"
             // Namespaces (typeof === "object" in spec).
+            | "globalThis"
             | "console"
             | "Math"
             | "JSON"
@@ -330,7 +336,7 @@ pub(crate) fn is_global_this_builtin_function_name(name: &str) -> bool {
     is_global_this_builtin_name(name)
         && !matches!(
             name,
-            "console" | "Math" | "JSON" | "Reflect" | "performance" | "process"
+            "globalThis" | "console" | "Math" | "JSON" | "Reflect" | "performance" | "process"
         )
 }
 

--- a/crates/perry-hir/src/analysis/builtins.rs
+++ b/crates/perry-hir/src/analysis/builtins.rs
@@ -15,9 +15,9 @@ pub(crate) fn is_builtin_function(name: &str) -> bool {
     )
 }
 
-/// Built-in constructor / namespace identifiers that should resolve to
-/// a real `globalThis.<Name>` closure pointer when used as a bare
-/// expression value (e.g. `inst.constructor === Date`, drizzle's
+/// Built-in constructor / namespace identifiers, plus `globalThis` itself,
+/// that should resolve to a real `globalThis.<Name>` value when used as a
+/// bare expression value (e.g. `inst.constructor === Date`, drizzle's
 /// `value.constructor === Object`, lodash's `var A = context.Array`).
 /// Mirrors `populate_global_this_builtins` in
 /// `crates/perry-runtime/src/object.rs` and
@@ -31,7 +31,8 @@ pub(crate) fn is_builtin_function(name: &str) -> bool {
 pub(crate) fn is_builtin_global_value_name(name: &str) -> bool {
     matches!(
         name,
-        "Array"
+        "globalThis"
+            | "Array"
             | "Object"
             | "String"
             | "Number"

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -154,6 +154,12 @@ pub(crate) const GLOBAL_THIS_BUILTIN_CONSTRUCTORS: &[&str] = &[
 pub(crate) const GLOBAL_THIS_BUILTIN_NAMESPACES: &[&str] =
     &["console", "process", "Math", "JSON", "Reflect"];
 
+/// JS global built-in functions exposed as function-valued properties on
+/// `globalThis`. Unlike constructor sentinels, these call through to Perry's
+/// real direct-call runtime helpers so rebinding works:
+/// `const clone = globalThis.structuredClone; clone(value)`.
+pub(crate) const GLOBAL_THIS_BUILTIN_FUNCTIONS: &[&str] = &["structuredClone", "atob", "btoa"];
+
 /// No-op thunk used as the function body for most singleton globalThis
 /// built-in constructor values. Lets `globalThis.Array` carry a real
 /// ClosureHeader (so `typeof globalThis.Array === "function"`) without
@@ -177,6 +183,30 @@ extern "C" fn global_this_string_thunk(
 ) -> f64 {
     let string_ptr = crate::builtins::js_string_coerce(value);
     crate::value::js_nanbox_string(string_ptr as i64)
+}
+
+extern "C" fn global_this_structured_clone_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+    _options: f64,
+) -> f64 {
+    crate::builtins::js_structured_clone(value)
+}
+
+extern "C" fn global_this_atob_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    let decoded = crate::string::js_atob(value);
+    crate::value::js_nanbox_string(decoded as i64)
+}
+
+extern "C" fn global_this_btoa_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    let encoded = crate::string::js_btoa(value);
+    crate::value::js_nanbox_string(encoded as i64)
 }
 
 /// Thunk for `Object.prototype.toString` exposed as a callable closure
@@ -499,6 +529,12 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
     let proto_key_bytes = b"prototype";
     let proto_key =
         crate::string::js_string_from_bytes(proto_key_bytes.as_ptr(), proto_key_bytes.len() as u32);
+    {
+        let name = b"globalThis";
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let value = crate::value::js_nanbox_pointer(singleton as i64);
+        js_object_set_field_by_name(singleton, key, value);
+    }
     // #2145: pre-allocate the shared `%TypedArray%` intrinsic so per-kind
     // typed-array constructors can link their `__proto__` to it as they're
     // built below, and the per-kind `.prototype` objects can be flagged with
@@ -571,6 +607,29 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             crate::string::js_string_from_bytes(name_bytes.as_ptr(), name_bytes.len() as u32);
         let ctor_value = crate::value::js_nanbox_pointer(closure_ptr as i64);
         js_object_set_field_by_name(singleton, name_key, ctor_value);
+    }
+    // Callable global functions: ClosureHeader-backed values with real
+    // dispatch so direct property reads and rebound calls match bare calls.
+    for name in GLOBAL_THIS_BUILTIN_FUNCTIONS.iter().copied() {
+        let (func_ptr, arity) = match name {
+            "structuredClone" => (global_this_structured_clone_thunk as *const u8, 2),
+            "atob" => (global_this_atob_thunk as *const u8, 1),
+            "btoa" => (global_this_btoa_thunk as *const u8, 1),
+            _ => continue,
+        };
+        let closure_ptr = crate::closure::js_closure_alloc(func_ptr, 0);
+        if closure_ptr.is_null() {
+            continue;
+        }
+        crate::closure::js_register_closure_arity(func_ptr, arity);
+        unsafe {
+            crate::builtins::js_register_function_name(func_ptr, name.as_ptr(), name.len() as u32);
+        }
+        let name_bytes = name.as_bytes();
+        let name_key =
+            crate::string::js_string_from_bytes(name_bytes.as_ptr(), name_bytes.len() as u32);
+        let fn_value = crate::value::js_nanbox_pointer(closure_ptr as i64);
+        js_object_set_field_by_name(singleton, name_key, fn_value);
     }
     // Namespaces: plain ObjectHeader so typeof is "object" per spec.
     for name in GLOBAL_THIS_BUILTIN_NAMESPACES.iter().copied() {

--- a/test-parity/node-suite/globals/global-functions.ts
+++ b/test-parity/node-suite/globals/global-functions.ts
@@ -1,0 +1,38 @@
+const g: any = globalThis;
+
+console.log(
+  "direct typeof:",
+  typeof globalThis.structuredClone,
+  typeof globalThis.atob,
+  typeof globalThis.btoa,
+);
+
+for (const name of ["structuredClone", "atob", "btoa"]) {
+  const fn = g[name];
+  const desc = Object.getOwnPropertyDescriptor(globalThis, name);
+  console.log(`${name} typeof:`, typeof fn);
+  console.log(`${name} name/length:`, fn?.name, fn?.length);
+  console.log(
+    `${name} desc:`,
+    !!desc,
+    desc?.writable,
+    desc?.enumerable,
+    desc?.configurable,
+  );
+}
+
+const original = { nested: { value: 7 } };
+const clone = g.structuredClone;
+const cloned = clone(original);
+console.log("structuredClone rebound distinct:", cloned !== original);
+console.log(
+  "structuredClone rebound nested:",
+  cloned.nested !== original.nested,
+  cloned.nested.value,
+);
+
+const encode = g.btoa;
+const decode = g.atob;
+console.log("btoa rebound:", encode("perry"));
+console.log("atob rebound:", decode("cGVycnk="));
+console.log("roundtrip rebound:", decode(encode("Hello")));


### PR DESCRIPTION
Closes #2585.

## Summary
- expose `structuredClone`, `atob`, and `btoa` as function-valued own properties on the `globalThis` singleton
- route bare `globalThis` value reads to the singleton via a self-reference so descriptor and rebinding patterns work
- add parity coverage for direct `globalThis.x`, computed `globalThis[name]`, descriptors, function `name`/`length`, and rebound calls

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `env RUSTC_WRAPPER= cargo check -p perry-runtime -p perry-codegen -p perry-hir`
- `env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module globals --filter global-functions`
- `env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module process --filter global`
- `env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module object --filter globals/string-call`
- `env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module buffer --filter atob-btoa`

## Notes
- `structuredClone(value, options)` keeps using Perry's existing structured clone helper; this PR exposes the callable global property surface and rebinding behavior rather than expanding transfer-list semantics.
