### PR TITLE
fix(node:os): return host version string from os.version

### DIFF
--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -5,6 +5,8 @@ use crate::object::ObjectHeader;
 use crate::string::{js_string_from_bytes, StringHeader};
 use std::cell::RefCell;
 use std::collections::HashMap;
+#[cfg(unix)]
+use std::ffi::CStr;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::OnceLock;
 use std::time::Instant;
@@ -423,7 +425,55 @@ pub extern "C" fn js_os_loadavg() -> *mut ArrayHeader {
 /// Get the operating system version string.
 #[no_mangle]
 pub extern "C" fn js_os_version() -> *mut StringHeader {
-    js_os_release()
+    #[cfg(unix)]
+    {
+        unsafe {
+            let mut info: libc::utsname = std::mem::zeroed();
+            if libc::uname(&mut info) == 0 {
+                let version = CStr::from_ptr(info.version.as_ptr()).to_string_lossy();
+                let bytes = version.as_bytes();
+                return js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+            }
+        }
+
+        let fallback = "unknown";
+        js_string_from_bytes(fallback.as_ptr(), fallback.len() as u32)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        #[repr(C)]
+        struct RTL_OSVERSIONINFOW {
+            dw_os_version_info_size: u32,
+            dw_major_version: u32,
+            dw_minor_version: u32,
+            dw_build_number: u32,
+            dw_platform_id: u32,
+            sz_csd_version: [u16; 128],
+        }
+        extern "system" {
+            fn RtlGetVersion(lpVersionInformation: *mut RTL_OSVERSIONINFOW) -> i32;
+        }
+        unsafe {
+            let mut info: RTL_OSVERSIONINFOW = std::mem::zeroed();
+            info.dw_os_version_info_size = std::mem::size_of::<RTL_OSVERSIONINFOW>() as u32;
+            if RtlGetVersion(&mut info) == 0 {
+                let version = format!(
+                    "Windows {}.{}.{}",
+                    info.dw_major_version, info.dw_minor_version, info.dw_build_number
+                );
+                let bytes = version.as_bytes();
+                return js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+            }
+        }
+
+        let fallback = "Windows";
+        js_string_from_bytes(fallback.as_ptr(), fallback.len() as u32)
+    }
+    #[cfg(not(any(unix, target_os = "windows")))]
+    {
+        let fallback = "unknown";
+        js_string_from_bytes(fallback.as_ptr(), fallback.len() as u32)
+    }
 }
 
 /// Get the process uptime in seconds (time since process started)
@@ -1931,6 +1981,12 @@ mod tests {
     fn test_os_release() {
         let release = js_os_release();
         assert!(!release.is_null());
+    }
+
+    #[test]
+    fn test_os_version() {
+        let version = js_os_version();
+        assert!(!version.is_null());
     }
 
     #[test]

--- a/test-parity/node-suite/os/methods/version.ts
+++ b/test-parity/node-suite/os/methods/version.ts
@@ -1,4 +1,15 @@
 import * as os from "node:os";
 
-console.log("version string:", typeof os.version() === "string");
-console.log("version nonempty:", os.version().length > 0);
+const release = os.release();
+const version = os.version();
+
+console.log("release string:", typeof release === "string" && release.length > 0);
+console.log("version string:", typeof version === "string" && version.length > 0);
+console.log("release equals version:", release === version);
+
+if (os.platform() === "linux") {
+  console.log("linux version starts hash:", version.startsWith("#"));
+  console.log("linux version includes release:", version.includes(release));
+} else if (os.platform() === "darwin") {
+  console.log("darwin version includes kernel label:", version.includes("Darwin Kernel Version"));
+}


### PR DESCRIPTION
Closes #2604

## Summary
- make `os.version()` read the host OS version field instead of delegating to `os.release()`
- use `uname(2).version` on Unix targets, matching the observable Linux/Darwin distinction from Node
- tighten the `node:os` parity fixture so release/version aliasing fails explicitly

## Tests Added
- updated `test-parity/node-suite/os/methods/version.ts` to assert the release/version distinction and Linux/Darwin version shape
- added `perry-runtime` unit smoke coverage for `js_os_version()` returning a string pointer

## Verification
- local Node v24.15.0 probe for `os.release()` vs `os.version()` on Linux
- baseline before fix: `env PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module os --filter methods/version` failed with Perry aliasing release/version
- `RUSTC_WRAPPER= cargo test -p perry-runtime test_os_version`
- `RUSTC_WRAPPER= cargo check -p perry-runtime`
- `env PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module os` (39 pass, 0 fail)
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `git diff --check && git diff --cached --check`

## Known Limitations / Non-goals
- this does not attempt byte-for-byte Windows product-name parity; it removes the direct alias and keeps Windows on an RtlGetVersion-backed string path
- no docs or manifest changes were needed because `os.version()` was already routed and marked covered
