### PR TITLE
fix(globals): expose structuredClone, atob, and btoa on globalThis

### DIFF
--- a/crates/perry-codegen/src/expr/helpers.rs
+++ b/crates/perry-codegen/src/expr/helpers.rs
@@ -245,15 +245,16 @@ pub(crate) fn unbox_to_i64(blk: &mut LlBlock, boxed: &str) -> String {
     blk.and(I64, &bits, POINTER_MASK_I64)
 }
 
-/// Built-in constructor / namespace names that the runtime pre-populates
-/// on the globalThis singleton (`populate_global_this_builtins` in
-/// crates/perry-runtime/src/object.rs). Used by codegen to decide whether
-/// `globalThis.<Name>` should route through `js_get_global_this`
-/// (returning the populated backing-object) or fall through to the `0.0`
-/// no-value placeholder. Keep this list in sync with
-/// `GLOBAL_THIS_BUILTIN_CONSTRUCTORS` + `GLOBAL_THIS_BUILTIN_NAMESPACES`
-/// in object.rs — the codegen check and the runtime population together
-/// implement the lodash `runInContext` blocker fix.
+/// Built-in constructor / global-function / namespace names that the runtime
+/// pre-populates on the globalThis singleton (`populate_global_this_builtins`
+/// in crates/perry-runtime/src/object/global_this.rs). Used by codegen to
+/// decide whether `globalThis.<Name>` should route through
+/// `js_get_global_this` (returning the populated backing-object) or fall
+/// through to the `0.0` no-value placeholder. Keep this list in sync with
+/// `GLOBAL_THIS_BUILTIN_CONSTRUCTORS`, `GLOBAL_THIS_BUILTIN_FUNCTIONS`, and
+/// `GLOBAL_THIS_BUILTIN_NAMESPACES` in object/global_this.rs — the codegen
+/// check and the runtime population together implement the lodash
+/// `runInContext` blocker fix.
 pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
     matches!(
         name,
@@ -311,6 +312,10 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
             | "Request"
             | "Response"
             | "FinalizationRegistry"
+            // Global functions (typeof === "function" in spec).
+            | "structuredClone"
+            | "atob"
+            | "btoa"
             // Namespaces (typeof === "object" in spec).
             | "console"
             | "Math"
@@ -322,10 +327,10 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
 }
 
 /// Subset of `is_global_this_builtin_name` whose `typeof` is `"function"`
-/// in spec (constructors). Used by the `Expr::TypeOf` short-circuit so
-/// `typeof globalThis.Array === "function"`. Math/JSON/Reflect are
-/// namespaces — they keep `typeof === "object"` via the existing match
-/// arms.
+/// in spec (constructors and global functions). Used by the `Expr::TypeOf`
+/// short-circuit so `typeof globalThis.Array === "function"`. Math/JSON/
+/// Reflect are namespaces — they keep `typeof === "object"` via the
+/// existing match arms.
 pub(crate) fn is_global_this_builtin_function_name(name: &str) -> bool {
     is_global_this_builtin_name(name)
         && !matches!(

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -855,7 +855,13 @@ pub(super) fn try_native_module_methods(
                                 }
                             }
                             let mut iter = args.into_iter();
-                            let obj = iter.next().unwrap_or(Expr::Undefined);
+                            let mut obj = iter.next().unwrap_or(Expr::Undefined);
+                            if matches!(
+                                call.args.first().map(|arg| unwrap_ts_wrappers(arg.expr.as_ref())),
+                                Some(ast::Expr::Ident(ident)) if ident.sym.as_ref() == "globalThis"
+                            ) {
+                                obj = Expr::GlobalThisExpr;
+                            }
                             let key = iter.next().unwrap_or(Expr::Undefined);
                             return Ok(Ok(Expr::ObjectGetOwnPropertyDescriptor(
                                 Box::new(obj),

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -154,6 +154,12 @@ pub(crate) const GLOBAL_THIS_BUILTIN_CONSTRUCTORS: &[&str] = &[
 pub(crate) const GLOBAL_THIS_BUILTIN_NAMESPACES: &[&str] =
     &["console", "process", "Math", "JSON", "Reflect"];
 
+/// JS built-in global functions exposed as own properties of `globalThis`.
+/// These are real callable closures rather than constructor sentinels because
+/// feature-detection and rebinding patterns call them through the property
+/// value: `const clone = globalThis.structuredClone; clone(value)`.
+pub(crate) const GLOBAL_THIS_BUILTIN_FUNCTIONS: &[&str] = &["structuredClone", "atob", "btoa"];
+
 /// No-op thunk used as the function body for most singleton globalThis
 /// built-in constructor values. Lets `globalThis.Array` carry a real
 /// ClosureHeader (so `typeof globalThis.Array === "function"`) without
@@ -176,6 +182,30 @@ extern "C" fn global_this_string_thunk(
     value: f64,
 ) -> f64 {
     let string_ptr = crate::builtins::js_string_coerce(value);
+    crate::value::js_nanbox_string(string_ptr as i64)
+}
+
+extern "C" fn global_this_structured_clone_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+    _options: f64,
+) -> f64 {
+    crate::builtins::js_structured_clone(value)
+}
+
+extern "C" fn global_this_atob_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    let string_ptr = crate::string::js_atob(value);
+    crate::value::js_nanbox_string(string_ptr as i64)
+}
+
+extern "C" fn global_this_btoa_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    let string_ptr = crate::string::js_btoa(value);
     crate::value::js_nanbox_string(string_ptr as i64)
 }
 
@@ -571,6 +601,27 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             crate::string::js_string_from_bytes(name_bytes.as_ptr(), name_bytes.len() as u32);
         let ctor_value = crate::value::js_nanbox_pointer(closure_ptr as i64);
         js_object_set_field_by_name(singleton, name_key, ctor_value);
+    }
+    // Global functions: ClosureHeader-backed callable values with the Node
+    // observable `name` and `length` properties.
+    for name in GLOBAL_THIS_BUILTIN_FUNCTIONS.iter().copied() {
+        let (func_ptr, arity) = match name {
+            "structuredClone" => (global_this_structured_clone_thunk as *const u8, 2),
+            "atob" => (global_this_atob_thunk as *const u8, 1),
+            "btoa" => (global_this_btoa_thunk as *const u8, 1),
+            _ => continue,
+        };
+        let closure_ptr = crate::closure::js_closure_alloc(func_ptr, 0);
+        if closure_ptr.is_null() {
+            continue;
+        }
+        crate::closure::js_register_closure_arity(func_ptr, arity);
+        super::native_module::set_bound_native_closure_name(closure_ptr, name);
+        let name_bytes = name.as_bytes();
+        let name_key =
+            crate::string::js_string_from_bytes(name_bytes.as_ptr(), name_bytes.len() as u32);
+        let value = crate::value::js_nanbox_pointer(closure_ptr as i64);
+        js_object_set_field_by_name(singleton, name_key, value);
     }
     // Namespaces: plain ObjectHeader so typeof is "object" per spec.
     for name in GLOBAL_THIS_BUILTIN_NAMESPACES.iter().copied() {

--- a/test-parity/node-suite/object/globals/global-structuredclone-atob-btoa.ts
+++ b/test-parity/node-suite/object/globals/global-structuredclone-atob-btoa.ts
@@ -1,0 +1,35 @@
+const names = ["structuredClone", "atob", "btoa"];
+
+for (const name of names) {
+  const value = globalThis[name];
+  const desc = Object.getOwnPropertyDescriptor(globalThis, name);
+
+  console.log(name + " typeof:", typeof value);
+  console.log(
+    name + " descriptor:",
+    desc !== undefined,
+    desc ? desc.writable : "missing",
+    desc ? desc.enumerable : "missing",
+    desc ? desc.configurable : "missing",
+  );
+  console.log(
+    name + " name-length:",
+    value ? value.name : "missing",
+    value ? value.length : "missing",
+  );
+}
+
+const clone = globalThis.structuredClone;
+const source = { nested: { value: 42 }, list: [1, 2, 3] };
+const cloned = clone(source);
+console.log(
+  "clone values:",
+  cloned.nested.value,
+  cloned.list.join(","),
+  cloned !== source,
+  cloned.nested !== source.nested,
+);
+
+const decode = globalThis.atob;
+const encode = globalThis.btoa;
+console.log("base64 values:", decode("cGVycnk="), encode("perry"));


### PR DESCRIPTION
Fixes #2585.

## Summary
- Populate `globalThis.structuredClone`, `globalThis.atob`, and `globalThis.btoa` as callable global function properties.
- Reuse existing runtime implementations so rebound calls like `const clone = globalThis.structuredClone; clone(value)` work.
- Preserve Node-observable `typeof`, descriptor, `name`, and `length` behavior for these global functions.
- Route literal `Object.getOwnPropertyDescriptor(globalThis, key)` through the existing `GlobalThisExpr` singleton materialization so descriptor checks inspect the real global object.

## Coverage
- Added `test-parity/node-suite/object/globals/global-structuredclone-atob-btoa.ts`.

## Verification
- `node -e '<inline parity probe>'` matches the new fixture's expected output on Node v22.22.1.
- Pre-fix direct Perry binary failed with `structuredClone typeof: undefined` followed by `TypeError: value is not a function`.
- `env PERRY_ALLOW_UNIMPLEMENTED=1 target/debug/perry test-parity/node-suite/object/globals/global-structuredclone-atob-btoa.ts -o /tmp/perry_global_structuredclone_atob_btoa_after_descriptor`
- `/tmp/perry_global_structuredclone_atob_btoa_after_descriptor`
- `cargo build -p perry -p perry-runtime -p perry-stdlib`
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `git diff --check`
- `./run_parity_tests.sh --suite node-suite --module object --filter global-structuredclone-atob-btoa` exits 1 locally because this Node build rejects `.ts` parity files with `ERR_UNKNOWN_FILE_EXTENSION`; the harness records the case as a Node.js error/skip and then fails the aggregate threshold with 0 executed tests.

## Non-goals / limitations
- Does not add new base64 or structured-clone algorithms; it wires the existing runtime implementations onto `globalThis`.
- Does not broadly change how every bare `globalThis` expression lowers; the descriptor routing is scoped to the literal `Object.getOwnPropertyDescriptor(globalThis, key)` shape.