### PR TITLE
feat(node:punycode): implement ucs2.decode / ucs2.encode (#2607)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -127,7 +127,7 @@ pub const NATIVE_MODULES: &[&str] = &[
 /// `node_submodules` runtime table rather than `NATIVE_MODULES`.
 /// Keeping these separate preserves the compiler's submodule import
 /// lowering while still allowing manifest/docs entries for the subpath.
-pub const NODE_SUBMODULES: &[&str] = &["stream/promises"];
+pub const NODE_SUBMODULES: &[&str] = &["stream/promises", "punycode.ucs2"];
 
 /// Modules handled entirely by `perry-runtime` — the linker doesn't
 /// need to pull in `perry-stdlib` for these. Migrated from
@@ -2729,6 +2729,12 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("punycode", "toASCII", false, None),
     method("punycode", "toUnicode", false, None),
     property("punycode", "version"),
+    // #2607: the `ucs2` code-point helper sub-namespace. The sub-namespace
+    // object is a `property` on `punycode`; its `decode`/`encode` methods carry
+    // the `punycode.ucs2` module key (mirrors `util/types`).
+    property("punycode", "ucs2"),
+    method("punycode.ucs2", "decode", false, None),
+    method("punycode.ucs2", "encode", false, None),
     // --- http (perry-ext-http surface + classes the framework spec
     //     exposes). Both http and https route through the same crate. ---
     method("http", "createServer", false, None),

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -370,6 +370,27 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    // punycode.ucs2 sub-namespace (#2607): decode(string)->code-point array,
+    // encode(code-point array)->string. The array arg/return ride as a
+    // NaN-boxed pointer in the NA_F64 slot.
+    NativeModSig {
+        module: "punycode.ucs2",
+        has_receiver: false,
+        method: "decode",
+        class_filter: None,
+        runtime: "js_punycode_ucs2_decode",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "punycode.ucs2",
+        has_receiver: false,
+        method: "encode",
+        class_filter: None,
+        runtime: "js_punycode_ucs2_encode",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     // ========== Node console ==========
     NativeModSig {
         module: "console",

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -69,7 +69,7 @@ use module_static::try_module_static_methods;
 use native_module::try_native_module_methods;
 use nested_namespace::{
     try_path_subnamespace, try_process_hrtime_bigint, try_process_memory_usage_rss,
-    try_util_types_namespace, try_web_crypto_subtle,
+    try_punycode_ucs2_namespace, try_util_types_namespace, try_web_crypto_subtle,
 };
 use post_args_dispatch::{
     try_object_has_own_call, try_object_prototype_call, try_object_static_alias_call,
@@ -297,6 +297,10 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                 Err(a) => a,
             };
             args = match try_util_types_namespace(ctx, expr, args)? {
+                Ok(e) => return Ok(e),
+                Err(a) => a,
+            };
+            args = match try_punycode_ucs2_namespace(ctx, expr, args)? {
                 Ok(e) => return Ok(e),
                 Err(a) => a,
             };

--- a/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
+++ b/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
@@ -349,6 +349,50 @@ pub(super) fn try_util_types_namespace(
     Ok(Err(args))
 }
 
+/// `punycode.ucs2.<method>(args)` (#2607) — sub-namespace dispatch for the
+/// deprecated `node:punycode` module's `ucs2` code-point helpers
+/// (`decode`/`encode`). Rewrites the namespace-access form to a
+/// `NativeMethodCall` on the `punycode.ucs2` module key, routed through
+/// `native_module_dispatch`. Without this the chain would greedily match the
+/// top-level `punycode.decode`/`encode` native-table rows (ignoring `.ucs2`).
+pub(super) fn try_punycode_ucs2_namespace(
+    ctx: &LoweringContext,
+    expr: &ast::Expr,
+    args: Vec<Expr>,
+) -> Result<Result<Expr, Vec<Expr>>> {
+    if let ast::Expr::Member(outer_member) = expr {
+        if let ast::Expr::Member(inner_member) = outer_member.obj.as_ref() {
+            if let ast::Expr::Ident(root_ident) = inner_member.obj.as_ref() {
+                let root_name = root_ident.sym.as_ref();
+                let is_punycode_root = root_name == "punycode"
+                    || ctx.lookup_builtin_module_alias(root_name) == Some("punycode")
+                    || ctx
+                        .lookup_native_module(root_name)
+                        .map(|(m, _)| m == "punycode")
+                        .unwrap_or(false);
+                if is_punycode_root {
+                    if let (ast::MemberProp::Ident(namespace), ast::MemberProp::Ident(method)) =
+                        (&inner_member.prop, &outer_member.prop)
+                    {
+                        if namespace.sym.as_ref() == "ucs2"
+                            && matches!(method.sym.as_ref(), "decode" | "encode")
+                        {
+                            return Ok(Ok(Expr::NativeMethodCall {
+                                module: "punycode.ucs2".to_string(),
+                                class_name: None,
+                                object: None,
+                                method: method.sym.to_string(),
+                                args,
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(Err(args))
+}
+
 /// `path.posix.<method>(args)` / `path.win32.<method>(args)` —
 /// sub-namespace dispatch (issue #810). Without this arm the
 /// generic mod.X.Y() block below skips the call (path.posix /

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1620,9 +1620,11 @@ pub(crate) unsafe fn get_native_module_constant(
     };
 
     match module_name {
-        // node:punycode (deprecated, #2513) — the bundled punycode.js version.
+        // node:punycode (deprecated, #2513) — the bundled punycode.js version
+        // and the `ucs2` code-point helper sub-namespace (#2607).
         "punycode" => match property {
             "version" => Some(str_val(crate::punycode::PUNYCODE_VERSION)),
+            "ucs2" => Some(create_sub_namespace("punycode.ucs2")),
             _ => None,
         },
         // node:perf_hooks — `performance.timeOrigin` (ms since epoch at start)

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1159,6 +1159,9 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("punycode", "encode") => crate::punycode::js_punycode_encode(arg(0)),
         ("punycode", "toASCII") => crate::punycode::js_punycode_to_ascii(arg(0)),
         ("punycode", "toUnicode") => crate::punycode::js_punycode_to_unicode(arg(0)),
+        // ── punycode.ucs2 sub-namespace (#2607) ──
+        ("punycode.ucs2", "decode") => crate::punycode::js_punycode_ucs2_decode(arg(0)),
+        ("punycode.ucs2", "encode") => crate::punycode::js_punycode_ucs2_encode(arg(0)),
 
         // ── console module namespace (`node:console` / `console`) ──
         ("console", "log") | ("console", "info") | ("console", "debug") | ("console", "dirxml") => {

--- a/crates/perry-runtime/src/punycode.rs
+++ b/crates/perry-runtime/src/punycode.rs
@@ -260,6 +260,44 @@ pub extern "C" fn js_punycode_to_unicode(value: f64) -> f64 {
     create_string_f64(&to_unicode(&get_string_content(value)))
 }
 
+/// `punycode.ucs2.decode(string)` — split a string into an array of Unicode
+/// code points (astral code points become a single number, combining the
+/// UTF-16 surrogate pair). Rust `char` is already a Unicode scalar value, so
+/// `chars()` yields code points directly.
+#[no_mangle]
+pub extern "C" fn js_punycode_ucs2_decode(value: f64) -> f64 {
+    let s = get_string_content(value);
+    let arr = crate::array::js_array_alloc(s.chars().count() as u32);
+    for c in s.chars() {
+        crate::array::js_array_push_f64(arr, c as u32 as f64);
+    }
+    f64::from_bits(crate::value::JSValue::array_ptr(arr).bits())
+}
+
+/// `punycode.ucs2.encode(codePoints)` — build a string from an array of code
+/// points (each astral code point is emitted as its character; `char::from_u32`
+/// handles the surrogate-pair recombination since Rust strings are UTF-8).
+#[no_mangle]
+pub extern "C" fn js_punycode_ucs2_encode(value: f64) -> f64 {
+    let jsval = crate::value::JSValue::from_bits(value.to_bits());
+    if !jsval.is_pointer() {
+        return create_string_f64("");
+    }
+    let arr = jsval.as_pointer::<crate::array::ArrayHeader>();
+    if arr.is_null() {
+        return create_string_f64("");
+    }
+    let len = unsafe { crate::array::js_array_length(arr) } as u32;
+    let mut out = String::new();
+    for i in 0..len {
+        let v = unsafe { crate::array::js_array_get_f64(arr, i) };
+        if let Some(c) = char::from_u32(v as u32) {
+            out.push(c);
+        }
+    }
+    create_string_f64(&out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1512 entries across 83 modules
+// Coverage: 1515 entries across 84 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1858,6 +1858,8 @@ declare module "process" {
 
 declare module "punycode" {
   /** stdlib */
+  export const ucs2: any;
+  /** stdlib */
   export const version: any;
   /** stdlib */
   export function decode(...args: any[]): any;
@@ -1867,6 +1869,13 @@ declare module "punycode" {
   export function toASCII(...args: any[]): any;
   /** stdlib */
   export function toUnicode(...args: any[]): any;
+}
+
+declare module "punycode.ucs2" {
+  /** stdlib */
+  export function decode(...args: any[]): any;
+  /** stdlib */
+  export function encode(...args: any[]): any;
 }
 
 declare module "querystring" {

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -282,15 +282,6 @@ Selected highlights (full list in `runtime-parity.md`):
 - `rl.commit()`
 - `rl.rollback()`
 
-### node:punycode
-
-**Total APIs: 7** · Perry covers: 5 · Gap: 2
-
-Remaining (the `ucs2` sub-namespace array helpers, #2513 follow-up):
-
-- `punycode.ucs2.decode(string)`
-- `punycode.ucs2.encode(codePoints)`
-
 ### node:stream/consumers
 
 **Total APIs: 6** · Perry covers: 0 · Gap: 6

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1512 entries across 83 modules.
+Total: 1515 entries across 84 modules.
 
 ## Modules
 
@@ -68,6 +68,7 @@ Total: 1512 entries across 83 modules.
 - [`pg`](#pg)
 - [`process`](#process)
 - [`punycode`](#punycode)
+- [`punycode.ucs2`](#punycode-ucs2)
 - [`querystring`](#querystring)
 - [`rate-limiter-flexible`](#rate-limiter-flexible)
 - [`readline`](#readline)
@@ -1738,7 +1739,15 @@ Total: 1512 entries across 83 modules.
 
 ### Properties
 
+- `ucs2`
 - `version`
+
+## `punycode.ucs2`
+
+### Methods
+
+- `decode` — module
+- `encode` — module
 
 ## `querystring`
 

--- a/test-parity/node-suite/punycode/ucs2.ts
+++ b/test-parity/node-suite/punycode/ucs2.ts
@@ -1,0 +1,14 @@
+// node:punycode ucs2 code-point helpers (#2607).
+import punycode from "node:punycode";
+
+console.log("decode abc:", JSON.stringify(punycode.ucs2.decode("abc")));
+console.log("encode abc:", punycode.ucs2.encode([97, 98, 99]));
+console.log("decode astral:", JSON.stringify(punycode.ucs2.decode("a\u{1F600}b")));
+console.log("encode astral:", punycode.ucs2.encode([97, 128512, 98]));
+console.log("decode accented:", JSON.stringify(punycode.ucs2.decode("héllo")));
+console.log("roundtrip:", punycode.ucs2.encode(punycode.ucs2.decode("héllo😀")));
+console.log("empty decode:", JSON.stringify(punycode.ucs2.decode("")));
+
+import * as p from "node:punycode";
+console.log("ns decode:", JSON.stringify(p.ucs2.decode("xy")));
+console.log("ns encode:", p.ucs2.encode([120, 121]));


### PR DESCRIPTION
Fixes #2607 (completes #2513 — `node:punycode` is now 7/7).

## Summary
Adds the `ucs2` code-point helper sub-namespace:
- `punycode.ucs2.decode(string)` → array of Unicode code points (astral code points are one number, combining the UTF-16 surrogate pair).
- `punycode.ucs2.encode(codePoints)` → string.

Runtime impl in `perry-runtime/src/punycode.rs` uses Rust `str::chars()` (already code points) + `char::from_u32`, with the array marshalling from `process.getgroups`/`setgroups`.

## Sub-namespace wiring
- **HIR**: `try_punycode_ucs2_namespace` rewrites `punycode.ucs2.<m>(...)` → `NativeMethodCall{module:"punycode.ucs2"}` (mirrors `try_util_types_namespace`). Without it the chain greedily matched the top-level `punycode.decode`/`encode` rows.
- **`native_module.rs`**: `punycode.ucs2` resolves to a sub-namespace object (`create_sub_namespace`).
- **codegen native-table** rows + **runtime dynamic-dispatch** arms for `("punycode.ucs2", decode/encode)`; **manifest** entries + `punycode.ucs2` added to `NODE_SUBMODULES` so the module key is known (satisfies the dispatch↔manifest + known-module consistency tests). Docs regenerated; `punycode` removed from `runtime-parity-gaps`.

## Testing
Byte-for-byte vs `node` (v25): decode/encode round-trips incl. astral (`a😀b` ↔ `[97,128512,98]`), accented chars, empty, and both default-import (`punycode.ucs2.x`) and namespace-import (`import * as p; p.ucs2.x`) forms. Adds `test-parity/node-suite/punycode/ucs2.ts`. fmt + size + api-manifest + codegen consistency + punycode unit tests pass locally.

## Known minor gap
`import { ucs2 } from "node:punycode"` (named sub-namespace import) doesn't bind `ucs2` to the sub-namespace — niche; the realistic default/namespace forms work. Deferred.
