### PR TITLE
test(stream): clear pause-in-data known failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -440,12 +440,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: writer.desiredSize does not restore to HWM after write resolves. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/flow/sync-pause-in-data-listener": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: pause() inside 'data' listener \u2014 does not stop further synchronous emits. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/compose-multi-async-fn": {
     "issue": "1531",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove stale known-failure entry for `stream/flow/sync-pause-in-data-listener`
- no runtime code changes; the pause-in-data fixture is green on current `main`

## Verification
- DeepWiki saved at `reference/deepwiki/nodejs-node-readable-pause-in-data-listener-2026-05-29.md`
- `./run_parity_tests.sh --suite node-suite --filter stream/flow/sync-pause-in-data-listener` PASS (`test-parity/reports/parity_report_20260529_125102.json`)
- focused `./run_parity_tests.sh --suite node-suite --filter stream/flow/` PASS 10/1; remaining failure is `sequential-reads` (`test-parity/reports/parity_report_20260529_125122.json`)
- post-rebase exact PASS (`test-parity/reports/parity_report_20260529_125206.json`)
- `jq empty test-parity/known_failures.json ...`
- `git diff --check`