### PR TITLE
Expose timer globals on globalThis

### DIFF
--- a/crates/perry-codegen/src/expr/helpers.rs
+++ b/crates/perry-codegen/src/expr/helpers.rs
@@ -310,6 +310,13 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
             | "structuredClone"
             | "atob"
             | "btoa"
+            | "setTimeout"
+            | "clearTimeout"
+            | "setInterval"
+            | "clearInterval"
+            | "setImmediate"
+            | "clearImmediate"
+            | "queueMicrotask"
             // Namespaces (typeof === "object" in spec).
             | "globalThis"
             | "console"

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -158,7 +158,18 @@ pub(crate) const GLOBAL_THIS_BUILTIN_NAMESPACES: &[&str] =
 /// `globalThis`. Unlike constructor sentinels, these call through to Perry's
 /// real direct-call runtime helpers so rebinding works:
 /// `const clone = globalThis.structuredClone; clone(value)`.
-pub(crate) const GLOBAL_THIS_BUILTIN_FUNCTIONS: &[&str] = &["structuredClone", "atob", "btoa"];
+pub(crate) const GLOBAL_THIS_BUILTIN_FUNCTIONS: &[&str] = &[
+    "structuredClone",
+    "atob",
+    "btoa",
+    "setTimeout",
+    "clearTimeout",
+    "setInterval",
+    "clearInterval",
+    "setImmediate",
+    "clearImmediate",
+    "queueMicrotask",
+];
 
 /// No-op thunk used as the function body for most singleton globalThis
 /// built-in constructor values. Lets `globalThis.Array` carry a real
@@ -207,6 +218,114 @@ extern "C" fn global_this_btoa_thunk(
 ) -> f64 {
     let encoded = crate::string::js_btoa(value);
     crate::value::js_nanbox_string(encoded as i64)
+}
+
+fn global_this_rest_array_values(rest: f64) -> Vec<f64> {
+    let value = crate::value::JSValue::from_bits(rest.to_bits());
+    if !value.is_pointer() {
+        return Vec::new();
+    }
+    let arr = value.as_pointer::<crate::array::ArrayHeader>();
+    if arr.is_null() {
+        return Vec::new();
+    }
+    let len = crate::array::js_array_length(arr);
+    (0..len)
+        .map(|i| crate::array::js_array_get_f64(arr, i))
+        .collect()
+}
+
+extern "C" fn global_this_set_timeout_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+    delay: f64,
+    rest: f64,
+) -> f64 {
+    let callback = unsafe { crate::timer::js_timer_validate_callback(callback, 0) };
+    let args = global_this_rest_array_values(rest);
+    if args.is_empty() {
+        crate::value::js_nanbox_pointer(crate::timer::js_set_timeout_callback(callback, delay))
+    } else {
+        crate::value::js_nanbox_pointer(unsafe {
+            crate::timer::js_set_timeout_callback_args(
+                callback,
+                delay,
+                args.as_ptr(),
+                args.len() as i32,
+            )
+        })
+    }
+}
+
+extern "C" fn global_this_clear_timeout_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    arg: f64,
+) -> f64 {
+    crate::timer::js_clear_timeout_value(arg);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+extern "C" fn global_this_set_interval_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+    delay: f64,
+    rest: f64,
+) -> f64 {
+    let callback = unsafe { crate::timer::js_timer_validate_callback(callback, 1) };
+    let args = global_this_rest_array_values(rest);
+    if args.is_empty() {
+        crate::value::js_nanbox_pointer(crate::timer::setInterval(callback, delay))
+    } else {
+        crate::value::js_nanbox_pointer(unsafe {
+            crate::timer::js_set_interval_callback_args(
+                callback,
+                delay,
+                args.as_ptr(),
+                args.len() as i32,
+            )
+        })
+    }
+}
+
+extern "C" fn global_this_clear_interval_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    arg: f64,
+) -> f64 {
+    crate::timer::js_clear_interval_value(arg);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+extern "C" fn global_this_set_immediate_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+    rest: f64,
+) -> f64 {
+    let callback = unsafe { crate::timer::js_timer_validate_callback(callback, 2) };
+    let args = global_this_rest_array_values(rest);
+    if args.is_empty() {
+        crate::value::js_nanbox_pointer(crate::timer::js_set_immediate_callback(callback))
+    } else {
+        crate::value::js_nanbox_pointer(unsafe {
+            crate::timer::js_set_immediate_callback_args(callback, args.as_ptr(), args.len() as i32)
+        })
+    }
+}
+
+extern "C" fn global_this_clear_immediate_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    arg: f64,
+) -> f64 {
+    crate::timer::js_clear_immediate_value(arg);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+extern "C" fn global_this_queue_microtask_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+) -> f64 {
+    let callback = unsafe { crate::timer::js_timer_validate_callback(callback, 3) };
+    crate::builtins::js_queue_microtask(callback);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
 }
 
 /// Thunk for `Object.prototype.toString` exposed as a callable closure
@@ -611,17 +730,28 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
     // Callable global functions: ClosureHeader-backed values with real
     // dispatch so direct property reads and rebound calls match bare calls.
     for name in GLOBAL_THIS_BUILTIN_FUNCTIONS.iter().copied() {
-        let (func_ptr, arity) = match name {
-            "structuredClone" => (global_this_structured_clone_thunk as *const u8, 2),
-            "atob" => (global_this_atob_thunk as *const u8, 1),
-            "btoa" => (global_this_btoa_thunk as *const u8, 1),
+        let (func_ptr, arity, has_rest) = match name {
+            "structuredClone" => (global_this_structured_clone_thunk as *const u8, 2, false),
+            "atob" => (global_this_atob_thunk as *const u8, 1, false),
+            "btoa" => (global_this_btoa_thunk as *const u8, 1, false),
+            "setTimeout" => (global_this_set_timeout_thunk as *const u8, 2, true),
+            "clearTimeout" => (global_this_clear_timeout_thunk as *const u8, 1, false),
+            "setInterval" => (global_this_set_interval_thunk as *const u8, 2, true),
+            "clearInterval" => (global_this_clear_interval_thunk as *const u8, 1, false),
+            "setImmediate" => (global_this_set_immediate_thunk as *const u8, 1, true),
+            "clearImmediate" => (global_this_clear_immediate_thunk as *const u8, 1, false),
+            "queueMicrotask" => (global_this_queue_microtask_thunk as *const u8, 1, false),
             _ => continue,
         };
         let closure_ptr = crate::closure::js_closure_alloc(func_ptr, 0);
         if closure_ptr.is_null() {
             continue;
         }
-        crate::closure::js_register_closure_arity(func_ptr, arity);
+        if has_rest {
+            crate::closure::js_register_closure_rest(func_ptr, arity);
+        } else {
+            crate::closure::js_register_closure_arity(func_ptr, arity);
+        }
         unsafe {
             crate::builtins::js_register_function_name(func_ptr, name.as_ptr(), name.len() as u32);
         }

--- a/test-parity/node-suite/timers/global-functions.ts
+++ b/test-parity/node-suite/timers/global-functions.ts
@@ -5,8 +5,95 @@ console.log("setImmediate:", typeof setImmediate);
 console.log("clearTimeout:", typeof clearTimeout);
 console.log("clearInterval:", typeof clearInterval);
 console.log("clearImmediate:", typeof clearImmediate);
+console.log(
+  "direct globalThis typeof:",
+  typeof globalThis.setTimeout,
+  typeof globalThis.queueMicrotask,
+);
+
+const g: any = globalThis;
+
+for (const name of [
+  "setTimeout",
+  "clearTimeout",
+  "setInterval",
+  "clearInterval",
+  "setImmediate",
+  "clearImmediate",
+  "queueMicrotask",
+]) {
+  const fn = g[name];
+  const desc = Object.getOwnPropertyDescriptor(globalThis, name);
+  console.log(
+    `${name} globalThis:`,
+    typeof fn,
+    fn?.name,
+    fn?.length,
+    !!desc,
+    desc?.writable,
+    desc?.enumerable,
+    desc?.configurable,
+  );
+}
+
 let fired = 0;
 const im = setImmediate(() => { fired++; });
 clearImmediate(im);
 await new Promise<void>((r) => setTimeout(() => r(), 15));
 console.log("cleared immediate:", fired === 0);
+
+const delay = g.setTimeout;
+const cancelDelay = g.clearTimeout;
+const every = g.setInterval;
+const cancelEvery = g.clearInterval;
+const immediate = g.setImmediate;
+const cancelImmediate = g.clearImmediate;
+const microtask = g.queueMicrotask;
+
+let timeoutCancelledFired = false;
+let immediateCancelledFired = false;
+let intervalFired = false;
+let microtaskFired = false;
+let immediateFired = false;
+let timeoutFired = false;
+let intervalArg = "";
+let immediateArg = "";
+let timeoutArg = "";
+
+const cancelledTimeout = delay(() => { timeoutCancelledFired = true; }, 1);
+cancelDelay(cancelledTimeout);
+
+const cancelledImmediate = immediate(() => { immediateCancelledFired = true; });
+cancelImmediate(cancelledImmediate);
+
+let interval: any;
+interval = every((value: string) => {
+  intervalFired = true;
+  intervalArg = value;
+  cancelEvery(interval);
+}, 1, "interval-arg");
+
+microtask(() => { microtaskFired = true; });
+immediate((value: string) => {
+  immediateFired = true;
+  immediateArg = value;
+}, "immediate-arg");
+delay((value: string) => {
+  timeoutFired = true;
+  timeoutArg = value;
+}, 1, "timeout-arg");
+
+await new Promise<void>((r) => delay(() => r(), 25));
+console.log(
+  "rebound fired:",
+  microtaskFired,
+  immediateFired,
+  timeoutFired,
+  intervalFired,
+);
+console.log("rebound args:", timeoutArg, immediateArg, intervalArg);
+console.log(
+  "rebound cancelled:",
+  !timeoutCancelledFired,
+  !immediateCancelledFired,
+);


### PR DESCRIPTION
Fixes #2584

## Summary
- expose `setTimeout`, `clearTimeout`, `setInterval`, `clearInterval`, `setImmediate`, `clearImmediate`, and `queueMicrotask` as function-valued `globalThis` properties
- route rebound timer calls through the same runtime scheduling/clearing helpers as bare globals, including trailing-argument forwarding for `setTimeout`, `setInterval`, and `setImmediate`
- mirror the new globalThis function names in codegen so direct `globalThis.<name>` reads and `typeof` feature detection use the populated singleton
- expand `node-suite/timers/global-functions` to cover descriptors, `name`/`length`, rebound calls, cancellations, microtasks, and timer varargs

## Repro
- Pre-fix expanded fixture failed: `globalThis` timer and microtask properties printed as `undefined`, then a rebound `setTimeout` call threw `TypeError: value is not a function`. Report: `test-parity/reports/parity_report_20260529_194818.json`.

## Tests
- `PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module timers --filter global-functions` PASS (`test-parity/reports/parity_report_20260529_195840.json`)
- `PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module globals --filter global-functions` PASS (`test-parity/reports/parity_report_20260529_200004.json`)
- `PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module timers --filter namespace/import-surface` PASS (`test-parity/reports/parity_report_20260529_200011.json`)
- `PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module timers --filter arg-validation` PASS (`test-parity/reports/parity_report_20260529_200020.json`)
- `env RUSTC_WRAPPER= cargo check -p perry-codegen -p perry-runtime` PASS with existing warnings
- `cargo fmt --all -- --check` PASS
- `git diff --check` PASS
- `jq empty test-parity/known_failures.json` PASS

## Known verification issue
- `./scripts/check_file_size.sh` fails on current `origin/main` because `crates/perry-codegen/tests/native_proof_regressions.rs` is 2269 lines. This branch does not touch that file.

## Notes
- I attempted to add the `inprogress` label to #2584, but GitHub rejected it due insufficient label permissions.
