### PR TITLE
fix(node): alias sys to util namespace

### DIFF
--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -643,7 +643,7 @@ thread_local! {
 static ANY_SINGLETON_ALLOCATED: AtomicI64 = AtomicI64::new(0);
 static SYS_DEPRECATION_WARNED: AtomicI64 = AtomicI64::new(0);
 
-fn emit_sys_deprecation_warning_once() {
+pub(crate) fn emit_sys_deprecation_warning_once() {
     if SYS_DEPRECATION_WARNED
         .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Acquire)
         .is_err()
@@ -657,12 +657,26 @@ fn emit_sys_deprecation_warning_once() {
     eprintln!("(Use `node --trace-deprecation ...` to show where the warning was created)");
 }
 
+fn sys_util_namespace_value() -> f64 {
+    crate::object::js_create_native_module_namespace(b"util".as_ptr(), "util".len())
+}
+
 fn sys_util_export_value(name: &str) -> Option<f64> {
-    match name {
-        "format" | "inspect" | "deprecate" | "promisify" | "callbackify" => Some(
-            crate::object::bound_native_callable_export_value("util", name),
-        ),
-        _ => None,
+    if name == "default" {
+        return Some(sys_util_namespace_value());
+    }
+    let value = unsafe {
+        crate::object::js_native_module_property_by_name(
+            b"util".as_ptr(),
+            "util".len(),
+            name.as_ptr(),
+            name.len(),
+        )
+    };
+    if value.to_bits() == crate::value::TAG_UNDEFINED {
+        None
+    } else {
+        Some(value)
     }
 }
 
@@ -946,6 +960,20 @@ pub unsafe extern "C" fn js_node_submodule_namespace_member(
         Some(s) => s,
         None => return f64::from_bits(crate::value::TAG_UNDEFINED),
     };
+    if submod.key == "sys" {
+        emit_sys_deprecation_warning_once();
+        if name == "default" {
+            return sys_util_namespace_value();
+        }
+        return unsafe {
+            crate::object::js_native_module_property_by_name(
+                b"util".as_ptr(),
+                "util".len(),
+                name.as_ptr(),
+                name.len(),
+            )
+        };
+    }
     if submod.key == "stream_promises" && name == "default" {
         let obj = ensure_namespace_singleton(submod);
         return f64::from_bits(JSValue::pointer(obj as *const u8).bits());
@@ -985,6 +1013,7 @@ pub unsafe extern "C" fn js_node_submodule_namespace(
     };
     if submod.key == "sys" {
         emit_sys_deprecation_warning_once();
+        return sys_util_namespace_value();
     }
     let obj = ensure_namespace_singleton(submod);
     f64::from_bits(JSValue::pointer(obj as *const u8).bits())
@@ -1192,6 +1221,44 @@ mod tests {
         };
 
         assert_eq!(sys_inspect.to_bits(), util_inspect.to_bits());
+    }
+
+    #[test]
+    fn sys_default_export_is_util_namespace() {
+        let sys_default = unsafe {
+            js_node_submodule_export_as_function(
+                b"sys".as_ptr(),
+                "sys".len() as u32,
+                b"default".as_ptr(),
+                "default".len() as u32,
+            )
+        };
+        let util_default =
+            crate::object::js_create_native_module_namespace(b"util".as_ptr(), "util".len());
+
+        assert_eq!(sys_default.to_bits(), util_default.to_bits());
+    }
+
+    #[test]
+    fn sys_namespace_types_member_reuses_util_types() {
+        let sys_types = unsafe {
+            js_node_submodule_namespace_member(
+                b"sys".as_ptr(),
+                "sys".len() as u32,
+                b"types".as_ptr(),
+                "types".len() as u32,
+            )
+        };
+        let util_types = unsafe {
+            crate::object::js_native_module_property_by_name(
+                b"util".as_ptr(),
+                "util".len(),
+                b"types".as_ptr(),
+                "types".len(),
+            )
+        };
+
+        assert_eq!(sys_types.to_bits(), util_types.to_bits());
     }
 
     #[test]

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -14,6 +14,8 @@ thread_local! {
     static NATIVE_CALLABLE_EXPORTS: RefCell<HashMap<String, u64>> =
         RefCell::new(HashMap::new());
     static BUFFER_CONSTRUCTOR_VALUE: Cell<u64> = const { Cell::new(0) };
+    static NATIVE_MODULE_NAMESPACES: RefCell<HashMap<String, u64>> =
+        RefCell::new(HashMap::new());
 }
 
 pub fn scan_native_callable_export_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
@@ -28,6 +30,12 @@ pub fn scan_native_callable_export_roots_mut(visitor: &mut crate::gc::RuntimeRoo
         if value_bits != 0 {
             visitor.visit_nanbox_u64_slot(&mut value_bits);
             slot.set(value_bits);
+        }
+    });
+    NATIVE_MODULE_NAMESPACES.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        for value_bits in cache.values_mut() {
+            visitor.visit_nanbox_u64_slot(value_bits);
         }
     });
     scan_stream_event_emitter_prototype_roots_mut(visitor);
@@ -61,14 +69,28 @@ pub extern "C" fn js_create_native_module_namespace(
     module_name_ptr: *const u8,
     module_name_len: usize,
 ) -> f64 {
+    let module_name = unsafe {
+        std::str::from_utf8(std::slice::from_raw_parts(module_name_ptr, module_name_len))
+            .unwrap_or("")
+    };
+    let module_name = normalize_native_module_alias(module_name);
+    if should_cache_native_module_namespace(module_name) {
+        if let Some(bits) =
+            NATIVE_MODULE_NAMESPACES.with(|cache| cache.borrow().get(module_name).copied())
+        {
+            return f64::from_bits(bits);
+        }
+    }
+
     // Create an object with one field to store the module name
     let obj = js_object_alloc(NATIVE_MODULE_CLASS_ID, 1);
 
     // Create a string from the module name
-    let module_name = crate::string::js_string_from_bytes(module_name_ptr, module_name_len as u32);
+    let module_name_header =
+        crate::string::js_string_from_bytes(module_name.as_ptr(), module_name.len() as u32);
 
     // Store the module name in the first field
-    js_object_set_field(obj, 0, JSValue::string_ptr(module_name));
+    js_object_set_field(obj, 0, JSValue::string_ptr(module_name_header));
 
     // Create a keys array with one key: "__module__"
     let keys_array = crate::array::js_array_alloc(1);
@@ -78,7 +100,28 @@ pub extern "C" fn js_create_native_module_namespace(
     js_object_set_keys(obj, keys_array);
 
     // Return as NaN-boxed pointer
-    crate::value::js_nanbox_pointer(obj as i64)
+    let value = crate::value::js_nanbox_pointer(obj as i64);
+    if should_cache_native_module_namespace(module_name) {
+        NATIVE_MODULE_NAMESPACES.with(|cache| {
+            cache
+                .borrow_mut()
+                .insert(module_name.to_string(), value.to_bits());
+        });
+    }
+    value
+}
+
+fn normalize_native_module_alias(module_name: &str) -> &str {
+    if module_name == "sys" {
+        crate::node_submodules::emit_sys_deprecation_warning_once();
+        "util"
+    } else {
+        module_name
+    }
+}
+
+fn should_cache_native_module_namespace(module_name: &str) -> bool {
+    matches!(module_name, "util" | "util.types")
 }
 
 /// #1479: read the module-name string stored in field 0 of a
@@ -120,6 +163,7 @@ pub unsafe extern "C" fn js_native_module_property_by_name(
     let module_name =
         std::str::from_utf8(std::slice::from_raw_parts(module_name_ptr, module_name_len))
             .unwrap_or("");
+    let module_name = normalize_native_module_alias(module_name);
     let property_name = std::str::from_utf8(std::slice::from_raw_parts(
         property_name_ptr,
         property_name_len,
@@ -369,6 +413,21 @@ pub(crate) fn buffer_constructor_value() -> f64 {
         slot.set(value.to_bits());
         value
     })
+}
+
+extern "C" fn util_debuglog_logger_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    _arg: f64,
+) -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+pub(crate) fn util_debuglog_logger_value() -> f64 {
+    let func_ptr = util_debuglog_logger_thunk as *const u8;
+    crate::closure::js_register_closure_arity(func_ptr, 1);
+    let closure = crate::closure::js_closure_alloc_singleton(func_ptr);
+    set_bound_native_closure_name(closure, "debuglog");
+    crate::value::js_nanbox_pointer(closure as i64)
 }
 
 fn fn_value(func_ptr: *const u8, name: &str) -> f64 {
@@ -798,6 +857,8 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("util", "format")
             | ("util", "formatWithOptions")
             | ("util", "inspect")
+            | ("util", "debuglog")
+            | ("util", "isArray")
             | ("util", "promisify")
             | ("util", "callbackify")
             | ("util", "parseArgs")
@@ -1238,7 +1299,7 @@ pub(crate) unsafe fn get_module_name_from_namespace(namespace_obj: f64) -> &'sta
 pub(crate) unsafe fn get_native_module_constant(
     module_name: &str,
     property: &str,
-    _namespace_obj: f64,
+    namespace_obj: f64,
 ) -> Option<f64> {
     let str_val = |s: &str| -> f64 {
         let ptr = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
@@ -1924,7 +1985,16 @@ pub(crate) unsafe fn get_native_module_constant(
         "os.constants.priority" => os_priority_const(property),
         "os.constants.dlopen" => os_dlopen_const(property),
         "util" => match property {
+            "default" => Some(native_namespace_or_create("util", namespace_obj)),
             "types" => Some(create_sub_namespace("util.types")),
+            "TextEncoder" => Some(crate::object::js_get_global_this_builtin_value(
+                b"TextEncoder".as_ptr(),
+                "TextEncoder".len(),
+            )),
+            "TextDecoder" => Some(crate::object::js_get_global_this_builtin_value(
+                b"TextDecoder".as_ptr(),
+                "TextDecoder".len(),
+            )),
             _ => None,
         },
         "assert" => match property {
@@ -2068,6 +2138,23 @@ pub(crate) unsafe fn get_native_module_constant(
 /// property accesses like `fs.constants.O_RDONLY` work through the dispatch table.
 fn create_sub_namespace(name: &str) -> f64 {
     js_create_native_module_namespace(name.as_ptr(), name.len())
+}
+
+fn native_namespace_or_create(module_name: &str, namespace_obj: f64) -> f64 {
+    let value = JSValue::from_bits(namespace_obj.to_bits());
+    if value.is_pointer() {
+        let obj = value.as_pointer::<ObjectHeader>();
+        if !obj.is_null() {
+            let is_matching_namespace = unsafe {
+                (*obj).class_id == NATIVE_MODULE_CLASS_ID
+                    && read_native_module_name(obj).as_deref() == Some(module_name)
+            };
+            if is_matching_namespace {
+                return namespace_obj;
+            }
+        }
+    }
+    js_create_native_module_namespace(module_name.as_ptr(), module_name.len())
 }
 
 fn create_cached_sub_namespace(name: &str, cache: &std::sync::atomic::AtomicU64) -> f64 {

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -910,6 +910,8 @@ pub(crate) unsafe fn dispatch_native_module_method(
             crate::builtins::js_util_format_with_options(arg(0), arr)
         }
         ("util", "inspect") => crate::builtins::js_util_inspect(arg(0), arg(1)),
+        ("util", "debuglog") => super::native_module::util_debuglog_logger_value(),
+        ("util", "isArray") => crate::array::js_array_is_array(arg(0)),
         ("util", "isDeepStrictEqual") => {
             crate::builtins::js_util_is_deep_strict_equal(arg(0), arg(1))
         }

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -3032,11 +3032,13 @@ pub fn run_with_parse_cache(
                             // submodules (`timers/promises` etc.) keep the
                             // function-singleton routing because no real
                             // code reads them as namespace objects.
-                            if submod_key == "diagnostics_channel" || submod_key == "timers" {
-                                // Default import of node:timers is the module
-                                // object — route to the namespace so
-                                // `import timers from "node:timers"` works
-                                // like `import * as timers` (#1213).
+                            if matches!(
+                                submod_key.as_str(),
+                                "diagnostics_channel" | "timers" | "sys"
+                            ) {
+                                // Default imports of these modules are module
+                                // objects — route to the namespace so they work
+                                // like `import * as ...` (#1213, #2629).
                                 namespace_node_submodules
                                     .insert(local.clone(), submod_key.clone());
                                 if !namespace_imports.contains(local) {

--- a/test-parity/node-suite/sys/imports/util-alias.ts
+++ b/test-parity/node-suite/sys/imports/util-alias.ts
@@ -1,0 +1,41 @@
+import * as sysNs from "node:sys";
+import * as utilNs from "node:util";
+import sysDefault from "node:sys";
+import utilDefault from "node:util";
+
+const sys = sysDefault;
+const util = utilDefault;
+
+console.log("default identity:", sys === util);
+console.log(
+  "namespace default identity:",
+  sysNs.default === utilNs.default,
+  sysNs.default === sys,
+  utilNs.default === util,
+);
+
+for (const name of [
+  "format",
+  "inspect",
+  "debuglog",
+  "isArray",
+  "types",
+  "TextEncoder",
+  "TextDecoder",
+  "parseArgs",
+  "stripVTControlCharacters",
+]) {
+  console.log(name + ":", typeof sys[name], sys[name] === util[name]);
+}
+
+console.log(
+  "types predicates:",
+  typeof sys.types.isArrayBuffer,
+  sys.types.isArrayBuffer === util.types.isArrayBuffer,
+);
+console.log(
+  "namespace member identity:",
+  sysNs.format === utilNs.format,
+  sysNs.types === utilNs.types,
+);
+console.log("keys:", Object.keys(sys).length === Object.keys(util).length);


### PR DESCRIPTION
## Summary
- route node:sys native module lookups through node:util while preserving the DEP0025 warning
- cache util/util.types native namespace objects so sys/default/util identity checks match Node
- expose util.debuglog, util.isArray, util.TextEncoder, and util.TextDecoder through the existing native module surface
- add a node-suite sys fixture covering default, namespace-member, util.types, and export identity

Fixes #2629

## Testing
- cargo build -p perry -p perry-runtime -p perry-stdlib
- cargo test -p perry-runtime sys_
- node --input-type=module -e '<inline probe>' (matches expected stdout)
- env PERRY_ALLOW_UNIMPLEMENTED=1 target/debug/perry test-parity/node-suite/sys/imports/util-alias.ts -o /tmp/perry_sys_util_alias_rebased
- /tmp/perry_sys_util_alias_rebased
- cargo fmt --all -- --check
- git diff --check HEAD~1..HEAD
- ./scripts/check_file_size.sh
- ./run_parity_tests.sh --suite node-suite --module sys --filter util-alias (Node fails locally before Perry runs: ERR_UNKNOWN_FILE_EXTENSION for .ts fixture; report node_fail: 1, total_run: 0)
