### PR TITLE
fix(fetch): combine Headers append values

### DIFF
--- a/crates/perry-codegen/src/lower_call/options/fetch.rs
+++ b/crates/perry-codegen/src/lower_call/options/fetch.rs
@@ -132,9 +132,14 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                 }
                 let key_ptr = get_raw_string_ptr(ctx, &args[0])?;
                 let val_ptr = get_raw_string_ptr(ctx, &args[1])?;
+                let runtime_fn = if method == "append" {
+                    "js_headers_append"
+                } else {
+                    "js_headers_set"
+                };
                 ctx.block().call(
                     DOUBLE,
-                    "js_headers_set",
+                    runtime_fn,
                     &[(DOUBLE, &h_handle), (I64, &key_ptr), (I64, &val_ptr)],
                 );
                 return Ok(Some(double_literal(f64::from_bits(

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1698,6 +1698,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_headers_new", DOUBLE, &[]);
     // headers.set(handle_f64, key_ptr, val_ptr) -> f64 (undefined-tag)
     module.declare_function("js_headers_set", DOUBLE, &[DOUBLE, I64, I64]);
+    // headers.append(handle_f64, key_ptr, val_ptr) -> f64 (undefined-tag)
+    module.declare_function("js_headers_append", DOUBLE, &[DOUBLE, I64, I64]);
     // headers.get(handle_f64, key_ptr) -> *mut StringHeader (i64)
     module.declare_function("js_headers_get", I64, &[DOUBLE, I64]);
     // headers.has(handle_f64, key_ptr) -> f64 (TAG_TRUE/FALSE)

--- a/crates/perry-ext-fetch/src/lib.rs
+++ b/crates/perry-ext-fetch/src/lib.rs
@@ -14,7 +14,7 @@
 //!   - response: status / statusText / ok / text / json /
 //!     array_buffer / blob / get_headers / clone / body /
 //!     static_json / static_redirect
-//!   - headers: new / set / get / has / delete / for_each
+//!   - headers: new / set / append / get / has / delete / for_each
 //!   - stream: start / poll / status / close
 //!   - blob: size / type / text / array_buffer / bytes / slice / stream
 //!   - request: new / get_url / get_method / get_body
@@ -601,6 +601,33 @@ pub unsafe extern "C" fn js_headers_set(
     let mut g = HEADERS_HANDLES.lock().unwrap();
     if let Some(h) = g.get_mut(&id) {
         h.insert(key.to_lowercase(), value);
+        1.0
+    } else {
+        0.0
+    }
+}
+
+/// # Safety
+/// Both pointers must be null or Perry-runtime `StringHeader`s.
+#[no_mangle]
+pub unsafe extern "C" fn js_headers_append(
+    handle: f64,
+    key_ptr: *const StringHeader,
+    value_ptr: *const StringHeader,
+) -> f64 {
+    let id = handle_id(handle);
+    let Some(key) = read_str(key_ptr) else {
+        return 0.0;
+    };
+    let value = read_str(value_ptr).unwrap_or_default();
+    let mut g = HEADERS_HANDLES.lock().unwrap();
+    if let Some(h) = g.get_mut(&id) {
+        h.entry(key.to_lowercase())
+            .and_modify(|existing| {
+                existing.push_str(", ");
+                existing.push_str(&value);
+            })
+            .or_insert(value);
         1.0
     } else {
         0.0
@@ -1217,6 +1244,23 @@ mod tests {
         assert_eq!(del, 1.0);
         let has2 = unsafe { js_headers_has(h, key.as_raw()) };
         assert_eq!(has2, 0.0);
+    }
+
+    #[test]
+    fn headers_append_combines_values() {
+        let h = js_headers_new();
+        let key = alloc_string("X-Test");
+        let first = alloc_string("a");
+        let second = alloc_string("b");
+
+        let append_first = unsafe { js_headers_append(h, key.as_raw(), first.as_raw()) };
+        let append_second = unsafe { js_headers_append(h, key.as_raw(), second.as_raw()) };
+        assert_eq!(append_first, 1.0);
+        assert_eq!(append_second, 1.0);
+
+        let got_ptr = unsafe { js_headers_get(h, key.as_raw()) };
+        let got = perry_ffi::read_string(unsafe { JsString::from_raw(got_ptr) }).expect("non-null");
+        assert_eq!(got, "a, b");
     }
 
     #[test]

--- a/test-parity/node-suite/fetch/headers/append-combines.ts
+++ b/test-parity/node-suite/fetch/headers/append-combines.ts
@@ -1,0 +1,14 @@
+const h = new Headers();
+h.append("x-test", "a");
+h.append("X-Test", "b");
+console.log("append get:", h.get("x-test"));
+
+h.set("x-test", "c");
+console.log("set replaces:", h.get("x-test"));
+h.append("x-test", "d");
+console.log("append after set:", h.get("x-test"));
+
+const withCookies = new Headers();
+withCookies.append("set-cookie", "a=1");
+withCookies.append("set-cookie", "b=2");
+console.log("set-cookie get:", withCookies.get("set-cookie"));


### PR DESCRIPTION
## Summary
- route typed Headers.append lowering to js_headers_append instead of js_headers_set
- add js_headers_append declaration and ext-fetch export with comma-combining semantics
- add Node parity coverage for repeated append, set replacement, and set-cookie get behavior

Closes #2647.

## Verification
- cargo fmt --all -- --check
- RUSTC_WRAPPER= cargo check -p perry-codegen -p perry-ext-fetch -p perry-stdlib
- RUSTC_WRAPPER= cargo test -p perry-ext-fetch headers_append_combines_values
- PATH=/home/github-runner/actions-runner/externals/node24/bin:/root/.codex/tmp/arg0/codex-arg0315Laj:/usr/local/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/root/.local/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --filter append-combines
- jq empty test-parity/known_failures.json test-parity/threshold.json
- git diff --check
- ./scripts/check_file_size.sh