### PR TITLE
fix(globals): validate queueMicrotask callbacks

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -505,7 +505,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::QueueMicrotask(cb) => {
             let cb_box = lower_expr(ctx, cb)?;
             let blk = ctx.block();
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            let cb_handle = blk.call(
+                I64,
+                "js_timer_validate_callback",
+                &[(DOUBLE, &cb_box), (I32, "-1")],
+            );
             blk.call_void("js_queue_microtask", &[(I64, &cb_handle)]);
             Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
         }

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -170,11 +170,12 @@ pub(super) fn try_global_builtins(
                 }
             }
             "queueMicrotask" => {
-                if !args.is_empty() {
-                    return Ok(Ok(Expr::QueueMicrotask(Box::new(args.remove(0)))));
+                let callback = if !args.is_empty() {
+                    args.remove(0)
                 } else {
-                    return Err(anyhow!("queueMicrotask requires one argument"));
-                }
+                    Expr::Undefined
+                };
+                return Ok(Ok(Expr::QueueMicrotask(Box::new(callback))));
             }
             "Symbol" => {
                 // Symbol() / Symbol(description)

--- a/test-parity/node-suite/timers/microtask/callback-validation.ts
+++ b/test-parity/node-suite/timers/microtask/callback-validation.ts
@@ -1,0 +1,26 @@
+import { setImmediate } from "node:timers";
+
+function probe(label: string, fn: () => unknown) {
+  try {
+    fn();
+    console.log(label, "no-throw");
+  } catch (err: any) {
+    console.log(label, err?.name, err?.code);
+  }
+}
+
+probe("missing", () => queueMicrotask());
+probe("undefined", () => queueMicrotask(undefined as any));
+probe("number", () => queueMicrotask(1 as any));
+probe("object", () => queueMicrotask({} as any));
+
+const order: string[] = [];
+queueMicrotask(() => order.push("micro"));
+order.push("sync");
+
+await new Promise<void>((resolve) => {
+  setImmediate(() => {
+    console.log("order:", order.join(","));
+    resolve();
+  });
+});


### PR DESCRIPTION
## Summary
- lower queueMicrotask() with no arguments to an undefined callback value instead of a compile-time lowering error
- validate queueMicrotask callback values with the existing Node-style timer callback validator before scheduling
- add parity coverage for missing, undefined, number, and object callbacks plus the valid microtask ordering path

Closes #2658.

## Verification
- cargo fmt --all -- --check
- RUSTC_WRAPPER= cargo check -p perry-hir -p perry-codegen -p perry-runtime
- PATH=/home/github-runner/actions-runner/externals/node24/bin:/root/.codex/tmp/arg0/codex-arg0315Laj:/usr/local/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/root/.local/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module timers --filter microtask/callback-validation
- jq empty test-parity/known_failures.json test-parity/threshold.json
- git diff --check
- ./scripts/check_file_size.sh