### PR TITLE
fix(globals): validate queueMicrotask callback

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -505,7 +505,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::QueueMicrotask(cb) => {
             let cb_box = lower_expr(ctx, cb)?;
             let blk = ctx.block();
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            let cb_handle = blk.call(
+                I64,
+                "js_timer_validate_callback",
+                &[(DOUBLE, &cb_box), (I32, "3")],
+            );
             blk.call_void("js_queue_microtask", &[(I64, &cb_handle)]);
             Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
         }

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -173,7 +173,7 @@ pub(super) fn try_global_builtins(
                 if !args.is_empty() {
                     return Ok(Ok(Expr::QueueMicrotask(Box::new(args.remove(0)))));
                 } else {
-                    return Err(anyhow!("queueMicrotask requires one argument"));
+                    return Ok(Ok(Expr::QueueMicrotask(Box::new(Expr::Undefined))));
                 }
             }
             "Symbol" => {

--- a/crates/perry-runtime/src/timer.rs
+++ b/crates/perry-runtime/src/timer.rs
@@ -383,14 +383,16 @@ pub extern "C" fn js_timer_refresh(timer_id: i64) {
     }
 }
 
-/// Issue #2013 — validate the first argument of `setTimeout`/`setInterval`
-/// /`setImmediate` so a non-callable value throws Node's
+/// Issue #2013 / #2658 — validate the first argument of `setTimeout`,
+/// `setInterval`, `setImmediate`, and `queueMicrotask` so a non-callable
+/// value throws Node's
 /// `TypeError [ERR_INVALID_ARG_TYPE]` shape instead of segfaulting on
 /// the downstream pointer-deref of the unboxed handle. `value` is the
 /// caller's NaN-boxed JS value (codegen passes the full f64 before the
 /// `unbox_to_i64` that the existing FFIs require). `fn_name` is the
 /// JS function name reported in the error message
-/// (`"setTimeout"` / `"setInterval"` / `"setImmediate"`).
+/// (`"setTimeout"` / `"setInterval"` / `"setImmediate"` /
+/// `"queueMicrotask"`).
 ///
 /// Returns the raw closure pointer (extracted via `unbox_to_i64`) for
 /// the callable case so the codegen can pass it straight to the
@@ -415,12 +417,14 @@ pub unsafe extern "C" fn js_timer_validate_callback(value: f64, fn_name_idx: i32
     if let Some(ptr) = raw_closure_pointer(bits) {
         return ptr as i64;
     }
-    // 0 = setTimeout, 1 = setInterval, 2 = setImmediate, anything
+    // 0 = setTimeout, 1 = setInterval, 2 = setImmediate, 3 = queueMicrotask,
+    // anything
     // else falls back to the generic "callback" wording.
     let fn_name: &str = match fn_name_idx {
         0 => "setTimeout",
         1 => "setInterval",
         2 => "setImmediate",
+        3 => "queueMicrotask",
         _ => "timer",
     };
     let message = format!(

--- a/test-parity/node-suite/timers/microtask/validation.ts
+++ b/test-parity/node-suite/timers/microtask/validation.ts
@@ -1,0 +1,21 @@
+function probe(label: string, fn: () => void) {
+  try {
+    fn();
+    console.log(label + ":", "no-throw");
+  } catch (err: any) {
+    console.log(label + ":", err?.name, err?.code || "no-code");
+  }
+}
+
+probe("missing", () => queueMicrotask());
+probe("undefined", () => queueMicrotask(undefined as any));
+probe("number", () => queueMicrotask(1 as any));
+probe("object", () => queueMicrotask({} as any));
+probe("null", () => queueMicrotask(null as any));
+
+const order: string[] = [];
+queueMicrotask(() => order.push("micro"));
+order.push("sync");
+
+await Promise.resolve();
+console.log("order:", order.join(","));


### PR DESCRIPTION
## Summary
- validate direct `queueMicrotask(callback)` calls before scheduling, reusing the existing Node-style callback validator
- lower the no-argument `queueMicrotask()` form to runtime `undefined` validation instead of a compile-time arity error
- add a node-suite microtask fixture covering missing, undefined, number, object, and null callbacks plus the valid ordering path

Fixes #2658

## Repro
Pre-fix Perry accepted invalid callbacks and later failed when the queued non-function ran:

```text
missing: TypeError no-code
undefined: no-throw
number: no-throw
object: no-throw
null: no-throw
TypeError: value is not a function
```

Node 24 expected output and fixed Perry output now match:

```text
missing: TypeError ERR_INVALID_ARG_TYPE
undefined: TypeError ERR_INVALID_ARG_TYPE
number: TypeError ERR_INVALID_ARG_TYPE
object: TypeError ERR_INVALID_ARG_TYPE
null: TypeError ERR_INVALID_ARG_TYPE
order: sync,micro
```

## Testing
- cargo build -p perry -p perry-codegen -p perry-hir -p perry-runtime
- cargo test -p perry-runtime test_queued_microtask_previous_context_survives_hook_gc
- node --input-type=module -e '<inline queueMicrotask validation probe>'
- /home/github-runner/actions-runner/externals/node24/bin/node --experimental-strip-types test-parity/node-suite/timers/microtask/validation.ts
- env PERRY_ALLOW_UNIMPLEMENTED=1 target/debug/perry test-parity/node-suite/timers/microtask/validation.ts -o /tmp/perry_qm_validation_fixed
- /tmp/perry_qm_validation_fixed
- PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH env PERRY_ALLOW_UNIMPLEMENTED=1 ./run_parity_tests.sh --suite node-suite --module timers --filter validation (PASS 2/2, report test-parity/reports/parity_report_20260529_201536.json)
- cargo fmt --all -- --check
- git diff --cached --check
- ./scripts/check_file_size.sh
