### PR TITLE
fix(hir): give TextEncoder encodeInto a unique hash tag

### DIFF
--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -222,7 +222,7 @@ impl SH for Expr {
             Expr::Btoa(e) => { tag(h, 178); e.as_ref().hash(h); }
             Expr::TextEncoderNew => tag(h, 179),
             Expr::TextEncoderEncode(e) => { tag(h, 180); e.as_ref().hash(h); }
-            Expr::TextEncoderEncodeInto { source, dest } => { tag(h, 12031); source.as_ref().hash(h); dest.as_ref().hash(h); }
+            Expr::TextEncoderEncodeInto { source, dest } => { tag(h, 12040); source.as_ref().hash(h); dest.as_ref().hash(h); }
             Expr::TextDecoderNew => tag(h, 181),
             Expr::TextDecoderDecode(e) => { tag(h, 182); e.as_ref().hash(h); }
             Expr::EncodeURI(e) => { tag(h, 183); e.as_ref().hash(h); }


### PR DESCRIPTION
## Summary
- assign TextEncoderEncodeInto a unique stable-hash tag
- fixes the cargo-test failure from duplicate Expr stable-hash tags

## Tests
- cargo fmt --all -- --check
- git diff --check origin/main...HEAD
- ./scripts/check_file_size.sh
- cargo test -p perry-hir stable_hash::tests::expr_variant_stable_hash_tags_are_unique
- cargo test -p perry-hir