### PR TITLE
fix(fetch): enforce Body bodyUsed consumption

### DIFF
--- a/crates/perry-codegen/src/lower_call/options/fetch.rs
+++ b/crates/perry-codegen/src/lower_call/options/fetch.rs
@@ -249,6 +249,12 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                     .call(DOUBLE, "js_request_get_body", &[(DOUBLE, &h_handle)]);
                 return Ok(Some(val));
             }
+            "bodyUsed" => {
+                let out = ctx
+                    .block()
+                    .call(DOUBLE, "js_request_body_used", &[(DOUBLE, &h_handle)]);
+                return Ok(Some(out));
+            }
             // #1649: `req.headers` returns a `Headers` object (NaN-boxed
             // handle), not the raw numeric request handle. Without this the
             // typed path fell through to `Ok(None)` → the receiver handle
@@ -278,6 +284,12 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                 let blk = ctx.block();
                 let promise = blk.call(I64, "js_request_array_buffer", &[(DOUBLE, &h_handle)]);
                 return Ok(Some(nanbox_pointer_inline(blk, &promise)));
+            }
+            "clone" => {
+                let out = ctx
+                    .block()
+                    .call(DOUBLE, "js_request_clone", &[(DOUBLE, &h_handle)]);
+                return Ok(Some(out));
             }
             _ => return Ok(None),
         }
@@ -335,6 +347,12 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                     crate::nanbox::TAG_FALSE_I64,
                 );
                 return Ok(Some(blk.bitcast_i64_to_double(&tagged)));
+            }
+            "bodyUsed" => {
+                let out =
+                    ctx.block()
+                        .call(DOUBLE, "js_response_body_used", &[(DOUBLE, &recv_handle)]);
+                return Ok(Some(out));
             }
             "headers" => {
                 let out =

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1716,6 +1716,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_request_get_url", I64, &[DOUBLE]);
     module.declare_function("js_request_get_method", I64, &[DOUBLE]);
     module.declare_function("js_request_get_body", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_request_body_used", DOUBLE, &[DOUBLE]);
     // #1649: `req.headers` → NaN-boxed Headers handle.
     module.declare_function("js_request_get_headers", DOUBLE, &[DOUBLE]);
     // #1688: request body-consuming methods. text/json/arrayBuffer return a
@@ -1723,6 +1724,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_request_text", I64, &[DOUBLE]);
     module.declare_function("js_request_json", I64, &[DOUBLE]);
     module.declare_function("js_request_array_buffer", I64, &[DOUBLE]);
+    module.declare_function("js_request_clone", DOUBLE, &[DOUBLE]);
 
     // Response body getters — handles flow as NaN-boxed POINTER_TAG f64
     // (Phase 1 unification, refs #421). Accessors call `handle_id` to
@@ -1730,6 +1732,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_fetch_response_status", DOUBLE, &[DOUBLE]);
     module.declare_function("js_fetch_response_status_text", I64, &[DOUBLE]);
     module.declare_function("js_fetch_response_ok", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_response_body_used", DOUBLE, &[DOUBLE]);
     module.declare_function("js_fetch_response_text", I64, &[DOUBLE]);
     module.declare_function("js_fetch_response_json", I64, &[DOUBLE]);
     // response.headers / .clone() / .arrayBuffer() / .blob() — all take

--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -53,7 +53,7 @@ pub fn dispatch_request_property(req_id: usize, prop: &str) -> Option<f64> {
     // closure so `typeof` reports "function" and the value stays callable —
     // calling it routes back through `js_native_call_method` → small-handle →
     // `dispatch_request_method`. Mirrors #1670's stream property dispatch.
-    if matches!(prop, "json" | "text" | "arrayBuffer") {
+    if matches!(prop, "json" | "text" | "arrayBuffer" | "clone") {
         // Membership check first so a non-Request id falls through.
         REQUEST_REGISTRY.lock().unwrap().get(&req_id)?;
         extern "C" {
@@ -67,6 +67,7 @@ pub fn dispatch_request_property(req_id: usize, prop: &str) -> Option<f64> {
             "json" => b"json",
             "text" => b"text",
             "arrayBuffer" => b"arrayBuffer",
+            "clone" => b"clone",
             _ => unreachable!(),
         };
         return Some(unsafe {
@@ -91,6 +92,9 @@ pub fn dispatch_request_property(req_id: usize, prop: &str) -> Option<f64> {
             }
             None => TAG_NULL,
         },
+        "bodyUsed" => {
+            return Some(tagged_bool(req.body_used));
+        }
         // Other Request properties not yet wired — fall through so other
         // dispatchers (or the final undefined fallback) can answer.
         _ => return None,
@@ -130,6 +134,7 @@ pub fn dispatch_request_method(req_id: usize, method: &str, _args: &[f64]) -> Op
                 let promise = js_request_array_buffer(req_f64);
                 Some(f64::from_bits(JSValue::pointer(promise as *mut u8).bits()))
             }
+            "clone" => Some(js_request_clone(req_f64)),
             _ => None,
         }
     }
@@ -199,6 +204,7 @@ pub fn dispatch_response_property(resp_id: usize, prop: &str) -> Option<f64> {
                 TAG_FALSE
             }))
         }
+        "bodyUsed" => return Some(tagged_bool(resp.body_used)),
         _ => return None,
     };
     Some(f64::from_bits(bits))

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -74,6 +74,8 @@ struct FetchResponse {
     status_text: String,
     headers: HashMap<String, String>,
     body: Vec<u8>,
+    body_present: bool,
+    body_used: bool,
     /// Cached Headers handle id, allocated on first `response.headers`
     /// access. None until a property/method dispatcher needs to expose
     /// the headers as a Headers instance. The Vec form (insertion-ordered
@@ -163,6 +165,27 @@ unsafe fn fetch_error_bits<S: AsRef<str>>(msg: S) -> u64 {
     JSValue::pointer(err as *const u8).bits()
 }
 
+const BODY_ALREADY_USED_MESSAGE: &str = "Body is unusable: Body has already been read";
+
+unsafe fn fetch_type_error_bits<S: AsRef<str>>(msg: S) -> u64 {
+    let s = msg.as_ref();
+    let msg_str = js_string_from_bytes(s.as_ptr(), s.len() as u32);
+    let err = perry_runtime::error::js_typeerror_new(msg_str);
+    JSValue::pointer(err as *const u8).bits()
+}
+
+unsafe fn reject_fetch_type_error(promise: *mut perry_runtime::Promise, msg: &str) {
+    perry_runtime::js_promise_reject(promise, f64::from_bits(fetch_type_error_bits(msg)));
+}
+
+unsafe fn throw_fetch_type_error(msg: &str) -> ! {
+    perry_runtime::exception::js_throw(f64::from_bits(fetch_type_error_bits(msg)))
+}
+
+fn tagged_bool(value: bool) -> f64 {
+    f64::from_bits(if value { TAG_TRUE } else { TAG_FALSE })
+}
+
 /// Perform a GET request
 /// fetch(url) -> Promise<Response>
 #[no_mangle]
@@ -212,6 +235,8 @@ pub unsafe extern "C" fn js_fetch_get(url_ptr: *const StringHeader) -> *mut perr
                         status_text,
                         headers,
                         body,
+                        body_present: true,
+                        body_used: false,
                         cached_headers_id: None,
                         cached_body_stream_id: None,
                     },
@@ -290,6 +315,8 @@ pub unsafe extern "C" fn js_fetch_get_with_auth(
                         status_text,
                         headers,
                         body,
+                        body_present: true,
+                        body_used: false,
                         cached_headers_id: None,
                         cached_body_stream_id: None,
                     },
@@ -370,6 +397,8 @@ pub unsafe extern "C" fn js_fetch_post_with_auth(
                         status_text,
                         headers,
                         body,
+                        body_present: true,
+                        body_used: false,
                         cached_headers_id: None,
                         cached_body_stream_id: None,
                     },
@@ -453,6 +482,8 @@ pub unsafe extern "C" fn js_fetch_post(
                         status_text,
                         headers,
                         body,
+                        body_present: true,
+                        body_used: false,
                         cached_headers_id: None,
                         cached_body_stream_id: None,
                     },
@@ -555,6 +586,8 @@ pub unsafe extern "C" fn js_fetch_with_options(
                         status_text,
                         headers,
                         body,
+                        body_present: true,
+                        body_used: false,
                         cached_headers_id: None,
                         cached_body_stream_id: None,
                     },
@@ -619,6 +652,35 @@ pub extern "C" fn js_fetch_response_ok(handle: f64) -> f64 {
     }
 }
 
+/// response.bodyUsed -> boolean
+#[no_mangle]
+pub extern "C" fn js_response_body_used(handle: f64) -> f64 {
+    let response_id = handle_id(handle);
+    let guard = FETCH_RESPONSES.lock().unwrap();
+    tagged_bool(
+        guard
+            .get(&response_id)
+            .map(|resp| resp.body_used)
+            .unwrap_or(false),
+    )
+}
+
+fn consume_response_body(handle: f64) -> Result<Vec<u8>, &'static str> {
+    let response_id = handle_id(handle);
+    let mut guard = FETCH_RESPONSES.lock().unwrap();
+    let resp = guard
+        .get_mut(&response_id)
+        .ok_or("Invalid response handle")?;
+    if !resp.body_present {
+        return Ok(Vec::new());
+    }
+    if resp.body_used {
+        return Err(BODY_ALREADY_USED_MESSAGE);
+    }
+    resp.body_used = true;
+    Ok(resp.body.clone())
+}
+
 /// Get response body as text
 /// response.text() -> Promise<string>
 ///
@@ -631,22 +693,16 @@ pub extern "C" fn js_fetch_response_ok(handle: f64) -> f64 {
 #[no_mangle]
 pub unsafe extern "C" fn js_fetch_response_text(handle: f64) -> *mut perry_runtime::Promise {
     let promise = perry_runtime::js_promise_new();
-    let response_id = handle_id(handle);
-
-    // Clone the body — JS spec says each body is readable once, but other
-    // accessors (status, headers) may still be used afterwards. The Response
-    // entry stays in FETCH_RESPONSES until cleanup; in practice the test suite
-    // doesn't accumulate enough responses to matter.
-    let body = {
-        let guard = FETCH_RESPONSES.lock().unwrap();
-        match guard.get(&response_id) {
-            Some(resp) => resp.body.clone(),
-            None => {
-                let err_msg = "Invalid response handle";
-                let err_nan = f64::from_bits(fetch_error_bits(err_msg));
-                perry_runtime::js_promise_reject(promise, err_nan);
-                return promise;
-            }
+    let body = match consume_response_body(handle) {
+        Ok(body) => body,
+        Err(err_msg) if err_msg == BODY_ALREADY_USED_MESSAGE => {
+            reject_fetch_type_error(promise, BODY_ALREADY_USED_MESSAGE);
+            return promise;
+        }
+        Err(err_msg) => {
+            let err_nan = f64::from_bits(fetch_error_bits(err_msg));
+            perry_runtime::js_promise_reject(promise, err_nan);
+            return promise;
         }
     };
 
@@ -706,19 +762,16 @@ unsafe fn json_value_to_jsvalue(value: &serde_json::Value) -> JSValue {
 #[no_mangle]
 pub unsafe extern "C" fn js_fetch_response_json(handle: f64) -> *mut perry_runtime::Promise {
     let promise = perry_runtime::js_promise_new();
-    let response_id = handle_id(handle);
-
-    // Take (not clone) the body — consumes the FETCH_RESPONSES entry.
-    let body = {
-        let guard = FETCH_RESPONSES.lock().unwrap();
-        match guard.get(&response_id) {
-            Some(resp) => resp.body.clone(),
-            None => {
-                let err_msg = "Invalid response handle";
-                let err_nan = f64::from_bits(fetch_error_bits(err_msg));
-                perry_runtime::js_promise_reject(promise, err_nan);
-                return promise;
-            }
+    let body = match consume_response_body(handle) {
+        Ok(body) => body,
+        Err(err_msg) if err_msg == BODY_ALREADY_USED_MESSAGE => {
+            reject_fetch_type_error(promise, BODY_ALREADY_USED_MESSAGE);
+            return promise;
+        }
+        Err(err_msg) => {
+            let err_nan = f64::from_bits(fetch_error_bits(err_msg));
+            perry_runtime::js_promise_reject(promise, err_nan);
+            return promise;
         }
     };
 
@@ -1002,6 +1055,7 @@ struct RequestRecord {
     url: String,
     method: String,
     body: Option<String>,
+    body_used: bool,
     headers: HeadersStore,
     /// Cached Headers handle id, allocated on first `request.headers` read so
     /// repeat reads return the same handle (preserves `req.headers ===
@@ -1054,7 +1108,13 @@ fn alloc_headers(store: HeadersStore) -> usize {
     id
 }
 
-fn alloc_response(status: u16, status_text: String, headers: HeadersStore, body: Vec<u8>) -> usize {
+fn alloc_response(
+    status: u16,
+    status_text: String,
+    headers: HeadersStore,
+    body: Vec<u8>,
+    body_present: bool,
+) -> usize {
     let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
     let id = *id_guard;
     *id_guard += 1;
@@ -1067,6 +1127,8 @@ fn alloc_response(status: u16, status_text: String, headers: HeadersStore, body:
             status_text,
             headers: hdr_map,
             body,
+            body_present,
+            body_used: false,
             cached_headers_id: None,
             cached_body_stream_id: None,
         },
@@ -1092,7 +1154,9 @@ pub unsafe extern "C" fn js_response_new(
     status_text_ptr: *const StringHeader,
     headers_handle: f64,
 ) -> f64 {
-    let body_str = string_from_header(body_ptr).unwrap_or_default();
+    let body_opt = string_from_header(body_ptr);
+    let body_present = body_opt.is_some();
+    let body_str = body_opt.unwrap_or_default();
     let body = body_str.into_bytes();
     let status_u16 = if status.is_nan() || status == 0.0 {
         200
@@ -1112,7 +1176,13 @@ pub unsafe extern "C" fn js_response_new(
     } else {
         HeadersStore::default()
     };
-    handle_to_f64(alloc_response(status_u16, status_text, headers, body))
+    handle_to_f64(alloc_response(
+        status_u16,
+        status_text,
+        headers,
+        body,
+        body_present,
+    ))
 }
 
 fn canonical_reason(status: u16) -> &'static str {
@@ -1153,13 +1223,22 @@ pub extern "C" fn js_response_clone(handle: f64) -> f64 {
     let id = handle_id(handle);
     let cloned = {
         let guard = FETCH_RESPONSES.lock().unwrap();
-        guard.get(&id).map(|resp| FetchResponse {
-            status: resp.status,
-            status_text: resp.status_text.clone(),
-            headers: resp.headers.clone(),
-            body: resp.body.clone(),
-            cached_headers_id: None,
-            cached_body_stream_id: None,
+        guard.get(&id).map(|resp| {
+            if resp.body_present && resp.body_used {
+                unsafe {
+                    throw_fetch_type_error("Response.clone: Body has already been consumed.")
+                };
+            }
+            FetchResponse {
+                status: resp.status,
+                status_text: resp.status_text.clone(),
+                headers: resp.headers.clone(),
+                body: resp.body.clone(),
+                body_present: resp.body_present,
+                body_used: false,
+                cached_headers_id: None,
+                cached_body_stream_id: None,
+            }
         })
     };
     if let Some(new_resp) = cloned {
@@ -1182,12 +1261,16 @@ pub extern "C" fn js_response_clone(handle: f64) -> f64 {
 #[no_mangle]
 pub unsafe extern "C" fn js_response_array_buffer(handle: f64) -> *mut perry_runtime::Promise {
     let promise = perry_runtime::js_promise_new();
-    let id = handle_id(handle);
-    let body: Vec<u8> = {
-        let guard = FETCH_RESPONSES.lock().unwrap();
-        match guard.get(&id) {
-            Some(resp) => resp.body.clone(),
-            None => Vec::new(),
+    let body = match consume_response_body(handle) {
+        Ok(body) => body,
+        Err(err_msg) if err_msg == BODY_ALREADY_USED_MESSAGE => {
+            reject_fetch_type_error(promise, BODY_ALREADY_USED_MESSAGE);
+            return promise;
+        }
+        Err(err_msg) => {
+            let err_nan = f64::from_bits(fetch_error_bits(err_msg));
+            perry_runtime::js_promise_reject(promise, err_nan);
+            return promise;
         }
     };
     let buf = perry_runtime::buffer::buffer_alloc(body.len() as u32);
@@ -1217,21 +1300,31 @@ pub unsafe extern "C" fn js_response_array_buffer(handle: f64) -> *mut perry_run
 pub unsafe extern "C" fn js_response_blob(handle: f64) -> *mut perry_runtime::Promise {
     let promise = perry_runtime::js_promise_new();
     let id = handle_id(handle);
-    let data = {
+    let content_type = {
         let guard = FETCH_RESPONSES.lock().unwrap();
-        match guard.get(&id) {
-            Some(resp) => {
-                let ct = resp
-                    .headers
+        guard
+            .get(&id)
+            .and_then(|resp| {
+                resp.headers
                     .iter()
                     .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
                     .map(|(_, v)| v.clone())
-                    .unwrap_or_default();
-                BlobData::blob(resp.body.clone(), ct)
-            }
-            None => BlobData::blob(Vec::new(), String::new()),
+            })
+            .unwrap_or_default()
+    };
+    let body = match consume_response_body(handle) {
+        Ok(body) => body,
+        Err(err_msg) if err_msg == BODY_ALREADY_USED_MESSAGE => {
+            reject_fetch_type_error(promise, BODY_ALREADY_USED_MESSAGE);
+            return promise;
+        }
+        Err(err_msg) => {
+            let err_nan = f64::from_bits(fetch_error_bits(err_msg));
+            perry_runtime::js_promise_reject(promise, err_nan);
+            return promise;
         }
     };
+    let data = BlobData::blob(body, content_type);
     let blob_id = alloc_blob(data);
     perry_runtime::js_promise_resolve(promise, handle_to_f64(blob_id));
     promise
@@ -1440,12 +1533,10 @@ fn response_body_stream(resp_id: usize) -> f64 {
         return id as f64;
     }
     let bytes = match FETCH_RESPONSES.lock().unwrap().get(&resp_id) {
-        Some(r) => r.body.clone(),
+        Some(r) if r.body_present => r.body.clone(),
+        Some(_) => return f64::from_bits(TAG_NULL),
         None => return f64::from_bits(TAG_NULL),
     };
-    if bytes.is_empty() {
-        return f64::from_bits(TAG_NULL);
-    }
     let stream_id = crate::streams::alloc_readable_from_bytes(bytes);
     if let Some(resp) = FETCH_RESPONSES.lock().unwrap().get_mut(&resp_id) {
         resp.cached_body_stream_id = Some(stream_id);
@@ -1483,6 +1574,7 @@ pub unsafe extern "C" fn js_response_static_json(value: f64) -> f64 {
         "OK".to_string(),
         headers,
         body_str.into_bytes(),
+        true,
     ))
 }
 
@@ -1505,6 +1597,7 @@ pub unsafe extern "C" fn js_response_static_redirect(
         canonical_reason(status_u16).to_string(),
         headers,
         Vec::new(),
+        false,
     ))
 }
 
@@ -1542,6 +1635,7 @@ pub unsafe extern "C" fn js_request_new(
             url,
             method,
             body,
+            body_used: false,
             headers,
             cached_headers_id: None,
         },
@@ -1624,15 +1718,60 @@ pub extern "C" fn js_request_get_body(handle: f64) -> f64 {
     }
 }
 
-/// Read a request's stored body (or empty for a bodiless request). Returns
-/// `None` only for an invalid handle, so callers can reject the promise.
-fn request_body_bytes(handle: f64) -> Option<Vec<u8>> {
+/// request.bodyUsed -> boolean
+#[no_mangle]
+pub extern "C" fn js_request_body_used(handle: f64) -> f64 {
     let id = handle_id(handle);
-    REQUEST_REGISTRY
-        .lock()
-        .unwrap()
-        .get(&id)
-        .map(|req| req.body.clone().unwrap_or_default().into_bytes())
+    let guard = REQUEST_REGISTRY.lock().unwrap();
+    tagged_bool(guard.get(&id).map(|req| req.body_used).unwrap_or(false))
+}
+
+/// request.clone() — duplicates the request unless its body was consumed.
+#[no_mangle]
+pub extern "C" fn js_request_clone(handle: f64) -> f64 {
+    let id = handle_id(handle);
+    let cloned = {
+        let guard = REQUEST_REGISTRY.lock().unwrap();
+        guard.get(&id).map(|req| {
+            if req.body.is_some() && req.body_used {
+                unsafe { throw_fetch_type_error("unusable") };
+            }
+            RequestRecord {
+                url: req.url.clone(),
+                method: req.method.clone(),
+                body: req.body.clone(),
+                body_used: false,
+                headers: req.headers.clone(),
+                cached_headers_id: None,
+            }
+        })
+    };
+    if let Some(new_req) = cloned {
+        let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
+        let new_id = *id_guard;
+        *id_guard += 1;
+        drop(id_guard);
+        REQUEST_REGISTRY.lock().unwrap().insert(new_id, new_req);
+        return handle_to_f64(new_id);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+/// Read and consume a request's stored body. Bodiless requests are reusable and
+/// resolve to an empty body, matching Node's Fetch Body behavior.
+fn consume_request_body(handle: f64) -> Result<Vec<u8>, &'static str> {
+    let id = handle_id(handle);
+    let mut guard = REQUEST_REGISTRY.lock().unwrap();
+    let req = guard.get_mut(&id).ok_or("Invalid request handle")?;
+    let body = match &req.body {
+        Some(body) => body.clone(),
+        None => return Ok(Vec::new()),
+    };
+    if req.body_used {
+        return Err(BODY_ALREADY_USED_MESSAGE);
+    }
+    req.body_used = true;
+    Ok(body.into_bytes())
 }
 
 /// request.text() -> Promise<string>. Mirrors `js_fetch_response_text`: the
@@ -1642,15 +1781,18 @@ fn request_body_bytes(handle: f64) -> Option<Vec<u8>> {
 #[no_mangle]
 pub unsafe extern "C" fn js_request_text(handle: f64) -> *mut perry_runtime::Promise {
     let promise = perry_runtime::js_promise_new();
-    match request_body_bytes(handle) {
-        Some(body) => {
+    match consume_request_body(handle) {
+        Ok(body) => {
             let text = String::from_utf8_lossy(&body).to_string();
             let result_str = js_string_from_bytes(text.as_ptr(), text.len() as u32);
             let result_nan = f64::from_bits(JSValue::string_ptr(result_str).bits());
             perry_runtime::js_promise_resolve(promise, result_nan);
         }
-        None => {
-            let err_nan = f64::from_bits(fetch_error_bits("Invalid request handle"));
+        Err(err_msg) if err_msg == BODY_ALREADY_USED_MESSAGE => {
+            reject_fetch_type_error(promise, BODY_ALREADY_USED_MESSAGE);
+        }
+        Err(err_msg) => {
+            let err_nan = f64::from_bits(fetch_error_bits(err_msg));
             perry_runtime::js_promise_reject(promise, err_nan);
         }
     }
@@ -1662,10 +1804,14 @@ pub unsafe extern "C" fn js_request_text(handle: f64) -> *mut perry_runtime::Pro
 #[no_mangle]
 pub unsafe extern "C" fn js_request_json(handle: f64) -> *mut perry_runtime::Promise {
     let promise = perry_runtime::js_promise_new();
-    let body = match request_body_bytes(handle) {
-        Some(b) => b,
-        None => {
-            let err_nan = f64::from_bits(fetch_error_bits("Invalid request handle"));
+    let body = match consume_request_body(handle) {
+        Ok(b) => b,
+        Err(err_msg) if err_msg == BODY_ALREADY_USED_MESSAGE => {
+            reject_fetch_type_error(promise, BODY_ALREADY_USED_MESSAGE);
+            return promise;
+        }
+        Err(err_msg) => {
+            let err_nan = f64::from_bits(fetch_error_bits(err_msg));
             perry_runtime::js_promise_reject(promise, err_nan);
             return promise;
         }
@@ -1689,10 +1835,14 @@ pub unsafe extern "C" fn js_request_json(handle: f64) -> *mut perry_runtime::Pro
 #[no_mangle]
 pub unsafe extern "C" fn js_request_array_buffer(handle: f64) -> *mut perry_runtime::Promise {
     let promise = perry_runtime::js_promise_new();
-    let body = match request_body_bytes(handle) {
-        Some(b) => b,
-        None => {
-            let err_nan = f64::from_bits(fetch_error_bits("Invalid request handle"));
+    let body = match consume_request_body(handle) {
+        Ok(b) => b,
+        Err(err_msg) if err_msg == BODY_ALREADY_USED_MESSAGE => {
+            reject_fetch_type_error(promise, BODY_ALREADY_USED_MESSAGE);
+            return promise;
+        }
+        Err(err_msg) => {
+            let err_nan = f64::from_bits(fetch_error_bits(err_msg));
             perry_runtime::js_promise_reject(promise, err_nan);
             return promise;
         }

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -8,13 +8,13 @@ This document is a structured gap analysis comparing the public Node.js + Bun ru
 |----------|---------|----------|------------------|
 | Whole-module gaps (zero coverage) | 20 | 484 | n/a |
 | Partial-module gaps | 29 | 1648 | 369 |
-| Web-global gaps | — | 284 | 105 |
+| Web-global gaps | — | 282 | 107 |
 | Bun-only gaps (out of scope) | — | 394 | n/a |
-| **Total true gaps** |  | **2416** |  |
+| **Total true gaps** |  | **2414** |  |
 
 **Top modules by remaining true gaps (Node + Web):**
 
-- `Web / Global APIs` — 284
+- `Web / Global APIs` — 282
 - `node:os` — 195
 - `node:fs` — 139
 - `node:crypto` — 128
@@ -2036,7 +2036,7 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 
 ## Web globals
 
-**Total APIs: 389** · Perry covers: 105 · Gap: 284
+**Total APIs: 389** · Perry covers: 107 · Gap: 282
 
 Web-global coverage is determined heuristically — Perry implements many of these via dedicated `Expr::*` lowering (e.g. `Expr::FetchWithOptions`, `Expr::TextEncoderEncode`, `Expr::UrlNew`) and `js_*` FFI surfaces (Headers/Request/Response/Blob via perry-ext-fetch and perry-stdlib). The covered list below is curated; the gap list is everything else in the parity reference's Web / Global APIs section.
 
@@ -2100,12 +2100,14 @@ Web-global coverage is determined heuristically — Perry implements many of the
 | `request.url` | `ffi:js_request_get_url` |
 | `request.headers` | `ffi:js_request_get_headers` |
 | `request.body` | `ffi:js_request_get_body` |
+| `request.bodyUsed` | `ffi:js_request_body_used` |
 | `request.arrayBuffer()` | `ffi:js_request_array_buffer` |
 | `request.clone()` | `ffi:js_request_clone` |
 | `request.json()` | `ffi:js_request_json` |
 | `request.text()` | `ffi:js_request_text` |
 | `new Response(body?, init?)` | `ffi:js_response_new` |
 | `response.body` | `ffi:js_response_body` |
+| `response.bodyUsed` | `ffi:js_response_body_used` |
 | `response.headers` | `ffi:js_response_get_headers` |
 | `response.ok` | `ffi:js_fetch_response_ok` |
 | `response.status` | `ffi:js_fetch_response_status` |
@@ -2152,7 +2154,7 @@ Web-global coverage is determined heuristically — Perry implements many of the
 
 ### Web globals — gaps
 
-Total gaps: 284. First 100 entries:
+Total gaps: 282. First 100 entries:
 
 - `reportError(err)`
 - `setImmediate(cb, ...args)`
@@ -2186,7 +2188,6 @@ Total gaps: 284. First 100 entries:
 - `request.integrity`
 - `request.keepalive`
 - `request.signal`
-- `request.bodyUsed`
 - `request.duplex`
 - `request.blob()`
 - `request.bytes()`
@@ -2194,7 +2195,6 @@ Total gaps: 284. First 100 entries:
 - `Response.error()`
 - `Response.json(data, init?)`
 - `Response.redirect(url, status?)`
-- `response.bodyUsed`
 - `response.redirected`
 - `response.type`
 - `response.url`

--- a/test-parity/node-suite/fetch/body-used.ts
+++ b/test-parity/node-suite/fetch/body-used.ts
@@ -1,0 +1,104 @@
+function requestWithBody(body: string): Request {
+  return new Request("https://example.test/body-used", {
+    method: "POST",
+    body,
+    duplex: "half",
+  } as any);
+}
+
+function errorName(e: any): string {
+  return e?.name ?? e?.constructor?.name ?? typeof e;
+}
+
+function errorMessage(e: any): string {
+  return e?.message ?? String(e);
+}
+
+async function reportRejected(label: string, promise: Promise<unknown>) {
+  try {
+    await promise;
+    console.log(`${label}: ok`);
+  } catch (e: any) {
+    console.log(`${label}:`, errorName(e), errorMessage(e));
+  }
+}
+
+function reportThrown(label: string, action: () => unknown) {
+  try {
+    action();
+    console.log(`${label}: ok`);
+  } catch (e: any) {
+    console.log(`${label}:`, errorName(e), errorMessage(e));
+  }
+}
+
+async function requestTextAndClone() {
+  const req = requestWithBody("request text");
+  const clone = req.clone();
+  console.log("Request text before:", req.bodyUsed, clone.bodyUsed);
+  console.log("Request text first:", await req.text(), req.bodyUsed, clone.bodyUsed);
+  console.log("Request clone text:", await clone.text(), req.bodyUsed, clone.bodyUsed);
+  await reportRejected("Request text second", req.text());
+}
+
+async function responseTextAndClone() {
+  const res = new Response("response text");
+  const clone = res.clone();
+  console.log("Response text before:", res.bodyUsed, clone.bodyUsed);
+  console.log("Response text first:", await res.text(), res.bodyUsed, clone.bodyUsed);
+  console.log("Response clone text:", await clone.text(), res.bodyUsed, clone.bodyUsed);
+  await reportRejected("Response text second", res.text());
+}
+
+async function otherConsumers() {
+  const reqJson = requestWithBody(JSON.stringify({ request: true }));
+  console.log("Request json before:", reqJson.bodyUsed);
+  console.log("Request json first:", (await reqJson.json()).request, reqJson.bodyUsed);
+  await reportRejected("Request json second", reqJson.arrayBuffer());
+
+  const reqArrayBuffer = requestWithBody("abc");
+  console.log("Request arrayBuffer before:", reqArrayBuffer.bodyUsed);
+  console.log(
+    "Request arrayBuffer first:",
+    (await reqArrayBuffer.arrayBuffer()).byteLength,
+    reqArrayBuffer.bodyUsed,
+  );
+  await reportRejected("Request arrayBuffer second", reqArrayBuffer.text());
+
+  const resJson = new Response(JSON.stringify({ response: true }));
+  console.log("Response json before:", resJson.bodyUsed);
+  console.log("Response json first:", (await resJson.json()).response, resJson.bodyUsed);
+  await reportRejected("Response json second", resJson.text());
+
+  const resArrayBuffer = new Response("abcd");
+  console.log("Response arrayBuffer before:", resArrayBuffer.bodyUsed);
+  console.log(
+    "Response arrayBuffer first:",
+    (await resArrayBuffer.arrayBuffer()).byteLength,
+    resArrayBuffer.bodyUsed,
+  );
+  await reportRejected("Response arrayBuffer second", resArrayBuffer.text());
+
+  const resBlob = new Response("blob-body", {
+    headers: { "content-type": "text/plain" },
+  });
+  console.log("Response blob before:", resBlob.bodyUsed);
+  const blob = await resBlob.blob();
+  console.log("Response blob first:", blob.size, await blob.text(), resBlob.bodyUsed);
+  await reportRejected("Response blob second", resBlob.text());
+}
+
+async function cloneAfterUsed() {
+  const req = requestWithBody("request clone");
+  await req.text();
+  reportThrown("Request clone after used", () => req.clone());
+
+  const res = new Response("response clone");
+  await res.text();
+  reportThrown("Response clone after used", () => res.clone());
+}
+
+await requestTextAndClone();
+await responseTextAndClone();
+await otherConsumers();
+await cloneAfterUsed();


### PR DESCRIPTION
## Summary

Fixes #2621.

- tracks `bodyUsed` for Fetch `Request` and `Response` records
- consumes bodies once across `text()`, `json()`, `arrayBuffer()`, and `blob()` where implemented
- rejects repeated reads with a `TypeError` and throws on clone-after-consumption
- wires `Request.clone()`, typed/dynamic `bodyUsed` access, and updates the runtime parity gap list

## Tests

- `PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" node test-parity/node-suite/fetch/body-used.ts`
- `env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module fetch --filter body-used`
- `env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --filter test_gap_fetch_response`
- `env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --filter test_issue_1698_request_body_method_value`
- `env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --filter test_issue_234_blob_methods`
- `env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --filter test_issue_237_streams_blob`
- `env RUSTC_WRAPPER= cargo check -p perry-stdlib -p perry-codegen`
- `cargo fmt --all -- --check`
- `git diff --check`
- `jq empty test-parity/known_failures.json`
- `./scripts/check_file_size.sh`

## Notes

`Request.blob()`, `Request.bytes()`, and `formData()` remain separate gaps tracked by #2622, #2619, and #2620.
