### PR TITLE
fix(globals): match atob/btoa semantics

### DIFF
--- a/crates/perry-runtime/src/string/base64_codec.rs
+++ b/crates/perry-runtime/src/string/base64_codec.rs
@@ -5,25 +5,51 @@
 
 use super::*;
 
+fn value_to_string_bytes(value: f64) -> &'static [u8] {
+    let str_ptr = crate::value::js_jsvalue_to_string(value) as *const StringHeader;
+    if !is_valid_string_ptr(str_ptr) {
+        return &[];
+    }
+    unsafe { std::slice::from_raw_parts(string_data(str_ptr), (*str_ptr).byte_len as usize) }
+}
+
+fn throw_invalid_character() -> ! {
+    let msg = b"The string to be decoded is not correctly encoded.";
+    let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_error_new_with_name_message(b"InvalidCharacterError", msg_ptr);
+    crate::node_submodules::set_error_user_prop(err as usize, "code", 5.0);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+fn is_base64_alphabet(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'/')
+}
+
 /// atob(base64) — decode a base64-encoded string to a binary string.
-/// Input is a NaN-boxed STRING_TAG f64. Output is a raw *const StringHeader (codegen NaN-boxes).
+/// Output is a raw *const StringHeader (codegen NaN-boxes).
 #[no_mangle]
 pub extern "C" fn js_atob(value: f64) -> *const StringHeader {
     use base64::Engine as _;
-    const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
-    const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
-    let bits = value.to_bits();
-    if (bits & 0xFFFF_0000_0000_0000) != STRING_TAG {
-        return js_string_from_bytes(ptr::null(), 0);
+
+    let mut cleaned = Vec::new();
+    for &byte in value_to_string_bytes(value) {
+        if !matches!(byte, b'\t' | b'\n' | 0x0c | b'\r' | b' ') {
+            cleaned.push(byte);
+        }
     }
-    let str_ptr = (bits & POINTER_MASK) as *const StringHeader;
-    if !is_valid_string_ptr(str_ptr) {
-        return js_string_from_bytes(ptr::null(), 0);
+    if cleaned.len() % 4 == 0 {
+        if cleaned.ends_with(b"==") {
+            cleaned.truncate(cleaned.len() - 2);
+        } else if cleaned.ends_with(b"=") {
+            cleaned.truncate(cleaned.len() - 1);
+        }
     }
-    let s = string_as_str(str_ptr);
-    match base64::engine::general_purpose::STANDARD.decode(s.as_bytes()) {
+    if cleaned.len() % 4 == 1 || cleaned.iter().any(|&byte| !is_base64_alphabet(byte)) {
+        throw_invalid_character();
+    }
+    match base64::engine::general_purpose::STANDARD_NO_PAD.decode(&cleaned) {
         Ok(decoded) => js_string_from_bytes(decoded.as_ptr(), decoded.len() as u32),
-        Err(_) => js_string_from_bytes(ptr::null(), 0),
+        Err(_) => throw_invalid_character(),
     }
 }
 
@@ -31,17 +57,21 @@ pub extern "C" fn js_atob(value: f64) -> *const StringHeader {
 #[no_mangle]
 pub extern "C" fn js_btoa(value: f64) -> *const StringHeader {
     use base64::Engine as _;
-    const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
-    const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
-    let bits = value.to_bits();
-    if (bits & 0xFFFF_0000_0000_0000) != STRING_TAG {
-        return js_string_from_bytes(ptr::null(), 0);
+
+    let input = value_to_string_bytes(value);
+    let mut bytes = Vec::with_capacity(input.len());
+    match std::str::from_utf8(input) {
+        Ok(s) => {
+            for ch in s.chars() {
+                let code = ch as u32;
+                if code > 0xff {
+                    throw_invalid_character();
+                }
+                bytes.push(code as u8);
+            }
+        }
+        Err(_) => bytes.extend_from_slice(input),
     }
-    let str_ptr = (bits & POINTER_MASK) as *const StringHeader;
-    if !is_valid_string_ptr(str_ptr) {
-        return js_string_from_bytes(ptr::null(), 0);
-    }
-    let s = string_as_str(str_ptr);
-    let encoded = base64::engine::general_purpose::STANDARD.encode(s.as_bytes());
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
     js_string_from_bytes(encoded.as_ptr(), encoded.len() as u32)
 }

--- a/test-parity/node-suite/globals/base64-codec.ts
+++ b/test-parity/node-suite/globals/base64-codec.ts
@@ -1,0 +1,35 @@
+import { atob as bufferAtob, btoa as bufferBtoa } from "node:buffer";
+
+function show(label: string, value: unknown) {
+  console.log(`${label}:`, value);
+}
+
+function showError(label: string, fn: () => unknown) {
+  try {
+    fn();
+    console.log(`${label}:`, "no throw");
+  } catch (err: any) {
+    console.log(`${label}:`, err?.name, err?.code, typeof err?.code);
+  }
+}
+
+show("global btoa string", btoa("hello"));
+show("global btoa number", btoa(123 as any));
+show("global btoa latin1", btoa("\u00ff"));
+show("global atob whitespace", atob(" aG Vs bG8=\n"));
+show("global atob unpadded", atob("YQ"));
+show("global atob object", atob({ toString() { return "YQ=="; } } as any));
+
+const encode = globalThis.btoa;
+const decode = globalThis.atob;
+show("rebound btoa", encode("x"));
+show("rebound atob", decode("eA=="));
+
+show("buffer btoa number", bufferBtoa(123 as any));
+show("buffer atob object", bufferAtob({ toString() { return "Yg=="; } } as any));
+
+showError("global btoa unicode", () => btoa("✓"));
+showError("global atob invalid", () => atob("%%%"));
+showError("global atob bad padding", () => atob("YQ="));
+showError("buffer btoa unicode", () => bufferBtoa("✓"));
+showError("buffer atob invalid", () => bufferAtob("%%%"));


### PR DESCRIPTION
## Summary
- coerce `atob`/`btoa` arguments with the runtime ToString path used by other JS APIs
- match Node/Web base64 behavior for ASCII whitespace, unpadded valid input, invalid padding, and Latin-1-only `btoa` input
- throw an `InvalidCharacterError`-named error with numeric `code` 5 for invalid decode/encode cases
- add Node parity coverage for globals, rebound globals, and `node:buffer` aliases

Fixes #2654

## Verification
- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER= cargo check -p perry-runtime -p perry-codegen`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module globals --filter base64-codec`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `git diff --check`
- `./scripts/check_file_size.sh`