### PR TITLE
fix(buffer): inherit static Buffer factories

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1717,6 +1717,18 @@ unsafe fn try_native_static_method_in_proto_chain(
     let mut cid = class_id;
     let mut depth = 0u32;
     while cid != 0 && depth < 64 {
+        if let Some(parent_addr) = class_parent_closure(cid) {
+            let parent_value = crate::value::js_nanbox_pointer(parent_addr as i64);
+            if is_buffer_constructor_value(parent_value) {
+                let module = b"buffer.Buffer";
+                let ns = js_create_native_module_namespace(module.as_ptr(), module.len());
+                let ns_obj = JSValue::from_bits(ns.to_bits()).as_pointer::<ObjectHeader>();
+                let result = dispatch_native_module_method(ns_obj, name, args_ptr, args_len);
+                if !JSValue::from_bits(result.to_bits()).is_undefined() {
+                    return Some(result);
+                }
+            }
+        }
         let proto_obj = class_prototype_object(cid);
         if !proto_obj.is_null() && (*proto_obj).class_id == NATIVE_MODULE_CLASS_ID {
             if read_native_module_name(proto_obj as *const ObjectHeader).as_deref()

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -62,6 +62,9 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
             }
         }
     }
+    if is_buffer_constructor_value(type_ref) {
+        return js_instanceof(value, crate::buffer::BUFFER_TYPE_ID);
+    }
     if crate::node_submodules::is_diagnostics_channel_constructor_value(type_ref) {
         return if crate::node_submodules::diagnostics_channel_is_channel_instance_value(value) {
             f64::from_bits(crate::value::TAG_TRUE)

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -415,6 +415,13 @@ pub(crate) fn buffer_constructor_value() -> f64 {
     })
 }
 
+pub(crate) fn is_buffer_constructor_value(value: f64) -> bool {
+    BUFFER_CONSTRUCTOR_VALUE.with(|slot| {
+        let cached = slot.get();
+        cached != 0 && cached == value.to_bits()
+    })
+}
+
 extern "C" fn util_debuglog_logger_thunk(
     _closure: *const crate::closure::ClosureHeader,
     _arg: f64,


### PR DESCRIPTION
## Summary
- route static method lookup for classes extending the native Buffer constructor through `buffer.Buffer` static dispatch
- make `MyBuffer.from("abc")` return a plain Buffer/FastBuffer-shaped value instead of the subclass class ref
- recognize the cached native Buffer constructor in dynamic `instanceof` as the Buffer reserved type

## Verification
- DeepWiki reference: `reference/deepwiki/nodejs-node-buffer-subclass-species-instanceof-2026-05-29.md`
- pre-fix full `node-suite/buffer`: 121 PASS / 1 FAIL (`properties/subclass-species`), report `test-parity/reports/parity_report_20260529_130916.json`
- pre-fix exact `node-suite/buffer/properties/subclass-species`: FAIL, report `test-parity/reports/parity_report_20260529_131535.json`
- post-fix exact: PASS, report `test-parity/reports/parity_report_20260529_132506.json`
- post-fix full `node-suite/buffer`: 122 PASS / 0 FAIL, report `test-parity/reports/parity_report_20260529_132558.json`
- post-rebase exact: PASS, report `test-parity/reports/parity_report_20260529_133414.json`
- post-rebase full `node-suite/buffer`: 122 PASS / 0 FAIL, report `test-parity/reports/parity_report_20260529_133506.json`
- `cargo check -p perry-runtime`
- `cargo fmt --all --check`
- `git diff --check && git diff --cached --check`

## Non-goals
- no general native-constructor subclass model
- no `new MyBuffer(...)` Buffer allocation support
- no broader species/prototype-chain rewrite
- no test metadata changes