### PR TITLE
fix(globals): expose File on globalThis

### DIFF
--- a/crates/perry-codegen/src/expr/helpers.rs
+++ b/crates/perry-codegen/src/expr/helpers.rs
@@ -302,6 +302,7 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
             | "EventTarget"
             | "FormData"
             | "Blob"
+            | "File"
             | "Headers"
             | "Request"
             | "Response"

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -93,7 +93,10 @@ pub(crate) fn lower_let(
         // real class instead of the empty-object placeholder.
         Some(perry_hir::Expr::PropertyGet { object, property }) => {
             if matches!(object.as_ref(), perry_hir::Expr::GlobalGet(_))
-                && matches!(property.as_str(), "TextEncoderStream" | "TextDecoderStream")
+                && matches!(
+                    property.as_str(),
+                    "TextEncoderStream" | "TextDecoderStream" | "File"
+                )
             {
                 ctx.local_class_aliases
                     .insert(name.to_string(), property.clone());

--- a/crates/perry-hir/src/analysis/builtins.rs
+++ b/crates/perry-hir/src/analysis/builtins.rs
@@ -69,6 +69,7 @@ pub(crate) fn is_builtin_global_value_name(name: &str) -> bool {
             | "Uint8ClampedArray"
             | "TextEncoderStream"
             | "TextDecoderStream"
+            | "File"
             | "Buffer"
             | "process"
             | "console"

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -902,6 +902,19 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                 );
                                 ctx.uses_fetch = true;
                             }
+                            other
+                                if ctx
+                                    .resolve_class_alias(other)
+                                    .as_deref()
+                                    .is_some_and(|resolved| resolved == "File") =>
+                            {
+                                ctx.register_native_instance(
+                                    name.clone(),
+                                    "blob".to_string(),
+                                    "File".to_string(),
+                                );
+                                ctx.uses_fetch = true;
+                            }
                             // Issue #237: Web Streams API constructors.
                             "ReadableStream" => {
                                 ctx.register_native_instance(
@@ -953,6 +966,35 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                     }
                                 }
                             }
+                        }
+                    } else if let ast::Expr::Member(member) = new_expr.callee.as_ref() {
+                        let is_global_file = match member.obj.as_ref() {
+                            ast::Expr::Ident(obj_ident)
+                                if obj_ident.sym.as_ref() == "globalThis" =>
+                            {
+                                match &member.prop {
+                                    ast::MemberProp::Ident(prop_ident) => {
+                                        prop_ident.sym.as_ref() == "File"
+                                    }
+                                    ast::MemberProp::Computed(prop) => {
+                                        matches!(
+                                            prop.expr.as_ref(),
+                                            ast::Expr::Lit(ast::Lit::Str(s))
+                                                if s.value.as_str() == Some("File")
+                                        )
+                                    }
+                                    _ => false,
+                                }
+                            }
+                            _ => false,
+                        };
+                        if is_global_file {
+                            ctx.register_native_instance(
+                                name.clone(),
+                                "blob".to_string(),
+                                "File".to_string(),
+                            );
+                            ctx.uses_fetch = true;
                         }
                     }
                 }
@@ -1488,6 +1530,12 @@ pub(crate) fn lower_var_decl_with_destructuring(
                         {
                             ctx.object_static_method_aliases.insert(id, method_name);
                         }
+                    }
+                    Expr::PropertyGet { object, property }
+                        if matches!(object.as_ref(), Expr::GlobalGet(_)) && property == "File" =>
+                    {
+                        ctx.register_let_class_alias(name.clone(), "File".to_string());
+                        ctx.uses_fetch = true;
                     }
                     // Issue #838: `var p = <ClassName>.prototype` records
                     // the alias so a later `p.<method> = <fn>` lowers to

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -786,6 +786,18 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                         .collect()
                 })
                 .unwrap_or_default();
+            if ctx.lookup_class(&class_name).is_none() {
+                if let Some(resolved) = ctx.resolve_class_alias(&class_name) {
+                    if resolved == "File" {
+                        ctx.uses_fetch = true;
+                        return Ok(Expr::New {
+                            class_name: resolved,
+                            args,
+                            type_args,
+                        });
+                    }
+                }
+            }
             // Issue #838 followup (b): when `<Ident>` is NOT a real
             // class but resolves to a local binding, route through
             // `Expr::NewDynamic { callee: LocalGet(id), … }` so codegen
@@ -911,6 +923,16 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 })
                 .transpose()?
                 .unwrap_or_default();
+            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+                if matches!(object.as_ref(), Expr::GlobalGet(_)) && property == "File" {
+                    ctx.uses_fetch = true;
+                    return Ok(Expr::New {
+                        class_name: property.clone(),
+                        args,
+                        type_args: Vec::new(),
+                    });
+                }
+            }
             Ok(Expr::NewDynamic { callee, args })
         }
     }

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -284,6 +284,7 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                     && name != "URLSearchParams"
                     && name != "AbortController"
                     && name != "FormData"
+                    && name != "File"
                     && name != "Headers"
                     && name != "fetch"
                     && name != "crypto"

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -142,6 +142,7 @@ pub(crate) const GLOBAL_THIS_BUILTIN_CONSTRUCTORS: &[&str] = &[
     "AbortSignal",
     "FormData",
     "Blob",
+    "File",
     "Headers",
     "Request",
     "Response",
@@ -686,6 +687,9 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         }
         if name == "String" {
             crate::closure::js_register_closure_arity(func_ptr, 1);
+        }
+        if name == "File" {
+            super::native_module::set_bound_native_closure_name(closure_ptr, name);
         }
         // Stash `prototype` on the closure's dynamic-prop side table.
         // `js_object_set_field_by_name` detects the CLOSURE_MAGIC tag

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1917,6 +1917,7 @@ pub(crate) unsafe fn get_native_module_constant(
         "fs.constants" => fs_const(property),
         "buffer" => match property {
             "Buffer" => Some(buffer_constructor_value()),
+            "File" => Some(js_get_global_this_builtin_value(b"File".as_ptr(), 4)),
             "constants" => Some(create_sub_namespace("buffer.constants")),
             // Match Node's common 64-bit max Buffer length value. Perry won't
             // actually allocate buffers this large, but shape/value parity lets

--- a/test-parity/node-suite/buffer/blob-file/global-file.ts
+++ b/test-parity/node-suite/buffer/blob-file/global-file.ts
@@ -1,0 +1,22 @@
+import { File as BufferFile } from "node:buffer";
+
+console.log("typeof File:", typeof File);
+console.log("File.name:", File.name);
+console.log("typeof globalThis.File:", typeof globalThis.File);
+console.log("global File identity:", globalThis.File === File);
+console.log("buffer File identity:", BufferFile === File, BufferFile === globalThis.File);
+
+const direct = new globalThis.File(["abc"], "x.txt", {
+  type: "text/plain",
+  lastModified: 123,
+});
+console.log("direct fields:", direct.name, direct.type, direct.size, direct.lastModified);
+console.log("direct text:", await direct.text());
+
+const FileCtor = globalThis.File;
+const rebound = new FileCtor(["xy"], "y.txt", {
+  type: "text/custom",
+  lastModified: 456,
+});
+console.log("rebound fields:", rebound.name, rebound.type, rebound.size, rebound.lastModified);
+console.log("rebound text:", await rebound.text());


### PR DESCRIPTION
Closes #2577

## Summary
- Expose `File` through the pre-populated `globalThis` builtin constructor path.
- Resolve `node:buffer`'s `File` export to the same global singleton.
- Lower `new globalThis.File(...)` and rebound `globalThis.File` constructor aliases through the existing File constructor/native-instance path.
- Add a Node parity fixture covering global, `globalThis`, `node:buffer`, and rebound constructor identity/fields.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `./scripts/check_file_size.sh`
- `RUSTC_WRAPPER= cargo check -p perry-hir -p perry-codegen -p perry-runtime`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module buffer --filter blob-file/global-file`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module buffer --filter blob-file/file-basic`