### PR TITLE
fix(buffer): match Node max length constants

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -724,6 +724,21 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
         }
     }
     unsafe {
+        if (*obj).class_id == NATIVE_MODULE_CLASS_ID {
+            if let Some(module_name) = read_native_module_name(obj) {
+                if let Some(keys) = native_module_enumerable_keys(&module_name) {
+                    let out = crate::array::js_array_alloc(keys.len() as u32);
+                    for key_bytes in keys {
+                        let key_str = crate::string::js_string_from_bytes(
+                            key_bytes.as_ptr(),
+                            key_bytes.len() as u32,
+                        );
+                        crate::array::js_array_push(out, JSValue::string_ptr(key_str));
+                    }
+                    return out;
+                }
+            }
+        }
         let keys = (*obj).keys_array;
         if keys.is_null() {
             return crate::array::js_array_alloc(0);

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -120,6 +120,13 @@ fn normalize_native_module_alias(module_name: &str) -> &str {
     }
 }
 
+pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'static [&'static [u8]]> {
+    match module_name {
+        "buffer.constants" => Some(&[b"MAX_LENGTH", b"MAX_STRING_LENGTH"]),
+        _ => None,
+    }
+}
+
 fn should_cache_native_module_namespace(module_name: &str) -> bool {
     matches!(module_name, "util" | "util.types")
 }
@@ -1921,13 +1928,13 @@ pub(crate) unsafe fn get_native_module_constant(
             // Match Node's common 64-bit max Buffer length value. Perry won't
             // actually allocate buffers this large, but shape/value parity lets
             // packages feature-detect the Buffer surface without falling over.
-            "kMaxLength" => Some(4294967296.0),
+            "kMaxLength" => Some(9_007_199_254_740_991.0),
             "kStringMaxLength" => Some(536870888.0),
             "INSPECT_MAX_BYTES" => Some(50.0),
             _ => None,
         },
         "buffer.constants" => match property {
-            "MAX_LENGTH" => Some(4294967296.0),
+            "MAX_LENGTH" => Some(9_007_199_254_740_991.0),
             "MAX_STRING_LENGTH" => Some(536870888.0),
             _ => None,
         },

--- a/test-parity/node-suite/buffer/properties/constants.ts
+++ b/test-parity/node-suite/buffer/properties/constants.ts
@@ -2,5 +2,10 @@ import { constants, kMaxLength, kStringMaxLength } from "node:buffer";
 
 console.log("constants types:", typeof constants.MAX_LENGTH, typeof constants.MAX_STRING_LENGTH);
 console.log("top-level types:", typeof kMaxLength, typeof kStringMaxLength);
+console.log("max length:", constants.MAX_LENGTH);
+console.log("top max length:", kMaxLength);
 console.log("same max:", constants.MAX_LENGTH === kMaxLength);
+console.log("string max:", constants.MAX_STRING_LENGTH);
+console.log("top string max:", kStringMaxLength);
 console.log("same string max:", constants.MAX_STRING_LENGTH === kStringMaxLength);
+console.log("keys:", Object.keys(constants).sort().join(","));


### PR DESCRIPTION
## Summary
- update `node:buffer` `kMaxLength` and `constants.MAX_LENGTH` to Node's current 64-bit value
- expose the Node-visible `buffer.constants` key set from `Object.keys(constants)` without changing the hidden native namespace dispatch slot
- strengthen the buffer constants parity fixture to assert values, aliases, string limits, and keys

Fixes #2669

## Verification
- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER= cargo check -p perry-runtime`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module buffer --filter properties/constants`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `git diff --check`
- `./scripts/check_file_size.sh`