### PR TITLE
Fix fs.promises.open create-mode failures

### DIFF
--- a/crates/perry-runtime/src/fs/callbacks.rs
+++ b/crates/perry-runtime/src/fs/callbacks.rs
@@ -613,27 +613,6 @@ pub extern "C" fn js_fs_open_callback(path_value: f64, arg1: f64, arg2: f64, arg
     f64::from_bits(TAG_UNDEFINED)
 }
 
-/// Probe used by `fs/promises.open` to decide whether to resolve with a
-/// FileHandle or reject. Returns `Some(err_val)` when the underlying open
-/// would fail with ENOENT/EACCES/EEXIST/etc., else `None`.
-///
-/// Exposed at `pub(crate)` so `node_submodules::thunk_fs_promises_open` can
-/// turn the io::Error into a rejected Promise instead of resolving with a
-/// FileHandle whose `fd === -1`.
-pub(crate) unsafe fn fs_promises_open_probe_error(
-    path_value: f64,
-    flags_value: f64,
-) -> Option<f64> {
-    // Only probe for read-only flags; anything that may create the file —
-    // including numeric `O_CREAT|…` bitsets — is left to the underlying
-    // open so it can succeed when the file doesn't exist yet.
-    if open_flag_is_read_only(flags_value) {
-        fs_callback_read_error(path_value, "open")
-    } else {
-        None
-    }
-}
-
 /// Returns true when an `open` flags value is unambiguously read-only.
 /// Treats `undefined` (Node's default) as read-only, the string flags
 /// `"r"` and `"r+"` as read-only, and everything else — including any

--- a/crates/perry-runtime/src/fs/fd_ops.rs
+++ b/crates/perry-runtime/src/fs/fd_ops.rs
@@ -20,101 +20,155 @@ pub(crate) fn array_ptr_from_value(value: f64) -> *const crate::array::ArrayHead
     }
 }
 
+fn open_options_from_flags(flags_value: f64) -> (fs::OpenOptions, bool) {
+    let mut opts = fs::OpenOptions::new();
+    let append_mode;
+    if flags_value.is_finite() {
+        let flags = flags_value as i32;
+        append_mode = apply_numeric_open_flags(&mut opts, flags);
+    } else {
+        let flags = flag_string(flags_value);
+        append_mode = matches!(flags.as_str(), "a" | "a+" | "ax" | "ax+");
+        match flags.as_str() {
+            "r" | "rs" => {
+                opts.read(true);
+            }
+            "r+" | "rs+" => {
+                opts.read(true).write(true);
+            }
+            "w" => {
+                opts.write(true).create(true).truncate(true);
+            }
+            "w+" => {
+                opts.read(true).write(true).create(true).truncate(true);
+            }
+            "a" => {
+                opts.write(true).create(true).append(true);
+            }
+            "a+" => {
+                opts.read(true).write(true).create(true).append(true);
+            }
+            "wx" => {
+                opts.write(true).create_new(true);
+            }
+            "wx+" => {
+                opts.read(true).write(true).create_new(true);
+            }
+            "ax" => {
+                opts.write(true).create_new(true).append(true);
+            }
+            "ax+" => {
+                opts.read(true).write(true).create_new(true).append(true);
+            }
+            _ => {
+                opts.read(true);
+            }
+        }
+    }
+    (opts, append_mode)
+}
+
+#[cfg(unix)]
+fn apply_numeric_open_flags(opts: &mut fs::OpenOptions, flags: i32) -> bool {
+    match flags & libc::O_ACCMODE {
+        libc::O_WRONLY => {
+            opts.write(true);
+        }
+        libc::O_RDWR => {
+            opts.read(true).write(true);
+        }
+        _ => {
+            opts.read(true);
+        }
+    }
+    if flags & libc::O_CREAT != 0 && flags & libc::O_EXCL != 0 {
+        opts.create_new(true);
+    } else if flags & libc::O_CREAT != 0 {
+        opts.create(true);
+    }
+    if flags & libc::O_TRUNC != 0 {
+        opts.truncate(true);
+    }
+    let append_mode = flags & libc::O_APPEND != 0;
+    if append_mode {
+        opts.append(true).write(true);
+    }
+    append_mode
+}
+
+#[cfg(not(unix))]
+fn apply_numeric_open_flags(opts: &mut fs::OpenOptions, flags: i32) -> bool {
+    let append_mode = flags & 0x8 != 0;
+    let access = flags & 0x3;
+    match access {
+        1 => {
+            opts.write(true);
+        }
+        2 => {
+            opts.read(true).write(true);
+        }
+        _ => {
+            opts.read(true);
+        }
+    }
+    if flags & 0x200 != 0 && flags & 0x800 != 0 {
+        opts.create_new(true);
+    } else if flags & 0x200 != 0 {
+        opts.create(true);
+    }
+    if flags & 0x400 != 0 {
+        opts.truncate(true);
+    }
+    if append_mode {
+        opts.append(true).write(true);
+    }
+    append_mode
+}
+
+pub(crate) unsafe fn fs_open_sync_result(
+    path_value: f64,
+    flags_value: f64,
+) -> Result<i32, (std::io::Error, String)> {
+    crate::fs::validate::validate_path("path", path_value);
+    let path_str = match decode_path_value(path_value) {
+        Some(s) => s,
+        None => {
+            return Err((
+                std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid path"),
+                String::new(),
+            ));
+        }
+    };
+    let (opts, append_mode) = open_options_from_flags(flags_value);
+    match opts.open(&path_str) {
+        Ok(file) => {
+            let fd = NEXT_FD.with(|n| {
+                let mut n = n.borrow_mut();
+                let fd = *n;
+                *n += 1;
+                fd
+            });
+            FD_REGISTRY.with(|r| {
+                r.borrow_mut().insert(fd, file);
+            });
+            FD_PATHS.with(|r| {
+                r.borrow_mut().insert(fd, path_str.to_string());
+            });
+            FD_APPEND_MODE.with(|r| {
+                r.borrow_mut().insert(fd, append_mode);
+            });
+            Ok(fd)
+        }
+        Err(err) => Err((err, path_str)),
+    }
+}
+
 /// `fs.openSync(path, flags)` — small fd registry for deterministic tests.
 #[no_mangle]
 pub extern "C" fn js_fs_open_sync(path_value: f64, flags_value: f64) -> f64 {
-    crate::fs::validate::validate_path("path", path_value);
     unsafe {
-        let path_str = match decode_path_value(path_value) {
-            Some(s) => s,
-            None => return -1.0,
-        };
-        let mut opts = fs::OpenOptions::new();
-        let append_mode;
-        if flags_value.is_finite() {
-            let flags = flags_value as i32;
-            append_mode = flags & 0x8 != 0;
-            let access = flags & 0x3;
-            match access {
-                1 => {
-                    opts.write(true);
-                }
-                2 => {
-                    opts.read(true).write(true);
-                }
-                _ => {
-                    opts.read(true);
-                }
-            }
-            if flags & 0x200 != 0 && flags & 0x800 != 0 {
-                opts.create_new(true);
-            } else if flags & 0x200 != 0 {
-                opts.create(true);
-            }
-            if flags & 0x400 != 0 {
-                opts.truncate(true);
-            }
-            if append_mode {
-                opts.append(true).write(true);
-            }
-        } else {
-            let flags = flag_string(flags_value);
-            append_mode = matches!(flags.as_str(), "a" | "a+" | "ax" | "ax+");
-            match flags.as_str() {
-                "r" | "rs" => {
-                    opts.read(true);
-                }
-                "r+" | "rs+" => {
-                    opts.read(true).write(true);
-                }
-                "w" => {
-                    opts.write(true).create(true).truncate(true);
-                }
-                "w+" => {
-                    opts.read(true).write(true).create(true).truncate(true);
-                }
-                "a" => {
-                    opts.write(true).create(true).append(true);
-                }
-                "a+" => {
-                    opts.read(true).write(true).create(true).append(true);
-                }
-                "wx" => {
-                    opts.write(true).create_new(true);
-                }
-                "wx+" => {
-                    opts.read(true).write(true).create_new(true);
-                }
-                "ax" => {
-                    opts.write(true).create_new(true).append(true);
-                }
-                "ax+" => {
-                    opts.read(true).write(true).create_new(true).append(true);
-                }
-                _ => {
-                    opts.read(true);
-                }
-            }
-        }
-        match opts.open(&path_str) {
-            Ok(file) => {
-                let fd = NEXT_FD.with(|n| {
-                    let mut n = n.borrow_mut();
-                    let fd = *n;
-                    *n += 1;
-                    fd
-                });
-                FD_REGISTRY.with(|r| {
-                    r.borrow_mut().insert(fd, file);
-                });
-                FD_PATHS.with(|r| {
-                    r.borrow_mut().insert(fd, path_str.to_string());
-                });
-                FD_APPEND_MODE.with(|r| {
-                    r.borrow_mut().insert(fd, append_mode);
-                });
-                fd as f64
-            }
+        match fs_open_sync_result(path_value, flags_value) {
+            Ok(fd) => fd as f64,
             Err(_) => -1.0,
         }
     }

--- a/crates/perry-runtime/src/fs/filehandle.rs
+++ b/crates/perry-runtime/src/fs/filehandle.rs
@@ -563,10 +563,7 @@ pub(crate) extern "C" fn filehandle_read_lines_impl(
     interface
 }
 
-/// Build a minimal `fs.promises.FileHandle` object for deterministic parity.
-#[no_mangle]
-pub extern "C" fn js_fs_filehandle_open(path_value: f64, flags_value: f64) -> f64 {
-    let fd = js_fs_open_sync(path_value, flags_value) as i32;
+fn build_filehandle_object(fd: i32) -> f64 {
     crate::closure::js_register_closure_arity(filehandle_stat_impl as *const u8, 1);
     crate::closure::js_register_closure_arity(filehandle_read_impl as *const u8, 5);
     crate::closure::js_register_closure_arity(filehandle_write_impl as *const u8, 5);
@@ -658,4 +655,21 @@ pub extern "C" fn js_fs_filehandle_open(path_value: f64, flags_value: f64) -> f6
         fds.borrow_mut().insert(obj as usize, fd);
     });
     handle
+}
+
+/// Build a minimal `fs.promises.FileHandle` object for deterministic parity.
+#[no_mangle]
+pub extern "C" fn js_fs_filehandle_open(path_value: f64, flags_value: f64) -> f64 {
+    let fd = js_fs_open_sync(path_value, flags_value) as i32;
+    build_filehandle_object(fd)
+}
+
+pub(crate) unsafe fn js_fs_filehandle_open_result(
+    path_value: f64,
+    flags_value: f64,
+) -> Result<f64, f64> {
+    match fs_open_sync_result(path_value, flags_value) {
+        Ok(fd) => Ok(build_filehandle_object(fd)),
+        Err((err, path)) => Err(build_fs_error_value(&err, "open", &path)),
+    }
 }

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -1620,15 +1620,7 @@ pub extern "C" fn js_fs_readlink_dispatch(path_value: f64, options_value: f64) -
 }
 
 fn flag_string(value: f64) -> String {
-    unsafe {
-        let ptr = extract_string_ptr(value);
-        if ptr.is_null() {
-            return "r".to_string();
-        }
-        let len = (*ptr).byte_len as usize;
-        let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-        String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned()
-    }
+    unsafe { decode_flags_string(value).unwrap_or_else(|| "r".to_string()) }
 }
 
 fn buffer_ptr_from_value(value: f64) -> *mut crate::buffer::BufferHeader {
@@ -1713,6 +1705,22 @@ pub extern "C" fn js_fs_access_sync_throw_mode(path_value: f64, mode_value: f64)
 // ============================================================
 
 fn io_error_code(err: &std::io::Error) -> &'static str {
+    #[cfg(unix)]
+    if let Some(raw) = err.raw_os_error() {
+        match raw {
+            code if code == libc::ENOENT => return "ENOENT",
+            code if code == libc::EACCES => return "EACCES",
+            code if code == libc::EEXIST => return "EEXIST",
+            code if code == libc::ENOTDIR => return "ENOTDIR",
+            code if code == libc::EISDIR => return "EISDIR",
+            code if code == libc::EINVAL => return "EINVAL",
+            code if code == libc::EINTR => return "EINTR",
+            code if code == libc::ENOSPC => return "ENOSPC",
+            code if code == libc::ETIMEDOUT => return "ETIMEDOUT",
+            code if code == libc::EAGAIN => return "EAGAIN",
+            _ => {}
+        }
+    }
     use std::io::ErrorKind;
     match err.kind() {
         ErrorKind::NotFound => "ENOENT",

--- a/crates/perry-runtime/src/node_submodules/fs_promises.rs
+++ b/crates/perry-runtime/src/node_submodules/fs_promises.rs
@@ -39,14 +39,10 @@ pub(crate) extern "C" fn thunk_fs_promises_open(
     flags: f64,
     _mode: f64,
 ) -> f64 {
-    // Probe before opening so a missing path rejects the Promise instead of
-    // resolving with a FileHandle whose `fd === -1`. Matches Node's behavior
-    // for `fs/promises.open(path)` on ENOENT/EACCES.
-    if let Some(err_val) = unsafe { crate::fs::fs_promises_open_probe_error(path, flags) } {
-        let promise = crate::promise::js_promise_rejected(err_val);
-        return f64::from_bits(JSValue::pointer(promise as *const u8).bits());
+    match unsafe { crate::fs::js_fs_filehandle_open_result(path, flags) } {
+        Ok(handle) => promise_value(handle),
+        Err(err_val) => promise_rejected(err_val),
     }
-    promise_value(crate::fs::js_fs_filehandle_open(path, flags))
 }
 
 pub(crate) extern "C" fn thunk_fs_promises_writeFile(

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1320,6 +1320,46 @@ pub(crate) unsafe fn get_native_module_constant(
             0x0100 as f64
         }
     };
+    let o_creat = {
+        #[cfg(unix)]
+        {
+            libc::O_CREAT as f64
+        }
+        #[cfg(not(unix))]
+        {
+            0x200 as f64
+        }
+    };
+    let o_trunc = {
+        #[cfg(unix)]
+        {
+            libc::O_TRUNC as f64
+        }
+        #[cfg(not(unix))]
+        {
+            0x400 as f64
+        }
+    };
+    let o_append = {
+        #[cfg(unix)]
+        {
+            libc::O_APPEND as f64
+        }
+        #[cfg(not(unix))]
+        {
+            0x8 as f64
+        }
+    };
+    let o_excl = {
+        #[cfg(unix)]
+        {
+            libc::O_EXCL as f64
+        }
+        #[cfg(not(unix))]
+        {
+            0x800 as f64
+        }
+    };
 
     // Helper for fs constants — shared between "fs" and "fs.constants" modules.
     // Using a nested match (module first, then property) instead of OR patterns
@@ -1335,10 +1375,10 @@ pub(crate) unsafe fn get_native_module_constant(
             "O_WRONLY" => Some(1.0),
             "O_RDWR" => Some(2.0),
             "O_NOFOLLOW" => Some(o_nofollow),
-            "O_CREAT" => Some(0x200 as f64),
-            "O_TRUNC" => Some(0x400 as f64),
-            "O_APPEND" => Some(0x8 as f64),
-            "O_EXCL" => Some(0x800 as f64),
+            "O_CREAT" => Some(o_creat),
+            "O_TRUNC" => Some(o_trunc),
+            "O_APPEND" => Some(o_append),
+            "O_EXCL" => Some(o_excl),
             "COPYFILE_EXCL" => Some(1.0),
             "COPYFILE_FICLONE" => Some(2.0),
             "COPYFILE_FICLONE_FORCE" => Some(4.0),

--- a/test-parity/node-suite/fs-promises/open/create-errors.ts
+++ b/test-parity/node-suite/fs-promises/open/create-errors.ts
@@ -1,0 +1,33 @@
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+
+const ROOT = "/tmp/perry_node_suite_fs_promises_open_create_errors";
+try { await fsp.rm(ROOT, { recursive: true, force: true }); } catch (_e) {}
+await fsp.mkdir(ROOT, { recursive: true });
+await fsp.mkdir(ROOT + "/dir");
+
+async function expectOpenReject(label: string, target: string, flags: string | number, expectedCode: string) {
+  await fsp.open(target, flags).then((fh) => {
+    console.log(label + " rejected:", false);
+    console.log(label + " fd valid:", fh.fd >= 0);
+    try { fh.close(); } catch (_e) {}
+  }, (err) => {
+    const e = err as any;
+    console.log(label + " rejected:", true);
+    console.log(label + " error name:", e.name);
+    console.log(label + " error code:", e.code);
+    console.log(label + " error syscall:", e.syscall);
+    console.log(label + " path match:", e.path === target);
+    console.log(label + " expected code:", e.code === expectedCode);
+  });
+}
+
+await expectOpenReject("missing parent write", ROOT + "/missing-parent/file.txt", "w", "ENOENT");
+await expectOpenReject(
+  "missing parent numeric create",
+  ROOT + "/missing-parent/numeric.txt",
+  fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_TRUNC,
+  "ENOENT",
+);
+await expectOpenReject("directory write", ROOT + "/dir", "w", "EISDIR");
+await expectOpenReject("directory readwrite", ROOT + "/dir", "r+", "EISDIR");

--- a/test-parity/node-suite/fs/STATUS.md
+++ b/test-parity/node-suite/fs/STATUS.md
@@ -5,8 +5,8 @@ This split suite replaces the legacy monolithic `test-files/test_parity_fs.ts` a
 ## Current coverage
 
 - `node:fs`: 108 TypeScript parity cases
-- `node:fs/promises`: 54 TypeScript parity cases
-- Total: 162 TypeScript parity cases
+- `node:fs/promises`: 55 TypeScript parity cases
+- Total: 163 TypeScript parity cases
 
 The suite was built from deterministic behavior in:
 
@@ -31,7 +31,7 @@ These areas are intentionally left as follow-up work because they require larger
 9. URL/path edge cases, especially full compatibility with `pathToFileURL()`-generated objects.
 10. Additional platform- and permission-sensitive behavior once the parity runner can model those deterministically.
 11. Real streaming for `createReadStream`/`createWriteStream`. The current implementation eagerly loads the source file into memory and emits one `data` chunk; arbitrary `highWaterMark`, mid-stream `pause`/`resume`, and backpressure-driven `drain` events are not yet modeled.
-12. Callback-style fs APIs now invoke `cb(err, …)` with a real `Error` carrying `err.code` (`"ENOENT"`, `"EACCES"`, `"EEXIST"`, …), `err.syscall`, and `err.path` — values are registered in per-message side tables (`register_error_code_pub` / `register_error_syscall` / `register_error_path`) and surfaced by the `OBJECT_TYPE_ERROR` getters in `object::field_get_set`. Errors raised inside the syscall after the pre-flight probe succeeds still surface as sentinel values (a deeper fix needs typed-error propagation through LLVM). `fs/promises.open` rejects on a missing read-only path; create-mode flags (`"w"`, `"a"`, numeric `O_CREAT|…`) still defer to the underlying syscall and may resolve with `fd === -1` on failure.
+12. Callback-style fs APIs now invoke `cb(err, …)` with a real `Error` carrying `err.code` (`"ENOENT"`, `"EACCES"`, `"EEXIST"`, …), `err.syscall`, and `err.path` — values are registered in per-message side tables (`register_error_code_pub` / `register_error_syscall` / `register_error_path`) and surfaced by the `OBJECT_TYPE_ERROR` getters in `object::field_get_set`. Errors raised inside the syscall after the pre-flight probe succeeds still surface as sentinel values (a deeper fix needs typed-error propagation through LLVM). `fs/promises.open` now rejects failed direct opens, including read-only and create/write-style flags, instead of resolving with `fd === -1`.
 13. `FileHandle` and the numeric-fd registry are `thread_local` — handles cannot be shared across threads spawned with `perry/thread` or `parallelMap`. The same fd in another thread is treated as missing.
 14. On POSIX, `ctime` is now read from `MetadataExt::ctime` (plus `ctime_nsec`) and the bigint `atimeNs`/`mtimeNs`/`ctimeNs` fields use real `*time_nsec` counters — so sub-millisecond precision is preserved. Windows still falls back to the millisecond×1e6 approximation.
 15. `mkdtemp` returns an empty path on exhaustion (after 64 collision retries) instead of throwing — once typed error propagation lands, promote this to a real ENOSPC/EACCES rejection.


### PR DESCRIPTION
Closes #2665

Summary:
- Route fs.promises.open through a result-returning open path so failed opens reject with Node-shaped Error objects instead of resolving FileHandle fd -1.
- Decode short string open flags in the fd opener and align exported numeric fs open constants with platform libc values.
- Add fs/promises.open parity coverage for missing parents, directories, string create/write flags, and numeric O_CREAT bitsets.

Baseline:
- Before fix: ./run_parity_tests.sh --suite node-suite --module fs-promises --filter open/create-errors failed; Perry resolved the first write case instead of rejecting (report test-parity/reports/parity_report_20260529_203446.json).

Validation:
- PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" node test-parity/node-suite/fs-promises/open/create-errors.ts
- env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module fs-promises --filter open/create-errors
- env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module fs-promises --filter open-
- env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module fs --filter open-
- env RUSTC_WRAPPER= cargo check -p perry-runtime -p perry-codegen
- cargo fmt --all -- --check
- git diff --check
- jq empty test-parity/known_failures.json
- ./scripts/check_file_size.sh