### PR TITLE
fix(runtime): handle optional child_process args in captured calls

### DIFF
--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -189,6 +189,14 @@ pub(crate) unsafe fn dispatch_native_module_method(
             bits as usize
         }
     };
+    let optional_ptr_addr = |v: f64| -> usize {
+        let value = JSValue::from_bits(v.to_bits());
+        if value.is_undefined() || value.is_null() {
+            0
+        } else {
+            ptr_addr(v)
+        }
+    };
     let arg_event_ptr = |n: usize| -> *const crate::StringHeader {
         crate::value::js_get_string_pointer_unified(arg(n)) as *const crate::StringHeader
     };
@@ -1261,20 +1269,20 @@ pub(crate) unsafe fn dispatch_native_module_method(
         // undefined inside the impls).
         ("child_process", "spawn") => {
             let cmd = crate::string::js_string_materialize_to_heap(arg(0)) as i64;
-            let args_p = ptr_addr(arg(1)) as i64;
-            let opts_p = ptr_addr(arg(2)) as i64;
+            let args_p = optional_ptr_addr(arg(1)) as i64;
+            let opts_p = optional_ptr_addr(arg(2)) as i64;
             crate::child_process::reactor::js_child_process_spawn_streams(cmd, args_p, opts_p)
         }
         ("child_process", "spawnSync") => {
             let cmd = crate::string::js_string_materialize_to_heap(arg(0));
-            let args_p = ptr_addr(arg(1)) as *const crate::array::ArrayHeader;
-            let opts_p = ptr_addr(arg(2)) as *const ObjectHeader;
+            let args_p = optional_ptr_addr(arg(1)) as *const crate::array::ArrayHeader;
+            let opts_p = optional_ptr_addr(arg(2)) as *const ObjectHeader;
             let result = crate::child_process::js_child_process_spawn_sync(cmd, args_p, opts_p);
             ptr_to_f64(result as *const u8)
         }
         ("child_process", "execSync") => {
             let cmd = crate::string::js_string_materialize_to_heap(arg(0));
-            let opts_p = ptr_addr(arg(1)) as *const ObjectHeader;
+            let opts_p = optional_ptr_addr(arg(1)) as *const ObjectHeader;
             crate::child_process::js_child_process_exec_sync(cmd, opts_p)
         }
         ("child_process", "exec") => {
@@ -1291,8 +1299,8 @@ pub(crate) unsafe fn dispatch_native_module_method(
         }
         ("child_process", "fork") => {
             let module = crate::string::js_string_materialize_to_heap(arg(0)) as i64;
-            let args_p = ptr_addr(arg(1)) as i64;
-            let opts_p = ptr_addr(arg(2)) as i64;
+            let args_p = optional_ptr_addr(arg(1)) as i64;
+            let opts_p = optional_ptr_addr(arg(2)) as i64;
             crate::child_process::fork::js_child_process_fork(module, args_p, opts_p)
         }
 

--- a/test-parity/node-suite/child_process/async/captured-spawn-optional-args.ts
+++ b/test-parity/node-suite/child_process/async/captured-spawn-optional-args.ts
@@ -1,0 +1,14 @@
+import * as cp from "node:child_process";
+
+const spawn = cp.spawn;
+console.log("spawn type:", typeof spawn);
+
+const shell = process.platform === "win32" ? "cmd" : "sh";
+const child = spawn(shell);
+console.log("child type:", typeof child);
+
+child.on("exit", () => {
+  console.log("exit");
+});
+
+child.stdin.end();


### PR DESCRIPTION
## Why
Captured child_process exports take a different runtime path from direct method calls. Direct `cp.spawn("cmd")` lowers through the dedicated child_process codegen path, which already passes `0` for omitted optional `args`/`options`.

But `const spawn = cp.spawn; spawn("cmd")` goes through the bound native-module dispatcher. That dispatcher synthesized missing arguments as Perry `undefined`, then decoded them with `ptr_addr`. For `undefined`, that produced address `0x1`, which later reached `cp_read_arg_strings` as if it were an array pointer and crashed on Windows with a misaligned pointer dereference.

## Summary
- Treat omitted/null optional pointer args as null in captured child_process dispatch
- Keep optional pointer handling local to native module dispatch beside the existing pointer decoder
- Add a child_process parity fixture for captured spawn with omitted args

## Files
- crates/perry-runtime/src/object/native_module_dispatch.rs
- test-parity/node-suite/child_process/async/captured-spawn-optional-args.ts

## Verification
- cargo fmt --check
- cargo build -p perry-runtime
- node --experimental-strip-types test-parity/node-suite/child_process/async/captured-spawn-optional-args.ts
- Compiled and ran test-parity/node-suite/child_process/async/captured-spawn-optional-args.ts with Perry on Windows

Note: I attempted the narrow parity runner command, but this Windows checkout has CRLF line endings in run_parity_tests.sh, so direct Bash execution failed on carriage returns. A normalized stdin run started but timed out during the release build/compile path.