### PR TITLE
fix(stream): expose compose callable export

### DIFF
--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -709,10 +709,23 @@ pub extern "C" fn js_node_stream_add_abort_signal(signal: f64, stream: f64) -> f
 /// helper returns a fresh Duplex — the typeof / instanceof checks
 /// callers do (`compose(a, b) instanceof Duplex`) hold, and the
 /// reads/writes are stubbed at the Duplex layer same as a bare
-/// `new Duplex()`. The variadic `...streams` arg list is ignored;
-/// real composition is tracked separately.
+/// `new Duplex()`. Real composition is tracked separately.
 #[no_mangle]
-pub extern "C" fn js_node_stream_compose(_streams_array: f64) -> f64 {
+pub extern "C" fn js_node_stream_compose(first_stream: f64) -> f64 {
+    if first_stream.to_bits() == TAG_UNDEFINED {
+        throw_pipeline_missing_streams();
+    }
+    js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
+}
+
+/// Variadic `stream.compose(...)` entry used by bound native-module property
+/// reads. Direct named imports still enter `js_node_stream_compose` with the
+/// first user argument only.
+pub extern "C" fn js_node_stream_compose_args(args: *const crate::array::ArrayHeader) -> f64 {
+    let args = pipeline_args(args);
+    if args.is_empty() {
+        throw_pipeline_missing_streams();
+    }
     js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
 }
 

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -631,6 +631,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("child_process", "fork")
             | ("events", "EventEmitter")
             | ("events", "on")
+            | ("stream", "compose")
             | ("stream", "pipeline")
             | ("stream", "Readable")
             | ("stream", "Writable")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1244,9 +1244,10 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("console", "profile") | ("console", "profileEnd") | ("console", "timeStamp") => {
             f64::from_bits(JSValue::undefined().bits())
         }
+        ("stream", "compose") => crate::node_stream::js_node_stream_compose_args(pack_args()),
+        ("stream", "pipeline") => crate::node_stream::js_node_stream_pipeline(pack_args()),
         // Classic stream constructors are legacy-callable in Node:
         // `PassThrough()` behaves like `new PassThrough()`.
-        ("stream", "pipeline") => crate::node_stream::js_node_stream_pipeline(pack_args()),
         ("stream", "Readable") => crate::node_stream::js_node_stream_readable_new(arg(0)),
         ("stream", "Writable") => crate::node_stream::js_node_stream_writable_new(arg(0)),
         ("stream", "Duplex") => crate::node_stream::js_node_stream_duplex_new(arg(0)),

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -518,12 +518,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose(src,t1,t2) \u2014 output transformation order wrong. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/readable/compose-non-stream-throws": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: compose(string) \u2014 does not throw TypeError. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/compose/two-stage-error-stops": {
     "issue": "1531",
     "added": "2026-05-24",

--- a/test-parity/node-suite/stream/readable/compose-non-stream-throws.ts
+++ b/test-parity/node-suite/stream/readable/compose-non-stream-throws.ts
@@ -1,5 +1,5 @@
 import { compose } from "node:stream";
-// compose(non-stream) — should throw TypeError.
+// compose(string) accepts strings as iterable readable sources.
 let caught: string | null = null;
 try {
   (compose as any)("just a string");


### PR DESCRIPTION
## Summary
- expose `node:stream.compose` as a callable native-module property-read export
- route bound `stream.compose(...)` calls through a packed-args helper while preserving direct named-import calls
- make the existing compose stub throw the Node-shaped missing-stream TypeError for no-arg calls
- remove the stale known-failure entry and correct the fixture comment for string iterable input

## Verification
- DeepWiki: `reference/deepwiki/nodejs-node-stream-compose-iterable-string-2026-05-29.md`
- baseline exact FAIL: `test-parity/reports/parity_report_20260529_134142.json`
- post-rebase exact PASS: `test-parity/reports/parity_report_20260529_140556.json`
- post-rebase adjacent no-args PASS: `test-parity/reports/parity_report_20260529_140645.json`
- post-rebase focused `readable/compose`: `test-parity/reports/parity_report_20260529_140651.json` (3 PASS / 1 known residual `compose-with-passthrough`)
- `cargo check -p perry-runtime`
- `cargo fmt --all --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check && git diff --cached --check`

## Non-goals
- no full compose data-flow implementation
- no PassThrough forwarding fix
- no async generator compose pipeline changes
- no stream position validation rewrite
- no Duplexify behavior beyond the existing stub shape