### PR TITLE
Add buffer INSPECT_MAX_BYTES to API manifest

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2707,6 +2707,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     class("buffer", "File"),
     method("buffer", "resolveObjectURL", false, None),
     property("buffer", "constants"),
+    property("buffer", "INSPECT_MAX_BYTES"),
     property("buffer", "kMaxLength"),
     property("buffer", "kStringMaxLength"),
     // --- url (additional helpers) ---

--- a/crates/perry-api-manifest/src/lib.rs
+++ b/crates/perry-api-manifest/src/lib.rs
@@ -262,6 +262,13 @@ mod tests {
     }
 
     #[test]
+    fn buffer_inspect_max_bytes_is_manifest_property() {
+        let entry = module_has_symbol("node:buffer", "INSPECT_MAX_BYTES")
+            .expect("buffer.INSPECT_MAX_BYTES should be in the manifest");
+        assert!(matches!(entry.kind, ApiKind::Property));
+    }
+
+    #[test]
     fn known_modules_consistent_with_manifest() {
         // Every entry's module must appear in NATIVE_MODULES.
         // Catches typos and entries on un-registered modules.

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1516 entries across 84 modules
+// Coverage: 1517 entries across 84 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -226,6 +226,8 @@ declare module "buffer" {
   export class Buffer { [key: string]: any; }
   /** stdlib */
   export class File { [key: string]: any; }
+  /** stdlib */
+  export const INSPECT_MAX_BYTES: any;
   /** stdlib */
   export const constants: any;
   /** stdlib */

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -1,16 +1,16 @@
 # Perry Runtime Parity Gap List
 
-This document is a structured gap analysis comparing the public Node.js + Bun runtime API surface (catalogued in `runtime-parity.md`) against the APIs Perry can dispatch at compile time. Coverage sources are: the unimplemented-API gate manifest (`crates/perry-api-manifest/src/entries.rs`, ~588 (module, method) entries), `Expr::*` HIR variants in `crates/perry-hir/src/ir.rs` that lower stdlib APIs directly to dedicated codegen arms (~301 stdlib-shaped variants), and `js_*` FFI exports across `perry-runtime` (~983), `perry-stdlib` (~631), and 35 `perry-ext-*` crates (~553). Output is intended for prioritizing which APIs to implement next.
+This document is a structured gap analysis comparing the public Node.js + Bun runtime API surface (catalogued in `runtime-parity.md`) against the APIs Perry can dispatch at compile time. Coverage sources are: the unimplemented-API gate manifest (`crates/perry-api-manifest/src/entries.rs`, ~589 (module, method) entries), `Expr::*` HIR variants in `crates/perry-hir/src/ir.rs` that lower stdlib APIs directly to dedicated codegen arms (~301 stdlib-shaped variants), and `js_*` FFI exports across `perry-runtime` (~983), `perry-stdlib` (~631), and 35 `perry-ext-*` crates (~553). Output is intended for prioritizing which APIs to implement next.
 
 ## Summary
 
 | Category | Modules | Gap APIs | Verified-covered |
 |----------|---------|----------|------------------|
 | Whole-module gaps (zero coverage) | 20 | 484 | n/a |
-| Partial-module gaps | 29 | 1648 | 369 |
+| Partial-module gaps | 29 | 1647 | 370 |
 | Web-global gaps | — | 282 | 107 |
 | Bun-only gaps (out of scope) | — | 394 | n/a |
-| **Total true gaps** |  | **2414** |  |
+| **Total true gaps** |  | **2413** |  |
 
 **Top modules by remaining true gaps (Node + Web):**
 
@@ -1578,7 +1578,7 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 
 ### node:buffer
 
-**Gap APIs: 40** · Already covered: 68
+**Gap APIs: 39** · Already covered: 69
 
 #### Missing from Perry
 
@@ -1613,7 +1613,6 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 - `buffer.isUtf8(input)`
 - `buffer.resolveObjectURL(id)`
 - `buffer.transcode(source, fromEnc, toEnc)`
-- `buffer.INSPECT_MAX_BYTES`
 - `buffer.kMaxLength`
 - `buffer.kStringMaxLength`
 - `buffer.constants.MAX_LENGTH`
@@ -1639,6 +1638,7 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 | `Buffer.from(object[, offsetOrEncoding[, length]])` | `manifest:buffer.from` |
 | `Buffer.from(string[, encoding])` | `manifest:buffer.from` |
 | `Buffer.isBuffer(obj)` | `manifest:buffer.isBuffer` |
+| `buffer.INSPECT_MAX_BYTES` | `manifest:buffer.INSPECT_MAX_BYTES` |
 | `buf.readDoubleBE([offset])` | `ffi:js_buffer_read_double_be` |
 | `buf.readDoubleLE([offset])` | `ffi:js_buffer_read_double_le` |
 | `buf.readFloatBE([offset])` | `ffi:js_buffer_read_float_be` |

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1516 entries across 84 modules.
+Total: 1517 entries across 84 modules.
 
 ## Modules
 
@@ -271,6 +271,7 @@ Total: 1516 entries across 84 modules.
 
 ### Properties
 
+- `INSPECT_MAX_BYTES`
 - `constants`
 - `kMaxLength`
 - `kStringMaxLength`

--- a/test-parity/node-suite/buffer/imports/inspect-max-bytes.ts
+++ b/test-parity/node-suite/buffer/imports/inspect-max-bytes.ts
@@ -1,0 +1,3 @@
+import * as buffer from "node:buffer";
+
+console.log("inspect max value:", buffer.INSPECT_MAX_BYTES);


### PR DESCRIPTION
Closes #2679

Summary:
- Add `buffer.INSPECT_MAX_BYTES` as a manifest property for `node:buffer`/`buffer` imports.
- Regenerate API reference and declaration output, and update runtime parity gap accounting.
- Add manifest unit coverage and a focused buffer import parity fixture.

Validation:
- `PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" node test-parity/node-suite/buffer/imports/inspect-max-bytes.ts`
- `env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module buffer --filter inspect-max-bytes`
- `env RUSTC_WRAPPER= cargo test -p perry-api-manifest`
- `env RUSTC_WRAPPER= cargo test -p perry-codegen --test manifest_consistency`
- `cargo fmt --all -- --check`
- `git diff --cached --check && git diff --check`
- `jq empty test-parity/known_failures.json`
- `./scripts/check_file_size.sh`