### PR TITLE
test(stream): drop stale readable compose failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -386,12 +386,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: writer.desiredSize does not restore to HWM after write resolves. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/readable/compose-multi-async-fn": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: r.compose(t1).compose(t2) chained \u2014 output stream produces wrong chunks. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/web/abort-during-pipeto": {
     "issue": "1545",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove stale known-failure metadata for `node-suite/stream/readable/compose-multi-async-fn`
- keep neighboring compose/data-flow failures listed

## Verification
- DeepWiki: `reference/deepwiki/nodejs-node-readable-compose-multi-async-fn-2026-05-29.md`
- baseline/probe exact PASS: `test-parity/reports/parity_report_20260529_141014.json`
- post-edit exact PASS: `test-parity/reports/parity_report_20260529_141158.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check && git diff --cached --check`

## Non-goals
- no runtime changes
- no `stream.compose(...)` free-function cleanup
- no PassThrough/data-flow residual changes