### PR TITLE
test(stream): drop stale readable mode failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -470,12 +470,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.from(asyncIter with awaits) \u2014 wrong collected output. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/readable-mode-only": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: 'readable' event with read() drain \u2014 chunk order or count wrong. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/from-promise-iterable": {
     "issue": "1545",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove stale known-failure metadata for `node-suite/stream/readable/readable-mode-only`
- keep neighboring readable/read(n) and readable-event residuals listed

## Verification
- DeepWiki: `reference/deepwiki/nodejs-node-readable-mode-drain-2026-05-29.md`
- baseline/probe exact PASS: `test-parity/reports/parity_report_20260529_141411.json`
- post-edit exact PASS: `test-parity/reports/parity_report_20260529_141512.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check && git diff --cached --check`

## Non-goals
- no runtime changes
- no readable-event scheduling changes
- no sequential `read(n)` buffering fix
- no broader paused-mode state-machine changes