### PR TITLE
fix(console): allow Console call form

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -135,6 +135,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 "PerformanceEntry" => 0xFFFF0080u32,
                 "PerformanceMark" => 0xFFFF0081u32,
                 "PerformanceMeasure" => 0xFFFF0082u32,
+                "Console" => 0xFFFF0083u32,
                 // `Object` — every non-primitive matches per ECMAScript;
                 // reserved id mapped in the runtime. Pre-#585 this fell
                 // into the `cid = 0` fallback and matched accidentally

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -905,6 +905,19 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         object: Box::new(object_expr),
                         property: property_name,
                     });
+                } else if module_name == "console"
+                    && class_name == "Console"
+                    && is_console_instance_method_name(&property_name)
+                {
+                    // `new Console(...).log` is a method value read, not a
+                    // zero-arg native getter. The call form still lowers
+                    // through NativeMethodCall; bare reads stay as PropertyGet
+                    // so runtime lookup can return a bound callable.
+                    let object_expr = lower_expr(ctx, &member.obj)?;
+                    return Ok(Expr::PropertyGet {
+                        object: Box::new(object_expr),
+                        property: property_name,
+                    });
                 } else if matches!(
                     module_name.as_str(),
                     "readable_stream"
@@ -1704,6 +1717,28 @@ fn is_classic_stream_method_name(prop: &str) -> bool {
             | "removeAllListeners"
             | "setMaxListeners"
             | "getMaxListeners"
+    )
+}
+
+fn is_console_instance_method_name(prop: &str) -> bool {
+    matches!(
+        prop,
+        "log"
+            | "info"
+            | "debug"
+            | "dir"
+            | "dirxml"
+            | "error"
+            | "warn"
+            | "count"
+            | "countReset"
+            | "group"
+            | "groupCollapsed"
+            | "groupEnd"
+            | "clear"
+            | "profile"
+            | "profileEnd"
+            | "timeStamp"
     )
 }
 

--- a/crates/perry-runtime/src/builtins/console.rs
+++ b/crates/perry-runtime/src/builtins/console.rs
@@ -446,7 +446,41 @@ thread_local! {
     static CONSOLE_INSTANCES: RefCell<HashMap<usize, ConsoleInstanceState>> = RefCell::new(HashMap::new());
 }
 
-pub(crate) const CONSOLE_INSTANCE_CLASS_ID: u32 = 0xFFFF_0081;
+pub(crate) const CONSOLE_INSTANCE_CLASS_ID: u32 = 0xFFFF_0083;
+
+pub(crate) fn is_console_instance_method_name(method_name: &str) -> bool {
+    matches!(
+        method_name,
+        "log"
+            | "info"
+            | "debug"
+            | "dir"
+            | "dirxml"
+            | "error"
+            | "warn"
+            | "count"
+            | "countReset"
+            | "group"
+            | "groupCollapsed"
+            | "groupEnd"
+            | "clear"
+            | "profile"
+            | "profileEnd"
+            | "timeStamp"
+    )
+}
+
+pub(crate) fn is_console_instance_value(value: f64) -> bool {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if !jsval.is_pointer() {
+        return false;
+    }
+    let obj = jsval.as_pointer::<crate::object::ObjectHeader>();
+    if obj.is_null() || (obj as usize) < 0x100000 {
+        return false;
+    }
+    unsafe { (*obj).class_id == CONSOLE_INSTANCE_CLASS_ID }
+}
 
 struct ConsoleInstanceState {
     stdout: f64,

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -69,7 +69,10 @@ pub use console::{
     scan_console_log_singleton_roots_mut,
 };
 
-pub(crate) use console::try_console_instance_method_dispatch;
+pub(crate) use console::{
+    is_console_instance_method_name, is_console_instance_value,
+    try_console_instance_method_dispatch, CONSOLE_INSTANCE_CLASS_ID,
+};
 
 pub use formatting::{
     function_name_for_ptr, js_array_print, js_register_function_name, js_util_format,

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1769,6 +1769,12 @@ pub extern "C" fn js_object_get_field_by_name(
                 // `First argument to _arity must be a non-negative
                 // integer no greater than ten` at module init.
                 if name_bytes == b"length" {
+                    let closure_value = crate::value::js_nanbox_pointer(obj as i64);
+                    if let Some(arity) =
+                        super::native_module::bound_native_callable_value_arity(closure_value)
+                    {
+                        return JSValue::number(arity as f64);
+                    }
                     let arity =
                         crate::closure::closure_arity(obj as *const crate::closure::ClosureHeader);
                     return JSValue::number(arity.unwrap_or(0) as f64);
@@ -2268,6 +2274,28 @@ pub extern "C" fn js_object_get_field_by_name(
                     }
                 }
             }
+            if class_id == crate::builtins::CONSOLE_INSTANCE_CLASS_ID {
+                let key_bytes = std::slice::from_raw_parts(
+                    (key as *const u8).add(std::mem::size_of::<crate::StringHeader>()),
+                    (*key).byte_len as usize,
+                );
+                if let Ok(name) = std::str::from_utf8(key_bytes) {
+                    if crate::builtins::is_console_instance_method_name(name) {
+                        let heap_name = {
+                            let layout =
+                                std::alloc::Layout::from_size_align(key_bytes.len().max(1), 1)
+                                    .unwrap();
+                            let ptr = std::alloc::alloc(layout);
+                            std::ptr::copy_nonoverlapping(key_bytes.as_ptr(), ptr, key_bytes.len());
+                            ptr
+                        };
+                        let this_f64 =
+                            f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+                        let result = js_class_method_bind(this_f64, heap_name, key_bytes.len());
+                        return JSValue::from_bits(result.to_bits());
+                    }
+                }
+            }
             return JSValue::undefined();
         }
 
@@ -2495,6 +2523,21 @@ pub extern "C" fn js_object_get_field_by_name(
             if let Ok(name) = std::str::from_utf8(key_bytes) {
                 if let Some(v) = lookup_prototype_method(class_id, name) {
                     return JSValue::from_bits(v.to_bits());
+                }
+                if class_id == crate::builtins::CONSOLE_INSTANCE_CLASS_ID
+                    && crate::builtins::is_console_instance_method_name(name)
+                {
+                    let heap_name = {
+                        let layout =
+                            std::alloc::Layout::from_size_align(key_bytes.len().max(1), 1).unwrap();
+                        let ptr = std::alloc::alloc(layout);
+                        std::ptr::copy_nonoverlapping(key_bytes.as_ptr(), ptr, key_bytes.len());
+                        ptr
+                    };
+                    let this_f64 =
+                        f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+                    let result = js_class_method_bind(this_f64, heap_name, key_bytes.len());
+                    return JSValue::from_bits(result.to_bits());
                 }
             }
 

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -50,6 +50,12 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
         {
             return f64::from_bits(crate::value::TAG_TRUE);
         }
+        if module == "console"
+            && method == "Console"
+            && crate::builtins::is_console_instance_value(value)
+        {
+            return f64::from_bits(crate::value::TAG_TRUE);
+        }
         if module == "perf_hooks" {
             let class_id = match method.as_str() {
                 "PerformanceEntry" => crate::perf_hooks::CLASS_ID_PERFORMANCE_ENTRY,

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -527,6 +527,14 @@ pub(crate) unsafe fn bound_native_callable_module_and_method(
     Some((module, method))
 }
 
+pub(crate) unsafe fn bound_native_callable_value_arity(value: f64) -> Option<u32> {
+    let (module, method) = bound_native_callable_module_and_method(value)?;
+    match (module.as_str(), method.as_str()) {
+        ("console", "Console") => Some(1),
+        _ => None,
+    }
+}
+
 pub(crate) fn set_bound_native_closure_name(
     closure: *mut crate::closure::ClosureHeader,
     name: &str,

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1170,6 +1170,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("punycode.ucs2", "encode") => crate::punycode::js_punycode_ucs2_encode(arg(0)),
 
         // ── console module namespace (`node:console` / `console`) ──
+        ("console", "Console") => crate::builtins::js_console_new(arg(0)),
         ("console", "log") | ("console", "info") | ("console", "debug") | ("console", "dirxml") => {
             crate::builtins::js_console_log_spread(pack_args());
             f64::from_bits(JSValue::undefined().bits())

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -841,11 +841,20 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                     // user-attached dynamic-property side table.
                     let resolved: Option<(f64, bool, bool)> = match name {
                         "length" => {
-                            let arity = crate::closure::closure_arity(
-                                ptr as *const crate::closure::ClosureHeader,
-                            );
-                            // Numbers are NaN-boxed as their raw f64 bits.
-                            Some((arity.unwrap_or(0) as f64, false, true))
+                            let closure_value = crate::value::js_nanbox_pointer(ptr as i64);
+                            if let Some(arity) =
+                                super::native_module::bound_native_callable_value_arity(
+                                    closure_value,
+                                )
+                            {
+                                Some((arity as f64, false, true))
+                            } else {
+                                let arity = crate::closure::closure_arity(
+                                    ptr as *const crate::closure::ClosureHeader,
+                                );
+                                // Numbers are NaN-boxed as their raw f64 bits.
+                                Some((arity.unwrap_or(0) as f64, false, true))
+                            }
                         }
                         "name" => {
                             let dynv = crate::closure::closure_get_dynamic_prop(ptr, "name");

--- a/test-parity/node-suite/console/console-class/without-new.ts
+++ b/test-parity/node-suite/console/console-class/without-new.ts
@@ -1,2 +1,27 @@
+import * as consoleModule from "node:console";
 import { Console } from "node:console";
-console.log("Console callable type:", typeof Console);
+import { Writable } from "node:stream";
+
+let out = "";
+const sink = new Writable({
+  write(chunk, _enc, cb) {
+    out += chunk.toString();
+    cb();
+  },
+});
+
+const called = (Console as any)({ stdout: sink, stderr: sink });
+const namespaceCalled = (consoleModule.Console as any)({ stdout: sink, stderr: sink });
+const constructed = new Console({ stdout: sink, stderr: sink });
+
+console.log("Console shape:", typeof Console, Console.length, Console.name);
+console.log("call instance:", typeof called.log, called instanceof Console);
+console.log("namespace instance:", typeof namespaceCalled.error, namespaceCalled instanceof Console);
+console.log("new instance:", typeof constructed.log, constructed instanceof Console);
+
+called.log("called");
+namespaceCalled.error("namespace");
+constructed.log("constructed");
+
+await new Promise(resolve => setImmediate(resolve));
+console.log("captured:", JSON.stringify(out.trim().split(/\n/)));


### PR DESCRIPTION
Closes #2675

## Summary
- dispatch callable `node:console` `Console(...)` through the same constructor path as `new Console(...)`
- preserve `Console.length === 1`, `Console.name`, and `instanceof Console` for callable exports
- return bound callable values for Console instance method reads and keep direct instance calls using per-instance streams
- strengthen the `console-class/without-new` parity fixture to compare the call form, namespace call form, constructor form, method shape, instanceof, and captured stream output

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `./scripts/check_file_size.sh`
- `RUSTC_WRAPPER= cargo check -p perry-hir -p perry-runtime -p perry-codegen`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module console --filter console-class/without-new`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module console --filter console-class`