### PR TITLE
test(stream): drop stale sequential reads failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -338,12 +338,6 @@
     "category": "bug-open",
     "reason": "node:stream: r.compose(t1).compose(t2) \u2014 chained compose() returns Duplex but pipeline breaks. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/flow/sequential-reads": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: sequential read(N) drain \u2014 buffer order or chunk boundaries wrong. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/compose/async-iter-handler-rejection": {
     "issue": "1531",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove stale known-failure metadata for `node-suite/stream/flow/sequential-reads`
- keep neighboring readable-event and flow residuals listed

## Verification
- DeepWiki: `reference/deepwiki/nodejs-node-readable-sequential-readn-2026-05-29.md`
- baseline/probe exact PASS: `test-parity/reports/parity_report_20260529_141700.json`
- post-edit exact PASS: `test-parity/reports/parity_report_20260529_141752.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check && git diff --cached --check`

## Non-goals
- no runtime changes
- no readable-event duplicate-emission fix
- no broad flow-mode cleanup