### PR TITLE
fix(fetch): support Headers getSetCookie

### DIFF
--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -81,6 +81,27 @@ fn is_map_method_name(name: &str) -> bool {
     )
 }
 
+fn is_headers_method_name(name: &str) -> bool {
+    matches!(
+        name,
+        "append"
+            | "delete"
+            | "entries"
+            | "forEach"
+            | "get"
+            | "getSetCookie"
+            | "has"
+            | "keys"
+            | "set"
+            | "values"
+    )
+}
+
+fn is_headers_instance_method(ctx: &FnCtx<'_>, object: &Expr, property: &str) -> bool {
+    is_headers_method_name(property)
+        && matches!(receiver_class_name(ctx, object).as_deref(), Some("Headers"))
+}
+
 fn is_classic_stream_method_name(name: &str) -> bool {
     matches!(
         name,
@@ -173,6 +194,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     Some("function")
                 }
                 Expr::ClassRef(_) => Some("function"),
+                Expr::NativeMethodCall {
+                    module,
+                    class_name: None,
+                    object: Some(_),
+                    method,
+                    ..
+                } if module == "Headers" && is_headers_method_name(method) => Some("function"),
                 // Issue #623: native-module default-imports (`import process
                 // from "node:process"`) lower as `NativeModuleRef`, which the
                 // codegen represents as a `0.0` stub double. `js_value_typeof`
@@ -197,6 +225,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     if (is_set_expr(ctx, object) && is_set_method_name(property))
                         || (is_map_expr(ctx, object) && is_map_method_name(property))
                     {
+                        Some("function")
+                    } else if is_headers_instance_method(ctx, object, property) {
                         Some("function")
                     } else if is_classic_stream_instance_method(ctx, object, property) {
                         Some("function")

--- a/crates/perry-codegen/src/lower_call/options/fetch.rs
+++ b/crates/perry-codegen/src/lower_call/options/fetch.rs
@@ -159,6 +159,12 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                 let blk = ctx.block();
                 return Ok(Some(nanbox_string_inline(blk, &str_ptr)));
             }
+            "getSetCookie" => {
+                let arr =
+                    ctx.block()
+                        .call(DOUBLE, "js_headers_get_set_cookie", &[(DOUBLE, &h_handle)]);
+                return Ok(Some(arr));
+            }
             "has" => {
                 if args.is_empty() {
                     return Ok(Some(double_literal(f64::from_bits(

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1702,6 +1702,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_headers_append", DOUBLE, &[DOUBLE, I64, I64]);
     // headers.get(handle_f64, key_ptr) -> *mut StringHeader (i64)
     module.declare_function("js_headers_get", I64, &[DOUBLE, I64]);
+    // headers.getSetCookie(handle_f64) -> f64 (NaN-boxed POINTER_TAG to ArrayHeader)
+    module.declare_function("js_headers_get_set_cookie", DOUBLE, &[DOUBLE]);
     // headers.has(handle_f64, key_ptr) -> f64 (TAG_TRUE/FALSE)
     module.declare_function("js_headers_has", DOUBLE, &[DOUBLE, I64]);
     // headers.delete(handle_f64, key_ptr) -> f64 (undefined-tag)

--- a/crates/perry-ext-fetch/src/lib.rs
+++ b/crates/perry-ext-fetch/src/lib.rs
@@ -64,8 +64,79 @@ fn handle_id(value: f64) -> usize {
 struct FetchResponse {
     status: u16,
     status_text: String,
-    headers: HashMap<String, String>,
+    headers: HeadersStore,
     body: Vec<u8>,
+}
+
+#[derive(Clone, Default)]
+struct HeadersStore {
+    entries: Vec<(String, String)>,
+}
+
+impl HeadersStore {
+    fn set(&mut self, key: &str, value: &str) {
+        let lk = key.to_ascii_lowercase();
+        self.entries.retain(|(k, _)| *k != lk);
+        self.entries.push((lk, value.to_string()));
+    }
+
+    fn append(&mut self, key: &str, value: &str) {
+        let lk = key.to_ascii_lowercase();
+        if lk == "set-cookie" {
+            self.entries.push((lk, value.to_string()));
+            return;
+        }
+        for entry in self.entries.iter_mut() {
+            if entry.0 == lk {
+                entry.1.push_str(", ");
+                entry.1.push_str(value);
+                return;
+            }
+        }
+        self.entries.push((lk, value.to_string()));
+    }
+
+    fn get(&self, key: &str) -> Option<String> {
+        let lk = key.to_ascii_lowercase();
+        if lk == "set-cookie" {
+            let values: Vec<&str> = self
+                .entries
+                .iter()
+                .filter(|(k, _)| *k == lk)
+                .map(|(_, v)| v.as_str())
+                .collect();
+            if values.is_empty() {
+                None
+            } else {
+                Some(values.join(", "))
+            }
+        } else {
+            self.entries
+                .iter()
+                .find(|(k, _)| *k == lk)
+                .map(|(_, v)| v.clone())
+        }
+    }
+
+    fn has(&self, key: &str) -> bool {
+        let lk = key.to_ascii_lowercase();
+        self.entries.iter().any(|(k, _)| *k == lk)
+    }
+
+    fn delete(&mut self, key: &str) -> bool {
+        let lk = key.to_ascii_lowercase();
+        let old_len = self.entries.len();
+        self.entries.retain(|(k, _)| *k != lk);
+        self.entries.len() != old_len
+    }
+
+    fn set_cookie_values(&self) -> Vec<String> {
+        self.entries
+            .iter()
+            .filter(|(k, _)| k == "set-cookie")
+            .map(|(_, v)| v.clone())
+            .collect()
+    }
 }
 
 lazy_static! {
@@ -73,7 +144,7 @@ lazy_static! {
         Mutex::new(HashMap::new());
     static ref NEXT_RESPONSE_ID: Mutex<usize> = Mutex::new(1);
 
-    static ref HEADERS_HANDLES: Mutex<HashMap<usize, HashMap<String, String>>> =
+    static ref HEADERS_HANDLES: Mutex<HashMap<usize, HeadersStore>> =
         Mutex::new(HashMap::new());
     static ref NEXT_HEADERS_ID: Mutex<usize> = Mutex::new(1);
 
@@ -133,13 +204,23 @@ fn store_response(resp: FetchResponse) -> usize {
     id
 }
 
-fn store_headers(headers: HashMap<String, String>) -> usize {
+fn store_headers(headers: HeadersStore) -> usize {
     let mut id_guard = NEXT_HEADERS_ID.lock().unwrap();
     let id = *id_guard;
     *id_guard += 1;
     drop(id_guard);
     HEADERS_HANDLES.lock().unwrap().insert(id, headers);
     id
+}
+
+fn headers_from_header_map(headers: &reqwest::header::HeaderMap) -> HeadersStore {
+    let mut store = HeadersStore::default();
+    for (key, value) in headers {
+        if let Ok(v) = value.to_str() {
+            store.append(key.as_str(), v);
+        }
+    }
+    store
 }
 
 fn store_blob(data: BlobData) -> usize {
@@ -198,12 +279,7 @@ fn do_fetch(
                         .canonical_reason()
                         .unwrap_or("")
                         .to_string();
-                    let mut headers = HashMap::new();
-                    for (key, value) in response.headers() {
-                        if let Ok(v) = value.to_str() {
-                            headers.insert(key.to_string(), v.to_string());
-                        }
-                    }
+                    let headers = headers_from_header_map(response.headers());
                     let body = response.bytes().await.unwrap_or_default().to_vec();
                     Ok(FetchResponse {
                         status,
@@ -582,7 +658,7 @@ pub extern "C" fn js_fetch_stream_close(handle: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_headers_new() -> f64 {
-    store_headers(HashMap::new()) as f64
+    store_headers(HeadersStore::default()) as f64
 }
 
 /// # Safety
@@ -600,7 +676,7 @@ pub unsafe extern "C" fn js_headers_set(
     let value = read_str(value_ptr).unwrap_or_default();
     let mut g = HEADERS_HANDLES.lock().unwrap();
     if let Some(h) = g.get_mut(&id) {
-        h.insert(key.to_lowercase(), value);
+        h.set(&key, &value);
         1.0
     } else {
         0.0
@@ -622,12 +698,7 @@ pub unsafe extern "C" fn js_headers_append(
     let value = read_str(value_ptr).unwrap_or_default();
     let mut g = HEADERS_HANDLES.lock().unwrap();
     if let Some(h) = g.get_mut(&id) {
-        h.entry(key.to_lowercase())
-            .and_modify(|existing| {
-                existing.push_str(", ");
-                existing.push_str(&value);
-            })
-            .or_insert(value);
+        h.append(&key, &value);
         1.0
     } else {
         0.0
@@ -646,9 +717,27 @@ pub unsafe extern "C" fn js_headers_get(
         return std::ptr::null_mut();
     };
     let g = HEADERS_HANDLES.lock().unwrap();
-    match g.get(&id).and_then(|h| h.get(&key.to_lowercase())) {
-        Some(v) => alloc_string(v).as_raw(),
+    match g.get(&id).and_then(|h| h.get(&key)) {
+        Some(v) => alloc_string(&v).as_raw(),
         None => std::ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_headers_get_set_cookie(handle: f64) -> f64 {
+    let id = handle_id(handle);
+    let values = HEADERS_HANDLES
+        .lock()
+        .unwrap()
+        .get(&id)
+        .map(HeadersStore::set_cookie_values)
+        .unwrap_or_default();
+    unsafe {
+        let mut arr = perry_ffi::js_array_alloc(values.len() as u32);
+        for v in values {
+            arr = perry_ffi::js_array_push(arr, js_string_value(&v));
+        }
+        nanbox_array_ptr(arr)
     }
 }
 
@@ -661,10 +750,7 @@ pub unsafe extern "C" fn js_headers_has(handle: f64, key_ptr: *const StringHeade
         return 0.0;
     };
     let g = HEADERS_HANDLES.lock().unwrap();
-    if g.get(&id)
-        .map(|h| h.contains_key(&key.to_lowercase()))
-        .unwrap_or(false)
-    {
+    if g.get(&id).map(|h| h.has(&key)).unwrap_or(false) {
         1.0
     } else {
         0.0
@@ -681,7 +767,7 @@ pub unsafe extern "C" fn js_headers_delete(handle: f64, key_ptr: *const StringHe
     };
     let mut g = HEADERS_HANDLES.lock().unwrap();
     if let Some(h) = g.get_mut(&id) {
-        if h.remove(&key.to_lowercase()).is_some() {
+        if h.delete(&key) {
             return 1.0;
         }
     }
@@ -698,7 +784,7 @@ fn snapshot_sorted(handle: f64) -> Vec<(String, String)> {
         .lock()
         .unwrap()
         .get(&id)
-        .map(|h| h.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        .map(|h| h.entries.clone())
         .unwrap_or_default();
     entries.sort_by(|a, b| a.0.cmp(&b.0));
     entries
@@ -828,7 +914,7 @@ pub unsafe extern "C" fn js_response_new(
             .cloned()
             .unwrap_or_default()
     } else {
-        HashMap::new()
+        HeadersStore::default()
     };
     store_response(FetchResponse {
         status,
@@ -897,7 +983,6 @@ pub unsafe extern "C" fn js_response_blob(handle: f64) -> *mut Promise {
             let content_type = r
                 .headers
                 .get("content-type")
-                .cloned()
                 .unwrap_or_else(|| "application/octet-stream".to_string());
             let blob_id = store_blob(BlobData {
                 bytes: r.body,
@@ -934,8 +1019,8 @@ pub extern "C" fn js_response_body(handle: f64) -> f64 {
 pub unsafe extern "C" fn js_response_static_json(value: f64) -> f64 {
     let v = JsValue::from_bits(value.to_bits());
     let body = perry_ffi::json_stringify(v).unwrap_or_default();
-    let mut headers = HashMap::new();
-    headers.insert("content-type".to_string(), "application/json".to_string());
+    let mut headers = HeadersStore::default();
+    headers.set("content-type", "application/json");
     store_response(FetchResponse {
         status: 200,
         status_text: "OK".to_string(),
@@ -955,8 +1040,8 @@ pub unsafe extern "C" fn js_response_static_redirect(
 ) -> f64 {
     let url = read_str(url_ptr).unwrap_or_default();
     let status = status as u16;
-    let mut headers = HashMap::new();
-    headers.insert("location".to_string(), url);
+    let mut headers = HeadersStore::default();
+    headers.set("location", &url);
     store_response(FetchResponse {
         status,
         status_text: "Found".to_string(),

--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -145,11 +145,11 @@ pub fn dispatch_request_method(req_id: usize, method: &str, _args: &[f64]) -> Op
 #[doc(hidden)]
 pub fn dispatch_response_property(resp_id: usize, prop: &str) -> Option<f64> {
     // `response.headers` — lazily allocate a Headers registry entry
-    // backed by the response's stored header map and cache the id on the
+    // backed by the response's stored headers and cache the id on the
     // FetchResponse so repeat reads return the same handle (preserves
     // `res.headers === res.headers`). Hono's `#newResponse` mutates the
     // returned Headers object via `.set(k, v)`, but our snapshot is a
-    // copy of the response's header HashMap — mutations land on the
+    // copy of the response's HeadersStore — mutations land on the
     // Headers handle's HeadersStore, not back on the FetchResponse.
     // For the read-only case (the issue #486 acceptance) this is
     // sufficient; spec-perfect "live header view" would need the
@@ -165,7 +165,7 @@ pub fn dispatch_response_property(resp_id: usize, prop: &str) -> Option<f64> {
             None => {
                 let store = {
                     let guard = FETCH_RESPONSES.lock().unwrap();
-                    HeadersStore::from_hashmap(&guard.get(&resp_id)?.headers)
+                    guard.get(&resp_id)?.headers.clone()
                 };
                 let new_id = alloc_headers(store);
                 if let Some(resp) = FETCH_RESPONSES.lock().unwrap().get_mut(&resp_id) {
@@ -211,12 +211,42 @@ pub fn dispatch_response_property(resp_id: usize, prop: &str) -> Option<f64> {
 }
 
 /// Try to read a property off a Headers handle by registry id.
-/// Returns `None` always today — Headers has no scalar properties exposed
-/// via property reads (`.get(k)` / `.has(k)` etc. are method calls that route
-/// through `HANDLE_METHOD_DISPATCH`).
+/// Headers exposes prototype methods as function-valued properties, so method
+/// feature checks such as `typeof headers.getSetCookie === "function"` work
+/// while call sites still route through `HANDLE_METHOD_DISPATCH`.
 #[doc(hidden)]
-pub fn dispatch_headers_property(_headers_id: usize, _prop: &str) -> Option<f64> {
-    None
+pub fn dispatch_headers_property(headers_id: usize, prop: &str) -> Option<f64> {
+    {
+        let guard = HEADERS_REGISTRY.lock().unwrap();
+        guard.get(&headers_id)?;
+    }
+    let name_bytes: &'static [u8] = match prop {
+        "append" => b"append",
+        "delete" => b"delete",
+        "entries" => b"entries",
+        "forEach" => b"forEach",
+        "get" => b"get",
+        "getSetCookie" => b"getSetCookie",
+        "has" => b"has",
+        "keys" => b"keys",
+        "set" => b"set",
+        "values" => b"values",
+        _ => return None,
+    };
+    extern "C" {
+        fn js_class_method_bind(
+            instance: f64,
+            method_name_ptr: *const u8,
+            method_name_len: usize,
+        ) -> f64;
+    }
+    Some(unsafe {
+        js_class_method_bind(
+            handle_to_f64(headers_id),
+            name_bytes.as_ptr(),
+            name_bytes.len(),
+        )
+    })
 }
 
 /// Try to dispatch a method call on a Response handle. Returns `Some(result)`
@@ -317,6 +347,7 @@ pub fn dispatch_headers_method(headers_id: usize, method: &str, args: &[f64]) ->
             "append" => Some(js_headers_append(h_f64, str_arg(0), str_arg(1))),
             "has" => Some(js_headers_has(h_f64, str_arg(0))),
             "delete" => Some(js_headers_delete(h_f64, str_arg(0))),
+            "getSetCookie" => Some(js_headers_get_set_cookie(h_f64)),
             "forEach" => {
                 let cb = args.first().copied().unwrap_or(f64::NAN);
                 Some(js_headers_for_each(h_f64, cb))

--- a/crates/perry-stdlib/src/fetch/headers.rs
+++ b/crates/perry-stdlib/src/fetch/headers.rs
@@ -66,6 +66,25 @@ pub unsafe extern "C" fn js_headers_get(
     std::ptr::null_mut()
 }
 
+/// `headers.getSetCookie()` — returns all preserved Set-Cookie values.
+#[no_mangle]
+pub extern "C" fn js_headers_get_set_cookie(handle: f64) -> f64 {
+    let id = handle_id(handle);
+    let values = HEADERS_REGISTRY
+        .lock()
+        .unwrap()
+        .get(&id)
+        .map(HeadersStore::set_cookie_values)
+        .unwrap_or_default();
+    let mut arr = perry_runtime::js_array_alloc(values.len() as u32);
+    for v in values {
+        let v_ptr = js_string_from_bytes(v.as_ptr(), v.len() as u32);
+        let v_nan = JSValue::string_ptr(v_ptr).bits();
+        arr = perry_runtime::js_array_push_f64(arr, f64::from_bits(v_nan));
+    }
+    nanbox_array_pointer(arr)
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn js_headers_has(handle: f64, key_ptr: *const StringHeader) -> f64 {
     let id = handle_id(handle);

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -72,17 +72,14 @@ struct StreamState {
 struct FetchResponse {
     status: u16,
     status_text: String,
-    headers: HashMap<String, String>,
+    headers: HeadersStore,
     body: Vec<u8>,
     body_present: bool,
     body_used: bool,
     /// Cached Headers handle id, allocated on first `response.headers`
     /// access. None until a property/method dispatcher needs to expose
-    /// the headers as a Headers instance. The Vec form (insertion-ordered
-    /// HeadersStore) is what dispatch_headers_method reads, so we copy
-    /// the HashMap into a fresh HeadersStore the first time and cache
-    /// the resulting registry id; subsequent reads of `.headers` return
-    /// the same id (preserves `res.headers === res.headers`).
+    /// the headers as a Headers instance. Subsequent reads of `.headers`
+    /// return the same id (preserves `res.headers === res.headers`).
     cached_headers_id: Option<usize>,
     /// Cached ReadableStream handle id for `response.body`, allocated on
     /// first read so repeat `.body` reads return the same stream (the spec
@@ -213,12 +210,7 @@ pub unsafe extern "C" fn js_fetch_get(url_ptr: *const StringHeader) -> *mut perr
                     .unwrap_or("")
                     .to_string();
 
-                let mut headers = HashMap::new();
-                for (key, value) in response.headers() {
-                    if let Ok(v) = value.to_str() {
-                        headers.insert(key.to_string(), v.to_string());
-                    }
-                }
+                let headers = headers_from_header_map(response.headers());
 
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
@@ -294,12 +286,7 @@ pub unsafe extern "C" fn js_fetch_get_with_auth(
                     .unwrap_or("")
                     .to_string();
 
-                let mut headers = HashMap::new();
-                for (key, value) in response.headers() {
-                    if let Ok(v) = value.to_str() {
-                        headers.insert(key.to_string(), v.to_string());
-                    }
-                }
+                let headers = headers_from_header_map(response.headers());
 
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
@@ -376,12 +363,7 @@ pub unsafe extern "C" fn js_fetch_post_with_auth(
                     .unwrap_or("")
                     .to_string();
 
-                let mut headers = HashMap::new();
-                for (key, value) in response.headers() {
-                    if let Ok(v) = value.to_str() {
-                        headers.insert(key.to_string(), v.to_string());
-                    }
-                }
+                let headers = headers_from_header_map(response.headers());
 
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
@@ -460,12 +442,7 @@ pub unsafe extern "C" fn js_fetch_post(
                     .unwrap_or("")
                     .to_string();
 
-                let mut headers = HashMap::new();
-                for (key, value) in response.headers() {
-                    if let Ok(v) = value.to_str() {
-                        headers.insert(key.to_string(), v.to_string());
-                    }
-                }
+                let headers = headers_from_header_map(response.headers());
 
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
@@ -564,12 +541,7 @@ pub unsafe extern "C" fn js_fetch_with_options(
                     .unwrap_or("")
                     .to_string();
 
-                let mut headers = HashMap::new();
-                for (key, value) in response.headers() {
-                    if let Ok(v) = value.to_str() {
-                        headers.insert(key.to_string(), v.to_string());
-                    }
-                }
+                let headers = headers_from_header_map(response.headers());
 
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
@@ -1003,20 +975,18 @@ struct HeadersStore {
 impl HeadersStore {
     fn set(&mut self, key: &str, value: &str) {
         let lk = key.to_ascii_lowercase();
-        for entry in self.entries.iter_mut() {
-            if entry.0 == lk {
-                entry.1 = value.to_string();
-                return;
-            }
-        }
+        self.entries.retain(|(k, _)| *k != lk);
         self.entries.push((lk, value.to_string()));
     }
-    /// Web Fetch `Headers.append` — adds a value without clobbering an existing
-    /// one. Per spec, repeated values for the same name are combined with
-    /// `", "` so `get` returns the joined string (e.g. multiple `Set-Cookie`-
-    /// style appends become `a, b`).
+    /// Web Fetch `Headers.append` — combines repeated normal headers with
+    /// `", "`, but keeps `Set-Cookie` values as separate entries so
+    /// `getSetCookie()` can return them individually.
     fn append(&mut self, key: &str, value: &str) {
         let lk = key.to_ascii_lowercase();
+        if lk == "set-cookie" {
+            self.entries.push((lk, value.to_string()));
+            return;
+        }
         for entry in self.entries.iter_mut() {
             if entry.0 == lk {
                 entry.1.push_str(", ");
@@ -1026,12 +996,26 @@ impl HeadersStore {
         }
         self.entries.push((lk, value.to_string()));
     }
-    fn get(&self, key: &str) -> Option<&str> {
+    fn get(&self, key: &str) -> Option<String> {
         let lk = key.to_ascii_lowercase();
-        self.entries
-            .iter()
-            .find(|(k, _)| *k == lk)
-            .map(|(_, v)| v.as_str())
+        if lk == "set-cookie" {
+            let values: Vec<&str> = self
+                .entries
+                .iter()
+                .filter(|(k, _)| *k == lk)
+                .map(|(_, v)| v.as_str())
+                .collect();
+            if values.is_empty() {
+                None
+            } else {
+                Some(values.join(", "))
+            }
+        } else {
+            self.entries
+                .iter()
+                .find(|(k, _)| *k == lk)
+                .map(|(_, v)| v.clone())
+        }
     }
     fn has(&self, key: &str) -> bool {
         let lk = key.to_ascii_lowercase();
@@ -1041,13 +1025,23 @@ impl HeadersStore {
         let lk = key.to_ascii_lowercase();
         self.entries.retain(|(k, _)| *k != lk);
     }
-    fn from_hashmap(m: &HashMap<String, String>) -> Self {
-        let mut s = Self::default();
-        for (k, v) in m {
-            s.set(k, v);
-        }
-        s
+    fn set_cookie_values(&self) -> Vec<String> {
+        self.entries
+            .iter()
+            .filter(|(k, _)| k == "set-cookie")
+            .map(|(_, v)| v.clone())
+            .collect()
     }
+}
+
+fn headers_from_header_map(headers: &reqwest::header::HeaderMap) -> HeadersStore {
+    let mut store = HeadersStore::default();
+    for (key, value) in headers {
+        if let Ok(v) = value.to_str() {
+            store.append(key.as_str(), v);
+        }
+    }
+    store
 }
 
 #[derive(Clone)]
@@ -1119,13 +1113,12 @@ fn alloc_response(
     let id = *id_guard;
     *id_guard += 1;
     drop(id_guard);
-    let hdr_map: HashMap<String, String> = headers.entries.iter().cloned().collect();
     FETCH_RESPONSES.lock().unwrap().insert(
         id,
         FetchResponse {
             status,
             status_text,
-            headers: hdr_map,
+            headers,
             body,
             body_present,
             body_used: false,
@@ -1210,7 +1203,7 @@ pub extern "C" fn js_response_get_headers(handle: f64) -> f64 {
     let store = {
         let guard = FETCH_RESPONSES.lock().unwrap();
         match guard.get(&id) {
-            Some(resp) => HeadersStore::from_hashmap(&resp.headers),
+            Some(resp) => resp.headers.clone(),
             None => return f64::from_bits(TAG_UNDEFINED),
         }
     };
@@ -1304,12 +1297,7 @@ pub unsafe extern "C" fn js_response_blob(handle: f64) -> *mut perry_runtime::Pr
         let guard = FETCH_RESPONSES.lock().unwrap();
         guard
             .get(&id)
-            .and_then(|resp| {
-                resp.headers
-                    .iter()
-                    .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
-                    .map(|(_, v)| v.clone())
-            })
+            .and_then(|resp| resp.headers.get("content-type"))
             .unwrap_or_default()
     };
     let body = match consume_response_body(handle) {

--- a/test-parity/node-suite/fetch/headers/get-set-cookie.ts
+++ b/test-parity/node-suite/fetch/headers/get-set-cookie.ts
@@ -1,0 +1,29 @@
+const h = new Headers();
+
+console.log("method type:", typeof h.getSetCookie);
+console.log("empty:", JSON.stringify(h.getSetCookie()));
+
+h.append("set-cookie", "a=1");
+h.append("X-Test", "x");
+h.append("SET-cookie", "b=2");
+h.append("x-test", "y");
+
+console.log("cookies:", JSON.stringify(h.getSetCookie()));
+console.log("set-cookie get:", h.get("set-cookie"));
+console.log("entries:", JSON.stringify(Array.from(h.entries())));
+console.log("keys:", JSON.stringify(Array.from(h.keys())));
+console.log("values:", JSON.stringify(Array.from(h.values())));
+
+const seen: string[] = [];
+h.forEach((value, key) => seen.push(key + "=" + value));
+console.log("forEach:", JSON.stringify(seen));
+
+h.set("set-cookie", "c=3");
+console.log("set replaces:", JSON.stringify(h.getSetCookie()), h.get("set-cookie"));
+
+h.delete("set-cookie");
+console.log("delete clears:", JSON.stringify(h.getSetCookie()), h.has("set-cookie"));
+
+const other = new Headers();
+other.append("cookie", "not-set");
+console.log("non set-cookie:", JSON.stringify(other.getSetCookie()));


### PR DESCRIPTION
## Summary
- preserve duplicate Set-Cookie entries in Fetch Headers while keeping normal append-combine behavior
- add Headers.getSetCookie() runtime/codegen dispatch in stdlib and ext-fetch
- add parity coverage for getSetCookie(), Set-Cookie append/set/delete, and iterator surfaces

Fixes #2633

## Verification
- cargo fmt --all -- --check
- RUSTC_WRAPPER= cargo check -p perry-codegen -p perry-stdlib -p perry-ext-fetch
- PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fetch --filter headers
- jq empty test-parity/known_failures.json test-parity/threshold.json
- git diff --check
- ./scripts/check_file_size.sh