### PR TITLE
fix(compile): link perry-ext-* libs out-of-the-box, no workspace source (#2532)

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -247,6 +247,28 @@ jobs:
           cargo build --release --target ${{ matrix.target }} -p perry-runtime
           cargo build --release --target ${{ matrix.target }} -p perry-stdlib
 
+      - name: Build native ext libraries (Unix)
+        # #2532 — the perry-ext-* wrapper crates ship the host functions for
+        # node:http (server), ws, net, zlib, fastify, the db drivers, etc.
+        # They are NOT dependencies of perry-stdlib, so `cargo build -p
+        # perry-stdlib` above does not produce them. An out-of-tree install
+        # needs the prebuilt `libperry_ext_*.a` sitting next to
+        # libperry_runtime.a so `perry compile` can link them without a
+        # workspace checkout (see optimized_libs.rs::resolve_prebuilt_ext_libs).
+        # Best-effort per crate: a wrapper that can't build on this host must
+        # not fail the whole release — the packaging glob below ships
+        # whatever was produced.
+        if: runner.os != 'Windows'
+        run: |
+          for d in crates/perry-ext-*; do
+            [ -d "$d" ] || continue
+            name=$(basename "$d")
+            echo "::group::build $name"
+            cargo build --release --target ${{ matrix.target }} -p "$name" \
+              || echo "  (skipped $name — failed to build on this host)"
+            echo "::endgroup::"
+          done
+
       - name: Build UI library (macOS)
         if: runner.os == 'macOS'
         run: cargo build --release --target ${{ matrix.target }} -p perry-ui-macos
@@ -365,6 +387,14 @@ jobs:
             if [ -f "target/${{ matrix.target }}/release/$lib" ]; then
               cp "target/${{ matrix.target }}/release/$lib" staging/
             fi
+          done
+          # #2532 — ship the perry-ext-* staticlibs so an out-of-tree install
+          # can link node:http server / ws / net / zlib / fastify / db
+          # drivers without the workspace source. `perry compile` finds them
+          # via the same exe-dir / PERRY_LIB_DIR search as the runtime/stdlib
+          # libs (optimized_libs.rs::resolve_prebuilt_ext_libs).
+          for lib in target/${{ matrix.target }}/release/libperry_ext_*.a; do
+            [ -f "$lib" ] && cp "$lib" staging/
           done
           # Closes #394: macOS legs also ship iOS-cross-compiled libs.
           # Device variant uses the canonical `_ios` suffix; simulator

--- a/crates/perry-codegen/src/ext_registry.rs
+++ b/crates/perry-codegen/src/ext_registry.rs
@@ -188,6 +188,17 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
     // `WellKnown("http")` makes the existing flip do the right thing:
     // the staticlib joins the link line, perry-stdlib's `http-client`
     // feature gets stripped, and the symbols resolve.
+    //
+    // #2532: codegen's `createServer` lowering (native_table/http.rs)
+    // emits `js_node_http_create_server_with_options`, NOT the bare
+    // `js_node_http_create_server` — so the bare name below never
+    // matched the emitted symbol and the owner-detection backup
+    // (compiled-package code with no `import "node:http"`) silently
+    // failed to flip `perry-ext-http` onto the link line. Register both
+    // the options-carrying variant codegen actually emits and the bare
+    // name (still referenced by the `#[used]` FORCE_LINK anchor and the
+    // `I64, &[I64]` decl in runtime_decls/stdlib_ffi.rs).
+    ("js_node_http_create_server_with_options",     OwnerKind::WellKnown("http")),
     ("js_node_http_create_server",                  OwnerKind::WellKnown("http")),
     ("js_node_http_server_listen",                  OwnerKind::WellKnown("http")),
     ("js_node_http_server_close",                   OwnerKind::WellKnown("http")),
@@ -355,5 +366,27 @@ mod tests {
         // assert it didn't show up by checking the only two variants we
         // care about. Done above. Drain semantics:
         let _ = take_used_providers();
+    }
+
+    /// #2532 regression: the symbol codegen actually emits for
+    /// `http.createServer(...)` is `js_node_http_create_server_with_options`
+    /// (see `lower_call/native_table/http.rs`). It must route to
+    /// `WellKnown("http")` so out-of-tree / compiled-package builds (no
+    /// `import "node:http"` in the entry module) still flip
+    /// `perry-ext-http` onto the link line. Before the fix, only the
+    /// pre-rename `js_node_http_create_server` was registered, so the
+    /// emitted symbol matched nothing and the owner-detection backup
+    /// silently no-op'd — the link then failed with
+    /// `Undefined symbols: _js_node_http_create_server_with_options`.
+    #[test]
+    fn emitted_create_server_symbol_routes_to_http() {
+        let _ = take_used_providers();
+        record_ffi_call("js_node_http_create_server_with_options");
+        let got = take_used_providers();
+        assert!(
+            got.contains(&OwnerKind::WellKnown("http")),
+            "js_node_http_create_server_with_options must route to WellKnown(http), got {:?}",
+            got
+        );
     }
 }

--- a/crates/perry-ext-http-server/src/lib.rs
+++ b/crates/perry-ext-http-server/src/lib.rs
@@ -85,6 +85,21 @@ static GC_REGISTERED: Once = Once::new();
 pub(crate) fn ensure_gc_scanner_registered() {
     GC_REGISTERED.call_once(|| {
         gc_register_mutable_root_scanner_named("perry-ext-http-server", scan_http_server_roots);
+        // #2532 — register the server pump + has-active with perry-runtime
+        // directly. In a workspace build perry-stdlib drains these via its
+        // `external-http-server-pump` arm, but an out-of-tree install links
+        // the prebuilt full stdlib with that arm compiled OUT — so without
+        // this the accepted requests would never be dispatched and the
+        // program would hang. Registration is idempotent on the runtime
+        // side, so the in-tree double-drain is a harmless no-op.
+        extern "C" {
+            fn js_register_aux_pump(f: extern "C" fn() -> i32);
+            fn js_register_aux_has_active(f: extern "C" fn() -> i32);
+        }
+        unsafe {
+            js_register_aux_pump(crate::server::js_node_http_server_process_pending);
+            js_register_aux_has_active(crate::server::js_node_http_server_has_active);
+        }
     });
 }
 

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -104,6 +104,25 @@ static HTTP_GC_REGISTERED: Once = Once::new();
 pub(crate) fn ensure_gc_scanner_registered() {
     HTTP_GC_REGISTERED.call_once(|| {
         gc_register_mutable_root_scanner_named("perry-ext-http", scan_http_roots);
+        // #2532 — register the client response/error pump with perry-runtime
+        // directly so `http.request` / `http.get` callbacks fire in an
+        // out-of-tree install (prebuilt full stdlib has the
+        // `external-http-client-pump` arm compiled out). No separate
+        // has-active is needed: the in-flight request is a perry-ffi async
+        // op, which `js_native_async_has_active` already keeps the loop alive
+        // for. Idempotent on the runtime side.
+        extern "C" {
+            fn js_register_aux_pump(f: extern "C" fn() -> i32);
+        }
+        // `js_http_process_pending` is an `unsafe extern "C" fn`; the
+        // registry takes a safe `extern "C" fn`, so route through a thin
+        // safe shim.
+        extern "C" fn client_pump() -> i32 {
+            unsafe { js_http_process_pending() }
+        }
+        unsafe {
+            js_register_aux_pump(client_pump);
+        }
     });
 }
 

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -228,8 +228,82 @@ mod ext_pump {
 mod stdlib_pump {
     use std::ptr::null_mut;
     use std::sync::atomic::{AtomicPtr, Ordering};
+    use std::sync::Mutex;
 
     static STDLIB_PUMP_FN: AtomicPtr<()> = AtomicPtr::new(null_mut());
+
+    // #2532 — auxiliary pump / has-active registries.
+    //
+    // perry-stdlib owns the single `STDLIB_PUMP_FN` slot above and drains
+    // every in-tree module's pending queue from there. But the
+    // `perry-ext-*` wrapper crates (perry-ext-http-server's request queue,
+    // perry-ext-http's client response queue, …) are normally drained by
+    // `js_stdlib_process_pending`'s `#[cfg(feature = "external-*-pump")]`
+    // arms — which are only compiled in when the *workspace* auto-optimize
+    // rebuilds perry-stdlib with that feature.
+    //
+    // In an out-of-tree install there is no workspace to rebuild from, so
+    // the link uses the prebuilt full `libperry_stdlib.a` with those pump
+    // arms compiled OUT. The ext lib would then link but its queue would
+    // never be drained — a `node:http` server accepts connections that
+    // nobody dispatches and the program hangs.
+    //
+    // These registries let each linked ext crate register its own
+    // `*_process_pending` / `*_has_active` directly with the runtime, which
+    // drains them on every tick regardless of which perry-stdlib features
+    // are present. Registration is idempotent (a given fn pointer is only
+    // stored once), so the in-tree path's compile-time arm calling the same
+    // function is harmless — the second drain of an already-empty queue is
+    // a no-op.
+    static AUX_PUMPS: Mutex<Vec<extern "C" fn() -> i32>> = Mutex::new(Vec::new());
+    static AUX_HAS_ACTIVE: Mutex<Vec<extern "C" fn() -> i32>> = Mutex::new(Vec::new());
+
+    /// Register an auxiliary pump callback (a `perry-ext-*` crate's
+    /// `*_process_pending`). Idempotent — registering the same function
+    /// twice stores it once. Called the first time the ext crate's entry
+    /// point runs (e.g. `js_node_http_create_server`).
+    #[no_mangle]
+    pub extern "C" fn js_register_aux_pump(f: extern "C" fn() -> i32) {
+        if let Ok(mut pumps) = AUX_PUMPS.lock() {
+            if !pumps.iter().any(|&g| g == f) {
+                pumps.push(f);
+            }
+        }
+    }
+
+    /// Register an auxiliary has-active callback (a `perry-ext-*` crate's
+    /// `*_has_active`). Idempotent. Keeps the event loop alive while the
+    /// ext crate reports live handles (e.g. a listening HTTP server).
+    #[no_mangle]
+    pub extern "C" fn js_register_aux_has_active(f: extern "C" fn() -> i32) {
+        if let Ok(mut fns) = AUX_HAS_ACTIVE.lock() {
+            if !fns.iter().any(|&g| g == f) {
+                fns.push(f);
+            }
+        }
+    }
+
+    /// Drain every registered auxiliary pump, returning the total work done.
+    fn run_aux_pumps() -> i32 {
+        let fns: Vec<extern "C" fn() -> i32> = match AUX_PUMPS.lock() {
+            Ok(g) => g.clone(),
+            Err(_) => return 0,
+        };
+        let mut count = 0i32;
+        for f in fns {
+            count = count.saturating_add(f());
+        }
+        count
+    }
+
+    /// True if any registered auxiliary has-active callback reports live work.
+    fn aux_has_active() -> bool {
+        let fns: Vec<extern "C" fn() -> i32> = match AUX_HAS_ACTIVE.lock() {
+            Ok(g) => g.clone(),
+            Err(_) => return false,
+        };
+        fns.iter().any(|f| f() != 0)
+    }
 
     /// Register the stdlib's process_pending function pointer.
     /// Called by perry-stdlib during initialization.
@@ -261,6 +335,10 @@ mod stdlib_pump {
                 func();
             }
         }
+        // #2532 — drain any `perry-ext-*` pumps registered directly with
+        // the runtime (out-of-tree installs where perry-stdlib's
+        // compile-time `external-*-pump` arms aren't present).
+        run_aux_pumps();
         let _ = crate::gc::gc_runtime_safepoint();
     }
 
@@ -285,6 +363,12 @@ mod stdlib_pump {
         if crate::child_process::reactor::cp_reactor_has_live() {
             return 1;
         }
+        // #2532 — a live `perry-ext-*` handle (e.g. a listening HTTP
+        // server registered out-of-tree) keeps the loop alive even when
+        // perry-stdlib reports none.
+        if aux_has_active() {
+            return 1;
+        }
         let f = STDLIB_HAS_ACTIVE_FN.load(Ordering::Acquire);
         if !f.is_null() {
             unsafe {
@@ -293,6 +377,36 @@ mod stdlib_pump {
             }
         } else {
             0
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::sync::atomic::{AtomicI32, Ordering as AtomicOrdering};
+
+        static PUMP_CALLS: AtomicI32 = AtomicI32::new(0);
+        extern "C" fn counting_pump() -> i32 {
+            PUMP_CALLS.fetch_add(1, AtomicOrdering::SeqCst);
+            0
+        }
+
+        #[test]
+        fn aux_pump_registration_is_idempotent() {
+            // Registering the same fn pointer repeatedly stores it once,
+            // so the in-tree compile-time arm calling the same function
+            // can't multiply the per-tick drain count.
+            js_register_aux_pump(counting_pump);
+            js_register_aux_pump(counting_pump);
+            js_register_aux_pump(counting_pump);
+            let before = PUMP_CALLS.load(AtomicOrdering::SeqCst);
+            run_aux_pumps();
+            let after = PUMP_CALLS.load(AtomicOrdering::SeqCst);
+            assert_eq!(
+                after - before,
+                1,
+                "counting_pump must be invoked exactly once per run_aux_pumps despite triple registration"
+            );
         }
     }
 }

--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -472,7 +472,28 @@ pub(super) fn build_optimized_libs(
                     rt_name, std_name
                 );
             }
-            return OptimizedLibs::empty();
+            // #2532 — out-of-tree (released / out-of-source) install:
+            // we can't rebuild perry-stdlib with a stripped feature set,
+            // so the link uses the prebuilt full `libperry_stdlib.a`.
+            // That full stdlib does NOT carry the `perry-ext-*` host
+            // functions — `node:http`'s server lives in perry-ext-http /
+            // perry-ext-http-server, which aren't perry-stdlib deps — so
+            // an out-of-box `node:http` server otherwise fails to link
+            // with `Undefined symbols: _js_node_http_create_server…`.
+            // Resolve the well-known ext staticlibs the program needs
+            // from the same search path the runtime/stdlib lookups use
+            // (PERRY_LIB_DIR / PERRY_RUNTIME_DIR, the exe dir, Homebrew
+            // `../lib`, …) and hand them back so they join the link line
+            // after the full stdlib.
+            let well_known_libs = if use_well_known {
+                resolve_prebuilt_ext_libs(&iteration_set, target, format, verbose)
+            } else {
+                Vec::new()
+            };
+            return OptimizedLibs {
+                well_known_libs,
+                ..OptimizedLibs::empty()
+            };
         }
     };
 
@@ -962,6 +983,74 @@ pub(super) fn build_optimized_libs(
         extra_bc,
         well_known_libs,
     }
+}
+
+/// #2532 — resolve the prebuilt `perry-ext-*` staticlibs a program needs
+/// when there is **no workspace source** to rebuild from (a released /
+/// out-of-tree install).
+///
+/// The in-tree path strips the matching perry-stdlib feature and rebuilds
+/// stdlib so the ext lib and stdlib don't both define the same `_js_*`
+/// symbols. Out-of-tree we can't rebuild — the link uses the prebuilt full
+/// `libperry_stdlib.a` and the ext lib is appended *after* it. That's safe:
+/// the ext lib's only otherwise-undefined symbols (e.g.
+/// `js_node_http_create_server_with_options`, `js_node_http_server_listen`,
+/// `js_node_http_res_end`) are server-side and absent from stdlib, so the
+/// linker pulls just those archive members; the ext crate's *client*-side
+/// duplicates (`js_http_*`) are never pulled because stdlib already resolves
+/// them.
+///
+/// Each well-known lib is located through `find_library`, which honours the
+/// `PERRY_LIB_DIR` / `PERRY_RUNTIME_DIR` overrides and the exe-dir /
+/// Homebrew `../lib` probes — the same precedence the runtime/stdlib
+/// lookups already use, so a release tarball or `brew` bottle that ships
+/// the ext libs alongside `libperry_runtime.a` resolves them with no extra
+/// configuration.
+fn resolve_prebuilt_ext_libs(
+    iteration_set: &std::collections::BTreeSet<String>,
+    target: Option<&str>,
+    format: OutputFormat,
+    verbose: u8,
+) -> Vec<PathBuf> {
+    let mut libs: Vec<PathBuf> = Vec::new();
+    // Dedup by lib basename — http / https / http2 all map to
+    // `perry_ext_http`, so without this the same `.a` would be added
+    // (and warned about) three times.
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for module in iteration_set {
+        let Some(binding) = super::well_known::lookup_well_known(module) else {
+            continue;
+        };
+        if !seen.insert(binding.lib.clone()) {
+            continue;
+        }
+        let filename =
+            super::well_known::ext_staticlib_filename(&binding.lib, rust_target_triple(target));
+        match super::library_search::find_library(&filename, target) {
+            Some(path) => {
+                if matches!(format, OutputFormat::Text) {
+                    println!(
+                        "  well-known (out-of-tree): routing `{}` → {} ({})",
+                        module,
+                        path.display(),
+                        binding.tracking.as_deref().unwrap_or("no tracking issue")
+                    );
+                }
+                libs.push(path);
+            }
+            None => {
+                if matches!(format, OutputFormat::Text) && verbose > 0 {
+                    eprintln!(
+                        "  well-known (out-of-tree): `{}` not found for `{}` — install \
+                         Perry's bundled ext libs next to the perry binary or set \
+                         PERRY_LIB_DIR; the link will fail with unresolved `js_*` symbols.",
+                        filename, module
+                    );
+                }
+            }
+        }
+    }
+    libs
 }
 
 /// True if this binding's wrapper crate has its own tokio dependency


### PR DESCRIPTION
## Summary

Fixes #2532 — an out-of-the-box install (any checkout that isn't this repo) couldn't link the per-feature `perry-ext-*` static libs, so a `node:http` **server** failed to link out of tree (`Undefined symbols: _js_node_http_create_server_with_options`, `_js_node_http_server_listen`, `_js_node_http_res_end`). This is the residual distribution-level half of #846.

Root causes and fixes:

1. **No ext libs linked without workspace source.** `build_optimized_libs` returned `OptimizedLibs::empty()` when `find_perry_workspace_root()` was `None`, so only `libperry_runtime.a` + `libperry_stdlib.a` went on the link line. The `node:http` server lives in `perry-ext-http` / `perry-ext-http-server`, which aren't perry-stdlib deps, so its symbols were nowhere.
   - `optimized_libs.rs`: new `resolve_prebuilt_ext_libs` — when there's no workspace, resolve the well-known ext `.a`s the program imports via the existing library search (`PERRY_LIB_DIR` / `PERRY_RUNTIME_DIR`, exe dir, Homebrew `../lib`) and add them to the link line. **Dormant in-tree** (the workspace path is unchanged), so it can't regress any existing build.

2. **Prebuilt full stdlib doesn't pump the ext queues.** Even once linked, the prebuilt `full` stdlib has the `external-*-pump` cfg arms compiled out, so an out-of-tree server would accept connections nobody dispatches and hang.
   - `perry-runtime`: add an auxiliary pump / has-active registry (`js_register_aux_pump` / `js_register_aux_has_active`), drained each tick from `js_run_stdlib_pump` / `js_stdlib_has_active_handles`. Registration is idempotent, so the in-tree compile-time arm calling the same function is a harmless no-op (second drain of an empty queue).
   - `perry-ext-http` / `perry-ext-http-server`: register their client / server pumps with the runtime on first use (inside `ensure_gc_scanner_registered`).

3. **Owner-detection key mismatch (the "verify while here" note in the issue).** Codegen emits `js_node_http_create_server_with_options` for `http.createServer`, but `ext_registry.rs` only had the pre-rename `js_node_http_create_server`, so the compiled-package backup (code with no `import "node:http"`) silently no-op'd.
   - `ext_registry.rs`: register the `_with_options` variant as `WellKnown("http")` (kept the bare name too — still referenced by the `#[used]` FORCE_LINK anchor + the `stdlib_ffi.rs` decl).

4. **Distribution didn't ship the ext libs.** `release-packages.yml` only staged runtime/stdlib/UI.
   - Build all `perry-ext-*` crates (best-effort per crate) and stage `libperry_ext_*.a` next to the runtime/stdlib libs.

## Validation

Built locally, then compiled + ran the issue's HTTP server from a **simulated out-of-tree install** (perry binary + libs copied to `/tmp`, no `crates/` reachable above the exe or cwd):

```
auto-optimize: Perry workspace source not found, using prebuilt libperry_runtime.a + libperry_stdlib.a
well-known (out-of-tree): routing `http` → /tmp/perry-oot/libperry_ext_http.a (#466)
```

…links cleanly, the server listens, and `curl` gets `ok` back (request dispatched via the aux pump). The **in-tree workspace path** still compiles, links, and dispatches unchanged.

Tests: `cargo fmt --check`, file-size gate, `perry-ext-http` (13) + `perry-ext-http-server` (17) suites, the new `ext_registry` symbol-routing test, and the new runtime aux-pump idempotency test all pass.

## Follow-ups (not in this PR)

- Windows ext-lib staging (`.lib`) and the Homebrew formula's `lib/` copy — this PR covers the GitHub-release Unix tarball layout the issue reported (macOS arm64).
