### PR TITLE
fix(stream): share native constructor prototypes

### DIFF
--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -246,6 +246,14 @@ pub(crate) fn bound_native_callable_export_value(module_name: &str, property_nam
     if module_name == "stream" && property_name == "Stream" {
         attach_stream_legacy_prototype(value);
     }
+    if module_name == "stream"
+        && matches!(
+            property_name,
+            "Readable" | "Writable" | "Duplex" | "Transform" | "PassThrough"
+        )
+    {
+        attach_stream_constructor_prototype(value, property_name);
+    }
 
     // `PerformanceObserver.supportedEntryTypes` is a static array on the
     // constructor. `PerformanceObserver` is a function value (a bound-method

--- a/crates/perry-runtime/src/object/native_module_stream.rs
+++ b/crates/perry-runtime/src/object/native_module_stream.rs
@@ -39,6 +39,36 @@ pub(crate) fn attach_stream_legacy_prototype(constructor_value: f64) {
     );
 }
 
+pub(crate) fn attach_stream_constructor_prototype(constructor_value: f64, name: &str) {
+    let shape_id = match name {
+        "Readable" => 0x7FFF_FF34,
+        "Writable" => 0x7FFF_FF35,
+        "Duplex" => 0x7FFF_FF36,
+        "Transform" => 0x7FFF_FF37,
+        "PassThrough" => 0x7FFF_FF38,
+        _ => return,
+    };
+    let proto = js_object_alloc_with_shape(
+        shape_id,
+        1,
+        b"constructor\0".as_ptr(),
+        b"constructor\0".len() as u32,
+    );
+    js_object_set_field(proto, 0, JSValue::from_bits(constructor_value.to_bits()));
+    let proto_value = crate::value::js_nanbox_pointer(proto as i64);
+    STREAM_EVENT_EMITTER_PROTOTYPES.with(|protos| {
+        let mut protos = protos.borrow_mut();
+        if !protos.contains(&proto_value.to_bits()) {
+            protos.push(proto_value.to_bits());
+        }
+    });
+    crate::closure::closure_set_dynamic_prop(
+        (constructor_value.to_bits() & crate::value::POINTER_MASK) as usize,
+        "prototype",
+        proto_value,
+    );
+}
+
 pub(crate) fn is_stream_event_emitter_prototype_value(value: f64) -> bool {
     let bits = value.to_bits();
     let jsval = JSValue::from_bits(bits);

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1434,6 +1434,34 @@ pub extern "C" fn js_object_is_extensible(obj_value: f64) -> f64 {
     }
 }
 
+fn constructor_dynamic_prototype(obj: *const ObjectHeader) -> Option<f64> {
+    if obj.is_null() {
+        return None;
+    }
+    let key =
+        crate::string::js_string_from_bytes(b"constructor".as_ptr(), b"constructor".len() as u32);
+    let constructor = js_object_get_field_by_name_f64(obj, key);
+    let bits = constructor.to_bits();
+    let top16 = bits >> 48;
+    if top16 != 0x7FFD {
+        return None;
+    }
+    let raw_addr = (bits & crate::value::POINTER_MASK) as usize;
+    if raw_addr < (crate::gc::GC_HEADER_SIZE as usize) + 0x1000 {
+        return None;
+    }
+    let gc = unsafe { gc_header_for(raw_addr as *const ObjectHeader) };
+    if unsafe { (*gc).obj_type } != crate::gc::GC_TYPE_CLOSURE {
+        return None;
+    }
+    let proto = crate::closure::closure_get_dynamic_prop(raw_addr, "prototype");
+    if crate::value::JSValue::from_bits(proto.to_bits()).is_undefined() {
+        None
+    } else {
+        Some(proto)
+    }
+}
+
 /// Object.getPrototypeOf(obj):
 /// - For an INT32-tagged class ref (top16 == 0x7FFE) — return the parent
 ///   class ref via CLASS_REGISTRY's parent_class_id chain, or null at
@@ -1519,6 +1547,9 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                     }
                     return f64::from_bits(TAG_NULL);
                 }
+                if let Some(proto) = constructor_dynamic_prototype(obj) {
+                    return proto;
+                }
             }
             return obj_value;
         }
@@ -1548,6 +1579,9 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                         return f64::from_bits(proto_bits);
                     }
                     return f64::from_bits(TAG_NULL);
+                }
+                if let Some(proto) = constructor_dynamic_prototype(obj) {
+                    return proto;
                 }
             }
             return obj_value;

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -506,12 +506,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose(src, t1, PassThrough, t2) \u2014 chain produces wrong output. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/readable/readable-stream-id-properties": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: distinct Readable instances \u2014 same identity or wrong prototype shared. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/web/transform-piped-twice": {
     "issue": "1545",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- attach shared prototype objects to native stream constructors
- have `Object.getPrototypeOf` return a constructor dynamic prototype for native stream instances
- remove the stale known-failure entry for `readable-stream-id-properties`

## Verification
- DeepWiki: `reference/deepwiki/nodejs-node-readable-prototype-identity-2026-05-29.md`
- baseline exact FAIL: `test-parity/reports/parity_report_20260529_141347.json`
- exact PASS before metadata removal: `test-parity/reports/parity_report_20260529_143520.json`
- exact PASS after metadata removal: `test-parity/reports/parity_report_20260529_144009.json`
- focused `readable/readable-`: `test-parity/reports/parity_report_20260529_144103.json` (4 PASS / 1 unrelated residual `readable-event-with-objectmode`)
- post-rebase exact PASS: `test-parity/reports/parity_report_20260529_144438.json`
- `cargo check -p perry-runtime`
- `cargo fmt --all --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check && git diff --cached --check`

## Non-goals
- no full JS prototype-chain model for all objects
- no stream inheritance chain beyond direct constructor prototypes
- no readable-event object-mode fix
- no stream lifecycle changes