### PR TITLE
Implement process getBuiltinModule

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2127,6 +2127,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("process", "nextTick", false, None),
     method("process", "chdir", false, None),
     method("process", "kill", false, None),
+    method("process", "getBuiltinModule", false, None),
     method("process", "loadEnvFile", false, None),
     method("process", "exit", false, None),
     method("process", "umask", false, None),

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -166,6 +166,15 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[],
         ret: NR_F64,
     },
+    NativeModSig {
+        module: "process",
+        has_receiver: false,
+        method: "getBuiltinModule",
+        class_filter: None,
+        runtime: "js_process_get_builtin_module",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     // #2135 (Node process parity): process.loadEnvFile(path?) — HIR
     // defaults the missing path to ".env" so this row always sees a
     // single string argument.

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -602,6 +602,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_event_names", I64, &[]);
     module.declare_function("js_process_set_max_listeners", DOUBLE, &[DOUBLE]);
     module.declare_function("js_process_get_max_listeners", DOUBLE, &[]);
+    module.declare_function("js_process_get_builtin_module", DOUBLE, &[DOUBLE]);
     module.declare_function("js_process_next_tick", VOID, &[I64]);
     module.declare_function("js_process_stdin", DOUBLE, &[]);
     module.declare_function("js_process_stdout", DOUBLE, &[]);

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -135,37 +135,13 @@ pub(super) fn try_native_module_methods(
                             return Ok(Ok(Expr::Undefined));
                         }
                         "getBuiltinModule" => {
-                            // #1398/#2482: process.getBuiltinModule(id) — Node
-                            // 22.3+ accessor. For a string-literal id naming a
-                            // Perry-supported Node built-in, return the native-
-                            // module namespace — the same `NativeModuleRef` an
-                            // `import * as m` binding produces — so
-                            // `getBuiltinModule("fs").readFileSync(...)` works
-                            // without `require`. `node:`-prefixed and prefixless
-                            // ids resolve to the same module. npm packages that
-                            // also live in NATIVE_MODULES (axios, lodash, …) are
-                            // excluded via the node-builtin gate. Unknown ids,
-                            // unsupported builtins, and non-literal args return
-                            // `undefined` (Node returns `undefined` for unknown
-                            // ids; Perry has no runtime "is it loaded?" query for
-                            // a dynamic id).
-                            if let Some(first) = call.args.first() {
-                                if first.spread.is_none() {
-                                    if let ast::Expr::Lit(ast::Lit::Str(s)) = first.expr.as_ref() {
-                                        if let Some(spec) = s.value.as_str() {
-                                            let name = spec.strip_prefix("node:").unwrap_or(spec);
-                                            if is_node_builtin_module(name)
-                                                && crate::ir::is_native_module(name)
-                                            {
-                                                return Ok(Ok(Expr::NativeModuleRef(
-                                                    name.to_string(),
-                                                )));
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            return Ok(Ok(Expr::Undefined));
+                            return Ok(Ok(Expr::NativeMethodCall {
+                                module: "process".to_string(),
+                                class_name: None,
+                                object: None,
+                                method: "getBuiltinModule".to_string(),
+                                args,
+                            }));
                         }
                         "dlopen" => {
                             // #1409: process.dlopen(module, filename, flags?)

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -531,6 +531,7 @@ pub(crate) unsafe fn bound_native_callable_value_arity(value: f64) -> Option<u32
     let (module, method) = bound_native_callable_module_and_method(value)?;
     match (module.as_str(), method.as_str()) {
         ("console", "Console") => Some(1),
+        ("process", "getBuiltinModule") => Some(1),
         _ => None,
     }
 }
@@ -612,6 +613,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("process", "removeAllListeners")
             | ("process", "setMaxListeners")
             | ("process", "getMaxListeners")
+            | ("process", "getBuiltinModule")
             | ("process", "cpuUsage")
             | ("process", "resourceUsage")
             | ("process", "getActiveResourcesInfo")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -352,6 +352,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("process", "eventNames") => ptr_to_f64(crate::os::js_process_event_names() as *const u8),
         ("process", "setMaxListeners") => crate::os::js_process_set_max_listeners(arg(0)),
         ("process", "getMaxListeners") => crate::os::js_process_get_max_listeners(),
+        ("process", "getBuiltinModule") => crate::process::js_process_get_builtin_module(arg(0)),
         ("process", "cwd") => str_to_f64(crate::os::js_process_cwd()),
         ("process", "uptime") => crate::os::js_process_uptime(),
         ("process", "memoryUsage") => crate::process::js_process_memory_usage(),

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -61,6 +61,41 @@ pub extern "C" fn js_process_abort() {
     std::process::abort();
 }
 
+fn supported_builtin_module_name(name: &str) -> Option<&str> {
+    match name {
+        "assert" | "assert/strict" | "async_hooks" | "buffer" | "child_process" | "cluster"
+        | "console" | "crypto" | "events" | "fs" | "http" | "http2" | "https" | "net" | "os"
+        | "path" | "perf_hooks" | "process" | "punycode" | "querystring" | "readline"
+        | "stream" | "stream/promises" | "string_decoder" | "sys" | "timers"
+        | "timers/promises" | "tty" | "url" | "util" | "util/types" | "worker_threads" | "zlib" => {
+            Some(name)
+        }
+        _ => None,
+    }
+}
+
+/// process.getBuiltinModule(id) -> module namespace | undefined
+#[no_mangle]
+pub extern "C" fn js_process_get_builtin_module(id: f64) -> f64 {
+    let value = JSValue::from_bits(id.to_bits());
+    let mut sso_buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let Some(bytes) = (unsafe { crate::string::js_string_key_bytes(value, &mut sso_buf) }) else {
+        let message = format!(
+            "The \"id\" argument must be of type string. Received {}",
+            crate::fs::validate::describe_received(id)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    };
+    let Ok(specifier) = std::str::from_utf8(bytes) else {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    };
+    let name = specifier.strip_prefix("node:").unwrap_or(specifier);
+    let Some(module_name) = supported_builtin_module_name(name) else {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    };
+    crate::object::js_create_native_module_namespace(module_name.as_ptr(), module_name.len())
+}
+
 /// Thread-local cell holding the process title set via `process.title = X`
 /// (#1401). `None` means "not assigned yet, fall back to argv[0]". The
 /// setter records the value here; on Linux it also calls `prctl(PR_SET_NAME)`

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1520 entries across 84 modules
+// Coverage: 1521 entries across 84 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -1845,6 +1845,8 @@ declare module "process" {
   export function exit(...args: any[]): any;
   /** stdlib */
   export function getActiveResourcesInfo(...args: any[]): any;
+  /** stdlib */
+  export function getBuiltinModule(...args: any[]): any;
   /** stdlib */
   export function getMaxListeners(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1520 entries across 84 modules.
+Total: 1521 entries across 84 modules.
 
 ## Modules
 
@@ -1683,6 +1683,7 @@ Total: 1520 entries across 84 modules.
 - `eventNames` — module
 - `exit` — module
 - `getActiveResourcesInfo` — module
+- `getBuiltinModule` — module
 - `getMaxListeners` — module
 - `getegid` — module
 - `geteuid` — module

--- a/test-parity/node-suite/process/methods/get-builtin-module.ts
+++ b/test-parity/node-suite/process/methods/get-builtin-module.ts
@@ -3,6 +3,7 @@
 // prefixed); returns undefined for unknown ids and for npm packages, without
 // throwing. Regression cover for #1398 / #2482.
 console.log("is function:", typeof process.getBuiltinModule === "function");
+console.log("length:", process.getBuiltinModule.length);
 const fs = process.getBuiltinModule("fs");
 console.log("fs typeof:", typeof fs);
 console.log("fs.readFileSync:", typeof fs.readFileSync);
@@ -10,6 +11,26 @@ console.log("node:fs existsSync:", typeof process.getBuiltinModule("node:fs").ex
 console.log("os.platform:", typeof process.getBuiltinModule("os").platform);
 const path = process.getBuiltinModule("node:path");
 console.log("path.join:", path.join("a", "b"));
+const getBuiltinModule = process.getBuiltinModule;
+const dynamicId = "fs";
+const dynamicFs = getBuiltinModule(dynamicId);
+console.log("captured dynamic fs typeof:", typeof dynamicFs);
+console.log("captured dynamic fs.readFileSync:", dynamicFs ? typeof dynamicFs.readFileSync : "missing");
+const timersId = "timers";
+const timers = getBuiltinModule(timersId);
+console.log("captured timers.setTimeout:", timers ? typeof timers.setTimeout : "missing");
 console.log("npm pkg:", process.getBuiltinModule("axios"));
 console.log("unknown:", process.getBuiltinModule("not-a-real-module"));
 console.log("empty:", process.getBuiltinModule(""));
+
+function invalid(label: string, value: any) {
+  try {
+    getBuiltinModule(value);
+    console.log(label, "no throw");
+  } catch (err: any) {
+    console.log(label, err.name, err.code, String(err.message).includes("\"id\""));
+  }
+}
+
+invalid("invalid number:", 123);
+invalid("invalid null:", null);


### PR DESCRIPTION
Closes #2708.

Summary:
- lower process.getBuiltinModule calls through a runtime helper so dynamic IDs and captured references behave like Node
- resolve supported built-in and node:-prefixed module IDs to Perry native module namespaces, and return undefined for unsupported IDs
- add ERR_INVALID_ARG_TYPE validation for non-string IDs plus manifest/docs coverage

Validation:
- PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" node test-parity/node-suite/process/methods/get-builtin-module.ts
- env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module process --filter get-builtin-module (report: test-parity/reports/parity_report_20260529_221008.json)
- env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module process (78/78, report: test-parity/reports/parity_report_20260529_221112.json)
- env RUSTC_WRAPPER= cargo test -p perry-api-manifest
- env RUSTC_WRAPPER= cargo test -p perry-codegen --test manifest_consistency
- env RUSTC_WRAPPER= cargo check -p perry-runtime -p perry-codegen
- cargo fmt --all -- --check
- git diff --check
- jq empty test-parity/known_failures.json
- ./scripts/check_file_size.sh