### PR TITLE
fix(stream): forward single-source compose chunks

### DIFF
--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -921,7 +921,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // #1541: addAbortSignal(signal, stream) — identity-returns the stream.
     module.declare_function("js_node_stream_add_abort_signal", DOUBLE, &[DOUBLE, DOUBLE]);
     // #1539: compose(...streams) -> new Duplex; duplexPair(opts) -> [Duplex, Duplex].
-    module.declare_function("js_node_stream_compose", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_node_stream_compose", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_pipeline", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_finished", DOUBLE, &[I64]);
     module.declare_function("js_node_stream_duplex_pair", DOUBLE, &[DOUBLE]);

--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -703,28 +703,60 @@ pub extern "C" fn js_node_stream_add_abort_signal(signal: f64, stream: f64) -> f
     stream
 }
 
-/// #1539: `stream.compose(...streams)` chains a sequence of streams
-/// into one composite Duplex (data flows through them in order).
-/// Perry's stream stubs don't propagate data through chains, so the
-/// helper returns a fresh Duplex — the typeof / instanceof checks
-/// callers do (`compose(a, b) instanceof Duplex`) hold, and the
-/// reads/writes are stubbed at the Duplex layer same as a bare
-/// `new Duplex()`. Real composition is tracked separately.
-#[no_mangle]
-pub extern "C" fn js_node_stream_compose(first_stream: f64) -> f64 {
-    if first_stream.to_bits() == TAG_UNDEFINED {
-        throw_pipeline_missing_streams();
+fn node_stream_duplex_from_source_chunks(source: f64) -> f64 {
+    let chunks = if let Some(chunks) = readable_hidden_chunks(source) {
+        chunks
+    } else {
+        match collect_pipeline_chunks(source) {
+            Ok(chunks) => chunks,
+            Err(err) => {
+                let duplex = js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED));
+                set_hidden_value(duplex, hidden_error_key(), err);
+                return duplex;
+            }
+        }
+    };
+    let values = pipeline_chunks_vec(chunks);
+    let mut arr = crate::array::js_array_alloc(values.len() as u32);
+    for chunk in values {
+        arr = crate::array::js_array_push_f64(arr, chunk);
     }
-    js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
+
+    let duplex = js_node_stream_duplex_new(readable_from_options(f64::from_bits(TAG_UNDEFINED)));
+    set_visible_writable(duplex, false);
+    set_hidden_value(duplex, hidden_chunks_key(), box_pointer(arr as *const u8));
+    set_hidden_value(
+        duplex,
+        hidden_buffered_key(),
+        crate::array::js_array_length(arr) as f64,
+    );
+    set_hidden_value(
+        duplex,
+        hidden_key(b"readableLength"),
+        crate::array::js_array_length(arr) as f64,
+    );
+    duplex
+}
+
+/// #1539: `stream.compose(...streams)` chains a sequence of streams
+/// into one composite Duplex (data flows through them in order). Perry
+/// now handles Node's single-source fast path by returning a Duplex
+/// wrapper whose readable side drains the source snapshot; multi-stage
+/// composition remains tracked separately.
+#[no_mangle]
+pub extern "C" fn js_node_stream_compose(args: *const crate::array::ArrayHeader) -> f64 {
+    js_node_stream_compose_args(args)
 }
 
 /// Variadic `stream.compose(...)` entry used by bound native-module property
-/// reads. Direct named imports still enter `js_node_stream_compose` with the
-/// first user argument only.
+/// reads and by direct named imports through codegen's packed varargs ABI.
 pub extern "C" fn js_node_stream_compose_args(args: *const crate::array::ArrayHeader) -> f64 {
     let args = pipeline_args(args);
     if args.is_empty() {
         throw_pipeline_missing_streams();
+    }
+    if args.len() == 1 {
+        return node_stream_duplex_from_source_chunks(args[0]);
     }
     js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
 }

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -164,7 +164,8 @@ static KEEP_NS_SET_DEFAULT_HWM: extern "C" fn(f64, f64) -> f64 =
 static KEEP_NS_ADD_ABORT_SIGNAL: extern "C" fn(f64, f64) -> f64 =
     super::js_node_stream_add_abort_signal;
 #[used]
-static KEEP_NS_COMPOSE: extern "C" fn(f64) -> f64 = super::js_node_stream_compose;
+static KEEP_NS_COMPOSE: extern "C" fn(*const crate::array::ArrayHeader) -> f64 =
+    super::js_node_stream_compose;
 #[used]
 static KEEP_NS_PIPELINE: extern "C" fn(*const crate::array::ArrayHeader) -> f64 =
     super::js_node_stream_pipeline;

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -362,12 +362,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose() error does not destroy source. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/compose/single-stream-arg": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: compose(stream) \u2014 single-stream form does not return Duplex wrap. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/web/desired-size-restores-after-drain": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -517,12 +511,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: pipeThrough().pipeThrough() \u2014 second transform output wrong. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/compose/just-source-only": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: compose(src) \u2014 only source given, Duplex output empty. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/readable/from-gen-with-early-return": {
     "issue": "1532",


### PR DESCRIPTION
## Summary
- align the direct `stream.compose(...args)` runtime ABI with codegen's packed-varargs call shape
- make the single-source `compose(src)` path return a Duplex whose readable side drains the source chunks
- remove stale known-failure entries for the two fixed single-source compose fixtures

## Verification
- Baseline FAIL: `node-suite/stream/compose/just-source-only`, report `test-parity/reports/parity_report_20260529_145122.json`
- Baseline FAIL: `node-suite/stream/compose/single-stream-arg`, report `test-parity/reports/parity_report_20260529_145317.json`
- PASS: `./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/compose/just-source-only`, report `test-parity/reports/parity_report_20260529_151358.json`
- PASS: `./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/compose/single-stream-arg`, report `test-parity/reports/parity_report_20260529_151401.json`
- Focused guard: `./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/compose/` -> 7 PASS / 14 known residual parity FAIL / 0 compile FAIL, report `test-parity/reports/parity_report_20260529_151411.json`
- `cargo check -p perry-runtime -p perry-codegen`
- `cargo fmt --all --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

DeepWiki reference: `reference/deepwiki/nodejs-node-stream-compose-single-source-2026-05-29.md`

## Non-goals
- no multi-stage compose data-flow
- no transform/function stage handling
- no compose error propagation changes
- no PassThrough two-stage forwarding fix

Fixes #1531 (single-source compose slice).
