### PR TITLE
feat(node:util): implement parseEnv (#2514)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2379,6 +2379,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("util", "getSystemErrorName", false, None),
     method("util", "getSystemErrorMessage", false, None),
     method("util", "getSystemErrorMap", false, None),
+    method("util", "parseEnv", false, None),
     // `util.formatWithOptions(options, format[, ...args])` — identical to
     // `util.format` except the first arg is an `util.inspect` options bag
     // applied to any `%o`/`%O` placeholders. Required by the `debug` npm

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -1005,6 +1005,16 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[],
         ret: NR_F64,
     },
+    // #2514: util.parseEnv(content) → object.
+    NativeModSig {
+        module: "util",
+        has_receiver: false,
+        method: "parseEnv",
+        class_filter: None,
+        runtime: "js_util_parse_env",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     NativeModSig {
         module: "util",
         has_receiver: false,

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -143,6 +143,7 @@ mod ui_harmonyos_stubs;
 /// startup. See module docs for the ohos-napi gating story.
 pub mod ui_text_registry;
 pub mod util_parse_args;
+pub mod util_parse_env;
 pub mod util_promisify;
 pub mod util_syserr;
 #[cfg(all(target_os = "watchos", feature = "watchos-game-loop"))]

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -884,6 +884,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("util", "getSystemErrorName")
             | ("util", "getSystemErrorMessage")
             | ("util", "getSystemErrorMap")
+            | ("util", "parseEnv")
             | ("util", "isArray")
             | ("util", "promisify")
             | ("util", "callbackify")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -916,6 +916,8 @@ pub(crate) unsafe fn dispatch_native_module_method(
             crate::util_syserr::js_util_get_system_error_message(arg(0))
         }
         ("util", "getSystemErrorMap") => crate::util_syserr::js_util_get_system_error_map(),
+        // #2514: util.parseEnv(content) → object.
+        ("util", "parseEnv") => crate::util_parse_env::js_util_parse_env(arg(0)),
         ("util", "debuglog") => super::native_module::util_debuglog_logger_value(),
         ("util", "isArray") => crate::array::js_array_is_array(arg(0)),
         ("util", "isDeepStrictEqual") => {

--- a/crates/perry-runtime/src/util_parse_env.rs
+++ b/crates/perry-runtime/src/util_parse_env.rs
@@ -1,0 +1,143 @@
+//! `util.parseEnv(content)` (#2514) — parse `.env`-format text into a plain
+//! object. Mirrors Node's built-in parser: skip blank / `#`-comment lines,
+//! strip an optional `export ` prefix, split on the first `=`, trim key+value;
+//! quoted values (`"`, `'`, backtick) keep their inner content (double-quoted
+//! values process `\n`/`\t`/`\r`/`\\`/`\"` escapes and treat `#` literally),
+//! unquoted values drop an inline `# comment`. Last duplicate key wins.
+
+use crate::url::{create_string_f64, get_string_content};
+
+/// Parse `.env` text → ordered `(key, value)` pairs (insertion order, last
+/// duplicate's value, first occurrence's position).
+fn parse_env(content: &str) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    for raw_line in content.lines() {
+        let line = raw_line.trim_start();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        // Optional `export ` prefix (Node strips it).
+        let line = match line.strip_prefix("export ") {
+            Some(rest) => rest.trim_start(),
+            None => line,
+        };
+        let Some((raw_key, raw_value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = raw_key.trim();
+        if key.is_empty() {
+            continue;
+        }
+        let value = parse_value(raw_value.trim());
+        if let Some(slot) = out.iter_mut().find(|(k, _)| k == key) {
+            slot.1 = value; // last duplicate wins
+        } else {
+            out.push((key.to_string(), value));
+        }
+    }
+    // Node's C++ parser stores into a sorted map, so the result object's keys
+    // come out byte-lexicographically sorted (e.g. `A`,`M`,`Z`,`m`), NOT in
+    // insertion order. Match that.
+    out.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+    out
+}
+
+fn parse_value(v: &str) -> String {
+    let chars: Vec<char> = v.chars().collect();
+    if let Some(&first) = chars.first() {
+        if first == '"' || first == '\'' || first == '`' {
+            if let Some(end_rel) = chars[1..].iter().position(|&c| c == first) {
+                let inner: String = chars[1..1 + end_rel].iter().collect();
+                return if first == '"' {
+                    unescape_double(&inner)
+                } else {
+                    inner
+                };
+            }
+            // No closing quote — fall through to the unquoted handling.
+        }
+    }
+    strip_inline_comment(v).trim_end().to_string()
+}
+
+/// Drop an inline `# comment` — a `#` at the start or preceded by whitespace.
+fn strip_inline_comment(v: &str) -> &str {
+    let b = v.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] == b'#' && (i == 0 || b[i - 1] == b' ' || b[i - 1] == b'\t') {
+            return &v[..i];
+        }
+        i += 1;
+    }
+    v
+}
+
+/// Process backslash escapes inside a double-quoted value.
+fn unescape_double(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('n') => out.push('\n'),
+                Some('t') => out.push('\t'),
+                Some('r') => out.push('\r'),
+                Some('\\') => out.push('\\'),
+                Some('"') => out.push('"'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// `util.parseEnv(content)` → plain object of parsed key/value strings.
+#[no_mangle]
+pub extern "C" fn js_util_parse_env(value: f64) -> f64 {
+    let content = get_string_content(value);
+    let entries = parse_env(&content);
+    let obj = crate::object::js_object_alloc(0, (entries.len() as u32).max(1));
+    for (k, v) in &entries {
+        let key_ptr = crate::string::js_string_from_bytes(k.as_ptr(), k.len() as u32);
+        let val = create_string_f64(v);
+        crate::object::js_object_set_field_by_name(obj, key_ptr, val);
+    }
+    f64::from_bits(crate::value::JSValue::pointer(obj as *const u8).bits())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_node_compatible() {
+        assert_eq!(
+            parse_env("A=1\nB=2"),
+            vec![("A".into(), "1".into()), ("B".into(), "2".into())]
+        );
+        assert_eq!(parse_env("A=b # c"), vec![("A".into(), "b".into())]);
+        assert_eq!(parse_env("A=\"b # c\""), vec![("A".into(), "b # c".into())]);
+        assert_eq!(parse_env("A="), vec![("A".into(), "".into())]);
+        assert_eq!(parse_env("A=b=c"), vec![("A".into(), "b=c".into())]);
+        assert_eq!(parse_env("A = b "), vec![("A".into(), "b".into())]);
+        assert_eq!(parse_env("export A=b"), vec![("A".into(), "b".into())]);
+        assert_eq!(parse_env("A='x y'"), vec![("A".into(), "x y".into())]);
+        assert_eq!(
+            parse_env("A=\"l1\\nl2\""),
+            vec![("A".into(), "l1\nl2".into())]
+        );
+        assert_eq!(parse_env("JUSTKEY\nA=1"), vec![("A".into(), "1".into())]);
+        assert_eq!(
+            parse_env("\n# hi\n  # ind\nA=1"),
+            vec![("A".into(), "1".into())]
+        );
+        assert_eq!(parse_env("A=1\nA=2"), vec![("A".into(), "2".into())]);
+    }
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1520 entries across 84 modules
+// Coverage: 1521 entries across 84 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -2148,6 +2148,8 @@ declare module "util" {
   export function isDeepStrictEqual(...args: any[]): any;
   /** stdlib */
   export function parseArgs(...args: any[]): any;
+  /** stdlib */
+  export function parseEnv(...args: any[]): any;
   /** stdlib */
   export function promisify(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1520 entries across 84 modules.
+Total: 1521 entries across 84 modules.
 
 ## Modules
 
@@ -2012,6 +2012,7 @@ Total: 1520 entries across 84 modules.
 - `inspect` — module
 - `isDeepStrictEqual` — module
 - `parseArgs` — module
+- `parseEnv` — module
 - `promisify` — module
 - `stripVTControlCharacters` — module
 

--- a/test-parity/node-suite/util/parse-env.ts
+++ b/test-parity/node-suite/util/parse-env.ts
@@ -1,0 +1,22 @@
+// util.parseEnv(content) — parse .env text to an object (#2514).
+import util from "node:util";
+
+const cases = [
+  "A=1\nB=2",
+  "A=b # c",
+  'A="b # c"',
+  "A=",
+  "A=b=c",
+  "A = b ",
+  "export A=b",
+  "A='x y'",
+  'A="l1\\nl2"',
+  "JUSTKEY\nA=1",
+  "\n# hi\n  # ind\nA=1",
+  "A=1\nA=2",
+  'DB="postgres://u:p@h/db"\nPORT=5432 # default\nNAME=app',
+];
+for (const c of cases) {
+  const r = util.parseEnv(c);
+  console.log(JSON.stringify(r), "|", Object.keys(r).join(","));
+}


### PR DESCRIPTION
Subset of #2514 — `util.parseEnv(content)`.

## Summary
Parses `.env`-format text into a plain object, mirroring Node's built-in parser:
- skip blank / `#`-comment lines; strip optional `export ` prefix;
- split on the first `=`, trim key + value;
- quoted values (`"`, `'`, backtick) keep inner content — double-quoted process `\n`/`\t`/`\r`/`\\`/`\"` escapes and treat `#` literally;
- unquoted values drop an inline `# comment`;
- last duplicate key wins;
- keys come out **byte-lexicographically sorted** (Node's C++ parser uses a sorted map — `A`,`M`,`Z`,`m`, not insertion order).

New `crates/perry-runtime/src/util_parse_env.rs` (fresh file → minimal hot-file surface).

## Testing
Byte-for-byte vs `node` (v25) across 13 cases: basic, inline comment, `#`-in-quotes, empty value, `=`-in-value, spaces-around-`=`, `export` prefix, single/double quotes, `\n` escape, no-`=` line skipped, comment/blank lines skipped, dup-key-last-wins, and multi-key sort order. Adds a unit test + `test-parity/node-suite/util/parse-env.ts`. fmt + file-size + manifest/codegen consistency pass locally.
