### PR TITLE
test(stream): drop stale readable compose instance failures

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -266,12 +266,6 @@
     "category": "bug-open",
     "reason": "node:stream: Duplex.from(asyncIterable) \u2014 async-gen \u2192 Duplex form not yet wired. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/compose/instance-method": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.prototype.compose(stream) instance method \u2014 not yet exposed (only free compose() works). Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/events/finish-end-close-order": {
     "issue": "1532",
     "added": "2026-05-24",
@@ -325,12 +319,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: compose(src, asyncGenWithAwait) \u2014 async-await handler not iterated correctly. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/compose/instance-chain": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: r.compose(t1).compose(t2) \u2014 chained compose() returns Duplex but pipeline breaks. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/compose/async-iter-handler-rejection": {
     "issue": "1531",


### PR DESCRIPTION
## Summary
- remove stale known-failure entries for `stream/compose/instance-method` and `stream/compose/instance-chain`
- both fixtures now pass on current `main`; no runtime code changes

## Verification
- Probe PASS while listed: `./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/compose/instance-chain`, report `test-parity/reports/parity_report_20260529_152103.json`
- Probe PASS while listed: `./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/compose/instance-method`, report `test-parity/reports/parity_report_20260529_152106.json`
- Post-removal PASS: `./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/compose/instance-chain`, report `test-parity/reports/parity_report_20260529_152234.json`
- Post-removal PASS: `./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/compose/instance-method`, report `test-parity/reports/parity_report_20260529_152237.json`
- Adjacent still FAIL: `node-suite/stream/compose/from-async-iterable`, report `test-parity/reports/parity_report_20260529_151939.json`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

DeepWiki reference: `reference/deepwiki/nodejs-node-readable-compose-instance-chain-2026-05-29.md`

## Non-goals
- no runtime compose changes
- no async iterable source compose fix
- no transform/function free-compose work

Refs #1531.
