### PR TITLE
fix(fs): surface open errors

### DIFF
--- a/crates/perry-runtime/src/fs/callbacks.rs
+++ b/crates/perry-runtime/src/fs/callbacks.rs
@@ -1,9 +1,6 @@
 //! Callback-style fs APIs — pre-flight probe + (err, value) dispatch.
 
-use std::fs;
-
 use crate::closure::ClosureHeader;
-use crate::string::js_string_from_bytes;
 
 use super::*;
 
@@ -593,40 +590,17 @@ pub extern "C" fn js_fs_open_callback(path_value: f64, arg1: f64, arg2: f64, arg
     } else {
         arg1
     };
-    // Probe only the clear read-only cases (`"r"`, `"r+"`, or undefined ⇒
-    // Node defaults to `"r"`). Anything else — `"w"`, `"a"`, numeric flag
-    // bitsets like `O_CREAT|O_WRONLY` — may create the file, so we defer
-    // to the underlying open instead of pre-rejecting on a missing path.
-    let read_only = unsafe { open_flag_is_read_only(flags) };
-    if read_only {
-        unsafe {
-            if let Some(err_val) = fs_callback_read_error(path_value, "open") {
-                call_cb_err2(cb, err_val);
-                return f64::from_bits(TAG_UNDEFINED);
-            }
-        }
-    }
-    let fd = js_fs_open_sync(path_value, flags);
+    let fd = match unsafe { fs_open_sync_result(path_value, flags) } {
+        Ok(fd) => fd as f64,
+        Err((err, path)) => unsafe {
+            call_cb_err2(cb, build_fs_error_value(&err, "open", &path));
+            return f64::from_bits(TAG_UNDEFINED);
+        },
+    };
     if !cb.is_null() {
         crate::closure::js_closure_call2(cb, f64::from_bits(TAG_NULL), fd);
     }
     f64::from_bits(TAG_UNDEFINED)
-}
-
-/// Returns true when an `open` flags value is unambiguously read-only.
-/// Treats `undefined` (Node's default) as read-only, the string flags
-/// `"r"` and `"r+"` as read-only, and everything else — including any
-/// numeric/integer flag — as potentially creating, so the caller skips
-/// the missing-path probe and defers to the syscall.
-pub(crate) unsafe fn open_flag_is_read_only(flags_value: f64) -> bool {
-    let jsval = crate::value::JSValue::from_bits(flags_value.to_bits());
-    if jsval.is_undefined() {
-        return true;
-    }
-    match decode_flags_string(flags_value).as_deref() {
-        Some("r") | Some("r+") => true,
-        _ => false,
-    }
 }
 
 pub(crate) unsafe fn decode_flags_string(value: f64) -> Option<String> {
@@ -1004,7 +978,7 @@ mod sso_tests_1781 {
     /// #1781: fs flag strings ("r", "r+", "w", "a", "wx", …) are all <= 5
     /// bytes, so they are inline SSO values (tag 0x7FF9). `is_string()` is
     /// STRING_TAG-only and rejected every one — `decode_flags_string`
-    /// returned None for all flags, breaking the read-only fast-path probe.
+    /// returned None for all flags, breaking string flag parsing.
     #[test]
     fn decode_flags_string_handles_sso_flags() {
         for flag in ["r", "r+", "w", "w+", "a", "a+", "wx", "ax", "as"] {
@@ -1017,13 +991,5 @@ mod sso_tests_1781 {
             let got = unsafe { decode_flags_string(f64::from_bits(v.bits())) };
             assert_eq!(got.as_deref(), Some(flag), "decode mismatch for {flag:?}");
         }
-    }
-
-    #[test]
-    fn open_flag_is_read_only_recognizes_sso_flags() {
-        let r = crate::value::JSValue::try_short_string(b"r").unwrap();
-        assert!(unsafe { open_flag_is_read_only(f64::from_bits(r.bits())) });
-        let w = crate::value::JSValue::try_short_string(b"w").unwrap();
-        assert!(!unsafe { open_flag_is_read_only(f64::from_bits(w.bits())) });
     }
 }

--- a/crates/perry-runtime/src/fs/fd_ops.rs
+++ b/crates/perry-runtime/src/fs/fd_ops.rs
@@ -4,8 +4,6 @@
 
 use std::fs;
 use std::io::{Read, Seek, SeekFrom, Write};
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 
 use crate::closure::ClosureHeader;
 
@@ -169,7 +167,9 @@ pub extern "C" fn js_fs_open_sync(path_value: f64, flags_value: f64) -> f64 {
     unsafe {
         match fs_open_sync_result(path_value, flags_value) {
             Ok(fd) => fd as f64,
-            Err(_) => -1.0,
+            Err((err, path)) => {
+                crate::exception::js_throw(build_fs_error_value(&err, "open", &path))
+            }
         }
     }
 }

--- a/test-parity/node-suite/fs/fd/open-errors.ts
+++ b/test-parity/node-suite/fs/fd/open-errors.ts
@@ -1,0 +1,27 @@
+import * as fs from "node:fs";
+
+const ROOT = "/tmp/perry_node_suite_fs_open_errors";
+const target = ROOT + "/missing-parent/file.txt";
+
+try { fs.rmSync(ROOT, { recursive: true, force: true }); } catch (_e) {}
+
+try {
+  fs.openSync(target, "w");
+  console.log("sync unexpectedly opened");
+} catch (e: any) {
+  console.log("sync error:", e instanceof Error, e.code, e.syscall, e.path === target);
+}
+
+await new Promise<void>((resolve) => {
+  fs.open(target, "w", (err, fd) => {
+    console.log(
+      "callback error:",
+      err instanceof Error,
+      err && (err as any).code,
+      err && (err as any).syscall,
+      err && (err as any).path === target,
+      fd === undefined,
+    );
+    resolve();
+  });
+});


### PR DESCRIPTION
## Summary
- make `fs.openSync` throw the existing Node-shaped fs error instead of returning `-1` on open failure
- make callback `fs.open` use the same open result path and call back with `(err, undefined)` on failure
- add parity coverage for missing-parent create-mode opens across sync and callback APIs

Closes #2726

## Verification
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH node --experimental-strip-types test-parity/node-suite/fs/fd/open-errors.ts`
- pre-fix Perry repro for `open-errors.ts`: `sync unexpectedly opened` and callback reported no error with `fd !== undefined`
- `RUSTC_WRAPPER= target/release/perry test-parity/node-suite/fs/fd/open-errors.ts -o /tmp/perry_open_errors_2726` and `/tmp/perry_open_errors_2726`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs --filter open-errors` (1/1 pass, report `test-parity/reports/parity_report_20260529_222422.json`)
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs --filter open` (8/8 pass, report `test-parity/reports/parity_report_20260529_222633.json`)
- `RUSTC_WRAPPER= cargo check -p perry-runtime`
- `RUSTC_WRAPPER= cargo test -p perry-runtime fs::callbacks::sso_tests_1781 --lib`
- `cargo fmt --all -- --check`
- `git diff --check` and `git diff --cached --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
