### PR TITLE
Fix Duplex finish/end/close ordering

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -284,11 +284,15 @@ extern "C" fn ns_writable_finish_microtask(closure: *const ClosureHeader) -> f64
             call_listener_args(stream, callback, &[]);
         }
         let _ = emit_stream_event(stream, string_value(b"finish"), &[]);
-        mark_stream_closed(stream);
-        if stream_auto_destroy_enabled(stream) {
-            mark_stream_destroyed(stream);
+        let readable_done = get_hidden_value(stream, hidden_readable_flag_key()).is_none()
+            || has_truthy_hidden(stream, hidden_end_emitted_key());
+        if readable_done {
+            mark_stream_closed(stream);
+            if stream_auto_destroy_enabled(stream) {
+                mark_stream_destroyed(stream);
+            }
+            let _ = emit_stream_event(stream, string_value(b"close"), &[]);
         }
-        let _ = emit_stream_event(stream, string_value(b"close"), &[]);
     }
     f64::from_bits(TAG_UNDEFINED)
 }
@@ -1176,7 +1180,9 @@ fn finish_stream(stream: f64, callback: Option<f64>) {
     mark_stream_ended(stream);
     refresh_readable_aborted_flag(stream);
     mark_writable_ended(stream);
-    if !has_truthy_hidden(stream, hidden_end_emitted_key()) {
+    if get_hidden_value(stream, hidden_readable_flag_key()).is_none()
+        && !has_truthy_hidden(stream, hidden_end_emitted_key())
+    {
         set_hidden_value(stream, hidden_end_emitted_key(), f64::from_bits(TAG_TRUE));
         refresh_readable_aborted_flag(stream);
         let _ = emit_stream_event(stream, string_value(b"end"), &[]);

--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -503,6 +503,9 @@ pub extern "C" fn js_node_stream_duplex_new(opts: f64) -> f64 {
     let methods = duplex_methods();
     let obj = build_object(&methods, DUPLEX_SHAPE_ID + methods.len() as u32);
     let duplex = f64::from_bits(JSValue::pointer(obj as *const u8).bits());
+    if let Some(read) = read_callback_from_options(opts) {
+        js_object_set_field_by_name(obj, hidden_read_key(), rebind_callback_this(read, duplex));
+    }
     if let Some(write) = write_callback_from_options(opts) {
         js_object_set_field_by_name(obj, hidden_write_key(), rebind_callback_this(write, duplex));
     }

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -763,17 +763,16 @@ pub(super) fn emit_readable_end_once(stream: f64) {
         refresh_readable_aborted_flag(stream);
         let _ = emit_stream_event(stream, string_value(b"end"), &[]);
         end_pipe_destinations(stream);
-        // autoDestroy (default) tears the stream down after 'end'; the
-        // destroy microtask marks it closed and emits 'close'. Only when
-        // autoDestroy is off do we fall back to the readable-only direct
-        // close path (#2302): a Readable-only stream (no writable side)
-        // emits 'close' after 'end' so `readable.closed` flips to true once
-        // the data is fully consumed. A Duplex defers `close` until BOTH
-        // 'end' and 'finish' have fired (handled in the writable-side
-        // `ns_end1`). Routing both through one branch avoids a double
-        // 'close' emission. Refs node-suite/stream/readable/closed-flag.
+        // autoDestroy (default) tears readable-only streams down after
+        // 'end'. Duplex streams defer `close` until BOTH readable `end`
+        // and writable `finish` have fired; whichever side finishes second
+        // performs the close. Refs node-suite/stream/readable/closed-flag.
         if stream_auto_destroy_enabled(stream) {
-            destroy_stream(stream, f64::from_bits(TAG_UNDEFINED));
+            let writable_pending = get_hidden_value(stream, hidden_writable_flag_key()).is_some()
+                && !has_truthy_hidden(stream, hidden_finish_emitted_key());
+            if !writable_pending {
+                destroy_stream(stream, f64::from_bits(TAG_UNDEFINED));
+            }
         } else if get_hidden_value(stream, hidden_writable_flag_key()).is_none() {
             mark_stream_closed(stream);
             let _ = emit_stream_event(stream, string_value(b"close"), &[]);

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -272,12 +272,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.prototype.compose(stream) instance method \u2014 not yet exposed (only free compose() works). Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/events/finish-end-close-order": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Duplex with finish/end/close event ordering \u2014 fails to compile (this/method context inside arrow callback). Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/duplex/from-object-form": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- store constructor-provided `read` callbacks on `Duplex` instances
- defer Duplex `close` until both readable `end` and writable `finish` have emitted
- remove the stale `node-suite/stream/events/finish-end-close-order` known-failure entry

## Verification
- `cargo check -p perry-runtime`
- `./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/events/finish-end-close-order` (`test-parity/reports/parity_report_20260529_153606.json`)
- `./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/events/finish` (`test-parity/reports/parity_report_20260529_153637.json`)
- `./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/readable/closed-flag` (`test-parity/reports/parity_report_20260529_153646.json`)
- `./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/duplex/options-merge` (`test-parity/reports/parity_report_20260529_153652.json`)
- `./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/duplex/allow-half-open-default` (`test-parity/reports/parity_report_20260529_153659.json`)
- `cargo fmt --all --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`