### PR TITLE
fix(fs): surface unlink errors

### DIFF
--- a/crates/perry-runtime/src/fs/callbacks.rs
+++ b/crates/perry-runtime/src/fs/callbacks.rs
@@ -151,13 +151,14 @@ pub extern "C" fn js_fs_unlink_callback(path_value: f64, callback: f64) -> f64 {
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
     let cb = last_callback(&[callback]);
     unsafe {
-        if let Some(err_val) = fs_callback_lstat_error(path_value, "unlink") {
-            call_cb_err1(cb, err_val);
-            return f64::from_bits(TAG_UNDEFINED);
+        match js_fs_unlink_result(path_value) {
+            Ok(()) => call_cb0(cb),
+            Err(err_val) => {
+                call_cb_err1(cb, err_val);
+                return f64::from_bits(TAG_UNDEFINED);
+            }
         }
     }
-    let _ = js_fs_unlink_sync(path_value);
-    call_cb0(cb);
     f64::from_bits(TAG_UNDEFINED)
 }
 

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -532,21 +532,30 @@ pub extern "C" fn js_fs_is_directory(path_value: f64) -> i32 {
     }
 }
 
-/// Remove a file synchronously
-/// Returns 1 on success, 0 on failure
-/// Accepts NaN-boxed string path
+pub(crate) unsafe fn js_fs_unlink_result(path_value: f64) -> Result<(), f64> {
+    validate::validate_path("path", path_value);
+    let path_str = match decode_path_value(path_value) {
+        Some(s) => s,
+        None => return Ok(()),
+    };
+
+    match fs::remove_file(&path_str) {
+        Ok(_) => Ok(()),
+        Err(err) => Err(build_fs_error_value(&err, "unlink", &path_str)),
+    }
+}
+
+/// Remove a file synchronously.
+/// Returns 1 on success and throws a Node-shaped fs error on failure.
+/// Accepts NaN-boxed string path.
 #[no_mangle]
 pub extern "C" fn js_fs_unlink_sync(path_value: f64) -> i32 {
-    validate::validate_path("path", path_value);
     unsafe {
-        let path_str = match decode_path_value(path_value) {
-            Some(s) => s,
-            None => return 0,
-        };
-
-        match fs::remove_file(path_str) {
-            Ok(_) => 1,
-            Err(_) => 0,
+        match js_fs_unlink_result(path_value) {
+            Ok(()) => 1,
+            Err(err_val) => {
+                crate::exception::js_throw(err_val);
+            }
         }
     }
 }

--- a/crates/perry-runtime/src/node_submodules/fs_promises.rs
+++ b/crates/perry-runtime/src/node_submodules/fs_promises.rs
@@ -177,8 +177,10 @@ pub(crate) extern "C" fn thunk_fs_promises_unlink(
     _closure: *const ClosureHeader,
     path: f64,
 ) -> f64 {
-    let _ = crate::fs::js_fs_unlink_sync(path);
-    promise_undefined()
+    match unsafe { crate::fs::js_fs_unlink_result(path) } {
+        Ok(()) => promise_undefined(),
+        Err(err_val) => promise_rejected(err_val),
+    }
 }
 
 pub(crate) extern "C" fn thunk_fs_promises_rename(

--- a/test-parity/node-suite/fs/unlink-errors.ts
+++ b/test-parity/node-suite/fs/unlink-errors.ts
@@ -1,0 +1,90 @@
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+
+const ROOT = "/tmp/perry_node_suite_fs_unlink_errors";
+try { fs.rmSync(ROOT, { recursive: true, force: true }); } catch (_e) {}
+fs.mkdirSync(ROOT, { recursive: true });
+
+const missing = ROOT + "/missing.txt";
+const dir = ROOT + "/dir";
+fs.mkdirSync(dir);
+
+function showMissing(label: string, err: unknown, expectedPath: string) {
+  const fsErr = err as any;
+  console.log(label + " is Error:", err instanceof Error);
+  console.log(label + " code:", fsErr && fsErr.code);
+  console.log(label + " syscall:", fsErr && fsErr.syscall);
+  console.log(label + " path matches:", fsErr && fsErr.path === expectedPath);
+}
+
+function showDirectory(label: string, err: unknown, expectedPath: string) {
+  const fsErr = err as any;
+  console.log(label + " is Error:", err instanceof Error);
+  console.log(label + " code ok:", fsErr && (fsErr.code === "EISDIR" || fsErr.code === "EPERM"));
+  console.log(label + " syscall:", fsErr && fsErr.syscall);
+  console.log(label + " path matches:", fsErr && fsErr.path === expectedPath);
+}
+
+try {
+  fs.unlinkSync(missing);
+  console.log("sync missing unexpectedly succeeded");
+} catch (err) {
+  showMissing("sync missing", err, missing);
+}
+
+try {
+  fs.unlinkSync(dir);
+  console.log("sync dir unexpectedly succeeded");
+} catch (err) {
+  showDirectory("sync dir", err, dir);
+}
+
+await new Promise<void>((resolve) => {
+  fs.unlink(missing, (err) => {
+    showMissing("callback missing", err, missing);
+    resolve();
+  });
+});
+
+await new Promise<void>((resolve) => {
+  fs.unlink(dir, (err) => {
+    showDirectory("callback dir", err, dir);
+    resolve();
+  });
+});
+
+try {
+  await fsp.unlink(missing);
+  console.log("promise missing unexpectedly resolved");
+} catch (err) {
+  showMissing("promise missing", err, missing);
+}
+
+try {
+  await fsp.unlink(dir);
+  console.log("promise dir unexpectedly resolved");
+} catch (err) {
+  showDirectory("promise dir", err, dir);
+}
+
+const syncFile = ROOT + "/sync.txt";
+fs.writeFileSync(syncFile, "sync");
+fs.unlinkSync(syncFile);
+console.log("sync success removed:", !fs.existsSync(syncFile));
+
+const callbackFile = ROOT + "/callback.txt";
+fs.writeFileSync(callbackFile, "callback");
+await new Promise<void>((resolve) => {
+  fs.unlink(callbackFile, (err) => {
+    console.log("callback success err null:", err === null);
+    console.log("callback success removed:", !fs.existsSync(callbackFile));
+    resolve();
+  });
+});
+
+const promiseFile = ROOT + "/promise.txt";
+fs.writeFileSync(promiseFile, "promise");
+await fsp.unlink(promiseFile);
+console.log("promise success removed:", !fs.existsSync(promiseFile));
+
+try { fs.rmSync(ROOT, { recursive: true, force: true }); } catch (_e) {}


### PR DESCRIPTION
Closes #2736.

## Summary
- route `fs.unlinkSync` through the actual `remove_file` result and throw Node-shaped fs errors on failure
- make callback `fs.unlink` report the unlink syscall error instead of preflighting then always succeeding
- make `fs.promises.unlink` reject with the same fs error value
- add parity coverage for missing paths, directory inputs, and successful removals across sync/callback/promise forms

## Verification
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH node --experimental-strip-types test-parity/node-suite/fs/unlink-errors.ts`
- pre-fix Perry repro for `unlink-errors.ts`: sync failures unexpectedly succeeded, callback directory input had no Error, and promise failures resolved
- `RUSTC_WRAPPER= target/release/perry test-parity/node-suite/fs/unlink-errors.ts -o /tmp/perry_unlink_errors_2736 && /tmp/perry_unlink_errors_2736`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs --filter unlink-errors` (1/1 pass, report `test-parity/reports/parity_report_20260529_224741.json`)
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs --filter unlink` (2/2 pass, report `test-parity/reports/parity_report_20260529_224953.json`)
- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER= cargo check -p perry-runtime`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `git diff --check`
- `git diff --cached --check`
