### PR TITLE
fix(stream): read from sync iterables

### DIFF
--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -168,6 +168,69 @@ pub(crate) fn has_iterator_next(value: f64) -> bool {
     has_named_next(value)
 }
 
+pub(crate) fn sync_iterator_to_array_if_not_async(iter_f64: f64) -> Option<*mut ArrayHeader> {
+    use crate::closure;
+    use crate::object::{js_object_get_field_by_name, ObjectHeader};
+    use crate::string::js_string_from_bytes;
+    use crate::value::{js_nanbox_get_pointer, TAG_UNDEFINED};
+
+    let arr = js_array_alloc(8);
+    let iter_ptr = js_nanbox_get_pointer(iter_f64);
+    if iter_ptr == 0 {
+        return Some(arr);
+    }
+    let iter_obj = iter_ptr as *const ObjectHeader;
+
+    let next_key = js_string_from_bytes(b"next".as_ptr(), 4);
+    let next_val = js_object_get_field_by_name(iter_obj, next_key);
+    let next_f64 = unsafe { f64::from_bits(std::mem::transmute::<_, u64>(next_val)) };
+    let next_ptr = if next_val.is_undefined() {
+        std::ptr::null::<closure::ClosureHeader>()
+    } else {
+        js_nanbox_get_pointer(next_f64) as *const closure::ClosureHeader
+    };
+    let use_method_dispatch = next_ptr.is_null();
+
+    let done_key = js_string_from_bytes(b"done".as_ptr(), 4);
+    let value_key = js_string_from_bytes(b"value".as_ptr(), 5);
+    let mut result = arr;
+
+    for _ in 0..100_000 {
+        let step = if use_method_dispatch {
+            unsafe {
+                crate::object::js_native_call_method(
+                    iter_f64,
+                    b"next".as_ptr() as *const i8,
+                    4,
+                    std::ptr::null(),
+                    0,
+                )
+            }
+        } else {
+            closure::js_closure_call1(next_ptr, f64::from_bits(TAG_UNDEFINED))
+        };
+        if crate::promise::js_value_is_promise(step) != 0 {
+            return None;
+        }
+        let result_ptr = js_nanbox_get_pointer(step);
+        if result_ptr == 0 {
+            break;
+        }
+        let result_obj = result_ptr as *const ObjectHeader;
+        let done_val = js_object_get_field_by_name(result_obj, done_key);
+        let done_f64 = unsafe { f64::from_bits(std::mem::transmute::<_, u64>(done_val)) };
+        if crate::value::js_is_truthy(done_f64) != 0 {
+            break;
+        }
+
+        let val = js_object_get_field_by_name(result_obj, value_key);
+        let val_f64 = unsafe { f64::from_bits(std::mem::transmute::<_, u64>(val)) };
+        result = js_array_push_f64(result, val_f64);
+    }
+
+    Some(result)
+}
+
 fn call_symbol_async_iterator(value: f64) -> Option<f64> {
     let sym = crate::symbol::well_known_symbol("asyncIterator");
     if sym.is_null() {

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -61,7 +61,7 @@ pub use self::iterator::{js_for_of_to_array, js_iterator_to_array};
 // protocol instead of being appended as a single chunk.
 pub(crate) use self::iterator::{
     async_iterator_to_array_for_flat_map, call_symbol_async_iterator_for_flat_map,
-    has_iterator_next,
+    has_iterator_next, sync_iterator_to_array_if_not_async,
 };
 pub use self::jsvalue_api::{
     js_array_from_jsvalue, js_array_get, js_array_get_jsvalue, js_array_push,

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -322,7 +322,7 @@ extern "C" fn ns_writable_final_callback_done(closure: *const ClosureHeader, err
         }
         return f64::from_bits(TAG_UNDEFINED);
     }
-    schedule_writable_finish(
+    schedule_writable_finish_then_transform_end(
         stream,
         if is_callable_value(callback) {
             Some(callback)
@@ -1186,7 +1186,7 @@ fn finish_stream(stream: f64, callback: Option<f64>) {
         set_pending_writable_finish_callback(stream, callback);
         return;
     }
-    schedule_writable_finish(stream, callback);
+    schedule_writable_finish_then_transform_end(stream, callback);
 }
 
 fn finish_stream_with_args(stream: f64, chunk: f64, encoding: f64, cb: f64) {

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -719,6 +719,17 @@ pub(super) fn schedule_writable_finish(stream: f64, callback: Option<f64>) {
     crate::builtins::js_queue_microtask(closure as i64);
 }
 
+pub(super) fn schedule_writable_finish_then_transform_end(stream: f64, callback: Option<f64>) {
+    schedule_writable_finish(stream, callback);
+    if is_transform_stream(stream)
+        && !has_truthy_hidden(stream, hidden_writable_final_pending_key())
+        && (has_truthy_hidden(stream, hidden_finish_scheduled_key())
+            || has_truthy_hidden(stream, hidden_finish_emitted_key()))
+    {
+        schedule_readable_end(stream);
+    }
+}
+
 pub(super) fn set_pending_writable_finish_callback(stream: f64, callback: Option<f64>) {
     let value = callback.unwrap_or_else(|| f64::from_bits(TAG_UNDEFINED));
     set_hidden_value(stream, hidden_writable_pending_finish_callback_key(), value);
@@ -743,7 +754,7 @@ pub(super) fn schedule_pending_writable_finish_if_ready(stream: f64) {
         return;
     }
     let callback = take_pending_writable_finish_callback(stream);
-    schedule_writable_finish(stream, callback);
+    schedule_writable_finish_then_transform_end(stream, callback);
 }
 
 pub(super) fn emit_readable_end_once(stream: f64) {

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -1609,13 +1609,41 @@ pub(super) fn normalize_readable_from_input(iterable: f64) -> f64 {
     if is_array_like_value(iterable) {
         return iterable;
     }
-
-    let arr = crate::array::js_array_alloc(1);
     if is_single_chunk_value(iterable) {
+        let arr = crate::array::js_array_alloc(1);
         let arr = crate::array::js_array_push_f64(arr, iterable);
         return box_pointer(arr as *const u8);
     }
+    if let Some(chunks) = flatten_sync_iterable_value(iterable) {
+        return box_pointer(chunks as *const u8);
+    }
+
+    let arr = crate::array::js_array_alloc(1);
     box_pointer(arr as *const u8)
+}
+
+fn flatten_sync_iterable_value(value: f64) -> Option<*mut crate::array::ArrayHeader> {
+    if has_symbol_async_iterator(value) {
+        return None;
+    }
+    if crate::object::js_util_types_is_generator_object(value).to_bits() == TAG_TRUE {
+        return crate::array::sync_iterator_to_array_if_not_async(value);
+    }
+    let iter = crate::symbol::js_get_iterator(value);
+    if iter.to_bits() != value.to_bits() {
+        return crate::array::sync_iterator_to_array_if_not_async(iter);
+    }
+    None
+}
+
+fn has_symbol_async_iterator(value: f64) -> bool {
+    let sym = crate::symbol::well_known_symbol("asyncIterator");
+    if sym.is_null() {
+        return false;
+    }
+    let sym_value = f64::from_bits(JSValue::pointer(sym as *const u8).bits());
+    let method = unsafe { crate::symbol::js_object_get_symbol_property(value, sym_value) };
+    is_callable_value(method)
 }
 
 pub(super) fn readable_from_options(opts: f64) -> f64 {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -188,12 +188,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.from(asyncIterable) \u2192 data event chain doesn't deliver. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/readable/from-generator": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.from(generator) \u2192 data event chain doesn't deliver. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/events/readable-event": {
     "issue": "1532",
     "added": "2026-05-23",
@@ -326,12 +320,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose() async-gen handler throw \u2014 composite does not emit 'error'. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/readable/from-iterable-object": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.from(POJO-with-Symbol.iterator) \u2014 does not iterate the custom iterable. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/compose/buffer-preserves": {
     "issue": "1531",
     "added": "2026-05-24",
@@ -397,12 +385,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Readable.from(array with one Promise.reject) \u2014 error not emitted at the right point. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/from-gen-yield-order": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Readable.from(gen()) \u2014 yield order lost. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/web/double-pipe-through": {
     "issue": "1545",
@@ -493,18 +475,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: pipeThrough().pipeThrough() \u2014 second transform output wrong. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/readable/from-gen-with-early-return": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: generator with explicit return \u2014 values yielded after return statement aren't reached. Flips to PASS when #1532 lands."
-  },
-  "node-suite/stream/readable/from-gen-return-value-ignored": {
-    "issue": "1532",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: gen 'return value' included as chunk (should be ignored). Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/composite-end-event": {
     "issue": "1531",


### PR DESCRIPTION
## Summary
- materialize sync iterator-protocol inputs for Readable.from() after string/Buffer single-chunk handling
- bail out of sync materialization when next() returns a Promise so async iterables stay on the existing async path
- remove stale known-failure entries for sync generator/custom iterable Readable.from() cases

## Verification
- ./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/readable/from-async-iterable (expected residual; old empty-output shape, no runaway chunks)
- ./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/readable/from-gen
- ./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/readable/from-iterable-object
- ./run_parity_tests.sh --suite node-suite --module stream --filter node-suite/stream/readable/from-string-single-chunk
- cargo check -p perry-runtime
- cargo fmt --all --check
- jq empty test-parity/known_failures.json
- git diff --check