### PR TITLE
Revert #2751 (regressed node_stream pipe tests, blocking merge queue)

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -284,15 +284,11 @@ extern "C" fn ns_writable_finish_microtask(closure: *const ClosureHeader) -> f64
             call_listener_args(stream, callback, &[]);
         }
         let _ = emit_stream_event(stream, string_value(b"finish"), &[]);
-        let readable_done = get_hidden_value(stream, hidden_readable_flag_key()).is_none()
-            || has_truthy_hidden(stream, hidden_end_emitted_key());
-        if readable_done {
-            mark_stream_closed(stream);
-            if stream_auto_destroy_enabled(stream) {
-                mark_stream_destroyed(stream);
-            }
-            let _ = emit_stream_event(stream, string_value(b"close"), &[]);
+        mark_stream_closed(stream);
+        if stream_auto_destroy_enabled(stream) {
+            mark_stream_destroyed(stream);
         }
+        let _ = emit_stream_event(stream, string_value(b"close"), &[]);
     }
     f64::from_bits(TAG_UNDEFINED)
 }
@@ -1180,9 +1176,7 @@ fn finish_stream(stream: f64, callback: Option<f64>) {
     mark_stream_ended(stream);
     refresh_readable_aborted_flag(stream);
     mark_writable_ended(stream);
-    if get_hidden_value(stream, hidden_readable_flag_key()).is_none()
-        && !has_truthy_hidden(stream, hidden_end_emitted_key())
-    {
+    if !has_truthy_hidden(stream, hidden_end_emitted_key()) {
         set_hidden_value(stream, hidden_end_emitted_key(), f64::from_bits(TAG_TRUE));
         refresh_readable_aborted_flag(stream);
         let _ = emit_stream_event(stream, string_value(b"end"), &[]);

--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -503,9 +503,6 @@ pub extern "C" fn js_node_stream_duplex_new(opts: f64) -> f64 {
     let methods = duplex_methods();
     let obj = build_object(&methods, DUPLEX_SHAPE_ID + methods.len() as u32);
     let duplex = f64::from_bits(JSValue::pointer(obj as *const u8).bits());
-    if let Some(read) = read_callback_from_options(opts) {
-        js_object_set_field_by_name(obj, hidden_read_key(), rebind_callback_this(read, duplex));
-    }
     if let Some(write) = write_callback_from_options(opts) {
         js_object_set_field_by_name(obj, hidden_write_key(), rebind_callback_this(write, duplex));
     }

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -763,16 +763,17 @@ pub(super) fn emit_readable_end_once(stream: f64) {
         refresh_readable_aborted_flag(stream);
         let _ = emit_stream_event(stream, string_value(b"end"), &[]);
         end_pipe_destinations(stream);
-        // autoDestroy (default) tears readable-only streams down after
-        // 'end'. Duplex streams defer `close` until BOTH readable `end`
-        // and writable `finish` have fired; whichever side finishes second
-        // performs the close. Refs node-suite/stream/readable/closed-flag.
+        // autoDestroy (default) tears the stream down after 'end'; the
+        // destroy microtask marks it closed and emits 'close'. Only when
+        // autoDestroy is off do we fall back to the readable-only direct
+        // close path (#2302): a Readable-only stream (no writable side)
+        // emits 'close' after 'end' so `readable.closed` flips to true once
+        // the data is fully consumed. A Duplex defers `close` until BOTH
+        // 'end' and 'finish' have fired (handled in the writable-side
+        // `ns_end1`). Routing both through one branch avoids a double
+        // 'close' emission. Refs node-suite/stream/readable/closed-flag.
         if stream_auto_destroy_enabled(stream) {
-            let writable_pending = get_hidden_value(stream, hidden_writable_flag_key()).is_some()
-                && !has_truthy_hidden(stream, hidden_finish_emitted_key());
-            if !writable_pending {
-                destroy_stream(stream, f64::from_bits(TAG_UNDEFINED));
-            }
+            destroy_stream(stream, f64::from_bits(TAG_UNDEFINED));
         } else if get_hidden_value(stream, hidden_writable_flag_key()).is_none() {
             mark_stream_closed(stream);
             let _ = emit_stream_event(stream, string_value(b"close"), &[]);

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -266,6 +266,12 @@
     "category": "bug-open",
     "reason": "node:stream: Duplex.from(asyncIterable) \u2014 async-gen \u2192 Duplex form not yet wired. Flips to PASS when #1532 lands."
   },
+  "node-suite/stream/events/finish-end-close-order": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Duplex with finish/end/close event ordering \u2014 fails to compile (this/method context inside arrow callback). Flips to PASS when #1532 lands."
+  },
   "node-suite/stream/duplex/from-object-form": {
     "issue": "1532",
     "added": "2026-05-24",


### PR DESCRIPTION
## Why

`#2751` (`fix(stream): order duplex finish end close`) regressed two `node_stream` unit tests on `main`:

- `node_stream::tests_extra::readable_from_pipe_ends_destination`
- `node_stream::tests_extra::readable_from_pipe_chain_ends_tail_destination`

Because `cargo-test` is a required check, this is currently **blocking every open PR from merging** (~20+ of Andrew's PRs are stuck on the inherited cargo-test failure, even though they're otherwise conflict-free).

## What this does

Cleanly reverts `#2751` (no conflicts against current `main`). After the revert the **full `node_stream` suite passes 63/0** — the two pipe tests are restored and nothing else in the suite breaks.

## Follow-up

`#2751`'s intent (ordering duplex `finish`/`end`/`close`) is fine, but its change to `emit_readable_end_once` / `finish_stream` skips the readable `'end'` emission for streams that carry a readable flag, which a piped destination relies on. It should be re-applied with those two pipe tests kept green.

Opened to unblock the merge queue; merge at your discretion.
