### PR TITLE
test(http): close upgraded websocket fixture sockets

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -326,7 +326,7 @@ extern "C" fn ns_writable_final_callback_done(closure: *const ClosureHeader, err
         }
         return f64::from_bits(TAG_UNDEFINED);
     }
-    schedule_writable_finish(
+    schedule_writable_finish_then_transform_end(
         stream,
         if is_callable_value(callback) {
             Some(callback)
@@ -1192,7 +1192,7 @@ fn finish_stream(stream: f64, callback: Option<f64>) {
         set_pending_writable_finish_callback(stream, callback);
         return;
     }
-    schedule_writable_finish(stream, callback);
+    schedule_writable_finish_then_transform_end(stream, callback);
 }
 
 fn finish_stream_with_args(stream: f64, chunk: f64, encoding: f64, cb: f64) {

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -719,6 +719,17 @@ pub(super) fn schedule_writable_finish(stream: f64, callback: Option<f64>) {
     crate::builtins::js_queue_microtask(closure as i64);
 }
 
+pub(super) fn schedule_writable_finish_then_transform_end(stream: f64, callback: Option<f64>) {
+    schedule_writable_finish(stream, callback);
+    if is_transform_stream(stream)
+        && !has_truthy_hidden(stream, hidden_writable_final_pending_key())
+        && (has_truthy_hidden(stream, hidden_finish_scheduled_key())
+            || has_truthy_hidden(stream, hidden_finish_emitted_key()))
+    {
+        schedule_readable_end(stream);
+    }
+}
+
 pub(super) fn set_pending_writable_finish_callback(stream: f64, callback: Option<f64>) {
     let value = callback.unwrap_or_else(|| f64::from_bits(TAG_UNDEFINED));
     set_hidden_value(stream, hidden_writable_pending_finish_callback_key(), value);
@@ -743,7 +754,7 @@ pub(super) fn schedule_pending_writable_finish_if_ready(stream: f64) {
         return;
     }
     let callback = take_pending_writable_finish_callback(stream);
-    schedule_writable_finish(stream, callback);
+    schedule_writable_finish_then_transform_end(stream, callback);
 }
 
 pub(super) fn emit_readable_end_once(stream: f64) {

--- a/test-parity/node-suite/http/server/upgrade-websocket.ts
+++ b/test-parity/node-suite/http/server/upgrade-websocket.ts
@@ -65,7 +65,7 @@ server.on("upgrade", (_req: any, wsOrSocket: any, head: Buffer) => {
       const msg = readClientTextFrame(frame);
       if (!msg) return;
       console.log("server-message:", msg);
-      socket.write(unmaskedTextFrame("echo:" + msg));
+      socket.write(unmaskedTextFrame("echo:" + msg), () => socket.end());
     };
     if (head && head.length > 0) handleFrame(head);
     socket.on("data", handleFrame);
@@ -75,6 +75,7 @@ server.on("upgrade", (_req: any, wsOrSocket: any, head: Buffer) => {
   wsOrSocket.on("message", (msg: string) => {
     console.log("server-message:", msg);
     wsOrSocket.send("echo:" + msg);
+    if (typeof wsOrSocket.close === "function") wsOrSocket.close();
   });
 });
 


### PR DESCRIPTION
## Summary
- close the server-side upgraded socket after echoing the websocket frame
- close Perry websocket handles when available so the fixture exits cleanly after success

## Verification
- perl -e 'alarm shift @ARGV; exec @ARGV' 10 node --experimental-strip-types test-parity/node-suite/http/server/upgrade-websocket.ts\n- ./run_parity_tests.sh --suite node-suite --module http/server --filter upgrade-websocket\n- ./run_parity_tests.sh --suite node-suite --module http\n- git diff --check