### PR TITLE
fix(object): handle Object.assign target errors and primitive sources

### DIFF
--- a/crates/perry-codegen/src/expr/logical_collections.rs
+++ b/crates/perry-codegen/src/expr/logical_collections.rs
@@ -526,6 +526,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // Refs #590.
         Expr::ObjectAssign { target, sources } => {
             let target_box = lower_expr(ctx, target)?;
+            let mut acc = ctx.block().call(
+                DOUBLE,
+                "js_object_assign_validate_target",
+                &[(DOUBLE, &target_box)],
+            );
             // Stash target in a temp slot if there are multiple sources, so
             // each helper call uses the same SSA value (defensive: helper
             // returns target_f64 unchanged, but the chain is clearer when we
@@ -534,9 +539,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // return target itself (matching `Object.assign(t)` which is a
             // valid no-op-and-return-target form).
             if sources.is_empty() {
-                return Ok(target_box);
+                return Ok(acc);
             }
-            let mut acc = target_box;
             for src in sources {
                 let src_box = lower_expr(ctx, src)?;
                 acc = ctx.block().call(

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1202,6 +1202,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // Object.assign(target, source): mutate target with source's own
     // string-keyed AND symbol-keyed enumerable properties; returns target.
     // Refs #590.
+    module.declare_function("js_object_assign_validate_target", DOUBLE, &[DOUBLE]);
     module.declare_function("js_object_assign_one", DOUBLE, &[DOUBLE, DOUBLE]);
     // String extras (already in string.rs; expr.rs was stubbing or missing dispatch).
     module.declare_function("js_string_at", DOUBLE, &[I64, I32]);

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -601,50 +601,10 @@ pub(super) fn try_native_module_methods(
                         // `result === target` and orphans target's symbol-keyed
                         // properties since the side table is keyed by raw pointer.
                         //
-                        // Special case: no target at all (`Object.assign()`) is
-                        // a TypeError per spec; we coerce to an empty object literal.
-                        // Special case: `Object.assign({}, ...)` with a fresh empty
-                        // object-literal target — the user is explicitly asking for
-                        // a fresh object, so we keep the old ObjectSpread path
-                        // (matches `{...src1, ...src2}` semantics, no observable
-                        // difference and avoids regressing the no-spread fold below).
                         "assign" => {
-                            if args.is_empty() {
-                                return Ok(Ok(Expr::Object(Vec::new())));
-                            }
                             let mut iter = args.into_iter();
-                            let target = iter.next().unwrap();
+                            let target = iter.next().unwrap_or(Expr::Undefined);
                             let sources: Vec<Expr> = iter.collect();
-                            // `Object.assign({}, ...sources)` — fresh empty object as
-                            // target. Preserve the literal-friendly fast paths
-                            // (no_spread fold to plain Object, otherwise ObjectSpread)
-                            // since there's no pre-existing identity / class_id to
-                            // preserve and downstream codegen has more aggressive
-                            // inlining for these shapes.
-                            if matches!(&target, Expr::Object(props) if props.is_empty()) {
-                                let mut parts: Vec<(Option<String>, Expr)> = Vec::new();
-                                for arg in &sources {
-                                    match arg {
-                                        Expr::Object(props) => {
-                                            for (key, val) in props {
-                                                parts.push((Some(key.clone()), val.clone()));
-                                            }
-                                        }
-                                        _ => {
-                                            parts.push((None, arg.clone()));
-                                        }
-                                    }
-                                }
-                                let has_spread = parts.iter().any(|(k, _)| k.is_none());
-                                if !has_spread {
-                                    let static_props: Vec<(String, Expr)> = parts
-                                        .into_iter()
-                                        .filter_map(|(k, v)| k.map(|key| (key, v)))
-                                        .collect();
-                                    return Ok(Ok(Expr::Object(static_props)));
-                                }
-                                return Ok(Ok(Expr::ObjectSpread { parts }));
-                            }
                             // Real `Object.assign(target, ...sources)` — mutate target.
                             return Ok(Ok(Expr::ObjectAssign {
                                 target: Box::new(target),

--- a/crates/perry-hir/src/lower/expr_call/object_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/object_static.rs
@@ -62,7 +62,7 @@ pub(super) fn build_object_static_method_call(method: &str, args: Vec<Expr>) -> 
         "values" => Expr::ObjectValues(Box::new(iter.next().unwrap_or(Expr::Undefined))),
         "entries" => Expr::ObjectEntries(Box::new(iter.next().unwrap_or(Expr::Undefined))),
         "assign" => {
-            let target = iter.next().unwrap_or(Expr::Object(Vec::new()));
+            let target = iter.next().unwrap_or(Expr::Undefined);
             let sources: Vec<Expr> = iter.collect();
             Expr::ObjectAssign {
                 target: Box::new(target),

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -326,7 +326,7 @@ extern "C" fn ns_writable_final_callback_done(closure: *const ClosureHeader, err
         }
         return f64::from_bits(TAG_UNDEFINED);
     }
-    schedule_writable_finish(
+    schedule_writable_finish_then_transform_end(
         stream,
         if is_callable_value(callback) {
             Some(callback)
@@ -1192,7 +1192,7 @@ fn finish_stream(stream: f64, callback: Option<f64>) {
         set_pending_writable_finish_callback(stream, callback);
         return;
     }
-    schedule_writable_finish(stream, callback);
+    schedule_writable_finish_then_transform_end(stream, callback);
 }
 
 fn finish_stream_with_args(stream: f64, chunk: f64, encoding: f64, cb: f64) {

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -719,6 +719,17 @@ pub(super) fn schedule_writable_finish(stream: f64, callback: Option<f64>) {
     crate::builtins::js_queue_microtask(closure as i64);
 }
 
+pub(super) fn schedule_writable_finish_then_transform_end(stream: f64, callback: Option<f64>) {
+    schedule_writable_finish(stream, callback);
+    if is_transform_stream(stream)
+        && !has_truthy_hidden(stream, hidden_writable_final_pending_key())
+        && (has_truthy_hidden(stream, hidden_finish_scheduled_key())
+            || has_truthy_hidden(stream, hidden_finish_emitted_key()))
+    {
+        schedule_readable_end(stream);
+    }
+}
+
 pub(super) fn set_pending_writable_finish_callback(stream: f64, callback: Option<f64>) {
     let value = callback.unwrap_or_else(|| f64::from_bits(TAG_UNDEFINED));
     set_hidden_value(stream, hidden_writable_pending_finish_callback_key(), value);
@@ -743,7 +754,7 @@ pub(super) fn schedule_pending_writable_finish_if_ready(stream: f64) {
         return;
     }
     let callback = take_pending_writable_finish_callback(stream);
-    schedule_writable_finish(stream, callback);
+    schedule_writable_finish_then_transform_end(stream, callback);
 }
 
 pub(super) fn emit_readable_end_once(stream: f64) {

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -603,61 +603,89 @@ pub unsafe extern "C" fn js_object_copy_own_fields(dst_i64: i64, src_f64: f64) {
 /// fresh object, breaking `result === target` and orphaning target's
 /// symbol-keyed properties since the side table is keyed by raw pointer).
 ///
-/// Per spec, undefined/null target throws TypeError; here we silently no-op
-/// to match the rest of perry-runtime's permissive style. Non-object sources
-/// are skipped (matching `Object.assign(t, null)` / `Object.assign(t, 5)`
-/// which are spec-allowed).
+fn throw_object_assign_nullish_target() -> ! {
+    let message = "Cannot convert undefined or null to object";
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_object_assign_validate_target(target_f64: f64) -> f64 {
+    let target = JSValue::from_bits(target_f64.to_bits());
+    if target.is_undefined() || target.is_null() {
+        throw_object_assign_nullish_target();
+    }
+    target_f64
+}
+
+unsafe fn object_assign_set_string_key(
+    target: *mut ObjectHeader,
+    target_is_array: bool,
+    key_ptr: *const crate::StringHeader,
+    value_f64: f64,
+) {
+    if target_is_array {
+        // Routes integer-index keys to array element-set (extending length);
+        // non-numeric keys fall back to the object setter.
+        crate::array::js_array_set_string_key(
+            target as *mut crate::array::ArrayHeader,
+            key_ptr,
+            value_f64,
+        );
+    } else {
+        js_object_set_field_by_name(target, key_ptr, value_f64);
+    }
+}
+
+unsafe fn object_assign_string_source(
+    target: *mut ObjectHeader,
+    target_is_array: bool,
+    source_f64: f64,
+) {
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let Some((ptr, blen)) = crate::string::str_bytes_from_jsvalue(source_f64, &mut scratch) else {
+        return;
+    };
+    if ptr.is_null() {
+        return;
+    }
+    let bytes = std::slice::from_raw_parts(ptr, blen as usize);
+    let Ok(s) = std::str::from_utf8(bytes) else {
+        return;
+    };
+    for (idx, ch) in s.chars().enumerate() {
+        let key = idx.to_string();
+        let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+        let mut buf = [0u8; 4];
+        let ch_str = ch.encode_utf8(&mut buf);
+        let value_ptr = crate::string::js_string_from_bytes(ch_str.as_ptr(), ch_str.len() as u32);
+        let value_f64 = f64::from_bits(JSValue::string_ptr(value_ptr).bits());
+        object_assign_set_string_key(target, target_is_array, key_ptr, value_f64);
+    }
+}
+
+/// Per spec, undefined/null target throws TypeError. Non-object sources
+/// are skipped except string primitives, which expose enumerable index
+/// properties (`Object.assign({}, "ab") -> {0:"a",1:"b"}`).
 #[no_mangle]
 pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) -> f64 {
-    const POINTER_TAG_LOCAL: u64 = 0x7FFD_0000_0000_0000;
-    const POINTER_MASK_LOCAL: u64 = 0x0000_FFFF_FFFF_FFFF;
+    js_object_assign_validate_target(target_f64);
 
-    // Decode target pointer. Accept either NaN-boxed POINTER_TAG or a raw
-    // pointer value (defensive: callers occasionally pass i64-typed handles).
-    let tgt_bits = target_f64.to_bits();
-    let tgt_top16 = tgt_bits >> 48;
-    let tgt_raw = if tgt_top16 >= 0x7FF8 {
-        if tgt_top16 == 0x7FFC {
-            // undefined/null/bool — spec says throw TypeError; silently return.
-            return target_f64;
-        }
-        (tgt_bits & POINTER_MASK_LOCAL) as usize
-    } else {
-        tgt_bits as usize
-    };
+    let target_value = JSValue::from_bits(target_f64.to_bits());
+    if !target_value.is_pointer() {
+        return target_f64;
+    }
+    let tgt_raw = target_value.as_pointer::<u8>() as usize;
     // A real `ObjectHeader` is heap-allocated and #[repr(C)] with u64 /
     // pointer fields, so a valid object pointer is always 8-byte aligned.
-    // The tag / `< 0x10000` checks let an untagged, unaligned bit pattern
-    // through (observed on Windows: a non-pointer value reaches here as
-    // `source`, e.g. 0x1d81ff6950a). Dereferencing it as `*ObjectHeader`
-    // is a misaligned read — a hard abort under debug pointer-alignment
-    // checks, silent memory corruption (→ later GC out-of-bounds) in
-    // release. Treat a misaligned value as a non-object and skip, exactly
-    // the documented behaviour for `Object.assign(t, <non-object>)`.
+    // If a non-object target reaches here after nullish validation, skip
+    // mutation rather than dereferencing an invalid pointer.
     if tgt_raw < 0x10000 || tgt_raw % 8 != 0 {
         return target_f64;
     }
 
-    // Decode source pointer. Skip null/undefined/non-pointer sources.
-    let src_bits = source_f64.to_bits();
-    let src_top16 = src_bits >> 48;
-    let src_raw = if src_top16 >= 0x7FF8 {
-        if src_top16 == 0x7FFC {
-            return target_f64;
-        }
-        (src_bits & POINTER_MASK_LOCAL) as usize
-    } else {
-        src_bits as usize
-    };
-    // Same alignment guard as the target above — `src` is dereferenced at
-    // `(*src).keys_array` just below; an unaligned non-object source must
-    // be skipped, not dereferenced.
-    if src_raw < 0x10000 || src_raw % 8 != 0 || src_raw == tgt_raw {
-        return target_f64;
-    }
-
     let target = tgt_raw as *mut ObjectHeader;
-    let src = src_raw as *const ObjectHeader;
 
     // #2439: When the target is an array, an integer-keyed source property
     // (e.g. `Object.assign([1,2], {2:3})`) must grow the array's length, not
@@ -670,6 +698,33 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
             (target as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
         (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY
     };
+
+    let source = JSValue::from_bits(source_f64.to_bits());
+    if source.is_undefined() || source.is_null() {
+        return target_f64;
+    }
+    if source.is_any_string() {
+        object_assign_string_source(target, target_is_array, source_f64);
+        return target_f64;
+    }
+
+    // Decode source pointer. Skip null/undefined/non-pointer sources.
+    if !source.is_pointer() {
+        return target_f64;
+    }
+    let src_raw = source.as_pointer::<u8>() as usize;
+    // Same alignment guard as the target above — `src` is dereferenced at
+    // `(*src).keys_array` just below; an unaligned non-object source must
+    // be skipped, not dereferenced.
+    if src_raw < 0x10000
+        || src_raw % 8 != 0
+        || src_raw == tgt_raw
+        || crate::symbol::is_registered_symbol(src_raw)
+    {
+        return target_f64;
+    }
+
+    let src = src_raw as *const ObjectHeader;
 
     // 1) Copy own string-keyed enumerable properties from source to target,
     //    in source insertion order. Mirrors `js_object_copy_own_fields`.
@@ -700,20 +755,7 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
                 let v = js_object_get_field(src, i as u32);
                 f64::from_bits(v.bits())
             };
-            if target_is_array {
-                // Routes integer-index keys to array element-set (extending
-                // length); non-numeric keys fall back to the object setter.
-                // The array may reallocate on growth, but #233 forwarding
-                // means the original `target_f64` still resolves to the new
-                // head, so we keep returning it for object identity.
-                crate::array::js_array_set_string_key(
-                    target as *mut crate::array::ArrayHeader,
-                    key_ptr,
-                    field_f64,
-                );
-            } else {
-                js_object_set_field_by_name(target, key_ptr, field_f64);
-            }
+            object_assign_set_string_key(target, target_is_array, key_ptr, field_f64);
         }
     }
 
@@ -723,7 +765,7 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
     //    Mutex; holding the lock across the iteration would deadlock.
     let entries = crate::symbol::clone_symbol_entries_for_obj_ptr(src_raw);
     for (sym_ptr, value_bits) in entries {
-        let sym_f64 = f64::from_bits(POINTER_TAG_LOCAL | (sym_ptr as u64 & POINTER_MASK_LOCAL));
+        let sym_f64 = f64::from_bits(JSValue::pointer(sym_ptr as *const u8).bits());
         let value_f64 = f64::from_bits(value_bits);
         crate::symbol::js_object_set_symbol_property(target_f64, sym_f64, value_f64);
     }

--- a/test-parity/node-suite/object/assign-coercion-errors.ts
+++ b/test-parity/node-suite/object/assign-coercion-errors.ts
@@ -1,0 +1,30 @@
+function log(label: string, fn: () => unknown) {
+  try {
+    console.log(label, JSON.stringify(fn()));
+  } catch (err: any) {
+    console.log(label, "throw", err.name, err.message);
+  }
+}
+
+log("assign mutates target", () => {
+  const target: any = { a: 1 };
+  const result = Object.assign(target, { b: 2 });
+  return [target, result, target === result];
+});
+
+log("assign no args", () => Object.assign());
+
+log("assign null target", () => Object.assign(null as any, { a: 1 }));
+
+log("assign undefined target", () => Object.assign(undefined as any, { a: 1 }));
+
+log("assign null source", () => Object.assign({ a: 1 }, null, undefined, { b: 2 }));
+
+log("assign primitives", () => Object.assign({}, "ab", 5, true));
+
+log("assign symbols", () => {
+  const sym = Symbol("s");
+  const source: any = { [sym]: 1, a: 2 };
+  const output: any = Object.assign({}, source);
+  return [output.a, output[sym], Object.getOwnPropertySymbols(output).length];
+});


### PR DESCRIPTION
Fixes #2813.

## Summary
- route all `Object.assign` lowering through `Expr::ObjectAssign` so missing targets and fresh `{}` targets use the runtime validation/copy path
- throw `TypeError: Cannot convert undefined or null to object` for missing, `null`, and `undefined` targets
- skip nullish and non-string primitive sources, and copy enumerable string-index properties from string primitive sources
- preserve target mutation/identity and symbol-key copying through the runtime helper

## Parity
- Added `test-parity/node-suite/object/assign-coercion-errors.ts`
- Pre-fix report: `/root/perry-worktrees/perry-node-compat-2813/test-parity/reports/parity_report_20260530_003513.json`
- Post-fix report: `/root/perry-worktrees/perry-node-compat-2813/test-parity/reports/parity_report_20260530_005032.json`

## Verification
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH node --experimental-strip-types test-parity/node-suite/object/assign-coercion-errors.ts`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module object --filter assign-coercion-errors`
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `RUSTC_WRAPPER= cargo check -p perry-hir -p perry-codegen -p perry-runtime`
- `RUSTC_WRAPPER= cargo test -p perry-runtime object -- --test-threads=1`
