### PR TITLE
Implement Error.captureStackTrace

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -590,6 +590,30 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // arrives. Other property shapes still fall through to
             // `0.0`.
             if matches!(object.as_ref(), Expr::GlobalGet(_)) {
+                if property == "captureStackTrace" {
+                    let error_idx = ctx.strings.intern("Error");
+                    let error_bytes_global =
+                        format!("@{}", ctx.strings.entry(error_idx).bytes_global);
+                    let error_len = "Error".len().to_string();
+                    let error_ctor = ctx.block().call(
+                        DOUBLE,
+                        "js_get_global_this_builtin_value",
+                        &[(PTR, &error_bytes_global), (I64, &error_len)],
+                    );
+                    let key_idx = ctx.strings.intern(property);
+                    let key_handle_global =
+                        format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                    let blk = ctx.block();
+                    let ctor_handle = unbox_to_i64(blk, &error_ctor);
+                    let key_box = blk.load(DOUBLE, &key_handle_global);
+                    let key_bits = blk.bitcast_double_to_i64(&key_box);
+                    let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
+                    return Ok(blk.call(
+                        DOUBLE,
+                        "js_object_get_field_by_name_f64",
+                        &[(I64, &ctor_handle), (I64, &key_raw)],
+                    ));
+                }
                 if matches!(
                     property.as_str(),
                     "Console"

--- a/crates/perry-runtime/src/error.rs
+++ b/crates/perry-runtime/src/error.rs
@@ -254,6 +254,46 @@ pub extern "C" fn js_error_get_stack(error: *mut ErrorHeader) -> *mut StringHead
     }
 }
 
+fn throw_capture_stack_trace_target_type_error() -> ! {
+    let message = b"The \"targetObject\" argument must be an object";
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+/// `Error.captureStackTrace(target[, constructorOpt])`.
+///
+/// Perry's stack strings are intentionally coarse today; this helper installs
+/// the same non-enumerable `stack` data property shape Node exposes and
+/// preserves the invalid-target TypeError contract.
+#[no_mangle]
+pub extern "C" fn js_error_capture_stack_trace(target: f64, _constructor_opt: f64) -> f64 {
+    let target_value = crate::value::JSValue::from_bits(target.to_bits());
+    if !target_value.is_pointer() {
+        throw_capture_stack_trace_target_type_error();
+    }
+
+    unsafe {
+        let target_ptr = target_value.as_pointer::<crate::object::ObjectHeader>()
+            as *mut crate::object::ObjectHeader;
+        if target_ptr.is_null() || !crate::object::is_valid_obj_ptr(target_ptr as *const u8) {
+            throw_capture_stack_trace_target_type_error();
+        }
+
+        let stack = make_stack("Error", "");
+        let key = js_string_from_bytes(b"stack".as_ptr(), 5);
+        let value = crate::value::js_nanbox_string(stack as i64);
+        crate::object::js_object_set_field_by_name(target_ptr, key, value);
+        crate::object::set_property_attrs(
+            target_ptr as usize,
+            "stack".to_string(),
+            crate::object::PropertyAttrs::new(true, false, true),
+        );
+    }
+
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
 /// Read a `StringHeader`'s UTF-8 bytes into an owned `String` (lossy on
 /// invalid UTF-8). Empty on null.
 unsafe fn read_string_header_owned(ptr: *const StringHeader) -> String {

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -228,6 +228,14 @@ extern "C" fn global_this_btoa_thunk(
     crate::value::js_nanbox_string(encoded as i64)
 }
 
+extern "C" fn global_this_error_capture_stack_trace_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    target: f64,
+    constructor_opt: f64,
+) -> f64 {
+    crate::error::js_error_capture_stack_trace(target, constructor_opt)
+}
+
 fn global_this_rest_array_values(rest: f64) -> Vec<f64> {
     let value = crate::value::JSValue::from_bits(rest.to_bits());
     if !value.is_pointer() {
@@ -697,6 +705,9 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         if name == "File" {
             super::native_module::set_bound_native_closure_name(closure_ptr, name);
         }
+        if name == "Error" {
+            install_error_static_methods(closure_ptr);
+        }
         // Stash `prototype` on the closure's dynamic-prop side table.
         // `js_object_set_field_by_name` detects the CLOSURE_MAGIC tag
         // at offset 12 and dispatches into `closure_set_dynamic_prop`
@@ -810,6 +821,28 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         let pval = crate::perf_hooks::performance_namespace();
         js_object_set_field_by_name(singleton, pkey, pval);
     }
+}
+
+fn install_error_static_methods(ctor: *mut crate::closure::ClosureHeader) {
+    if ctor.is_null() {
+        return;
+    }
+    let func_ptr = global_this_error_capture_stack_trace_thunk as *const u8;
+    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+    if closure.is_null() {
+        return;
+    }
+    crate::closure::js_register_closure_arity(func_ptr, 2);
+    super::native_module::set_bound_native_closure_name(closure, "captureStackTrace");
+
+    let key = crate::string::js_string_from_bytes(b"captureStackTrace".as_ptr(), 17);
+    let value = crate::value::js_nanbox_pointer(closure as i64);
+    js_object_set_field_by_name(ctor as *mut ObjectHeader, key, value);
+    super::set_builtin_property_attrs(
+        ctor as usize,
+        "captureStackTrace".to_string(),
+        super::PropertyAttrs::new(true, false, true),
+    );
 }
 
 /// Install a method on a prototype object as a callable closure value with

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1840,20 +1840,43 @@ pub unsafe extern "C" fn js_native_call_method(
         }
 
         // `obj.propertyIsEnumerable(key)` — same shape as
-        // `hasOwnProperty`. Spec says true for own enumerable
-        // properties (the typical case for object literals). Without
-        // walking the receiver's keys, we approximate as
-        // `truthy receiver → true` — matches Node for ramda's
-        // `keys.js` IIFE (`!{toString:null}.propertyIsEnumerable('toString')`
-        // expects `true`, so `hasEnumBug` resolves to `false`).
-        // Arguments-like receivers also return true here, which
-        // matches the legacy non-Safari behavior ramda's IIFE checks
-        // against.
+        // `hasOwnProperty`, but descriptor-aware for ordinary objects so
+        // non-enumerable properties installed by Error.captureStackTrace /
+        // Object.defineProperty report false.
         "propertyIsEnumerable" => {
             if jsval.is_undefined() || jsval.is_null() {
                 return f64::from_bits(JSValue::bool(false).bits());
             }
-            return f64::from_bits(JSValue::bool(true).bits());
+            if !jsval.is_pointer() {
+                return f64::from_bits(JSValue::bool(false).bits());
+            }
+            let key_value = if args_len >= 1 && !args_ptr.is_null() {
+                *args_ptr
+            } else {
+                f64::from_bits(crate::value::TAG_UNDEFINED)
+            };
+            let key_str = crate::builtins::js_string_coerce(key_value);
+            if key_str.is_null() {
+                return f64::from_bits(JSValue::bool(false).bits());
+            }
+            let obj_ptr = jsval.as_pointer::<ObjectHeader>();
+            if obj_ptr.is_null() || !is_valid_obj_ptr(obj_ptr as *const u8) {
+                return f64::from_bits(JSValue::bool(false).bits());
+            }
+            if !own_key_present(obj_ptr as *mut ObjectHeader, key_str) {
+                return f64::from_bits(JSValue::bool(false).bits());
+            }
+            let name_ptr = (key_str as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+            let name_len = (*key_str).byte_len as usize;
+            let key_name = match std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len))
+            {
+                Ok(s) => s,
+                Err(_) => return f64::from_bits(JSValue::bool(false).bits()),
+            };
+            let enumerable = get_property_attrs(obj_ptr as usize, &key_name)
+                .map(|attrs| attrs.enumerable())
+                .unwrap_or(true);
+            return f64::from_bits(JSValue::bool(enumerable).bits());
         }
 
         // `prim.isPrototypeOf(v)` — true iff the receiver appears in `v`'s

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -990,7 +990,10 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
 }
 
 /// Helper: does `key` appear in `obj.keys_array`?
-unsafe fn own_key_present(obj: *mut ObjectHeader, key: *const crate::StringHeader) -> bool {
+pub(crate) unsafe fn own_key_present(
+    obj: *mut ObjectHeader,
+    key: *const crate::StringHeader,
+) -> bool {
     if obj.is_null() || (obj as usize) < 0x10000 || key.is_null() {
         return false;
     }

--- a/test-parity/node-suite/globals/error-capture-stack-trace.ts
+++ b/test-parity/node-suite/globals/error-capture-stack-trace.ts
@@ -1,0 +1,25 @@
+function show(label: string, fn: () => unknown) {
+  try {
+    console.log(label, fn());
+  } catch (err: any) {
+    console.log(label, "throw", err?.name);
+  }
+}
+
+const obj: any = {};
+console.log("typeof:", typeof Error.captureStackTrace);
+Error.captureStackTrace(obj);
+console.log("stack string:", typeof obj.stack === "string");
+console.log("direct non-enum:", obj.propertyIsEnumerable("stack"));
+console.log("keys hidden:", Object.keys(obj).includes("stack"));
+console.log("undefined enum:", ({ x: undefined } as any).propertyIsEnumerable("x"));
+
+function factory() {
+  const out: any = {};
+  Error.captureStackTrace(out, factory);
+  return String(out.stack).includes("factory");
+}
+console.log("filtered:", factory());
+
+show("null target:", () => Error.captureStackTrace(null as any));
+show("number target:", () => Error.captureStackTrace(1 as any));


### PR DESCRIPTION
## Summary
- adds Error.captureStackTrace as a static Error helper on globalThis
- installs a non-enumerable stack data property and throws TypeError for invalid targets
- tightens propertyIsEnumerable for ordinary own properties and adds a Node parity fixture

Closes #2839

## Validation
- PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" node --experimental-strip-types test-parity/node-suite/globals/error-capture-stack-trace.ts
- env RUSTC_WRAPPER= cargo check -p perry-codegen -p perry-runtime
- env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module globals --filter error-capture-stack-trace
- cargo fmt --all -- --check
- git diff --check
- jq empty test-parity/known_failures.json test-parity/threshold.json
- ./scripts/check_file_size.sh