### PR TITLE
fix(runtime): validate WeakRef and FinalizationRegistry args

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
@@ -391,27 +391,23 @@ pub(super) fn try_url_date_weakref_instance(
                     let registry_id = ctx.lookup_local(&recv_name).unwrap_or(0);
                     match method_name {
                         "register" => {
-                            if args.len() >= 2 {
-                                let mut iter = args.into_iter();
-                                let target = iter.next().unwrap();
-                                let held = iter.next().unwrap();
-                                let token = iter.next().map(Box::new);
-                                return Ok(Ok(Expr::FinalizationRegistryRegister {
-                                    registry: Box::new(Expr::LocalGet(registry_id)),
-                                    target: Box::new(target),
-                                    held: Box::new(held),
-                                    token,
-                                }));
-                            }
+                            let mut iter = args.into_iter();
+                            let target = iter.next().unwrap_or(Expr::Undefined);
+                            let held = iter.next().unwrap_or(Expr::Undefined);
+                            let token = iter.next().map(Box::new);
+                            return Ok(Ok(Expr::FinalizationRegistryRegister {
+                                registry: Box::new(Expr::LocalGet(registry_id)),
+                                target: Box::new(target),
+                                held: Box::new(held),
+                                token,
+                            }));
                         }
                         "unregister" => {
-                            if !args.is_empty() {
-                                let token = args.into_iter().next().unwrap();
-                                return Ok(Ok(Expr::FinalizationRegistryUnregister {
-                                    registry: Box::new(Expr::LocalGet(registry_id)),
-                                    token: Box::new(token),
-                                }));
-                            }
+                            let token = args.into_iter().next().unwrap_or(Expr::Undefined);
+                            return Ok(Ok(Expr::FinalizationRegistryUnregister {
+                                registry: Box::new(Expr::LocalGet(registry_id)),
+                                token: Box::new(token),
+                            }));
                         }
                         _ => {}
                     }

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -19,7 +19,22 @@ use crate::lower_types::extract_ts_type_with_ctx;
 
 use super::{lower_expr, LoweringContext};
 
+fn peel_new_callee(mut expr: &ast::Expr) -> &ast::Expr {
+    loop {
+        match expr {
+            ast::Expr::Paren(paren) => expr = paren.expr.as_ref(),
+            ast::Expr::TsAs(ts_as) => expr = ts_as.expr.as_ref(),
+            ast::Expr::TsTypeAssertion(ts_ta) => expr = ts_ta.expr.as_ref(),
+            ast::Expr::TsNonNull(ts_non_null) => expr = ts_non_null.expr.as_ref(),
+            ast::Expr::TsConstAssertion(ts_const) => expr = ts_const.expr.as_ref(),
+            _ => return expr,
+        }
+    }
+}
+
 pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> Result<Expr> {
+    let callee_expr = peel_new_callee(new_expr.callee.as_ref());
+
     // Issue #422: `new net.Socket()` over a `net` module alias. The
     // generic Member-callee path below would lower this to
     // `Expr::NewDynamic`, whose codegen fallback returns an empty
@@ -30,7 +45,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
     // pointing at `js_net_socket_alloc`, and the let-stmt machinery in
     // `lower.rs` registers the result as a `("net", "Socket")` native
     // instance so subsequent method calls dispatch correctly.
-    if let ast::Expr::Member(member) = new_expr.callee.as_ref() {
+    if let ast::Expr::Member(member) = callee_expr {
         if let (ast::Expr::Ident(obj_ident), ast::MemberProp::Ident(prop_ident)) =
             (member.obj.as_ref(), &member.prop)
         {
@@ -220,7 +235,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
     }
 
     // Try to extract class name from callee
-    match new_expr.callee.as_ref() {
+    match callee_expr {
         ast::Expr::Ident(ident) => {
             let class_name = ident.sym.to_string();
 
@@ -679,10 +694,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                     })
                     .transpose()?
                     .unwrap_or_default();
-                let target = args
-                    .into_iter()
-                    .next()
-                    .ok_or_else(|| anyhow!("WeakRef constructor requires 1 argument"))?;
+                let target = args.into_iter().next().unwrap_or(Expr::Undefined);
                 return Ok(Expr::WeakRefNew(Box::new(target)));
             }
 
@@ -700,9 +712,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                     })
                     .transpose()?
                     .unwrap_or_default();
-                let cb = args.into_iter().next().ok_or_else(|| {
-                    anyhow!("FinalizationRegistry constructor requires a callback argument")
-                })?;
+                let cb = args.into_iter().next().unwrap_or(Expr::Undefined);
                 return Ok(Expr::FinalizationRegistryNew(Box::new(cb)));
             }
             // Handle TextEncoder constructor
@@ -873,7 +883,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
         // Non-identifier callee (e.g., new (condition ? A : B)() or new someVar())
         _ => {
             // Check for class expressions: new (class extends X { ... })()
-            let class_expr_opt = match new_expr.callee.as_ref() {
+            let class_expr_opt = match callee_expr {
                 ast::Expr::Class(ce) => Some(ce),
                 ast::Expr::Paren(paren) => match paren.expr.as_ref() {
                     ast::Expr::Class(ce) => Some(ce),
@@ -912,7 +922,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 });
             }
 
-            let callee = Box::new(lower_expr(ctx, &new_expr.callee)?);
+            let callee = Box::new(lower_expr(ctx, callee_expr)?);
             let args = new_expr
                 .args
                 .as_ref()

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -180,6 +180,19 @@ pub fn is_registered_symbol(ptr: usize) -> bool {
     guard.as_ref().is_some_and(|s| s.contains(&ptr))
 }
 
+/// True for symbols created through `Symbol.for(...)`. These are known symbols
+/// too, but WeakRef / FinalizationRegistry must reject them while accepting
+/// fresh and well-known symbols.
+pub(crate) fn is_global_registered_symbol(ptr: usize) -> bool {
+    if !is_registered_symbol(ptr) {
+        return false;
+    }
+    unsafe {
+        let sym = ptr as *const SymbolHeader;
+        !sym.is_null() && (*sym).magic == SYMBOL_MAGIC && (*sym).registered != 0
+    }
+}
+
 // Side-table for symbol-keyed properties on objects. The object pointer is
 // the key (as usize); the value is a list of (symbol_ptr, value_bits) pairs.
 // Storage is intentionally simple (linear scan per lookup) — symbol-keyed

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -17,7 +17,7 @@ use crate::array::{
 use crate::object::{
     js_object_alloc_with_shape, js_object_get_field_by_name, js_object_set_field, ObjectHeader,
 };
-use crate::value::{js_nanbox_get_pointer, JSValue};
+use crate::value::{js_nanbox_get_pointer, JSValue, POINTER_MASK};
 
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
@@ -89,12 +89,54 @@ pub(crate) fn weak_collection_entries(obj: *const ObjectHeader) -> Vec<(f64, f64
     }
 }
 
+fn weakref_type_error(message: &str) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    let err_val = JSValue::pointer(err as *const u8);
+    crate::exception::js_throw(f64::from_bits(err_val.bits()))
+}
+
+fn is_valid_weak_target(value: f64) -> bool {
+    if crate::value::is_js_handle(value) {
+        return true;
+    }
+
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return false;
+    }
+
+    let ptr = (jv.bits() & POINTER_MASK) as usize;
+    ptr != 0 && !crate::symbol::is_global_registered_symbol(ptr)
+}
+
+fn is_undefined_value(value: f64) -> bool {
+    JSValue::from_bits(value.to_bits()).is_undefined()
+}
+
+fn is_callable_value(value: f64) -> bool {
+    if crate::value::is_js_handle(value) && crate::value::js_handle_is_function(value) {
+        return true;
+    }
+
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return false;
+    }
+
+    crate::closure::is_closure_ptr((jv.bits() & POINTER_MASK) as usize)
+}
+
 /// Allocate a `WeakRef` wrapper object that strongly holds the target value
 /// in a single sentinel-named field. #1766: the field name uses a `__perry_`
 /// prefix so user code reading `(wr as any).target` returns `undefined` like
 /// Node, instead of leaking the internal storage slot.
 #[no_mangle]
 pub extern "C" fn js_weakref_new(target: f64) -> *mut ObjectHeader {
+    if !is_valid_weak_target(target) {
+        weakref_type_error("WeakRef: invalid target");
+    }
+
     let packed = b"__perry_wr_target\0";
     let obj = js_object_alloc_with_shape(WEAKREF_SHAPE_ID, 1, packed.as_ptr(), packed.len() as u32);
     js_object_set_field(obj, 0, JSValue::from_bits(target.to_bits()));
@@ -128,6 +170,10 @@ pub extern "C" fn js_weakref_deref(weakref: f64) -> f64 {
 /// 2-element `[token, held]` array used by `unregister(token)` to find matches.
 #[no_mangle]
 pub extern "C" fn js_finreg_new(callback: f64) -> *mut ObjectHeader {
+    if !is_callable_value(callback) {
+        weakref_type_error("FinalizationRegistry: cleanup must be callable");
+    }
+
     // #1766: sentinel-name internal slots so `(fr as any).callback` /
     // `.entries` return `undefined` like Node.
     let packed = b"__perry_fr_callback\0__perry_fr_entries\0";
@@ -147,7 +193,19 @@ pub extern "C" fn js_finreg_new(callback: f64) -> *mut ObjectHeader {
 /// provided, we still record an `[undefined, held]` pair so the registration count
 /// is correct (but it can never be unregistered).
 #[no_mangle]
-pub extern "C" fn js_finreg_register(registry: f64, _target: f64, held: f64, token: f64) -> f64 {
+pub extern "C" fn js_finreg_register(registry: f64, target: f64, held: f64, token: f64) -> f64 {
+    if !is_valid_weak_target(target) {
+        weakref_type_error("FinalizationRegistry.prototype.register: invalid target");
+    }
+    if target.to_bits() == held.to_bits() {
+        weakref_type_error(
+            "FinalizationRegistry.prototype.register: target and holdings must not be same",
+        );
+    }
+    if !is_undefined_value(token) && !is_valid_weak_target(token) {
+        weakref_type_error("Invalid unregisterToken");
+    }
+
     let reg_ptr = js_nanbox_get_pointer(registry) as *mut ObjectHeader;
     if reg_ptr.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
@@ -173,6 +231,10 @@ pub extern "C" fn js_finreg_register(registry: f64, _target: f64, held: f64, tok
 /// references — both sides are stored as POINTER_TAG-tagged f64 values.
 #[no_mangle]
 pub extern "C" fn js_finreg_unregister(registry: f64, token: f64) -> f64 {
+    if !is_valid_weak_target(token) {
+        weakref_type_error("Invalid unregisterToken");
+    }
+
     let reg_ptr = js_nanbox_get_pointer(registry) as *mut ObjectHeader;
     if reg_ptr.is_null() {
         return f64::from_bits(TAG_FALSE);
@@ -536,7 +598,9 @@ mod tests {
             Some("WeakSet { <items unknown> }")
         );
         // WeakRef / FinalizationRegistry have no items placeholder.
-        let wr = js_weakref_new(f64::from_bits(TAG_UNDEFINED));
+        let target = crate::object::js_object_alloc(0, 0);
+        let target_val = f64::from_bits(JSValue::pointer(target as *const u8).bits());
+        let wr = js_weakref_new(target_val);
         assert_eq!(weak_wrapper_inspect_label(wr), Some("WeakRef {}"));
     }
 }

--- a/test-parity/node-suite/globals/weakref-finalization-validation.ts
+++ b/test-parity/node-suite/globals/weakref-finalization-validation.ts
@@ -1,0 +1,29 @@
+function show(label: string, fn: () => unknown) {
+  try {
+    console.log(label + ":", fn());
+  } catch (err: any) {
+    console.log(label + ":", err?.name);
+  }
+}
+
+const weakTarget = {};
+const weakRef = new WeakRef(weakTarget);
+show("weakref object", () => weakRef.deref() === weakTarget);
+show("weakref primitive", () => new WeakRef(1 as any));
+show("weakref no arg", () => new (WeakRef as any)());
+
+show("fr callback", () => !!new FinalizationRegistry(() => {}));
+show("fr callback primitive", () => new FinalizationRegistry(1 as any));
+show("fr no callback", () => new (FinalizationRegistry as any)());
+
+const fr = new FinalizationRegistry(() => {});
+show("fr primitive target", () => fr.register(1 as any, "held"));
+
+const obj = {};
+show("fr held same target", () => fr.register(obj, obj));
+show("fr primitive register token", () => fr.register(obj, "held", 1 as any));
+show("fr primitive token", () => fr.unregister(1 as any));
+
+const token = {};
+fr.register(obj, "held", token);
+show("fr object token", () => fr.unregister(token));


### PR DESCRIPTION
## Summary
- route omitted WeakRef / FinalizationRegistry constructor args through runtime validation instead of lowering errors
- validate WeakRef targets plus FinalizationRegistry cleanup callbacks, targets, held-value identity, and register/unregister tokens with catchable TypeErrors
- add a Node parity fixture for the validation cases

Closes #2834.

## Tests
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH node --experimental-strip-types test-parity/node-suite/globals/weakref-finalization-validation.ts`
- pre-fix reproduction: `/root/perry-worktrees/perry-node-compat-2811/target/release/perry test-parity/node-suite/globals/weakref-finalization-validation.ts -o /tmp/perry_weakref_validation_2834_pre` failed with `WeakRef constructor requires 1 argument`
- `RUSTC_WRAPPER= cargo check -p perry-hir -p perry-runtime`
- `RUSTC_WRAPPER= cargo test -p perry-runtime weak_collections_inspect_with_items_unknown`
- `RUSTC_WRAPPER= cargo build --release -p perry`
- `target/release/perry test-parity/node-suite/globals/weakref-finalization-validation.ts -o /tmp/perry_weakref_validation_2834_post`
- `/tmp/perry_weakref_validation_2834_post`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module globals --filter weakref-finalization-validation`
- `cargo fmt --all -- --check`
- `git diff --check` and `git diff --check --cached`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `./scripts/check_file_size.sh`
- `rg -n "^(<<<<<<<|>>>>>>>)"`
