### PR TITLE
fix(promise): implement Promise.try

### DIFF
--- a/crates/perry-codegen/src/lower_call/console_promise.rs
+++ b/crates/perry-codegen/src/lower_call/console_promise.rs
@@ -552,6 +552,32 @@ pub fn try_lower_promise_static_call(
                     let handle = blk.call(I64, "js_promise_with_resolvers", &[]);
                     return Ok(Some(nanbox_pointer_inline(blk, &handle)));
                 }
+                "try" => {
+                    let callback = if args.is_empty() {
+                        double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                    } else {
+                        lower_expr(ctx, &args[0])?
+                    };
+                    let extra_count = args.len().saturating_sub(1);
+                    let mut current_arr =
+                        ctx.block()
+                            .call(I64, "js_array_alloc", &[(I32, &extra_count.to_string())]);
+                    for arg in args.iter().skip(1) {
+                        let value = lower_expr(ctx, arg)?;
+                        current_arr = ctx.block().call(
+                            I64,
+                            "js_array_push_f64",
+                            &[(I64, &current_arr), (DOUBLE, &value)],
+                        );
+                    }
+                    let blk = ctx.block();
+                    let handle = blk.call(
+                        I64,
+                        "js_promise_try",
+                        &[(DOUBLE, &callback), (I64, &current_arr)],
+                    );
+                    return Ok(Some(nanbox_pointer_inline(blk, &handle)));
+                }
                 _ => {}
             }
         }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1677,6 +1677,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_promise_any", I64, &[I64]);
     module.declare_function("js_promise_all_settled", I64, &[I64]);
     module.declare_function("js_promise_with_resolvers", I64, &[]);
+    module.declare_function("js_promise_try", I64, &[DOUBLE, I64]);
     module.declare_function("js_array_unshift_f64", I64, &[I64, DOUBLE]);
     module.declare_function("js_array_entries", I64, &[I64]);
     module.declare_function("js_array_keys", I64, &[I64]);

--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -3,6 +3,7 @@
 //! assimilation, the scheduled-resolve queue, and `is_promise` probes.
 
 use super::*;
+use std::os::raw::c_int;
 
 #[derive(Clone, Copy)]
 pub(super) struct PromiseAllState {
@@ -79,6 +80,88 @@ pub extern "C" fn js_promise_rejected(reason: f64) -> *mut Promise {
     let promise = js_promise_new();
     js_promise_reject(promise, reason);
     promise
+}
+
+fn string_header_to_string(ptr: *const crate::string::StringHeader) -> String {
+    if ptr.is_null() || (ptr as usize) < 0x10000 {
+        return String::new();
+    }
+    unsafe {
+        let len = (*ptr).byte_len as usize;
+        if len > 1 << 30 {
+            return String::new();
+        }
+        let bytes_ptr = (ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+        let bytes = std::slice::from_raw_parts(bytes_ptr, len);
+        String::from_utf8_lossy(bytes).into_owned()
+    }
+}
+
+fn promise_try_type_error_value(callback: f64) -> f64 {
+    let type_name = string_header_to_string(crate::builtins::js_value_typeof(callback));
+    let rendered = string_header_to_string(crate::value::js_jsvalue_to_string(callback));
+    let message = match (type_name.as_str(), rendered.as_str()) {
+        ("", "") => "value is not a function".to_string(),
+        (_, "") => format!("{type_name} is not a function"),
+        ("undefined", _) => "undefined is not a function".to_string(),
+        _ => format!("{type_name} {rendered} is not a function"),
+    };
+    let message_ptr = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let error = crate::error::js_typeerror_new(message_ptr);
+    let bits = crate::value::JSValue::pointer(error as *const u8).bits();
+    f64::from_bits(bits)
+}
+
+fn promise_try_closure_ptr(callback: f64) -> Option<*const crate::closure::ClosureHeader> {
+    let ptr = crate::value::js_nanbox_get_pointer(callback) as usize;
+    if ptr < 0x100000 {
+        return None;
+    }
+    crate::closure::is_closure_ptr(ptr).then_some(ptr as *const crate::closure::ClosureHeader)
+}
+
+fn promise_try_call(callback: f64, args_ptr: *const f64, args_len: usize) -> Result<f64, f64> {
+    let Some(closure) = promise_try_closure_ptr(callback) else {
+        return Err(promise_try_type_error_value(callback));
+    };
+
+    let trap_buf = crate::exception::js_try_push();
+    let jumped = unsafe { crate::ffi::setjmp::setjmp(trap_buf as *mut c_int) };
+    let result = if jumped == 0 {
+        let value = unsafe {
+            crate::closure::js_closure_call_array(closure as i64, args_ptr, args_len as i64)
+        };
+        Ok(value)
+    } else {
+        let exc = crate::exception::js_get_exception();
+        crate::exception::js_clear_exception();
+        Err(exc)
+    };
+    crate::exception::js_try_end();
+    result
+}
+
+/// `Promise.try(fn, ...args)`: call `fn` with forwarded args and normalize the
+/// result or synchronous throw into a Promise.
+#[no_mangle]
+pub extern "C" fn js_promise_try(
+    callback: f64,
+    args: *const crate::array::ArrayHeader,
+) -> *mut Promise {
+    let (args_ptr, args_len) = if args.is_null() {
+        (std::ptr::null(), 0)
+    } else {
+        let len = unsafe { (*args).length as usize };
+        let data = unsafe {
+            (args as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const f64
+        };
+        (data, len)
+    };
+
+    match promise_try_call(callback, args_ptr, args_len) {
+        Ok(value) => js_promise_resolved(value),
+        Err(reason) => js_promise_rejected(reason),
+    }
 }
 
 /// Check if a value is a promise (by checking if it's a valid pointer)

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -37,7 +37,7 @@ pub use async_step::{
 pub use combinators::{
     js_assimilate_thenable, js_await_any_promise, js_is_promise, js_promise_all,
     js_promise_all_settled, js_promise_any, js_promise_new_with_executor, js_promise_race,
-    js_promise_rejected, js_promise_schedule_resolve, js_value_is_promise,
+    js_promise_rejected, js_promise_schedule_resolve, js_promise_try, js_value_is_promise,
 };
 pub use microtasks::js_promise_run_microtasks;
 pub use native_async::{

--- a/test-parity/node-suite/globals/promise-try.ts
+++ b/test-parity/node-suite/globals/promise-try.ts
@@ -1,0 +1,16 @@
+function show(label: string, promise: Promise<unknown>) {
+  promise.then(
+    (value) => console.log(label + ":fulfilled:" + String(value)),
+    (error: any) => console.log(label + ":rejected:" + error.name + ":" + error.message),
+  );
+}
+
+show("return", Promise.try(() => 42));
+show("args", Promise.try((a: number, b: number) => a + b, 2, 3));
+show("throw", Promise.try(() => {
+  throw new TypeError("boom");
+}));
+show("nonfn", Promise.try(123 as any));
+console.log("after scheduling");
+
+await Promise.resolve();


### PR DESCRIPTION
## Summary
- add `Promise.try(fn, ...args)` static-call lowering
- add a runtime helper that forwards args, fulfills with callback return values, and rejects on thrown or non-callable callbacks
- add focused Node parity coverage for return, forwarded args, thrown TypeError, and non-callable rejection

Fixes #2873.

## Validation
- `PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" node --experimental-strip-types test-parity/node-suite/globals/promise-try.ts`
- pre-fix focused parity failed as expected: `test-parity/reports/parity_report_20260530_021452.json`
- `env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module globals --filter promise-try` (`test-parity/reports/parity_report_20260530_021958.json`)
- `env RUSTC_WRAPPER= cargo check -p perry-codegen -p perry-runtime`
- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check`
- `jq empty test-parity/reports/parity_report_20260530_021452.json test-parity/reports/parity_report_20260530_021958.json`

`./scripts/check_file_size.sh` still fails on the pre-existing `crates/perry-runtime/src/node_stream_readwrite.rs` 2001-line limit breach present on `origin/main`; this PR does not touch that file.