### PR TITLE
runtime: implement Object.prototype.isPrototypeOf

### DIFF
--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -412,6 +412,16 @@ extern "C" fn object_prototype_to_string_thunk(
     f64::from_bits(crate::js_nanbox_string(s as i64).to_bits())
 }
 
+extern "C" fn object_prototype_is_prototype_of_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    f64::from_bits(
+        JSValue::bool(unsafe { super::js_object_is_prototype_of_value(this_value, value) }).bits(),
+    )
+}
+
 /// Thunk for `Array.prototype.slice` exposed as a real callable closure
 /// value. Reads the array receiver from `IMPLICIT_THIS` (set by
 /// `Function.prototype.call`/`.apply`'s runtime arm in
@@ -978,7 +988,21 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
                 object_prototype_to_string_thunk as *const u8,
                 0,
             );
-            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+            install_proto_method(
+                proto_obj,
+                "isPrototypeOf",
+                object_prototype_is_prototype_of_thunk as *const u8,
+                1,
+            );
+            install_noop_proto_methods(
+                proto_obj,
+                &[
+                    ("hasOwnProperty", 1),
+                    ("propertyIsEnumerable", 1),
+                    ("toLocaleString", 0),
+                    ("valueOf", 0),
+                ],
+            );
         }
         "Function" => {
             install_noop_proto_methods(

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -167,6 +167,120 @@ fn root_string_arg_handle<'scope>(
     }
 }
 
+#[inline]
+unsafe fn gc_pointer_and_type_from_value(value: f64) -> Option<(*const u8, u8)> {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if !jsval.is_pointer() {
+        return None;
+    }
+    let ptr = jsval.as_pointer::<u8>();
+    if ptr.is_null()
+        || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000
+        || !is_valid_obj_ptr(ptr as *const u8)
+    {
+        return None;
+    }
+    let addr = ptr as usize;
+    if crate::set::is_registered_set(addr)
+        || crate::map::is_registered_map(addr)
+        || crate::regex::is_regex_pointer(ptr as *const u8)
+        || crate::symbol::is_registered_symbol(addr)
+    {
+        return None;
+    }
+    let gc_header = (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    Some((ptr, (*gc_header).obj_type))
+}
+
+#[inline]
+unsafe fn object_ptr_from_value(value: f64) -> Option<*mut ObjectHeader> {
+    let (ptr, gc_type) = gc_pointer_and_type_from_value(value)?;
+    if gc_type == crate::gc::GC_TYPE_OBJECT {
+        Some(ptr as *mut ObjectHeader)
+    } else {
+        None
+    }
+}
+
+/// Shared implementation for `Object.prototype.isPrototypeOf`.
+pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64) -> bool {
+    let receiver_ptr = match object_ptr_from_value(receiver) {
+        Some(ptr) => ptr,
+        None => return false,
+    };
+
+    let target_jsval = JSValue::from_bits(target.to_bits());
+    if !target_jsval.is_pointer() {
+        return false;
+    }
+
+    if let Some(target_ptr) = object_ptr_from_value(target) {
+        let mut cid = crate::object::js_object_get_class_id(target_ptr as *const ObjectHeader);
+        let mut depth = 0usize;
+        let mut visited: [u32; 32] = [0; 32];
+        while cid != 0 && depth < visited.len() {
+            if visited[..depth].contains(&cid) {
+                break;
+            }
+            visited[depth] = cid;
+
+            let proto_obj = crate::object::class_registry::class_prototype_object(cid);
+            let mut next_cid = 0;
+            if !proto_obj.is_null() {
+                if std::ptr::addr_eq(proto_obj, receiver_ptr) {
+                    return true;
+                }
+                next_cid = crate::object::js_object_get_class_id(proto_obj as *const ObjectHeader);
+            }
+
+            if next_cid != 0 && next_cid != cid {
+                cid = next_cid;
+                depth += 1;
+                continue;
+            }
+
+            match crate::object::class_registry::get_parent_class_id(cid) {
+                Some(parent_id) if parent_id != 0 && parent_id != cid => {
+                    cid = parent_id;
+                    depth += 1;
+                }
+                _ => break,
+            }
+        }
+    } else {
+        let (_, target_gc_type) = match gc_pointer_and_type_from_value(target) {
+            Some(info) => info,
+            None => return false,
+        };
+        if target_gc_type != crate::gc::GC_TYPE_CLOSURE {
+            return false;
+        }
+    }
+
+    let mut current = target;
+    for _ in 0..32 {
+        let current_ptr = object_ptr_from_value(current);
+        let proto = crate::object::js_object_get_prototype_of(current);
+        let proto_jsval = JSValue::from_bits(proto.to_bits());
+        if proto_jsval.is_null() || proto_jsval.is_undefined() {
+            break;
+        }
+        let proto_ptr = match object_ptr_from_value(proto) {
+            Some(ptr) => ptr,
+            None => break,
+        };
+        if current_ptr.is_some_and(|ptr| std::ptr::addr_eq(ptr, proto_ptr)) {
+            break;
+        }
+        if std::ptr::addr_eq(proto_ptr, receiver_ptr) {
+            return true;
+        }
+        current = proto;
+    }
+
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn js_native_call_method(
     object: f64,
@@ -1877,16 +1991,20 @@ pub unsafe extern "C" fn js_native_call_method(
             return f64::from_bits(JSValue::bool(enumerable).bits());
         }
 
-        // `prim.isPrototypeOf(v)` — true iff the receiver appears in `v`'s
-        // prototype chain. #2058: a primitive receiver (number/string/boolean,
-        // reached via the `js_class_method_bind` value-read path) is never on
-        // another object's prototype chain, so the result is always `false`.
-        // Scoped to non-pointer receivers so object/class-prototype receivers
-        // keep their existing dispatch. Returning a clean boolean keeps
-        // `typeof n.isPrototypeOf === "function"` honest: the bound value is
-        // actually callable rather than throwing.
-        "isPrototypeOf" if !jsval.is_pointer() => {
-            return f64::from_bits(JSValue::bool(false).bits());
+        // `obj.isPrototypeOf(v)` — true iff `obj` appears in `v`'s modeled
+        // prototype chain. Object.create links live in Perry's synthetic
+        // class/prototype side table; closure/static prototype links use
+        // `Object.getPrototypeOf` state. Primitive/nullish receivers or
+        // arguments are never a match.
+        "isPrototypeOf" => {
+            let arg = if args_len >= 1 && !args_ptr.is_null() {
+                *args_ptr
+            } else {
+                f64::from_bits(crate::value::TAG_UNDEFINED)
+            };
+            return f64::from_bits(
+                JSValue::bool(js_object_is_prototype_of_value(object, arg)).bits(),
+            );
         }
 
         // `prim.valueOf()` — a primitive's `valueOf` returns the primitive

--- a/test-parity/node-suite/object/is-prototype-of.ts
+++ b/test-parity/node-suite/object/is-prototype-of.ts
@@ -1,0 +1,25 @@
+function logCall(label: string, fn: () => boolean) {
+  try {
+    console.log(label, "ok", fn());
+  } catch (err: any) {
+    console.log(label, "throw", err.name, err.message, err instanceof TypeError);
+  }
+}
+
+const proto = { marker: true };
+const child = Object.create(proto);
+const grandchild = Object.create(child);
+const unrelated = { marker: true };
+
+logCall("direct child", () => proto.isPrototypeOf(child));
+logCall("direct grandchild", () => proto.isPrototypeOf(grandchild));
+logCall("direct reversed", () => child.isPrototypeOf(proto));
+logCall("direct unrelated", () => proto.isPrototypeOf(unrelated));
+logCall("direct self", () => proto.isPrototypeOf(proto));
+logCall("direct null arg", () => proto.isPrototypeOf(null));
+logCall("direct primitive arg", () => proto.isPrototypeOf(42));
+
+logCall("call child", () => Object.prototype.isPrototypeOf.call(proto, child));
+logCall("call grandchild", () => Object.prototype.isPrototypeOf.call(proto, grandchild));
+logCall("call unrelated", () => Object.prototype.isPrototypeOf.call(proto, unrelated));
+logCall("primitive receiver", () => (42 as any).isPrototypeOf(child));


### PR DESCRIPTION
Closes #2893.

## Summary
- implement `Object.prototype.isPrototypeOf` for ordinary object receivers by walking Perry's modeled prototype links
- use the synthetic `Object.create` class/prototype side table with cycle bounds, and keep primitive/nullish receivers and arguments false
- replace the `Object.prototype.isPrototypeOf` no-op prototype value with a real thunk for `.call(...)` forms
- add focused parity coverage for direct, transitive, unrelated, self, null/primitive-argument, primitive-receiver, and `.call` cases

## Tests
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH node --experimental-strip-types test-parity/node-suite/object/is-prototype-of.ts`
- `RUSTC_WRAPPER= cargo check -p perry-runtime`
- `RUSTC_WRAPPER= cargo build --release -p perry`
- `target/release/perry test-parity/node-suite/object/is-prototype-of.ts -o /tmp/perry_is_prototype_of_2893_post && /tmp/perry_is_prototype_of_2893_post`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module object --filter is-prototype-of` (passed 1/1; latest report: `test-parity/reports/parity_report_20260530_022050.json`)
- `RUSTC_WRAPPER= cargo test -p perry-runtime object:: -- --test-threads=1` (11 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `rg -n "^(<<<<<<<|>>>>>>>)"` (no matches; exit 1)
- `./scripts/check_file_size.sh` (fails only on existing `crates/perry-runtime/src/node_stream_readwrite.rs` at 2001 lines)
