### PR TITLE
fix(util): validate promisify and callbackify inputs

### DIFF
--- a/crates/perry-runtime/src/util_promisify.rs
+++ b/crates/perry-runtime/src/util_promisify.rs
@@ -88,6 +88,17 @@ fn is_callable_closure(value: f64) -> bool {
     crate::closure::is_closure_ptr(ptr)
 }
 
+fn validate_original_function(fn_value: f64) {
+    if is_callable_closure(fn_value) {
+        return;
+    }
+    let message = format!(
+        "The \"original\" argument must be of type function. Received {}",
+        crate::fs::validate::describe_received(fn_value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
 fn custom_promisified_value(fn_value: f64) -> Option<f64> {
     let scope = crate::gc::RuntimeHandleScope::new();
     let fn_handle = scope.root_nanbox_f64(fn_value);
@@ -137,19 +148,9 @@ fn register_thunks_once() {
 }
 
 /// `util.promisify(fn)` — returns a wrapper closure as a NaN-boxed f64.
-///
-/// If `fn` isn't pointer-shaped (not a closure / native callable), we fall
-/// back to returning `fn` unchanged. Node throws `TypeError [ERR_INVALID_ARG_TYPE]`
-/// in that case; we keep behavior conservative for now so callers that
-/// accidentally promisify a non-function still get a clear "value is not a
-/// function" error at the call site rather than crashing here.
 #[no_mangle]
 pub extern "C" fn js_util_promisify(fn_value: f64) -> f64 {
-    let bits = fn_value.to_bits();
-    let tag = bits & TAG_MASK;
-    if tag != POINTER_TAG {
-        return fn_value;
-    }
+    validate_original_function(fn_value);
 
     if let Some(custom) = custom_promisified_value(fn_value) {
         return custom;
@@ -221,11 +222,7 @@ pub extern "C" fn js_util_deprecate(fn_value: f64, _msg: f64, _code: f64) -> f64
 /// `util.callbackify(fn)` — returns a wrapper closure as a NaN-boxed f64.
 #[no_mangle]
 pub extern "C" fn js_util_callbackify(fn_value: f64) -> f64 {
-    let bits = fn_value.to_bits();
-    let tag = bits & TAG_MASK;
-    if tag != POINTER_TAG {
-        return fn_value;
-    }
+    validate_original_function(fn_value);
 
     register_thunks_once();
 

--- a/test-parity/node-suite/util/promisify/input-validation.ts
+++ b/test-parity/node-suite/util/promisify/input-validation.ts
@@ -1,0 +1,42 @@
+import { callbackify, promisify } from "node:util";
+
+const values: Array<[string, any]> = [
+  ["undefined", undefined],
+  ["null", null],
+  ["number", 0],
+  ["string", "x"],
+  ["object", {}],
+  ["array", []],
+  ["promise", Promise.resolve(1)],
+];
+
+function probe(label: string, adapter: (value: any) => any, value: any) {
+  try {
+    const out = adapter(value);
+    console.log(label, "ok", typeof out);
+  } catch (err: any) {
+    console.log(label, "throw", err.name, err.code, err instanceof TypeError);
+  }
+}
+
+for (const [label, value] of values) {
+  probe(`promisify ${label}`, promisify, value);
+  probe(`callbackify ${label}`, callbackify, value);
+}
+
+function nodeback(cb: (err: any, value: number) => void) {
+  cb(null, 1);
+}
+
+async function asyncValue() {
+  return 1;
+}
+
+function custom(cb: (err: any, value: string) => void) {
+  cb(null, "unused");
+}
+(custom as any)[promisify.custom] = () => Promise.resolve("custom");
+
+console.log("promisify callable", typeof promisify(nodeback));
+console.log("callbackify callable", typeof callbackify(asyncValue));
+console.log("promisify custom", typeof promisify(custom));


### PR DESCRIPTION
## Summary
- validate `util.promisify(original)` and `util.callbackify(original)` before wrapping
- throw Node-shaped `TypeError [ERR_INVALID_ARG_TYPE]` for primitive, object, array, and Promise inputs
- add focused parity coverage for invalid inputs while keeping callable, callbackify, and `promisify.custom` behavior covered

Fixes #2915.

## Baseline
Pre-fix Perry returned primitives unchanged and wrapped object-shaped non-callables as functions in `test-parity/node-suite/util/promisify/input-validation.ts`; Node throws `TypeError ERR_INVALID_ARG_TYPE` for every non-function case.

## Verification
- PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH node --experimental-strip-types test-parity/node-suite/util/promisify/input-validation.ts
- target/release/perry test-parity/node-suite/util/promisify/input-validation.ts -o /tmp/perry_util_input_validation_2915_final && /tmp/perry_util_input_validation_2915_final
- PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module util --filter input-validation (`test-parity/reports/parity_report_20260530_032631.json`, 1 pass / 0 fail)
- PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module util --filter custom-and-this (`test-parity/reports/parity_report_20260530_032736.json`, 1 pass / 0 fail)
- PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module util --filter rejection-reasons (`test-parity/reports/parity_report_20260530_032741.json`, 1 pass / 0 fail)
- RUSTC_WRAPPER= cargo check -p perry-runtime
- RUSTC_WRAPPER= cargo build --release -p perry
- cargo fmt --all -- --check
- git diff --check origin/main...HEAD
- jq empty test-parity/known_failures.json test-parity/threshold.json
- rg -n "^(<<<<<<<|>>>>>>>)"
- ./scripts/check_file_size.sh
