### PR TITLE
fix(stream/web): expose BYOB reader closed

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -965,6 +965,35 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
     }
 
     if !obj_val.is_pointer() {
+        // Web Streams handles are raw finite f64 ids, not NaN-boxed pointers.
+        // Property reads already route these through the stdlib handle
+        // dispatcher; mirror that for the `in` operator so `"closed" in reader`
+        // observes getter-backed handle properties without dereferencing the id.
+        let f = f64::from_bits(obj.to_bits());
+        if key_val.is_any_string() && f.is_finite() && f > 0.0 && f.fract() == 0.0 {
+            let id = f as usize;
+            if (0x40000..0x100000).contains(&id) {
+                if let Some(probe) = crate::object::stream_handle_probe() {
+                    unsafe {
+                        if probe(id) {
+                            if let Some(dispatch) =
+                                super::class_registry::handle_property_dispatch()
+                            {
+                                let key_ptr = crate::value::js_get_string_pointer_unified(key)
+                                    as *const crate::StringHeader;
+                                let name_ptr = (key_ptr as *const u8)
+                                    .add(std::mem::size_of::<crate::StringHeader>());
+                                let name_len = (*key_ptr).byte_len as usize;
+                                let result = dispatch(id as i64, name_ptr, name_len);
+                                if result.to_bits() != crate::value::TAG_UNDEFINED {
+                                    return nanbox_true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
         return nanbox_false;
     }
 

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -2037,6 +2037,7 @@ pub(crate) unsafe fn dispatch_stream_property(handle: f64, name: &str) -> f64 {
     match (kind, name) {
         (1, "locked") => return js_readable_stream_locked(handle),
         (2, "locked") => return js_writable_stream_locked(handle),
+        (3, "closed") => return box_promise(js_reader_closed(handle)),
         _ => {}
     }
     // Callable members → bound-method closure so `typeof` reports

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -398,12 +398,6 @@
     "category": "bug-open",
     "reason": "node:stream: for-await break \u2014 custom iterator.return() not invoked. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/web/byob-reader-method-shape": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: BYOB reader missing methods (read/releaseLock) or .closed prop. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/compose/three-stages-order": {
     "issue": "1531",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary

- Expose `ReadableStream` reader `closed` through the generic Web Streams handle property dispatcher.
- Teach the `in` operator path to consult the same raw Web Streams handle property dispatcher used by property reads, so `"closed" in reader` observes handle-backed properties without dereferencing raw stream ids.
- Remove the now-passing BYOB reader method-shape known-failure entry.

## Verification

- Baseline exact `./run_parity_tests.sh --suite node-suite --module stream/web --filter byob-reader-method-shape`: FAIL, report `test-parity/reports/parity_report_20260529_200918.json` (`Perry: has closed: false`).
- Intermediate exact after reader property dispatch only: still FAIL, report `test-parity/reports/parity_report_20260529_201254.json`, proving the missing path was the `in` operator.
- Post-rebase exact `./run_parity_tests.sh --suite node-suite --module stream/web --filter byob-reader-method-shape`: PASS, report `test-parity/reports/parity_report_20260529_202303.json`.
- `./run_parity_tests.sh --suite node-suite --module stream/web --filter reader-closed-promise`: PASS, report `test-parity/reports/parity_report_20260529_202410.json`.
- `cargo fmt --all --check`: PASS.
- `cargo check -p perry-runtime -p perry-stdlib`: PASS with existing warnings.
- `jq empty test-parity/known_failures.json`: PASS.
- `git diff --check` and `git diff --cached --check`: PASS.

## Notes

- DeepWiki reference kept local/untracked: `reference/deepwiki/nodejs-node-readable-stream-byob-reader-closed-property-2026-05-29.md`.
- Non-goals: no BYOB `read(view)` data-transfer changes, no BYOB lock-release rejection semantics, no writable writer `closed` property broadening, and no Web Streams backpressure work.
