### PR TITLE
fix(fs): propagate fstat invalid fd errors

### DIFF
--- a/crates/perry-runtime/src/fs/callbacks.rs
+++ b/crates/perry-runtime/src/fs/callbacks.rs
@@ -361,15 +361,22 @@ pub extern "C" fn js_fs_glob_callback(pattern_value: f64, arg1: f64, arg2: f64) 
 pub extern "C" fn js_fs_fstat_callback(fd_value: f64, arg1: f64, arg2: f64) -> f64 {
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
     const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
+    crate::fs::validate::validate_fd(fd_value);
     let options = if extract_closure_ptr(arg1).is_null() {
         arg1
     } else {
         f64::from_bits(TAG_UNDEFINED)
     };
-    let stats = js_fs_fstat_sync_options(fd_value, options);
+    let bigint = unsafe { options_bool_field(options, b"bigint") };
+    let result = fstat_stats_value(fd_value as i32, bigint);
     let cb = last_callback(&[arg1, arg2]);
     if !cb.is_null() {
-        crate::closure::js_closure_call2(cb, f64::from_bits(TAG_NULL), stats);
+        match result {
+            Ok(stats) => {
+                crate::closure::js_closure_call2(cb, f64::from_bits(TAG_NULL), stats);
+            }
+            Err(err) => unsafe { call_cb_err2(cb, err) },
+        }
     }
     f64::from_bits(TAG_UNDEFINED)
 }

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -1396,16 +1396,20 @@ pub extern "C" fn js_fs_fstat_sync(fd_value: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_fs_fstat_sync_options(fd_value: f64, options_value: f64) -> f64 {
+    crate::fs::validate::validate_fd(fd_value);
     let bigint = unsafe { options_bool_field(options_value, b"bigint") };
     let fd = fd_value as i32;
+    match fstat_stats_value(fd, bigint) {
+        Ok(stats) => stats,
+        Err(err) => crate::exception::js_throw(err),
+    }
+}
+
+pub(crate) fn fstat_stats_value(fd: i32, bigint: bool) -> Result<f64, f64> {
     FD_REGISTRY.with(|r| {
         let reg = r.borrow();
         let Some(file) = reg.get(&fd) else {
-            return unsafe {
-                build_stats_object(
-                    false, false, false, 0, 0, -1.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, bigint, None,
-                )
-            };
+            return Err(crate::fs::validate::build_ebadf_error_value("fstat"));
         };
         match file.metadata() {
             Ok(meta) => {
@@ -1421,7 +1425,7 @@ pub extern "C" fn js_fs_fstat_sync_options(fd_value: f64, options_value: f64) ->
                 let (uid, gid) = metadata_owner_ids(&meta);
                 let nlink = metadata_nlink(&meta);
                 let (atime, mtime, ctime, birth) = metadata_times_ms(&meta);
-                unsafe {
+                Ok(unsafe {
                     build_stats_object(
                         ft.is_file(),
                         ft.is_dir(),
@@ -1438,13 +1442,9 @@ pub extern "C" fn js_fs_fstat_sync_options(fd_value: f64, options_value: f64) ->
                         bigint,
                         Some(&meta),
                     )
-                }
+                })
             }
-            Err(_) => unsafe {
-                build_stats_object(
-                    false, false, false, 0, 0, -1.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, bigint, None,
-                )
-            },
+            Err(_) => Err(crate::fs::validate::build_ebadf_error_value("fstat")),
         }
     })
 }

--- a/crates/perry-runtime/src/fs/validate.rs
+++ b/crates/perry-runtime/src/fs/validate.rs
@@ -167,12 +167,16 @@ pub(crate) fn throw_invalid_path_arg(arg_name: &str, value: f64) -> ! {
 
 /// Throw `Error [EBADF]` for a numeric fd that is not an open descriptor.
 fn throw_ebadf(syscall: &'static str) -> ! {
+    crate::exception::js_throw(build_ebadf_error_value(syscall))
+}
+
+pub(crate) fn build_ebadf_error_value(syscall: &'static str) -> f64 {
     let message = format!("EBADF: bad file descriptor, {}", syscall);
     let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
     crate::node_submodules::register_error_code_pub(msg, "EBADF");
     crate::node_submodules::register_error_syscall(msg, syscall);
     let err = crate::error::js_error_new_with_message(msg);
-    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+    crate::value::js_nanbox_pointer(err as i64)
 }
 
 pub fn throw_type_error_with_code(message: &str, code: &'static str) -> ! {

--- a/test-parity/node-suite/fs/fd/fstat-invalid-fd.ts
+++ b/test-parity/node-suite/fs/fd/fstat-invalid-fd.ts
@@ -1,0 +1,43 @@
+import * as fs from "node:fs";
+
+const ROOT = "/tmp/perry_node_suite_fs_fstat_invalid_fd";
+try { fs.rmSync(ROOT, { recursive: true, force: true }); } catch (_e) {}
+fs.mkdirSync(ROOT);
+const path = ROOT + "/file.txt";
+fs.writeFileSync(path, "abc");
+
+function probe(label: string, fn: () => void) {
+  try {
+    fn();
+    console.log(label, "no-throw");
+  } catch (err: any) {
+    console.log(label, err.name, err.code || "", err.syscall || "");
+  }
+}
+
+probe("fstatSync negative", () => fs.fstatSync(-1));
+probe("fstatSync fractional", () => fs.fstatSync(1.5));
+probe("fstatSync string", () => fs.fstatSync("x" as any));
+probe("fstatSync bad fd", () => fs.fstatSync(99999999));
+
+const fd = fs.openSync(path, "r");
+const stats = fs.fstatSync(fd, { bigint: true });
+console.log("fstatSync valid bigint:", typeof stats.size, stats.isFile());
+fs.closeSync(fd);
+
+probe("fstat callback fractional", () => {
+  fs.fstat(1.5, () => {});
+});
+
+await new Promise<void>((resolve) => {
+  fs.fstat(99999999, (err, stats) => {
+    console.log(
+      "fstat callback bad fd",
+      err && err.name,
+      err && (err as any).code,
+      err && (err as any).syscall,
+      stats === undefined,
+    );
+    resolve();
+  });
+});


### PR DESCRIPTION
## Summary

- validate `fs.fstatSync` fd arguments before looking up the registry
- return Node-shaped `EBADF` errors for unknown fds instead of fake Stats objects
- make `fs.fstat` callback report bad descriptors as `(err, undefined)` while keeping invalid type/range failures synchronous
- add focused Node parity coverage for invalid fstat fds and valid bigint stats

Closes #2922.

## Tests

- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH node --experimental-strip-types test-parity/node-suite/fs/fd/fstat-invalid-fd.ts`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs/fd --filter fstat-invalid-fd`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs/fd --filter fstat-ftruncate-fsync`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module fs/callbacks --filter fd-and-statfs`
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `git diff --check && git diff --cached --check`
- `./scripts/check_file_size.sh`
- `RUSTC_WRAPPER= cargo check -p perry-runtime`