### PR TITLE
fix(math): preserve expm1 and log1p precision

### DIFF
--- a/crates/perry-codegen/src/expr/math_simple.rs
+++ b/crates/perry-codegen/src/expr/math_simple.rs
@@ -229,12 +229,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(ctx.block().call(DOUBLE, "llvm.log10.f64", &[(DOUBLE, &v)]))
         }
         Expr::MathLog1p(operand) => {
-            // log(1 + x). LLVM has no log1p intrinsic that doesn't
-            // require linking libm, so emulate via log(1+x).
             let v = lower_expr(ctx, operand)?;
-            let blk = ctx.block();
-            let one_plus_v = blk.fadd(&v, "1.0");
-            Ok(blk.call(DOUBLE, "llvm.log.f64", &[(DOUBLE, &one_plus_v)]))
+            Ok(ctx.block().call(DOUBLE, "js_math_log1p", &[(DOUBLE, &v)]))
         }
         // Math.random — return 0.5 sentinel. Real impl needs a PRNG
         // we'd link in; sentinel keeps the compile-pass count up.

--- a/crates/perry-codegen/src/expr/string_regex_proc.rs
+++ b/crates/perry-codegen/src/expr/string_regex_proc.rs
@@ -201,12 +201,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             ))
         }
         Expr::MathExpm1(o) => {
-            // expm1(x) = exp(x) - 1. No llvm.expm1 intrinsic; use llvm.exp.f64
-            // and subtract 1.0.
             let v = lower_expr(ctx, o)?;
-            let blk = ctx.block();
-            let exp_v = blk.call(DOUBLE, "llvm.exp.f64", &[(DOUBLE, &v)]);
-            Ok(blk.fsub(&exp_v, "1.0"))
+            Ok(ctx.block().call(DOUBLE, "js_math_expm1", &[(DOUBLE, &v)]))
         }
         Expr::MathExp(o) => {
             let v = lower_expr(ctx, o)?;

--- a/test-parity/node-suite/globals/math-expm1-log1p-precision.ts
+++ b/test-parity/node-suite/globals/math-expm1-log1p-precision.ts
@@ -1,0 +1,15 @@
+function close(label: string, actual: number, expected: number) {
+  const tolerance = Math.max(Number.EPSILON * Math.abs(expected), 1e-30);
+  console.log(label, Math.abs(actual - expected) <= tolerance);
+}
+
+close("expm1 tiny positive", Math.expm1(1e-16), 1e-16);
+close("expm1 tiny negative", Math.expm1(-1e-16), -1e-16);
+close("log1p tiny positive", Math.log1p(1e-16), 1e-16);
+close("log1p tiny negative", Math.log1p(-1e-16), -1e-16);
+
+close("expm1 sanity", Math.expm1(1e-9), 1.0000000005000001e-9);
+close("log1p sanity", Math.log1p(1e-9), 9.999999995e-10);
+
+console.log("naive expm1 collapses", Math.exp(1e-16) - 1 === 0);
+console.log("naive log1p collapses", Math.log(1 + 1e-16) === 0);


### PR DESCRIPTION
## Summary
- route direct `Math.expm1` / `Math.log1p` codegen through the existing precision-preserving runtime helpers
- add parity coverage for tiny positive/negative values and 1e-9 sanity cases
- keep the naive `exp(x) - 1` / `log(1 + x)` collapse contrast in the fixture

Fixes #2946.

## Baseline
Pre-fix Perry lowered direct `Math.expm1` / `Math.log1p` to `exp(x) - 1` / `log(1 + x)`, causing all six precision checks in the new fixture to print `false`.

## Verification
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH node --experimental-strip-types test-parity/node-suite/globals/math-expm1-log1p-precision.ts`
- `target/release/perry test-parity/node-suite/globals/math-expm1-log1p-precision.ts -o /tmp/perry_math_precision_2946_post && /tmp/perry_math_precision_2946_post`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module globals --filter math-expm1-log1p-precision`
  - report: `test-parity/reports/parity_report_20260530_035423.json`
- `RUSTC_WRAPPER= cargo check -p perry-codegen -p perry-runtime`
- `RUSTC_WRAPPER= cargo build --release -p perry`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `rg -n "^(<<<<<<<|>>>>>>>)"`
- `./scripts/check_file_size.sh`
