### PR TITLE
fix(events): pass emit args to listeners

### DIFF
--- a/crates/perry-stdlib/src/events.rs
+++ b/crates/perry-stdlib/src/events.rs
@@ -615,6 +615,32 @@ unsafe fn first_arg_or_undefined(args_ptr: *const ArrayHeader) -> f64 {
     }
 }
 
+unsafe fn collect_emit_args(args_ptr: *const ArrayHeader) -> Vec<f64> {
+    if args_ptr.is_null() {
+        return Vec::new();
+    }
+
+    let len = js_array_length(args_ptr) as usize;
+    let mut args = Vec::with_capacity(len);
+    for index in 0..len {
+        args.push(perry_runtime::array::js_array_get_f64(
+            args_ptr,
+            index as u32,
+        ));
+    }
+    args
+}
+
+unsafe fn call_emitter_listener(handle: Handle, callback: i64, args: &[f64]) -> f64 {
+    let receiver = js_nanbox_pointer(handle);
+    let callback_value = js_nanbox_pointer(callback);
+    let previous_this = perry_runtime::object::js_implicit_this_set(receiver);
+    let result =
+        perry_runtime::closure::js_native_call_value(callback_value, args.as_ptr(), args.len());
+    perry_runtime::object::js_implicit_this_set(previous_this);
+    result
+}
+
 const TAG_UNDEFINED_F64_BITS: u64 = 0x7FFC_0000_0000_0001;
 
 extern "C" fn events_capture_rejection_handler(closure: *const ClosureHeader, reason: f64) -> f64 {
@@ -683,6 +709,7 @@ pub unsafe extern "C" fn js_event_emitter_emit(
         }
 
         let first_arg = first_arg_or_undefined(args_ptr);
+        let emitted_args = collect_emit_args(args_ptr);
         if event_name == "error" {
             dispatch_error_monitor(emitter, Some(first_arg));
             let has_error_once = emitter
@@ -702,8 +729,7 @@ pub unsafe extern "C" fn js_event_emitter_emit(
         let capture_rejections = emitter.capture_rejections && event_name != "error";
         for l in snapshot {
             if l.callback != 0 {
-                let closure_ptr = l.callback as *const ClosureHeader;
-                let result = js_closure_call1(closure_ptr, first_arg);
+                let result = call_emitter_listener(handle, l.callback, &emitted_args);
                 if capture_rejections {
                     capture_listener_rejection(handle, result);
                 }
@@ -742,6 +768,7 @@ pub unsafe extern "C" fn js_event_emitter_emit0(
         }
 
         let empty_args = js_array_alloc(0);
+        let emitted_args: &[f64] = &[];
         if event_name == "error" {
             dispatch_error_monitor(emitter, None);
             let has_error_once = emitter
@@ -762,8 +789,7 @@ pub unsafe extern "C" fn js_event_emitter_emit0(
         let capture_rejections = emitter.capture_rejections && event_name != "error";
         for l in snapshot {
             if l.callback != 0 {
-                let closure_ptr = l.callback as *const ClosureHeader;
-                let result = js_closure_call0(closure_ptr);
+                let result = call_emitter_listener(handle, l.callback, emitted_args);
                 if capture_rejections {
                     capture_listener_rejection(handle, result);
                 }

--- a/test-parity/node-suite/events/emitter/emit-multiple-args.ts
+++ b/test-parity/node-suite/events/emitter/emit-multiple-args.ts
@@ -1,0 +1,20 @@
+import { EventEmitter, once } from "node:events";
+
+const em = new EventEmitter();
+const seen: unknown[] = [];
+
+em.on("data", function (a: unknown, b: unknown, c: unknown) {
+  seen.push([arguments.length, a, b, c, this === em]);
+});
+
+em.once("data", function (a: unknown, b: unknown, c: unknown) {
+  seen.push(["once", arguments.length, a, b, c, this === em]);
+});
+
+const p = once(em, "data");
+console.log("emit ret:", em.emit("data", "a", 2, true));
+console.log("seen first:", JSON.stringify(seen));
+console.log("once promise:", JSON.stringify(await p));
+
+console.log("emit second ret:", em.emit("data", "b", 3, false));
+console.log("seen second:", JSON.stringify(seen));


### PR DESCRIPTION
## Summary
- call EventEmitter listeners through the variadic native dispatch path so every emit argument reaches the listener
- bind listener `this` to the EventEmitter during emit dispatch, including zero-arg emits
- add a Node parity fixture covering multiple emitted args, once-listeners, `events.once`, and a second emit

Fixes #2953.

## Verification
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH node --experimental-strip-types test-parity/node-suite/events/emitter/emit-multiple-args.ts`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module events/emitter --filter emit-multiple-args`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module events/emitter --filter emit`
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `git diff --check && git diff --cached --check`
- `./scripts/check_file_size.sh`
- `RUSTC_WRAPPER= cargo check -p perry-stdlib`