### PR TITLE
fix(stream): read byte-mode async iterator chunks

### DIFF
--- a/crates/perry-runtime/src/node_stream/async_iterator.rs
+++ b/crates/perry-runtime/src/node_stream/async_iterator.rs
@@ -113,6 +113,19 @@ extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
         return readable_iterator_done();
     };
     prepare_readable_for_iteration(stream);
+
+    if !readable_object_mode(stream) {
+        let value = read_stream_available_default(stream);
+        if value.to_bits() != TAG_NULL {
+            set_hidden_value(
+                iterator,
+                hidden_key(READABLE_ITERATOR_INDEX_KEY),
+                (iterator_local_index(iterator) + 1) as f64,
+            );
+            return resolved_promise(iterator_result(value, false));
+        }
+    }
+
     let arr = readable_chunks_array(stream);
     let index = stream_consume_index(stream);
     if !arr.is_null() && index < crate::array::js_array_length(arr) {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -278,12 +278,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose() \u2014 Buffer chunks not preserved through pipeline (typed as string?). Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/readable/iter-yields-buffer-no-encoding": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: for-await on Readable without setEncoding \u2014 chunks are not Buffer instances. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/compose/error-propagates-to-source": {
     "issue": "1531",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- route byte-mode Readable async iterator reads through the existing read() path
- preserve object-mode iterator behavior while byte-mode streams coalesce buffered chunks and return Buffer values when no encoding is set
- remove the now-green iter-yields-buffer-no-encoding known failure

## Verification
- cargo fmt --check
- jq empty test-parity/known_failures.json
- cargo check -p perry-runtime
- ./run_parity_tests.sh --suite node-suite --module stream/readable --filter iter-yields-buffer-no-encoding (1 pass; parity_report_20260529_211616.json)
- ./run_parity_tests.sh --suite node-suite --module stream/readable --filter from-string (6 pass; parity_report_20260529_211716.json)
- ./run_parity_tests.sh --suite node-suite --module stream/readable --filter from-buffer (3 pass; parity_report_20260529_211725.json)
- ./run_parity_tests.sh --suite node-suite --module stream/readable --filter iterator (7 pass; parity_report_20260529_211731.json)