### PR TITLE
fix(events): remove latest duplicate listener

### DIFF
--- a/crates/perry-stdlib/src/events.rs
+++ b/crates/perry-stdlib/src/events.rs
@@ -775,7 +775,7 @@ pub unsafe extern "C" fn js_event_emitter_emit0(
 }
 
 /// EventEmitter.removeListener(eventName, listener)
-/// Remove the first matching listener for the event.
+/// Remove the most recently added matching listener for the event.
 #[no_mangle]
 pub unsafe extern "C" fn js_event_emitter_remove_listener(
     handle: Handle,
@@ -790,8 +790,9 @@ pub unsafe extern "C" fn js_event_emitter_remove_listener(
     if let Some(emitter) = get_handle_mut::<EventEmitterHandle>(handle) {
         let mut removed = false;
         if let Some(listeners) = emitter.events.get_mut(&event_name) {
-            // Node removes only the first matching listener, not all.
-            if let Some(pos) = listeners.iter().position(|l| l.callback == callback_ptr) {
+            // Node removes only one matching listener: the most recently added
+            // instance among duplicates.
+            if let Some(pos) = listeners.iter().rposition(|l| l.callback == callback_ptr) {
                 listeners.remove(pos);
                 removed = true;
             }

--- a/test-parity/node-suite/events/listeners/remove-listener-removes-latest.ts
+++ b/test-parity/node-suite/events/listeners/remove-listener-removes-latest.ts
@@ -1,0 +1,26 @@
+import { EventEmitter } from "node:events";
+
+const ee = new EventEmitter();
+const order: string[] = [];
+
+function h() {
+  order.push("h");
+}
+
+function a() {
+  order.push("a");
+}
+
+ee.on("x", h);
+ee.on("x", a);
+ee.on("x", h);
+
+const before = ee.listeners("x");
+console.log("before:", before[0] === h, before[1] === a, before[2] === h, before.length);
+console.log("chain:", ee.removeListener("x", h) === ee);
+
+const after = ee.listeners("x");
+console.log("after:", after[0] === h, after[1] === a, after.length);
+
+ee.emit("x");
+console.log("order:", order.join(","));


### PR DESCRIPTION
## Summary
- make EventEmitter.removeListener remove the most recently added duplicate listener
- add a Node parity fixture that registers the same function twice around another listener and verifies remaining order/emission

Fixes #2968.

## Testing
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH node --experimental-strip-types test-parity/node-suite/events/listeners/remove-listener-removes-latest.ts`
- `target/release/perry test-parity/node-suite/events/listeners/remove-listener-removes-latest.ts -o /tmp/perry_event_remove_latest_2968_rebased && /tmp/perry_event_remove_latest_2968_rebased`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module events/listeners --filter remove-listener`
- `RUSTC_WRAPPER= cargo check -p perry-stdlib -p perry-runtime`
- `RUSTC_WRAPPER= cargo build --release -p perry`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `rg -n "^(<<<<<<<|>>>>>>>)"` (exit 1, no conflict markers)
- `./scripts/check_file_size.sh`
