### PR TITLE
runtime: match URI decode error semantics

### DIFF
--- a/crates/perry-runtime/src/builtins/globals.rs
+++ b/crates/perry-runtime/src/builtins/globals.rs
@@ -58,24 +58,40 @@ fn percent_encode(input: &str, safe_chars: &[u8]) -> String {
     result
 }
 
-fn percent_decode(input: &str) -> String {
+fn percent_decode(input: &str, preserve_reserved: bool) -> Result<String, ()> {
     let bytes = input.as_bytes();
     let mut result = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
+        if bytes[i] == b'%' {
+            if i + 2 >= bytes.len() {
+                return Err(());
+            }
             let hi = hex_digit(bytes[i + 1]);
             let lo = hex_digit(bytes[i + 2]);
             if let (Some(h), Some(l)) = (hi, lo) {
-                result.push(h * 16 + l);
+                let decoded = h * 16 + l;
+                if preserve_reserved && URI_RESERVED.contains(&decoded) {
+                    result.extend_from_slice(&bytes[i..i + 3]);
+                } else {
+                    result.push(decoded);
+                }
                 i += 3;
                 continue;
             }
+            return Err(());
         }
         result.push(bytes[i]);
         i += 1;
     }
-    String::from_utf8_lossy(&result).into_owned()
+    String::from_utf8(result).map_err(|_| ())
+}
+
+fn throw_uri_malformed() -> ! {
+    let message = b"URI malformed";
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_urierror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
 fn hex_digit(b: u8) -> Option<u8> {
@@ -117,7 +133,7 @@ pub extern "C" fn js_encode_uri(value: f64) -> i64 {
 #[no_mangle]
 pub extern "C" fn js_decode_uri(value: f64) -> i64 {
     let input = extract_str_from_nanbox(value);
-    let decoded = percent_decode(&input);
+    let decoded = percent_decode(&input, true).unwrap_or_else(|_| throw_uri_malformed());
     let ptr = js_string_from_bytes(decoded.as_ptr(), decoded.len() as u32);
     ptr as i64
 }
@@ -135,7 +151,7 @@ pub extern "C" fn js_encode_uri_component(value: f64) -> i64 {
 #[no_mangle]
 pub extern "C" fn js_decode_uri_component(value: f64) -> i64 {
     let input = extract_str_from_nanbox(value);
-    let decoded = percent_decode(&input);
+    let decoded = percent_decode(&input, false).unwrap_or_else(|_| throw_uri_malformed());
     let ptr = js_string_from_bytes(decoded.as_ptr(), decoded.len() as u32);
     ptr as i64
 }

--- a/test-parity/node-suite/globals/uri-decode-errors.ts
+++ b/test-parity/node-suite/globals/uri-decode-errors.ts
@@ -1,0 +1,53 @@
+type DecoderName = "decodeURI" | "decodeURIComponent";
+
+function runDecode(name: DecoderName, input: string): string {
+  if (name === "decodeURI") return decodeURI(input);
+  return decodeURIComponent(input);
+}
+
+function showDecode(name: DecoderName, input: string): void {
+  try {
+    console.log(name, input, "ok", JSON.stringify(runDecode(name, input)));
+  } catch (err) {
+    const e = err as Error;
+    console.log(name, input, "throw", e.name, e.message, err instanceof URIError);
+  }
+}
+
+for (const input of [
+  "%",
+  "%ZZ",
+  "%E0%A4%A",
+  "%C0%AF",
+  "%ED%A0%80",
+  "%80",
+  "%F4%90%80%80",
+]) {
+  showDecode("decodeURI", input);
+  showDecode("decodeURIComponent", input);
+}
+
+for (const input of [
+  "%3B",
+  "%2F",
+  "%3F",
+  "%3f",
+  "%3A",
+  "%40",
+  "%26",
+  "%3D",
+  "%2B",
+  "%24",
+  "%2C",
+  "%23",
+]) {
+  console.log("reserved", input, decodeURI(input), decodeURIComponent(input));
+}
+
+console.log("space", decodeURI("%20") === " ", decodeURIComponent("%20") === " ");
+console.log(
+  "utf8",
+  decodeURI("%C3%A9") === "\u00e9",
+  decodeURIComponent("%C3%A9") === "\u00e9",
+);
+console.log("percent", decodeURI("%25") === "%", decodeURIComponent("%25") === "%");


### PR DESCRIPTION
## Summary
- make decodeURI/decodeURIComponent reject malformed percent escapes and invalid UTF-8 with URIError("URI malformed")
- preserve reserved escaped characters for decodeURI while decoding them for decodeURIComponent
- add parity coverage for malformed escapes, invalid UTF-8, reserved escapes, and valid decoded cases

Closes #2958.

## Validation
- `PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" node --experimental-strip-types test-parity/node-suite/globals/uri-decode-errors.ts`
- `env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module globals --filter uri-decode-errors` (report: `test-parity/reports/parity_report_20260530_041646.json`)
- `cargo fmt --all -- --check`
- `git diff --check HEAD~1..HEAD`
- `./scripts/check_file_size.sh`
- `env RUSTC_WRAPPER= cargo check -p perry-runtime` (passes with existing warnings)