### PR TITLE
fix(buffer): throw numeric bounds errors

### DIFF
--- a/crates/perry-runtime/src/buffer/numeric.rs
+++ b/crates/perry-runtime/src/buffer/numeric.rs
@@ -25,6 +25,15 @@ fn buffer_slice_at_or_throw<'a>(buf: *const BufferHeader, offset: i32, n: usize)
 }
 
 #[inline]
+fn buffer_slice_at_or_throw_bounds<'a>(
+    buf: *const BufferHeader,
+    offset: i32,
+    n: usize,
+) -> &'a [u8] {
+    buffer_slice_at(buf, offset, n).unwrap_or_else(|| throw_buffer_out_of_bounds())
+}
+
+#[inline]
 fn buffer_slice_at_mut<'a>(buf: *mut BufferHeader, offset: i32, n: usize) -> Option<&'a mut [u8]> {
     if buf.is_null() || offset < 0 {
         return None;
@@ -42,26 +51,49 @@ fn buffer_slice_at_mut<'a>(buf: *mut BufferHeader, offset: i32, n: usize) -> Opt
     }
 }
 
-pub(super) fn throw_out_of_range() -> ! {
+#[inline]
+fn buffer_slice_at_mut_or_throw<'a>(buf: *mut BufferHeader, offset: i32, n: usize) -> &'a mut [u8] {
+    buffer_slice_at_mut(buf, offset, n).unwrap_or_else(|| throw_out_of_range())
+}
+
+#[inline]
+fn buffer_slice_at_mut_or_throw_bounds<'a>(
+    buf: *mut BufferHeader,
+    offset: i32,
+    n: usize,
+) -> &'a mut [u8] {
+    buffer_slice_at_mut(buf, offset, n).unwrap_or_else(|| throw_buffer_out_of_bounds())
+}
+
+fn throw_range_error_code(code: &[u8], message: &[u8]) -> ! {
     static REGISTER_RANGE_ERROR: std::sync::Once = std::sync::Once::new();
     REGISTER_RANGE_ERROR.call_once(|| {
         crate::object::js_register_class_extends_error(crate::error::CLASS_ID_RANGE_ERROR);
     });
     let obj = crate::object::js_object_alloc(crate::error::CLASS_ID_RANGE_ERROR, 4);
-    unsafe {
-        let set = |key: &[u8], value: f64| {
-            let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
-            crate::object::js_object_set_field_by_name(obj, key_ptr, value);
-        };
-        let str_val = |s: &[u8]| -> f64 {
-            let ptr = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
-            f64::from_bits(crate::JSValue::string_ptr(ptr).bits())
-        };
-        set(b"name", str_val(b"RangeError"));
-        set(b"code", str_val(b"ERR_OUT_OF_RANGE"));
-        set(b"message", str_val(b"The value is out of range"));
-    }
+    let set = |key: &[u8], value: f64| {
+        let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+        crate::object::js_object_set_field_by_name(obj, key_ptr, value);
+    };
+    let str_val = |s: &[u8]| -> f64 {
+        let ptr = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+        f64::from_bits(crate::JSValue::string_ptr(ptr).bits())
+    };
+    set(b"name", str_val(b"RangeError"));
+    set(b"code", str_val(code));
+    set(b"message", str_val(message));
     crate::exception::js_throw(crate::value::js_nanbox_pointer(obj as i64))
+}
+
+pub(super) fn throw_out_of_range() -> ! {
+    throw_range_error_code(b"ERR_OUT_OF_RANGE", b"The value is out of range")
+}
+
+fn throw_buffer_out_of_bounds() -> ! {
+    throw_range_error_code(
+        b"ERR_BUFFER_OUT_OF_BOUNDS",
+        b"Attempt to access memory outside buffer bounds",
+    )
 }
 
 #[inline]
@@ -165,167 +197,145 @@ pub extern "C" fn js_buffer_read_int32_le(buf_ptr: f64, offset: i32) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_buffer_read_float_be(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    match buffer_slice_at(buf, offset, 4) {
-        Some(s) => f32::from_be_bytes([s[0], s[1], s[2], s[3]]) as f64,
-        None => 0.0,
-    }
+    let s = buffer_slice_at_or_throw(buf, offset, 4);
+    f32::from_be_bytes([s[0], s[1], s[2], s[3]]) as f64
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_float_le(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    match buffer_slice_at(buf, offset, 4) {
-        Some(s) => f32::from_le_bytes([s[0], s[1], s[2], s[3]]) as f64,
-        None => 0.0,
-    }
+    let s = buffer_slice_at_or_throw(buf, offset, 4);
+    f32::from_le_bytes([s[0], s[1], s[2], s[3]]) as f64
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_double_be(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    match buffer_slice_at(buf, offset, 8) {
-        Some(s) => f64::from_be_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]]),
-        None => 0.0,
-    }
+    let s = buffer_slice_at_or_throw_bounds(buf, offset, 8);
+    f64::from_be_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]])
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_double_le(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    match buffer_slice_at(buf, offset, 8) {
-        Some(s) => f64::from_le_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]]),
-        None => 0.0,
-    }
+    let s = buffer_slice_at_or_throw_bounds(buf, offset, 8);
+    f64::from_le_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]])
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_uint8(buf_ptr: f64, value: f64, offset: i32) {
     let value = checked_uint_write_value(value, 8);
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 1) {
-        s[0] = value as u8;
-    }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, 1);
+    s[0] = value as u8;
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_int8(buf_ptr: f64, value: f64, offset: i32) {
     let value = checked_int_write_value(value, 8);
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 1) {
-        s[0] = value as i8 as u8;
-    }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, 1);
+    s[0] = value as i8 as u8;
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_uint16_be(buf_ptr: f64, value: f64, offset: i32) {
     let value = checked_uint_write_value(value, 16);
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 2) {
-        let bytes = (value as u16).to_be_bytes();
-        s[0] = bytes[0];
-        s[1] = bytes[1];
-    }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, 2);
+    let bytes = (value as u16).to_be_bytes();
+    s[0] = bytes[0];
+    s[1] = bytes[1];
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_uint16_le(buf_ptr: f64, value: f64, offset: i32) {
     let value = checked_uint_write_value(value, 16);
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 2) {
-        let bytes = (value as u16).to_le_bytes();
-        s[0] = bytes[0];
-        s[1] = bytes[1];
-    }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, 2);
+    let bytes = (value as u16).to_le_bytes();
+    s[0] = bytes[0];
+    s[1] = bytes[1];
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_int16_be(buf_ptr: f64, value: f64, offset: i32) {
     let value = checked_int_write_value(value, 16);
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 2) {
-        s.copy_from_slice(&(value as i16).to_be_bytes());
-    }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, 2);
+    s.copy_from_slice(&(value as i16).to_be_bytes());
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_int16_le(buf_ptr: f64, value: f64, offset: i32) {
     let value = checked_int_write_value(value, 16);
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 2) {
-        s.copy_from_slice(&(value as i16).to_le_bytes());
-    }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, 2);
+    s.copy_from_slice(&(value as i16).to_le_bytes());
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_uint32_be(buf_ptr: f64, value: f64, offset: i32) {
     let value = checked_uint_write_value(value, 32);
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 4) {
-        let bytes = (value as u32).to_be_bytes();
-        s[..4].copy_from_slice(&bytes);
-    }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, 4);
+    let bytes = (value as u32).to_be_bytes();
+    s[..4].copy_from_slice(&bytes);
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_uint32_le(buf_ptr: f64, value: f64, offset: i32) {
     let value = checked_uint_write_value(value, 32);
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 4) {
-        let bytes = (value as u32).to_le_bytes();
-        s[..4].copy_from_slice(&bytes);
-    }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, 4);
+    let bytes = (value as u32).to_le_bytes();
+    s[..4].copy_from_slice(&bytes);
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_int32_be(buf_ptr: f64, value: f64, offset: i32) {
     let value = checked_int_write_value(value, 32);
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 4) {
-        s[..4].copy_from_slice(&(value as i32).to_be_bytes());
-    }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, 4);
+    s[..4].copy_from_slice(&(value as i32).to_be_bytes());
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_int32_le(buf_ptr: f64, value: f64, offset: i32) {
     let value = checked_int_write_value(value, 32);
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 4) {
-        s[..4].copy_from_slice(&(value as i32).to_le_bytes());
-    }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, 4);
+    s[..4].copy_from_slice(&(value as i32).to_le_bytes());
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_float_be(buf_ptr: f64, value: f64, offset: i32) {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 4) {
-        let bytes = (value as f32).to_be_bytes();
-        s[..4].copy_from_slice(&bytes);
-    }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, 4);
+    let bytes = (value as f32).to_be_bytes();
+    s[..4].copy_from_slice(&bytes);
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_float_le(buf_ptr: f64, value: f64, offset: i32) {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 4) {
-        let bytes = (value as f32).to_le_bytes();
-        s[..4].copy_from_slice(&bytes);
-    }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, 4);
+    let bytes = (value as f32).to_le_bytes();
+    s[..4].copy_from_slice(&bytes);
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_double_be(buf_ptr: f64, value: f64, offset: i32) {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 8) {
-        s[..8].copy_from_slice(&value.to_be_bytes());
-    }
+    let s = buffer_slice_at_mut_or_throw_bounds(buf, offset, 8);
+    s[..8].copy_from_slice(&value.to_be_bytes());
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_double_le(buf_ptr: f64, value: f64, offset: i32) {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 8) {
-        s[..8].copy_from_slice(&value.to_le_bytes());
-    }
+    let s = buffer_slice_at_mut_or_throw_bounds(buf, offset, 8);
+    s[..8].copy_from_slice(&value.to_le_bytes());
 }
 
 // ---- Variable byteLength read/write (1..=6) ----
@@ -339,39 +349,31 @@ pub extern "C" fn js_buffer_write_double_le(buf_ptr: f64, value: f64, offset: i3
 #[no_mangle]
 pub extern "C" fn js_buffer_read_uint_be(buf_ptr: f64, offset: i32, byte_length: i32) -> f64 {
     if !(1..=6).contains(&byte_length) {
-        return f64::from_bits(crate::value::TAG_UNDEFINED);
+        throw_out_of_range();
     }
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
     let n = byte_length as usize;
-    match buffer_slice_at(buf, offset, n) {
-        Some(s) => {
-            let mut v: u64 = 0;
-            for &b in s.iter() {
-                v = (v << 8) | (b as u64);
-            }
-            v as f64
-        }
-        None => f64::from_bits(crate::value::TAG_UNDEFINED),
+    let s = buffer_slice_at_or_throw(buf, offset, n);
+    let mut v: u64 = 0;
+    for &b in s.iter() {
+        v = (v << 8) | (b as u64);
     }
+    v as f64
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_uint_le(buf_ptr: f64, offset: i32, byte_length: i32) -> f64 {
     if !(1..=6).contains(&byte_length) {
-        return f64::from_bits(crate::value::TAG_UNDEFINED);
+        throw_out_of_range();
     }
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
     let n = byte_length as usize;
-    match buffer_slice_at(buf, offset, n) {
-        Some(s) => {
-            let mut v: u64 = 0;
-            for (i, &b) in s.iter().enumerate() {
-                v |= (b as u64) << (i * 8);
-            }
-            v as f64
-        }
-        None => f64::from_bits(crate::value::TAG_UNDEFINED),
+    let s = buffer_slice_at_or_throw(buf, offset, n);
+    let mut v: u64 = 0;
+    for (i, &b) in s.iter().enumerate() {
+        v |= (b as u64) << (i * 8);
     }
+    v as f64
 }
 
 #[inline]
@@ -393,39 +395,31 @@ fn sign_extend(v: u64, bits: u32) -> i64 {
 #[no_mangle]
 pub extern "C" fn js_buffer_read_int_be(buf_ptr: f64, offset: i32, byte_length: i32) -> f64 {
     if !(1..=6).contains(&byte_length) {
-        return f64::from_bits(crate::value::TAG_UNDEFINED);
+        throw_out_of_range();
     }
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
     let n = byte_length as usize;
-    match buffer_slice_at(buf, offset, n) {
-        Some(s) => {
-            let mut v: u64 = 0;
-            for &b in s.iter() {
-                v = (v << 8) | (b as u64);
-            }
-            sign_extend(v, (n * 8) as u32) as f64
-        }
-        None => f64::from_bits(crate::value::TAG_UNDEFINED),
+    let s = buffer_slice_at_or_throw(buf, offset, n);
+    let mut v: u64 = 0;
+    for &b in s.iter() {
+        v = (v << 8) | (b as u64);
     }
+    sign_extend(v, (n * 8) as u32) as f64
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_int_le(buf_ptr: f64, offset: i32, byte_length: i32) -> f64 {
     if !(1..=6).contains(&byte_length) {
-        return f64::from_bits(crate::value::TAG_UNDEFINED);
+        throw_out_of_range();
     }
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
     let n = byte_length as usize;
-    match buffer_slice_at(buf, offset, n) {
-        Some(s) => {
-            let mut v: u64 = 0;
-            for (i, &b) in s.iter().enumerate() {
-                v |= (b as u64) << (i * 8);
-            }
-            sign_extend(v, (n * 8) as u32) as f64
-        }
-        None => f64::from_bits(crate::value::TAG_UNDEFINED),
+    let s = buffer_slice_at_or_throw(buf, offset, n);
+    let mut v: u64 = 0;
+    for (i, &b) in s.iter().enumerate() {
+        v |= (b as u64) << (i * 8);
     }
+    sign_extend(v, (n * 8) as u32) as f64
 }
 
 #[no_mangle]
@@ -436,10 +430,9 @@ pub extern "C" fn js_buffer_write_uint_be(buf_ptr: f64, value: f64, offset: i32,
     let v = checked_uint_write_value(value, (byte_length as u32) * 8);
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
     let n = byte_length as usize;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, n) {
-        for i in 0..n {
-            s[n - 1 - i] = ((v >> (i * 8)) & 0xFF) as u8;
-        }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, n);
+    for i in 0..n {
+        s[n - 1 - i] = ((v >> (i * 8)) & 0xFF) as u8;
     }
 }
 
@@ -451,10 +444,9 @@ pub extern "C" fn js_buffer_write_uint_le(buf_ptr: f64, value: f64, offset: i32,
     let v = checked_uint_write_value(value, (byte_length as u32) * 8);
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
     let n = byte_length as usize;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, n) {
-        for i in 0..n {
-            s[i] = ((v >> (i * 8)) & 0xFF) as u8;
-        }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, n);
+    for i in 0..n {
+        s[i] = ((v >> (i * 8)) & 0xFF) as u8;
     }
 }
 
@@ -466,10 +458,9 @@ pub extern "C" fn js_buffer_write_int_be(buf_ptr: f64, value: f64, offset: i32, 
     let v = checked_int_write_value(value, (byte_length as u32) * 8) as u64;
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
     let n = byte_length as usize;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, n) {
-        for i in 0..n {
-            s[n - 1 - i] = ((v >> (i * 8)) & 0xFF) as u8;
-        }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, n);
+    for i in 0..n {
+        s[n - 1 - i] = ((v >> (i * 8)) & 0xFF) as u8;
     }
 }
 
@@ -481,10 +472,9 @@ pub extern "C" fn js_buffer_write_int_le(buf_ptr: f64, value: f64, offset: i32, 
     let v = checked_int_write_value(value, (byte_length as u32) * 8) as u64;
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
     let n = byte_length as usize;
-    if let Some(s) = buffer_slice_at_mut(buf, offset, n) {
-        for i in 0..n {
-            s[i] = ((v >> (i * 8)) & 0xFF) as u8;
-        }
+    let s = buffer_slice_at_mut_or_throw(buf, offset, n);
+    for i in 0..n {
+        s[i] = ((v >> (i * 8)) & 0xFF) as u8;
     }
 }
 
@@ -493,10 +483,8 @@ pub extern "C" fn js_buffer_write_int_le(buf_ptr: f64, value: f64, offset: i32, 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_bigint64_be(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    let val = match buffer_slice_at(buf, offset, 8) {
-        Some(s) => i64::from_be_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]]),
-        None => 0,
-    };
+    let s = buffer_slice_at_or_throw_bounds(buf, offset, 8);
+    let val = i64::from_be_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]]);
     let bi = crate::bigint::js_bigint_from_i64(val);
     f64::from_bits(crate::JSValue::bigint_ptr(bi).bits())
 }
@@ -504,10 +492,8 @@ pub extern "C" fn js_buffer_read_bigint64_be(buf_ptr: f64, offset: i32) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_buffer_read_bigint64_le(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    let val = match buffer_slice_at(buf, offset, 8) {
-        Some(s) => i64::from_le_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]]),
-        None => 0,
-    };
+    let s = buffer_slice_at_or_throw_bounds(buf, offset, 8);
+    let val = i64::from_le_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]]);
     let bi = crate::bigint::js_bigint_from_i64(val);
     f64::from_bits(crate::JSValue::bigint_ptr(bi).bits())
 }
@@ -515,10 +501,8 @@ pub extern "C" fn js_buffer_read_bigint64_le(buf_ptr: f64, offset: i32) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_buffer_read_biguint64_be(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    let val = match buffer_slice_at(buf, offset, 8) {
-        Some(s) => u64::from_be_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]]),
-        None => 0,
-    };
+    let s = buffer_slice_at_or_throw_bounds(buf, offset, 8);
+    let val = u64::from_be_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]]);
     let bi = crate::bigint::js_bigint_from_u64(val);
     f64::from_bits(crate::JSValue::bigint_ptr(bi).bits())
 }
@@ -526,10 +510,8 @@ pub extern "C" fn js_buffer_read_biguint64_be(buf_ptr: f64, offset: i32) -> f64 
 #[no_mangle]
 pub extern "C" fn js_buffer_read_biguint64_le(buf_ptr: f64, offset: i32) -> f64 {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
-    let val = match buffer_slice_at(buf, offset, 8) {
-        Some(s) => u64::from_le_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]]),
-        None => 0,
-    };
+    let s = buffer_slice_at_or_throw_bounds(buf, offset, 8);
+    let val = u64::from_le_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]]);
     let bi = crate::bigint::js_bigint_from_u64(val);
     f64::from_bits(crate::JSValue::bigint_ptr(bi).bits())
 }
@@ -538,18 +520,16 @@ pub extern "C" fn js_buffer_read_biguint64_le(buf_ptr: f64, offset: i32) -> f64 
 pub extern "C" fn js_buffer_write_bigint64_be(buf_ptr: f64, value: f64, offset: i32) {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
     let val = bigint_value_to_i64(value);
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 8) {
-        s[..8].copy_from_slice(&val.to_be_bytes());
-    }
+    let s = buffer_slice_at_mut_or_throw_bounds(buf, offset, 8);
+    s[..8].copy_from_slice(&val.to_be_bytes());
 }
 
 #[no_mangle]
 pub extern "C" fn js_buffer_write_bigint64_le(buf_ptr: f64, value: f64, offset: i32) {
     let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *mut BufferHeader;
     let val = bigint_value_to_i64(value);
-    if let Some(s) = buffer_slice_at_mut(buf, offset, 8) {
-        s[..8].copy_from_slice(&val.to_le_bytes());
-    }
+    let s = buffer_slice_at_mut_or_throw_bounds(buf, offset, 8);
+    s[..8].copy_from_slice(&val.to_le_bytes());
 }
 
 #[no_mangle]

--- a/test-parity/node-suite/buffer/read-write-int/numeric-bounds-errors.ts
+++ b/test-parity/node-suite/buffer/read-write-int/numeric-bounds-errors.ts
@@ -1,0 +1,33 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.alloc(4);
+
+const cases: [string, () => unknown][] = [
+  ["readFloatBE 1", () => b.readFloatBE(1)],
+  ["readFloatLE -1", () => b.readFloatLE(-1 as any)],
+  ["readDoubleBE 0", () => b.readDoubleBE(0)],
+  ["readDoubleLE -1", () => b.readDoubleLE(-1 as any)],
+  ["writeUInt16BE 4", () => b.writeUInt16BE(1, 4)],
+  ["writeInt32LE 1", () => b.writeInt32LE(1, 1)],
+  ["writeFloatLE 2", () => b.writeFloatLE(1.5, 2)],
+  ["writeDoubleLE -1", () => b.writeDoubleLE(1.5, -1 as any)],
+  ["readUIntBE len7", () => b.readUIntBE(0, 7)],
+  ["readUIntBE oob", () => b.readUIntBE(2, 3)],
+  ["readIntLE len0", () => b.readIntLE(0, 0)],
+  ["readIntLE oob", () => b.readIntLE(2, 3)],
+  ["writeUIntBE oob", () => b.writeUIntBE(1, 2, 3)],
+  ["writeIntLE oob", () => b.writeIntLE(-1, 2, 3)],
+  ["readBigUInt64BE 0", () => b.readBigUInt64BE(0)],
+  ["readBigInt64LE -1", () => b.readBigInt64LE(-1 as any)],
+  ["writeBigUInt64BE 0", () => b.writeBigUInt64BE(1n, 0)],
+  ["writeBigInt64LE -1", () => b.writeBigInt64LE(-1n, -1 as any)],
+];
+
+for (const [label, fn] of cases) {
+  try {
+    const value = fn();
+    console.log(label + ":", typeof value === "bigint" ? value.toString() : value);
+  } catch (err: any) {
+    console.log(label + ":", err?.name, err?.code ?? "no-code");
+  }
+}


### PR DESCRIPTION
## Summary
- make Buffer float, fixed/variable-width integer, and BigInt numeric accesses throw on out-of-bounds offsets instead of returning sentinel values or no-oping
- add Buffer `ERR_BUFFER_OUT_OF_BOUNDS` errors for double and BigInt 64-bit bounds where Node reports that code
- add focused parity coverage for invalid numeric read/write bounds across float, double, integer, and BigInt paths

Fixes #2980.

## Verification
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH node --experimental-strip-types test-parity/node-suite/buffer/read-write-int/numeric-bounds-errors.ts`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module buffer/read-write-int --filter numeric-bounds-errors`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module buffer/read-write-int`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module buffer/read-write-float`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module buffer/bigint`
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `git diff --check && git diff --cached --check`
- `./scripts/check_file_size.sh`
- `RUSTC_WRAPPER= cargo check -p perry-runtime`