### PR TITLE
fix(stream): avoid duplicate readable after drain

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -179,6 +179,9 @@ extern "C" fn ns_readable_event_microtask(closure: *const ClosureHeader) -> f64 
         return f64::from_bits(TAG_UNDEFINED);
     }
     let stream = f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64);
+    if !has_truthy_hidden(stream, hidden_readable_scheduled_key()) {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
     set_hidden_value(
         stream,
         hidden_readable_scheduled_key(),

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -609,6 +609,14 @@ pub(super) fn queue_readable_event(stream: f64) {
     crate::builtins::js_queue_microtask(closure as i64);
 }
 
+pub(super) fn cancel_readable_event(stream: f64) {
+    set_hidden_value(
+        stream,
+        hidden_readable_scheduled_key(),
+        f64::from_bits(TAG_FALSE),
+    );
+}
+
 pub(super) fn schedule_readable_end(stream: f64) {
     if has_truthy_hidden(stream, hidden_end_emitted_key())
         || has_truthy_hidden(stream, hidden_end_scheduled_key())
@@ -820,6 +828,7 @@ pub(super) fn read_stream_default_size(stream: f64) -> f64 {
 pub(super) fn read_stream_available_default(stream: f64) -> f64 {
     if get_hidden_value(stream, hidden_buffered_key()).unwrap_or(0.0) <= 0.0 {
         if stream_hidden_ended(stream) {
+            cancel_readable_event(stream);
             refresh_readable_aborted_flag(stream);
         }
         return f64::from_bits(TAG_NULL);
@@ -833,6 +842,7 @@ pub(super) fn read_stream_available_default(stream: f64) -> f64 {
     }
     if values.is_empty() {
         if stream_hidden_ended(stream) {
+            cancel_readable_event(stream);
             refresh_readable_aborted_flag(stream);
         }
         return f64::from_bits(TAG_NULL);
@@ -841,6 +851,7 @@ pub(super) fn read_stream_available_default(stream: f64) -> f64 {
     mark_disturbed(stream);
     clear_pending_readable_chunks(stream);
     if stream_hidden_ended(stream) {
+        queue_readable_event(stream);
         schedule_readable_end(stream);
     }
     let encoded = readable_encoding_tag(stream).is_some();
@@ -868,6 +879,7 @@ pub(super) fn read_stream_exact_size(stream: f64, size: f64) -> f64 {
         .max(0.0) as usize;
     if available == 0 {
         if stream_hidden_ended(stream) {
+            cancel_readable_event(stream);
             refresh_readable_aborted_flag(stream);
         }
         return f64::from_bits(TAG_NULL);
@@ -943,6 +955,7 @@ pub(super) fn read_stream_object_mode_chunk(stream: f64) -> f64 {
     mark_disturbed(stream);
     if stream_hidden_ended(stream) && remaining == 0.0 {
         clear_pending_readable_chunks(stream);
+        queue_readable_event(stream);
         schedule_readable_end(stream);
     }
     chunk

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -841,7 +841,6 @@ pub(super) fn read_stream_available_default(stream: f64) -> f64 {
     mark_disturbed(stream);
     clear_pending_readable_chunks(stream);
     if stream_hidden_ended(stream) {
-        queue_readable_event(stream);
         schedule_readable_end(stream);
     }
     let encoded = readable_encoding_tag(stream).is_some();
@@ -944,7 +943,6 @@ pub(super) fn read_stream_object_mode_chunk(stream: f64) -> f64 {
     mark_disturbed(stream);
     if stream_hidden_ended(stream) && remaining == 0.0 {
         clear_pending_readable_chunks(stream);
-        queue_readable_event(stream);
         schedule_readable_end(stream);
     }
     chunk

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -164,12 +164,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.from(asyncIterable) \u2192 data event chain doesn't deliver. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/events/readable-event": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: `readable` event (paused-mode trigger) doesn't fire. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/readable/wrap-old-stream": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- stop queueing an extra readable event when read() drains the final buffered chunk after EOF
- keep scheduling end once the readable buffer is empty
- remove the now-green stream/events/readable-event known failure

## Verification
- cargo fmt --check
- jq empty test-parity/known_failures.json
- cargo check -p perry-runtime
- ./run_parity_tests.sh --suite node-suite --module stream/events --filter readable-event (2 pass; parity_report_20260529_213606.json)
- ./run_parity_tests.sh --suite node-suite --module stream/events --filter end-event (1 pass; parity_report_20260529_213739.json)
- ./run_parity_tests.sh --suite node-suite --module stream/readable --filter read-after-end (1 pass; parity_report_20260529_213745.json)