### PR TITLE
node:util: validate deprecate target

### DIFF
--- a/crates/perry-runtime/src/util_promisify.rs
+++ b/crates/perry-runtime/src/util_promisify.rs
@@ -99,6 +99,23 @@ fn validate_original_function(fn_value: f64) {
     crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
 }
 
+fn throw_plain_type_error(message: &str) -> ! {
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+fn validate_deprecate_target(fn_value: f64) {
+    if is_callable_closure(fn_value) {
+        return;
+    }
+    let message = format!(
+        "The \"fn\" argument must be of type function. Received {}",
+        crate::fs::validate::describe_received(fn_value)
+    );
+    throw_plain_type_error(&message);
+}
+
 fn custom_promisified_value(fn_value: f64) -> Option<f64> {
     let scope = crate::gc::RuntimeHandleScope::new();
     let fn_handle = scope.root_nanbox_f64(fn_value);
@@ -216,6 +233,7 @@ pub extern "C" fn js_util_promisify(fn_value: f64) -> f64 {
 /// contain spaces.
 #[no_mangle]
 pub extern "C" fn js_util_deprecate(fn_value: f64, _msg: f64, _code: f64) -> f64 {
+    validate_deprecate_target(fn_value);
     fn_value
 }
 

--- a/test-parity/node-suite/util/deprecate/target-validation.ts
+++ b/test-parity/node-suite/util/deprecate/target-validation.ts
@@ -1,0 +1,20 @@
+import { deprecate } from "node:util";
+
+function show(label: string, value: any): void {
+  try {
+    const wrapped = deprecate(value, "deprecated fn", "DEP_PERRY_TARGET");
+    console.log(label, "ok", typeof wrapped);
+  } catch (err) {
+    const e = err as Error & { code?: string };
+    console.log(label, "throw", e.name, e.code ?? "no-code", err instanceof TypeError);
+  }
+}
+
+show("number", 1);
+show("string", "x");
+show("boolean", true);
+show("null", null);
+show("undefined", undefined);
+
+const wrapped = deprecate((x: number) => x + 1, "deprecated fn", "DEP_PERRY_VALID");
+console.log("valid", typeof wrapped);


### PR DESCRIPTION
## Summary
- make `util.deprecate(fn, msg[, code])` synchronously reject non-callable targets instead of returning them unchanged
- throw a plain `TypeError` without an `err.code`, matching the observed Node shape for these bad targets
- add focused parity coverage for primitive/nullish targets while keeping valid callable behavior covered

Closes #2983.

## Validation
- `PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" node --experimental-strip-types test-parity/node-suite/util/deprecate/target-validation.ts`
- pre-fix parity failure: `test-parity/reports/parity_report_20260530_042532.json`
- `env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module util --filter deprecate/target-validation` (report: `test-parity/reports/parity_report_20260530_043934.json`)
- `env RUSTC_WRAPPER= PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module util --filter deprecate` (report: `test-parity/reports/parity_report_20260530_043516.json`)
- `cargo fmt --all -- --check`
- `git diff --check HEAD~1..HEAD`
- `./scripts/check_file_size.sh`
- `env RUSTC_WRAPPER= cargo check -p perry-runtime` (passes with existing warnings)