### PR TITLE
fix(util): validate deprecate target

### DIFF
--- a/crates/perry-runtime/src/util_promisify.rs
+++ b/crates/perry-runtime/src/util_promisify.rs
@@ -216,6 +216,8 @@ pub extern "C" fn js_util_promisify(fn_value: f64) -> f64 {
 /// contain spaces.
 #[no_mangle]
 pub extern "C" fn js_util_deprecate(fn_value: f64, _msg: f64, _code: f64) -> f64 {
+    validate_original_function(fn_value);
+
     fn_value
 }
 

--- a/test-parity/node-suite/util/deprecate/input-validation.ts
+++ b/test-parity/node-suite/util/deprecate/input-validation.ts
@@ -1,0 +1,18 @@
+import { deprecate } from "node:util";
+
+function check(label: string, value: any) {
+  try {
+    const wrapped = deprecate(value, "deprecated");
+    console.log(label, "ok", typeof wrapped);
+  } catch (err: any) {
+    console.log(label, "throw", err?.name, err instanceof TypeError);
+  }
+}
+
+check("undefined", undefined);
+check("null", null);
+check("number", 1);
+check("string", "fn");
+
+const wrapped = deprecate((x: number) => x + 1, "deprecated", "DEP_PERRY_TEST");
+console.log("callable", typeof wrapped, wrapped(1));


### PR DESCRIPTION
## Summary
- validate `util.deprecate()` targets with the existing callable check used by `promisify` and `callbackify`
- add a focused parity fixture for nullish/primitive targets while preserving callable behavior

Fixes #2983.

## Pre-fix Perry Output
The new fixture previously returned non-callables unchanged:

```text
undefined ok undefined
null ok object
number ok number
string ok string
callable function 2
```

## Testing
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH node --experimental-strip-types test-parity/node-suite/util/deprecate/input-validation.ts`
- `target/release/perry test-parity/node-suite/util/deprecate/input-validation.ts -o /tmp/perry_util_deprecate_validation_2983_rebased && /tmp/perry_util_deprecate_validation_2983_rebased`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module util/deprecate --filter input-validation` (`test-parity/reports/parity_report_20260530_044239.json`)
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module util/deprecate --filter basic-warning` (`test-parity/reports/parity_report_20260530_044247.json`)
- `RUSTC_WRAPPER= cargo check -p perry-runtime`
- `RUSTC_WRAPPER= cargo build --release -p perry`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `rg -n "^(<<<<<<<|>>>>>>>)"` (exit 1, no conflict markers)
- `./scripts/check_file_size.sh`
