### PR TITLE
fix(punycode): preserve uppercase toUnicode prefixes

### DIFF
--- a/crates/perry-runtime/src/punycode.rs
+++ b/crates/perry-runtime/src/punycode.rs
@@ -228,9 +228,8 @@ fn to_ascii(domain: &str) -> String {
 /// `punycode.toUnicode(domain)` — decode each `xn--` label back to Unicode.
 fn to_unicode(domain: &str) -> Result<String, &'static str> {
     map_labels_result(domain, |label| {
-        let lower = label.to_ascii_lowercase();
-        if let Some(rest) = lower.strip_prefix("xn--") {
-            decode(rest)
+        if let Some(rest) = label.strip_prefix("xn--") {
+            decode(&rest.to_ascii_lowercase())
         } else {
             Ok(label.to_string())
         }

--- a/test-parity/node-suite/punycode/to-unicode-prefix-case.ts
+++ b/test-parity/node-suite/punycode/to-unicode-prefix-case.ts
@@ -1,0 +1,27 @@
+(process as any).noDeprecation = true;
+const punycode = (process as any).getBuiltinModule("punycode");
+
+console.log(
+  "lower prefix lower payload:",
+  punycode.toUnicode("xn--bcher-kva.example"),
+);
+console.log(
+  "lower prefix upper payload:",
+  punycode.toUnicode("xn--BCHER-KVA.example"),
+);
+console.log(
+  "upper prefix preserved:",
+  punycode.toUnicode("XN--BCHER-KVA.example"),
+);
+console.log(
+  "mixed prefix preserved 1:",
+  punycode.toUnicode("Xn--bcher-kva.example"),
+);
+console.log(
+  "mixed prefix preserved 2:",
+  punycode.toUnicode("xN--bcher-kva.example"),
+);
+console.log(
+  "multi labels:",
+  punycode.toUnicode("XN--BCHER-KVA.xn--BCHER-KVA"),
+);


### PR DESCRIPTION
## Summary
- make `punycode.toUnicode()` recognize only lowercase `xn--` prefixes
- keep decoding lowercase-prefix payloads case-insensitively by normalizing only the payload before decode
- add focused parity coverage for lowercase, uppercase, mixed-case, and multi-label prefix behavior

Fixes #3001.

## Verification
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH node --experimental-strip-types test-parity/node-suite/punycode/to-unicode-prefix-case.ts`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module punycode --filter to-unicode-prefix-case`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module punycode`
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `git diff --check && git diff --cached --check`
- `./scripts/check_file_size.sh`
- `RUSTC_WRAPPER= cargo check -p perry-runtime`