### PR TITLE
fix(util): coerce TextEncoder encode input

### DIFF
--- a/crates/perry-runtime/src/builtins/globals.rs
+++ b/crates/perry-runtime/src/builtins/globals.rs
@@ -14,8 +14,8 @@ use super::*;
 #[no_mangle]
 pub extern "C" fn js_text_encoder_encode(value: f64) -> i64 {
     use crate::buffer::js_buffer_from_string;
-    let str_ptr = crate::value::js_get_string_pointer_unified(value);
-    let buf = js_buffer_from_string(str_ptr as *const StringHeader, 0); // 0 = UTF-8
+    let str_ptr = crate::text::text_encoder_string_ptr(value);
+    let buf = js_buffer_from_string(str_ptr, 0); // 0 = UTF-8
     buf as i64
 }
 

--- a/crates/perry-runtime/src/text.rs
+++ b/crates/perry-runtime/src/text.rs
@@ -16,6 +16,27 @@ use crate::buffer::{buffer_alloc, buffer_data_mut, mark_as_uint8array, BufferHea
 use crate::object::{js_object_alloc, js_object_set_field_by_name, ObjectHeader};
 use crate::string::{js_string_from_bytes, StringHeader};
 
+fn throw_type_error(message: &[u8]) -> ! {
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    let bits = crate::value::JSValue::pointer(err as *const u8).bits();
+    crate::exception::js_throw(f64::from_bits(bits))
+}
+
+pub(crate) fn text_encoder_string_ptr(value: f64) -> *const StringHeader {
+    let jsval = crate::value::JSValue::from_bits(value.to_bits());
+
+    if jsval.is_undefined() {
+        return js_string_from_bytes(std::ptr::null(), 0) as *const StringHeader;
+    }
+
+    if unsafe { crate::symbol::js_is_symbol(value) != 0 } {
+        throw_type_error(b"Cannot convert a Symbol value to a string");
+    }
+
+    crate::value::js_jsvalue_to_string(value) as *const StringHeader
+}
+
 /// `new TextEncoder()` — returns a non-null sentinel integer pointer.
 ///
 /// The returned value is a small integer (`1`) that the codegen NaN-boxes
@@ -45,16 +66,11 @@ pub extern "C" fn js_text_decoder_new() -> i64 {
 /// with `POINTER_TAG` before handing it to user code.
 #[no_mangle]
 pub extern "C" fn js_text_encoder_encode_llvm(value: f64) -> i64 {
-    let str_ptr_i = crate::value::js_get_string_pointer_unified(value);
-    let (data_ptr, len) = if str_ptr_i == 0 {
-        (std::ptr::null::<u8>(), 0usize)
-    } else {
-        let str_ptr = str_ptr_i as *const StringHeader;
-        unsafe {
-            let l = (*str_ptr).byte_len as usize;
-            let d = (str_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-            (d, l)
-        }
+    let str_ptr = text_encoder_string_ptr(value);
+    let (data_ptr, len) = unsafe {
+        let l = (*str_ptr).byte_len as usize;
+        let d = (str_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        (d, l)
     };
 
     let buf = buffer_alloc(len as u32);

--- a/test-parity/node-suite/util/text-encoder-encode-coercion.ts
+++ b/test-parity/node-suite/util/text-encoder-encode-coercion.ts
@@ -1,0 +1,32 @@
+import { TextEncoder } from "node:util";
+
+const encoder = new TextEncoder();
+
+function show(label: string, fn: () => Uint8Array): void {
+  try {
+    const bytes = fn();
+    console.log(`${label}:`, Array.from(bytes).join(","));
+  } catch (error: any) {
+    console.log(
+      `${label}:`,
+      error?.name,
+      error?.code === undefined,
+      String(error?.message).split("\n")[0],
+    );
+  }
+}
+
+show("encode omitted", () => encoder.encode());
+show("encode undefined", () => encoder.encode(undefined));
+show("encode null", () => encoder.encode(null as any));
+show("encode number", () => encoder.encode(123 as any));
+show("encode boolean", () => encoder.encode(false as any));
+show("encode object", () =>
+  encoder.encode({
+    toString() {
+      return "obj";
+    },
+  } as any),
+);
+show("encode array", () => encoder.encode(["a", 2] as any));
+show("encode symbol", () => encoder.encode(Symbol("x") as any));


### PR DESCRIPTION
## Summary
- coerce TextEncoder.encode inputs through JS string conversion, while treating undefined as the default empty string
- throw TypeError for Symbol inputs before stringification
- add focused node:util parity coverage for omitted, undefined, primitive, object, array, and Symbol inputs

Closes #3023.

## Verification
- PATH=/home/github-runner/actions-runner/externals/node24/bin:/root/.codex/tmp/arg0/codex-arg0315Laj:/usr/local/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/root/.local/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin node --experimental-strip-types test-parity/node-suite/util/text-encoder-encode-coercion.ts
- pre-fix focused parity failed: test-parity/reports/parity_report_20260530_050200.json
- PATH=/home/github-runner/actions-runner/externals/node24/bin:/root/.codex/tmp/arg0/codex-arg0315Laj:/usr/local/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/root/.local/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module util --filter text-encoder-encode-coercion
- PATH=/home/github-runner/actions-runner/externals/node24/bin:/root/.codex/tmp/arg0/codex-arg0315Laj:/usr/local/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/root/.local/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module util --filter text-encoder
- PATH=/home/github-runner/actions-runner/externals/node24/bin:/root/.codex/tmp/arg0/codex-arg0315Laj:/usr/local/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/root/.local/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module globals --filter text-encoder
- cargo fmt --all -- --check
- jq empty test-parity/known_failures.json test-parity/threshold.json
- git diff --check
- git diff --cached --check
- ./scripts/check_file_size.sh
- RUSTC_WRAPPER= cargo check -p perry-runtime