### PR TITLE
fix(querystring): ignore fractional maxKeys

### DIFF
--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -408,10 +408,10 @@ fn resolve_max_keys(options: f64) -> Option<usize> {
     } else {
         return Some(1000);
     };
-    if n <= 0.0 || !n.is_finite() {
+    if n <= 0.0 || !n.is_finite() || n.fract() != 0.0 {
         None
     } else {
-        Some(n.floor() as usize)
+        Some(n as usize)
     }
 }
 

--- a/test-parity/node-suite/querystring/options/maxkeys-edge.ts
+++ b/test-parity/node-suite/querystring/options/maxkeys-edge.ts
@@ -1,7 +1,18 @@
 import querystring from "node:querystring";
 
 const input = "a=1&b=2&c=3";
-for (const maxKeys of [0, 1, 2, -1, Infinity, NaN] as any[]) {
+for (const maxKeys of [0, 0.1, 0.9, 1, 1.1, 2, 2.1, -1, Infinity, NaN] as any[]) {
   const out = querystring.parse(input, undefined, undefined, { maxKeys });
   console.log("maxKeys", String(maxKeys) + ":", Object.keys(out).join(","));
 }
+
+let large = "";
+for (let i = 0; i < 1005; i++) {
+  if (i > 0) large += "&";
+  large += "k" + i + "=v";
+}
+
+console.log(
+  "fractional large:",
+  Object.keys(querystring.parse(large, undefined, undefined, { maxKeys: 1.1 })).length,
+);


### PR DESCRIPTION
## Summary
- Treat fractional positive `querystring.parse` `maxKeys` values as unlimited, matching Node.
- Extend the `maxkeys-edge` parity fixture to cover fractional caps and a >1000-pair fractional case.

## Verification
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH node test-parity/node-suite/querystring/options/maxkeys-edge.ts`
- `target/release/perry run test-parity/node-suite/querystring/options/maxkeys-edge.ts`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module querystring/options --filter maxkeys-edge`
- `RUSTC_WRAPPER= cargo check -p perry-stdlib`
- `RUSTC_WRAPPER= cargo build --release -p perry`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD && git diff --check`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `rg -n "^(<<<<<<<|>>>>>>>)"` (no matches)
- `./scripts/check_file_size.sh`

Closes #3033
