### PR TITLE
fix(querystring): coerce public codec inputs

### DIFF
--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -171,23 +171,31 @@ fn hex_nibble(b: u8) -> Option<u8> {
     }
 }
 
+fn throw_symbol_to_string_type_error() -> ! {
+    let message = b"Cannot convert a Symbol value to a string";
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = perry_runtime::error::js_typeerror_new(msg);
+    perry_runtime::exception::js_throw(perry_runtime::value::js_nanbox_pointer(err as i64))
+}
+
+unsafe fn querystring_public_arg_to_string(value: f64) -> String {
+    if perry_runtime::symbol::js_is_symbol(value) != 0 {
+        throw_symbol_to_string_type_error();
+    }
+    jsvalue_to_owned_string(value)
+}
+
 /// `querystring.escape(str)` → string.
 #[no_mangle]
 pub unsafe extern "C" fn js_querystring_escape(str_arg: f64) -> f64 {
-    let s = match nanboxed_to_string(str_arg) {
-        Some(s) => s,
-        None => return f64::from_bits(JSValue::undefined().bits()),
-    };
+    let s = querystring_public_arg_to_string(str_arg);
     nanbox_string(intern_string(&percent_encode(&s)))
 }
 
 /// `querystring.unescape(str)` → string.
 #[no_mangle]
 pub unsafe extern "C" fn js_querystring_unescape(str_arg: f64) -> f64 {
-    let s = match nanboxed_to_string(str_arg) {
-        Some(s) => s,
-        None => return f64::from_bits(JSValue::undefined().bits()),
-    };
+    let s = querystring_public_arg_to_string(str_arg);
     nanbox_string(intern_string(&percent_decode(&s, false)))
 }
 

--- a/test-parity/node-suite/querystring/escape/coerce-inputs.ts
+++ b/test-parity/node-suite/querystring/escape/coerce-inputs.ts
@@ -1,0 +1,29 @@
+import querystring from "node:querystring";
+
+const values = [
+  ["undefined", undefined],
+  ["null", null],
+  ["number", 123],
+  ["boolean", true],
+  ["object", {}],
+] as any[];
+
+console.log("escape omitted:", JSON.stringify(querystring.escape()));
+console.log("unescape omitted:", JSON.stringify(querystring.unescape()));
+
+for (const [label, value] of values) {
+  console.log("escape", label + ":", JSON.stringify(querystring.escape(value)));
+  console.log("unescape", label + ":", JSON.stringify(querystring.unescape(value)));
+}
+
+try {
+  console.log("escape symbol:", JSON.stringify(querystring.escape(Symbol("x") as any)));
+} catch (error: any) {
+  console.log("escape symbol throw:", String(error).slice(0, 9));
+}
+
+try {
+  console.log("unescape symbol:", JSON.stringify(querystring.unescape(Symbol("x") as any)));
+} catch (error: any) {
+  console.log("unescape symbol throw:", String(error).slice(0, 9));
+}


### PR DESCRIPTION
Summary:
- Coerce public `querystring.escape` and `querystring.unescape` inputs through string conversion instead of returning undefined for non-strings.
- Preserve Node's Symbol conversion TypeError behavior for both helpers.
- Add parity coverage for omitted, undefined, null, number, boolean, object, and Symbol inputs.

Verification:
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module querystring/escape` (4/4 passed; report: `test-parity/reports/parity_report_20260530_055422.json`)
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module querystring/unescape` (4/4 passed; report: `test-parity/reports/parity_report_20260530_055541.json`)
- `RUSTC_WRAPPER= cargo check -p perry-stdlib`
- `RUSTC_WRAPPER= cargo build --release -p perry`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `rg -n "^(<<<<<<<|>>>>>>>)"` (no matches)
- `./scripts/check_file_size.sh`

Closes #3031.
