### PR TITLE
fix(stream): support Duplex.from object wrappers

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -764,12 +764,21 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         args: &[NA_STR],
         ret: NR_PTR,
     },
-    // ========== node:stream — Readable.from(iterable) (#631) ==========
+    // ========== node:stream — Readable.from / Duplex.from (#631/#1532) ==========
     // The other stream constructors (`new Readable(opts)` etc.) are wired
     // via `lower_builtin_new` so the codegen can carry the closure-fields
     // ObjectHeader with NaN-boxed POINTER_TAG; they never reach this
-    // table. `Readable.from` is a static factory call surfaced as
-    // `Readable.from(...)` → `stream.from(...)`, so it lives here.
+    // table. Static factory calls surface as `stream.from(...)` with a
+    // class filter for constructor imports like `Duplex.from(...)`.
+    NativeModSig {
+        module: "stream",
+        has_receiver: false,
+        method: "from",
+        class_filter: Some("Duplex"),
+        runtime: "js_node_stream_duplex_from_options",
+        args: &[NA_F64, NA_F64],
+        ret: NR_F64,
+    },
     NativeModSig {
         module: "stream",
         has_receiver: false,

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -915,6 +915,11 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, DOUBLE],
     );
+    module.declare_function(
+        "js_node_stream_duplex_from_options",
+        DOUBLE,
+        &[DOUBLE, DOUBLE],
+    );
     // #1534: static introspection helpers reflecting tracked stream state.
     module.declare_function("js_node_stream_is_disturbed", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_is_errored", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -45,6 +45,13 @@ fn unwrap_ts_wrappers(e: &ast::Expr) -> &ast::Expr {
     }
 }
 
+fn is_node_stream_class_name(name: &str) -> bool {
+    matches!(
+        name,
+        "Readable" | "Writable" | "Duplex" | "Transform" | "PassThrough"
+    )
+}
+
 pub(super) fn try_native_module_methods(
     ctx: &mut LoweringContext,
     call: &ast::CallExpr,
@@ -1212,10 +1219,17 @@ pub(super) fn try_native_module_methods(
                                 crate::lower_bail!(member.span, "{}", msg);
                             }
                         }
+                        let class_name = if module_name == "stream"
+                            && imported_method.is_some_and(is_node_stream_class_name)
+                        {
+                            imported_method.map(str::to_string)
+                        } else {
+                            None
+                        };
                         return Ok(Ok(Expr::NativeMethodCall {
                             module: module_name.to_string(),
-                            class_name: None, // Will be set by js_transform if needed
-                            object: None,     // Static call on module itself
+                            class_name,
+                            object: None, // Static call on module itself
                             method: method_name,
                             args,
                         }));

--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -796,18 +796,11 @@ pub extern "C" fn js_node_stream_add_abort_signal(signal: f64, stream: f64) -> f
     stream
 }
 
-fn node_stream_duplex_from_source_chunks(source: f64) -> f64 {
+fn attach_duplex_readable_source(duplex: f64, source: f64) -> Result<(), f64> {
     let chunks = if let Some(chunks) = readable_hidden_chunks(source) {
         chunks
     } else {
-        match collect_pipeline_chunks(source) {
-            Ok(chunks) => chunks,
-            Err(err) => {
-                let duplex = js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED));
-                set_hidden_value(duplex, hidden_error_key(), err);
-                return duplex;
-            }
-        }
+        collect_pipeline_chunks(source)?
     };
     let values = pipeline_chunks_vec(chunks);
     let mut arr = crate::array::js_array_alloc(values.len() as u32);
@@ -815,8 +808,6 @@ fn node_stream_duplex_from_source_chunks(source: f64) -> f64 {
         arr = crate::array::js_array_push_f64(arr, chunk);
     }
 
-    let duplex = js_node_stream_duplex_new(readable_from_options(f64::from_bits(TAG_UNDEFINED)));
-    set_visible_writable(duplex, false);
     set_hidden_value(duplex, hidden_chunks_key(), box_pointer(arr as *const u8));
     set_hidden_value(
         duplex,
@@ -828,7 +819,102 @@ fn node_stream_duplex_from_source_chunks(source: f64) -> f64 {
         hidden_key(b"readableLength"),
         crate::array::js_array_length(arr) as f64,
     );
+    Ok(())
+}
+
+fn node_stream_duplex_from_source_chunks(source: f64) -> f64 {
+    let duplex = js_node_stream_duplex_new(readable_from_options(f64::from_bits(TAG_UNDEFINED)));
+    set_visible_writable(duplex, false);
+    if let Err(err) = attach_duplex_readable_source(duplex, source) {
+        set_hidden_value(duplex, hidden_error_key(), err);
+    }
     duplex
+}
+
+pub(super) extern "C" fn duplex_from_writable_write_callback(
+    closure: *const ClosureHeader,
+    chunk: f64,
+    encoding: f64,
+    cb: f64,
+) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let writable = js_closure_get_capture_f64(closure, 0);
+    js_node_stream_method_write(raw_ptr_from_value(writable) as i64, chunk, encoding, cb)
+}
+
+pub(super) extern "C" fn duplex_from_writable_final_callback(
+    closure: *const ClosureHeader,
+    cb: f64,
+) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let writable = js_closure_get_capture_f64(closure, 0);
+    js_node_stream_method_end(
+        raw_ptr_from_value(writable) as i64,
+        f64::from_bits(TAG_UNDEFINED),
+    );
+    call_listener_args(writable, cb, &[]);
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+fn install_duplex_from_writable(duplex: f64, writable: f64) {
+    let raw = raw_ptr_from_value(duplex);
+    if raw < 0x10000 {
+        return;
+    }
+    let obj = raw as *mut ObjectHeader;
+    let write = js_closure_alloc(duplex_from_writable_write_callback as *const u8, 1);
+    js_closure_set_capture_f64(write, 0, writable);
+    js_object_set_field_by_name(
+        obj,
+        hidden_write_key(),
+        f64::from_bits(JSValue::pointer(write as *const u8).bits()),
+    );
+
+    let final_cb = js_closure_alloc(duplex_from_writable_final_callback as *const u8, 1);
+    js_closure_set_capture_f64(final_cb, 0, writable);
+    js_object_set_field_by_name(
+        obj,
+        hidden_writable_final_key(),
+        f64::from_bits(JSValue::pointer(final_cb as *const u8).bits()),
+    );
+
+    set_hidden_value(duplex, hidden_key(b"duplexWrappedWritable"), writable);
+    set_hidden_value(
+        duplex,
+        hidden_key(b"writableCustomSink"),
+        f64::from_bits(TAG_TRUE),
+    );
+}
+
+#[no_mangle]
+pub extern "C" fn js_node_stream_duplex_from_options(body: f64, _opts: f64) -> f64 {
+    if object_ptr_from_value(body).is_some() && !is_classic_stream_instance_value(body) {
+        let readable = get_hidden_value(body, hidden_key(b"readable"));
+        let writable = get_hidden_value(body, hidden_key(b"writable"));
+        if readable.is_some() || writable.is_some() {
+            let duplex =
+                js_node_stream_duplex_new(readable_from_options(f64::from_bits(TAG_UNDEFINED)));
+            if let Some(readable) = readable {
+                if let Err(err) = attach_duplex_readable_source(duplex, readable) {
+                    set_hidden_value(duplex, hidden_error_key(), err);
+                }
+            } else {
+                set_visible_readable(duplex, false);
+            }
+            if let Some(writable) = writable {
+                install_duplex_from_writable(duplex, writable);
+            } else {
+                set_visible_writable(duplex, false);
+            }
+            return duplex;
+        }
+    }
+
+    node_stream_duplex_from_source_chunks(body)
 }
 
 /// #1539: `stream.compose(...streams)` chains a sequence of streams

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -224,12 +224,6 @@
     "category": "bug-open",
     "reason": "node:stream: Duplex.from(asyncIterable) \u2014 async-gen \u2192 Duplex form not yet wired. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/duplex/from-object-form": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: Duplex.from({readable, writable}) \u2014 combine-form not yet wired. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/compose/compose-array-form": {
     "issue": "1531",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- route named node:stream class static calls with their class filter so Duplex.from can use a Duplex-specific runtime entry
- implement Duplex.from({ readable, writable }) by copying the readable source and forwarding writes/finalization to the wrapped writable
- remove node-suite/stream/duplex/from-object-form from known failures

## Verification
- cargo check -p perry-runtime -p perry-hir -p perry-codegen
- cargo fmt --check
- jq empty test-parity/known_failures.json
- git diff --check
- ./run_parity_tests.sh --suite node-suite --module stream/duplex --filter from-object-form
- ./run_parity_tests.sh --suite node-suite --module stream/duplex --filter from-readable
- ./run_parity_tests.sh --suite node-suite --module stream/readable --filter from-array