### PR TITLE
fix(querystring): coerce separator inputs

### DIFF
--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -262,8 +262,8 @@ pub unsafe extern "C" fn js_querystring_parse(
     options_arg: f64,
 ) -> *mut ObjectHeader {
     let input = nanboxed_to_string(str_arg).unwrap_or_default();
-    let sep = resolve_separator_str(sep_arg, "&");
-    let eq = resolve_separator_str(eq_arg, "=");
+    let sep = resolve_parse_separator_str(sep_arg, "&");
+    let eq = resolve_parse_separator_str(eq_arg, "=");
     let max_keys = resolve_max_keys(options_arg);
     let decode = resolve_codec_option(options_arg, "decodeURIComponent");
 
@@ -493,8 +493,8 @@ pub unsafe extern "C" fn js_querystring_stringify(
 ) -> f64 {
     // Default separators are the bytes Node uses; we read into UTF-8
     // strings instead of bytes since the chars are always ASCII.
-    let sep = resolve_separator_str(sep_arg, "&");
-    let eq = resolve_separator_str(eq_arg, "=");
+    let sep = resolve_stringify_separator_str(sep_arg, "&");
+    let eq = resolve_stringify_separator_str(eq_arg, "=");
     let encode = resolve_codec_option(options_arg, "encodeURIComponent");
 
     let bits = obj_arg.to_bits();
@@ -530,15 +530,29 @@ pub unsafe extern "C" fn js_querystring_stringify(
     nanbox_string(intern_string(&out))
 }
 
-fn resolve_separator_str(value: f64, default: &'static str) -> String {
-    let bits = value.to_bits();
-    if bits == JSValue::undefined().bits() || bits == JSValue::null().bits() {
+unsafe fn resolve_parse_separator_str(value: f64, default: &'static str) -> String {
+    if perry_runtime::value::js_is_truthy(value) == 0 {
         return default.to_string();
     }
-    match unsafe { nanboxed_to_string(value) } {
-        Some(s) if !s.is_empty() => s,
-        _ => default.to_string(),
+    jsvalue_to_owned_string(value)
+}
+
+unsafe fn resolve_stringify_separator_str(value: f64, default: &'static str) -> String {
+    if perry_runtime::value::js_is_truthy(value) == 0 {
+        return default.to_string();
     }
+    if perry_runtime::symbol::js_is_symbol(value) != 0 {
+        throw_symbol_to_string_type_error();
+    }
+    jsvalue_to_owned_string(value)
+}
+
+fn throw_symbol_to_string_type_error() -> ! {
+    let msg = "Cannot convert a Symbol value to a string";
+    let msg_str = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err_ptr = perry_runtime::error::js_typeerror_new(msg_str);
+    let err_value = JSValue::pointer(err_ptr as *const u8).bits();
+    perry_runtime::exception::js_throw(f64::from_bits(err_value))
 }
 
 /// Append `key=value` (or `key=v1&key=v2` for arrays) to `out`.

--- a/test-parity/node-suite/querystring/options/separator-coercion.ts
+++ b/test-parity/node-suite/querystring/options/separator-coercion.ts
@@ -1,0 +1,53 @@
+import querystring from "node:querystring";
+
+const parseCases = [
+  ["sep empty", () => querystring.parse("a&b", "", "=")],
+  ["sep number", () => querystring.parse("a1b1c", 1 as any, "=")],
+  ["sep zero", () => querystring.parse("a0b", 0 as any, "=")],
+  ["sep true", () => querystring.parse("a=trueb=truec", true as any, "=")],
+  ["sep false", () => querystring.parse("afalseb", false as any, "=")],
+  ["sep object", () => querystring.parse("a[object Object]b", {} as any, "=")],
+  ["sep symbol", () => querystring.parse("aSymbol(x)b", Symbol("x") as any, "=")],
+  ["eq empty", () => querystring.parse("a=1&b=2", "&", "")],
+  ["eq number", () => querystring.parse("a=1&b=2", "&", 1 as any)],
+  ["eq zero", () => querystring.parse("a0 1&b0 2", "&", 0 as any)],
+  ["eq true", () => querystring.parse("a=1&b=2", "&", true as any)],
+  ["eq false", () => querystring.parse("afalse1&bfalse2", "&", false as any)],
+  ["eq object", () => querystring.parse("a[object Object]1&b[object Object]2", "&", {} as any)],
+  ["eq symbol", () => querystring.parse("aSymbol(x)1&bSymbol(x)2", "&", Symbol("x") as any)],
+] as const;
+
+for (const [label, run] of parseCases) {
+  console.log("parse", label + ":", JSON.stringify(run()));
+}
+
+const stringifyCases = [
+  ["sep empty", () => querystring.stringify({ a: 1, b: 2 }, "", "=")],
+  ["sep number", () => querystring.stringify({ a: 1, b: 2 }, 1 as any, "=")],
+  ["sep zero", () => querystring.stringify({ a: 1, b: 2 }, 0 as any, "=")],
+  ["sep true", () => querystring.stringify({ a: 1, b: 2 }, true as any, "=")],
+  ["sep false", () => querystring.stringify({ a: 1, b: 2 }, false as any, "=")],
+  ["sep object", () => querystring.stringify({ a: 1, b: 2 }, {} as any, "=")],
+  ["eq empty", () => querystring.stringify({ a: 1, b: 2 }, "&", "")],
+  ["eq number", () => querystring.stringify({ a: 1, b: 2 }, "&", 1 as any)],
+  ["eq zero", () => querystring.stringify({ a: 1, b: 2 }, "&", 0 as any)],
+  ["eq true", () => querystring.stringify({ a: 1, b: 2 }, "&", true as any)],
+  ["eq false", () => querystring.stringify({ a: 1, b: 2 }, "&", false as any)],
+  ["eq object", () => querystring.stringify({ a: 1, b: 2 }, "&", {} as any)],
+] as const;
+
+for (const [label, run] of stringifyCases) {
+  console.log("stringify", label + ":", JSON.stringify(run()));
+}
+
+try {
+  console.log("stringify sep symbol:", querystring.stringify({ a: 1, b: 2 }, Symbol("x") as any, "="));
+} catch (error: any) {
+  console.log("stringify sep symbol throw:", error.name);
+}
+
+try {
+  console.log("stringify eq symbol:", querystring.stringify({ a: 1, b: 2 }, "&", Symbol("x") as any));
+} catch (error: any) {
+  console.log("stringify eq symbol throw:", error.name);
+}


### PR DESCRIPTION
Summary:
- Coerce `querystring.parse()` separator and equality arguments from truthy non-string values instead of treating them as omitted.
- Coerce `querystring.stringify()` separators similarly while preserving Node's Symbol TypeError behavior.
- Add parity coverage for falsy defaults, numeric/boolean/object/Symbol separator inputs, and both `sep`/`eq` positions.

Verification:
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module querystring/options` (12/12 passed; report: `test-parity/reports/parity_report_20260530_062055.json`)
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module querystring/parse` (19/19 passed; report: `test-parity/reports/parity_report_20260530_062216.json`)
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module querystring/stringify` (14/14 passed; report: `test-parity/reports/parity_report_20260530_062246.json`)
- `RUSTC_WRAPPER= cargo check -p perry-stdlib`
- `RUSTC_WRAPPER= cargo build --release -p perry`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `rg -n "^(<<<<<<<|>>>>>>>)"` (no matches)
- `./scripts/check_file_size.sh`

Closes #3032.
