### PR TITLE
fix(timers/promises): validate delay and options arguments (#3067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1038 — validate `node:timers/promises` delay and options arguments (#3067)
+
+`node:timers/promises` helpers passed `delay` and `options` straight into the
+timer primitive. Node rejects a non-number `delay` and a non-object `options`
+with `TypeError [ERR_INVALID_ARG_TYPE]`; Perry silently accepted them, and
+`setImmediate` didn't even take an `options` argument.
+
+`crates/perry-runtime/src/node_submodules/timers.rs` gains two small validators:
+
+- `validate_delay` throws unless `delay` is `undefined` (Node defaults it) or a
+  number. `NaN` still passes — the warn/coerce path is tracked separately by
+  #2966.
+- `validate_options` throws unless `options` is `undefined` (treated as the
+  empty object) or a non-null, non-array object, mirroring Node's
+  `validateObject`. Array/`null` detection reuses the GC-header check that
+  `describe_received` already performs.
+
+Both are wired into `timers_promises_set_timeout`, `timers_promises_set_immediate`,
+and — by delegation — `timers_promises_scheduler_wait`. `setImmediate` now
+accepts an `options` argument: its `ExportThunk` arity is bumped from `Fn1` to
+`Fn2` in `ensure_export_singleton`, and the closure dispatch pads a missing
+options arg with `undefined`. Honoring the `signal`/`ref` fields of `options`
+remains tracked by #2603.
+
+New `test-parity/node-suite/timers/promises/delay-options-validation.ts` is
+byte-identical to `node --experimental-strip-types`; the rest of the
+`timers/promises` suite is unchanged (the validators no-op for valid inputs).
+
 ## v0.5.1037 — split `node_stream.rs` into topical sub-modules (#1987)
 
 `crates/perry-runtime/src/node_stream.rs` had grown to ~5,980 lines during

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1037
+**Current Version:** 0.5.1038
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4880,7 +4880,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "anyhow",
  "base64",
@@ -4935,14 +4935,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "cc",
  "libc",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "anyhow",
  "log",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "anyhow",
  "base64",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "serde",
  "serde_json",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1037"
+version = "0.5.1038"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "anyhow",
  "clap",
@@ -5056,14 +5056,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "chrono",
  "cron",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5162,14 +5162,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "base64",
  "image",
@@ -5354,14 +5354,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5388,7 +5388,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "brotli",
  "flate2",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "anyhow",
  "base64",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5571,14 +5571,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "base64",
  "itoa",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "base64",
  "block2",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "base64",
  "block2",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1037"
+version = "0.5.1038"
 
 [[package]]
 name = "perry-ui-test"
@@ -5667,11 +5667,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1037"
+version = "0.5.1038"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "base64",
  "block2",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "base64",
  "block2",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "block2",
  "libc",
@@ -5716,7 +5716,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "base64",
  "libc",
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1037"
+version = "0.5.1038"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1037"
+version = "0.5.1038"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -218,7 +218,7 @@ const SUBMODULES: &[SubmoduleSpec] = &[
             },
             ExportSpec {
                 name: "setImmediate",
-                thunk: ExportThunk::Fn1(timers_promises_set_immediate),
+                thunk: ExportThunk::Fn2(timers_promises_set_immediate),
             },
             ExportSpec {
                 name: "setInterval",

--- a/crates/perry-runtime/src/node_submodules/timers.rs
+++ b/crates/perry-runtime/src/node_submodules/timers.rs
@@ -11,6 +11,53 @@ use crate::object::{js_object_alloc, js_object_set_field_by_name};
 use crate::string::js_string_from_bytes;
 use crate::value::JSValue;
 
+/// #3067 — `node:timers/promises` helpers reject a non-number `delay` and a
+/// non-object `options` with the same `TypeError [ERR_INVALID_ARG_TYPE]` shape
+/// Node emits. A missing (`undefined`) argument is allowed: Node defaults the
+/// delay and treats absent options as the empty object. `NaN` is a number, so
+/// it passes here (the warn/coerce path is tracked by #2966).
+fn validate_delay(delay: f64) {
+    let jv = JSValue::from_bits(delay.to_bits());
+    if jv.is_undefined() || crate::fs::validate::is_numeric(jv) {
+        return;
+    }
+    let message = format!(
+        "The \"delay\" argument must be of type number. Received {}",
+        crate::fs::validate::describe_received(delay)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
+/// Accept `undefined` (no options) or a non-null, non-array object; anything
+/// else throws like Node's `validateObject`. Mirrors the `Array`/`null`
+/// detection used by `describe_received`.
+fn validate_options(options: f64) {
+    let jv = JSValue::from_bits(options.to_bits());
+    if jv.is_undefined() || is_plain_object(options) {
+        return;
+    }
+    let message = format!(
+        "The \"options\" argument must be of type object. Received {}",
+        crate::fs::validate::describe_received(options)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
+/// True when `value` is a heap object that is not an array — the shape Node's
+/// `validateObject` admits for a timer `options` bag.
+fn is_plain_object(value: f64) -> bool {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return false;
+    }
+    let ptr = jv.as_pointer::<u8>();
+    if ptr.is_null() || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return false;
+    }
+    let gc_header = unsafe { &*(ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader) };
+    gc_header.obj_type != crate::gc::GC_TYPE_ARRAY
+}
+
 /// node:timers/promises.setTimeout(delay, value?) — a Promise that resolves
 /// with `value` (or undefined) after `delay` ms. Composes the existing
 /// promise-returning timer primitive; the closure dispatch pads a missing
@@ -22,6 +69,8 @@ pub(crate) extern "C" fn timers_promises_set_timeout(
     value: f64,
     options: f64,
 ) -> f64 {
+    validate_delay(delay_ms);
+    validate_options(options);
     let signal = super::stream_promises::options_signal(options);
     if let Some(signal) = signal {
         if super::stream_promises::signal_aborted(signal) {
@@ -38,12 +87,16 @@ pub(crate) extern "C" fn timers_promises_set_timeout(
     crate::value::js_nanbox_pointer(promise as i64)
 }
 
-/// node:timers/promises.setImmediate(value?) — a Promise that resolves with
-/// `value` (or undefined) on a later turn. Refs #1213.
+/// node:timers/promises.setImmediate(value?, options?) — a Promise that
+/// resolves with `value` (or undefined) on a later turn. `options` is validated
+/// for type (#3067); honoring its `signal`/`ref` fields is tracked by #2603.
+/// Refs #1213.
 pub(crate) extern "C" fn timers_promises_set_immediate(
     _closure: *const ClosureHeader,
     value: f64,
+    options: f64,
 ) -> f64 {
+    validate_options(options);
     let promise = crate::timer::js_set_timeout_value(0.0, value);
     crate::value::js_nanbox_pointer(promise as i64)
 }

--- a/test-parity/node-suite/timers/promises/delay-options-validation.ts
+++ b/test-parity/node-suite/timers/promises/delay-options-validation.ts
@@ -1,0 +1,31 @@
+// Issue #3067 — `node:timers/promises` helpers reject a non-number `delay`
+// and a non-object `options` with `TypeError [ERR_INVALID_ARG_TYPE]`, matching
+// Node. A missing argument is allowed (delay defaults, options treated as the
+// empty object); a non-null, non-array object is a valid options bag. The
+// `NaN`-delay warn/coerce path is excluded here — it is tracked by #2966.
+import * as timers from "node:timers/promises";
+
+async function probe(label: string, fn: () => Promise<unknown>) {
+  try {
+    const result = await fn();
+    console.log(label, "OK", result);
+  } catch (err: any) {
+    console.log(label, "THROW", err.name, err.code, err.message.split("\n")[0]);
+  }
+}
+
+await probe("setTimeout string delay", () => timers.setTimeout("x" as any, "v"));
+await probe("setTimeout null delay", () => timers.setTimeout(null as any, "v"));
+await probe("setTimeout object delay", () => timers.setTimeout({} as any, "v"));
+await probe("setTimeout no delay", () => timers.setTimeout());
+await probe("setTimeout undefined delay", () => timers.setTimeout(undefined, "v"));
+await probe("setTimeout options primitive", () => timers.setTimeout(0, "v", 1 as any));
+await probe("setTimeout options null", () => timers.setTimeout(0, "v", null as any));
+await probe("setTimeout options array", () => timers.setTimeout(0, "v", [] as any));
+await probe("setTimeout options object", () => timers.setTimeout(0, "v", {}));
+await probe("setTimeout options undefined", () => timers.setTimeout(0, "v", undefined));
+await probe("setImmediate options primitive", () => timers.setImmediate("v", 1 as any));
+await probe("setImmediate options null", () => timers.setImmediate("v", null as any));
+await probe("setImmediate no options", () => timers.setImmediate("v"));
+await probe("scheduler.wait string delay", () => timers.scheduler.wait("x" as any));
+await probe("scheduler.wait number", () => timers.scheduler.wait(0));


### PR DESCRIPTION
Closes #3067.

## Problem

`node:timers/promises` helpers passed `delay`/`options` straight through. Node rejects a non-number `delay` and a non-object `options` with `TypeError [ERR_INVALID_ARG_TYPE]`; Perry silently accepted them, and `setImmediate` didn't even take an `options` argument.

## Fix

`crates/perry-runtime/src/node_submodules/timers.rs`:

- `validate_delay` — throws unless `delay` is `undefined` (defaulted) or a number (`NaN` passes; the warn/coerce path is tracked by #2966).
- `validate_options` — throws unless `options` is `undefined` or a non-null, non-array object (mirrors Node's `validateObject`).
- Wired into `setTimeout`, `setImmediate`, and (via delegation) `scheduler.wait`.
- `setImmediate` now accepts an `options` argument — arity bumped to `Fn2` in `ensure_export_singleton`. Honoring `signal`/`ref` stays tracked by #2603.

## Validation

New `test-parity/node-suite/timers/promises/delay-options-validation.ts` is byte-identical to `node --experimental-strip-types`. All other `timers/promises` parity tests still pass (the lone `timeout-value-and-ref` diff is a pre-existing `ref:false`/#2603 discrepancy, unaffected by this change — the new validation no-ops for valid inputs).
