### PR TITLE
fix(stream): expose async disposal to await using

### DIFF
--- a/crates/perry-runtime/src/node_stream_dispatch.rs
+++ b/crates/perry-runtime/src/node_stream_dispatch.rs
@@ -209,6 +209,11 @@ pub(super) fn install_stream_async_dispose_symbol(stream: f64) {
     }
     let closure = js_closure_alloc(ns_async_dispose as *const u8, 1);
     crate::closure::js_closure_set_capture_ptr(closure, 0, stream.to_bits() as i64);
+    set_hidden_value(
+        stream,
+        hidden_key(b"__perry_async_dispose__"),
+        box_pointer(closure as *const u8),
+    );
     unsafe {
         crate::symbol::js_object_set_symbol_property(
             stream,

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -194,12 +194,6 @@
     "category": "bug-open",
     "reason": "node:stream: stream.compose(single-transform) does not deliver data through. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/dispose/await-using-disposes": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: await using does not trigger Symbol.asyncDispose on the stream. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/compose/from-async-iterable": {
     "issue": "1539",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- expose stream Symbol.asyncDispose through Perry's internal __perry_async_dispose__ alias used by await using lowering
- remove node-suite/stream/dispose/await-using-disposes from known failures

## Verification
- cargo check -p perry-runtime
- cargo fmt --check
- jq empty test-parity/known_failures.json
- git diff --check
- ./run_parity_tests.sh --suite node-suite --module stream/dispose --filter await-using-disposes
- ./run_parity_tests.sh --suite node-suite --module stream/dispose --filter dispose