### PR TITLE
fix(events): validate max listener values

### DIFF
--- a/crates/perry-runtime/src/node_stream_event_emitter.rs
+++ b/crates/perry-runtime/src/node_stream_event_emitter.rs
@@ -17,8 +17,60 @@ pub extern "C" fn js_node_stream_method_set_max_listeners(stream_handle: i64, va
 }
 
 fn set_stream_max_listeners(stream: f64, value: f64) -> f64 {
+    let value = validate_max_listeners(value);
     super::set_hidden_value(stream, super::hidden_max_listeners_key(), value);
     stream
+}
+
+fn format_max_listeners_received(n: f64) -> String {
+    if n.is_nan() {
+        return "NaN".to_string();
+    }
+    if n.is_infinite() {
+        return if n.is_sign_negative() {
+            "-Infinity"
+        } else {
+            "Infinity"
+        }
+        .to_string();
+    }
+    if n.fract() == 0.0 && n.abs() < 1e21 {
+        format!("{}", n as i64)
+    } else {
+        format!("{}", n)
+    }
+}
+
+fn throw_max_listeners_invalid_type(value: f64) -> ! {
+    let message = format!(
+        "The \"setMaxListeners\" argument must be of type number. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn throw_max_listeners_out_of_range(n: f64) -> ! {
+    let message = format!(
+        "The value of \"setMaxListeners\" is out of range. It must be >= 0. Received {}",
+        format_max_listeners_received(n)
+    );
+    crate::fs::validate::throw_range_error_with_code(&message)
+}
+
+fn validate_max_listeners(value: f64) -> f64 {
+    let js_value = JSValue::from_bits(value.to_bits());
+    if !crate::fs::validate::is_numeric(js_value) {
+        throw_max_listeners_invalid_type(value);
+    }
+    let n = if js_value.is_int32() {
+        js_value.as_int32() as f64
+    } else {
+        js_value.as_number()
+    };
+    if n.is_nan() || n < 0.0 {
+        throw_max_listeners_out_of_range(n);
+    }
+    n
 }
 
 pub(super) extern "C" fn ns_get_max_listeners(closure: *const ClosureHeader) -> f64 {

--- a/crates/perry-stdlib/src/events.rs
+++ b/crates/perry-stdlib/src/events.rs
@@ -74,34 +74,56 @@ unsafe fn stream_listeners_for_heap_object(
     )
 }
 
-fn throw_max_listeners_out_of_range() -> ! {
-    static REGISTER_RANGE_ERROR: std::sync::Once = std::sync::Once::new();
-    REGISTER_RANGE_ERROR.call_once(|| {
-        perry_runtime::object::js_register_class_extends_error(
-            perry_runtime::error::CLASS_ID_RANGE_ERROR,
-        );
-    });
+fn format_max_listeners_received(n: f64) -> String {
+    if n.is_nan() {
+        return "NaN".to_string();
+    }
+    if n.is_infinite() {
+        return if n.is_sign_negative() {
+            "-Infinity"
+        } else {
+            "Infinity"
+        }
+        .to_string();
+    }
+    if n.fract() == 0.0 && n.abs() < 1e21 {
+        format!("{}", n as i64)
+    } else {
+        format!("{}", n)
+    }
+}
 
-    let obj = js_object_alloc(perry_runtime::error::CLASS_ID_RANGE_ERROR, 4);
-    let string_value = |bytes: &[u8]| -> f64 {
-        let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
-        js_nanbox_string(ptr as i64)
-    };
-    let set = |key: &[u8], value: f64| {
-        let key_ptr = js_string_from_bytes(key.as_ptr(), key.len() as u32);
-        perry_runtime::js_object_set_field_by_name(obj, key_ptr, value);
-    };
-    set(b"name", string_value(b"RangeError"));
-    set(b"code", string_value(b"ERR_OUT_OF_RANGE"));
-    set(b"message", string_value(b"The value is out of range"));
-    perry_runtime::exception::js_throw(js_nanbox_pointer(obj as i64))
+fn throw_max_listeners_invalid_type(value: f64) -> ! {
+    let message = format!(
+        "The \"setMaxListeners\" argument must be of type number. Received {}",
+        perry_runtime::fs::validate::describe_received(value)
+    );
+    perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn throw_max_listeners_out_of_range(n: f64) -> ! {
+    let message = format!(
+        "The value of \"setMaxListeners\" is out of range. It must be >= 0. Received {}",
+        format_max_listeners_received(n)
+    );
+    perry_runtime::fs::validate::throw_range_error_with_code(&message)
 }
 
 #[inline]
-fn validate_max_listeners(n: f64) {
-    if n.is_nan() || n < 0.0 {
-        throw_max_listeners_out_of_range();
+fn validate_max_listeners(value: f64) -> f64 {
+    let js_value = JSValue::from_bits(value.to_bits());
+    if !perry_runtime::fs::validate::is_numeric(js_value) {
+        throw_max_listeners_invalid_type(value);
     }
+    let n = if js_value.is_int32() {
+        js_value.as_int32() as f64
+    } else {
+        js_value.as_number()
+    };
+    if n.is_nan() || n < 0.0 {
+        throw_max_listeners_out_of_range(n);
+    }
+    n
 }
 
 use crate::common::{for_each_handle_mut_of, get_handle, get_handle_mut, register_handle, Handle};
@@ -905,7 +927,7 @@ pub unsafe extern "C" fn js_event_emitter_listener_count(
 /// EventEmitter.setMaxListeners(n).
 #[no_mangle]
 pub unsafe extern "C" fn js_event_emitter_set_max_listeners(handle: Handle, n: f64) -> Handle {
-    validate_max_listeners(n);
+    let n = validate_max_listeners(n);
     if let Some(emitter) = get_handle_mut::<EventEmitterHandle>(handle) {
         emitter.max_listeners = n;
     }
@@ -1392,7 +1414,7 @@ pub unsafe extern "C" fn js_events_set_max_listeners(
     n: f64,
     handles_ptr: *const ArrayHeader,
 ) -> f64 {
-    validate_max_listeners(n);
+    let n = validate_max_listeners(n);
     if !handles_ptr.is_null() {
         let len = js_array_length(handles_ptr);
         for i in 0..len {

--- a/test-parity/node-suite/events/max-listeners/validation.ts
+++ b/test-parity/node-suite/events/max-listeners/validation.ts
@@ -1,0 +1,33 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+function showEmitter(label: string, value: any): void {
+  const emitter = new EventEmitter();
+  try {
+    const result = emitter.setMaxListeners(value);
+    console.log(label, "OK", String(emitter.getMaxListeners()), result === emitter);
+  } catch (error) {
+    const e = error as Error & { code?: string };
+    console.log(label, "THROW", e.name, e.code, String(e.message).split("\n")[0]);
+  }
+}
+
+function showStream(label: string, value: any): void {
+  const stream = new PassThrough();
+  try {
+    const result = stream.setMaxListeners(value);
+    console.log(label, "OK", String(stream.getMaxListeners()), result === stream);
+  } catch (error) {
+    const e = error as Error & { code?: string };
+    console.log(label, "THROW", e.name, e.code, String(e.message).split("\n")[0]);
+  }
+}
+
+for (const value of [0, 1, Infinity, -1, NaN, "5", null, undefined, 1.5]) {
+  showEmitter(`emitter ${String(value)}`, value);
+}
+
+showStream("stream infinity", Infinity);
+showStream("stream negative", -1);
+showStream("stream string", "5");
+showStream("stream nan", NaN);


### PR DESCRIPTION
## Summary
- validate `EventEmitter.setMaxListeners` / `events.setMaxListeners` values with Node-style type and range errors
- apply the same validation to stream EventEmitter-compatible `setMaxListeners`
- add a parity fixture covering accepted values, invalid types, `NaN`, and negative counts

Closes #3030.

## Verification
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module events --filter max-listeners/validation` (`parity_report_20260530_063328.json`)
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module events --filter max-listeners` (`parity_report_20260530_063500.json`)
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module stream --filter max-listeners` (`parity_report_20260530_063511.json`)
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module stream --filter setmaxlisteners` (`parity_report_20260530_063626.json`)
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json test-parity/threshold.json`
- `git diff --check`
- `git diff --cached --check`
- `./scripts/check_file_size.sh`
- `RUSTC_WRAPPER= cargo check -p perry-runtime -p perry-stdlib`