### PR TITLE
Fix node:timers namespace callback rest args

### DIFF
--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -690,8 +690,8 @@ fn ensure_export_singleton(
     }
     let thunk_ptr = export.thunk.as_ptr();
     let allocated = js_closure_alloc(thunk_ptr, 0);
-    if submod.key == "stream_promises" && export.name == "pipeline" {
-        crate::closure::js_register_closure_rest(thunk_ptr, 2);
+    if let Some(fixed_arity) = export_rest_fixed_arity(submod.key, export.name) {
+        crate::closure::js_register_closure_rest(thunk_ptr, fixed_arity);
     } else {
         // Arity is encoded in the ExportThunk variant, so the closure dispatch
         // pads missing args with undefined for variadic-friendly thunks. This
@@ -720,6 +720,15 @@ fn ensure_export_singleton(
     });
     ANY_SINGLETON_ALLOCATED.store(1, Ordering::Release);
     allocated
+}
+
+fn export_rest_fixed_arity(submod_key: &str, export_name: &str) -> Option<u32> {
+    match (submod_key, export_name) {
+        ("stream_promises", "pipeline") => Some(2),
+        ("timers", "setTimeout" | "setInterval") => Some(2),
+        ("timers", "setImmediate") => Some(1),
+        _ => None,
+    }
 }
 
 pub(crate) fn is_diagnostics_channel_constructor_value(value: f64) -> bool {

--- a/crates/perry-runtime/src/node_submodules/timers.rs
+++ b/crates/perry-runtime/src/node_submodules/timers.rs
@@ -233,36 +233,66 @@ pub(crate) extern "C" fn timers_promises_set_interval(
 fn callback_arg_to_i64(v: f64) -> i64 {
     (v.to_bits() & 0x0000_FFFF_FFFF_FFFF) as i64
 }
+
+fn rest_array_values(rest: f64) -> Vec<f64> {
+    let value = JSValue::from_bits(rest.to_bits());
+    if !value.is_pointer() {
+        return Vec::new();
+    }
+
+    let arr = value.as_pointer::<crate::array::ArrayHeader>();
+    let len = crate::array::js_array_length(arr);
+    let mut values = Vec::with_capacity(len as usize);
+    for index in 0..len {
+        values.push(crate::array::js_array_get_f64(arr, index));
+    }
+    values
+}
+
 pub(crate) extern "C" fn timers_ns_set_timeout(
     _c: *const ClosureHeader,
     cb: f64,
     ms: f64,
-    arg0: f64,
+    rest: f64,
 ) -> f64 {
-    let args = [arg0];
+    let args = rest_array_values(rest);
     crate::value::js_nanbox_pointer(unsafe {
-        crate::timer::js_set_timeout_callback_args(callback_arg_to_i64(cb), ms, args.as_ptr(), 1)
+        crate::timer::js_set_timeout_callback_args(
+            callback_arg_to_i64(cb),
+            ms,
+            args.as_ptr(),
+            args.len() as i32,
+        )
     })
 }
 pub(crate) extern "C" fn timers_ns_set_interval(
     _c: *const ClosureHeader,
     cb: f64,
     ms: f64,
-    arg0: f64,
+    rest: f64,
 ) -> f64 {
-    let args = [arg0];
+    let args = rest_array_values(rest);
     crate::value::js_nanbox_pointer(unsafe {
-        crate::timer::js_set_interval_callback_args(callback_arg_to_i64(cb), ms, args.as_ptr(), 1)
+        crate::timer::js_set_interval_callback_args(
+            callback_arg_to_i64(cb),
+            ms,
+            args.as_ptr(),
+            args.len() as i32,
+        )
     })
 }
 pub(crate) extern "C" fn timers_ns_set_immediate(
     _c: *const ClosureHeader,
     cb: f64,
-    arg0: f64,
+    rest: f64,
 ) -> f64 {
-    let args = [arg0];
+    let args = rest_array_values(rest);
     crate::value::js_nanbox_pointer(unsafe {
-        crate::timer::js_set_immediate_callback_args(callback_arg_to_i64(cb), args.as_ptr(), 1)
+        crate::timer::js_set_immediate_callback_args(
+            callback_arg_to_i64(cb),
+            args.as_ptr(),
+            args.len() as i32,
+        )
     })
 }
 pub(crate) extern "C" fn timers_ns_clear_timeout(_c: *const ClosureHeader, arg: f64) -> f64 {

--- a/test-parity/node-suite/timers/namespace/detached-varargs.ts
+++ b/test-parity/node-suite/timers/namespace/detached-varargs.ts
@@ -1,0 +1,25 @@
+import * as timers from "node:timers";
+
+const setTimeoutFn = timers.setTimeout;
+const setIntervalFn = timers["setInterval"];
+const setImmediateFn = timers.setImmediate;
+const clearIntervalFn = timers.clearInterval;
+
+const events: string[] = [];
+
+const timeout: any = setTimeoutFn(function (this: any, a: string, b: string, c: string) {
+  events.push("timeout:" + (this === timeout) + ":" + [a, b, c].join(","));
+}, 1, "a", "b", "c");
+
+const interval: any = setIntervalFn(function (this: any, a: string, b: string, c: string) {
+  events.push("interval:" + (this === interval) + ":" + [a, b, c].join(","));
+  clearIntervalFn(interval);
+}, 1, "d", "e", "f");
+
+const immediate: any = setImmediateFn(function (this: any, a: string, b: string, c: string) {
+  events.push("immediate:" + (this === immediate) + ":" + [a, b, c].join(","));
+}, "g", "h", "i");
+
+setTimeoutFn(() => {
+  console.log(events.sort().join("\n"));
+}, 20);


### PR DESCRIPTION
## Summary
- Fixes #3027.
- Registers `node:timers` namespace `setTimeout`, `setInterval`, and `setImmediate` exports as rest-bundled runtime closures.
- Copies the bundled rest array into the existing callback scheduling APIs so detached namespace functions forward every callback argument.
- Adds a parity regression for detached `node:timers` namespace functions with three callback args and timer-handle `this` checks.

## Tests
- `node --experimental-strip-types test-parity/node-suite/timers/namespace/detached-varargs.ts`
- `env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module timers --filter detached-varargs`
- `env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module timers --filter namespace`
- `cargo fmt --all -- --check`
- `git diff --check HEAD`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `env RUSTC_WRAPPER= cargo check -p perry-runtime -p perry-codegen -p perry-hir`

## Notes
- No compatibility path or alias behavior changed; this only affects the runtime namespace closure path used when timer functions are read then called later.
