### PR TITLE
fix(string): coerce missing/undefined/NaN char index to 0 (#2787)

### DIFF
--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -197,16 +197,23 @@ pub(crate) fn lower_string_method(
             Ok(nanbox_string_inline(blk, &result))
         }
         "charAt" => {
-            if args.len() != 1 {
+            // #2787: a missing index defaults to 0; the provided index is
+            // coerced with JS `ToIntegerOrInfinity` (undefined/NaN -> 0) rather
+            // than a raw `fptosi`, which is UB on a NaN bit pattern.
+            if args.len() > 1 {
                 bail!(
-                    "perry-codegen: String.charAt expects 1 arg, got {}",
+                    "perry-codegen: String.charAt expects at most 1 arg, got {}",
                     args.len()
                 );
             }
-            let idx_d = lower_expr(ctx, &args[0])?;
+            let idx_d = if args.is_empty() {
+                crate::nanbox::double_literal(0.0)
+            } else {
+                lower_expr(ctx, &args[0])?
+            };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
-            let idx_i32 = blk.fptosi(DOUBLE, &idx_d, I32);
+            let idx_i32 = blk.call(I32, "js_string_index_to_i32", &[(DOUBLE, &idx_d)]);
             let result = blk.call(
                 I64,
                 "js_string_char_at",
@@ -311,13 +318,22 @@ pub(crate) fn lower_string_method(
         }
         // str.at(i) / str.charCodeAt(i) / str.codePointAt(i)
         "at" => {
-            if args.len() != 1 {
-                bail!("perry-codegen: String.at expects 1 arg, got {}", args.len());
+            // #2787: missing index -> 0; JS index coercion (undefined/NaN -> 0).
+            // `js_string_at` already resolves negative indices relative to len.
+            if args.len() > 1 {
+                bail!(
+                    "perry-codegen: String.at expects at most 1 arg, got {}",
+                    args.len()
+                );
             }
-            let idx_d = lower_expr(ctx, &args[0])?;
+            let idx_d = if args.is_empty() {
+                crate::nanbox::double_literal(0.0)
+            } else {
+                lower_expr(ctx, &args[0])?
+            };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
-            let idx_i32 = blk.fptosi(DOUBLE, &idx_d, I32);
+            let idx_i32 = blk.call(I32, "js_string_index_to_i32", &[(DOUBLE, &idx_d)]);
             // js_string_at returns a NaN-boxed string or undefined directly.
             Ok(blk.call(
                 DOUBLE,
@@ -326,16 +342,21 @@ pub(crate) fn lower_string_method(
             ))
         }
         "codePointAt" => {
-            if args.is_empty() || args.len() > 1 {
+            // #2787: missing index -> 0; JS index coercion (undefined/NaN -> 0).
+            if args.len() > 1 {
                 bail!(
-                    "perry-codegen: String.codePointAt expects 1 arg, got {}",
+                    "perry-codegen: String.codePointAt expects at most 1 arg, got {}",
                     args.len()
                 );
             }
-            let idx_d = lower_expr(ctx, &args[0])?;
+            let idx_d = if args.is_empty() {
+                crate::nanbox::double_literal(0.0)
+            } else {
+                lower_expr(ctx, &args[0])?
+            };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
-            let idx_i32 = blk.fptosi(DOUBLE, &idx_d, I32);
+            let idx_i32 = blk.call(I32, "js_string_index_to_i32", &[(DOUBLE, &idx_d)]);
             // Returns NaN-boxed number or undefined directly.
             Ok(blk.call(
                 DOUBLE,
@@ -344,16 +365,21 @@ pub(crate) fn lower_string_method(
             ))
         }
         "charCodeAt" => {
-            if args.is_empty() || args.len() > 1 {
+            // #2787: missing index -> 0; JS index coercion (undefined/NaN -> 0).
+            if args.len() > 1 {
                 bail!(
-                    "perry-codegen: String.charCodeAt expects 1 arg, got {}",
+                    "perry-codegen: String.charCodeAt expects at most 1 arg, got {}",
                     args.len()
                 );
             }
-            let idx_d = lower_expr(ctx, &args[0])?;
+            let idx_d = if args.is_empty() {
+                crate::nanbox::double_literal(0.0)
+            } else {
+                lower_expr(ctx, &args[0])?
+            };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
-            let idx_i32 = blk.fptosi(DOUBLE, &idx_d, I32);
+            let idx_i32 = blk.call(I32, "js_string_index_to_i32", &[(DOUBLE, &idx_d)]);
             // js_string_char_code_at returns a plain f64 (NaN for OOB).
             Ok(blk.call(
                 DOUBLE,

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -440,6 +440,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_string_trim_start", I64, &[I64]);
     module.declare_function("js_string_trim_end", I64, &[I64]);
     module.declare_function("js_string_char_at", I64, &[I64, I32]);
+    // #2787: NaN-safe JS index coercion (undefined/NaN -> 0, trunc, clamp) for
+    // the char-access methods, replacing a raw `fptosi` that is UB on a NaN.
+    module.declare_function("js_string_index_to_i32", I32, &[DOUBLE]);
     // Issue #514: tag-aware dynamic index dispatch — routes `obj[idx]` to
     // `js_string_char_at` / `js_array_get_f64` / `js_object_get_field_by_name_f64`
     // based on the receiver's NaN-box tag at runtime. Used by IndexGet's

--- a/crates/perry-runtime/src/string/char_ops.rs
+++ b/crates/perry-runtime/src/string/char_ops.rs
@@ -3,6 +3,28 @@
 
 use super::*;
 
+/// JS index coercion for the String character-access methods (#2787).
+/// Applies `ToIntegerOrInfinity`: `undefined`, `null`, and `NaN` are all NaN /
+/// non-numeric bit patterns that map to `0`; finite values truncate toward
+/// zero; the result is clamped into `i32` so the integer-index helpers below
+/// see a safe value (a far-out-of-range magnitude clamps to a still-OOB index,
+/// which the helpers already handle). Codegen routes the raw NaN-boxed index
+/// through here instead of `fptosi`, which is undefined behavior on a NaN.
+#[no_mangle]
+pub extern "C" fn js_string_index_to_i32(index: f64) -> i32 {
+    if index.is_nan() {
+        return 0;
+    }
+    let truncated = index.trunc();
+    if truncated <= i32::MIN as f64 {
+        i32::MIN
+    } else if truncated >= i32::MAX as f64 {
+        i32::MAX
+    } else {
+        truncated as i32
+    }
+}
+
 /// Get character code at index (returns UTF-16 code unit, or NaN if out of bounds).
 /// Index is in UTF-16 code units (matches JS spec). For ASCII strings this is
 /// equivalent to byte indexing; for multi-byte UTF-8 we walk codepoints without

--- a/test-parity/node-suite/string/char-index/missing-and-coerced-index.ts
+++ b/test-parity/node-suite/string/char-index/missing-and-coerced-index.ts
@@ -1,0 +1,28 @@
+// #2787: String character-access methods coerce a missing, `undefined`, or
+// `NaN` index to 0 (JS ToIntegerOrInfinity); negative and out-of-range
+// indices keep their per-method out-of-bounds shapes.
+const s = "abc";
+
+console.log("charAt:missing", JSON.stringify(s.charAt()));
+console.log("charAt:undefined", JSON.stringify(s.charAt(undefined)));
+console.log("charAt:NaN", JSON.stringify(s.charAt(NaN)));
+console.log("charAt:-1", JSON.stringify(s.charAt(-1)));
+console.log("charAt:99", JSON.stringify(s.charAt(99)));
+
+console.log("charCodeAt:missing", s.charCodeAt());
+console.log("charCodeAt:undefined", s.charCodeAt(undefined));
+console.log("charCodeAt:NaN", s.charCodeAt(NaN));
+console.log("charCodeAt:-1", s.charCodeAt(-1));
+console.log("charCodeAt:99", s.charCodeAt(99));
+
+console.log("codePointAt:missing", s.codePointAt());
+console.log("codePointAt:undefined", s.codePointAt(undefined));
+console.log("codePointAt:NaN", s.codePointAt(NaN));
+console.log("codePointAt:-1", s.codePointAt(-1));
+console.log("codePointAt:99", s.codePointAt(99));
+
+console.log("at:missing", JSON.stringify(s.at()));
+console.log("at:undefined", JSON.stringify(s.at(undefined)));
+console.log("at:NaN", JSON.stringify(s.at(NaN)));
+console.log("at:-1", JSON.stringify(s.at(-1)));
+console.log("at:99", JSON.stringify(s.at(99)));


### PR DESCRIPTION
## Summary

Fixes #2787 — String character-access methods now treat a missing, `undefined`, or `NaN` index as `0` (JS `ToIntegerOrInfinity`), matching Node.

The typed string lowering for `charAt`, `charCodeAt`, `codePointAt`, and `at` rejected omitted arguments and converted the provided index with `fptosi(DOUBLE -> I32)` — which is **undefined behavior** when the NaN-boxed index is a NaN bit pattern (`undefined`/`NaN`). So `"abc".charCodeAt()` / `.charCodeAt(undefined)` / `.charCodeAt(NaN)` produced garbage instead of `97`.

## Fix

- Add `js_string_index_to_i32(f64) -> i32` in `string/char_ops.rs`: `NaN` (covers `undefined`/`null`/`NaN`) → `0`, finite values truncate toward zero, clamp into `i32`.
- Route all four char-access lowering sites through it and default a missing argument to `0`. The runtime helpers already return the correct out-of-bounds shapes for integer indices (`charAt` → `""`, `charCodeAt` → `NaN`, `codePointAt`/`at` → `undefined`, `at` negative → relative-to-length), so no runtime indexing logic changed.

## Verification

Byte-for-byte against `node --experimental-strip-types` across the full `{<missing>, undefined, NaN, -1, 99}` × `{charAt, charCodeAt, codePointAt, at}` matrix — identical. Normal indexed access (`s.charAt(1)`, variable index) unchanged. `perry-runtime` string tests: 88 passed / 0 failed.

New parity fixture: `test-parity/node-suite/string/char-index/missing-and-coerced-index.ts`.

## Scope

Targets the static typed-lowering path called out in the issue's "Perry evidence" (`lower_string_method.rs`). The `s[method](...args)` dynamic/spread dispatch path is separate and not part of this issue.
