### PR TITLE
fix(fs): validate path and throw real errors from statfsSync (#2921)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1039 — validate path and throw real errors from `fs.statfsSync` (#2921)
+
+`fs.statfsSync(path[, options])` returned a zero-filled `StatFs` object when the
+path could not be decoded, contained an interior NUL, or `statvfs` failed —
+letting callers proceed with fake filesystem statistics instead of seeing
+Node's `ERR_INVALID_ARG_TYPE` or `ENOENT`.
+
+`crates/perry-runtime/src/fs/fd_ops.rs::js_fs_statfs_sync_options` now:
+
+- calls `validate_path("path", path_value)` up front, so a non path-like
+  argument (number, `null`, object, boolean) throws
+  `TypeError [ERR_INVALID_ARG_TYPE]` with Node's exact message, and
+- throws the OS error via `build_fs_error_value(&err, "statfs", &path)` when
+  `statvfs` fails (`ENOENT`, …) or the path holds an interior NUL, instead of
+  swallowing it into default stats. The thrown `Error` carries `code`,
+  `syscall: "statfs"`, and `path`.
+
+The successful StatFs field construction and the bigint option behavior (#2561)
+are unchanged, and the callback `fs.statfs` path — which already has error-first
+handling — is untouched.
+
+New `test-parity/node-suite/fs/stats/statfs-sync-invalid.ts` is byte-identical
+to `node --experimental-strip-types`; the existing `statfs`, `statfs-bigint-options`,
+`stat-lstat-missing-errors`, and `fd-and-statfs` parity tests still pass.
+
 ## v0.5.1038 — validate `node:timers/promises` delay and options arguments (#3067)
 
 `node:timers/promises` helpers passed `delay` and `options` straight into the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1038
+**Current Version:** 0.5.1039
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4880,7 +4880,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "anyhow",
  "base64",
@@ -4935,14 +4935,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "cc",
  "libc",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "anyhow",
  "log",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "anyhow",
  "base64",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "serde",
  "serde_json",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1038"
+version = "0.5.1039"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "anyhow",
  "clap",
@@ -5056,14 +5056,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "chrono",
  "cron",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5162,14 +5162,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "base64",
  "image",
@@ -5354,14 +5354,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5388,7 +5388,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "brotli",
  "flate2",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "anyhow",
  "base64",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5571,14 +5571,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "base64",
  "itoa",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "base64",
  "block2",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "base64",
  "block2",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1038"
+version = "0.5.1039"
 
 [[package]]
 name = "perry-ui-test"
@@ -5667,11 +5667,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1038"
+version = "0.5.1039"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "base64",
  "block2",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "base64",
  "block2",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "block2",
  "libc",
@@ -5716,7 +5716,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "base64",
  "libc",
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1038"
+version = "0.5.1039"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1038"
+version = "0.5.1039"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/fs/fd_ops.rs
+++ b/crates/perry-runtime/src/fs/fd_ops.rs
@@ -634,17 +634,33 @@ pub extern "C" fn js_fs_statfs_sync(path_value: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_fs_statfs_sync_options(path_value: f64, options_value: f64) -> f64 {
+    // #2921 — Node validates `path` and surfaces filesystem errors instead of
+    // returning a zero-filled StatFs object. A non path-like argument throws
+    // `TypeError [ERR_INVALID_ARG_TYPE]`; a missing/unreadable path throws the
+    // OS error (`ENOENT`, …) with syscall `statfs`.
+    crate::fs::validate::validate_path("path", path_value);
     let bigint = unsafe { options_bool_field(options_value, b"bigint") };
     unsafe {
         let path = match decode_path_value(path_value) {
             Some(s) => s,
-            None => return build_statfs_object(StatFsFields::default(), bigint),
+            None => {
+                // The type was accepted by `validate_path` but could not be
+                // decoded — treat as a missing target rather than fake stats.
+                let err = std::io::Error::from(std::io::ErrorKind::NotFound);
+                crate::exception::js_throw(build_fs_error_value(&err, "statfs", ""))
+            }
         };
         #[cfg(unix)]
         {
-            let c_path = match std::ffi::CString::new(path) {
+            let c_path = match std::ffi::CString::new(path.as_bytes()) {
                 Ok(s) => s,
-                Err(_) => return build_statfs_object(StatFsFields::default(), bigint),
+                Err(_) => {
+                    let err = std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "path contained an interior null byte",
+                    );
+                    crate::exception::js_throw(build_fs_error_value(&err, "statfs", &path))
+                }
             };
             let mut stat: libc::statvfs = std::mem::zeroed();
             if libc::statvfs(c_path.as_ptr(), &mut stat) == 0 {
@@ -662,12 +678,16 @@ pub extern "C" fn js_fs_statfs_sync_options(path_value: f64, options_value: f64)
                     bigint,
                 );
             }
+            // statvfs failed — surface the OS error (ENOENT, EACCES, …) the way
+            // Node does instead of swallowing it into default stats.
+            let err = std::io::Error::last_os_error();
+            crate::exception::js_throw(build_fs_error_value(&err, "statfs", &path))
         }
         #[cfg(not(unix))]
         {
             let _ = path;
+            build_statfs_object(StatFsFields::default(), bigint)
         }
-        build_statfs_object(StatFsFields::default(), bigint)
     }
 }
 

--- a/test-parity/node-suite/fs/stats/statfs-sync-invalid.ts
+++ b/test-parity/node-suite/fs/stats/statfs-sync-invalid.ts
@@ -1,0 +1,36 @@
+// Issue #2921 — `fs.statfsSync(path)` validates `path` and surfaces
+// filesystem errors instead of returning a zero-filled StatFs object. An
+// invalid path type throws `TypeError [ERR_INVALID_ARG_TYPE]`; a missing
+// path throws `Error [ENOENT]` with syscall `statfs`.
+import * as fs from "node:fs";
+
+// Mirror the established fs error-shape probes (stat-lstat-missing-errors.ts):
+// assert name/code/syscall, not the raw message body — Perry's `std::io::Error`
+// Display divergence ("(os error N)", capitalization) is a pre-existing
+// fs-wide formatting gap, orthogonal to throwing-vs-fake-stats here.
+function probe(label: string, expectedPath: string | null, fn: () => any) {
+  try {
+    fn();
+    console.log(label, "no-throw");
+  } catch (err: any) {
+    console.log(
+      label,
+      err.name,
+      err.code,
+      err.syscall,
+      expectedPath === null ? "" : err.path === expectedPath,
+    );
+  }
+}
+
+const MISSING = "/tmp/__perry_missing_statfs_target__";
+probe("statfsSync missing", MISSING, () => fs.statfsSync(MISSING));
+probe("statfsSync number", null, () => fs.statfsSync(123 as any));
+probe("statfsSync null", null, () => fs.statfsSync(null as any));
+probe("statfsSync object", null, () => fs.statfsSync({} as any));
+probe("statfsSync boolean", null, () => fs.statfsSync(true as any));
+
+// A valid path still returns a populated StatFs object (regression guard for
+// the success path / #2561 fields).
+const ok = fs.statfsSync("/tmp");
+console.log("statfsSync ok:", typeof ok.bsize, ok.bsize > 0, ok.blocks >= ok.bfree);


### PR DESCRIPTION
Closes #2921.

## Problem

`fs.statfsSync(path[, options])` returned a default zero-filled `StatFs` object when the path could not be decoded, contained an interior NUL, or `statvfs` failed — so code continued with fake filesystem statistics instead of seeing Node's `ERR_INVALID_ARG_TYPE` or `ENOENT`.

## Fix

`crates/perry-runtime/src/fs/fd_ops.rs::js_fs_statfs_sync_options`:

- Calls `validate_path("path", path_value)` up front → a non path-like argument (number/null/object/boolean) throws `TypeError [ERR_INVALID_ARG_TYPE]` with Node's exact message.
- On `statvfs` failure, throws the OS error via `build_fs_error_value(&err, "statfs", &path)` → `Error [ENOENT]` with `syscall: "statfs"` and the offending `path`, instead of returning default stats. An interior-NUL path likewise throws rather than fabricating stats.

The success path and bigint-option behavior (#2561) are unchanged; the callback `fs.statfs` path already had error-first handling and is untouched.

## Validation

New `test-parity/node-suite/fs/stats/statfs-sync-invalid.ts` is byte-identical to `node --experimental-strip-types`. Existing `statfs.ts`, `statfs-bigint-options.ts`, `stat-lstat-missing-errors.ts`, and `fd-and-statfs.ts` all still pass.

Following the established fs error-shape probes (and the issue's own suggested test), the new test asserts `name`/`code`/`syscall`/`path` rather than the raw message body — Perry's `std::io::Error` Display divergence (`"(os error N)"`, capitalization) is a pre-existing fs-wide formatting gap, orthogonal to this throw-vs-fake-stats fix.
