### PR TITLE
node:crypto: implement crypto.randomUUIDv7 (#2550)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2007,6 +2007,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // up in the dispatch-table extraction.
     method("crypto", "randomBytes", false, None),
     method("crypto", "randomUUID", false, None),
+    method("crypto", "randomUUIDv7", false, None),
     method("crypto", "randomInt", false, None),
     method("crypto", "hash", false, None),
     method("crypto", "sha256", false, None),

--- a/crates/perry-codegen-js/src/emit/exprs.rs
+++ b/crates/perry-codegen-js/src/emit/exprs.rs
@@ -900,6 +900,9 @@ impl JsEmitter {
             Expr::CryptoRandomUUID => {
                 self.output.push_str("crypto.randomUUID()");
             }
+            Expr::CryptoRandomUUIDv7 => {
+                self.output.push_str("crypto.randomUUIDv7()");
+            }
             Expr::CryptoSha256(data) => {
                 // Use SubtleCrypto (async in browser, but we emit it inline)
                 self.output.push_str("(await (async () => { const d = new TextEncoder().encode(");

--- a/crates/perry-codegen-wasm/src/emit/expr/net_fetch_crypto.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/net_fetch_crypto.rs
@@ -231,6 +231,10 @@ impl<'a> FuncEmitCtx<'a> {
                 self.emit_frame_begin(func, 0);
                 self.emit_memcall(func, "crypto_random_uuid", 0);
             }
+            Expr::CryptoRandomUUIDv7 => {
+                self.emit_frame_begin(func, 0);
+                self.emit_memcall(func, "crypto_random_uuidv7", 0);
+            }
             Expr::CryptoRandomBytes(n) => {
                 self.emit_frame_begin(func, 1);
                 self.emit_store_arg(func, 0, n);

--- a/crates/perry-codegen-wasm/src/wasm_runtime.js
+++ b/crates/perry-codegen-wasm/src/wasm_runtime.js
@@ -2106,6 +2106,7 @@ const __memDispatch = {
 
   // Crypto — args are plain JS values
   crypto_random_uuid: () => crypto.randomUUID(),
+  crypto_random_uuidv7: () => crypto.randomUUIDv7(),
   crypto_random_bytes: (n) => crypto.getRandomValues(new Uint8Array(n)),
   crypto_sha256: (data) => {
     const str = String(data);

--- a/crates/perry-codegen/src/collectors/escape_objects.rs
+++ b/crates/perry-codegen/src/collectors/escape_objects.rs
@@ -424,6 +424,7 @@ pub fn check_object_literal_escapes_in_expr(
         // Time / perf leaf intrinsics
         | Expr::DateNow | Expr::PerformanceNow | Expr::MathRandom
         | Expr::CryptoRandomUUID
+        | Expr::CryptoRandomUUIDv7
         // Iter-result scratch (zero-arg leaves)
         | Expr::IterResultGetValue | Expr::IterResultGetDone
         // Process leaf intrinsics

--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -942,6 +942,22 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_string_inline(blk, &handle))
         }
 
+        // `crypto.randomUUIDv7([options])` — RFC 9562 v7 (#2550).
+        Expr::Call {
+            callee, args: _, ..
+        } if matches!(
+            callee.as_ref(),
+            Expr::PropertyGet { object, property } if property == "randomUUIDv7" && matches!(
+                object.as_ref(),
+                Expr::NativeModuleRef(n) if n == "crypto"
+            )
+        ) =>
+        {
+            let blk = ctx.block();
+            let handle = blk.call(I64, "js_crypto_random_uuidv7", &[]);
+            Ok(nanbox_string_inline(blk, &handle))
+        }
+
         // Phase H crypto: `crypto.randomInt([min,] max[, callback])` —
         // uniform integer in `[min, max)`. The single-arg form defaults
         // `min` to 0. The runtime returns the value as a plain double (a

--- a/crates/perry-codegen/src/expr/misc_methods.rs
+++ b/crates/perry-codegen/src/expr/misc_methods.rs
@@ -153,6 +153,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let handle = blk.call(I64, "js_crypto_random_uuid", &[]);
             Ok(nanbox_string_inline(blk, &handle))
         }
+        Expr::CryptoRandomUUIDv7 => {
+            let blk = ctx.block();
+            let handle = blk.call(I64, "js_crypto_random_uuidv7", &[]);
+            Ok(nanbox_string_inline(blk, &handle))
+        }
         Expr::CryptoRandomBytes(operand) => {
             // Returns a raw *mut BufferHeader i64. NaN-box with
             // POINTER_TAG so downstream BUFFER_REGISTRY checks

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1578,6 +1578,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ProcessSetTitle(..)
         | Expr::RegExpExecIndex
         | Expr::CryptoRandomUUID
+        | Expr::CryptoRandomUUIDv7
         | Expr::CryptoRandomBytes(..)
         | Expr::CryptoSha256(..)
         | Expr::CryptoMd5(..)

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1341,6 +1341,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_crypto_random_bytes_buffer", I64, &[DOUBLE]);
     module.declare_function("js_crypto_random_bytes_async", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_crypto_random_uuid", I64, &[]);
+    module.declare_function("js_crypto_random_uuidv7", I64, &[]);
     // crypto.randomInt([min,] max[, cb]) -> number; codegen passes min=0 for the
     // single-arg form. Returns the integer as a plain double.
     module.declare_function("js_crypto_random_int", DOUBLE, &[DOUBLE, DOUBLE]);

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -688,6 +688,7 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
             collect_assigned_locals_expr(expr, assigned);
         }
         Expr::CryptoRandomUUID => {}
+        Expr::CryptoRandomUUIDv7 => {}
         // OS operations (no assignments)
         Expr::OsPlatform
         | Expr::OsArch

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -829,6 +829,7 @@ pub enum Expr {
     // Crypto operations
     CryptoRandomBytes(Box<Expr>), // crypto.randomBytes(size) -> string (hex)
     CryptoRandomUUID,             // crypto.randomUUID() -> string
+    CryptoRandomUUIDv7,           // crypto.randomUUIDv7() -> string (RFC 9562 v7)
     CryptoSha256(Box<Expr>),      // crypto.sha256(data) -> string (hex)
     CryptoMd5(Box<Expr>),         // crypto.md5(data) -> string (hex)
 

--- a/crates/perry-hir/src/js_transform/imports.rs
+++ b/crates/perry-hir/src/js_transform/imports.rs
@@ -1235,7 +1235,7 @@ pub fn transform_expr(
         Expr::Null | Expr::Undefined | Expr::This | Expr::LocalGet(_) | Expr::GlobalGet(_) |
         Expr::FuncRef(_) | Expr::ClassRef(_) | Expr::EnumMember { .. } |
         Expr::RegExp { .. } | Expr::NativeModuleRef(_) | Expr::StaticFieldGet { .. } |
-        Expr::EnvGet(_) | Expr::ProcessUptime | Expr::ProcessMemoryUsage | Expr::ProcessEnv | Expr::MathRandom | Expr::CryptoRandomUUID | Expr::DateNow |
+        Expr::EnvGet(_) | Expr::ProcessUptime | Expr::ProcessMemoryUsage | Expr::ProcessEnv | Expr::MathRandom | Expr::CryptoRandomUUID | Expr::CryptoRandomUUIDv7 | Expr::DateNow |
         Expr::MapNew | Expr::SetNew | Expr::Update { .. } |
         Expr::ArrayPop(_) | Expr::ArrayShift(_) |
         // OS module expressions

--- a/crates/perry-hir/src/lower/expr_call/crypto.rs
+++ b/crates/perry-hir/src/lower/expr_call/crypto.rs
@@ -27,6 +27,7 @@ pub(super) fn is_passthrough_method(method: &str) -> bool {
         // arg munging.
         "randomFillSync"
             | "randomUUID"
+            | "randomUUIDv7"
             | "randomBytes"
             | "hash"
             // Plain `crypto.<method>(...)` → `Expr::Call { PropertyGet {
@@ -105,6 +106,9 @@ pub(super) fn lower_crypto_passthrough(method: &str, args: Vec<Expr>) -> Option<
             })
         }
         "randomUUID" => Some(Expr::CryptoRandomUUID),
+        // `randomUUIDv7([options])` — options accepted for shape parity but
+        // do not affect the generated value (#2550).
+        "randomUUIDv7" => Some(Expr::CryptoRandomUUIDv7),
         "randomBytes" => {
             if args.is_empty() {
                 return None;

--- a/crates/perry-hir/src/monomorph/driver.rs
+++ b/crates/perry-hir/src/monomorph/driver.rs
@@ -535,6 +535,7 @@ fn collect_instantiations_in_expr(
             collect_instantiations_in_expr(expr, ctx, module, idx);
         }
         Expr::CryptoRandomUUID => {}
+        Expr::CryptoRandomUUIDv7 => {}
         // Date operations
         Expr::DateNow => {}
         Expr::DateNew(args) => {

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -685,6 +685,7 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
             Expr::CryptoRandomBytes(Box::new(substitute_expr(expr, substitutions)))
         }
         Expr::CryptoRandomUUID => Expr::CryptoRandomUUID,
+        Expr::CryptoRandomUUIDv7 => Expr::CryptoRandomUUIDv7,
         Expr::CryptoSha256(expr) => {
             Expr::CryptoSha256(Box::new(substitute_expr(expr, substitutions)))
         }

--- a/crates/perry-hir/src/monomorph/update_call_sites.rs
+++ b/crates/perry-hir/src/monomorph/update_call_sites.rs
@@ -467,6 +467,7 @@ fn update_call_sites_in_expr(
             update_call_sites_in_expr(expr, ctx, lookup);
         }
         Expr::CryptoRandomUUID => {}
+        Expr::CryptoRandomUUIDv7 => {}
         // Date operations
         Expr::DateNow => {}
         Expr::DateNew(args) => {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -238,6 +238,7 @@ impl SH for Expr {
             Expr::AsyncStepChain { value, step_closure, } => { tag(h, 192); value.as_ref().hash(h); step_closure.as_ref().hash(h); }
             Expr::CryptoRandomBytes(e) => { tag(h, 193); e.as_ref().hash(h); }
             Expr::CryptoRandomUUID => tag(h, 194),
+            Expr::CryptoRandomUUIDv7 => tag(h, 12042),
             Expr::CryptoSha256(e) => { tag(h, 195); e.as_ref().hash(h); }
             Expr::CryptoMd5(e) => { tag(h, 196); e.as_ref().hash(h); }
             Expr::WebCryptoDigest { algo, data } => { tag(h, 197); algo.as_ref().hash(h); data.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -67,6 +67,7 @@ where
         | Expr::TextEncoderNew
         | Expr::TextDecoderNew
         | Expr::CryptoRandomUUID
+        | Expr::CryptoRandomUUIDv7
         | Expr::OsPlatform
         | Expr::OsArch
         | Expr::OsHostname

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -68,6 +68,7 @@ where
         | Expr::TextEncoderNew
         | Expr::TextDecoderNew
         | Expr::CryptoRandomUUID
+        | Expr::CryptoRandomUUIDv7
         | Expr::OsPlatform
         | Expr::OsArch
         | Expr::OsHostname

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1378,6 +1378,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("crypto", "secureHeapUsed")
             | ("crypto", "randomBytes")
             | ("crypto", "randomUUID")
+            | ("crypto", "randomUUIDv7")
             | ("crypto", "randomInt")
             | ("crypto", "generatePrime")
             | ("crypto", "generatePrimeSync")

--- a/crates/perry-stdlib/src/crypto/random.rs
+++ b/crates/perry-stdlib/src/crypto/random.rs
@@ -107,6 +107,19 @@ pub extern "C" fn js_crypto_random_uuid() -> *mut StringHeader {
     js_string_from_bytes(uuid_str.as_ptr(), uuid_str.len() as u32)
 }
 
+/// Generate an RFC 9562 version 7 UUID — a 48-bit millisecond Unix
+/// timestamp in the most-significant bits followed by cryptographically
+/// secure randomness, with the version (`7`) and variant (`10`) bits set
+/// per spec. `crypto.randomUUIDv7([options])` -> string (#2550). The
+/// optional `options` object (Node's `{ disableEntropyCache }`) is
+/// accepted for shape parity but does not change the generated value.
+#[no_mangle]
+pub extern "C" fn js_crypto_random_uuidv7() -> *mut StringHeader {
+    let uuid = uuid::Uuid::now_v7();
+    let uuid_str = uuid.to_string();
+    js_string_from_bytes(uuid_str.as_ptr(), uuid_str.len() as u32)
+}
+
 /// Issue #2013 — validate one of `randomInt`'s integer arguments
 /// (min/max). Non-number → ERR_INVALID_ARG_TYPE; non-finite /
 /// fractional / out-of-(-2^48, 2^48) → ERR_OUT_OF_RANGE. Mirrors
@@ -207,6 +220,7 @@ pub unsafe extern "C" fn js_crypto_native_dispatch(
         "createHash" => js_crypto_create_hash(str_ptr(0)),
         "createHmac" => js_crypto_create_hmac(str_ptr(0), bytes_ptr(1)),
         "randomUUID" => f64::from_bits(JSValue::string_ptr(js_crypto_random_uuid()).bits()),
+        "randomUUIDv7" => f64::from_bits(JSValue::string_ptr(js_crypto_random_uuidv7()).bits()),
         "randomBytes" => {
             let buf = js_crypto_random_bytes_buffer(arg(0));
             f64::from_bits(JSValue::pointer(buf as *const u8).bits())
@@ -602,5 +616,48 @@ mod tests {
         assert!(catch_runtime_throw(|| {
             let _ = js_crypto_random_fill_sync(target, undefined(), undefined());
         }));
+    }
+
+    /// #2550 — `crypto.randomUUIDv7()` must emit an RFC 9562 v7 UUID:
+    /// canonical 36-char dashed form, version nibble `7`, variant nibble
+    /// in `{8,9,a,b}`, a non-zero timestamp prefix, and fresh randomness
+    /// on every call.
+    fn read_uuid_string(ptr: *mut StringHeader) -> String {
+        unsafe {
+            let blen = (*ptr).byte_len as usize;
+            let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+            let bytes = std::slice::from_raw_parts(data, blen);
+            std::str::from_utf8(bytes).unwrap().to_string()
+        }
+    }
+
+    #[test]
+    fn random_uuidv7_has_version_and_variant_bits() {
+        let s = read_uuid_string(js_crypto_random_uuidv7());
+        assert_eq!(s.len(), 36, "v7 UUID is 36 chars, got {:?}", s);
+        let b = s.as_bytes();
+        assert_eq!(b[8], b'-');
+        assert_eq!(b[13], b'-');
+        assert_eq!(b[18], b'-');
+        assert_eq!(b[23], b'-');
+        // version nibble (index 14) must be '7'
+        assert_eq!(b[14] as char, '7', "version nibble in {:?}", s);
+        // variant nibble (index 19) must encode the 10xx variant
+        assert!(
+            matches!(b[19], b'8' | b'9' | b'a' | b'b'),
+            "variant nibble {:?} not in {{8,9,a,b}} for {:?}",
+            b[19] as char,
+            s
+        );
+        // The 48-bit millisecond timestamp prefix is non-zero for a
+        // current-epoch value (it would only be all-zero near 1970).
+        assert_ne!(&s[0..8], "00000000", "timestamp prefix should be set");
+    }
+
+    #[test]
+    fn random_uuidv7_is_fresh_each_call() {
+        let a = read_uuid_string(js_crypto_random_uuidv7());
+        let b = read_uuid_string(js_crypto_random_uuidv7());
+        assert_ne!(a, b, "consecutive v7 UUIDs must differ");
     }
 }

--- a/crates/perry-ui-android/src/stdlib_stubs.rs
+++ b/crates/perry-ui-android/src/stdlib_stubs.rs
@@ -312,6 +312,10 @@ pub extern "C" fn js_crypto_random_uuid() -> i64 {
     0
 }
 #[no_mangle]
+pub extern "C" fn js_crypto_random_uuidv7() -> i64 {
+    0
+}
+#[no_mangle]
 pub extern "C" fn js_crypto_scrypt() -> i64 {
     0
 }

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1782 entries across 88 modules
+// Coverage: 1783 entries across 88 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -870,6 +870,8 @@ declare module "crypto" {
   export function randomInt(...args: any[]): any;
   /** stdlib */
   export function randomUUID(...args: any[]): any;
+  /** stdlib */
+  export function randomUUIDv7(...args: any[]): any;
   /** stdlib */
   export function scryptSync(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1782 entries across 88 modules.
+Total: 1783 entries across 88 modules.
 
 ## Modules
 
@@ -656,6 +656,7 @@ Total: 1782 entries across 88 modules.
 - `randomInt` — module
 - `randomInt` — module
 - `randomUUID` — module
+- `randomUUIDv7` — module
 - `scryptSync` — module
 - `sha256` — module
 - `sign` — module


### PR DESCRIPTION
## Summary

Implements `crypto.randomUUIDv7([options])` (Node v26.1.0 / RFC 9562 version 7 UUIDs) — closes #2550. Perry already had `randomUUID` (v4); this mirrors that path end to end so all call shapes work.

```js
const crypto = require("node:crypto");
const id = crypto.randomUUIDv7();
typeof id;   // "string"
id.length;   // 36
id[14];      // "7"  (version nibble)
```

## What changed

- **runtime** (`perry-stdlib/src/crypto/random.rs`): `js_crypto_random_uuidv7` via the `uuid` crate's `now_v7()` (the `v7` feature was already enabled), plus the `"randomUUIDv7"` arm in the crypto method dispatcher.
- **HIR**: new `Expr::CryptoRandomUUIDv7` variant + `randomUUIDv7` → variant lowering in the shared crypto passthrough (covers both `import { randomUUIDv7 }` and `crypto.randomUUIDv7()` forms). All walker/monomorph/analysis/stable-hash match sites updated.
- **codegen**: `misc_methods` + `calls.rs` dotted-form arms calling `js_crypto_random_uuidv7`, runtime decl, and the `native_module` callable-value list so `const { randomUUIDv7 } = crypto` yields a callable.
- **api manifest** entry (drives the regenerated `.d.ts` / reference docs) + js/wasm emit parity + android stub for cross-target builds.

The optional `options` object (Node's `{ disableEntropyCache }`) is accepted for shape parity but does not affect output.

## Testing

- Rust unit tests (`random_uuidv7_has_version_and_variant_bits`, `random_uuidv7_is_fresh_each_call`) assert the canonical 36-char dashed form, version nibble `7`, variant nibble in `{8,9,a,b}`, non-zero timestamp prefix, and per-call freshness. Both pass.
- Manual smoke (compiled): dotted, named-import, and destructure-from-namespace (`const { randomUUIDv7 } = crypto`) forms all return valid v7 UUIDs. (Local Node v25.8.0 predates the API, so byte-diff parity is N/A here; structural checks used instead.)
- `cargo fmt --all --check` clean; API docs regenerated (no drift).
