### PR TITLE
fix(stream): support ReadableStream.from custom iterables

### DIFF
--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -555,14 +555,6 @@ unsafe fn resolve_stringify_separator_str(value: f64, default: &'static str) -> 
     jsvalue_to_owned_string(value)
 }
 
-fn throw_symbol_to_string_type_error() -> ! {
-    let msg = "Cannot convert a Symbol value to a string";
-    let msg_str = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-    let err_ptr = perry_runtime::error::js_typeerror_new(msg_str);
-    let err_value = JSValue::pointer(err_ptr as *const u8).bits();
-    perry_runtime::exception::js_throw(f64::from_bits(err_value))
-}
-
 /// Append `key=value` (or `key=v1&key=v2` for arrays) to `out`.
 unsafe fn append_stringify_value(
     out: &mut String,

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -838,30 +838,46 @@ pub unsafe extern "C" fn js_readable_stream_from_response(_resp_id: f64) -> f64 
     alloc_readable_from_bytes(Vec::new()) as f64
 }
 
-/// `ReadableStream.from(iterable)` (Node 20+, #1645) — build a Web
-/// ReadableStream pre-loaded with the iterable's items, then closed. Today we
-/// handle the synchronous-array case (the overwhelmingly common form: a literal
-/// array, a spread, `[...set]`, etc.); each element becomes one chunk so
-/// `getReader().read()` / `for await` yield them in order, then `done`.
-#[no_mangle]
-pub unsafe extern "C" fn js_readable_stream_from_iterable(value: f64) -> f64 {
-    ensure_gc_registered();
+fn ptr_addr_from_nanbox(value: f64) -> Option<usize> {
     let bits = value.to_bits();
     let top = bits >> 48;
-    let ptr_addr = if top == 0x7FFD || top == 0x7FFF {
+    if top == 0x7FFD || top == 0x7FFF {
         Some((bits & POINTER_MASK) as usize)
     } else if top == 0 && bits >= 0x10000 {
         Some(bits as usize)
     } else {
         None
-    };
+    }
+}
+
+unsafe fn chunks_from_array_ptr(arr_ptr: *const perry_runtime::ArrayHeader) -> Vec<u64> {
+    let len = perry_runtime::array::js_array_length(arr_ptr);
+    (0..len)
+        .map(|i| perry_runtime::array::js_array_get(arr_ptr, i).bits())
+        .collect()
+}
+
+unsafe fn chunks_from_sync_iterable(value: f64) -> Option<Vec<u64>> {
+    let iter = perry_runtime::symbol::js_get_iterator(value);
+    if iter.to_bits() == value.to_bits() {
+        return None;
+    }
+    let arr = perry_runtime::array::js_iterator_to_array(iter);
+    Some(chunks_from_array_ptr(arr))
+}
+
+/// `ReadableStream.from(iterable)` (Node 20+, #1645) — build a Web
+/// ReadableStream pre-loaded with the iterable's items, then closed. Each
+/// element becomes one chunk so `getReader().read()` / `for await` yield them
+/// in order, then `done`.
+#[no_mangle]
+pub unsafe extern "C" fn js_readable_stream_from_iterable(value: f64) -> f64 {
+    ensure_gc_registered();
+    let ptr_addr = ptr_addr_from_nanbox(value);
 
     let chunks: Vec<u64> = if perry_runtime::array::js_array_is_array(value).to_bits() == TAG_TRUE {
         let arr_ptr = ptr_addr.unwrap_or(0) as *const perry_runtime::ArrayHeader;
-        let len = perry_runtime::array::js_array_length(arr_ptr);
-        (0..len)
-            .map(|i| perry_runtime::array::js_array_get(arr_ptr, i).bits())
-            .collect()
+        chunks_from_array_ptr(arr_ptr)
     } else if let Some(addr) = ptr_addr {
         if perry_runtime::typedarray::lookup_typed_array_kind(addr).is_some() {
             let ta = addr as *const perry_runtime::typedarray::TypedArrayHeader;
@@ -877,6 +893,8 @@ pub unsafe extern "C" fn js_readable_stream_from_iterable(value: f64) -> f64 {
             let len = (*buf).length as usize;
             let data = perry_runtime::buffer::buffer_data(buf);
             (0..len).map(|i| (*data.add(i) as f64).to_bits()).collect()
+        } else if let Some(chunks) = chunks_from_sync_iterable(value) {
+            chunks
         } else {
             throw_type_error("ReadableStream.from requires an iterable");
         }

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -737,6 +737,21 @@ pub(super) fn collect_modules(
             import.is_native = perry_hir::is_native_module(&import.source);
         }
 
+        // `node:stream/web` is routed as a runtime submodule so its named
+        // imports keep their singleton shape, but the implementations live in
+        // perry-stdlib's `bundled-streams` module. Mark the import explicitly
+        // instead of relying only on codegen-side FFI provenance, which object
+        // cache hits can skip.
+        if import
+            .source
+            .strip_prefix("node:")
+            .unwrap_or(&import.source)
+            == "stream/web"
+        {
+            ctx.needs_stdlib = true;
+            ctx.native_module_imports.insert("stream/web".to_string());
+        }
+
         // Refs #665: an opt-in via `perry.compilePackages` overrides the
         // built-in native binding. HIR lowering set `is_native` based on the
         // NATIVE_MODULES manifest alone; downgrade it here so the import

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -302,12 +302,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: TS readable.cancel \u2014 writable.write does not reject after. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/web/from-promise-iterable": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: ReadableStream.from(customIterable) \u2014 value or done wrong. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/web/writer-write-resolves-after-sink": {
     "issue": "1545",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- materialize custom synchronous iterables in node:stream/web ReadableStream.from
- make node:stream/web imports explicitly enable bundled stream stdlib linkage even on object-cache hits
- remove the now-passing stream/web from-promise-iterable known failure

## Verification
- RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo check -p perry -p perry-stdlib
- cargo fmt --check
- jq empty test-parity/known_failures.json
- git diff --check
- RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 ./run_parity_tests.sh --suite node-suite --module stream/web --filter from-promise-iterable
- RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 ./run_parity_tests.sh --suite node-suite --module stream/web --filter from-iterable
- RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 ./run_parity_tests.sh --suite node-suite --module stream/web --filter from-plain-array
- RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 ./run_parity_tests.sh --suite node-suite --module stream/web --filter readable-stream-from-non-iterable
- RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 ./run_parity_tests.sh --suite node-suite --module stream/web --filter from-uint8array-direct