### PR TITLE
fix(node:async_hooks): forward AsyncLocalStorage run/exit arguments (#3093)

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/async_decimal.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/async_decimal.rs
@@ -3,18 +3,20 @@ use super::*;
 pub(super) const ASYNC_DECIMAL_ROWS: &[NativeModSig] = &[
     // ========== async_hooks.AsyncLocalStorage ==========
     // `new AsyncLocalStorage()` is dispatched by `lower_builtin_new`; the rows
-    // below cover the instance methods. `run(store, cb)` and `exit(cb)` need
-    // the closure pointer arg coerced via NA_PTR (the runtime function takes
-    // it as a raw `i64` ClosureHeader pointer + invokes `js_closure_call0`
-    // internally). Pre-fix every method silently no-op'd through the
-    // unknown-method sentinel.
+    // below cover the instance methods. `run(store, cb, ...args)` and
+    // `exit(cb, ...args)` coerce the closure pointer arg via NA_PTR (the
+    // runtime takes it as a raw `i64` ClosureHeader pointer) and forward any
+    // trailing call arguments through NA_VARARGS — the codegen packs them into
+    // a JS array and passes a single `i64` ArrayHeader pointer the runtime
+    // unpacks and replays via `js_closure_call_array` (#3093). Pre-fix every
+    // method silently no-op'd through the unknown-method sentinel.
     NativeModSig {
         module: "async_hooks",
         has_receiver: true,
         method: "run",
         class_filter: None,
         runtime: "js_async_local_storage_run",
-        args: &[NA_F64, NA_PTR],
+        args: &[NA_F64, NA_PTR, NA_VARARGS],
         ret: NR_F64,
     },
     NativeModSig {
@@ -41,7 +43,7 @@ pub(super) const ASYNC_DECIMAL_ROWS: &[NativeModSig] = &[
         method: "exit",
         class_filter: None,
         runtime: "js_async_local_storage_exit",
-        args: &[NA_PTR],
+        args: &[NA_PTR, NA_VARARGS],
         ret: NR_F64,
     },
     NativeModSig {

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -368,10 +368,14 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_async_resource_static_bind", I64, &[I64, DOUBLE]);
     module.declare_function("js_async_local_storage_disable", VOID, &[I64]);
     module.declare_function("js_async_local_storage_enter_with", VOID, &[I64, DOUBLE]);
-    module.declare_function("js_async_local_storage_exit", DOUBLE, &[I64, I64]);
+    module.declare_function("js_async_local_storage_exit", DOUBLE, &[I64, I64, I64]);
     module.declare_function("js_async_local_storage_get_store", DOUBLE, &[I64]);
     module.declare_function("js_async_local_storage_new", I64, &[]);
-    module.declare_function("js_async_local_storage_run", DOUBLE, &[I64, DOUBLE, I64]);
+    module.declare_function(
+        "js_async_local_storage_run",
+        DOUBLE,
+        &[I64, DOUBLE, I64, I64],
+    );
 
     // ========== zlib ==========
     module.declare_function("js_zlib_deflate_sync", I64, &[I64]);

--- a/crates/perry-stdlib/src/async_local_storage.rs
+++ b/crates/perry-stdlib/src/async_local_storage.rs
@@ -3,11 +3,39 @@
 //! Native implementation of Node.js AsyncLocalStorage from `async_hooks`.
 //! Provides run(), getStore(), enterWith(), exit(), and disable().
 
-use perry_runtime::{async_context, js_closure_call0};
+use perry_runtime::array::{js_array_length, ArrayHeader};
+use perry_runtime::async_context;
+use perry_runtime::closure::js_closure_call_array;
 
 use crate::common::{get_handle_mut, register_handle, Handle};
 
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
+/// Invoke `callback` with the forwarded call arguments packed by the codegen
+/// `NA_VARARGS` ABI into `args_array` (a NaN-boxed `*const ArrayHeader` raw
+/// pointer, or 0 when no trailing args were supplied). Returns the callback's
+/// return value, or `undefined` when there is no callback.
+///
+/// Mirrors the array-unpacking done by `js_async_resource_run_in_async_scope`:
+/// the element data lives immediately after the `ArrayHeader` and each slot is
+/// already a NaN-boxed `f64`, so we hand `(data, len)` straight to
+/// `js_closure_call_array`.
+unsafe fn call_forwarding_args(callback: i64, args_array: i64) -> f64 {
+    if callback == 0 {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    if args_array == 0 {
+        return js_closure_call_array(callback, std::ptr::null(), 0);
+    }
+    let arr = args_array as *const ArrayHeader;
+    let len = js_array_length(arr) as i64;
+    let data = if arr.is_null() {
+        std::ptr::null()
+    } else {
+        (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64
+    };
+    js_closure_call_array(callback, data, len)
+}
 
 /// AsyncLocalStorage handle. Store stacks live in perry-runtime's active
 /// async context so schedulers can snapshot and restore them across async
@@ -33,21 +61,20 @@ pub extern "C" fn js_async_local_storage_new() -> Handle {
     register_handle(AsyncLocalStorageHandle::new())
 }
 
-/// AsyncLocalStorage.run(store, callback)
-/// Push store onto stack, call callback, pop store, return result
+/// AsyncLocalStorage.run(store, callback, ...args)
+/// Push store onto stack, call `callback(...args)`, pop store, return result.
+/// `args_array` carries the forwarded trailing call arguments (codegen
+/// `NA_VARARGS` ABI); they are passed through to the callback unchanged.
 #[no_mangle]
 pub unsafe extern "C" fn js_async_local_storage_run(
     handle: Handle,
     store: f64,
     callback: i64,
+    args_array: i64,
 ) -> f64 {
     async_context::push_store(handle, store);
 
-    let result = if callback != 0 {
-        js_closure_call0(callback as *const perry_runtime::ClosureHeader)
-    } else {
-        f64::from_bits(TAG_UNDEFINED)
-    };
+    let result = call_forwarding_args(callback, args_array);
 
     async_context::pop_store(handle);
 
@@ -75,21 +102,23 @@ pub extern "C" fn js_async_local_storage_enter_with(handle: Handle, store: f64) 
     }
 }
 
-/// AsyncLocalStorage.exit(callback)
-/// Save current stack, clear it, call callback, restore stack
+/// AsyncLocalStorage.exit(callback, ...args)
+/// Save current stack, clear it, call `callback(...args)`, restore stack.
+/// `args_array` carries the forwarded trailing call arguments (codegen
+/// `NA_VARARGS` ABI); they are passed through to the callback unchanged.
 #[no_mangle]
-pub unsafe extern "C" fn js_async_local_storage_exit(handle: Handle, callback: i64) -> f64 {
+pub unsafe extern "C" fn js_async_local_storage_exit(
+    handle: Handle,
+    callback: i64,
+    args_array: i64,
+) -> f64 {
     let saved = if get_handle_mut::<AsyncLocalStorageHandle>(handle).is_some() {
         Some(async_context::take_store(handle))
     } else {
         None
     };
 
-    let result = if callback != 0 {
-        js_closure_call0(callback as *const perry_runtime::ClosureHeader)
-    } else {
-        f64::from_bits(TAG_UNDEFINED)
-    };
+    let result = call_forwarding_args(callback, args_array);
 
     if let Some(saved) = saved {
         async_context::restore_store(handle, saved);

--- a/test-files/test_gap_async_hooks_als_forward_args.ts
+++ b/test-files/test_gap_async_hooks_als_forward_args.ts
@@ -1,0 +1,40 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const als = new AsyncLocalStorage<string>();
+
+// run() forwards three trailing args and returns the callback's return value;
+// the store remains readable from inside the callback.
+const runRet = als.run(
+  "store",
+  function (...args) {
+    console.log("run args:", JSON.stringify(args), "store:", als.getStore());
+    return "r";
+  },
+  "a",
+  "b",
+  "c",
+);
+console.log("run ret:", runRet);
+
+// run() arrow callback summing forwarded numbers.
+const sum = als.run("nums", (x: number, y: number) => x + y, 2, 3);
+console.log("run sum:", sum);
+
+// run() with no extra args still works (empty forwarded list).
+const none = als.run("solo", () => "ok");
+console.log("run none:", none);
+
+// exit() forwards two trailing args, clears the store inside the callback,
+// returns the callback's return value, and restores the store afterward.
+const exitRet = als.run("outer", () =>
+  als.exit(
+    function (...args) {
+      console.log("exit args:", JSON.stringify(args), "store:", als.getStore());
+      return "e";
+    },
+    "x",
+    "y",
+  ),
+);
+console.log("exit ret:", exitRet);
+console.log("store after run:", als.getStore());


### PR DESCRIPTION
## What

Extends Node argument-validation parity (#2013) to the global `Buffer` factory methods, following the `fs` slice landed in #2035 / #2328. These functions previously coerced bad input silently, so `assert.throws`-style tests reported "Missing expected exception".

| API | Bad input | Now throws |
|---|---|---|
| `Buffer.alloc` / `allocUnsafe` / `allocUnsafeSlow` | non-number `size` | `TypeError [ERR_INVALID_ARG_TYPE]` |
| ″ | `NaN` / `Infinity` / negative / `> kMaxLength` | `RangeError [ERR_OUT_OF_RANGE]` |
| `Buffer.concat` | non-Array `list` | `TypeError [ERR_INVALID_ARG_TYPE]` |
| ″ | non-Buffer/Uint8Array element | `TypeError [ERR_INVALID_ARG_TYPE]` (`list[i]`) |
| ″ | non-integer / negative `totalLength` | `ERR_INVALID_ARG_TYPE` / `ERR_OUT_OF_RANGE` |
| `Buffer.byteLength` | non string/Buffer/ArrayBuffer/TypedArray | `TypeError [ERR_INVALID_ARG_TYPE]` |

Non-integer sizes still truncate toward zero (`Buffer.alloc(2.5).length === 2`), matching Node.

## How

- **Reuses the `fs::validate` primitives** (`describe_received`, `throw_type_error_with_code`, `throw_range_error_with_code`, `validate_int32`) — the issue explicitly names this the shared validation home. `describe_received` gains string/bigint rendering (Node's `determineSpecificType` shape) — purely additive; `fs` never reaches those branches.
- New `buffer/validate.rs` with `js_buffer_validate_size`, `js_buffer_validate_concat_list`, `validate_concat_length`, `validate_byte_length_arg`.
- The `size`/`list` values reach validation as raw NaN-boxed values: the Buffer factory codegen (`env_clones.rs`, `array_methods.rs`) now calls the validators before coercing to `i32` / treating as an `ArrayHeader` (the latter also closes a latent UB where `Buffer.concat('x')` cast a string pointer to an array header). `byteLength` / `concat(totalLength)` validate inside the runtime entry points.
- `Buffer.alloc()` / `allocUnsafe()` with no argument now default to `undefined` so they surface `ERR_INVALID_ARG_TYPE` like Node, instead of silently allocating empty.

## Testing

Verified **byte-identical to Node v25** across the full `buffer` node-suite (120 cases, including 3 new arg-validation tests under `allocation/`, `concat/`, `byte-length/`) — 0 diffs, 0 regressions. `cargo fmt --all --check` clean.

## Scope

#2013 is a cross-cutting umbrella (~85 tests across fs/buffer/net/http/crypto/zlib/process/url). `fs` landed earlier; this is the **buffer** slice. `Buffer.compare` is deferred (it lowers to an instance `a.compare(b)` dispatch — a separate path); remaining APIs remain follow-ups.
