### PR TITLE
feat(node:process): expose process.features capability flags (#2588)

### DIFF
--- a/test-files/test_gap_process_features.ts
+++ b/test-files/test_gap_process_features.ts
@@ -1,0 +1,32 @@
+// process.features must be a real, non-null object of capability flags.
+// Node exposes boolean flags plus a `typescript` string. We assert the
+// deterministic structural invariants (object-ness, presence, and the JS
+// type of each flag) rather than the concrete boolean values, which
+// legitimately differ between a Perry build and a Node build.
+const f = process.features;
+
+console.log("typeof:", typeof f);
+console.log("non-null:", f !== null);
+
+// Boolean capability flags Node always exposes.
+const boolKeys = [
+  "inspector",
+  "debug",
+  "ipv6",
+  "tls",
+  "tls_alpn",
+  "tls_ocsp",
+  "tls_sni",
+  "uv",
+  "cached_builtins",
+  "require_module",
+];
+for (const k of boolKeys) {
+  console.log(k, "is boolean:", typeof f[k] === "boolean");
+}
+
+// `typescript` is a string in modern Node (the strip/transform mode).
+console.log("typescript is string:", typeof f.typescript === "string");
+
+// Chained reads must not crash.
+console.log("chained tls ok:", f.tls === true || f.tls === false);

--- a/test-files/test_parity_process.ts
+++ b/test-files/test_parity_process.ts
@@ -117,10 +117,27 @@ console.log("config typeof:", typeof process.config);
 console.log("allowedNodeEnvironmentFlags typeof:", typeof process.allowedNodeEnvironmentFlags);
 // PERRY-SKIP: process.allowedNodeEnvironmentFlags.size — chained on undefined crashes.
 // PERRY-SKIP: process.debugPort — Host-dependent default debug port; can vary between runtime versions.
-// process.features — typeof only on the top-level binding. Chained accesses
-// like process.features.tls crash when features itself is undefined under Perry.
+// process.features is a real, non-null object of capability flags, so chained
+// reads work. We assert the JS type of each flag (deterministic) rather than the
+// concrete boolean values, which legitimately differ between a Perry build and a
+// Node build (e.g. require_module / uv).
 console.log("features typeof:", typeof process.features);
-// PERRY-SKIP: process.features.{cached_builtins,debug,inspector,ipv6,tls,tls_alpn,tls_ocsp,tls_sni,uv,require_module,typescript} — chained on undefined features crashes.
+console.log("features non-null:", process.features !== null);
+for (const k of [
+  "cached_builtins",
+  "debug",
+  "inspector",
+  "ipv6",
+  "tls",
+  "tls_alpn",
+  "tls_ocsp",
+  "tls_sni",
+  "uv",
+  "require_module",
+]) {
+  console.log("features." + k + " is boolean:", typeof process.features[k] === "boolean");
+}
+console.log("features.typescript is string:", typeof process.features.typescript === "string");
 console.log("process.noDeprecation:", process.noDeprecation);
 console.log("process.throwDeprecation:", process.throwDeprecation);
 console.log("process.traceDeprecation:", process.traceDeprecation);


### PR DESCRIPTION
## Summary

Closes the test-side gap in `process.features`: it is now exercised as a real, non-null object of capability flags whose chained reads (`process.features.tls`, `process.features.typescript`, etc.) work and match Node's JS types.

While investigating #2588 I found that the `process.features` runtime/lowering already landed in #1474 — `process_features_literal()` in `crates/perry-hir/src/lower/expr_member.rs` returns a real `Expr::Object` of boolean capability flags plus a `typescript` string. The remaining gap called out by the issue was purely on the test side: `test-files/test_parity_process.ts` still skipped all chained `process.features.*` reads with a stale "chained on undefined features crashes" comment, and there was no dedicated gap test.

This PR closes that gap:

- **`test-files/test_parity_process.ts`** — un-skips the chained feature reads. It now asserts `typeof process.features`, non-null-ness, and the JS type of each documented flag (`boolean` for the capability flags, `string` for `typescript`).
- **`test-files/test_gap_process_features.ts`** (new) — a focused gap test asserting the same deterministic structural invariants (object-ness, non-null, each key's JS type, chained read doesn't crash).

Both assert *types and presence*, not concrete boolean/string values, because some flags legitimately differ between a Perry build and a Node build (Perry surfaces `typescript: "transform"` for its AOT pipeline vs Node's `"strip"`; the `uv` / `inspector` / `require_module` booleans also differ).

## Validation

Compiled with the `cargo`-built runtime/stdlib and compared byte-for-byte against `node --experimental-strip-types`.

`test-files/test_gap_process_features.ts` — byte-identical to Node:

```
typeof: object
non-null: true
inspector is boolean: true
debug is boolean: true
ipv6 is boolean: true
tls is boolean: true
tls_alpn is boolean: true
tls_ocsp is boolean: true
tls_sni is boolean: true
uv is boolean: true
cached_builtins is boolean: true
require_module is boolean: true
typescript is string: true
chained tls ok: true
```

`test-files/test_parity_process.ts` — the `process.features` section is byte-identical to Node (`diff <(grep features node) <(grep features perry)` => FEATURES_IDENTICAL), and the full fixture diff against Node is empty. Verified against the unmodified `origin/main` fixture as a baseline, so this PR introduces no new diffs.

- `cargo fmt --all -- --check` passes (no Rust files changed).
- No api-manifest entry added; `process.features` is handled by HIR lowering (mirroring `process.report`), so `api-docs-drift` is unaffected.

Closes #2588.
