### PR TITLE
fix(querystring): remove duplicate throw_symbol_to_string_type_error (E0428, main red)

### DIFF
--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -555,14 +555,6 @@ unsafe fn resolve_stringify_separator_str(value: f64, default: &'static str) -> 
     jsvalue_to_owned_string(value)
 }
 
-fn throw_symbol_to_string_type_error() -> ! {
-    let msg = "Cannot convert a Symbol value to a string";
-    let msg_str = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-    let err_ptr = perry_runtime::error::js_typeerror_new(msg_str);
-    let err_value = JSValue::pointer(err_ptr as *const u8).bits();
-    perry_runtime::exception::js_throw(f64::from_bits(err_value))
-}
-
 /// Append `key=value` (or `key=v1&key=v2` for arrays) to `out`.
 unsafe fn append_stringify_value(
     out: &mut String,


### PR DESCRIPTION
## Problem

`main` does not compile. PRs #3087 (*coerce public codec inputs*) and #3105 (*coerce separator inputs*) each independently added an identical `throw_symbol_to_string_type_error` helper to `crates/perry-stdlib/src/querystring.rs`. Both merged, so the function is now defined twice (lines 174 and 558):

```
error[E0428]: the name `throw_symbol_to_string_type_error` is defined multiple times
   --> crates/perry-stdlib/src/querystring.rs:558:1
```

This hard error breaks every `perry-stdlib` build. On PR CI it surfaces in `compiler-output-regression`: the auto-optimize stdlib rebuild fails, so `perry compile --verify-native-regions` can't find `libperry_runtime.a` and the native-region-proof suite fails — reddening **all** open PRs, not just the one that introduced it.

## Fix

Remove the second, behavior-identical definition. The canonical one at line 174 (throws a `TypeError: Cannot convert a Symbol value to a string`) serves every caller in the module.

## Verification

`cargo build --release -p perry-stdlib` succeeds (was E0428 before). One definition remains.
