### PR TITLE
fix(querystring): remove duplicate throw_symbol_to_string_type_error (main red)

### DIFF
--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -555,14 +555,6 @@ unsafe fn resolve_stringify_separator_str(value: f64, default: &'static str) -> 
     jsvalue_to_owned_string(value)
 }
 
-fn throw_symbol_to_string_type_error() -> ! {
-    let msg = "Cannot convert a Symbol value to a string";
-    let msg_str = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-    let err_ptr = perry_runtime::error::js_typeerror_new(msg_str);
-    let err_value = JSValue::pointer(err_ptr as *const u8).bits();
-    perry_runtime::exception::js_throw(f64::from_bits(err_value))
-}
-
 /// Append `key=value` (or `key=v1&key=v2` for arrays) to `out`.
 unsafe fn append_stringify_value(
     out: &mut String,


### PR DESCRIPTION
## Summary

**Main is red** — `cargo-test` fails to compile `perry-stdlib` for every open PR.

PRs #3087 (`fix(querystring): coerce public codec inputs`) and #3105 (`fix(querystring): coerce separator inputs`) each independently added a file-local helper named `throw_symbol_to_string_type_error` to `crates/perry-stdlib/src/querystring.rs`. Both landed on `main`, so the crate now has two definitions of the same name:

```
error[E0428]: the name `throw_symbol_to_string_type_error` is defined multiple times
  --> crates/perry-stdlib/src/querystring.rs:174  (first, from #3087)
  --> crates/perry-stdlib/src/querystring.rs:558  (duplicate, from #3105)
```

The two are functionally identical (both throw `TypeError: Cannot convert a Symbol value to a string`). This keeps the first definition and removes the duplicate.

## Verification

`cargo build --release -p perry-stdlib` compiles cleanly (E0428 gone; only the pre-existing unrelated warnings remain). The remaining definition is module-scoped, so all callers in the file still resolve.
