### PR TITLE
fix(string): ToUint16 fromCharCode + fromCodePoint RangeError (#2788)

### DIFF
--- a/crates/perry-codegen/src/expr/string_regex_proc.rs
+++ b/crates/perry-codegen/src/expr/string_regex_proc.rs
@@ -58,10 +58,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
 
         // -------- String.fromCodePoint(cp) — returns single-char string --------
         Expr::StringFromCodePoint(o) => {
+            // #2788: pass the raw NaN-boxed value; the runtime validates the
+            // code point and throws RangeError for negative/non-integer/>0x10FFFF.
+            // A prior fptosi truncated `3.14` to `3` and hid the error.
             let v = lower_expr(ctx, o)?;
             let blk = ctx.block();
-            let i32_v = blk.fptosi(DOUBLE, &v, I32);
-            let handle = blk.call(I64, "js_string_from_code_point", &[(I32, &i32_v)]);
+            let handle = blk.call(I64, "js_string_from_code_point", &[(DOUBLE, &v)]);
             Ok(nanbox_string_inline(blk, &handle))
         }
         // -------- str.at(i) — returns single-char string or undefined --------
@@ -378,10 +380,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
 
         // -------- String.fromCharCode(code) --------
         Expr::StringFromCharCode(o) => {
+            // #2788: pass the raw NaN-boxed value; the runtime applies ToUint16
+            // so negative/out-of-range codes wrap modulo 65536. A prior fptosi
+            // is UB on a NaN and dropped the wrap semantics.
             let v = lower_expr(ctx, o)?;
             let blk = ctx.block();
-            let i32_v = blk.fptosi(DOUBLE, &v, I32);
-            let handle = blk.call(I64, "js_string_from_char_code", &[(I32, &i32_v)]);
+            let handle = blk.call(I64, "js_string_from_char_code", &[(DOUBLE, &v)]);
             Ok(nanbox_string_inline(blk, &handle))
         }
         Expr::RegExpSetLastIndex { regex, value } => {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1217,8 +1217,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // String extras (already in string.rs; expr.rs was stubbing or missing dispatch).
     module.declare_function("js_string_at", DOUBLE, &[I64, I32]);
     module.declare_function("js_string_code_point_at", DOUBLE, &[I64, I32]);
-    module.declare_function("js_string_from_code_point", I64, &[I32]);
-    module.declare_function("js_string_from_char_code", I64, &[I32]);
+    // #2788: take the raw NaN-boxed f64 so the runtime can apply ToUint16
+    // (fromCharCode) / RangeError validation (fromCodePoint) — a prior fptosi
+    // truncated fractional/non-finite inputs before they could be observed.
+    module.declare_function("js_string_from_code_point", I64, &[DOUBLE]);
+    module.declare_function("js_string_from_char_code", I64, &[DOUBLE]);
     module.declare_function("js_string_char_code_at", DOUBLE, &[I64, I32]);
     module.declare_function("js_string_last_index_of", I32, &[I64, I64]);
     module.declare_function(

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -812,6 +812,10 @@ pub(super) fn try_module_static_methods(
                     let method_name = method_ident.sym.as_ref();
                     match method_name {
                         "fromCharCode" => {
+                            if args.is_empty() {
+                                // #2788: String.fromCharCode() -> "".
+                                return Ok(Ok(Expr::String(String::new())));
+                            }
                             if args.len() == 1 {
                                 return Ok(Ok(Expr::StringFromCharCode(Box::new(
                                     args.into_iter().next().unwrap(),
@@ -832,6 +836,10 @@ pub(super) fn try_module_static_methods(
                             }
                         }
                         "fromCodePoint" => {
+                            if args.is_empty() {
+                                // #2788: String.fromCodePoint() -> "".
+                                return Ok(Ok(Expr::String(String::new())));
+                            }
                             if args.len() == 1 {
                                 return Ok(Ok(Expr::StringFromCodePoint(Box::new(
                                     args.into_iter().next().unwrap(),

--- a/crates/perry-runtime/src/string/char_ops.rs
+++ b/crates/perry-runtime/src/string/char_ops.rs
@@ -110,38 +110,69 @@ pub extern "C" fn js_string_to_char_array(s: i64) -> i64 {
     arr as i64
 }
 
-/// Create a string from a character code (String.fromCharCode)
-/// Takes a single character code and returns a 1-character string
-#[no_mangle]
-pub extern "C" fn js_string_from_char_code(code: i32) -> *mut StringHeader {
-    if !(0..=0xFFFF).contains(&code) {
-        // Invalid character code, return empty string
-        return js_string_from_bytes(std::ptr::null(), 0);
+/// JS `ToUint16` for `String.fromCharCode` (#2788): a non-finite value
+/// (`NaN`/`±Inf`) maps to `0`; otherwise truncate toward zero and reduce
+/// modulo 2^16 into `[0, 65535]`. `rem_euclid` keeps the result non-negative,
+/// so `-1` wraps to `65535` and `0x1F600` wraps to `0xF600`.
+fn to_uint16(code: f64) -> u16 {
+    if !code.is_finite() {
+        return 0;
     }
+    code.trunc().rem_euclid(65536.0) as u16
+}
 
-    // For ASCII characters, create a simple 1-byte string
-    if code < 128 {
-        let byte = code as u8;
+/// Create a string from a character code (String.fromCharCode).
+/// The argument is coerced with `ToUint16` (#2788), so out-of-range and
+/// negative values wrap modulo 65536 rather than returning `""`. Codegen
+/// passes the raw NaN-boxed `f64` (not `fptosi`, which is UB on a NaN).
+#[no_mangle]
+pub extern "C" fn js_string_from_char_code(code: f64) -> *mut StringHeader {
+    let unit = to_uint16(code);
+
+    // For ASCII characters, create a simple 1-byte string.
+    if unit < 128 {
+        let byte = unit as u8;
         return js_string_from_bytes(&byte as *const u8, 1);
     }
 
-    // For non-ASCII, encode as UTF-8
-    let ch = char::from_u32(code as u32).unwrap_or('\u{FFFD}');
+    // For non-ASCII, encode as UTF-8. Lone surrogates (0xD800..=0xDFFF) are
+    // not valid Rust `char`s; emit U+FFFD (the documented WTF-8 / lone-
+    // surrogate categorical gap — Node would emit the lone surrogate).
+    let ch = char::from_u32(unit as u32).unwrap_or('\u{FFFD}');
     let mut buf = [0u8; 4];
     let encoded = ch.encode_utf8(&mut buf);
     js_string_from_bytes(encoded.as_ptr(), encoded.len() as u32)
 }
 
+/// Throw `RangeError: Invalid code point <n>` for `String.fromCodePoint`,
+/// matching Node's message. Rust's `f64` Display drops the trailing `.0` for
+/// integer-valued floats (`1114112.0` -> "1114112") and keeps fractional
+/// digits (`3.14` -> "3.14"), so it matches JS number formatting here.
+fn throw_invalid_code_point(code: f64) -> ! {
+    let msg = format!("Invalid code point {}", code);
+    let msg_str = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err_ptr = crate::error::js_rangeerror_new(msg_str);
+    let err_value = crate::value::JSValue::pointer(err_ptr as *const u8).bits();
+    crate::exception::js_throw(f64::from_bits(err_value))
+}
+
 /// Create a string from a Unicode code point (String.fromCodePoint).
-/// Supports the full Unicode range (0..0x10FFFF), unlike fromCharCode (0..0xFFFF).
+/// Supports the full Unicode range (0..=0x10FFFF), unlike fromCharCode
+/// (0..=0xFFFF). Per spec (#2788), a negative, non-integer, or `> 0x10FFFF`
+/// argument throws `RangeError`. Codegen passes the raw NaN-boxed `f64` so the
+/// non-integer/non-finite cases are observable (a prior `fptosi` truncated
+/// `3.14` to `3` and silently produced a character).
 #[no_mangle]
-pub extern "C" fn js_string_from_code_point(code: i32) -> *mut StringHeader {
-    if !(0..=0x10FFFF).contains(&code) {
-        return js_string_from_bytes(std::ptr::null(), 0);
+pub extern "C" fn js_string_from_code_point(code: f64) -> *mut StringHeader {
+    if !code.is_finite() || code.fract() != 0.0 || code < 0.0 || code > 0x10FFFF as f64 {
+        throw_invalid_code_point(code);
     }
-    let ch = match char::from_u32(code as u32) {
+    let cp = code as u32;
+    let ch = match char::from_u32(cp) {
         Some(c) => c,
-        None => return js_string_from_bytes(std::ptr::null(), 0),
+        // Lone surrogate: a valid code point for fromCodePoint but not a Rust
+        // `char`. Emit U+FFFD (WTF-8 categorical gap); do NOT throw.
+        None => '\u{FFFD}',
     };
     let mut buf = [0u8; 4];
     let encoded = ch.encode_utf8(&mut buf);

--- a/test-parity/node-suite/string/from-char/wrapping-and-rangeerror.ts
+++ b/test-parity/node-suite/string/from-char/wrapping-and-rangeerror.ts
@@ -1,0 +1,20 @@
+// #2788: String.fromCharCode applies ToUint16 (negative/out-of-range wrap
+// modulo 65536); String.fromCodePoint throws RangeError for negative,
+// non-integer, and > 0x10FFFF code points; zero-arg calls return "".
+console.log("fcc(65,66,67):", String.fromCharCode(65, 66, 67));
+console.log("fcc(0x1F600)->cp:", String.fromCharCode(0x1F600).codePointAt(0)); // 0xF600
+console.log("fcc(-1)->cp:", String.fromCharCode(-1).codePointAt(0)); // 0xFFFF
+console.log("fcc(65.9):", String.fromCharCode(65.9)); // "A"
+console.log("fcc(65536)->cp:", String.fromCharCode(65536).codePointAt(0)); // 0 wraps -> "\0"
+console.log("fcc():", JSON.stringify(String.fromCharCode())); // ""
+
+console.log("fcp(0x1F600,65):", String.fromCodePoint(0x1F600, 65)); // "😀A"
+console.log("fcp():", JSON.stringify(String.fromCodePoint())); // ""
+for (const cp of [1114112, -1, 3.14]) {
+  try {
+    String.fromCodePoint(cp);
+    console.log("fcp(" + cp + "): NO THROW");
+  } catch (e) {
+    console.log("fcp(" + cp + "):", (e as Error).name + ": " + (e as Error).message);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #2788 — `String.fromCharCode` and `String.fromCodePoint` edge semantics now match Node.

- **`fromCharCode`** coerces each argument with `ToUint16`: non-finite → `0`, else truncate toward zero then wrap modulo 65536. So `fromCharCode(-1)` → `U+FFFF`, `fromCharCode(0x1F600)` → `U+F600`, `fromCharCode(65.9)` → `"A"` (previously returned `""` for out-of-range).
- **`fromCodePoint`** throws `RangeError: Invalid code point <n>` for negative, non-integer, and `> 0x10FFFF` arguments (previously returned `""`). Message matches Node.
- **Zero-argument** `fromCharCode()` / `fromCodePoint()` return `""`.

## Fix

The runtime helpers now take the raw NaN-boxed `f64` instead of a codegen-side `fptosi(DOUBLE → I32)` — that truncation is UB on a NaN and silently dropped both the wrap semantics (`fromCharCode`) and the non-integer detection (`fromCodePoint(3.14)` became `3`). `js_string_from_char_code` applies `ToUint16`; `js_string_from_code_point` validates and throws via the standard `js_rangeerror_new` + `js_throw` path. Zero-arg lowering returns an empty-string literal in HIR.

## Verification

Byte-for-byte against `node --experimental-strip-types` across the issue's probe matrix (wrapping, RangeError code points, non-integer, zero-arg) — identical. New parity fixture: `test-parity/node-suite/string/from-char/wrapping-and-rangeerror.ts`.

Note: lone-surrogate inputs (`fromCharCode(0xD800)`) still emit `U+FFFD` — the documented WTF-8 / lone-surrogate categorical gap, not part of this issue.
