### PR TITLE
fix(crypto): validate random and timing inputs

### DIFF
--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -927,18 +927,22 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         }
 
         // Phase H crypto: `crypto.randomUUID()`.
-        Expr::Call {
-            callee, args: _, ..
-        } if matches!(
-            callee.as_ref(),
-            Expr::PropertyGet { object, property } if property == "randomUUID" && matches!(
-                object.as_ref(),
-                Expr::NativeModuleRef(n) if n == "crypto"
-            )
-        ) =>
+        Expr::Call { callee, args, .. }
+            if matches!(
+                callee.as_ref(),
+                Expr::PropertyGet { object, property } if property == "randomUUID" && matches!(
+                    object.as_ref(),
+                    Expr::NativeModuleRef(n) if n == "crypto"
+                )
+            ) =>
         {
+            let options_box = if let Some(options) = args.first() {
+                lower_expr(ctx, options)?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
             let blk = ctx.block();
-            let handle = blk.call(I64, "js_crypto_random_uuid", &[]);
+            let handle = blk.call(I64, "js_crypto_random_uuid", &[(DOUBLE, &options_box)]);
             Ok(nanbox_string_inline(blk, &handle))
         }
 
@@ -1009,12 +1013,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let a_box = lower_expr(ctx, &args[0])?;
             let b_box = lower_expr(ctx, &args[1])?;
             let blk = ctx.block();
-            let a_handle = unbox_to_i64(blk, &a_box);
-            let b_handle = unbox_to_i64(blk, &b_box);
             Ok(blk.call(
                 DOUBLE,
                 "js_crypto_timing_safe_equal",
-                &[(I64, &a_handle), (I64, &b_handle)],
+                &[(DOUBLE, &a_box), (DOUBLE, &b_box)],
             ))
         }
 

--- a/crates/perry-codegen/src/expr/misc_methods.rs
+++ b/crates/perry-codegen/src/expr/misc_methods.rs
@@ -150,7 +150,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // -------- Crypto.* wired to real runtime helpers --------
         Expr::CryptoRandomUUID => {
             let blk = ctx.block();
-            let handle = blk.call(I64, "js_crypto_random_uuid", &[]);
+            let undefined = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+            let handle = blk.call(I64, "js_crypto_random_uuid", &[(DOUBLE, &undefined)]);
             Ok(nanbox_string_inline(blk, &handle))
         }
         Expr::CryptoRandomBytes(operand) => {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1340,7 +1340,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_crypto_secure_heap_used", I64, &[]);
     module.declare_function("js_crypto_random_bytes_buffer", I64, &[DOUBLE]);
     module.declare_function("js_crypto_random_bytes_async", DOUBLE, &[DOUBLE, DOUBLE]);
-    module.declare_function("js_crypto_random_uuid", I64, &[]);
+    module.declare_function("js_crypto_random_uuid", I64, &[DOUBLE]);
     // crypto.randomInt([min,] max[, cb]) -> number; codegen passes min=0 for the
     // single-arg form. Returns the integer as a plain double.
     module.declare_function("js_crypto_random_int", DOUBLE, &[DOUBLE, DOUBLE]);
@@ -1349,9 +1349,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, DOUBLE, DOUBLE],
     );
-    // crypto.timingSafeEqual(a, b) -> boolean (NaN-boxed). Args are unboxed
-    // to raw i64 pointers (Buffer / TypedArray / string).
-    module.declare_function("js_crypto_timing_safe_equal", DOUBLE, &[I64, I64]);
+    // crypto.timingSafeEqual(a, b) -> boolean (NaN-boxed). Args stay boxed so
+    // stdlib can validate BufferSource types before reading bytes.
+    module.declare_function("js_crypto_timing_safe_equal", DOUBLE, &[DOUBLE, DOUBLE]);
     // crypto.getHashes() / getCiphers() -> string[]; returns *mut ArrayHeader.
     module.declare_function("js_crypto_get_hashes", I64, &[]);
     module.declare_function("js_crypto_get_ciphers", I64, &[]);

--- a/crates/perry-hir/src/lower/expr_call/crypto.rs
+++ b/crates/perry-hir/src/lower/expr_call/crypto.rs
@@ -86,7 +86,8 @@ pub(super) fn is_passthrough_method(method: &str) -> bool {
 ///
 /// Today's set:
 /// - `randomFillSync(buffer, offset?, size?)` → `Expr::CryptoRandomFillSync`.
-/// - `randomUUID()` → `Expr::CryptoRandomUUID`.
+/// - `randomUUID()` → `Expr::CryptoRandomUUID`; option-bearing calls keep
+///   the generic call shape so codegen can pass the options value through.
 /// - `randomBytes(size)` → `Expr::CryptoRandomBytes`.
 pub(super) fn lower_crypto_passthrough(method: &str, args: Vec<Expr>) -> Option<Expr> {
     match method {
@@ -104,7 +105,15 @@ pub(super) fn lower_crypto_passthrough(method: &str, args: Vec<Expr>) -> Option<
                 size: Box::new(size),
             })
         }
-        "randomUUID" => Some(Expr::CryptoRandomUUID),
+        "randomUUID" if args.is_empty() => Some(Expr::CryptoRandomUUID),
+        "randomUUID" => Some(Expr::Call {
+            callee: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::NativeModuleRef("crypto".to_string())),
+                property: "randomUUID".to_string(),
+            }),
+            args,
+            type_args: vec![],
+        }),
         "randomBytes" => {
             if args.is_empty() {
                 return None;

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -7,6 +7,115 @@
 
 use super::*;
 
+fn crypto_dispatch_value_addr(value: f64) -> usize {
+    let bits = value.to_bits();
+    if (bits >> 48) >= 0x7FF8 {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else {
+        bits as usize
+    }
+}
+
+fn crypto_random_fill_number_arg(value: f64, name: &str) -> Option<f64> {
+    let js = JSValue::from_bits(value.to_bits());
+    if js.is_undefined() {
+        return None;
+    }
+    if !js.is_number() && !js.is_int32() {
+        let message = format!(
+            "The \"{}\" argument must be of type number. Received {}",
+            name,
+            crate::fs::validate::describe_received(value)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    Some(if js.is_int32() {
+        js.as_int32() as f64
+    } else {
+        value
+    })
+}
+
+fn crypto_random_fill_range(total: usize, offset_bits: f64, size_bits: f64) -> (usize, usize) {
+    let offset = match crypto_random_fill_number_arg(offset_bits, "offset") {
+        Some(n) if n.is_finite() && n >= 0.0 && n <= total as f64 => n as usize,
+        Some(n) => {
+            let message = format!(
+                "The value of \"offset\" is out of range. It must be >= 0 && <= {}. Received {}",
+                total, n
+            );
+            crate::fs::validate::throw_range_error_with_code(&message);
+        }
+        None => 0,
+    };
+    let size = match crypto_random_fill_number_arg(size_bits, "size") {
+        Some(n) if n.is_finite() && n >= 0.0 && n <= i32::MAX as f64 => n as usize,
+        Some(n) => {
+            let message = format!(
+                "The value of \"size\" is out of range. It must be >= 0 && <= 2147483647. Received {}",
+                n
+            );
+            crate::fs::validate::throw_range_error_with_code(&message);
+        }
+        None => total.saturating_sub(offset),
+    };
+    let end = offset.saturating_add(size);
+    if end > total {
+        let message = format!(
+            "The value of \"size + offset\" is out of range. It must be <= {}. Received {}",
+            total, end
+        );
+        crate::fs::validate::throw_range_error_with_code(&message);
+    }
+    (offset, size)
+}
+
+fn crypto_random_fill_invalid_buf(value: f64) -> ! {
+    let message = format!(
+        "The \"buf\" argument must be an instance of Buffer, TypedArray, DataView, or ArrayBuffer. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+unsafe fn crypto_random_fill_sync_dispatch(target: f64, offset_bits: f64, size_bits: f64) -> f64 {
+    use rand::RngCore;
+
+    let addr = crypto_dispatch_value_addr(target);
+    if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
+        let ta = addr as *mut crate::typedarray::TypedArrayHeader;
+        if let Some(data) = crate::typedarray::typed_array_bytes_mut(ta) {
+            let elem_size = (*ta).elem_size as usize;
+            let len = if elem_size == 0 {
+                0
+            } else {
+                data.len() / elem_size
+            };
+            let (start_elem, count_elem) = crypto_random_fill_range(len, offset_bits, size_bits);
+            let start = start_elem.saturating_mul(elem_size);
+            let end = start
+                .saturating_add(count_elem.saturating_mul(elem_size))
+                .min(data.len());
+            if end > start {
+                rand::thread_rng().fill_bytes(&mut data[start..end]);
+            }
+            return target;
+        }
+        crypto_random_fill_invalid_buf(target);
+    }
+    if crate::buffer::is_registered_buffer(addr) {
+        let buf = addr as *mut crate::buffer::BufferHeader;
+        let total = (*buf).length as usize;
+        let (start, count) = crypto_random_fill_range(total, offset_bits, size_bits);
+        if count > 0 {
+            let data = crate::buffer::buffer_data_mut(buf);
+            rand::thread_rng().fill_bytes(std::slice::from_raw_parts_mut(data.add(start), count));
+        }
+        return target;
+    }
+    crypto_random_fill_invalid_buf(target);
+}
+
 /// Dispatch a method call on a native module namespace object.
 /// Extracts the module name from the object and dispatches to the appropriate
 /// runtime function based on (module_name, method_name).
@@ -216,26 +325,6 @@ pub(crate) unsafe fn dispatch_native_module_method(
             crate::typedarray::lookup_typed_array_kind(addr)
         }
     };
-    let usize_arg = |v: f64| -> Option<usize> {
-        let raw = v.to_bits();
-        let top16 = (raw >> 48) as u16;
-        if JSValue::from_bits(raw).is_undefined() || JSValue::from_bits(raw).is_null() {
-            return None;
-        }
-        if top16 == 0x7FFE {
-            let i = (raw & 0xFFFF_FFFF) as u32 as i32;
-            return (i >= 0).then_some(i as usize);
-        }
-        // `is_sign_negative` is true for -0.0 too (a normal result of
-        // `0 - 0` in JS land). Accept -0.0 as 0 and only reject genuinely
-        // negative numbers.
-        if v.is_nan() || v.is_infinite() || (v.is_sign_negative() && v != 0.0) {
-            None
-        } else {
-            Some(v as usize)
-        }
-    };
-
     match (module_name, method_name) {
         // ── Buffer constructor static API ──
         // `class MyBuffer extends Buffer {}; MyBuffer.from(...)` reaches this
@@ -408,48 +497,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("process", "cpuUsage") => crate::process::js_process_cpu_usage(arg(0)),
         // ── crypto module ──
         ("crypto", "randomFillSync") if args_len >= 1 => {
-            use rand::RngCore;
-            let target = arg(0);
-            let addr = ptr_addr(target);
-            let offset = usize_arg(arg(1));
-            let size = usize_arg(arg(2));
-            let range = |total: usize| -> (usize, usize) {
-                let start = offset.unwrap_or(0).min(total);
-                let end = size
-                    .map(|s| start.saturating_add(s).min(total))
-                    .unwrap_or(total);
-                (start, end)
-            };
-            if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
-                let ta = addr as *mut crate::typedarray::TypedArrayHeader;
-                if let Some(data) = crate::typedarray::typed_array_bytes_mut(ta) {
-                    let elem_size = (*ta).elem_size as usize;
-                    let len = if elem_size == 0 {
-                        0
-                    } else {
-                        data.len() / elem_size
-                    };
-                    let (start_elem, end_elem) = range(len);
-                    let start = start_elem.saturating_mul(elem_size);
-                    let end = end_elem.saturating_mul(elem_size).min(data.len());
-                    if end > start {
-                        rand::thread_rng().fill_bytes(&mut data[start..end]);
-                    }
-                }
-                target
-            } else if crate::buffer::is_registered_buffer(addr) {
-                let buf = addr as *mut crate::buffer::BufferHeader;
-                let total = (*buf).length as usize;
-                let (start, end) = range(total);
-                if end > start {
-                    let data = crate::buffer::buffer_data_mut(buf);
-                    rand::thread_rng()
-                        .fill_bytes(std::slice::from_raw_parts_mut(data.add(start), end - start));
-                }
-                target
-            } else {
-                target
-            }
+            crypto_random_fill_sync_dispatch(arg(0), arg(1), arg(2))
         }
 
         // ── tty module ──

--- a/crates/perry-stdlib/src/crypto/kdf.rs
+++ b/crates/perry-stdlib/src/crypto/kdf.rs
@@ -155,17 +155,50 @@ pub unsafe extern "C" fn js_crypto_scrypt_async(
 
 /// Constant-time equality for equal-length byte inputs.
 #[no_mangle]
-pub unsafe extern "C" fn js_crypto_timing_safe_equal(a_ptr: i64, b_ptr: i64) -> f64 {
-    let a = bytes_from_ptr(a_ptr);
-    let b = bytes_from_ptr(b_ptr);
+pub unsafe extern "C" fn js_crypto_timing_safe_equal(a_bits: f64, b_bits: f64) -> f64 {
+    let a = validate_timing_safe_equal_buffer_source(a_bits, "buf1");
+    let b = validate_timing_safe_equal_buffer_source(b_bits, "buf2");
     if a.len() != b.len() {
-        return f64::from_bits(JSValue::bool(false).bits());
+        perry_runtime::fs::validate::throw_range_error_named(
+            "Input buffers must have the same byte length",
+            "ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH",
+        );
     }
     let mut diff = 0u8;
     for (x, y) in a.iter().zip(b.iter()) {
         diff |= x ^ y;
     }
     f64::from_bits(JSValue::bool(diff == 0).bits())
+}
+
+unsafe fn validate_timing_safe_equal_buffer_source(value: f64, arg_name: &str) -> Vec<u8> {
+    let addr = {
+        let bits = value.to_bits();
+        if (bits >> 48) >= 0x7FF8 {
+            (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+        } else {
+            bits as usize
+        }
+    };
+    if perry_runtime::typedarray::lookup_typed_array_kind(addr).is_some() {
+        if let Some(bytes) = perry_runtime::typedarray::typed_array_bytes(
+            addr as *const perry_runtime::typedarray::TypedArrayHeader,
+        ) {
+            return bytes.to_vec();
+        }
+    }
+    if perry_runtime::buffer::is_registered_buffer(addr) {
+        let buf = addr as *const perry_runtime::buffer::BufferHeader;
+        let len = (*buf).length as usize;
+        let data =
+            (buf as *const u8).add(std::mem::size_of::<perry_runtime::buffer::BufferHeader>());
+        return std::slice::from_raw_parts(data, len).to_vec();
+    }
+    let message = format!(
+        "The \"{}\" argument must be an instance of ArrayBuffer, Buffer, TypedArray, or DataView.",
+        arg_name
+    );
+    perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
 }
 
 #[no_mangle]

--- a/crates/perry-stdlib/src/crypto/random.rs
+++ b/crates/perry-stdlib/src/crypto/random.rs
@@ -99,17 +99,67 @@ pub extern "C" fn js_crypto_random_bytes_hex(size: f64) -> *mut StringHeader {
 }
 
 /// Generate a random UUID v4 using crypto-secure random
-/// crypto.randomUUID() -> string
+/// crypto.randomUUID([options]) -> string
 #[no_mangle]
-pub extern "C" fn js_crypto_random_uuid() -> *mut StringHeader {
+pub unsafe extern "C" fn js_crypto_random_uuid(options_bits: f64) -> *mut StringHeader {
+    validate_random_uuid_options(options_bits);
     let uuid = uuid::Uuid::new_v4();
     let uuid_str = uuid.to_string();
     js_string_from_bytes(uuid_str.as_ptr(), uuid_str.len() as u32)
 }
 
+unsafe fn validate_random_uuid_options(options_bits: f64) {
+    let value = JSValue::from_bits(options_bits.to_bits());
+    if value.is_undefined() {
+        return;
+    }
+    if !value.is_pointer() {
+        let message = format!(
+            "The \"options\" argument must be of type object. Received {}",
+            perry_runtime::fs::validate::describe_received(options_bits)
+        );
+        perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    let ptr = value.as_pointer::<u8>();
+    if ptr.is_null() || (ptr as usize) < perry_runtime::gc::GC_HEADER_SIZE + 0x1000 {
+        let message = format!(
+            "The \"options\" argument must be of type object. Received {}",
+            perry_runtime::fs::validate::describe_received(options_bits)
+        );
+        perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    let header =
+        &*(ptr.sub(perry_runtime::gc::GC_HEADER_SIZE) as *const perry_runtime::gc::GcHeader);
+    if header.obj_type == perry_runtime::gc::GC_TYPE_ARRAY {
+        let message = format!(
+            "The \"options\" argument must be of type object. Received {}",
+            perry_runtime::fs::validate::describe_received(options_bits)
+        );
+        perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    if header.obj_type != perry_runtime::gc::GC_TYPE_OBJECT {
+        return;
+    }
+    let key = js_string_from_bytes(b"disableEntropyCache".as_ptr(), 19);
+    let field = js_object_get_field_by_name(ptr as *const ObjectHeader, key);
+    if field.is_undefined() {
+        return;
+    }
+    if !field.is_bool() {
+        let message = format!(
+            "The \"options.disableEntropyCache\" property must be of type boolean. Received {}",
+            perry_runtime::fs::validate::describe_received(f64::from_bits(field.bits()))
+        );
+        perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+}
+
+const RANDOM_INT_MAX_RANGE: i64 = (1i64 << 48) - 1;
+const MAX_SAFE_INTEGER: f64 = 9_007_199_254_740_991.0;
+
 /// Issue #2013 — validate one of `randomInt`'s integer arguments
 /// (min/max). Non-number → ERR_INVALID_ARG_TYPE; non-finite /
-/// fractional / out-of-(-2^48, 2^48) → ERR_OUT_OF_RANGE. Mirrors
+/// fractional / unsafe integer → ERR_OUT_OF_RANGE. Mirrors
 /// `validate_random_bytes_size` but with the wider int bound Node
 /// accepts for randomInt's `min`/`max`.
 fn validate_random_int_arg(value: f64, arg_name: &str) -> i64 {
@@ -127,9 +177,6 @@ fn validate_random_int_arg(value: f64, arg_name: &str) -> i64 {
     } else {
         value
     };
-    // Node's `validateInteger` splits the rejection by error code:
-    // non-integer (NaN, Infinity, fractional) → ERR_INVALID_ARG_TYPE;
-    // out-of-range integer (outside [-2^48, 2^48]) → ERR_OUT_OF_RANGE.
     if !n.is_finite() || n.fract() != 0.0 {
         let message = format!(
             "The \"{}\" argument must be a safe integer. Received {}",
@@ -138,8 +185,7 @@ fn validate_random_int_arg(value: f64, arg_name: &str) -> i64 {
         );
         perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
     }
-    let bound = (1i64 << 48) as f64;
-    if n < -bound || n > bound {
+    if !(-MAX_SAFE_INTEGER..=MAX_SAFE_INTEGER).contains(&n) {
         let message = format!(
             "The value of \"{}\" is out of range. It must be a safe integer type number. Received {}",
             arg_name, n
@@ -156,7 +202,19 @@ pub extern "C" fn js_crypto_random_int(min_bits: f64, max_bits: f64) -> f64 {
     let min = validate_random_int_arg(min_bits, "min");
     let max = validate_random_int_arg(max_bits, "max");
     if max <= min {
-        return f64::NAN;
+        let message = format!(
+            "The value of \"max\" is out of range. It must be greater than the value of \"min\" ({}). Received {}",
+            min, max
+        );
+        perry_runtime::fs::validate::throw_range_error_with_code(&message);
+    }
+    let range = max as i128 - min as i128;
+    if range > RANDOM_INT_MAX_RANGE as i128 {
+        let message = format!(
+            "The value of \"max - min\" is out of range. It must be <= {}. Received {}",
+            RANDOM_INT_MAX_RANGE, range
+        );
+        perry_runtime::fs::validate::throw_range_error_with_code(&message);
     }
     rand::thread_rng().gen_range(min..max) as f64
 }
@@ -206,7 +264,7 @@ pub unsafe extern "C" fn js_crypto_native_dispatch(
     match method {
         "createHash" => js_crypto_create_hash(str_ptr(0)),
         "createHmac" => js_crypto_create_hmac(str_ptr(0), bytes_ptr(1)),
-        "randomUUID" => f64::from_bits(JSValue::string_ptr(js_crypto_random_uuid()).bits()),
+        "randomUUID" => f64::from_bits(JSValue::string_ptr(js_crypto_random_uuid(arg(0))).bits()),
         "randomBytes" => {
             let buf = js_crypto_random_bytes_buffer(arg(0));
             f64::from_bits(JSValue::pointer(buf as *const u8).bits())
@@ -214,6 +272,7 @@ pub unsafe extern "C" fn js_crypto_native_dispatch(
         // Node: randomInt(max) → [0,max); randomInt(min,max) → [min,max).
         "randomInt" if args_len >= 2 => js_crypto_random_int(arg(0), arg(1)),
         "randomInt" => js_crypto_random_int(0.0, arg(0)),
+        "timingSafeEqual" => js_crypto_timing_safe_equal(arg(0), arg(1)),
         "Certificate.verifySpkac" => js_crypto_certificate_verify_spkac(arg(0)),
         "Certificate.exportPublicKey" => js_crypto_certificate_export_public_key(arg(0)),
         "Certificate.exportChallenge" => js_crypto_certificate_export_challenge(arg(0)),
@@ -253,27 +312,8 @@ pub extern "C" fn js_crypto_random_fill_sync(
     offset_bits: f64,
     size_bits: f64,
 ) -> f64 {
-    let bits = buf_bits.to_bits();
-    // Accept either form the codegen can hand us:
-    //   - NaN-boxed POINTER_TAG (top16 0x7FFD) → Buffer / Uint8Array
-    //   - Raw heap pointer in low 48 bits (top16 == 0) → TypedArray
-    //     (Uint32Array etc — see `Expr::TypedArrayNew` codegen, the
-    //     pointer is `bitcast_i64_to_double` without a tag).
-    let top16 = (bits >> 48) as u16;
-    let raw = if top16 >= 0x7FF8 {
-        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
-    } else {
-        bits as usize
-    };
-    if raw < 0x1000 {
-        return buf_bits;
-    }
-
-    // Read optional numeric args; undefined / NaN → use default.
-    let offset_arg = nanboxed_to_usize(offset_bits);
-    let size_arg = nanboxed_to_usize(size_bits);
-
     unsafe {
+        let raw = raw_addr_from_value(buf_bits);
         // TypedArrayHeader path (Uint8Array, Uint32Array, Float32Array, …).
         if perry_runtime::typedarray::lookup_typed_array_kind(raw).is_some() {
             let ta = raw as *mut perry_runtime::typedarray::TypedArrayHeader;
@@ -284,26 +324,27 @@ pub extern "C" fn js_crypto_random_fill_sync(
                 } else {
                     data.len() / elem_size
                 };
-                // Node interprets offset/size for TypedArray inputs in elements,
-                // not bytes. Convert the resolved element range back to byte
-                // offsets before filling the underlying storage.
-                let (start_elem, end_elem) = resolve_range(len, offset_arg, size_arg);
+                let (start_elem, count_elem) =
+                    validate_random_fill_range(len, offset_bits, size_bits);
                 let start = start_elem.saturating_mul(elem_size);
-                let end = end_elem.saturating_mul(elem_size).min(data.len());
+                let end = start
+                    .saturating_add(count_elem.saturating_mul(elem_size))
+                    .min(data.len());
                 if end > start {
                     rand::thread_rng().fill_bytes(&mut data[start..end]);
                 }
+                return buf_bits;
             }
-            return buf_bits;
+            throw_invalid_random_fill_buffer(buf_bits);
         }
         // BufferHeader / Uint8Array path.
         if perry_runtime::buffer::is_registered_buffer(raw) {
             let buf = raw as *mut perry_runtime::buffer::BufferHeader;
             let total = (*buf).length as usize;
-            let (start, end) = resolve_range(total, offset_arg, size_arg);
-            if end > start {
+            let (start, count) = validate_random_fill_range(total, offset_bits, size_bits);
+            if count > 0 {
                 let data = perry_runtime::buffer::buffer_data_mut(buf);
-                let slice = std::slice::from_raw_parts_mut(data.add(start), end - start);
+                let slice = std::slice::from_raw_parts_mut(data.add(start), count);
                 rand::thread_rng().fill_bytes(slice);
             }
             // Hand back the same NaN-boxed value the caller passed.
@@ -311,10 +352,78 @@ pub extern "C" fn js_crypto_random_fill_sync(
         }
     }
 
-    // Unsupported value shape — return the original (no-op) rather
-    // than crashing. The HIR-level type check is "any", so the
-    // compiler can't statically rule this out.
-    buf_bits
+    throw_invalid_random_fill_buffer(buf_bits);
+}
+
+fn raw_addr_from_value(value: f64) -> usize {
+    let bits = value.to_bits();
+    if (bits >> 48) >= 0x7FF8 {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else {
+        bits as usize
+    }
+}
+
+fn throw_invalid_random_fill_buffer(value: f64) -> ! {
+    let message = format!(
+        "The \"buf\" argument must be an instance of Buffer, TypedArray, DataView, or ArrayBuffer. Received {}",
+        perry_runtime::fs::validate::describe_received(value)
+    );
+    perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn random_fill_number_arg(value: f64, name: &str) -> Option<f64> {
+    let js = JSValue::from_bits(value.to_bits());
+    if js.is_undefined() {
+        return None;
+    }
+    if !js.is_number() && !js.is_int32() {
+        let message = format!(
+            "The \"{}\" argument must be of type number. Received {}",
+            name,
+            perry_runtime::fs::validate::describe_received(value)
+        );
+        perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    Some(if js.is_int32() {
+        js.as_int32() as f64
+    } else {
+        value
+    })
+}
+
+fn validate_random_fill_range(total: usize, offset_bits: f64, size_bits: f64) -> (usize, usize) {
+    let offset = match random_fill_number_arg(offset_bits, "offset") {
+        Some(n) if n.is_finite() && n >= 0.0 && n <= total as f64 => n as usize,
+        Some(n) => {
+            let message = format!(
+                "The value of \"offset\" is out of range. It must be >= 0 && <= {}. Received {}",
+                total, n
+            );
+            perry_runtime::fs::validate::throw_range_error_with_code(&message);
+        }
+        None => 0,
+    };
+    let size = match random_fill_number_arg(size_bits, "size") {
+        Some(n) if n.is_finite() && n >= 0.0 && n <= i32::MAX as f64 => n as usize,
+        Some(n) => {
+            let message = format!(
+                "The value of \"size\" is out of range. It must be >= 0 && <= 2147483647. Received {}",
+                n
+            );
+            perry_runtime::fs::validate::throw_range_error_with_code(&message);
+        }
+        None => total.saturating_sub(offset),
+    };
+    let end = offset.saturating_add(size);
+    if end > total {
+        let message = format!(
+            "The value of \"size + offset\" is out of range. It must be <= {}. Received {}",
+            total, end
+        );
+        perry_runtime::fs::validate::throw_range_error_with_code(&message);
+    }
+    (offset, size)
 }
 
 /// `crypto.randomFill(buffer[, offset][, size], callback)` — async callback

--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -555,14 +555,6 @@ unsafe fn resolve_stringify_separator_str(value: f64, default: &'static str) -> 
     jsvalue_to_owned_string(value)
 }
 
-fn throw_symbol_to_string_type_error() -> ! {
-    let msg = "Cannot convert a Symbol value to a string";
-    let msg_str = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-    let err_ptr = perry_runtime::error::js_typeerror_new(msg_str);
-    let err_value = JSValue::pointer(err_ptr as *const u8).bits();
-    perry_runtime::exception::js_throw(f64::from_bits(err_value))
-}
-
 /// Append `key=value` (or `key=v1&key=v2` for arrays) to `out`.
 unsafe fn append_stringify_value(
     out: &mut String,

--- a/test-parity/node-suite/crypto/random/random-fill-validation.ts
+++ b/test-parity/node-suite/crypto/random/random-fill-validation.ts
@@ -1,0 +1,31 @@
+import * as crypto from "node:crypto";
+import { Buffer } from "node:buffer";
+
+function probe(label: string, fn: () => unknown) {
+  try {
+    const value = fn();
+    console.log(label, "OK", value);
+  } catch (err: any) {
+    console.log(label, "THROW", err?.name, err?.code || "no-code");
+  }
+}
+
+probe("offset negative", () => crypto.randomFillSync(Buffer.alloc(4), -1).length);
+probe("offset too large", () => crypto.randomFillSync(Buffer.alloc(4), 5).length);
+probe("size beyond end", () => crypto.randomFillSync(Buffer.alloc(4), 1, 10).length);
+probe("invalid buffer", () => crypto.randomFillSync(123 as any));
+
+const fractional = Buffer.alloc(4);
+const fractionalRet = crypto.randomFillSync(fractional, 1.5, 2.5);
+console.log("fractional valid:", fractionalRet === fractional, fractionalRet.length);
+
+const ab = new ArrayBuffer(4);
+const abRet = crypto.randomFillSync(ab);
+console.log("arraybuffer valid:", abRet === ab, abRet.byteLength);
+
+const u16 = new Uint16Array(4);
+const u16Ret = crypto.randomFillSync(u16, 1, 2);
+console.log("typedarray valid:", u16Ret === u16, u16Ret.byteLength);
+
+const captured = crypto.randomFillSync;
+probe("captured offset too large", () => captured(Buffer.alloc(4), 5).length);

--- a/test-parity/node-suite/crypto/random/random-int-range-validation.ts
+++ b/test-parity/node-suite/crypto/random/random-int-range-validation.ts
@@ -1,0 +1,24 @@
+import * as crypto from "node:crypto";
+
+function probe(label: string, fn: () => unknown) {
+  try {
+    const value = fn();
+    console.log(label, "OK", typeof value, Number.isSafeInteger(value));
+  } catch (err: any) {
+    console.log(label, "THROW", err?.name, err?.code || "no-code");
+  }
+}
+
+probe("max less than min", () => crypto.randomInt(10, 0));
+probe("max equals min", () => crypto.randomInt(0, 0));
+probe("negative equal", () => crypto.randomInt(-5, -5));
+probe("range too large", () => crypto.randomInt(0, 2 ** 48 + 1));
+probe("valid high boundary", () => crypto.randomInt(2 ** 48, 2 ** 48 + 1));
+
+let callbackCalled = false;
+probe("callback max less than min", () =>
+  crypto.randomInt(10, 0, () => {
+    callbackCalled = true;
+  })
+);
+console.log("callback called:", callbackCalled);

--- a/test-parity/node-suite/crypto/random/random-uuid-validation.ts
+++ b/test-parity/node-suite/crypto/random/random-uuid-validation.ts
@@ -1,0 +1,23 @@
+import * as crypto from "node:crypto";
+
+const re = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function probe(label: string, fn: () => unknown) {
+  try {
+    const value = fn();
+    console.log(label, "OK", typeof value, re.test(String(value)));
+  } catch (err: any) {
+    console.log(label, "THROW", err?.name, err?.code || "no-code");
+  }
+}
+
+probe("no options", () => crypto.randomUUID());
+probe("empty options", () => crypto.randomUUID({}));
+probe("disable cache true", () => crypto.randomUUID({ disableEntropyCache: true }));
+probe("disable cache false", () => crypto.randomUUID({ disableEntropyCache: false }));
+probe("bad option property", () => crypto.randomUUID({ disableEntropyCache: 1 } as any));
+probe("null options", () => crypto.randomUUID(null as any));
+probe("number options", () => crypto.randomUUID(123 as any));
+
+const captured = crypto.randomUUID;
+probe("captured bad property", () => captured({ disableEntropyCache: 1 } as any));

--- a/test-parity/node-suite/crypto/timing/timing-safe-equal-validation.ts
+++ b/test-parity/node-suite/crypto/timing/timing-safe-equal-validation.ts
@@ -1,0 +1,24 @@
+import * as crypto from "node:crypto";
+import { Buffer } from "node:buffer";
+
+function probe(label: string, fn: () => unknown) {
+  try {
+    console.log(label, "OK", fn());
+  } catch (err: any) {
+    console.log(label, "THROW", err?.name, err?.code || "no-code");
+  }
+}
+
+probe("buffer equal", () => crypto.timingSafeEqual(Buffer.from([1]), Buffer.from([1])));
+probe("buffer diff", () => crypto.timingSafeEqual(Buffer.from([1]), Buffer.from([2])));
+probe("length mismatch", () => crypto.timingSafeEqual(Buffer.from([1]), Buffer.from([1, 2])));
+probe("typed array equal", () => crypto.timingSafeEqual(new Uint16Array([1]), new Uint16Array([1])));
+probe("arraybuffer equal", () => crypto.timingSafeEqual(new ArrayBuffer(2), new ArrayBuffer(2)));
+probe("dataview equal", () =>
+  crypto.timingSafeEqual(new DataView(new ArrayBuffer(2)), new DataView(new ArrayBuffer(2)))
+);
+probe("string invalid", () => crypto.timingSafeEqual("a" as any, "a" as any));
+probe("buf2 invalid", () => crypto.timingSafeEqual(Buffer.from([1]), 123 as any));
+
+const captured = crypto.timingSafeEqual;
+probe("captured length mismatch", () => captured(Buffer.from([1]), Buffer.from([1, 2])));


### PR DESCRIPTION
## Summary

Fixes #3063
Fixes #3064
Fixes #3065
Fixes #3066

This closes a related `node:crypto` validation cluster:

- `randomInt` now throws `ERR_OUT_OF_RANGE` when `max <= min` or `max - min` exceeds Node's 48-bit range cap, while still allowing safe high-boundary values.
- `randomFillSync` / `randomFill` now validate BufferSource inputs and offset/size ranges instead of silently no-oping or clamping invalid requests.
- `randomUUID` now validates the options object and `disableEntropyCache` boolean on both direct and captured-call paths.
- `timingSafeEqual` now validates BufferSource arguments and throws `ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH` for mismatched byte lengths.
- Removes a duplicate querystring helper that prevented the current base from building `perry-stdlib`; this is a build unblock only.

## Why Batched

These fixes all tighten synchronous `node:crypto` validation behavior and share the same direct-call vs captured-method dispatch surface. Landing them together keeps the argument validation and parity coverage consistent across the random/timing helpers.

## Tests Added

- `test-parity/node-suite/crypto/random/random-int-range-validation.ts`
- `test-parity/node-suite/crypto/random/random-fill-validation.ts`
- `test-parity/node-suite/crypto/random/random-uuid-validation.ts`
- `test-parity/node-suite/crypto/timing/timing-safe-equal-validation.ts`

## Validation

- `env RUSTC_WRAPPER= cargo check -p perry-hir -p perry-codegen -p perry-runtime -p perry-stdlib`
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module crypto --filter validation` (5/5 pass after rebase)
- `PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module crypto --filter random` (19/19 pass)
- `PATH="/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module crypto --filter timing` (2/2 pass)
- `cargo fmt --all -- --check`
- `git diff --check HEAD~1..HEAD`
- `./scripts/check_file_size.sh`

## Known Limitations / Non-goals

- `randomUUID({ disableEntropyCache })` validates the option for Node parity, but Perry still does not model Node's entropy cache internals.
- This PR does not attempt to broaden crypto algorithm support beyond the validation paths covered above.
