### PR TITLE
Validate zlib one-shot data inputs

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/media.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/media.rs
@@ -274,7 +274,7 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
         method: "gzipSync",
         class_filter: None,
         runtime: "js_zlib_gzip_sync",
-        args: &[NA_STR],
+        args: &[NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -283,7 +283,7 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
         method: "gunzipSync",
         class_filter: None,
         runtime: "js_zlib_gunzip_sync",
-        args: &[NA_STR],
+        args: &[NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -292,7 +292,7 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
         method: "deflateSync",
         class_filter: None,
         runtime: "js_zlib_deflate_sync",
-        args: &[NA_STR],
+        args: &[NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -301,7 +301,7 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
         method: "inflateSync",
         class_filter: None,
         runtime: "js_zlib_inflate_sync",
-        args: &[NA_STR],
+        args: &[NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -330,7 +330,7 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
         method: "deflateRawSync",
         class_filter: None,
         runtime: "js_zlib_deflate_raw_sync",
-        args: &[NA_STR],
+        args: &[NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -339,7 +339,7 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
         method: "inflateRawSync",
         class_filter: None,
         runtime: "js_zlib_inflate_raw_sync",
-        args: &[NA_STR],
+        args: &[NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -348,7 +348,7 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
         method: "unzipSync",
         class_filter: None,
         runtime: "js_zlib_unzip_sync",
-        args: &[NA_STR],
+        args: &[NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -357,7 +357,7 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
         method: "crc32",
         class_filter: None,
         runtime: "js_zlib_crc32",
-        args: &[NA_STR, NA_F64],
+        args: &[NA_F64, NA_F64],
         ret: NR_F64,
     },
     // `zlib.brotli{Compress,Decompress}Sync(data)` — one-shot Brotli via the
@@ -368,7 +368,7 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
         method: "brotliCompressSync",
         class_filter: None,
         runtime: "js_zlib_brotli_compress_sync",
-        args: &[NA_STR],
+        args: &[NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -377,7 +377,7 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
         method: "brotliDecompressSync",
         class_filter: None,
         runtime: "js_zlib_brotli_decompress_sync",
-        args: &[NA_STR],
+        args: &[NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -374,19 +374,19 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_async_local_storage_run", DOUBLE, &[I64, DOUBLE, I64]);
 
     // ========== zlib ==========
-    module.declare_function("js_zlib_deflate_sync", I64, &[I64]);
+    module.declare_function("js_zlib_deflate_sync", I64, &[DOUBLE]);
     module.declare_function("js_zlib_gunzip", I64, &[I64]);
-    module.declare_function("js_zlib_gunzip_sync", I64, &[I64]);
+    module.declare_function("js_zlib_gunzip_sync", I64, &[DOUBLE]);
     module.declare_function("js_zlib_gzip", I64, &[I64]);
-    module.declare_function("js_zlib_gzip_sync", I64, &[I64]);
-    module.declare_function("js_zlib_inflate_sync", I64, &[I64]);
-    module.declare_function("js_zlib_deflate_raw_sync", I64, &[I64]);
-    module.declare_function("js_zlib_inflate_raw_sync", I64, &[I64]);
-    module.declare_function("js_zlib_unzip_sync", I64, &[I64]);
-    module.declare_function("js_zlib_crc32", DOUBLE, &[I64, DOUBLE]);
-    // #1843 — Brotli one-shots (StringHeader ptr in/out; async returns a Promise ptr).
-    module.declare_function("js_zlib_brotli_compress_sync", I64, &[I64]);
-    module.declare_function("js_zlib_brotli_decompress_sync", I64, &[I64]);
+    module.declare_function("js_zlib_gzip_sync", I64, &[DOUBLE]);
+    module.declare_function("js_zlib_inflate_sync", I64, &[DOUBLE]);
+    module.declare_function("js_zlib_deflate_raw_sync", I64, &[DOUBLE]);
+    module.declare_function("js_zlib_inflate_raw_sync", I64, &[DOUBLE]);
+    module.declare_function("js_zlib_unzip_sync", I64, &[DOUBLE]);
+    module.declare_function("js_zlib_crc32", DOUBLE, &[DOUBLE, DOUBLE]);
+    // #1843 — Brotli one-shots (sync validates JS values; async returns a Promise ptr).
+    module.declare_function("js_zlib_brotli_compress_sync", I64, &[DOUBLE]);
+    module.declare_function("js_zlib_brotli_decompress_sync", I64, &[DOUBLE]);
     module.declare_function("js_zlib_brotli_compress", I64, &[I64]);
     module.declare_function("js_zlib_brotli_decompress", I64, &[I64]);
     // #1843 — Transform-stream factories: `_opts` (DOUBLE) in, i64 handle out.

--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -555,14 +555,6 @@ unsafe fn resolve_stringify_separator_str(value: f64, default: &'static str) -> 
     jsvalue_to_owned_string(value)
 }
 
-fn throw_symbol_to_string_type_error() -> ! {
-    let msg = "Cannot convert a Symbol value to a string";
-    let msg_str = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-    let err_ptr = perry_runtime::error::js_typeerror_new(msg_str);
-    let err_value = JSValue::pointer(err_ptr as *const u8).bits();
-    perry_runtime::exception::js_throw(f64::from_bits(err_value))
-}
-
 /// Append `key=value` (or `key=v1&key=v2` for arrays) to `out`.
 unsafe fn append_stringify_value(
     out: &mut String,

--- a/crates/perry-stdlib/src/zlib.rs
+++ b/crates/perry-stdlib/src/zlib.rs
@@ -74,14 +74,88 @@ unsafe fn bytes_from_header(ptr: *const StringHeader) -> Option<Vec<u8>> {
     Some(std::slice::from_raw_parts(data_ptr, len).to_vec())
 }
 
+fn raw_addr_from_value(value: f64) -> usize {
+    let bits = value.to_bits();
+    let js_value = JSValue::from_bits(bits);
+    if js_value.is_pointer() || js_value.is_string() {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else if !value.is_nan() && bits >= 0x1000 && bits < 0x0001_0000_0000_0000 {
+        bits as usize
+    } else {
+        0
+    }
+}
+
+fn throw_invalid_data_arg(value: f64, arg_name: &str, accepted: &str) -> ! {
+    let message = format!(
+        "The \"{}\" argument must be of type string or an instance of {}. Received {}",
+        arg_name,
+        accepted,
+        perry_runtime::fs::validate::describe_received(value)
+    );
+    perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
+unsafe fn bytes_from_js_data(
+    value: f64,
+    allow_array_buffer: bool,
+    arg_name: &str,
+    accepted: &str,
+) -> Vec<u8> {
+    let js_value = JSValue::from_bits(value.to_bits());
+    if js_value.is_any_string() {
+        let ptr = js_get_string_pointer_unified(value) as *const StringHeader;
+        if ptr.is_null() {
+            throw_invalid_data_arg(value, arg_name, accepted);
+        }
+        let len = (*ptr).byte_len as usize;
+        let data_ptr = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        return std::slice::from_raw_parts(data_ptr, len).to_vec();
+    }
+
+    let raw = raw_addr_from_value(value);
+    if raw >= 0x1000 {
+        if perry_runtime::typedarray::lookup_typed_array_kind(raw).is_some() {
+            let ta = raw as *const perry_runtime::typedarray::TypedArrayHeader;
+            if let Some(bytes) = perry_runtime::typedarray::typed_array_bytes(ta) {
+                return bytes.to_vec();
+            }
+        }
+        if is_registered_buffer(raw) {
+            if !allow_array_buffer
+                && perry_runtime::buffer::is_any_array_buffer(raw)
+                && !perry_runtime::buffer::is_data_view(raw)
+            {
+                throw_invalid_data_arg(value, arg_name, accepted);
+            }
+            let buf = raw as *const BufferHeader;
+            let len = (*buf).length as usize;
+            let data_ptr = buffer_data(buf);
+            return std::slice::from_raw_parts(data_ptr, len).to_vec();
+        }
+    }
+
+    throw_invalid_data_arg(value, arg_name, accepted);
+}
+
+unsafe fn codec_bytes(value: f64) -> Vec<u8> {
+    bytes_from_js_data(
+        value,
+        true,
+        "buffer",
+        "Buffer, TypedArray, DataView, or ArrayBuffer",
+    )
+}
+
+unsafe fn crc32_bytes(value: f64) -> Vec<u8> {
+    bytes_from_js_data(value, false, "data", "Buffer, TypedArray, or DataView")
+}
+
 /// Gzip compress data synchronously
 /// zlib.gzipSync(data) -> Buffer
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_gzip_sync(data_ptr: *const StringHeader) -> *mut BufferHeader {
-    let data = match bytes_from_header(data_ptr) {
-        Some(d) => d,
-        None => return std::ptr::null_mut(),
-    };
+pub unsafe extern "C" fn js_zlib_gzip_sync(data_value: f64) -> *mut BufferHeader {
+    let data = codec_bytes(data_value);
 
     let mut encoder = GzEncoder::new(&data[..], Compression::default());
     let mut compressed = Vec::new();
@@ -95,11 +169,8 @@ pub unsafe extern "C" fn js_zlib_gzip_sync(data_ptr: *const StringHeader) -> *mu
 /// Gunzip decompress data synchronously
 /// zlib.gunzipSync(data) -> Buffer
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_gunzip_sync(data_ptr: *const StringHeader) -> *mut BufferHeader {
-    let data = match bytes_from_header(data_ptr) {
-        Some(d) => d,
-        None => return std::ptr::null_mut(),
-    };
+pub unsafe extern "C" fn js_zlib_gunzip_sync(data_value: f64) -> *mut BufferHeader {
+    let data = codec_bytes(data_value);
 
     // `MultiGzDecoder` walks every concatenated gzip member, matching Node's
     // semantics where `gunzipSync(concat(gzip(a), gzip(b)))` returns `a + b`
@@ -116,11 +187,8 @@ pub unsafe extern "C" fn js_zlib_gunzip_sync(data_ptr: *const StringHeader) -> *
 /// Deflate compress data synchronously
 /// zlib.deflateSync(data) -> Buffer
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_deflate_sync(data_ptr: *const StringHeader) -> *mut BufferHeader {
-    let data = match bytes_from_header(data_ptr) {
-        Some(d) => d,
-        None => return std::ptr::null_mut(),
-    };
+pub unsafe extern "C" fn js_zlib_deflate_sync(data_value: f64) -> *mut BufferHeader {
+    let data = codec_bytes(data_value);
 
     // Node's `deflateSync` produces the zlib format (RFC 1950), not raw
     // deflate — `deflateRawSync` is the raw form. Use ZlibEncoder so the
@@ -138,11 +206,8 @@ pub unsafe extern "C" fn js_zlib_deflate_sync(data_ptr: *const StringHeader) -> 
 /// Inflate decompress data synchronously
 /// zlib.inflateSync(data) -> Buffer
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_inflate_sync(data_ptr: *const StringHeader) -> *mut BufferHeader {
-    let data = match bytes_from_header(data_ptr) {
-        Some(d) => d,
-        None => return std::ptr::null_mut(),
-    };
+pub unsafe extern "C" fn js_zlib_inflate_sync(data_value: f64) -> *mut BufferHeader {
+    let data = codec_bytes(data_value);
 
     let mut decoder = ZlibDecoder::new(&data[..]);
     let mut decompressed = Vec::new();
@@ -156,13 +221,8 @@ pub unsafe extern "C" fn js_zlib_inflate_sync(data_ptr: *const StringHeader) -> 
 /// Raw deflate compress synchronously (no zlib header, no adler32).
 /// zlib.deflateRawSync(data) -> Buffer
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_deflate_raw_sync(
-    data_ptr: *const StringHeader,
-) -> *mut BufferHeader {
-    let data = match bytes_from_header(data_ptr) {
-        Some(d) => d,
-        None => return std::ptr::null_mut(),
-    };
+pub unsafe extern "C" fn js_zlib_deflate_raw_sync(data_value: f64) -> *mut BufferHeader {
+    let data = codec_bytes(data_value);
     let mut encoder = DeflateEncoder::new(&data[..], Compression::default());
     let mut compressed = Vec::new();
     match encoder.read_to_end(&mut compressed) {
@@ -174,13 +234,8 @@ pub unsafe extern "C" fn js_zlib_deflate_raw_sync(
 /// Raw deflate decompress synchronously.
 /// zlib.inflateRawSync(data) -> Buffer
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_inflate_raw_sync(
-    data_ptr: *const StringHeader,
-) -> *mut BufferHeader {
-    let data = match bytes_from_header(data_ptr) {
-        Some(d) => d,
-        None => return std::ptr::null_mut(),
-    };
+pub unsafe extern "C" fn js_zlib_inflate_raw_sync(data_value: f64) -> *mut BufferHeader {
+    let data = codec_bytes(data_value);
     let mut decoder = DeflateDecoder::new(&data[..]);
     let mut decompressed = Vec::new();
     match decoder.read_to_end(&mut decompressed) {
@@ -194,11 +249,8 @@ pub unsafe extern "C" fn js_zlib_inflate_raw_sync(
 /// deflate.
 /// zlib.unzipSync(data) -> Buffer
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_unzip_sync(data_ptr: *const StringHeader) -> *mut BufferHeader {
-    let data = match bytes_from_header(data_ptr) {
-        Some(d) => d,
-        None => return std::ptr::null_mut(),
-    };
+pub unsafe extern "C" fn js_zlib_unzip_sync(data_value: f64) -> *mut BufferHeader {
+    let data = codec_bytes(data_value);
     let mut out = Vec::new();
     let ok = if data.len() >= 2 && data[0] == 0x1f && data[1] == 0x8b {
         // Multi-member gzip support per RFC 1952 §2.2.
@@ -217,11 +269,8 @@ pub unsafe extern "C" fn js_zlib_unzip_sync(data_ptr: *const StringHeader) -> *m
 /// `seed = 0` (or absent) produces the canonical one-shot CRC32.
 /// zlib.crc32(data, seed?) -> number
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_crc32(data_ptr: *const StringHeader, seed: f64) -> f64 {
-    let data = match bytes_from_header(data_ptr) {
-        Some(d) => d,
-        None => return 0.0,
-    };
+pub unsafe extern "C" fn js_zlib_crc32(data_value: f64, seed: f64) -> f64 {
+    let data = crc32_bytes(data_value);
     // Reflected IEEE polynomial 0xEDB88320 — same as zlib's. Built once on
     // first call. Sync::Once is enough here: every thread sees the populated
     // table after the first init.
@@ -336,32 +385,17 @@ fn brotli_decompress_bytes(data: &[u8]) -> std::io::Result<Vec<u8>> {
 
 /// `zlib.brotliCompressSync(data)` -> Buffer
 ///
-/// # Safety
-/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_brotli_compress_sync(
-    data_ptr: *const StringHeader,
-) -> *mut BufferHeader {
-    let data = match bytes_from_header(data_ptr) {
-        Some(d) => d,
-        None => return std::ptr::null_mut(),
-    };
+pub unsafe extern "C" fn js_zlib_brotli_compress_sync(data_value: f64) -> *mut BufferHeader {
+    let data = codec_bytes(data_value);
     let out = brotli_compress_bytes(&data);
     buffer_from_slice(&out)
 }
 
 /// `zlib.brotliDecompressSync(data)` -> Buffer
-///
-/// # Safety
-/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_brotli_decompress_sync(
-    data_ptr: *const StringHeader,
-) -> *mut BufferHeader {
-    let data = match bytes_from_header(data_ptr) {
-        Some(d) => d,
-        None => return std::ptr::null_mut(),
-    };
+pub unsafe extern "C" fn js_zlib_brotli_decompress_sync(data_value: f64) -> *mut BufferHeader {
+    let data = codec_bytes(data_value);
     match brotli_decompress_bytes(&data) {
         Ok(out) => buffer_from_slice(&out),
         Err(e) => throw_zlib_error(&format!("brotli: {}", e)),
@@ -1218,8 +1252,8 @@ pub unsafe extern "C" fn js_zlib_native_dispatch(
             undefined
         }
     };
-    // NaN-box-aware string pointer extraction. Mirrors what the codegen's
-    // NA_STR arg coercion does for direct calls.
+    // NaN-box-aware string pointer extraction. Mirrors the codegen's NA_STR
+    // arg coercion for async codecs, which still use the older pointer ABI.
     let as_str_ptr =
         |v: f64| -> *const StringHeader { js_get_string_pointer_unified(v) as *const StringHeader };
     // Helper: pointer return → POINTER_TAG NaN-box (matches NR_PTR).
@@ -1231,23 +1265,19 @@ pub unsafe extern "C" fn js_zlib_native_dispatch(
         }
     };
     match name {
-        // Sync codecs — all take 1 string/buffer arg, return Buffer pointer.
-        "gzipSync" => ptr_to_f64(js_zlib_gzip_sync(as_str_ptr(arg(0))) as *const u8),
-        "gunzipSync" => ptr_to_f64(js_zlib_gunzip_sync(as_str_ptr(arg(0))) as *const u8),
-        "deflateSync" => ptr_to_f64(js_zlib_deflate_sync(as_str_ptr(arg(0))) as *const u8),
-        "inflateSync" => ptr_to_f64(js_zlib_inflate_sync(as_str_ptr(arg(0))) as *const u8),
-        "deflateRawSync" => ptr_to_f64(js_zlib_deflate_raw_sync(as_str_ptr(arg(0))) as *const u8),
-        "inflateRawSync" => ptr_to_f64(js_zlib_inflate_raw_sync(as_str_ptr(arg(0))) as *const u8),
-        "unzipSync" => ptr_to_f64(js_zlib_unzip_sync(as_str_ptr(arg(0))) as *const u8),
-        "brotliCompressSync" => {
-            ptr_to_f64(js_zlib_brotli_compress_sync(as_str_ptr(arg(0))) as *const u8)
-        }
-        "brotliDecompressSync" => {
-            ptr_to_f64(js_zlib_brotli_decompress_sync(as_str_ptr(arg(0))) as *const u8)
-        }
+        // Sync codecs — all take 1 string/buffer-like JS value, return Buffer pointer.
+        "gzipSync" => ptr_to_f64(js_zlib_gzip_sync(arg(0)) as *const u8),
+        "gunzipSync" => ptr_to_f64(js_zlib_gunzip_sync(arg(0)) as *const u8),
+        "deflateSync" => ptr_to_f64(js_zlib_deflate_sync(arg(0)) as *const u8),
+        "inflateSync" => ptr_to_f64(js_zlib_inflate_sync(arg(0)) as *const u8),
+        "deflateRawSync" => ptr_to_f64(js_zlib_deflate_raw_sync(arg(0)) as *const u8),
+        "inflateRawSync" => ptr_to_f64(js_zlib_inflate_raw_sync(arg(0)) as *const u8),
+        "unzipSync" => ptr_to_f64(js_zlib_unzip_sync(arg(0)) as *const u8),
+        "brotliCompressSync" => ptr_to_f64(js_zlib_brotli_compress_sync(arg(0)) as *const u8),
+        "brotliDecompressSync" => ptr_to_f64(js_zlib_brotli_decompress_sync(arg(0)) as *const u8),
         "crc32" => {
             let seed = if args_len >= 2 { arg(1) } else { 0.0 };
-            js_zlib_crc32(as_str_ptr(arg(0)), seed)
+            js_zlib_crc32(arg(0), seed)
         }
         // Async codecs return a Promise pointer (NR_PTR).
         "gzip" => ptr_to_f64(js_zlib_gzip(as_str_ptr(arg(0))) as *const u8),

--- a/test-parity/node-suite/zlib/validation/one-shot-buffer-sources.ts
+++ b/test-parity/node-suite/zlib/validation/one-shot-buffer-sources.ts
@@ -1,0 +1,25 @@
+import * as zlib from "node:zlib";
+
+const arrayBuffer = new ArrayBuffer(1);
+new Uint8Array(arrayBuffer)[0] = 120;
+
+const sources: Array<[string, any]> = [
+  ["string", "x"],
+  ["buffer", Buffer.from("x")],
+  ["uint8array", new Uint8Array([120])],
+  ["dataview", new DataView(new Uint8Array([120]).buffer)],
+  ["arraybuffer", arrayBuffer],
+];
+
+function crc32Shape(value: any) {
+  try {
+    return typeof zlib.crc32(value);
+  } catch (error: any) {
+    return `${error.name}:${error.code}`;
+  }
+}
+
+for (const [label, value] of sources) {
+  console.log(`${label} gzip buffer:`, Buffer.isBuffer(zlib.gzipSync(value)) ? "yes" : "no");
+  console.log(`${label} crc32 shape:`, crc32Shape(value));
+}

--- a/test-parity/node-suite/zlib/validation/one-shot-invalid-data.ts
+++ b/test-parity/node-suite/zlib/validation/one-shot-invalid-data.ts
@@ -1,0 +1,40 @@
+import * as zlib from "node:zlib";
+
+const invalidValues: Array<[string, any]> = [
+  ["undefined", undefined],
+  ["null", null],
+  ["number", 0],
+  ["boolean", true],
+  ["object", {}],
+  ["array", []],
+  ["symbol", Symbol("s")],
+];
+
+const methods: Array<[string, (value: any) => any]> = [
+  ["gzipSync", (value) => zlib.gzipSync(value)],
+  ["gunzipSync", (value) => zlib.gunzipSync(value)],
+  ["deflateSync", (value) => zlib.deflateSync(value)],
+  ["inflateSync", (value) => zlib.inflateSync(value)],
+  ["deflateRawSync", (value) => zlib.deflateRawSync(value)],
+  ["inflateRawSync", (value) => zlib.inflateRawSync(value)],
+  ["unzipSync", (value) => zlib.unzipSync(value)],
+  ["brotliCompressSync", (value) => zlib.brotliCompressSync(value)],
+  ["brotliDecompressSync", (value) => zlib.brotliDecompressSync(value)],
+  ["crc32", (value) => zlib.crc32(value)],
+];
+
+function errorShape(call: (value: any) => any, value: any) {
+  try {
+    call(value);
+    return "no-throw";
+  } catch (error: any) {
+    return `${error.name}:${error.code}`;
+  }
+}
+
+for (const [method, call] of methods) {
+  console.log(
+    `${method} invalid data:`,
+    invalidValues.map(([label, value]) => `${label}=${errorShape(call, value)}`).join(","),
+  );
+}


### PR DESCRIPTION
Closes #3095.

## Summary
- validate `node:zlib` sync one-shot codec inputs and `zlib.crc32()` against Node-shaped `ERR_INVALID_ARG_TYPE` errors
- preserve accepted source coverage for strings, `Buffer`, `TypedArray`, `DataView`, and codec-only `ArrayBuffer`; reject `ArrayBuffer` for `crc32()` to match Node
- update zlib direct-call and native-dispatch FFI signatures so invalid JS values reach runtime validation instead of being coerced through string pointers
- remove a duplicate `querystring` symbol helper that currently prevents `perry-stdlib` from compiling on `origin/main`

## PR Cut
This is a single-issue zlib validation cut because the affected APIs share the same one-shot data-input ABI and runtime byte extraction path. Keeping it scoped here avoids mixing in zlib option-object semantics or callback-form routing.

## Tests Added
- `test-parity/node-suite/zlib/validation/one-shot-invalid-data.ts`
- `test-parity/node-suite/zlib/validation/one-shot-buffer-sources.ts`

## Commands Run
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `git diff --check && git diff --cached --check`
- `env RUSTC_WRAPPER= cargo check -p perry-stdlib`
- `env RUSTC_WRAPPER= cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `env FORCE_COLOR=0 node test-parity/node-suite/zlib/validation/one-shot-invalid-data.ts`
- `env FORCE_COLOR=0 node test-parity/node-suite/zlib/validation/one-shot-buffer-sources.ts`
- `env RUSTC_WRAPPER= target/release/perry compile test-parity/node-suite/zlib/validation/one-shot-invalid-data.ts -o /tmp/perry-zlib-invalid && /tmp/perry-zlib-invalid`
- `env RUSTC_WRAPPER= target/release/perry compile test-parity/node-suite/zlib/validation/one-shot-buffer-sources.ts -o /tmp/perry-zlib-buffer-sources && /tmp/perry-zlib-buffer-sources`
- `env RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module zlib --filter validation/` (2 pass, 0 fail; report `test-parity/reports/parity_report_20260530_003230.json`)

## Non-goals
- zlib option object semantics, tracked separately by #2557
- callback-form routing, tracked separately by #2667
- broad async one-shot zlib validation changes beyond preserving the existing async pointer ABI
