### PR TITLE
fix(node:diagnostics_channel): forward runStores callback arguments (#3082)

### DIFF
--- a/crates/perry-runtime/src/node_submodules/diagnostics.rs
+++ b/crates/perry-runtime/src/node_submodules/diagnostics.rs
@@ -787,11 +787,7 @@ pub(crate) fn ensure_channel(name: f64) -> i64 {
         "unbindStore",
         method_closure(cast1(diag_channel_unbind_store), 1, id),
     );
-    set_field_value(
-        obj,
-        "runStores",
-        method_closure(cast5(diag_channel_run_stores), 5, id),
-    );
+    set_field_value(obj, "runStores", run_stores_method_closure(id));
     DIAG_CHANNEL_BY_KEY.with(|m| {
         m.borrow_mut().insert(key, id);
     });
@@ -1101,9 +1097,12 @@ pub(crate) extern "C" fn store_next_thunk(closure: *const ClosureHeader) -> f64 
     let data = f64::from_bits(js_closure_get_capture_ptr(closure, 1) as u64);
     let fn_value = f64::from_bits(js_closure_get_capture_ptr(closure, 2) as u64);
     let this_arg = f64::from_bits(js_closure_get_capture_ptr(closure, 3) as u64);
-    let a = f64::from_bits(js_closure_get_capture_ptr(closure, 4) as u64);
-    let b = f64::from_bits(js_closure_get_capture_ptr(closure, 5) as u64);
-    run_store_wrapped(id, data, fn_value, this_arg, &[a, b])
+    // Capture slot 4 holds a NaN-boxed JS array of the trailing callback
+    // arguments (everything after `thisArg` in `runStores`), so the full
+    // `...args` list is forwarded — not just the first two (#3082).
+    let cb_args = f64::from_bits(js_closure_get_capture_ptr(closure, 4) as u64);
+    let args = unbox_arg_array(cb_args);
+    run_store_wrapped(id, data, fn_value, this_arg, &args)
 }
 
 pub(crate) extern "C" fn store_chain_thunk(closure: *const ClosureHeader) -> f64 {
@@ -1113,17 +1112,72 @@ pub(crate) extern "C" fn store_chain_thunk(closure: *const ClosureHeader) -> f64
     call_store_run(store, context, next)
 }
 
+/// Build the `runStores` method closure. Registered as a synthetic-arguments
+/// rest closure (fixed_arity 0) so the dispatcher bundles the FULL argument
+/// list — `context`, `callback`, `thisArg`, and every trailing `...args` — into
+/// a single JS array, regardless of how many arguments the caller passed
+/// (#3082). The fixed five-argument `cast5` entrypoint used previously capped
+/// the forwarded callback arguments at two.
+pub(crate) fn run_stores_method_closure(id: i64) -> f64 {
+    let func = cast1(diag_channel_run_stores);
+    let c = js_closure_alloc(func, 1);
+    js_closure_set_capture_ptr(c, 0, id);
+    js_register_closure_synthetic_arguments(func, 0);
+    boxed_ptr(c)
+}
+
+/// Build a NaN-boxed JS array value from a slice of callback arguments.
+///
+/// # Safety
+/// Allocates on the current thread's arena; callers must ensure the runtime
+/// is initialized (always true on the diagnostics_channel call path).
+unsafe fn build_arg_array(values: &[f64]) -> f64 {
+    let arr = js_array_new();
+    for &v in values {
+        js_array_push(arr, v);
+    }
+    boxed_ptr(arr)
+}
+
+/// Decode a NaN-boxed JS array value into a `Vec<f64>` of its elements.
+/// Returns an empty vec for null/non-array inputs.
+fn unbox_arg_array(arr_value: f64) -> Vec<f64> {
+    let arr = js_nanbox_get_pointer(arr_value) as *const crate::array::ArrayHeader;
+    if arr.is_null() {
+        return Vec::new();
+    }
+    unsafe {
+        let len = (*arr).length as usize;
+        let data = (*arr).data;
+        if data.is_null() {
+            return Vec::new();
+        }
+        let mut out = Vec::with_capacity(len);
+        for i in 0..len {
+            out.push(f64::from_bits((*data.add(i)).bits()));
+        }
+        out
+    }
+}
+
 pub(crate) extern "C" fn diag_channel_run_stores(
     closure: *const ClosureHeader,
-    data: f64,
-    fn_value: f64,
-    this_arg: f64,
-    a: f64,
-    b: f64,
+    all_args: f64,
 ) -> f64 {
     let id = method_id(closure);
-    // Minimal implementation: apply all bound stores in insertion order for
-    // the two-argument shape used by the parity suite.
+    // `all_args` is the synthetic-arguments rest array: [context, callback,
+    // thisArg, ...args]. Split it back into the documented parameters and the
+    // trailing callback argument list (#3082).
+    let all = unbox_arg_array(all_args);
+    let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let data = all.first().copied().unwrap_or(undef);
+    let fn_value = all.get(1).copied().unwrap_or(undef);
+    let this_arg = all.get(2).copied().unwrap_or(undef);
+    let cb_args: Vec<f64> = if all.len() > 3 {
+        all[3..].to_vec()
+    } else {
+        Vec::new()
+    };
     let stores = DIAG_CHANNELS.with(|m| {
         m.borrow()
             .get(&id)
@@ -1131,16 +1185,20 @@ pub(crate) extern "C" fn diag_channel_run_stores(
             .unwrap_or_default()
     });
     if stores.is_empty() {
-        return run_store_wrapped(id, data, fn_value, this_arg, &[a, b]);
+        return run_store_wrapped(id, data, fn_value, this_arg, &cb_args);
     }
-    let mut next = js_closure_alloc(cast0(store_next_thunk), 6);
+    // Re-bundle the trailing callback arguments into a JS array so the chained
+    // store-`run` thunk can forward the full list (closure captures are
+    // fixed-width scalar slots, so the variadic tail rides in a single array
+    // handle).
+    let cb_args_arr = unsafe { build_arg_array(&cb_args) };
+    let mut next = js_closure_alloc(cast0(store_next_thunk), 5);
     js_register_closure_arity(cast0(store_next_thunk), 0);
     js_closure_set_capture_ptr(next, 0, id);
     js_closure_set_capture_ptr(next, 1, data.to_bits() as i64);
     js_closure_set_capture_ptr(next, 2, fn_value.to_bits() as i64);
     js_closure_set_capture_ptr(next, 3, this_arg.to_bits() as i64);
-    js_closure_set_capture_ptr(next, 4, a.to_bits() as i64);
-    js_closure_set_capture_ptr(next, 5, b.to_bits() as i64);
+    js_closure_set_capture_ptr(next, 4, cb_args_arr.to_bits() as i64);
     let mut next_value = boxed_ptr(next);
     for (store, transform) in stores.into_iter().rev() {
         let context = if let Some(t) = transform {

--- a/test-files/test_gap_dc_runstores_forward_args.ts
+++ b/test-files/test_gap_dc_runstores_forward_args.ts
@@ -1,0 +1,48 @@
+// #3082: Channel#runStores(context, fn[, thisArg[, ...args]]) must forward the
+// full trailing argument list to `fn` and bind `thisArg` as the receiver, both
+// with and without a bound store, returning the callback's value.
+import diagnostics_channel from "node:diagnostics_channel";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+// No bound store: thisArg bound, three extra args forwarded, value returned.
+const plain = diagnostics_channel.channel("dc:gap:runstores:plain");
+const plainRet = plain.runStores(
+  { phase: "plain" },
+  function (...args: unknown[]): string {
+    console.log("plain args:", JSON.stringify(args));
+    console.log("plain this.tag:", (this as { tag?: string }).tag);
+    return "plain-ret";
+  },
+  { tag: "plain-ctx" },
+  "a",
+  "b",
+  "c",
+);
+console.log("plain ret:", plainRet);
+
+// Bound store: full arg list forwarded through the store-run chain, store
+// visible inside the callback, thisArg bound, value returned.
+const bound = diagnostics_channel.channel("dc:gap:runstores:bound");
+const als = new AsyncLocalStorage<{ value: number }>();
+bound.bindStore(als);
+const boundRet = bound.runStores(
+  { value: 42 },
+  function (...args: unknown[]): string {
+    console.log("bound args:", JSON.stringify(args));
+    console.log("bound this.tag:", (this as { tag?: string }).tag);
+    console.log("bound store:", JSON.stringify(als.getStore()));
+    return "bound-ret";
+  },
+  { tag: "bound-ctx" },
+  1,
+  2,
+  3,
+);
+console.log("bound ret:", boundRet);
+
+// Zero extra args: callback receives no positional args.
+const none = diagnostics_channel.channel("dc:gap:runstores:none");
+const noneRet = none.runStores({}, function (a: unknown, b: unknown): string {
+  return String(a) + "/" + String(b);
+});
+console.log("none ret:", noneRet);


### PR DESCRIPTION
## What

Extends Node argument-validation parity (#2013) to the global `Buffer` factory methods, following the `fs` slice landed in #2035 / #2328. These functions previously coerced bad input silently, so `assert.throws`-style tests reported "Missing expected exception".

| API | Bad input | Now throws |
|---|---|---|
| `Buffer.alloc` / `allocUnsafe` / `allocUnsafeSlow` | non-number `size` | `TypeError [ERR_INVALID_ARG_TYPE]` |
| ″ | `NaN` / `Infinity` / negative / `> kMaxLength` | `RangeError [ERR_OUT_OF_RANGE]` |
| `Buffer.concat` | non-Array `list` | `TypeError [ERR_INVALID_ARG_TYPE]` |
| ″ | non-Buffer/Uint8Array element | `TypeError [ERR_INVALID_ARG_TYPE]` (`list[i]`) |
| ″ | non-integer / negative `totalLength` | `ERR_INVALID_ARG_TYPE` / `ERR_OUT_OF_RANGE` |
| `Buffer.byteLength` | non string/Buffer/ArrayBuffer/TypedArray | `TypeError [ERR_INVALID_ARG_TYPE]` |

Non-integer sizes still truncate toward zero (`Buffer.alloc(2.5).length === 2`), matching Node.

## How

- **Reuses the `fs::validate` primitives** (`describe_received`, `throw_type_error_with_code`, `throw_range_error_with_code`, `validate_int32`) — the issue explicitly names this the shared validation home. `describe_received` gains string/bigint rendering (Node's `determineSpecificType` shape) — purely additive; `fs` never reaches those branches.
- New `buffer/validate.rs` with `js_buffer_validate_size`, `js_buffer_validate_concat_list`, `validate_concat_length`, `validate_byte_length_arg`.
- The `size`/`list` values reach validation as raw NaN-boxed values: the Buffer factory codegen (`env_clones.rs`, `array_methods.rs`) now calls the validators before coercing to `i32` / treating as an `ArrayHeader` (the latter also closes a latent UB where `Buffer.concat('x')` cast a string pointer to an array header). `byteLength` / `concat(totalLength)` validate inside the runtime entry points.
- `Buffer.alloc()` / `allocUnsafe()` with no argument now default to `undefined` so they surface `ERR_INVALID_ARG_TYPE` like Node, instead of silently allocating empty.

## Testing

Verified **byte-identical to Node v25** across the full `buffer` node-suite (120 cases, including 3 new arg-validation tests under `allocation/`, `concat/`, `byte-length/`) — 0 diffs, 0 regressions. `cargo fmt --all --check` clean.

## Scope

#2013 is a cross-cutting umbrella (~85 tests across fs/buffer/net/http/crypto/zlib/process/url). `fs` landed earlier; this is the **buffer** slice. `Buffer.compare` is deferred (it lowers to an instance `a.compare(b)` dispatch — a separate path); remaining APIs remain follow-ups.
