### PR TITLE
fix(node:console): validate Console stream write methods (#3080)

### DIFF
--- a/crates/perry-runtime/src/builtins/console.rs
+++ b/crates/perry-runtime/src/builtins/console.rs
@@ -578,21 +578,69 @@ fn object_property(value: f64, name: &[u8]) -> f64 {
 }
 
 #[cold]
-fn throw_console_writable_stream() -> ! {
-    let msg = b"Console expects a writable stream instance";
-    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+fn throw_console_writable_stream(stream_name: &str) -> ! {
+    // Mirror Node's `ERR_CONSOLE_WRITABLE_STREAM` wording, which names the
+    // offending stream (e.g. "... instance for stdout").
+    let msg = format!("Console expects a writable stream instance for {stream_name}");
+    let bytes = msg.as_bytes();
+    let s = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
     crate::node_submodules::register_error_code_pub(s, "ERR_CONSOLE_WRITABLE_STREAM");
     let err = crate::error::js_typeerror_new(s);
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
+/// True when `value` is callable, matching Node's `typeof x === "function"`.
+/// Reuses the canonical `typeof` implementation so closures, function
+/// references and class refs are all classified consistently.
+fn is_callable(value: f64) -> bool {
+    let header = crate::builtins::arithmetic::js_value_typeof(value);
+    if header.is_null() {
+        return false;
+    }
+    unsafe { (*header).as_str() == "function" }
+}
+
+/// True when `value` is an object that exposes a callable `write` method, which
+/// is Node's definition of an acceptable Console stream.
+fn has_write_method(value: f64) -> bool {
+    if null_or_undefined(value) {
+        return false;
+    }
+    is_callable(object_property(value, b"write"))
+}
+
 #[no_mangle]
 pub extern "C" fn js_console_new(options: f64) -> f64 {
-    let stdout = object_property(options, b"stdout");
-    if null_or_undefined(stdout) {
-        throw_console_writable_stream();
+    // Both `new Console(stdout, stderr?)` and `new Console(options)` are
+    // normalized by codegen into a single value exposing `.stdout` / `.stderr`.
+    // The lone exception is `new Console(stream)` where the single positional
+    // argument is itself a writable stream — there it has no `.stdout` of its
+    // own, so detect that case by checking whether the argument is itself a
+    // writable stream.
+    let stdout_prop = object_property(options, b"stdout");
+    let stdout;
+    let stderr_candidate;
+    if !null_or_undefined(stdout_prop) {
+        stdout = stdout_prop;
+        stderr_candidate = object_property(options, b"stderr");
+    } else if has_write_method(options) {
+        // Single positional stream form: the argument is stdout itself.
+        stdout = options;
+        stderr_candidate = undefined_value();
+    } else {
+        // Options-object form whose stdout is missing/nullish.
+        stdout = stdout_prop;
+        stderr_candidate = object_property(options, b"stderr");
     }
-    let stderr_candidate = object_property(options, b"stderr");
+
+    if !has_write_method(stdout) {
+        throw_console_writable_stream("stdout");
+    }
+    // stderr is validated only when explicitly provided (non-nullish);
+    // otherwise it defaults to stdout, matching Node.
+    if !null_or_undefined(stderr_candidate) && !has_write_method(stderr_candidate) {
+        throw_console_writable_stream("stderr");
+    }
     let stderr = if null_or_undefined(stderr_candidate) {
         stdout
     } else {

--- a/test-files/test_gap_console_validate_write.ts
+++ b/test-files/test_gap_console_validate_write.ts
@@ -1,0 +1,62 @@
+// Console stream-write validation parity (#3080).
+// Node's `new Console(...)` throws ERR_CONSOLE_WRITABLE_STREAM (a TypeError)
+// when a resolved stdout/stderr does not expose a callable `write` method.
+const Console = (console as any).Console;
+
+function check(label: string, fn: () => void): void {
+  try {
+    fn();
+    console.log(label + ": ok");
+  } catch (e: any) {
+    console.log(label + ": " + e.name + " " + e.code + " | " + e.message);
+  }
+}
+
+// stdout object without a write method -> stdout error.
+check("no-write", () => {
+  new Console({});
+});
+
+// single positional stream with a callable write -> accepted.
+check("with-write", () => {
+  const c = new Console({ write() {} });
+  void c;
+});
+
+// write present but not callable -> stdout error.
+check("write-not-fn", () => {
+  new Console({ write: 5 });
+});
+
+// valid stdout, second positional stderr without write -> stderr error.
+check("stderr-bad", () => {
+  new Console({ write() {} }, {});
+});
+
+// valid stdout, stderr omitted -> defaults to stdout, accepted.
+check("stderr-omitted", () => {
+  const c = new Console({ write() {} });
+  void c;
+});
+
+// options-bag form with valid stdout -> accepted.
+check("opts-ok", () => {
+  const c = new Console({ stdout: { write() {} } });
+  void c;
+});
+
+// options-bag form with invalid stdout -> stdout error.
+check("opts-bad-stdout", () => {
+  new Console({ stdout: {} });
+});
+
+// options-bag form, valid stdout, invalid stderr -> stderr error.
+check("opts-bad-stderr", () => {
+  new Console({ stdout: { write() {} }, stderr: {} });
+});
+
+// options-bag form, valid stdout and stderr -> accepted.
+check("opts-both-ok", () => {
+  const c = new Console({ stdout: { write() {} }, stderr: { write() {} } });
+  void c;
+});


### PR DESCRIPTION
## Summary

`new console.Console(...)` previously accepted any object as stdout/stderr and only rejected a nullish stdout, deferring the real failure to a later no-op `.write()`. Node validates at construction time: each resolved stream must expose a callable `write` method, otherwise it throws a `TypeError` with code `ERR_CONSOLE_WRITABLE_STREAM`.

This makes `js_console_new` perform that validation, matching Node's wording and code.

## Behavior matched against Node

- Error: `TypeError`, `code === "ERR_CONSOLE_WRITABLE_STREAM"`
- Messages: `Console expects a writable stream instance for stdout` / `... for stderr`

Rules (verified byte-identical):
- stdout without a callable `write` -> stdout error; `write` present but not a function -> stdout error
- single positional stream with a callable `write` -> accepted
- second positional stderr without `write` -> stderr error; stderr omitted/nullish -> defaults to stdout
- options-bag form `new Console({ stdout, stderr })` validated the same way

## Implementation

`crates/perry-runtime/src/builtins/console.rs`:
- `throw_console_writable_stream` now takes the offending stream name so the message reads `... for stdout` / `... for stderr`.
- `is_callable` reuses the canonical `js_value_typeof` (`typeof x === "function"`).
- `has_write_method` accepts an object only when its `write` is callable.
- `js_console_new` resolves the effective stdout/stderr (handling the single-positional-stream form), validates stdout always and stderr only when non-nullish.

No codegen changes needed.

## Verification

New gap test `test-files/test_gap_console_validate_write.ts` (9 cases) compiled with Perry diffs byte-identical against `node --experimental-strip-types`. Global console + a custom-stream Console instance `.log()` remain byte-identical (no regression). `cargo fmt --all -- --check` clean.

Closes #3080.
