### PR TITLE
fix(node:crypto): validate timingSafeEqual inputs

### DIFF
--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -993,7 +993,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         }
 
         // Phase H crypto: `crypto.timingSafeEqual(a, b)` — constant-time
-        // compare of two byte sequences. Returns a NaN-boxed boolean.
+        // compare of two BufferSource values. Returns a NaN-boxed boolean.
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
@@ -1009,12 +1009,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let a_box = lower_expr(ctx, &args[0])?;
             let b_box = lower_expr(ctx, &args[1])?;
             let blk = ctx.block();
-            let a_handle = unbox_to_i64(blk, &a_box);
-            let b_handle = unbox_to_i64(blk, &b_box);
             Ok(blk.call(
                 DOUBLE,
                 "js_crypto_timing_safe_equal",
-                &[(I64, &a_handle), (I64, &b_handle)],
+                &[(DOUBLE, &a_box), (DOUBLE, &b_box)],
             ))
         }
 

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1349,9 +1349,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, DOUBLE, DOUBLE],
     );
-    // crypto.timingSafeEqual(a, b) -> boolean (NaN-boxed). Args are unboxed
-    // to raw i64 pointers (Buffer / TypedArray / string).
-    module.declare_function("js_crypto_timing_safe_equal", DOUBLE, &[I64, I64]);
+    // crypto.timingSafeEqual(a, b) -> boolean (NaN-boxed). Args stay boxed so
+    // stdlib can validate BufferSource inputs and preserve Node error shapes.
+    module.declare_function("js_crypto_timing_safe_equal", DOUBLE, &[DOUBLE, DOUBLE]);
     // crypto.getHashes() / getCiphers() -> string[]; returns *mut ArrayHeader.
     module.declare_function("js_crypto_get_hashes", I64, &[]);
     module.declare_function("js_crypto_get_ciphers", I64, &[]);

--- a/crates/perry-stdlib/src/crypto/kdf.rs
+++ b/crates/perry-stdlib/src/crypto/kdf.rs
@@ -155,11 +155,14 @@ pub unsafe extern "C" fn js_crypto_scrypt_async(
 
 /// Constant-time equality for equal-length byte inputs.
 #[no_mangle]
-pub unsafe extern "C" fn js_crypto_timing_safe_equal(a_ptr: i64, b_ptr: i64) -> f64 {
-    let a = bytes_from_ptr(a_ptr);
-    let b = bytes_from_ptr(b_ptr);
+pub unsafe extern "C" fn js_crypto_timing_safe_equal(a_value: f64, b_value: f64) -> f64 {
+    let a = bytes_from_buffer_source_arg(a_value, "buf1");
+    let b = bytes_from_buffer_source_arg(b_value, "buf2");
     if a.len() != b.len() {
-        return f64::from_bits(JSValue::bool(false).bits());
+        perry_runtime::fs::validate::throw_range_error_named(
+            "Input buffers must have the same byte length",
+            "ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH",
+        );
     }
     let mut diff = 0u8;
     for (x, y) in a.iter().zip(b.iter()) {

--- a/crates/perry-stdlib/src/crypto/util.rs
+++ b/crates/perry-stdlib/src/crypto/util.rs
@@ -80,6 +80,48 @@ pub(super) unsafe fn bytes_from_ptr(ptr: i64) -> Vec<u8> {
     std::slice::from_raw_parts(data, len).to_vec()
 }
 
+fn raw_addr_from_value(value: f64) -> usize {
+    let bits = value.to_bits();
+    let jsval = JSValue::from_bits(bits);
+    if jsval.is_pointer() || jsval.is_string() {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else if !value.is_nan() && bits >= 0x1000 && bits < 0x0001_0000_0000_0000 {
+        bits as usize
+    } else {
+        0
+    }
+}
+
+fn throw_invalid_buffer_source_arg(arg_name: &str) -> ! {
+    let msg = format!(
+        "The \"{}\" argument must be an instance of ArrayBuffer, Buffer, TypedArray, or DataView.",
+        arg_name
+    );
+    perry_runtime::fs::validate::throw_type_error_with_code(&msg, "ERR_INVALID_ARG_TYPE")
+}
+
+pub(super) unsafe fn bytes_from_buffer_source_arg(value: f64, arg_name: &str) -> Vec<u8> {
+    if JSValue::from_bits(value.to_bits()).is_any_string() {
+        throw_invalid_buffer_source_arg(arg_name);
+    }
+    let addr = raw_addr_from_value(value);
+    if addr == 0 {
+        throw_invalid_buffer_source_arg(arg_name);
+    }
+    if perry_runtime::buffer::is_registered_buffer(addr) {
+        let buf = addr as *const perry_runtime::buffer::BufferHeader;
+        let data = perry_runtime::buffer::buffer_data(buf);
+        return std::slice::from_raw_parts(data, (*buf).length as usize).to_vec();
+    }
+    if perry_runtime::typedarray::lookup_typed_array_kind(addr).is_some() {
+        let ta = addr as *const perry_runtime::typedarray::TypedArrayHeader;
+        return perry_runtime::typedarray::typed_array_bytes(ta)
+            .unwrap_or_else(|| throw_invalid_buffer_source_arg(arg_name))
+            .to_vec();
+    }
+    throw_invalid_buffer_source_arg(arg_name);
+}
+
 /// Allocate a new Buffer, copy `bytes` into it, return the registered pointer.
 pub(super) unsafe fn alloc_buffer_from_slice(
     bytes: &[u8],

--- a/test-parity/node-suite/crypto/timing/timing-safe-equal-validation.ts
+++ b/test-parity/node-suite/crypto/timing/timing-safe-equal-validation.ts
@@ -1,0 +1,22 @@
+import { timingSafeEqual } from "node:crypto";
+import { Buffer } from "node:buffer";
+
+function show(label: string, fn: () => unknown) {
+  try {
+    console.log(label, "OK", fn());
+  } catch (err) {
+    const e = err as Error & { code?: string };
+    console.log(label, "THROW", e.name, e.code, e.message.split("\n")[0]);
+  }
+}
+
+show("buffer-equal", () => timingSafeEqual(Buffer.from([1, 2, 3]), Buffer.from([1, 2, 3])));
+show("buffer-different", () => timingSafeEqual(Buffer.from([1, 2, 3]), Buffer.from([1, 2, 4])));
+show("length-mismatch", () => timingSafeEqual(Buffer.from([1]), Buffer.from([1, 2])));
+show("uint16array", () => timingSafeEqual(new Uint16Array([0x0102]), new Uint16Array([0x0102])));
+show("arraybuffer", () => timingSafeEqual(new ArrayBuffer(2), new ArrayBuffer(2)));
+show("dataview", () => timingSafeEqual(new DataView(new ArrayBuffer(2)), new DataView(new ArrayBuffer(2))));
+show("invalid-buf1-string", () => timingSafeEqual("aa" as any, Buffer.from([1, 2])));
+show("invalid-buf1-null", () => timingSafeEqual(null as any, Buffer.from([1, 2])));
+show("invalid-buf2-number", () => timingSafeEqual(Buffer.from([1, 2]), 123 as any));
+show("invalid-buf2-object", () => timingSafeEqual(Buffer.from([1, 2]), {} as any));


### PR DESCRIPTION
Closes #3065

## Summary
- Keeps `crypto.timingSafeEqual()` arguments boxed through codegen so stdlib can validate the original JS values.
- Adds BufferSource validation for Buffer, ArrayBuffer, DataView, and TypedArray inputs, with Node-shaped `ERR_INVALID_ARG_TYPE` errors for invalid arguments.
- Throws `RangeError [ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH]` for length mismatches instead of returning `false`, and prevents invalid values from being treated as raw pointers.
- Adds a Node parity case covering supported inputs, length mismatch, and invalid argument positions.

## Verification
- `env FORCE_COLOR=0 NO_COLOR=1 NODE_DISABLE_COLORS=1 node --experimental-strip-types test-parity/node-suite/crypto/timing/timing-safe-equal-validation.ts`
- Baseline pre-fix: `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module crypto/timing --filter timing-safe-equal-validation` failed, report `test-parity/reports/parity_report_20260529_235908.json`
- Post-fix focused: `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module crypto/timing --filter timing-safe-equal-validation`, report `test-parity/reports/parity_report_20260530_014054.json`
- Post-fix slice: `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module crypto/timing`, report `test-parity/reports/parity_report_20260530_014113.json`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

Note: `cargo check -p perry-stdlib -p perry-codegen` was attempted; `perry-codegen` checked successfully, then the local debug build failed while compiling `aws-lc-sys` because the filesystem reported `No space left on device` before `perry-stdlib` completed.
