### PR TITLE
fix(async_hooks): validate AsyncLocalStorage run/exit callbacks (#3092)

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/async_decimal.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/async_decimal.rs
@@ -3,18 +3,19 @@ use super::*;
 pub(super) const ASYNC_DECIMAL_ROWS: &[NativeModSig] = &[
     // ========== async_hooks.AsyncLocalStorage ==========
     // `new AsyncLocalStorage()` is dispatched by `lower_builtin_new`; the rows
-    // below cover the instance methods. `run(store, cb)` and `exit(cb)` need
-    // the closure pointer arg coerced via NA_PTR (the runtime function takes
-    // it as a raw `i64` ClosureHeader pointer + invokes `js_closure_call0`
-    // internally). Pre-fix every method silently no-op'd through the
-    // unknown-method sentinel.
+    // below cover the instance methods. `run(store, cb)` and `exit(cb)` pass
+    // the callback as a full NaN-boxed value (NA_F64) so the runtime can
+    // reject a non-callable callback with a `TypeError` (#3092) before
+    // mutating the async context; it extracts the closure pointer and invokes
+    // `js_closure_call0` internally. Pre-fix every method silently no-op'd
+    // through the unknown-method sentinel.
     NativeModSig {
         module: "async_hooks",
         has_receiver: true,
         method: "run",
         class_filter: None,
         runtime: "js_async_local_storage_run",
-        args: &[NA_F64, NA_PTR],
+        args: &[NA_F64, NA_F64],
         ret: NR_F64,
     },
     NativeModSig {
@@ -41,7 +42,7 @@ pub(super) const ASYNC_DECIMAL_ROWS: &[NativeModSig] = &[
         method: "exit",
         class_filter: None,
         runtime: "js_async_local_storage_exit",
-        args: &[NA_PTR],
+        args: &[NA_F64],
         ret: NR_F64,
     },
     NativeModSig {

--- a/crates/perry-stdlib/src/async_local_storage.rs
+++ b/crates/perry-stdlib/src/async_local_storage.rs
@@ -3,11 +3,35 @@
 //! Native implementation of Node.js AsyncLocalStorage from `async_hooks`.
 //! Provides run(), getStore(), enterWith(), exit(), and disable().
 
+use perry_runtime::closure::{is_closure_ptr, ClosureHeader};
 use perry_runtime::{async_context, js_closure_call0};
 
 use crate::common::{get_handle_mut, register_handle, Handle};
 
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
+const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+
+/// #3092 — `AsyncLocalStorage#run`/`#exit` must reject a non-callable callback
+/// with a `TypeError`, matching Node (which throws through its function-apply
+/// path). Returns the validated `ClosureHeader` pointer for a callable value,
+/// or diverges via `js_throw`. The POINTER_TAG check guards `is_closure_ptr`
+/// from the short-string/double bit patterns that can otherwise look
+/// pointer-ish enough to segfault.
+unsafe fn validate_callback(callback: f64) -> *const ClosureHeader {
+    let bits = callback.to_bits();
+    if (bits & !POINTER_MASK) == POINTER_TAG {
+        let ptr = (bits & POINTER_MASK) as usize;
+        if is_closure_ptr(ptr) {
+            return ptr as *const ClosureHeader;
+        }
+    }
+    let message = "callback is not a function";
+    let msg = perry_runtime::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = perry_runtime::error::js_typeerror_new(msg);
+    perry_runtime::exception::js_throw(perry_runtime::value::js_nanbox_pointer(err as i64))
+}
 
 /// AsyncLocalStorage handle. Store stacks live in perry-runtime's active
 /// async context so schedulers can snapshot and restore them across async
@@ -39,16 +63,14 @@ pub extern "C" fn js_async_local_storage_new() -> Handle {
 pub unsafe extern "C" fn js_async_local_storage_run(
     handle: Handle,
     store: f64,
-    callback: i64,
+    callback: f64,
 ) -> f64 {
+    // Validate before mutating the async context so an invalid callback throws
+    // without leaving a pushed store behind (#3092).
+    let cb = validate_callback(callback);
+
     async_context::push_store(handle, store);
-
-    let result = if callback != 0 {
-        js_closure_call0(callback as *const perry_runtime::ClosureHeader)
-    } else {
-        f64::from_bits(TAG_UNDEFINED)
-    };
-
+    let result = js_closure_call0(cb);
     async_context::pop_store(handle);
 
     result
@@ -78,18 +100,18 @@ pub extern "C" fn js_async_local_storage_enter_with(handle: Handle, store: f64) 
 /// AsyncLocalStorage.exit(callback)
 /// Save current stack, clear it, call callback, restore stack
 #[no_mangle]
-pub unsafe extern "C" fn js_async_local_storage_exit(handle: Handle, callback: i64) -> f64 {
+pub unsafe extern "C" fn js_async_local_storage_exit(handle: Handle, callback: f64) -> f64 {
+    // Validate before clearing the context so an invalid callback throws
+    // without disturbing the saved store (#3092).
+    let cb = validate_callback(callback);
+
     let saved = if get_handle_mut::<AsyncLocalStorageHandle>(handle).is_some() {
         Some(async_context::take_store(handle))
     } else {
         None
     };
 
-    let result = if callback != 0 {
-        js_closure_call0(callback as *const perry_runtime::ClosureHeader)
-    } else {
-        f64::from_bits(TAG_UNDEFINED)
-    };
+    let result = js_closure_call0(cb);
 
     if let Some(saved) = saved {
         async_context::restore_store(handle, saved);

--- a/test-parity/node-suite/async_hooks/als-run-exit-callback-validation.ts
+++ b/test-parity/node-suite/async_hooks/als-run-exit-callback-validation.ts
@@ -1,0 +1,41 @@
+// Issue #3092 — `AsyncLocalStorage#run(store, cb)` and `#exit(cb)` reject a
+// non-callable callback with a `TypeError` (Node throws through its
+// function-apply path). Assert the error name only — the V8-internal apply
+// message is an implementation detail, not part of the observable contract.
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const als = new AsyncLocalStorage<string>();
+
+function probe(method: string, label: string, fn: () => unknown) {
+  try {
+    fn();
+    console.log(method, label, "no-throw");
+  } catch (err: any) {
+    console.log(method, label, err.name);
+  }
+}
+
+const bad: [string, unknown][] = [
+  ["undefined", undefined],
+  ["null", null],
+  ["number", 0],
+  ["boolean", true],
+  ["string", "x"],
+  ["object", {}],
+  ["array", []],
+];
+for (const [label, value] of bad) {
+  probe("run", label, () => als.run("store", value as any));
+}
+for (const [label, value] of bad) {
+  probe("exit", label, () => als.exit(value as any));
+}
+
+// Valid callbacks still run, with the expected store visibility.
+const runOut = als.run("S", () => als.getStore());
+console.log("valid run store:", runOut);
+
+als.enterWith("OUTER");
+const exitOut = als.exit(() => als.getStore());
+console.log("valid exit store:", exitOut);
+console.log("store after exit:", als.getStore());


### PR DESCRIPTION
Closes #3092.

## Problem

`AsyncLocalStorage#run(store, callback, ...)` and `#exit(callback, ...)` lowered the callback to a raw pointer and treated a null pointer as a no-op, so a non-callable callback returned `undefined` instead of throwing. Node rejects every non-callable callback with a `TypeError` (through its function-apply path).

## Fix

- `crates/perry-codegen/src/lower_call/native_table/async_decimal.rs` — pass the `run`/`exit` callback as a full NaN-boxed value (`NA_F64`) instead of `NA_PTR`, so the runtime can inspect its type.
- `crates/perry-stdlib/src/async_local_storage.rs` — add `validate_callback`: a callable closure (POINTER_TAG + `is_closure_ptr`, the SSO-safe order) is invoked; anything else throws a `TypeError`. Validation runs **before** the async context is mutated, so an invalid callback never leaves a pushed/cleared store behind.

`enterWith(store)` stays permissive (unchanged). Rest-argument forwarding to the callback is not part of this fix (the lowering doesn't forward varargs for `run`/`exit`; tracked separately).

## Validation

New `test-parity/node-suite/async_hooks/als-run-exit-callback-validation.ts` is byte-identical to `node --experimental-strip-types`: every non-callable callback (undefined/null/number/boolean/string/object/array) throws `TypeError` for both `run` and `exit`, and the valid path preserves store visibility (`run`→store, inside `exit`→undefined, after `exit`→restored).

The test asserts `err.name` only — Node's error is V8's internal `Function.prototype.apply was called on...` message with no error code, which is an implementation detail rather than an observable contract.
