### PR TITLE
fix(node:url): validate URLSearchParams.forEach callback (#3058)

### DIFF
--- a/crates/perry-runtime/src/url/search_params.rs
+++ b/crates/perry-runtime/src/url/search_params.rs
@@ -819,6 +819,9 @@ pub extern "C" fn js_url_search_params_for_each(
     callback: f64,
     this_arg: f64,
 ) {
+    // #3058: Node validates the callback before iterating — a missing or
+    // non-function argument throws `TypeError [ERR_INVALID_ARG_TYPE]`.
+    crate::fs::validate::validate_function("callback", callback);
     let entries = get_url_search_params_entries(params);
     let this_value = crate::value::js_nanbox_pointer(params as i64);
     for (key, value) in entries {

--- a/test-parity/node-suite/url/search-params/foreach-validation.ts
+++ b/test-parity/node-suite/url/search-params/foreach-validation.ts
@@ -1,0 +1,22 @@
+// #3058: URLSearchParams.prototype.forEach validates its callback argument
+// like Node — a missing or non-function callback throws
+// TypeError [ERR_INVALID_ARG_TYPE] before any iteration happens.
+const sp = new URLSearchParams("a=1&b=2");
+
+function probe(label: string, fn: () => void): void {
+  try {
+    fn();
+    console.log(label, "OK");
+  } catch (e: any) {
+    console.log(label, "THROW", e.name, e.code, e.message);
+  }
+}
+
+probe("no arg", () => sp.forEach(undefined as any));
+probe("number", () => sp.forEach(123 as any));
+probe("string", () => sp.forEach("x" as any));
+probe("null", () => sp.forEach(null as any));
+
+const out: string[] = [];
+sp.forEach((v, k) => out.push(`${k}=${v}`));
+console.log("run:", out.join("&"));


### PR DESCRIPTION
## Summary

Fixes #3058. `URLSearchParams.prototype.forEach(callback)` now validates its callback argument like Node before iterating: a missing or non-function callback throws `TypeError [ERR_INVALID_ARG_TYPE]` with Node's exact message, instead of silently iterating (and treating a non-callable as a no-op).

## Change

`js_url_search_params_for_each` (crates/perry-runtime/src/url/search_params.rs) calls the shared `fs::validate::validate_function("callback", callback)` helper at entry, which produces:

```
The "callback" argument must be of type function. Received <described value>
```

## Verification

New parity test `test-parity/node-suite/url/search-params/foreach-validation.ts` is byte-identical to `node --experimental-strip-types`:

```
no arg THROW TypeError ERR_INVALID_ARG_TYPE The "callback" argument must be of type function. Received undefined
number THROW TypeError ERR_INVALID_ARG_TYPE The "callback" argument must be of type function. Received type number (123)
string THROW TypeError ERR_INVALID_ARG_TYPE The "callback" argument must be of type function. Received type string ('x')
null   THROW TypeError ERR_INVALID_ARG_TYPE The "callback" argument must be of type function. Received null
run: a=1&b=2
```

All 14 existing `url/search-params` node-suite tests still pass (including `forEach_thisarg`); `cargo fmt --check` clean.
