### PR TITLE
fix(async_hooks): validate AsyncLocalStorage run/exit callbacks (#3092)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1042 — validate AsyncLocalStorage run/exit callbacks (#3092)
+
+`AsyncLocalStorage#run(store, callback, ...)` and `#exit(callback, ...)` lowered
+the callback to a raw pointer and treated a null pointer as a no-op, so a
+non-callable callback returned `undefined` instead of throwing. Node rejects
+every non-callable callback with a `TypeError` (through its function-apply path).
+
+- `crates/perry-codegen/src/lower_call/native_table/async_decimal.rs` and the
+  matching `runtime_decls/stdlib_ffi.rs` declaration now pass the `run`/`exit`
+  callback as a full NaN-boxed value (`NA_F64`/`DOUBLE`) rather than a raw
+  pointer, so the runtime can inspect its type.
+- `crates/perry-stdlib/src/async_local_storage.rs` adds `validate_callback`: a
+  callable closure (POINTER_TAG + `is_closure_ptr`, the SSO-safe order) is
+  invoked; anything else throws a `TypeError`. Validation runs before the async
+  context is mutated, so an invalid callback never leaves a pushed/cleared store
+  behind. `enterWith(store)` stays permissive.
+
+Rest-argument forwarding to the callback is not part of this change.
+
+New `test-parity/node-suite/async_hooks/als-run-exit-callback-validation.ts` is
+byte-identical to `node --experimental-strip-types`: every non-callable callback
+throws `TypeError` for both `run` and `exit`, and the valid path preserves store
+visibility.
+
 ## v0.5.1041 — unblock main lint: rustfmt + allowlist oversized expr_member.rs
 
 #3161 (allowedNodeEnvironmentFlags) landed two `lint`-gate failures on main:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1041
+**Current Version:** 0.5.1042
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4880,7 +4880,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "anyhow",
  "base64",
@@ -4935,14 +4935,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "cc",
  "libc",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "anyhow",
  "log",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "anyhow",
  "base64",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "serde",
  "serde_json",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1041"
+version = "0.5.1042"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "anyhow",
  "clap",
@@ -5056,14 +5056,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "chrono",
  "cron",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5162,14 +5162,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "base64",
  "image",
@@ -5354,14 +5354,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5388,7 +5388,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "brotli",
  "flate2",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "anyhow",
  "base64",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5571,14 +5571,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "base64",
  "itoa",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "base64",
  "block2",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "base64",
  "block2",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1041"
+version = "0.5.1042"
 
 [[package]]
 name = "perry-ui-test"
@@ -5667,11 +5667,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1041"
+version = "0.5.1042"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "base64",
  "block2",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "base64",
  "block2",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "block2",
  "libc",
@@ -5716,7 +5716,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "base64",
  "libc",
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1041"
+version = "0.5.1042"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1041"
+version = "0.5.1042"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/lower_call/native_table/async_decimal.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/async_decimal.rs
@@ -3,18 +3,19 @@ use super::*;
 pub(super) const ASYNC_DECIMAL_ROWS: &[NativeModSig] = &[
     // ========== async_hooks.AsyncLocalStorage ==========
     // `new AsyncLocalStorage()` is dispatched by `lower_builtin_new`; the rows
-    // below cover the instance methods. `run(store, cb)` and `exit(cb)` need
-    // the closure pointer arg coerced via NA_PTR (the runtime function takes
-    // it as a raw `i64` ClosureHeader pointer + invokes `js_closure_call0`
-    // internally). Pre-fix every method silently no-op'd through the
-    // unknown-method sentinel.
+    // below cover the instance methods. `run(store, cb)` and `exit(cb)` pass
+    // the callback as a full NaN-boxed value (NA_F64) so the runtime can
+    // reject a non-callable callback with a `TypeError` (#3092) before
+    // mutating the async context; it extracts the closure pointer and invokes
+    // `js_closure_call0` internally. Pre-fix every method silently no-op'd
+    // through the unknown-method sentinel.
     NativeModSig {
         module: "async_hooks",
         has_receiver: true,
         method: "run",
         class_filter: None,
         runtime: "js_async_local_storage_run",
-        args: &[NA_F64, NA_PTR],
+        args: &[NA_F64, NA_F64],
         ret: NR_F64,
     },
     NativeModSig {
@@ -41,7 +42,7 @@ pub(super) const ASYNC_DECIMAL_ROWS: &[NativeModSig] = &[
         method: "exit",
         class_filter: None,
         runtime: "js_async_local_storage_exit",
-        args: &[NA_PTR],
+        args: &[NA_F64],
         ret: NR_F64,
     },
     NativeModSig {

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -368,10 +368,12 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_async_resource_static_bind", I64, &[I64, DOUBLE]);
     module.declare_function("js_async_local_storage_disable", VOID, &[I64]);
     module.declare_function("js_async_local_storage_enter_with", VOID, &[I64, DOUBLE]);
-    module.declare_function("js_async_local_storage_exit", DOUBLE, &[I64, I64]);
+    // #3092 — callback is passed as a full NaN-boxed value (DOUBLE), not a raw
+    // pointer, so the runtime can reject non-callable callbacks.
+    module.declare_function("js_async_local_storage_exit", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_async_local_storage_get_store", DOUBLE, &[I64]);
     module.declare_function("js_async_local_storage_new", I64, &[]);
-    module.declare_function("js_async_local_storage_run", DOUBLE, &[I64, DOUBLE, I64]);
+    module.declare_function("js_async_local_storage_run", DOUBLE, &[I64, DOUBLE, DOUBLE]);
 
     // ========== zlib ==========
     module.declare_function("js_zlib_deflate_sync", I64, &[DOUBLE]);

--- a/crates/perry-stdlib/src/async_local_storage.rs
+++ b/crates/perry-stdlib/src/async_local_storage.rs
@@ -3,11 +3,35 @@
 //! Native implementation of Node.js AsyncLocalStorage from `async_hooks`.
 //! Provides run(), getStore(), enterWith(), exit(), and disable().
 
+use perry_runtime::closure::{is_closure_ptr, ClosureHeader};
 use perry_runtime::{async_context, js_closure_call0};
 
 use crate::common::{get_handle_mut, register_handle, Handle};
 
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
+const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+
+/// #3092 — `AsyncLocalStorage#run`/`#exit` must reject a non-callable callback
+/// with a `TypeError`, matching Node (which throws through its function-apply
+/// path). Returns the validated `ClosureHeader` pointer for a callable value,
+/// or diverges via `js_throw`. The POINTER_TAG check guards `is_closure_ptr`
+/// from the short-string/double bit patterns that can otherwise look
+/// pointer-ish enough to segfault.
+unsafe fn validate_callback(callback: f64) -> *const ClosureHeader {
+    let bits = callback.to_bits();
+    if (bits & !POINTER_MASK) == POINTER_TAG {
+        let ptr = (bits & POINTER_MASK) as usize;
+        if is_closure_ptr(ptr) {
+            return ptr as *const ClosureHeader;
+        }
+    }
+    let message = "callback is not a function";
+    let msg = perry_runtime::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = perry_runtime::error::js_typeerror_new(msg);
+    perry_runtime::exception::js_throw(perry_runtime::value::js_nanbox_pointer(err as i64))
+}
 
 /// AsyncLocalStorage handle. Store stacks live in perry-runtime's active
 /// async context so schedulers can snapshot and restore them across async
@@ -39,16 +63,14 @@ pub extern "C" fn js_async_local_storage_new() -> Handle {
 pub unsafe extern "C" fn js_async_local_storage_run(
     handle: Handle,
     store: f64,
-    callback: i64,
+    callback: f64,
 ) -> f64 {
+    // Validate before mutating the async context so an invalid callback throws
+    // without leaving a pushed store behind (#3092).
+    let cb = validate_callback(callback);
+
     async_context::push_store(handle, store);
-
-    let result = if callback != 0 {
-        js_closure_call0(callback as *const perry_runtime::ClosureHeader)
-    } else {
-        f64::from_bits(TAG_UNDEFINED)
-    };
-
+    let result = js_closure_call0(cb);
     async_context::pop_store(handle);
 
     result
@@ -78,18 +100,18 @@ pub extern "C" fn js_async_local_storage_enter_with(handle: Handle, store: f64) 
 /// AsyncLocalStorage.exit(callback)
 /// Save current stack, clear it, call callback, restore stack
 #[no_mangle]
-pub unsafe extern "C" fn js_async_local_storage_exit(handle: Handle, callback: i64) -> f64 {
+pub unsafe extern "C" fn js_async_local_storage_exit(handle: Handle, callback: f64) -> f64 {
+    // Validate before clearing the context so an invalid callback throws
+    // without disturbing the saved store (#3092).
+    let cb = validate_callback(callback);
+
     let saved = if get_handle_mut::<AsyncLocalStorageHandle>(handle).is_some() {
         Some(async_context::take_store(handle))
     } else {
         None
     };
 
-    let result = if callback != 0 {
-        js_closure_call0(callback as *const perry_runtime::ClosureHeader)
-    } else {
-        f64::from_bits(TAG_UNDEFINED)
-    };
+    let result = js_closure_call0(cb);
 
     if let Some(saved) = saved {
         async_context::restore_store(handle, saved);

--- a/test-parity/node-suite/async_hooks/als-run-exit-callback-validation.ts
+++ b/test-parity/node-suite/async_hooks/als-run-exit-callback-validation.ts
@@ -1,0 +1,41 @@
+// Issue #3092 — `AsyncLocalStorage#run(store, cb)` and `#exit(cb)` reject a
+// non-callable callback with a `TypeError` (Node throws through its
+// function-apply path). Assert the error name only — the V8-internal apply
+// message is an implementation detail, not part of the observable contract.
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const als = new AsyncLocalStorage<string>();
+
+function probe(method: string, label: string, fn: () => unknown) {
+  try {
+    fn();
+    console.log(method, label, "no-throw");
+  } catch (err: any) {
+    console.log(method, label, err.name);
+  }
+}
+
+const bad: [string, unknown][] = [
+  ["undefined", undefined],
+  ["null", null],
+  ["number", 0],
+  ["boolean", true],
+  ["string", "x"],
+  ["object", {}],
+  ["array", []],
+];
+for (const [label, value] of bad) {
+  probe("run", label, () => als.run("store", value as any));
+}
+for (const [label, value] of bad) {
+  probe("exit", label, () => als.exit(value as any));
+}
+
+// Valid callbacks still run, with the expected store visibility.
+const runOut = als.run("S", () => als.getStore());
+console.log("valid run store:", runOut);
+
+als.enterWith("OUTER");
+const exitOut = als.exit(() => als.getStore());
+console.log("valid exit store:", exitOut);
+console.log("store after exit:", als.getStore());


### PR DESCRIPTION
Closes #3092.

## Problem

`AsyncLocalStorage#run(store, callback, ...)` and `#exit(callback, ...)` lowered the callback to a raw pointer and treated a null pointer as a no-op, so a non-callable callback returned `undefined` instead of throwing. Node rejects every non-callable callback with a `TypeError` (through its function-apply path).

## Fix

- `crates/perry-codegen/src/lower_call/native_table/async_decimal.rs` — pass the `run`/`exit` callback as a full NaN-boxed value (`NA_F64`) instead of `NA_PTR`, so the runtime can inspect its type.
- `crates/perry-stdlib/src/async_local_storage.rs` — add `validate_callback`: a callable closure (POINTER_TAG + `is_closure_ptr`, the SSO-safe order) is invoked; anything else throws a `TypeError`. Validation runs **before** the async context is mutated, so an invalid callback never leaves a pushed/cleared store behind.

`enterWith(store)` stays permissive (unchanged). Rest-argument forwarding to the callback is not part of this fix (the lowering doesn't forward varargs for `run`/`exit`; tracked separately).

## Validation

New `test-parity/node-suite/async_hooks/als-run-exit-callback-validation.ts` is byte-identical to `node --experimental-strip-types`: every non-callable callback (undefined/null/number/boolean/string/object/array) throws `TypeError` for both `run` and `exit`, and the valid path preserves store visibility (`run`→store, inside `exit`→undefined, after `exit`→restored).

The test asserts `err.name` only — Node's error is V8's internal `Function.prototype.apply was called on...` message with no error code, which is an implementation detail rather than an observable contract.
