### PR TITLE
fix(node:crypto): validate timingSafeEqual BufferSource inputs (#3065)

### DIFF
--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -1006,15 +1006,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             if args.len() < 2 {
                 return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
             }
+            // Pass the full NaN-boxed bits (raw bitcast, NOT the masked
+            // pointer) so the runtime helper can type-discriminate BufferSource
+            // inputs and throw Node's ERR_INVALID_ARG_TYPE for strings/numbers
+            // (#3065). A plain `(DOUBLE, box)` pass mis-coerces non-f64 lowered
+            // values, so bitcast each box to its i64 bit pattern first.
             let a_box = lower_expr(ctx, &args[0])?;
             let b_box = lower_expr(ctx, &args[1])?;
             let blk = ctx.block();
-            let a_handle = unbox_to_i64(blk, &a_box);
-            let b_handle = unbox_to_i64(blk, &b_box);
+            let a_bits = blk.bitcast_double_to_i64(&a_box);
+            let b_bits = blk.bitcast_double_to_i64(&b_box);
             Ok(blk.call(
                 DOUBLE,
                 "js_crypto_timing_safe_equal",
-                &[(I64, &a_handle), (I64, &b_handle)],
+                &[(I64, &a_bits), (I64, &b_bits)],
             ))
         }
 

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1349,8 +1349,10 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, DOUBLE, DOUBLE],
     );
-    // crypto.timingSafeEqual(a, b) -> boolean (NaN-boxed). Args are unboxed
-    // to raw i64 pointers (Buffer / TypedArray / string).
+    // crypto.timingSafeEqual(a, b) -> boolean (NaN-boxed). Args are the full
+    // NaN-boxed bits (raw bitcast) so the runtime can type-discriminate
+    // BufferSource inputs and throw Node's ERR_INVALID_ARG_TYPE / length
+    // errors (#3065).
     module.declare_function("js_crypto_timing_safe_equal", DOUBLE, &[I64, I64]);
     // crypto.getHashes() / getCiphers() -> string[]; returns *mut ArrayHeader.
     module.declare_function("js_crypto_get_hashes", I64, &[]);

--- a/crates/perry-stdlib/src/crypto/kdf.rs
+++ b/crates/perry-stdlib/src/crypto/kdf.rs
@@ -153,13 +153,71 @@ pub unsafe extern "C" fn js_crypto_scrypt_async(
     f64::from_bits(JSValue::undefined().bits())
 }
 
-/// Constant-time equality for equal-length byte inputs.
+/// Classify a NaN-boxed value as a Node `BufferSource` (ArrayBuffer /
+/// SharedArrayBuffer / Buffer / TypedArray / DataView) and return its raw
+/// bytes. Strings, numbers, and any other value are rejected with a
+/// `TypeError [ERR_INVALID_ARG_TYPE]` carrying Node's exact `timingSafeEqual`
+/// message (`#3065`). All of these shapes share the length-prefixed
+/// `BufferHeader` storage except genuine typed-array views, which carry a
+/// byte offset/length and must go through `typed_array_bytes`.
+unsafe fn timing_safe_buffer_source(value: f64, arg_name: &str) -> Vec<u8> {
+    // Strip a NaN-box if present, otherwise read the raw pointer bits. This
+    // mirrors the runtime's own `jsvalue_addr`/`jsvalue_typed_array_kind`
+    // helpers: typed-array views are not always POINTER_TAG-boxed, so an
+    // `is_pointer()` gate would miss `new Uint16Array(...)`. Genuine numbers /
+    // strings / null land on an address that is in none of the registries and
+    // fall through to the TypeError below.
+    let bits = value.to_bits();
+    let addr = if (bits >> 48) >= 0x7FF8 {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else {
+        bits as usize
+    };
+    if addr >= 0x1000 {
+        // Real TypedArray views (Uint16Array, Int32Array, …) carry a byte
+        // offset/length, so route them through `typed_array_bytes`.
+        if perry_runtime::typedarray::lookup_typed_array_kind(addr).is_some() {
+            let ta = addr as *const perry_runtime::typedarray::TypedArrayHeader;
+            if let Some(bytes) = perry_runtime::typedarray::typed_array_bytes(ta) {
+                return bytes.to_vec();
+            }
+        }
+        // Buffer / Uint8Array-backed buffer / ArrayBuffer / SharedArrayBuffer /
+        // DataView all share the length-prefixed `BufferHeader` storage.
+        if perry_runtime::buffer::is_registered_buffer(addr)
+            || perry_runtime::buffer::is_uint8array_buffer(addr)
+            || perry_runtime::buffer::is_any_array_buffer(addr)
+            || perry_runtime::buffer::is_data_view(addr)
+        {
+            let buf = addr as *const perry_runtime::buffer::BufferHeader;
+            let len = (*buf).length as usize;
+            let data =
+                (buf as *const u8).add(std::mem::size_of::<perry_runtime::buffer::BufferHeader>());
+            return std::slice::from_raw_parts(data, len).to_vec();
+        }
+    }
+    let message = format!(
+        "The \"{}\" argument must be an instance of ArrayBuffer, Buffer, TypedArray, or DataView.",
+        arg_name
+    );
+    perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
+/// Constant-time equality for equal-length byte inputs. Args arrive as the full
+/// NaN-boxed bits (`f64`) so the helper can type-discriminate BufferSource
+/// inputs the way Node does (`#3065`): non-BufferSource values throw
+/// `ERR_INVALID_ARG_TYPE`, and a byte-length mismatch throws
+/// `RangeError [ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH]` rather than returning
+/// `false`.
 #[no_mangle]
-pub unsafe extern "C" fn js_crypto_timing_safe_equal(a_ptr: i64, b_ptr: i64) -> f64 {
-    let a = bytes_from_ptr(a_ptr);
-    let b = bytes_from_ptr(b_ptr);
+pub unsafe extern "C" fn js_crypto_timing_safe_equal(a_bits: i64, b_bits: i64) -> f64 {
+    let a = timing_safe_buffer_source(f64::from_bits(a_bits as u64), "buf1");
+    let b = timing_safe_buffer_source(f64::from_bits(b_bits as u64), "buf2");
     if a.len() != b.len() {
-        return f64::from_bits(JSValue::bool(false).bits());
+        perry_runtime::fs::validate::throw_range_error_named(
+            "Input buffers must have the same byte length",
+            "ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH",
+        );
     }
     let mut diff = 0u8;
     for (x, y) in a.iter().zip(b.iter()) {

--- a/test-files/test_gap_crypto_timingsafeequal.ts
+++ b/test-files/test_gap_crypto_timingsafeequal.ts
@@ -1,0 +1,39 @@
+// @covers crypto.timingSafeEqual(a, b) BufferSource validation (#3065)
+// Node accepts ArrayBuffer/Buffer/TypedArray/DataView, throws
+// ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH (RangeError) on a byte-length mismatch,
+// and ERR_INVALID_ARG_TYPE (TypeError) for non-BufferSource inputs.
+import crypto from "node:crypto";
+
+function show(label: string, fn: () => unknown): void {
+  try {
+    console.log(label, "OK", fn());
+  } catch (err: any) {
+    console.log(label, "THROW", err.name, err.code, err.message);
+  }
+}
+
+show("equal-buffers", () =>
+  crypto.timingSafeEqual(Buffer.from([1, 2, 3]), Buffer.from([1, 2, 3])),
+);
+show("unequal-buffers", () =>
+  crypto.timingSafeEqual(Buffer.from([1, 2, 3]), Buffer.from([1, 2, 4])),
+);
+show("length-mismatch", () =>
+  crypto.timingSafeEqual(Buffer.from([1]), Buffer.from([1, 2])),
+);
+show("uint16-equal", () =>
+  crypto.timingSafeEqual(new Uint16Array([1, 2]), new Uint16Array([1, 2])),
+);
+show("arraybuffer-equal", () =>
+  crypto.timingSafeEqual(new ArrayBuffer(4), new ArrayBuffer(4)),
+);
+show("dataview-equal", () =>
+  crypto.timingSafeEqual(
+    new DataView(new ArrayBuffer(2)),
+    new DataView(new ArrayBuffer(2)),
+  ),
+);
+show("string-arg", () => crypto.timingSafeEqual("a" as any, "a" as any));
+show("number-arg", () =>
+  crypto.timingSafeEqual(Buffer.from([1]), 123 as any),
+);


### PR DESCRIPTION
## Summary

Implements Node-compatible argument validation for `crypto.timingSafeEqual(a, b)` (#3065).

Previously both arguments were read through a permissive raw-byte helper, so strings/invalid pointers were accepted as byte arrays and a length mismatch returned `false` instead of throwing.

Now the helper type-discriminates each argument:

- **Accepts** `ArrayBuffer` / `SharedArrayBuffer` / `Buffer` / `TypedArray` / `DataView`.
- **Byte-length mismatch** → `RangeError [ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH]` (`Input buffers must have the same byte length`).
- **Non-BufferSource** (string, number, null, …) → `TypeError [ERR_INVALID_ARG_TYPE]` (`The "buf1"/"buf2" argument must be an instance of ArrayBuffer, Buffer, TypedArray, or DataView.`).

## Implementation

- `crates/perry-stdlib/src/crypto/kdf.rs`: `js_crypto_timing_safe_equal` now takes the full NaN-boxed bits of each argument and classifies it via the typed-array / buffer registries (`lookup_typed_array_kind`, `is_registered_buffer`, `is_uint8array_buffer`, `is_any_array_buffer`, `is_data_view`) — mirroring the runtime's own `jsvalue_typed_array_kind` so `new Uint16Array(...)` (not POINTER_TAG-boxed) is recognized.
- `crates/perry-codegen/src/expr/calls.rs` + `runtime_decls/strings.rs`: pass each argument's raw NaN-boxed bits (bitcast to `i64`, not the masked pointer) so the runtime can see the value tag.

## Testing

`test-files/test_gap_crypto_timingsafeequal.ts` is byte-identical to `node --experimental-strip-types` (Node v25). The existing `test-parity/node-suite/crypto/timing/timing-safe-equal.ts` also remains byte-identical.
