### PR TITLE
fix(async_hooks): validate AsyncLocalStorage callbacks

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/async_decimal.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/async_decimal.rs
@@ -3,18 +3,16 @@ use super::*;
 pub(super) const ASYNC_DECIMAL_ROWS: &[NativeModSig] = &[
     // ========== async_hooks.AsyncLocalStorage ==========
     // `new AsyncLocalStorage()` is dispatched by `lower_builtin_new`; the rows
-    // below cover the instance methods. `run(store, cb)` and `exit(cb)` need
-    // the closure pointer arg coerced via NA_PTR (the runtime function takes
-    // it as a raw `i64` ClosureHeader pointer + invokes `js_closure_call0`
-    // internally). Pre-fix every method silently no-op'd through the
-    // unknown-method sentinel.
+    // below cover the instance methods. `run(store, cb)` and `exit(cb)` keep
+    // the callback as a full JS value so the runtime can validate
+    // non-callables before mutating async context.
     NativeModSig {
         module: "async_hooks",
         has_receiver: true,
         method: "run",
         class_filter: None,
         runtime: "js_async_local_storage_run",
-        args: &[NA_F64, NA_PTR],
+        args: &[NA_F64, NA_F64],
         ret: NR_F64,
     },
     NativeModSig {
@@ -41,7 +39,7 @@ pub(super) const ASYNC_DECIMAL_ROWS: &[NativeModSig] = &[
         method: "exit",
         class_filter: None,
         runtime: "js_async_local_storage_exit",
-        args: &[NA_PTR],
+        args: &[NA_F64],
         ret: NR_F64,
     },
     NativeModSig {

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -368,10 +368,10 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_async_resource_static_bind", I64, &[I64, DOUBLE]);
     module.declare_function("js_async_local_storage_disable", VOID, &[I64]);
     module.declare_function("js_async_local_storage_enter_with", VOID, &[I64, DOUBLE]);
-    module.declare_function("js_async_local_storage_exit", DOUBLE, &[I64, I64]);
+    module.declare_function("js_async_local_storage_exit", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_async_local_storage_get_store", DOUBLE, &[I64]);
     module.declare_function("js_async_local_storage_new", I64, &[]);
-    module.declare_function("js_async_local_storage_run", DOUBLE, &[I64, DOUBLE, I64]);
+    module.declare_function("js_async_local_storage_run", DOUBLE, &[I64, DOUBLE, DOUBLE]);
 
     // ========== zlib ==========
     module.declare_function("js_zlib_deflate_sync", I64, &[DOUBLE]);

--- a/crates/perry-stdlib/src/async_local_storage.rs
+++ b/crates/perry-stdlib/src/async_local_storage.rs
@@ -3,11 +3,13 @@
 //! Native implementation of Node.js AsyncLocalStorage from `async_hooks`.
 //! Provides run(), getStore(), enterWith(), exit(), and disable().
 
-use perry_runtime::{async_context, js_closure_call0};
+use perry_runtime::{async_context, js_closure_call0, JSValue};
 
 use crate::common::{get_handle_mut, register_handle, Handle};
 
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
 
 /// AsyncLocalStorage handle. Store stacks live in perry-runtime's active
 /// async context so schedulers can snapshot and restore them across async
@@ -33,22 +35,44 @@ pub extern "C" fn js_async_local_storage_new() -> Handle {
     register_handle(AsyncLocalStorageHandle::new())
 }
 
+fn throw_apply_type_error() -> ! {
+    let msg = b"Function.prototype.apply was called on a non-function value";
+    let msg_str = perry_runtime::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err_ptr = perry_runtime::error::js_typeerror_new(msg_str);
+    let err_value = JSValue::pointer(err_ptr as *const u8).bits();
+    perry_runtime::exception::js_throw(f64::from_bits(err_value))
+}
+
+fn closure_ptr_from_value(callback: f64) -> i64 {
+    let bits = callback.to_bits();
+    if (bits & !POINTER_MASK) == POINTER_TAG {
+        let ptr = (bits & POINTER_MASK) as usize;
+        if perry_runtime::closure::is_closure_ptr(ptr) {
+            return ptr as i64;
+        }
+    }
+    throw_apply_type_error()
+}
+
+unsafe fn call_callback(callback: i64) -> f64 {
+    let scope = perry_runtime::gc::RuntimeHandleScope::new();
+    let callback_handle = scope.root_raw_const_ptr(callback as *const perry_runtime::ClosureHeader);
+
+    js_closure_call0(callback_handle.get_raw_const_ptr::<perry_runtime::ClosureHeader>())
+}
+
 /// AsyncLocalStorage.run(store, callback)
 /// Push store onto stack, call callback, pop store, return result
 #[no_mangle]
 pub unsafe extern "C" fn js_async_local_storage_run(
     handle: Handle,
     store: f64,
-    callback: i64,
+    callback: f64,
 ) -> f64 {
+    let callback = closure_ptr_from_value(callback);
+
     async_context::push_store(handle, store);
-
-    let result = if callback != 0 {
-        js_closure_call0(callback as *const perry_runtime::ClosureHeader)
-    } else {
-        f64::from_bits(TAG_UNDEFINED)
-    };
-
+    let result = call_callback(callback);
     async_context::pop_store(handle);
 
     result
@@ -78,18 +102,16 @@ pub extern "C" fn js_async_local_storage_enter_with(handle: Handle, store: f64) 
 /// AsyncLocalStorage.exit(callback)
 /// Save current stack, clear it, call callback, restore stack
 #[no_mangle]
-pub unsafe extern "C" fn js_async_local_storage_exit(handle: Handle, callback: i64) -> f64 {
+pub unsafe extern "C" fn js_async_local_storage_exit(handle: Handle, callback: f64) -> f64 {
+    let callback = closure_ptr_from_value(callback);
+
     let saved = if get_handle_mut::<AsyncLocalStorageHandle>(handle).is_some() {
         Some(async_context::take_store(handle))
     } else {
         None
     };
 
-    let result = if callback != 0 {
-        js_closure_call0(callback as *const perry_runtime::ClosureHeader)
-    } else {
-        f64::from_bits(TAG_UNDEFINED)
-    };
+    let result = call_callback(callback);
 
     if let Some(saved) = saved {
         async_context::restore_store(handle, saved);

--- a/test-parity/node-suite/async_hooks/async_local_storage/run-exit-callback-validation.ts
+++ b/test-parity/node-suite/async_hooks/async_local_storage/run-exit-callback-validation.ts
@@ -1,0 +1,44 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const als = new AsyncLocalStorage();
+const badCallbacks = [
+  ["undefined", undefined],
+  ["null", null],
+  ["number", 0],
+  ["boolean", false],
+  ["string", "callback"],
+];
+
+function probe(method: string, invoke: (callback: any) => void) {
+  for (const [label, callback] of badCallbacks) {
+    als.enterWith("outer");
+    try {
+      invoke(callback);
+      console.log(`${method}:${label}:no-throw:${als.getStore()}`);
+    } catch (err: any) {
+      console.log(`${method}:${label}:${err.name}:${err.code ?? "no-code"}:${als.getStore()}`);
+    }
+  }
+}
+
+probe("run", (callback) => {
+  als.run("inner", callback);
+});
+
+probe("exit", (callback) => {
+  als.exit(callback);
+});
+
+als.enterWith("outer");
+const runReturn = als.run("inner", () => {
+  console.log("run-valid-store", als.getStore());
+  return "run-ok";
+});
+console.log("run-valid-return", runReturn, "after", als.getStore());
+
+als.enterWith("outer");
+const exitReturn = als.exit(() => {
+  console.log("exit-valid-store", String(als.getStore()));
+  return "exit-ok";
+});
+console.log("exit-valid-return", exitReturn, "after", als.getStore());


### PR DESCRIPTION
## Summary
- pass `AsyncLocalStorage.run`/`exit` callbacks as full JS values instead of raw closure pointers
- validate non-callable callbacks before changing async context state, preserving the outer store on throw
- update stdlib FFI declarations for the new callback ABI and add a Node/Perry parity fixture

Fixes #3092.

Note: this overlaps with #3241, but this branch is rebased on current `main` after the #3093 revert and includes the stdlib FFI declaration update needed for the callback ABI.

## Testing
- `cargo fmt -- crates/perry-runtime/src/node_submodules/diagnostics.rs crates/perry-runtime/src/builtins/console.rs crates/perry-codegen/src/lower_call/native_table/async_decimal.rs crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs crates/perry-stdlib/src/async_local_storage.rs`
- `CARGO_TARGET_DIR=/Users/dutchess/Documents/PerryTS/perry/target cargo check -p perry-codegen`
- `CARGO_TARGET_DIR=/Users/dutchess/Documents/PerryTS/perry/target cargo check -p perry-stdlib --features full`
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- LLVM trace check confirms `js_async_local_storage_run(i64, double, double)` and `js_async_local_storage_exit(i64, double)` declarations/calls
- Node/Perry parity diff: `test-parity/node-suite/async_hooks/async_local_storage/run-exit-callback-validation.ts`