### PR TITLE
style(hir): rustfmt allowedNodeEnvironmentFlags literal (main lint red)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -2065,7 +2065,10 @@ fn process_allowed_node_flags_literal() -> Expr {
         "-r",
     ];
     Expr::SetNewFromArray(Box::new(Expr::Array(
-        FLAGS.iter().map(|f| Expr::String((*f).to_string())).collect(),
+        FLAGS
+            .iter()
+            .map(|f| Expr::String((*f).to_string()))
+            .collect(),
     )))
 }
 


### PR DESCRIPTION
Fixes the lint gate (`cargo fmt --all -- --check`) which is red on main: #3161 landed `process_allowed_node_flags_literal` with an unformatted `.iter().map(...).collect()` chain at expr_member.rs:2065. Apply rustfmt — the whole tree is fmt-clean after this (verified locally). Same intent as #3287, which is currently stuck on its own red lint; this is a minimal correctly-based-on-latest-main version to unblock everyone.