### PR TITLE
fix(node:console): honor positional stderr stream

### DIFF
--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -219,8 +219,16 @@ pub(super) fn lower_builtin_new(
             } else {
                 double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
             };
-            for a in args.iter().skip(1) {
-                let _ = lower_expr(ctx, a)?;
+            if let Some(stderr_arg) = args.get(1) {
+                let stderr = lower_expr(ctx, stderr_arg)?;
+                for a in args.iter().skip(2) {
+                    let _ = lower_expr(ctx, a)?;
+                }
+                return Ok(Some(ctx.block().call(
+                    DOUBLE,
+                    "js_console_new2",
+                    &[(DOUBLE, &opts), (DOUBLE, &stderr)],
+                )));
             }
             Ok(Some(ctx.block().call(
                 DOUBLE,

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1632,6 +1632,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_console_count_value", VOID, &[DOUBLE]);
     module.declare_function("js_console_count_reset_value", VOID, &[DOUBLE]);
     module.declare_function("js_console_new", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_console_new2", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_console_group_begin", VOID, &[]);
     module.declare_function("js_console_group_end", VOID, &[]);
     module.declare_function("js_console_clear", VOID, &[]);

--- a/crates/perry-runtime/src/builtins/console.rs
+++ b/crates/perry-runtime/src/builtins/console.rs
@@ -637,6 +637,20 @@ pub extern "C" fn js_console_new(options: f64) -> f64 {
         stderr_candidate = object_property(options, b"stderr");
     }
 
+    let ignore_errors = unsafe { decode_dir_bool_option(options, "ignoreErrors") }.unwrap_or(true);
+    js_console_new_resolved(stdout, stderr_candidate, ignore_errors)
+}
+
+#[no_mangle]
+pub extern "C" fn js_console_new2(stdout: f64, stderr_candidate: f64) -> f64 {
+    let has_options_stdout = !null_or_undefined(object_property(stdout, b"stdout"));
+    if null_or_undefined(stderr_candidate) && has_options_stdout {
+        return js_console_new(stdout);
+    }
+    js_console_new_resolved(stdout, stderr_candidate, true)
+}
+
+fn js_console_new_resolved(stdout: f64, stderr_candidate: f64, ignore_errors: bool) -> f64 {
     if !has_write_method(stdout) {
         throw_console_writable_stream("stdout");
     }
@@ -650,8 +664,6 @@ pub extern "C" fn js_console_new(options: f64) -> f64 {
     } else {
         stderr_candidate
     };
-    let ignore_errors = unsafe { decode_dir_bool_option(options, "ignoreErrors") }.unwrap_or(true);
-
     let obj = crate::object::js_object_alloc(CONSOLE_INSTANCE_CLASS_ID, 0);
     let value = crate::value::js_nanbox_pointer(obj as i64);
     CONSOLE_INSTANCES.with(|instances| {

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -61,7 +61,7 @@ pub use console::{
     js_console_error_number, js_console_error_spread, js_console_group, js_console_group_begin,
     js_console_group_end, js_console_log, js_console_log_as_closure, js_console_log_dynamic,
     js_console_log_i32, js_console_log_i64, js_console_log_number, js_console_log_spread,
-    js_console_new, js_console_noop, js_console_time, js_console_time_end,
+    js_console_new, js_console_new2, js_console_noop, js_console_time, js_console_time_end,
     js_console_time_end_value, js_console_time_log, js_console_time_log_spread,
     js_console_time_log_value, js_console_time_value, js_console_trace, js_console_trace_spread,
     js_console_warn_dynamic, js_console_warn_i32, js_console_warn_number, js_console_warn_spread,

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1242,7 +1242,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("punycode.ucs2", "encode") => crate::punycode::js_punycode_ucs2_encode(arg(0)),
 
         // ── console module namespace (`node:console` / `console`) ──
-        ("console", "Console") => crate::builtins::js_console_new(arg(0)),
+        ("console", "Console") => crate::builtins::js_console_new2(arg(0), arg(1)),
         ("console", "log") | ("console", "info") | ("console", "debug") | ("console", "dirxml") => {
             crate::builtins::js_console_log_spread(pack_args());
             f64::from_bits(JSValue::undefined().bits())

--- a/test-files/test_gap_console_validate_write.ts
+++ b/test-files/test_gap_console_validate_write.ts
@@ -1,0 +1,62 @@
+// Console stream-write validation parity (#3080).
+// Node's `new Console(...)` throws ERR_CONSOLE_WRITABLE_STREAM (a TypeError)
+// when a resolved stdout/stderr does not expose a callable `write` method.
+const Console = (console as any).Console;
+
+function check(label: string, fn: () => void): void {
+  try {
+    fn();
+    console.log(label + ": ok");
+  } catch (e: any) {
+    console.log(label + ": " + e.name + " " + e.code + " | " + e.message);
+  }
+}
+
+// stdout object without a write method -> stdout error.
+check("no-write", () => {
+  new Console({});
+});
+
+// single positional stream with a callable write -> accepted.
+check("with-write", () => {
+  const c = new Console({ write() {} });
+  void c;
+});
+
+// write present but not callable -> stdout error.
+check("write-not-fn", () => {
+  new Console({ write: 5 });
+});
+
+// valid stdout, second positional stderr without write -> stderr error.
+check("stderr-bad", () => {
+  new Console({ write() {} }, {});
+});
+
+// valid stdout, stderr omitted -> defaults to stdout, accepted.
+check("stderr-omitted", () => {
+  const c = new Console({ write() {} });
+  void c;
+});
+
+// options-bag form with valid stdout -> accepted.
+check("opts-ok", () => {
+  const c = new Console({ stdout: { write() {} } });
+  void c;
+});
+
+// options-bag form with invalid stdout -> stdout error.
+check("opts-bad-stdout", () => {
+  new Console({ stdout: {} });
+});
+
+// options-bag form, valid stdout, invalid stderr -> stderr error.
+check("opts-bad-stderr", () => {
+  new Console({ stdout: { write() {} }, stderr: {} });
+});
+
+// options-bag form, valid stdout and stderr -> accepted.
+check("opts-both-ok", () => {
+  const c = new Console({ stdout: { write() {} }, stderr: { write() {} } });
+  void c;
+});


### PR DESCRIPTION
## Summary
- route `new Console(stdout, stderr)` through a two-argument runtime constructor instead of dropping the second stream
- validate positional stderr with the same Node-compatible writable stream checks used for stdout/options objects
- add a gap test covering missing/invalid stdout, positional stderr, and options-bag stderr cases

## Verification
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `cargo check -p perry-runtime -p perry-codegen`
- `cargo build --release -p perry`
- `target/release/perry compile test-files/test_gap_console_validate_write.ts -o /tmp/perry-test-gap-console-validate-current`
- `/tmp/perry-test-gap-console-validate-current`
- `node --experimental-strip-types test-files/test_gap_console_validate_write.ts`