### PR TITLE
fix(stream): compose source through transform stage

### DIFF
--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -937,6 +937,11 @@ pub extern "C" fn js_node_stream_compose_args(args: *const crate::array::ArrayHe
     if args.len() == 1 {
         return node_stream_duplex_from_source_chunks(args[0]);
     }
+    if args.len() == 2 {
+        if let Some(readable) = compose_readable_snapshot(args[0], args[1]) {
+            return node_stream_duplex_from_source_chunks(readable);
+        }
+    }
     js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
 }
 

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -601,6 +601,34 @@ fn transform_pipe_chain_applies_callback_output() {
 }
 
 #[test]
+fn compose_source_transform_applies_stage_snapshot() {
+    TRANSFORM_THIS_HAS_STREAM_STATE.with(|matches| matches.borrow_mut().clear());
+
+    let mut chunks = crate::array::js_array_alloc(1);
+    chunks = crate::array::js_array_push_f64(chunks, string_value("ab"));
+    let src = js_node_stream_readable_from(box_pointer(chunks as *const u8));
+
+    let opts = crate::object::js_object_alloc(0, 1);
+    let transform_cb = js_closure_alloc(transform_upper_callback as *const u8, 0);
+    crate::closure::js_register_closure_arity(transform_upper_callback as *const u8, 3);
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"transform"),
+        box_pointer(transform_cb as *const u8),
+    );
+    let upper = js_node_stream_transform_new(box_pointer(opts as *const u8));
+
+    let mut args = crate::array::js_array_alloc(2);
+    args = crate::array::js_array_push_f64(args, src);
+    args = crate::array::js_array_push_f64(args, upper);
+    let composed = js_node_stream_compose_args(args);
+
+    assert_eq!(js_node_stream_collect_bytes(composed), b"AB".to_vec());
+    TRANSFORM_THIS_HAS_STREAM_STATE
+        .with(|matches| assert_eq!(matches.borrow().as_slice(), &[true]));
+}
+
+#[test]
 fn transform_flush_callback_pushes_tail_before_finish() {
     READABLE_DATA_CAPTURED.with(|captured| captured.borrow_mut().clear());
     TRANSFORM_THIS_HAS_STREAM_STATE.with(|matches| matches.borrow_mut().clear());

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -242,12 +242,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose() async-gen handler throw \u2014 composite does not emit 'error'. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/compose/buffer-preserves": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: compose() \u2014 Buffer chunks not preserved through pipeline (typed as string?). Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/compose/error-propagates-to-source": {
     "issue": "1531",
     "added": "2026-05-24",
@@ -271,12 +265,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: ReadableStream.from(asyncGen()) \u2014 iteration wrong or fails. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/readable/compose-with-passthrough": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: compose(src, PassThrough) \u2014 data not preserved through PT in composite. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/web/double-pipe-through": {
     "issue": "1545",


### PR DESCRIPTION
## Summary
- make two-argument `stream.compose(source, transform)` snapshot the source through the transform stage instead of returning the source unchanged
- add runtime coverage for source-to-transform compose snapshots
- unskip the two node-suite parity cases that now pass

## Verification
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD && git diff --check`
- `cargo test -p perry-runtime compose_source_transform_applies_stage_snapshot`
- `cargo check -p perry-runtime`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/compose/buffer-preserves`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/readable/compose-with-passthrough`