### PR TITLE
test(parity): unskip stream on smoke

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -152,12 +152,6 @@
     "category": "ci-env",
     "reason": "Tracked in #1634 (parity CI environment fixtures). Ramda npm-package fixture failure on Linux CI; observed on #1038's CI run pre-merge. Companion to the existing test_ramda_user_import skip in the compile-smoke list \u2014 the parity harness can't npm-install ramda. File a CI-side fixture issue if/when this matters for sweep coverage."
   },
-  "test_stream_on": {
-    "issue": "1532",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream EventEmitter wiring incomplete \u2014 re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS. Real Perry gap (not ci-env); rolled under the open stream-events tracker #1532."
-  },
   "node-suite/stream/readable/wrap-old-stream": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- remove `test_stream_on` from the parity known-failures file now that it passes locally
- keep this PR scoped to the allowlist change only

## Verification
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD && git diff --check`
- `cargo fmt --all -- --check`
- `./run_parity_tests.sh --filter test_stream_on`