### PR TITLE
test(parity): unskip Duplex.from async iterable

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -200,12 +200,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose(readable, asyncGenFn) \u2014 fails to compile (single-fn compose form not yet wired). Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/duplex/from-async-iterable": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: Duplex.from(asyncIterable) \u2014 async-gen \u2192 Duplex form not yet wired. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/compose/compose-array-form": {
     "issue": "1531",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- remove `node-suite/stream/duplex/from-async-iterable` from the known-failures list now that the fixture passes
- keep the branch scoped to parity allowlist cleanup only

## Verification
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD && git diff --check`
- `cargo fmt --all -- --check`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/duplex/from-async-iterable`