### PR TITLE
fix(stream): call source iterator return on early break

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -73,6 +73,7 @@ const DUPLEX_SHAPE_ID: u32 = 0x7FFF_FEE0;
 // can't collide as method sets grow.
 const WEB_STREAM_SHAPE_ID: u32 = 0x7FFF_FF20;
 const READABLE_CHUNKS_KEY: &[u8] = b"__perryReadableChunks";
+const READABLE_SOURCE_ITERATOR_KEY: &[u8] = b"__perryReadableSourceIterator";
 const READABLE_ERROR_KEY: &[u8] = b"__perryReadableError";
 const READABLE_SIGNAL_KEY: &[u8] = b"__perryReadableSignal";
 const READABLE_READ_KEY: &[u8] = b"__perryReadableRead";

--- a/crates/perry-runtime/src/node_stream/async_iterator.rs
+++ b/crates/perry-runtime/src/node_stream/async_iterator.rs
@@ -102,6 +102,41 @@ fn set_stream_consume_index(stream: f64, index: u32) {
     );
 }
 
+fn settle_iterator_return_value(value: f64) {
+    if crate::promise::js_value_is_promise(value) == 0 {
+        return;
+    }
+    let promise = crate::value::js_nanbox_get_pointer(value) as *mut crate::promise::Promise;
+    if promise.is_null() {
+        return;
+    }
+    for _ in 0..10_000 {
+        if unsafe { (*promise).state } != crate::promise::PromiseState::Pending {
+            return;
+        }
+        if crate::promise::js_promise_run_microtasks() == 0 {
+            return;
+        }
+    }
+}
+
+fn call_source_iterator_return(stream: f64) {
+    let Some(source_iterator) = get_hidden_value(stream, hidden_key(READABLE_SOURCE_ITERATOR_KEY))
+    else {
+        return;
+    };
+    let returned = unsafe {
+        crate::object::js_native_call_method(
+            source_iterator,
+            b"return".as_ptr() as *const i8,
+            6,
+            std::ptr::null(),
+            0,
+        )
+    };
+    settle_iterator_return_value(returned);
+}
+
 extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
     let iterator = this_value(closure);
     if get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_DONE_KEY))
@@ -179,6 +214,7 @@ extern "C" fn ns_readable_iterator_return(closure: *const ClosureHeader) -> f64 
     );
     if !already_done && iterator_has_yielded(iterator) && iterator_destroys_on_return(iterator) {
         if let Some(stream) = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_STREAM_KEY)) {
+            call_source_iterator_return(stream);
             destroy_stream(stream, f64::from_bits(TAG_UNDEFINED));
         }
     }

--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -664,9 +664,20 @@ pub extern "C" fn js_node_stream_readable_from_options(iterable: f64, opts: f64)
         let trap_buf = crate::exception::js_try_push();
         let jumped = unsafe { crate::ffi::setjmp::setjmp(trap_buf as *mut c_int) };
         if jumped == 0 {
-            let chunks = normalize_readable_from_input(iterable);
+            let normalized = normalize_readable_from_input(iterable);
             crate::exception::js_try_end();
-            js_object_set_field_by_name(raw as *mut ObjectHeader, hidden_chunks_key(), chunks);
+            js_object_set_field_by_name(
+                raw as *mut ObjectHeader,
+                hidden_chunks_key(),
+                normalized.chunks,
+            );
+            if let Some(source_iterator) = normalized.source_iterator {
+                js_object_set_field_by_name(
+                    raw as *mut ObjectHeader,
+                    hidden_key(READABLE_SOURCE_ITERATOR_KEY),
+                    source_iterator,
+                );
+            }
         } else {
             let err = crate::exception::js_get_exception();
             crate::exception::js_clear_exception();

--- a/crates/perry-runtime/src/node_stream_iter_helpers.rs
+++ b/crates/perry-runtime/src/node_stream_iter_helpers.rs
@@ -670,14 +670,19 @@ pub(super) extern "C" fn ns_iter_flat_map(
 ///
 /// `None` signals "not iterable" so the caller can fall back to the
 /// "append as a single chunk" path that pre-#1572 was the only branch.
-pub(super) fn flatten_async_iterable_value(value: f64) -> Option<*mut crate::array::ArrayHeader> {
+pub(super) fn flatten_async_iterable_with_source(
+    value: f64,
+) -> Option<(*mut crate::array::ArrayHeader, Option<f64>)> {
     use crate::array::{
         async_iterator_to_array_for_flat_map, call_symbol_async_iterator_for_flat_map,
         has_iterator_next,
     };
     use crate::symbol::js_get_iterator;
     if let Some(async_iter) = call_symbol_async_iterator_for_flat_map(value) {
-        return Some(async_iterator_to_array_for_flat_map(async_iter));
+        return Some((
+            async_iterator_to_array_for_flat_map(async_iter),
+            Some(async_iter),
+        ));
     }
     if has_iterator_next(value) {
         // Async generator step values may be already-settled promises that
@@ -685,13 +690,20 @@ pub(super) fn flatten_async_iterable_value(value: f64) -> Option<*mut crate::arr
         // helper for a bare-iterator receiver too — `js_async_iterator_to_array`
         // is a strict superset of `js_iterator_to_array` (it transparently
         // returns non-promise step results unchanged).
-        return Some(async_iterator_to_array_for_flat_map(value));
+        return Some((async_iterator_to_array_for_flat_map(value), Some(value)));
     }
     let sync_iter = js_get_iterator(value);
     if sync_iter.to_bits() != value.to_bits() {
-        return Some(async_iterator_to_array_for_flat_map(sync_iter));
+        return Some((
+            async_iterator_to_array_for_flat_map(sync_iter),
+            Some(sync_iter),
+        ));
     }
     None
+}
+
+pub(super) fn flatten_async_iterable_value(value: f64) -> Option<*mut crate::array::ArrayHeader> {
+    flatten_async_iterable_with_source(value).map(|(chunks, _)| chunks)
 }
 
 pub(super) extern "C" fn ns_iter_take(closure: *const ClosureHeader, count: f64) -> f64 {

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -1540,9 +1540,21 @@ pub(super) fn collection_iterable_chunks(raw: usize) -> Option<f64> {
     None
 }
 
-pub(super) fn normalize_readable_from_input(iterable: f64) -> f64 {
+pub(super) struct NormalizedReadableInput {
+    pub chunks: f64,
+    pub source_iterator: Option<f64>,
+}
+
+fn normalized_readable_chunks(chunks: f64) -> NormalizedReadableInput {
+    NormalizedReadableInput {
+        chunks,
+        source_iterator: None,
+    }
+}
+
+pub(super) fn normalize_readable_from_input(iterable: f64) -> NormalizedReadableInput {
     if let Some(chunks) = readable_hidden_chunks(iterable) {
-        return chunks;
+        return normalized_readable_chunks(chunks);
     }
     let raw = raw_ptr_from_value(iterable);
     if raw >= 0x10000
@@ -1550,43 +1562,53 @@ pub(super) fn normalize_readable_from_input(iterable: f64) -> f64 {
         && crate::buffer::is_uint8array_buffer(raw)
         && !crate::buffer::is_array_buffer(raw)
     {
-        return uint8array_byte_chunks(raw);
+        return normalized_readable_chunks(uint8array_byte_chunks(raw));
     }
     if let Some(chunks) = typed_uint8array_byte_chunks(raw) {
-        return chunks;
+        return normalized_readable_chunks(chunks);
     }
     if let Some(chunks) = collection_iterable_chunks(raw) {
-        return chunks;
+        return normalized_readable_chunks(chunks);
     }
     if is_array_like_value(iterable) {
-        return iterable;
+        return normalized_readable_chunks(iterable);
     }
     if is_single_chunk_value(iterable) {
         let arr = crate::array::js_array_alloc(1);
         let arr = crate::array::js_array_push_f64(arr, iterable);
-        return box_pointer(arr as *const u8);
+        return normalized_readable_chunks(box_pointer(arr as *const u8));
     }
-    if let Some(chunks) = flatten_async_iterable_value(iterable) {
-        return box_pointer(chunks as *const u8);
+    if let Some((chunks, source_iterator)) = flatten_async_iterable_with_source(iterable) {
+        return NormalizedReadableInput {
+            chunks: box_pointer(chunks as *const u8),
+            source_iterator,
+        };
     }
-    if let Some(chunks) = flatten_sync_iterable_value(iterable) {
-        return box_pointer(chunks as *const u8);
+    if let Some((chunks, source_iterator)) = flatten_sync_iterable_value(iterable) {
+        return NormalizedReadableInput {
+            chunks: box_pointer(chunks as *const u8),
+            source_iterator,
+        };
     }
 
     let arr = crate::array::js_array_alloc(1);
-    box_pointer(arr as *const u8)
+    normalized_readable_chunks(box_pointer(arr as *const u8))
 }
 
-fn flatten_sync_iterable_value(value: f64) -> Option<*mut crate::array::ArrayHeader> {
+fn flatten_sync_iterable_value(
+    value: f64,
+) -> Option<(*mut crate::array::ArrayHeader, Option<f64>)> {
     if has_symbol_async_iterator(value) {
         return None;
     }
     if crate::object::js_util_types_is_generator_object(value).to_bits() == TAG_TRUE {
-        return crate::array::sync_iterator_to_array_if_not_async(value);
+        return crate::array::sync_iterator_to_array_if_not_async(value)
+            .map(|chunks| (chunks, Some(value)));
     }
     let iter = crate::symbol::js_get_iterator(value);
     if iter.to_bits() != value.to_bits() {
-        return crate::array::sync_iterator_to_array_if_not_async(iter);
+        return crate::array::sync_iterator_to_array_if_not_async(iter)
+            .map(|chunks| (chunks, Some(iter)));
     }
     None
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -308,12 +308,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: cancel() during pull \u2014 read() does not resolve {done:true}. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/readable/iter-with-custom-return": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: for-await break \u2014 custom iterator.return() not invoked. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/compose/three-stages-order": {
     "issue": "1531",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- keep track of the source iterator used by `Readable.from()` when snapshotting iterable input
- call the source iterator `return()` path when a readable async iterator is broken early and would destroy the stream
- unskip the `iter-with-custom-return` node-suite parity fixture

## Verification
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD && git diff --check`
- `cargo check -p perry-runtime`
- `cargo test -p perry-runtime node_stream`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/readable/iter-with-custom-return`