### PR TITLE
fix(stream): initialize Transform subclasses

### DIFF
--- a/crates/perry-codegen/src/codegen/method.rs
+++ b/crates/perry-codegen/src/codegen/method.rs
@@ -25,6 +25,7 @@ fn node_stream_parent_kind(
         match name {
             "Readable" => return Some("readable"),
             "Duplex" => return Some("duplex"),
+            "Transform" => return Some("transform"),
             _ => {}
         }
         cur = classes
@@ -293,6 +294,7 @@ pub(super) fn compile_method(
             let builtin_parent_runtime = match class.extends_name.as_deref() {
                 Some("Writable") => Some("js_node_stream_writable_subclass_init"),
                 Some("Duplex") => Some("js_node_stream_duplex_subclass_init"),
+                Some("Transform") => Some("js_node_stream_transform_subclass_init"),
                 _ => None,
             };
             let mut effective_parent: Option<&str> = if builtin_parent_runtime.is_some() {
@@ -334,6 +336,7 @@ pub(super) fn compile_method(
                     let runtime_fn = match kind {
                         "readable" => "js_node_stream_readable_subclass_init",
                         "duplex" => "js_node_stream_duplex_subclass_init",
+                        "transform" => "js_node_stream_transform_subclass_init",
                         _ => unreachable!("node stream parent kind {}", kind),
                     };
                     ctx.block().call(

--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -131,6 +131,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             | "AggregateError"
                             | "Readable"
                             | "Writable"
+                            | "Duplex"
+                            | "Transform"
                             | "ReadableStream"
                             | "WritableStream"
                             | "TransformStream"
@@ -226,6 +228,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     let node_stream_kind = match parent_name.as_str() {
                         "Writable" => Some("writable"),
                         "Duplex" => Some("duplex"),
+                        "Transform" => Some("transform"),
                         _ => None,
                     };
                     if let Some(kind) = node_stream_kind {
@@ -271,6 +274,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     let node_stream_kind = match parent_name.as_str() {
                         "Readable" => Some("readable"),
                         "Duplex" => Some("duplex"),
+                        "Transform" => Some("transform"),
                         _ => None,
                     };
                     if let Some(kind) = node_stream_kind {

--- a/crates/perry-codegen/src/expr/write_barrier.rs
+++ b/crates/perry-codegen/src/expr/write_barrier.rs
@@ -272,6 +272,7 @@ pub(crate) fn lower_node_stream_super_init(
         "readable" => "js_node_stream_readable_subclass_init",
         "writable" => "js_node_stream_writable_subclass_init",
         "duplex" => "js_node_stream_duplex_subclass_init",
+        "transform" => "js_node_stream_transform_subclass_init",
         _ => unreachable!(
             "lower_node_stream_super_init: unexpected Node stream kind {}",
             kind

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -20,6 +20,7 @@ fn node_stream_parent_kind(ctx: &FnCtx<'_>, class: &perry_hir::Class) -> Option<
         match name {
             "Readable" => return Some("readable"),
             "Duplex" => return Some("duplex"),
+            "Transform" => return Some("transform"),
             _ => {}
         }
         if ctx.imported_class_ctors.contains_key(name) {
@@ -467,6 +468,7 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
         match class.extends_name.as_deref() {
             Some("Writable") => Some("js_node_stream_writable_subclass_init"),
             Some("Duplex") => Some("js_node_stream_duplex_subclass_init"),
+            Some("Transform") => Some("js_node_stream_transform_subclass_init"),
             _ => None,
         }
     } else {
@@ -607,6 +609,7 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
                 let runtime_fn = match kind {
                     "readable" => "js_node_stream_readable_subclass_init",
                     "duplex" => "js_node_stream_duplex_subclass_init",
+                    "transform" => "js_node_stream_transform_subclass_init",
                     _ => unreachable!("node stream parent kind {}", kind),
                 };
                 ctx.block().call(

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -910,6 +910,11 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
         &[DOUBLE, DOUBLE],
     );
     module.declare_function("js_node_stream_transform_new", DOUBLE, &[DOUBLE]);
+    module.declare_function(
+        "js_node_stream_transform_subclass_init",
+        DOUBLE,
+        &[DOUBLE, DOUBLE],
+    );
     module.declare_function("js_node_stream_passthrough_new", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_readable_from", DOUBLE, &[DOUBLE]);
     module.declare_function(

--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -632,6 +632,47 @@ pub extern "C" fn js_node_stream_transform_new(opts: f64) -> f64 {
 }
 
 #[no_mangle]
+pub extern "C" fn js_node_stream_transform_subclass_init(this: f64, opts: f64) -> f64 {
+    let transform = js_node_stream_duplex_subclass_init(this, opts);
+    let raw = raw_ptr_from_value(transform);
+    if raw == 0 {
+        return transform;
+    }
+    if unsafe { gc_type_for_ptr(raw) } != Some(crate::gc::GC_TYPE_OBJECT) {
+        return transform;
+    }
+
+    let obj = raw as *mut ObjectHeader;
+    let subclass_transform = js_object_get_field_by_name_f64(obj, hidden_key(b"_transform"));
+    let subclass_flush = js_object_get_field_by_name_f64(obj, hidden_key(b"_flush"));
+
+    if let Some(callback) = transform_callback_from_options(opts) {
+        set_hidden_value(
+            transform,
+            hidden_transform_callback_key(),
+            rebind_callback_this(callback, transform),
+        );
+    } else if is_callable_value(subclass_transform) {
+        set_hidden_value(
+            transform,
+            hidden_transform_callback_key(),
+            subclass_transform,
+        );
+    }
+    if let Some(flush) = transform_flush_from_options(opts) {
+        set_hidden_value(
+            transform,
+            hidden_transform_flush_key(),
+            rebind_callback_this(flush, transform),
+        );
+    } else if is_callable_value(subclass_flush) {
+        set_hidden_value(transform, hidden_transform_flush_key(), subclass_flush);
+    }
+    init_constructor(transform, "Transform");
+    transform
+}
+
+#[no_mangle]
 pub extern "C" fn js_node_stream_passthrough_new(opts: f64) -> f64 {
     let passthrough = js_node_stream_duplex_new(opts);
     set_hidden_value(

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -170,12 +170,6 @@
     "category": "bug-open",
     "reason": "node:stream: stream.compose() composite Duplex doesn't forward data through the chain, so the joined output never arrives. Shape sub-tests pass; reopened #1539 for pipeline execution."
   },
-  "node-suite/stream/subclass/extends-transform": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: class extends Transform + _transform doesn't deliver. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/compose/with-async-fn": {
     "issue": "1539",
     "added": "2026-05-24",


### PR DESCRIPTION
## Summary
- add a Transform subclass initialization path that reuses Duplex setup on the existing subclass object
- capture subclass `_transform` / `_flush` methods or constructor option callbacks for Transform stream behavior
- teach codegen super/new lowering that `Transform` is a native stream superclass and unskip the matching parity fixture

## Verification
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD && git diff --check`
- `cargo check -p perry-runtime -p perry-codegen -p perry`
- `cargo test -p perry-runtime node_stream`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/subclass/extends-transform`