### PR TITLE
fix(runtime): restore default auto-optimize compile via keepalive anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1043 — fix(runtime): restore the default auto-optimize compile (keepalive anchors)
+
+The default `perry file.ts -o out` flow (auto-optimize on) was broken on `main`:
+linking failed with `Undefined symbols for architecture arm64` for
+`_js_write_barrier_root_nanbox`, `_js_write_barrier_root_heap_word`, and
+`_js_array_join_value`. Any program with module-level string variables (which
+emit barrier-root calls in `__perry_init_strings`) or an `arr.join(sep)` call
+could not compile.
+
+**Root cause.** #2345 ("Tighten GC root and barrier contracts") added the two
+`js_write_barrier_root_*` entry points and made codegen emit them, but added no
+symbol-retention anchor. `js_array_join_value` has the same exposure. These are
+`#[no_mangle]` functions called only from generated code (and, for join, an
+in-crate caller behind a dispatch path the optimizer can prove unreachable). The
+default `.a` staticlib keeps them via staticlib-export semantics, but the
+auto-optimize build round-trips the runtime through whole-program LLVM bitcode
+and is free to internalize and dead-strip an unreferenced `#[no_mangle]` symbol —
+so the auto-optimized `libperry_runtime.a` dropped all three, breaking the link.
+PR CI did not catch this because `compile-smoke` is gated to tag pushes only
+(v0.5.1018), not PRs.
+
+**Fix.** Add `#[used]` keepalive anchors for the three symbols — `KEEP_*` statics
+holding their function pointers — mirroring the established pattern in
+`node_stream_keepalive.rs` / `typedarray.rs`. The anchors pin retained reference
+edges so the symbols survive every link mode (default staticlib + auto-optimize
+bitcode). Verified by clearing the `perry-auto-*` cache and compiling/running
+representative programs (module strings, classes, async/await, `arr.join`,
+objects, `Map`/`Set`, `JSON.stringify`, `reduce`) with auto-optimize on — all
+link and produce correct output, and the three symbols are present in the
+rebuilt auto-optimized runtime lib.
+
 ## v0.5.1042 — validate AsyncLocalStorage run/exit callbacks (#3092)
 
 `AsyncLocalStorage#run(store, callback, ...)` and `#exit(callback, ...)` lowered

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1042
+**Current Version:** 0.5.1043
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4880,7 +4880,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "anyhow",
  "base64",
@@ -4935,14 +4935,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "cc",
  "libc",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "anyhow",
  "log",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "anyhow",
  "base64",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "serde",
  "serde_json",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1042"
+version = "0.5.1043"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "anyhow",
  "clap",
@@ -5056,14 +5056,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "chrono",
  "cron",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5162,14 +5162,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "base64",
  "image",
@@ -5354,14 +5354,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5388,7 +5388,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "brotli",
  "flate2",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "anyhow",
  "base64",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5571,14 +5571,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "base64",
  "itoa",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "base64",
  "block2",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "base64",
  "block2",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1042"
+version = "0.5.1043"
 
 [[package]]
 name = "perry-ui-test"
@@ -5667,11 +5667,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1042"
+version = "0.5.1043"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "base64",
  "block2",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "base64",
  "block2",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "block2",
  "libc",
@@ -5716,7 +5716,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "base64",
  "libc",
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1042"
+version = "0.5.1043"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1042"
+version = "0.5.1043"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -760,3 +760,15 @@ pub extern "C" fn js_array_join_value(
     };
     js_array_join(arr, separator)
 }
+
+// Symbol retention: codegen lowers `arr.join(sep)` to a call to
+// `js_array_join_value`, but its only in-crate caller sits behind a dispatch
+// path the auto-optimize whole-program-bitcode build can prove unreachable and
+// dead-strip — which broke the default `perry file.ts -o out` link with
+// `undefined _js_array_join_value`. The `#[used]` static pins the symbol so it
+// survives every link mode. Same pattern as `node_stream_keepalive.rs`.
+#[used]
+static KEEP_ARRAY_JOIN_VALUE: extern "C" fn(
+    *const ArrayHeader,
+    f64,
+) -> *mut crate::string::StringHeader = js_array_join_value;

--- a/crates/perry-runtime/src/gc/barrier.rs
+++ b/crates/perry-runtime/src/gc/barrier.rs
@@ -1290,6 +1290,20 @@ pub extern "C" fn js_write_barrier_root_nanbox(value_bits: u64) {
     runtime_write_barrier_root_nanbox(value_bits);
 }
 
+// #2345 symbol retention. Codegen emits calls to these two root write-barrier
+// entry points from `__perry_init_strings` (module-level string roots), but no
+// Rust caller in the crate graph references them. The default `.a` staticlib
+// keeps them via staticlib-export semantics; the auto-optimize build round-trips
+// the runtime through whole-program LLVM bitcode and is free to internalize and
+// dead-strip an unreferenced `#[no_mangle]` symbol — which broke the default
+// `perry file.ts -o out` link with `undefined _js_write_barrier_root_*`. The
+// `#[used]` statics pin retained reference edges so both survive every link mode.
+// Same pattern as `node_stream_keepalive.rs` / `typedarray.rs`.
+#[used]
+static KEEP_WRITE_BARRIER_ROOT_HEAP_WORD: extern "C" fn(u64) = js_write_barrier_root_heap_word;
+#[used]
+static KEEP_WRITE_BARRIER_ROOT_NANBOX: extern "C" fn(u64) = js_write_barrier_root_nanbox;
+
 #[inline]
 pub(crate) fn runtime_store_gc_heap_word_slot(
     parent_user: usize,


### PR DESCRIPTION
## Summary

The **default** `perry file.ts -o out` flow (auto-optimize on) was broken on `main`. Linking failed with:

```
Undefined symbols for architecture arm64:
  "_js_array_join_value", referenced from: _main in <prog>.o
  "_js_write_barrier_root_heap_word", referenced from: ___perry_init_strings_<prog>
  "_js_write_barrier_root_nanbox", referenced from: ___perry_init_strings_<prog>
ld: symbol(s) not found for architecture arm64
```

Any program with **module-level string variables** (which emit barrier-root calls in `__perry_init_strings`) or an **`arr.join(sep)`** call could not compile by default. A minimal `class` + `const` + `.join()` + `async` program reproduces it.

## Root cause

`#2345` ("Tighten GC root and barrier contracts") added the two `js_write_barrier_root_*` entry points and made codegen emit them, but added **no symbol-retention anchor**. `js_array_join_value` has the same exposure (its only in-crate caller sits behind a dispatch path the optimizer can prove unreachable).

These are `#[no_mangle]` functions called only from generated code. The default `.a` staticlib keeps them via staticlib-export semantics, but the **auto-optimize build round-trips the runtime through whole-program LLVM bitcode** and is free to internalize and dead-strip an unreferenced `#[no_mangle]` symbol — so the auto-optimized `libperry_runtime.a` dropped all three.

PR CI did **not** catch this because `compile-smoke` is gated to tag pushes only (v0.5.1018), not PRs.

## Fix

Add `#[used]` keepalive anchors (`KEEP_*` statics holding the function pointers) for the three symbols, mirroring the established pattern in `node_stream_keepalive.rs` / `typedarray.rs`. The anchors pin retained reference edges so the symbols survive every link mode (default staticlib + auto-optimize bitcode).

## Validation

- Cleared the `perry-auto-*` cache to force a fresh auto-optimize runtime rebuild.
- Compiled + ran representative programs **with auto-optimize on**: module strings, classes, `async`/`await`, `arr.join`, object literals, `Map`/`Set`, `JSON.stringify`, `reduce`, `for...of` destructuring — all link and produce correct output.
- Confirmed all three symbols (`js_array_join_value`, `js_write_barrier_root_nanbox`, `js_write_barrier_root_heap_word`) are present in the rebuilt auto-optimized runtime lib.
- `cargo fmt --all -- --check`, file-size gate, and the full workspace test suite are green; no API-docs drift.
