### PR TITLE
fix(stream): handle single transform compose

### DIFF
--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -972,7 +972,8 @@ pub extern "C" fn js_node_stream_duplex_from_options(body: f64, _opts: f64) -> f
 /// #1539: `stream.compose(...streams)` chains a sequence of streams
 /// into one composite Duplex (data flows through them in order). Perry
 /// now handles Node's single-source fast path by returning a Duplex
-/// wrapper whose readable side drains the source snapshot; multi-stage
+/// wrapper whose readable side drains the source snapshot, and the
+/// single-Transform stage form by returning the stage itself. Multi-stage
 /// composition remains tracked separately.
 #[no_mangle]
 pub extern "C" fn js_node_stream_compose(args: *const crate::array::ArrayHeader) -> f64 {
@@ -987,6 +988,9 @@ pub extern "C" fn js_node_stream_compose_args(args: *const crate::array::ArrayHe
         throw_pipeline_missing_streams();
     }
     if args.len() == 1 {
+        if is_transform_stream(args[0]) {
+            return args[0];
+        }
         return node_stream_duplex_from_source_chunks(args[0]);
     }
     if args.len() == 2 {

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -629,6 +629,51 @@ fn compose_source_transform_applies_stage_snapshot() {
 }
 
 #[test]
+fn compose_single_transform_returns_stage() {
+    READABLE_DATA_CAPTURED.with(|captured| captured.borrow_mut().clear());
+    TRANSFORM_THIS_HAS_STREAM_STATE.with(|matches| matches.borrow_mut().clear());
+
+    let opts = crate::object::js_object_alloc(0, 1);
+    let transform_cb = js_closure_alloc(transform_upper_callback as *const u8, 0);
+    crate::closure::js_register_closure_arity(transform_upper_callback as *const u8, 3);
+    js_object_set_field_by_name(
+        opts,
+        hidden_key(b"transform"),
+        box_pointer(transform_cb as *const u8),
+    );
+    let upper = js_node_stream_transform_new(box_pointer(opts as *const u8));
+
+    let mut args = crate::array::js_array_alloc(1);
+    args = crate::array::js_array_push_f64(args, upper);
+    let composed = js_node_stream_compose_args(args);
+    assert_eq!(composed.to_bits(), upper.to_bits());
+
+    let handle = raw_ptr_from_value(composed) as i64;
+    let data_closure = js_closure_alloc(capture_data_listener as *const u8, 1);
+    crate::closure::js_register_closure_arity(capture_data_listener as *const u8, 1);
+    crate::closure::js_closure_set_capture_f64(data_closure, 0, composed);
+    let _ = js_node_stream_method_on(
+        handle,
+        string_value("data"),
+        box_pointer(data_closure as *const u8),
+    );
+
+    let _ = js_node_stream_method_write(
+        handle,
+        string_value("ab"),
+        f64::from_bits(TAG_UNDEFINED),
+        f64::from_bits(TAG_UNDEFINED),
+    );
+    let _ = js_node_stream_method_end(handle, f64::from_bits(TAG_UNDEFINED));
+
+    READABLE_DATA_CAPTURED.with(|captured| {
+        assert_eq!(captured.borrow().as_slice(), &[b"AB".to_vec()]);
+    });
+    TRANSFORM_THIS_HAS_STREAM_STATE
+        .with(|matches| assert_eq!(matches.borrow().as_slice(), &[true]));
+}
+
+#[test]
 fn transform_flush_callback_pushes_tail_before_finish() {
     READABLE_DATA_CAPTURED.with(|captured| captured.borrow_mut().clear());
     TRANSFORM_THIS_HAS_STREAM_STATE.with(|matches| matches.borrow_mut().clear());

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -170,12 +170,6 @@
     "category": "bug-open",
     "reason": "node:stream: stream.compose(asyncGenerator) doesn't run the async stage / forward data. Reopened #1539 for pipeline execution."
   },
-  "node-suite/stream/compose/single-transform": {
-    "issue": "1532",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: stream.compose(single-transform) does not deliver data through. Flips to PASS when #1532 lands."
-  },
   "node-suite/stream/compose/single-sync-fn": {
     "issue": "1531",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary
- return a single Transform stage directly from `stream.compose(transform)` instead of treating it as an iterable source
- add runtime coverage for the returned stage applying its transform callback
- unskip the Node parity case for `stream.compose(single-transform)`

## Verification
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD && git diff --check`
- `cargo test -p perry-runtime compose_single_transform_returns_stage`
- `cargo check -p perry-runtime`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/compose/single-transform`
- `./run_parity_tests.sh --suite node-suite --filter node-suite/stream/compose/just-source-only`