### PR TITLE
fix(stream/web): dispatch chained pipeThrough

### DIFF
--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -2235,6 +2235,12 @@ pub(crate) unsafe fn dispatch_stream_method(
             "cancel" => return Some(box_promise(js_readable_stream_cancel(handle, arg0))),
             "tee" => return Some(js_readable_stream_tee(handle)),
             "pipeTo" => return Some(box_promise(js_readable_stream_pipe_to(handle, arg0, arg1))),
+            "pipeThrough" => {
+                let transform = js_stream_unwrap_handle(arg0);
+                let writable = js_transform_stream_writable(transform);
+                let readable = js_transform_stream_readable(transform);
+                return Some(js_readable_stream_pipe_through(handle, writable, readable));
+            }
             // #1644: a readable handle is also its own controller. The
             // start/transform/flush callbacks receive it as `controller`, so
             // `controller.enqueue/close/error/terminate` dispatch here when the

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -230,12 +230,6 @@
     "category": "bug-open",
     "reason": "node:stream/web: ReadableStream.from(asyncGen()) \u2014 iteration wrong or fails. Flips to PASS when #1545 lands."
   },
-  "node-suite/stream/web/double-pipe-through": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: pipeThrough().pipeThrough() chain \u2014 second transform output wrong. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/web/writer-write-resolves-after-sink": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -271,12 +265,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: compose(src, t1, PassThrough, t2) \u2014 chain produces wrong output. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/web/transform-piped-twice": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: pipeThrough().pipeThrough() \u2014 second transform output wrong. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/compose/composite-end-event": {
     "issue": "1531",


### PR DESCRIPTION
## Summary
- route generic readable-handle `pipeThrough()` calls through the Web Streams dispatcher
- unwrap TransformStream subclass handles before extracting writable/readable sides
- retire chained `pipeThrough` Web Stream parity known failures

## Verification
- cargo fmt --all -- --check
- ./scripts/check_file_size.sh
- jq empty test-parity/known_failures.json
- git diff --check origin/main...HEAD && git diff --check
- cargo check -p perry-stdlib
- ./run_parity_tests.sh --suite node-suite --filter node-suite/stream/web/double-pipe-through
- ./run_parity_tests.sh --suite node-suite --filter node-suite/stream/web/transform-piped-twice