### PR TITLE
fix(stream/web): propagate transform readable cancel

### DIFF
--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -798,6 +798,9 @@ unsafe fn js_readable_stream_cancel_inner(
         reject_type_error(promise, "ReadableStream is locked");
         return promise;
     }
+    if let Some(writable_id) = transform_writable_for_readable(id) {
+        let _ = js_writable_stream_abort(writable_id as f64, reason);
+    }
     if cb != 0 {
         js_closure_call1(cb as *const ClosureHeader, reason);
     }
@@ -1936,12 +1939,35 @@ lazy_static::lazy_static! {
     static ref TRANSFORM_PAIRS: Mutex<HashMap<usize, usize>> = Mutex::new(HashMap::new());
 }
 
+fn transform_writable_for_readable(readable_id: usize) -> Option<usize> {
+    TRANSFORM_STREAMS
+        .lock()
+        .unwrap()
+        .values()
+        .find_map(|t| (t.readable_handle == readable_id).then_some(t.writable_handle))
+}
+
 /// Replacement `writer.write` for the writable side of a TransformStream
 /// — invokes the user transform with (chunk, transformController) where
 /// the transformController is the readable-side stream handle (so
 /// `controller.enqueue(...)` reuses the readable controller path).
 unsafe fn transform_write(writable_id: usize, chunk: f64) -> *mut Promise {
     let promise = js_promise_new();
+    {
+        let g = WRITABLE_STREAMS.lock().unwrap();
+        match g.get(&writable_id) {
+            Some(s) if s.state == WritableState::Writable => {}
+            Some(s) if s.state == WritableState::Errored => {
+                js_promise_reject(promise, f64::from_bits(s.error_value));
+                return promise;
+            }
+            _ => {
+                let err = make_error_with_message("Stream is closed or closing");
+                js_promise_reject(promise, f64::from_bits(err));
+                return promise;
+            }
+        }
+    }
     let (transform_cb, readable_id) = {
         let pairs = TRANSFORM_PAIRS.lock().unwrap();
         match pairs.get(&writable_id) {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -224,12 +224,6 @@
     "category": "bug-open",
     "reason": "node:stream: compose() \u2014 error in middle transform does not propagate to composite 'error' event. Flips to PASS when #1531 lands."
   },
-  "node-suite/stream/web/transform-cancel-propagates": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: TransformStream readable.cancel() does not propagate to writable \u2014 writes still succeed after cancel. Flips to PASS when #1545 lands."
-  },
   "node-suite/stream/compose/async-handler-promise": {
     "issue": "1531",
     "added": "2026-05-24",
@@ -283,12 +277,6 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: pipeThrough().pipeThrough() chain \u2014 second transform output wrong. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/web/transform-readable-cancel-propagates": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: TS readable.cancel \u2014 writable.write does not reject after. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/web/writer-write-resolves-after-sink": {
     "issue": "1545",


### PR DESCRIPTION
## Summary
- propagate TransformStream readable-side cancellation to the paired writable side
- reject later TransformStream writes when the writable side is errored or closed
- retire the two transform readable-cancel parity known failures

## Verification
- cargo fmt --all -- --check
- ./scripts/check_file_size.sh
- jq empty test-parity/known_failures.json
- git diff --check origin/main...HEAD && git diff --check
- cargo check -p perry-stdlib
- ./run_parity_tests.sh --suite node-suite --filter node-suite/stream/web/transform-cancel-propagates
- ./run_parity_tests.sh --suite node-suite --filter node-suite/stream/web/transform-readable-cancel-propagates
- ./run_parity_tests.sh --suite node-suite --filter node-suite/stream/web/transform-stream