### PR TITLE
fix(worker_threads): expose main thread constants

### DIFF
--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -2467,11 +2467,17 @@ pub(crate) unsafe fn get_native_module_constant(
         // when they should have been running. (#2135)
         "worker_threads" => match property {
             "isMainThread" => Some(f64::from_bits(JSValue::bool(true).bits())),
+            "isInternalThread" => Some(f64::from_bits(JSValue::bool(false).bits())),
+            "parentPort" | "workerData" => Some(f64::from_bits(crate::value::TAG_NULL)),
             "threadId" => Some(0.0),
+            "threadName" => Some(str_val("")),
             "resourceLimits" => {
                 let obj = crate::object::js_object_alloc(0, 0);
                 Some(crate::value::js_nanbox_pointer(obj as i64))
             }
+            "SHARE_ENV" => Some(crate::symbol::js_symbol_for(str_val(
+                "nodejs.worker_threads.SHARE_ENV",
+            ))),
             _ => None,
         },
         // `zlib.constants` and the top-level Z_*/DEFLATE/INFLATE shortcuts

--- a/test-parity/node-suite/worker_threads/main-thread/properties.ts
+++ b/test-parity/node-suite/worker_threads/main-thread/properties.ts
@@ -1,0 +1,10 @@
+import * as worker_threads from "node:worker_threads";
+
+console.log("isMainThread:", worker_threads.isMainThread);
+console.log("isInternalThread:", worker_threads.isInternalThread);
+console.log("parentPort:", worker_threads.parentPort);
+console.log("threadId:", worker_threads.threadId);
+console.log("threadName JSON:", JSON.stringify(worker_threads.threadName));
+console.log("workerData:", worker_threads.workerData);
+console.log("resourceLimits keys:", Object.keys(worker_threads.resourceLimits).length);
+console.log("SHARE_ENV:", String(worker_threads.SHARE_ENV));


### PR DESCRIPTION
## Summary
- expose worker_threads main-thread value exports for namespace property reads
- return Node-shaped null/empty-string/symbol values for parentPort, workerData, threadName, and SHARE_ENV on the main thread
- add a focused worker_threads parity fixture for those property shapes

## Verification
- cargo fmt --all -- --check
- ./scripts/check_file_size.sh
- jq empty test-parity/known_failures.json
- git diff --check origin/main...HEAD && git diff --check
- cargo check -p perry-runtime
- ./run_parity_tests.sh --suite node-suite --filter node-suite/worker_threads/main-thread/properties