### PR TITLE
fix(object): allocate nullish Object calls

### DIFF
--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -204,6 +204,20 @@ extern "C" fn global_this_string_thunk(
     crate::value::js_nanbox_string(string_ptr as i64)
 }
 
+extern "C" fn global_this_object_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    let js_value = crate::value::JSValue::from_bits(value.to_bits());
+    if js_value.is_undefined() || js_value.is_null() {
+        return crate::value::js_nanbox_pointer(js_object_alloc(0, 0) as i64);
+    }
+    if crate::value::js_nanbox_get_pointer(value) != 0 {
+        return value;
+    }
+    crate::value::js_nanbox_pointer(js_object_alloc(0, 0) as i64)
+}
+
 extern "C" fn global_this_structured_clone_thunk(
     _closure: *const crate::closure::ClosureHeader,
     value: f64,
@@ -699,16 +713,16 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             );
             continue;
         }
-        let func_ptr = if name == "String" {
-            global_this_string_thunk as *const u8
-        } else {
-            global_this_builtin_noop_thunk as *const u8
+        let func_ptr = match name {
+            "Object" => global_this_object_thunk as *const u8,
+            "String" => global_this_string_thunk as *const u8,
+            _ => global_this_builtin_noop_thunk as *const u8,
         };
         let closure_ptr = crate::closure::js_closure_alloc(func_ptr, 0);
         if closure_ptr.is_null() {
             continue;
         }
-        if name == "String" {
+        if matches!(name, "Object" | "String") {
             crate::closure::js_register_closure_arity(func_ptr, 1);
         }
         if matches!(name, "File" | "EvalError" | "URIError" | "Uint8Array") {

--- a/test-parity/node-suite/globals/object-nullish-call.ts
+++ b/test-parity/node-suite/globals/object-nullish-call.ts
@@ -1,0 +1,7 @@
+const base = { marker: 1 };
+
+console.log("Object() typeof:", typeof Object());
+console.log("Object(null) typeof:", typeof Object(null));
+console.log("Object(undefined) typeof:", typeof Object(undefined));
+console.log("Object(base) same:", Object(base) === base);
+console.log("new Object(null) typeof:", typeof new Object(null));


### PR DESCRIPTION
## Summary
- add a real global Object call thunk for nullish inputs
- preserve identity when Object() receives an existing object
- add an exact Node parity fixture for Issue #3149 Bug 1

## Scope
This addresses only Issue #3149 Bug 1: Object(), Object(null), and Object(undefined) call-form behavior. Function-declaration reassignment from the same issue is intentionally left out of this PR.

## Verification
- Baseline exact fixture failed before the fix: Object()/Object(null)/Object(undefined) returned undefined and Object(base) did not preserve identity
- ./run_parity_tests.sh --suite node-suite --filter node-suite/globals/object-nullish-call
- ./run_parity_tests.sh --suite node-suite --filter node-suite/globals/global-functions
- cargo fmt --all -- --check
- ./scripts/check_file_size.sh
- jq empty test-parity/known_failures.json
- git diff --check origin/main...HEAD && git diff --check
- cargo check -p perry-runtime