### PR TITLE
fix(fs): deliver EBADF to callback for bad fd in close/fsync/fdatasync/fchmod (#3332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1044 — fix(fs): deliver EBADF to callback for bad fd in close/fsync/fdatasync/fchmod (#3332)
+
+The callback forms of `fs.close`, `fs.fsync`, `fs.fdatasync`, and `fs.fchmod`
+previously routed through the sync helpers (which *throw* `EBADF` on a bad
+descriptor) and then unconditionally invoked the success callback. Node delivers
+the filesystem error to the callback's first argument for these async forms
+rather than throwing synchronously.
+
+Added `fs::validate::fd_open_callback_error(value, syscall)` — it still validates
+the fd *type* synchronously (matching Node's `validateInt32` on a non-numeric
+fd) but returns the `EBADF` error value for a valid-typed-but-unregistered
+descriptor instead of throwing. The four callback wrappers in
+`crates/perry-runtime/src/fs/callbacks.rs` now deliver that error via
+`call_cb_err1(...)` and only run the underlying sync op when the fd is open.
+
+New fixture `test-parity/node-suite/fs/callbacks/fd-callback-errors.ts` proves
+byte-identical `close/fsync/fdatasync/fchmod EBADF <syscall>` output against
+Node v25.
+
 ## v0.5.1043 — fix(runtime): restore the default auto-optimize compile (keepalive anchors)
 
 The default `perry file.ts -o out` flow (auto-optimize on) was broken on `main`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1043
+**Current Version:** 0.5.1044
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4880,7 +4880,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "anyhow",
  "base64",
@@ -4935,14 +4935,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "cc",
  "libc",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "anyhow",
  "log",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "anyhow",
  "base64",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "serde",
  "serde_json",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1043"
+version = "0.5.1044"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "anyhow",
  "clap",
@@ -5056,14 +5056,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "chrono",
  "cron",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5162,14 +5162,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "base64",
  "image",
@@ -5354,14 +5354,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5388,7 +5388,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "brotli",
  "flate2",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "anyhow",
  "base64",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5571,14 +5571,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "base64",
  "itoa",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "base64",
  "block2",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "base64",
  "block2",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1043"
+version = "0.5.1044"
 
 [[package]]
 name = "perry-ui-test"
@@ -5667,11 +5667,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1043"
+version = "0.5.1044"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "base64",
  "block2",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "base64",
  "block2",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "block2",
  "libc",
@@ -5716,7 +5716,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "base64",
  "libc",
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1043"
+version = "0.5.1044"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1043"
+version = "0.5.1044"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/fs/callbacks.rs
+++ b/crates/perry-runtime/src/fs/callbacks.rs
@@ -640,8 +640,15 @@ pub(crate) unsafe fn decode_flags_string(value: f64) -> Option<String> {
 #[no_mangle]
 pub extern "C" fn js_fs_close_callback(fd_value: f64, callback: f64) -> f64 {
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+    let cb = last_callback(&[callback]);
+    // #3332: deliver EBADF to the callback for a bad descriptor rather than
+    // throwing it; the close only runs when the fd is open.
+    if let Some(err_val) = crate::fs::validate::fd_open_callback_error(fd_value, "close") {
+        unsafe { call_cb_err1(cb, err_val) };
+        return f64::from_bits(TAG_UNDEFINED);
+    }
     let _ = js_fs_close_sync(fd_value);
-    call_cb0(last_callback(&[callback]));
+    call_cb0(cb);
     f64::from_bits(TAG_UNDEFINED)
 }
 
@@ -700,8 +707,13 @@ pub extern "C" fn js_fs_ftruncate_callback(fd_value: f64, len_value: f64, callba
 #[no_mangle]
 pub extern "C" fn js_fs_fsync_callback(fd_value: f64, callback: f64) -> f64 {
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+    let cb = last_callback(&[callback]);
+    if let Some(err_val) = crate::fs::validate::fd_open_callback_error(fd_value, "fsync") {
+        unsafe { call_cb_err1(cb, err_val) };
+        return f64::from_bits(TAG_UNDEFINED);
+    }
     let _ = js_fs_fsync_sync(fd_value);
-    call_cb0(last_callback(&[callback]));
+    call_cb0(cb);
     f64::from_bits(TAG_UNDEFINED)
 }
 
@@ -709,8 +721,13 @@ pub extern "C" fn js_fs_fsync_callback(fd_value: f64, callback: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_fs_fdatasync_callback(fd_value: f64, callback: f64) -> f64 {
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+    let cb = last_callback(&[callback]);
+    if let Some(err_val) = crate::fs::validate::fd_open_callback_error(fd_value, "fdatasync") {
+        unsafe { call_cb_err1(cb, err_val) };
+        return f64::from_bits(TAG_UNDEFINED);
+    }
     let _ = js_fs_fdatasync_sync(fd_value);
-    call_cb0(last_callback(&[callback]));
+    call_cb0(cb);
     f64::from_bits(TAG_UNDEFINED)
 }
 
@@ -718,8 +735,13 @@ pub extern "C" fn js_fs_fdatasync_callback(fd_value: f64, callback: f64) -> f64 
 #[no_mangle]
 pub extern "C" fn js_fs_fchmod_callback(fd_value: f64, mode_value: f64, callback: f64) -> f64 {
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+    let cb = last_callback(&[callback]);
+    if let Some(err_val) = crate::fs::validate::fd_open_callback_error(fd_value, "fchmod") {
+        unsafe { call_cb_err1(cb, err_val) };
+        return f64::from_bits(TAG_UNDEFINED);
+    }
     let _ = js_fs_fchmod_sync(fd_value, mode_value);
-    call_cb0(last_callback(&[callback]));
+    call_cb0(cb);
     f64::from_bits(TAG_UNDEFINED)
 }
 

--- a/crates/perry-runtime/src/fs/validate.rs
+++ b/crates/perry-runtime/src/fs/validate.rs
@@ -258,6 +258,24 @@ pub(crate) fn throw_ebadf_pub(syscall: &'static str) -> ! {
     throw_ebadf(syscall)
 }
 
+/// Issue #3332 — callback-style fd helpers (`fs.close`, `fs.fsync`,
+/// `fs.fdatasync`, `fs.fchmod`) must DELIVER the `EBADF` error to the
+/// callback rather than throw it. The fd *type* validation still throws
+/// synchronously (matching Node's `validateInt32` on a non-numeric fd);
+/// only the "valid type but unknown descriptor" case becomes a deferred
+/// callback error. Returns `Some(err_value)` when the fd is not open,
+/// `None` when it is registered.
+pub(crate) fn fd_open_callback_error(value: f64, syscall: &'static str) -> Option<f64> {
+    validate_fd(value);
+    let jv = JSValue::from_bits(value.to_bits());
+    let fd = numeric_to_i32(jv);
+    if crate::fs::fd_is_registered(fd) {
+        None
+    } else {
+        Some(build_ebadf_error_value(syscall))
+    }
+}
+
 /// Validate that `value` is a finite integer in `[min, max]`. On type or
 /// range failure throws Node's `ERR_INVALID_ARG_TYPE` / `ERR_OUT_OF_RANGE`
 /// with the same `Received` clause shape Node uses.

--- a/test-parity/node-suite/fs/callbacks/fd-callback-errors.ts
+++ b/test-parity/node-suite/fs/callbacks/fd-callback-errors.ts
@@ -1,0 +1,35 @@
+import * as fs from "node:fs";
+
+// #3332: callback-style fd helpers (close/fsync/fdatasync/fchmod) must
+// DELIVER the EBADF error to the callback for a bad descriptor rather
+// than calling the success path. The sync forms throw EBADF, but the
+// callback forms report it through the first callback argument.
+const BAD_FD = 987654321;
+
+await new Promise<void>((resolve) => {
+  fs.close(BAD_FD, (err) => {
+    console.log("close", err && (err as any).code, err && (err as any).syscall);
+    resolve();
+  });
+});
+
+await new Promise<void>((resolve) => {
+  fs.fsync(BAD_FD, (err) => {
+    console.log("fsync", err && (err as any).code, err && (err as any).syscall);
+    resolve();
+  });
+});
+
+await new Promise<void>((resolve) => {
+  fs.fdatasync(BAD_FD, (err) => {
+    console.log("fdatasync", err && (err as any).code, err && (err as any).syscall);
+    resolve();
+  });
+});
+
+await new Promise<void>((resolve) => {
+  fs.fchmod(BAD_FD, 0o600, (err) => {
+    console.log("fchmod", err && (err as any).code, err && (err as any).syscall);
+    resolve();
+  });
+});


### PR DESCRIPTION
Fixes #3332.

## Problem
The callback forms of `fs.close`, `fs.fsync`, `fs.fdatasync`, and `fs.fchmod` routed through the sync helpers — which *throw* `EBADF` on a bad descriptor — and then unconditionally called the success callback. Node delivers the filesystem error to the callback's first argument for these async forms rather than throwing synchronously.

## Fix
Added `fs::validate::fd_open_callback_error(value, syscall)`: it still validates the fd *type* synchronously (matching Node's `validateInt32` on a non-numeric fd) but returns the `EBADF` error value for a valid-typed-but-unregistered descriptor instead of throwing. The four callback wrappers now deliver that error via `call_cb_err1(...)` and only run the underlying sync op when the fd is open.

## Verification
New fixture `test-parity/node-suite/fs/callbacks/fd-callback-errors.ts`. Byte-identical to Node v25:

```
close EBADF close
fsync EBADF fsync
fdatasync EBADF fdatasync
fchmod EBADF fchmod
```

Valid-fd path still delivers `err === null`.
