### PR TITLE
fix(module): expose isBuiltin

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -67,6 +67,7 @@ pub const NATIVE_MODULES: &[&str] = &[
     "stream",
     "streams",
     "fs",
+    "module",
     "path",
     "path/posix",
     "path/win32",
@@ -146,6 +147,7 @@ pub const RUNTIME_ONLY_MODULES: &[&str] = &[
     "assert/strict",
     "child_process",
     "stream",
+    "module",
     "url",
     "console",
     "util",
@@ -2403,6 +2405,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("path/win32", "delimiter"),
     property("path/win32", "posix"),
     property("path/win32", "win32"),
+    // node:module - first runtime-backed slice: builtin detection.
+    method("module", "isBuiltin", false, None),
     // process — properties mapped to Expr::Process* / Expr::Os* in expr_member.rs.
     method("process", "abort", false, None),
     method("process", "cwd", false, None),

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -1,6 +1,16 @@
 use super::*;
 
 pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
+    // ========== Node module ==========
+    NativeModSig {
+        module: "module",
+        has_receiver: false,
+        method: "isBuiltin",
+        class_filter: None,
+        runtime: "js_module_is_builtin",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     // ========== Node TTY ==========
     NativeModSig {
         module: "tty",

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -605,6 +605,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_set_max_listeners", DOUBLE, &[DOUBLE]);
     module.declare_function("js_process_get_max_listeners", DOUBLE, &[]);
     module.declare_function("js_process_get_builtin_module", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_module_is_builtin", DOUBLE, &[DOUBLE]);
     module.declare_function("js_process_next_tick", VOID, &[I64]);
     module.declare_function("js_process_stdin", DOUBLE, &[]);
     module.declare_function("js_process_stdout", DOUBLE, &[]);

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -822,6 +822,7 @@ pub(crate) unsafe fn bound_native_callable_value_arity(value: f64) -> Option<u32
     match (module.as_str(), method.as_str()) {
         ("console", "Console") => Some(1),
         ("util", "isArray") => Some(1),
+        ("module", "isBuiltin") => Some(1),
         ("process", "getBuiltinModule") => Some(1),
         _ => native_callable_export_arity(module.as_str(), method.as_str()),
     }
@@ -884,6 +885,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
         // #1533: node:stream `promises` namespace exports.
         ("stream/promises", "pipeline")
             | ("stream/promises", "finished")
+            | ("module", "isBuiltin")
             | ("process", "abort")
             | ("process", "cwd")
             | ("process", "uptime")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -445,6 +445,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("process", "setMaxListeners") => crate::os::js_process_set_max_listeners(arg(0)),
         ("process", "getMaxListeners") => crate::os::js_process_get_max_listeners(),
         ("process", "getBuiltinModule") => crate::process::js_process_get_builtin_module(arg(0)),
+        ("module", "isBuiltin") => crate::process::js_module_is_builtin(arg(0)),
         ("process", "cwd") => str_to_f64(crate::os::js_process_cwd()),
         ("process", "uptime") => crate::os::js_process_uptime(),
         ("process", "memoryUsage") => crate::process::js_process_memory_usage(),

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -74,6 +74,104 @@ fn supported_builtin_module_name(name: &str) -> Option<&str> {
     }
 }
 
+const MODULE_BUILTIN_MODULES: &[&str] = &[
+    "_http_agent",
+    "_http_client",
+    "_http_common",
+    "_http_incoming",
+    "_http_outgoing",
+    "_http_server",
+    "_stream_duplex",
+    "_stream_passthrough",
+    "_stream_readable",
+    "_stream_transform",
+    "_stream_wrap",
+    "_stream_writable",
+    "_tls_common",
+    "_tls_wrap",
+    "assert",
+    "assert/strict",
+    "async_hooks",
+    "buffer",
+    "child_process",
+    "cluster",
+    "console",
+    "constants",
+    "crypto",
+    "dgram",
+    "diagnostics_channel",
+    "dns",
+    "dns/promises",
+    "domain",
+    "events",
+    "fs",
+    "fs/promises",
+    "http",
+    "http2",
+    "https",
+    "inspector",
+    "inspector/promises",
+    "module",
+    "net",
+    "node:sea",
+    "node:sqlite",
+    "node:test",
+    "node:test/reporters",
+    "os",
+    "path",
+    "path/posix",
+    "path/win32",
+    "perf_hooks",
+    "process",
+    "punycode",
+    "querystring",
+    "readline",
+    "readline/promises",
+    "repl",
+    "stream",
+    "stream/consumers",
+    "stream/promises",
+    "stream/web",
+    "string_decoder",
+    "sys",
+    "timers",
+    "timers/promises",
+    "tls",
+    "trace_events",
+    "tty",
+    "url",
+    "util",
+    "util/types",
+    "v8",
+    "vm",
+    "wasi",
+    "worker_threads",
+    "zlib",
+];
+
+/// Module.isBuiltin(id) -> boolean
+#[no_mangle]
+pub extern "C" fn js_module_is_builtin(id: f64) -> f64 {
+    let value = JSValue::from_bits(id.to_bits());
+    let mut sso_buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let Some(bytes) = (unsafe { crate::string::js_string_key_bytes(value, &mut sso_buf) }) else {
+        return f64::from_bits(crate::value::TAG_FALSE);
+    };
+    let Ok(specifier) = std::str::from_utf8(bytes) else {
+        return f64::from_bits(crate::value::TAG_FALSE);
+    };
+    let is_builtin = if let Some(name) = specifier.strip_prefix("node:") {
+        MODULE_BUILTIN_MODULES.contains(&specifier) || MODULE_BUILTIN_MODULES.contains(&name)
+    } else {
+        MODULE_BUILTIN_MODULES.contains(&specifier)
+    };
+    f64::from_bits(if is_builtin {
+        crate::value::TAG_TRUE
+    } else {
+        crate::value::TAG_FALSE
+    })
+}
+
 /// process.getBuiltinModule(id) -> module namespace | undefined
 #[no_mangle]
 pub extern "C" fn js_process_get_builtin_module(id: f64) -> f64 {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1782 entries across 88 modules
+// Coverage: 1783 entries across 89 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -1332,6 +1332,11 @@ declare module "lodash" {
 declare module "lru-cache" {
   /** stdlib */
   export default function (p0: any): any;
+}
+
+declare module "module" {
+  /** stdlib */
+  export function isBuiltin(...args: any[]): any;
 }
 
 declare module "moment" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1782 entries across 88 modules.
+Total: 1783 entries across 89 modules.
 
 ## Modules
 
@@ -42,6 +42,7 @@ Total: 1782 entries across 88 modules.
 - [`jsonwebtoken`](#jsonwebtoken)
 - [`lodash`](#lodash)
 - [`lru-cache`](#lru-cache)
+- [`module`](#module)
 - [`moment`](#moment)
 - [`mongodb`](#mongodb)
 - [`mysql2`](#mysql2)
@@ -1226,6 +1227,12 @@ Total: 1782 entries across 88 modules.
 - `has` — instance
 - `set` — instance
 - `size` — instance
+
+## `module`
+
+### Methods
+
+- `isBuiltin` — module
 
 ## `moment`
 

--- a/test-parity/node-suite/module/methods/is-builtin.ts
+++ b/test-parity/node-suite/module/methods/is-builtin.ts
@@ -1,0 +1,24 @@
+import * as nodeModule from "node:module";
+import { isBuiltin } from "node:module";
+
+console.log("is function:", typeof nodeModule.isBuiltin === "function");
+console.log("length:", nodeModule.isBuiltin.length);
+console.log("fs:", nodeModule.isBuiltin("fs"));
+console.log("node fs:", nodeModule.isBuiltin("node:fs"));
+console.log("fs promises:", nodeModule.isBuiltin("fs/promises"));
+console.log("node fs promises:", nodeModule.isBuiltin("node:fs/promises"));
+console.log("internal http:", nodeModule.isBuiltin("_http_agent"));
+console.log("node internal http:", nodeModule.isBuiltin("node:_http_agent"));
+console.log("inspector promises:", nodeModule.isBuiltin("inspector/promises"));
+console.log("node sea:", nodeModule.isBuiltin("node:sea"));
+console.log("bare sea:", nodeModule.isBuiltin("sea"));
+console.log("npm pkg:", nodeModule.isBuiltin("axios"));
+console.log("unknown:", nodeModule.isBuiltin("not-a-real-module"));
+console.log("empty:", nodeModule.isBuiltin(""));
+console.log("number:", nodeModule.isBuiltin(123 as any));
+console.log("null:", nodeModule.isBuiltin(null as any));
+
+const captured = nodeModule.isBuiltin;
+console.log("captured node fs:", captured("node:fs"));
+console.log("named fs:", isBuiltin("fs"));
+console.log("named same:", isBuiltin === nodeModule.isBuiltin);


### PR DESCRIPTION
## Summary
- register `node:module` / `module` as a runtime-only native module surface
- implement `Module.isBuiltin()` for namespace, named-import, captured-callable, and `node:`-prefixed forms
- add focused parity coverage and regenerate API docs for the new manifest entry

## Validation
- `./run_parity_tests.sh --suite node-suite --filter is-builtin` (report `test-parity/reports/parity_report_20260530_064858.json`)
- `./run_parity_tests.sh --suite node-suite --filter get-builtin-module` (report `test-parity/reports/parity_report_20260530_064237.json`)
- `./run_parity_tests.sh --filter test_parity_module` now compiles and reaches the remaining `Module.builtinModules` mismatch (report `test-parity/reports/parity_report_20260530_064248.json`)
- `cargo check -p perry-api-manifest -p perry-runtime -p perry-codegen`
- `./scripts/regen_api_docs.sh`
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `git diff --check origin/main...HEAD && git diff --check`

## Non-goals
- no `Module.builtinModules` array support yet
- no loader hooks, `createRequire`, compile-cache, or `SourceMap` support in `node:module`
