### PR TITLE
fix(array): coerce splice undefined deleteCount

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -691,7 +691,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             blk.store(I64, "0", &out_slot);
             let arr_handle = unbox_to_i64(blk, &arr_box);
             let start_i32 = blk.fptosi(DOUBLE, &start_d, I32);
-            let count_i32 = blk.fptosi(DOUBLE, &count_d, I32);
+            let count_i32 = blk.call(I32, "js_array_splice_delete_count", &[(DOUBLE, &count_d)]);
 
             let (items_ptr, items_count_str) = if item_vals.is_empty() {
                 ("null".to_string(), "0".to_string())

--- a/crates/perry-codegen/src/lower_array_method.rs
+++ b/crates/perry-codegen/src/lower_array_method.rs
@@ -657,7 +657,7 @@ pub(crate) fn lower_array_method(
             blk.store(I64, "0", &out_slot);
             let recv_handle = unbox_to_i64(blk, &recv_box);
             let start_i32 = blk.fptosi(DOUBLE, &start_d, I32);
-            let count_i32 = blk.fptosi(DOUBLE, &count_d, I32);
+            let count_i32 = blk.call(I32, "js_array_splice_delete_count", &[(DOUBLE, &count_d)]);
             let (items_ptr, items_count_str) = if item_vals.is_empty() {
                 ("null".to_string(), "0".to_string())
             } else {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -749,6 +749,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // realloc). Param order is (arr, start, delete_count, items_ptr,
     // items_count, out_arr_ptr).
     module.declare_function("js_array_splice", I64, &[I64, I32, I32, PTR, I32, PTR]);
+    module.declare_function("js_array_splice_delete_count", I32, &[DOUBLE]);
     module.declare_function("js_parse_int", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_parse_float", DOUBLE, &[I64]);
     module.declare_function("js_array_reduce", DOUBLE, &[I64, I64, I32, DOUBLE]);

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -80,7 +80,9 @@ pub use self::search::{
     js_array_indexOf_jsvalue, js_array_last_index_of_jsvalue,
 };
 pub use self::sort::{js_array_sort_default, js_array_sort_with_comparator};
-pub use self::splice_slice::{js_array_slice, js_array_slice_values, js_array_splice};
+pub use self::splice_slice::{
+    js_array_slice, js_array_slice_values, js_array_splice, js_array_splice_delete_count,
+};
 
 pub(crate) use self::alloc::array_length_from_property_value_or_throw;
 pub(crate) use self::alloc::{js_array_from_arraylike, js_array_from_string_codepoints};

--- a/crates/perry-runtime/src/array/splice_slice.rs
+++ b/crates/perry-runtime/src/array/splice_slice.rs
@@ -115,6 +115,11 @@ fn array_slice_value_to_index(value: f64) -> i32 {
     }
 }
 
+#[no_mangle]
+pub extern "C" fn js_array_splice_delete_count(value: f64) -> i32 {
+    array_slice_value_to_index(value)
+}
+
 fn array_slice_start_index(value: f64) -> i32 {
     array_slice_value_to_index(value)
 }

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -941,6 +941,26 @@ fn test_array_splice_delete_to_end() {
 }
 
 #[test]
+fn test_array_splice_delete_count_coerces_js_values() {
+    assert_eq!(
+        js_array_splice_delete_count(f64::from_bits(crate::value::TAG_UNDEFINED)),
+        0
+    );
+    assert_eq!(
+        js_array_splice_delete_count(f64::from_bits(crate::value::TAG_NULL)),
+        0
+    );
+    assert_eq!(
+        js_array_splice_delete_count(crate::value::js_nanbox_string(
+            crate::string::js_string_from_bytes(b"2.8".as_ptr(), 3) as i64,
+        )),
+        2
+    );
+    assert_eq!(js_array_splice_delete_count(f64::INFINITY), i32::MAX);
+    assert_eq!(js_array_splice_delete_count(f64::NAN), 0);
+}
+
+#[test]
 fn test_array_splice_negative_start() {
     // [1,2,3,4].splice(-2, 1) -> deleted=[3], arr=[1,2,4]
     let arr = js_array_alloc(8);


### PR DESCRIPTION
## Summary
- add a shared runtime helper for Array.prototype.splice deleteCount coercion using JS Number(...) semantics
- route both direct ArraySplice lowering and generic/chained splice lowering through that helper instead of raw fptosi
- cover undefined/null/string/Infinity/NaN deleteCount coercion with a runtime unit test

## Verification
- ./run_parity_tests.sh --suite node-suite --filter array-splice-omitted (PASS, report test-parity/reports/parity_report_20260530_070243.json)
- ./run_parity_tests.sh --suite node-suite --filter globals (PASS 28/0/0, report test-parity/reports/parity_report_20260530_070343.json)
- cargo test -p perry-runtime test_array_splice_delete_count_coerces_js_values
- cargo check -p perry-runtime -p perry-codegen
- cargo fmt --all -- --check
- ./scripts/check_file_size.sh
- git diff --check