### PR TITLE
test(parity): unskip compose end event

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -247,11 +247,5 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: compose(src, t1, PassThrough, t2) \u2014 chain produces wrong output. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/compose/composite-end-event": {
-    "issue": "1531",
-    "added": "2026-05-25",
-    "category": "bug-open",
-    "reason": "node:stream: composite 'end' event does not fire after src exhausts. Flips to PASS when #1531 lands."
   }
 }


### PR DESCRIPTION
## Summary
- remove the stale known-failure entry for node-suite/stream/compose/composite-end-event
- leave the remaining stream.compose failures listed; the broader compose sweep still shows the other residuals failing

## Verification
- ./run_parity_tests.sh --suite node-suite --filter composite-end-event before removal (PASS, report test-parity/reports/parity_report_20260530_071238.json)
- ./run_parity_tests.sh --suite node-suite --filter composite-end-event after removal (PASS, report test-parity/reports/parity_report_20260530_071305.json)
- jq empty test-parity/known_failures.json
- git diff --check

## Context
- Broader ./run_parity_tests.sh --suite node-suite --filter stream/compose still has 11 residual compose failures, report test-parity/reports/parity_report_20260530_071119.json