### PR TITLE
fix(url): coerce URL / URL.canParse / URL.parse arguments via String() (#3054, #3055)

### DIFF
--- a/crates/perry-codegen/src/expr/url_main.rs
+++ b/crates/perry-codegen/src/expr/url_main.rs
@@ -56,15 +56,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         }
 
         Expr::UrlNew { url, base } => {
+            // #3055: `new URL(input[, base])` applies `String(value)` coercion
+            // to both arguments (numbers/null/objects stringify, Symbols throw)
+            // BEFORE parsing. `js_url_coerce_string` replaces plain
+            // string-pointer extraction, which dropped non-string values to a
+            // null/garbage pointer.
             let url_v = lower_expr(ctx, url)?;
-            let url_ptr =
-                ctx.block()
-                    .call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &url_v)]);
+            let url_ptr = ctx
+                .block()
+                .call(I64, "js_url_coerce_string", &[(DOUBLE, &url_v)]);
             let obj = if let Some(base) = base {
                 let base_v = lower_expr(ctx, base)?;
-                let base_ptr =
-                    ctx.block()
-                        .call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &base_v)]);
+                let base_ptr = ctx
+                    .block()
+                    .call(I64, "js_url_coerce_string", &[(DOUBLE, &base_v)]);
                 ctx.block().call(
                     I64,
                     "js_url_new_with_base",
@@ -141,10 +146,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // Issue #650: URL.canParse(s) -> boolean. Runtime returns 1/0 as i32;
         // we NaN-box to TAG_TRUE / TAG_FALSE to match perry's boolean repr.
         Expr::UrlCanParse(arg) => {
+            // #3054: coerce the input via `String(value)` (Symbols throw).
             let v = lower_expr(ctx, arg)?;
             let str_ptr = ctx
                 .block()
-                .call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &v)]);
+                .call(I64, "js_url_coerce_string", &[(DOUBLE, &v)]);
             let result_i32 = ctx
                 .block()
                 .call(I32, "js_url_can_parse", &[(I64, &str_ptr)]);
@@ -161,14 +167,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         }
 
         Expr::UrlCanParseWithBase { input, base } => {
+            // #3054: coerce input + base via `String(value)` (Symbols throw).
             let input_v = lower_expr(ctx, input)?;
-            let input_ptr =
-                ctx.block()
-                    .call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &input_v)]);
+            let input_ptr = ctx
+                .block()
+                .call(I64, "js_url_coerce_string", &[(DOUBLE, &input_v)]);
             let base_v = lower_expr(ctx, base)?;
-            let base_ptr =
-                ctx.block()
-                    .call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &base_v)]);
+            let base_ptr = ctx
+                .block()
+                .call(I64, "js_url_coerce_string", &[(DOUBLE, &base_v)]);
             let result_i32 = ctx.block().call(
                 I32,
                 "js_url_can_parse_with_base",
@@ -190,10 +197,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // ObjectHeader* `js_url_new` produces on success, or null when the
         // input fails to parse.
         Expr::UrlParse(arg) => {
+            // #3054: coerce the input via `String(value)` (Symbols throw).
             let v = lower_expr(ctx, arg)?;
             let str_ptr = ctx
                 .block()
-                .call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &v)]);
+                .call(I64, "js_url_coerce_string", &[(DOUBLE, &v)]);
             let obj = ctx.block().call(I64, "js_url_parse", &[(I64, &str_ptr)]);
             // Runtime returns 0 for parse failure; we map that to TAG_NULL so
             // `URL.parse(bad)?.href` short-circuits via optional-chain semantics.
@@ -206,14 +214,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         }
 
         Expr::UrlParseWithBase { input, base } => {
+            // #3054: coerce input + base via `String(value)` (Symbols throw).
             let input_v = lower_expr(ctx, input)?;
-            let input_ptr =
-                ctx.block()
-                    .call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &input_v)]);
+            let input_ptr = ctx
+                .block()
+                .call(I64, "js_url_coerce_string", &[(DOUBLE, &input_v)]);
             let base_v = lower_expr(ctx, base)?;
-            let base_ptr =
-                ctx.block()
-                    .call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &base_v)]);
+            let base_ptr = ctx
+                .block()
+                .call(I64, "js_url_coerce_string", &[(DOUBLE, &base_v)]);
             let obj = ctx.block().call(
                 I64,
                 "js_url_parse_with_base",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -560,6 +560,9 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
         VOID,
         &[I64, DOUBLE, DOUBLE],
     );
+    // `String(value)` coercion (throws TypeError for Symbols) for WHATWG URL
+    // arguments — #3054/#3055. Returns a `*mut StringHeader` (I64).
+    module.declare_function("js_url_coerce_string", I64, &[DOUBLE]);
     module.declare_function("js_url_path_to_file_url", DOUBLE, &[DOUBLE]);
     module.declare_function("js_url_domain_to_ascii", DOUBLE, &[DOUBLE]);
     module.declare_function("js_url_domain_to_unicode", DOUBLE, &[DOUBLE]);

--- a/crates/perry-runtime/src/url/mod.rs
+++ b/crates/perry-runtime/src/url/mod.rs
@@ -91,6 +91,31 @@ pub(crate) fn string_from_header(ptr: *mut crate::StringHeader) -> String {
     }
 }
 
+/// `String(value)` per Web-IDL / ECMAScript string conversion, used to
+/// normalize arguments to the WHATWG URL / URLSearchParams APIs (#3054,
+/// #3055). Numbers, `null`, `undefined`, booleans, BigInts, and objects with
+/// a custom `toString`/`valueOf` are stringified; **Symbols throw**
+/// `TypeError: Cannot convert a Symbol value to a string` (matching Node /
+/// V8). Returns a heap `*mut StringHeader` (never null for non-symbol inputs).
+///
+/// Callers previously routed arguments through `js_get_string_pointer_unified`,
+/// which only extracts an existing string pointer and yields a null/garbage
+/// pointer for non-string values — so `new URL(123, base)` lost its argument
+/// and symbols silently produced the wrong result instead of throwing. This
+/// mirrors `text::text_encoder_string_ptr`, the analogous coercion used by
+/// `TextEncoder.encode`.
+#[no_mangle]
+pub extern "C" fn js_url_coerce_string(value: f64) -> *mut StringHeader {
+    if unsafe { crate::symbol::js_is_symbol(value) != 0 } {
+        let msg = b"Cannot convert a Symbol value to a string";
+        let m = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+        let err = crate::error::js_typeerror_new(m);
+        let bits = crate::value::JSValue::pointer(err as *const u8).bits();
+        crate::exception::js_throw(f64::from_bits(bits));
+    }
+    crate::value::js_jsvalue_to_string(value)
+}
+
 pub(crate) fn object_from_f64(value: f64) -> Option<*mut ObjectHeader> {
     let bits = value.to_bits();
     if (bits & 0xFFFF_0000_0000_0000) == 0x7FFD_0000_0000_0000 {

--- a/test-files/test_gap_3054_3055_url_arg_coercion.ts
+++ b/test-files/test_gap_3054_3055_url_arg_coercion.ts
@@ -1,0 +1,58 @@
+// Issues #3054 / #3055 — WHATWG URL static helpers and the `URL` constructor
+// must apply `String(value)` (Web-IDL / ECMAScript) coercion to their
+// arguments BEFORE parsing: numbers, `null`, and objects with a custom
+// `toString` are stringified, and Symbols throw
+// `TypeError: Cannot convert a Symbol value to a string`.
+//
+// Previously Perry routed these arguments through plain string-pointer
+// extraction, so non-string values became a null/garbage pointer (lost the
+// argument) and Symbols silently produced the wrong result instead of
+// throwing. All lines compare byte-for-byte against
+// `node --experimental-strip-types`.
+//
+// NOTE: invalid-URL throws print only `err.name` (Perry's message is
+// "Invalid URL: <input>", Node's is "Invalid URL" — a separate, pre-existing
+// formatting gap unrelated to argument coercion).
+
+const base = "http://example.com/root/";
+const obj = { toString() { return "child"; } };
+const sym = Symbol("x");
+
+function run(label: string, fn: () => unknown): void {
+  try {
+    console.log(label, "OK", String(fn()));
+  } catch (err) {
+    const e = err as { name: string; message: string };
+    // Only the Symbol-conversion message is asserted verbatim; invalid-URL
+    // messages differ in a pre-existing way, so just report the name.
+    if (e.message === "Cannot convert a Symbol value to a string") {
+      console.log(label, "THROW", e.name, e.message);
+    } else {
+      console.log(label, "THROW", e.name);
+    }
+  }
+}
+
+// ---- #3055: new URL(input[, base]) ----
+run("new number base", () => new URL(123 as unknown as string, base).href);
+run("new null base", () => new URL(null as unknown as string, base).href);
+run("new object base", () => new URL(obj as unknown as string, base).href);
+run("new symbol base", () => new URL(sym as unknown as string, base).href);
+run("new number no base", () => new URL(123 as unknown as string).href);
+run("new bad base number", () => new URL("/x", 123 as unknown as string).href);
+
+// ---- #3054: URL.canParse(input[, base]) ----
+run("canParse number no base", () => URL.canParse(123 as unknown as string));
+run("canParse number base", () => URL.canParse(123 as unknown as string, base));
+run("canParse null base", () => URL.canParse(null as unknown as string, base));
+run("canParse object base", () => URL.canParse(obj as unknown as string, base));
+run("canParse symbol base", () => URL.canParse(sym as unknown as string, base));
+run("canParse bad base number", () => URL.canParse("/x", 123 as unknown as string));
+
+// ---- #3054: URL.parse(input[, base]) ----
+run("parse number no base", () => URL.parse(123 as unknown as string));
+run("parse number base", () => URL.parse(123 as unknown as string, base)?.href);
+run("parse null base", () => URL.parse(null as unknown as string, base)?.href);
+run("parse object base", () => URL.parse(obj as unknown as string, base)?.href);
+run("parse symbol base", () => URL.parse(sym as unknown as string, base)?.href);
+run("parse bad base number", () => URL.parse("/x", 123 as unknown as string));


### PR DESCRIPTION
## Summary

WHATWG URL static helpers and the `URL` constructor now apply `String(value)`
(Web-IDL / ECMAScript) coercion to their arguments **before** parsing, instead
of routing them through plain string-pointer extraction (which dropped
non-string values to a null/garbage pointer and let Symbols silently produce
the wrong result).

- Numbers, `null`, `undefined`, booleans, BigInts, and objects with a custom
  `toString`/`valueOf` are stringified.
- Symbols throw `TypeError: Cannot convert a Symbol value to a string`
  (matching Node / V8).

Closes #3054
Closes #3055

## Implementation

- **runtime** `crates/perry-runtime/src/url/mod.rs`: new `js_url_coerce_string(value: f64) -> *mut StringHeader`
  FFI — throws on Symbols, otherwise delegates to `js_jsvalue_to_string`
  (mirrors `text::text_encoder_string_ptr`). A `#[used]` `KEEP_` anchor pins
  the symbol so the auto-optimize whole-program-LLVM build does not
  dead-strip it (the #3320 pattern — it is referenced only from generated
  codegen).
- **codegen** `crates/perry-codegen/src/expr/url_main.rs`: `UrlNew`,
  `UrlCanParse{,WithBase}`, and `UrlParse{,WithBase}` arms call
  `js_url_coerce_string` instead of `js_get_string_pointer_unified`.
- **codegen** `crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs`: declare
  the new FFI.

## Test

`test-files/test_gap_3054_3055_url_arg_coercion.ts` — covers `new URL`,
`URL.canParse`, and `URL.parse` with number / null / object-`toString` /
Symbol / invalid-base arguments. Byte-identical to
`node --experimental-strip-types`.

Invalid-URL throws assert only `err.name` (Perry's message is
`"Invalid URL: <input>"` vs Node's `"Invalid URL"` — a separate, pre-existing
formatting gap unrelated to argument coercion). `url.domainToASCII`/setter
host-canonicalization coercion (#3056/#3059) and `URLSearchParams`/file-URL
coercion (#3057/#3060/#3062) are deliberately scoped to follow-up PRs.

## Validation

- new gap test byte-identical to Node
- `test_issue_650_url_static.ts` unchanged; `test_parity_url.ts` unchanged
  (only Node's DEP0169 stderr deprecation warning differs)
- `cargo test -p perry-runtime url` green; `cargo fmt --all --check` clean
- verified under **default auto-optimize** compile (not just `PERRY_NO_AUTO_OPTIMIZE`)
