### PR TITLE
fix(runtime): join heap string array elements

### DIFF
--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -643,7 +643,7 @@ pub extern "C" fn js_array_join(
 
             // Convert element to string based on its type
             if jsvalue.is_string() {
-                let str_ptr = jsvalue.as_pointer() as *const StringHeader;
+                let str_ptr = jsvalue.as_string_ptr();
                 let str_len = (*str_ptr).byte_len as usize;
                 let str_data = (str_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
                 let s =

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -1007,3 +1007,26 @@ fn join_routes_objects_and_nested_arrays_through_tostring() {
         assert_eq!(s, "1,2;[object Object]");
     }
 }
+
+#[test]
+fn join_accepts_heap_string_tagged_elements() {
+    unsafe {
+        let left = crate::string::js_string_from_bytes(b"alpha".as_ptr(), 5);
+        let right = crate::string::js_string_from_bytes(b"beta".as_ptr(), 4);
+        let left_v =
+            f64::from_bits(crate::value::STRING_TAG | (left as u64 & crate::value::POINTER_MASK));
+        let right_v =
+            f64::from_bits(crate::value::STRING_TAG | (right as u64 & crate::value::POINTER_MASK));
+
+        let mut arr = js_array_alloc(2);
+        arr = js_array_push_f64(arr, left_v);
+        arr = js_array_push_f64(arr, right_v);
+
+        let sep = crate::string::js_string_from_bytes(b"|".as_ptr(), 1);
+        let out = js_array_join(arr, sep);
+        let len = (*out).byte_len as usize;
+        let data = (out as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+        let s = std::str::from_utf8(std::slice::from_raw_parts(data, len)).unwrap();
+        assert_eq!(s, "alpha|beta");
+    }
+}


### PR DESCRIPTION
## Why

While testing `ps-node` on Windows, Perry got past compilation and child process spawning, but crashed at runtime in `Array.prototype.join`.

The ps-node path was:

```js
stdout = stdout.split(EOL);
stdout.join(SystemEOL);
```

The split result stores heap strings with `STRING_TAG`. `js_array_join` correctly detected those values with `is_string()`, but then extracted them with `as_pointer()`, which only accepts generic `POINTER_TAG` values. In debug builds this panicked with `Value is not a pointer`.

## What changed

- Use `as_string_ptr()` for `STRING_TAG` values inside `js_array_join`.
- Add a regression test for joining arrays containing heap-string-tagged elements.

## Verification

```text
cargo test -p perry-runtime join_accepts_heap_string_tagged_elements
```