### PR TITLE
fix(promise): resolve identity, finally adoption, iterable combinators

### DIFF
--- a/crates/perry-codegen/src/lower_call/console_promise.rs
+++ b/crates/perry-codegen/src/lower_call/console_promise.rs
@@ -529,19 +529,26 @@ pub fn try_lower_promise_static_call(
                     return Ok(Some(nanbox_pointer_inline(blk, &handle)));
                 }
                 "all" | "race" | "allSettled" | "any" => {
-                    if args.is_empty() {
-                        return Ok(Some(double_literal(0.0)));
-                    }
-                    let arr_box = lower_expr(ctx, &args[0])?;
-                    let blk = ctx.block();
-                    let arr_handle = unbox_to_i64(blk, &arr_box);
-                    let runtime_fn = match property.as_str() {
-                        "all" => "js_promise_all",
-                        "race" => "js_promise_race",
-                        "any" => "js_promise_any",
-                        _ => "js_promise_all_settled",
+                    // Issue #2822: the combinators accept any iterable and must
+                    // reject with `TypeError` for non-iterable / omitted input
+                    // (`undefined` is not iterable). Pass the boxed argument
+                    // value to the `*_iterable` runtime entry points, which
+                    // coerce iterables to an array and produce the rejected
+                    // Promise otherwise. A missing argument lowers to
+                    // `undefined` so the runtime rejects it just like Node.
+                    let value = if args.is_empty() {
+                        double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                    } else {
+                        lower_expr(ctx, &args[0])?
                     };
-                    let handle = blk.call(I64, runtime_fn, &[(I64, &arr_handle)]);
+                    let runtime_fn = match property.as_str() {
+                        "all" => "js_promise_all_iterable",
+                        "race" => "js_promise_race_iterable",
+                        "any" => "js_promise_any_iterable",
+                        _ => "js_promise_all_settled_iterable",
+                    };
+                    let blk = ctx.block();
+                    let handle = blk.call(I64, runtime_fn, &[(DOUBLE, &value)]);
                     return Ok(Some(nanbox_pointer_inline(blk, &handle)));
                 }
                 "withResolvers" => {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1695,6 +1695,12 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_promise_race", I64, &[I64]);
     module.declare_function("js_promise_any", I64, &[I64]);
     module.declare_function("js_promise_all_settled", I64, &[I64]);
+    // #2822: iterable-accepting combinator entries (take a boxed f64 value,
+    // coerce iterables to an array, reject non-iterables with TypeError).
+    module.declare_function("js_promise_all_iterable", I64, &[DOUBLE]);
+    module.declare_function("js_promise_race_iterable", I64, &[DOUBLE]);
+    module.declare_function("js_promise_any_iterable", I64, &[DOUBLE]);
+    module.declare_function("js_promise_all_settled_iterable", I64, &[DOUBLE]);
     module.declare_function("js_promise_with_resolvers", I64, &[]);
     module.declare_function("js_promise_try", I64, &[DOUBLE, I64]);
     module.declare_function("js_array_unshift_f64", I64, &[I64, DOUBLE]);

--- a/crates/perry-runtime/src/promise/async_step.rs
+++ b/crates/perry-runtime/src/promise/async_step.rs
@@ -23,15 +23,21 @@ pub extern "C" fn js_promise_resolved(value: f64) -> *mut Promise {
         }
         return promise;
     }
-    let promise = js_promise_new();
+    // Issue #2823: `Promise.resolve(p)` MUST return `p` itself when `p` is
+    // already a native Promise (constructor === Promise). The spec defines
+    // Promise.resolve to short-circuit and return the argument unchanged in
+    // that case — object identity and pending-promise sharing are
+    // observable (`Promise.resolve(p) === p`). Perry only constructs native
+    // `Promise` instances, so a GC_TYPE_PROMISE value always satisfies the
+    // "constructor is Promise" check. Return the existing pointer directly
+    // instead of allocating a fresh wrapper and chaining to it.
     if js_value_is_promise(value) != 0 {
-        bump(&MT_INNER_PROMISE_UNWRAP_COUNT);
         let inner = crate::value::js_nanbox_get_pointer(value) as *mut Promise;
-        if !inner.is_null() && inner != promise {
-            js_promise_resolve_with_promise(promise, inner);
-            return promise;
+        if !inner.is_null() {
+            return inner;
         }
     }
+    let promise = js_promise_new();
 
     // Issue #586: ECMAScript thenable assimilation. The async-to-generator
     // transform rewrites every `await x` into `Promise.resolve(x).then(...)`

--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -213,6 +213,203 @@ pub extern "C" fn js_value_is_promise(value: f64) -> i32 {
     }
 }
 
+/// Issue #2822: compute the Node-compatible prefix for the
+/// "<x> is not iterable (cannot read property Symbol(Symbol.iterator))"
+/// TypeError message for a non-iterable combinator argument.
+///
+/// Node's `%TypeError%` text varies by `typeof`:
+///   number 1 / number -3.5 / boolean true → "<type> <value>"
+///   object null                            → "object null"
+///   undefined / object / symbol / function / bigint → "<type>"
+fn not_iterable_prefix(value: f64) -> String {
+    use crate::value::JSValue;
+    let jsval = JSValue::from_bits(value.to_bits());
+    if jsval.is_undefined() {
+        return "undefined".to_string();
+    }
+    if jsval.is_null() {
+        return "object null".to_string();
+    }
+    if jsval.is_number() {
+        let s = crate::value::js_jsvalue_to_string(value);
+        let num_str = crate::string::string_as_str(s);
+        return format!("number {}", num_str);
+    }
+    if jsval.is_bool() {
+        let b = value.to_bits() == crate::value::TAG_TRUE;
+        return format!("boolean {}", b);
+    }
+    if jsval.is_bigint() {
+        return "bigint".to_string();
+    }
+    if jsval.is_any_string() {
+        // Strings ARE iterable; this branch should never be reached for
+        // strings, but keep it defensive.
+        return "string".to_string();
+    }
+    if jsval.is_pointer() {
+        let raw = (value.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize;
+        if crate::symbol::is_registered_symbol(raw) {
+            return "symbol".to_string();
+        }
+        if crate::closure::is_closure_ptr(raw) {
+            return "function".to_string();
+        }
+        return "object".to_string();
+    }
+    "object".to_string()
+}
+
+/// Build a rejected Promise carrying a `TypeError: <prefix> is not iterable
+/// (cannot read property Symbol(Symbol.iterator))` — Node's exact message for
+/// a non-iterable Promise-combinator argument (issue #2822).
+fn rejected_not_iterable(value: f64) -> *mut Promise {
+    let msg = format!(
+        "{} is not iterable (cannot read property Symbol(Symbol.iterator))",
+        not_iterable_prefix(value)
+    );
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err_ptr = crate::error::js_typeerror_new(msg_str);
+    let err_value = crate::value::JSValue::pointer(err_ptr as *const u8).bits();
+    let p = js_promise_new();
+    js_promise_reject(p, f64::from_bits(err_value));
+    p
+}
+
+/// Issue #2822: decide whether a boxed pointer value is iterable, and if so
+/// return its elements as a flat array. Returns `Ok(arr)` for iterables
+/// (arrays, Set, Map, strings, generators / objects with `[Symbol.iterator]`,
+/// iterator objects with a `.next` field) and `Err(())` for everything else.
+///
+/// Reuses `js_array_clone`'s established iterable-collection path (the same
+/// engine that backs spread / `Array.from`), but gates it behind an explicit
+/// iterability probe so non-iterable primitives and plain objects reject with
+/// a `TypeError` instead of silently coercing to `[]`.
+fn combinator_iterable_to_array(value: f64) -> Result<*mut crate::array::ArrayHeader, ()> {
+    use crate::value::JSValue;
+
+    // Arrays and strings are always iterable.
+    if crate::array::js_array_is_array(value).to_bits() == crate::value::TAG_TRUE {
+        return Ok(crate::array::js_array_clone(
+            crate::value::js_nanbox_get_pointer(value) as *const crate::array::ArrayHeader,
+        ));
+    }
+    let jsval = JSValue::from_bits(value.to_bits());
+    if jsval.is_any_string() {
+        return Ok(crate::array::js_array_clone(
+            crate::value::js_nanbox_get_pointer(value) as *const crate::array::ArrayHeader,
+        ));
+    }
+    if !jsval.is_pointer() {
+        return Err(());
+    }
+
+    let raw = (value.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize;
+    if raw < 0x100000 {
+        return Err(());
+    }
+
+    // Side-table iterables.
+    if crate::set::is_registered_set(raw) || crate::map::is_registered_map(raw) {
+        return Ok(crate::array::js_array_clone(raw as *const crate::array::ArrayHeader));
+    }
+    if crate::buffer::is_registered_buffer(raw) {
+        return Ok(crate::array::js_array_clone(raw as *const crate::array::ArrayHeader));
+    }
+
+    // Symbols / closures are not iterable.
+    if crate::symbol::is_registered_symbol(raw) || crate::closure::is_closure_ptr(raw) {
+        return Err(());
+    }
+
+    // GC_TYPE_OBJECT: iterable only if it exposes `[Symbol.iterator]` or a
+    // `.next` closure field (a bare iterator object).
+    let obj_type = unsafe {
+        if raw < crate::gc::GC_HEADER_SIZE + 0x1000 {
+            return Err(());
+        }
+        let hdr = (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        (*hdr).obj_type
+    };
+    if obj_type == crate::gc::GC_TYPE_OBJECT {
+        let has_iterator = {
+            let iter_sym = crate::symbol::well_known_symbol("iterator");
+            if iter_sym.is_null() {
+                false
+            } else {
+                let sym_f64 =
+                    f64::from_bits(crate::value::JSValue::pointer(iter_sym as *const u8).bits());
+                let iter_fn = unsafe { crate::symbol::js_object_get_symbol_property(value, sym_f64) };
+                iter_fn.to_bits() != crate::value::TAG_UNDEFINED
+            }
+        };
+        let has_next_field = {
+            let next_key = crate::string::js_string_from_bytes(b"next".as_ptr(), 4);
+            let next_val = crate::object::js_object_get_field_by_name(
+                raw as *const crate::object::ObjectHeader,
+                next_key,
+            );
+            let next_ptr = crate::value::js_nanbox_get_pointer(f64::from_bits(next_val.bits()));
+            !next_val.is_undefined() && crate::closure::is_closure_ptr(next_ptr as usize)
+        };
+        if has_iterator || has_next_field {
+            return Ok(crate::array::js_array_clone(raw as *const crate::array::ArrayHeader));
+        }
+    }
+
+    Err(())
+}
+
+/// Iterable-accepting entry for `Promise.all` (issue #2822). Coerces any
+/// iterable to an array (rejecting non-iterables with a `TypeError`) before
+/// delegating to the array-shaped `js_promise_all`.
+#[no_mangle]
+pub extern "C" fn js_promise_all_iterable(value: f64) -> *mut Promise {
+    match combinator_iterable_to_array(value) {
+        Ok(arr) => js_promise_all(arr),
+        Err(()) => rejected_not_iterable(value),
+    }
+}
+
+/// Iterable-accepting entry for `Promise.race` (issue #2822).
+#[no_mangle]
+pub extern "C" fn js_promise_race_iterable(value: f64) -> *mut Promise {
+    match combinator_iterable_to_array(value) {
+        Ok(arr) => js_promise_race(arr),
+        Err(()) => rejected_not_iterable(value),
+    }
+}
+
+/// Iterable-accepting entry for `Promise.allSettled` (issue #2822).
+#[no_mangle]
+pub extern "C" fn js_promise_all_settled_iterable(value: f64) -> *mut Promise {
+    match combinator_iterable_to_array(value) {
+        Ok(arr) => js_promise_all_settled(arr),
+        Err(()) => rejected_not_iterable(value),
+    }
+}
+
+/// Iterable-accepting entry for `Promise.any` (issue #2822).
+#[no_mangle]
+pub extern "C" fn js_promise_any_iterable(value: f64) -> *mut Promise {
+    match combinator_iterable_to_array(value) {
+        Ok(arr) => js_promise_any(arr),
+        Err(()) => rejected_not_iterable(value),
+    }
+}
+
+/// #2822/#3320: keepalive anchors so the whole-program LLVM (auto-optimize)
+/// build does not dead-strip these codegen-only `#[no_mangle]` entry points.
+#[used]
+static KEEP_PROMISE_ALL_ITERABLE: extern "C" fn(f64) -> *mut Promise = js_promise_all_iterable;
+#[used]
+static KEEP_PROMISE_RACE_ITERABLE: extern "C" fn(f64) -> *mut Promise = js_promise_race_iterable;
+#[used]
+static KEEP_PROMISE_ALL_SETTLED_ITERABLE: extern "C" fn(f64) -> *mut Promise =
+    js_promise_all_settled_iterable;
+#[used]
+static KEEP_PROMISE_ANY_ITERABLE: extern "C" fn(f64) -> *mut Promise = js_promise_any_iterable;
+
 // Queue for scheduled promise resolutions
 thread_local! {
     pub(in crate::promise) static SCHEDULED_RESOLVES: RefCell<Vec<(*mut Promise, f64)>> = const { RefCell::new(Vec::new()) };

--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -311,10 +311,14 @@ fn combinator_iterable_to_array(value: f64) -> Result<*mut crate::array::ArrayHe
 
     // Side-table iterables.
     if crate::set::is_registered_set(raw) || crate::map::is_registered_map(raw) {
-        return Ok(crate::array::js_array_clone(raw as *const crate::array::ArrayHeader));
+        return Ok(crate::array::js_array_clone(
+            raw as *const crate::array::ArrayHeader,
+        ));
     }
     if crate::buffer::is_registered_buffer(raw) {
-        return Ok(crate::array::js_array_clone(raw as *const crate::array::ArrayHeader));
+        return Ok(crate::array::js_array_clone(
+            raw as *const crate::array::ArrayHeader,
+        ));
     }
 
     // Symbols / closures are not iterable.
@@ -339,7 +343,8 @@ fn combinator_iterable_to_array(value: f64) -> Result<*mut crate::array::ArrayHe
             } else {
                 let sym_f64 =
                     f64::from_bits(crate::value::JSValue::pointer(iter_sym as *const u8).bits());
-                let iter_fn = unsafe { crate::symbol::js_object_get_symbol_property(value, sym_f64) };
+                let iter_fn =
+                    unsafe { crate::symbol::js_object_get_symbol_property(value, sym_f64) };
                 iter_fn.to_bits() != crate::value::TAG_UNDEFINED
             }
         };
@@ -353,7 +358,9 @@ fn combinator_iterable_to_array(value: f64) -> Result<*mut crate::array::ArrayHe
             !next_val.is_undefined() && crate::closure::is_closure_ptr(next_ptr as usize)
         };
         if has_iterator || has_next_field {
-            return Ok(crate::array::js_array_clone(raw as *const crate::array::ArrayHeader));
+            return Ok(crate::array::js_array_clone(
+                raw as *const crate::array::ArrayHeader,
+            ));
         }
     }
 

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -625,47 +625,171 @@ pub unsafe fn js_promise_bound_method(promise: *mut Promise, property: &str) -> 
 /// Fulfilled-path wrapper for `.finally()`.
 /// Captures [on_finally, next_promise].
 /// Called with the upstream fulfilled `value`.
-/// Runs `on_finally()`, then resolves `next` with `value` via ONE extra
-/// microtask hop (matching Node.js `.finally()` microtask depth).
 extern "C" fn finally_fulfill_wrapper(
     closure: *const crate::closure::ClosureHeader,
     value: f64,
 ) -> f64 {
+    finally_wrapper_common(closure, value, true)
+}
+
+/// Rejected-path wrapper for `.finally()`.
+/// Captures [on_finally, next_promise].
+/// Called with the upstream rejection `reason`.
+extern "C" fn finally_reject_wrapper(
+    closure: *const crate::closure::ClosureHeader,
+    reason: f64,
+) -> f64 {
+    finally_wrapper_common(closure, reason, false)
+}
+
+/// Shared body for both `.finally()` wrappers (issue #2825).
+///
+/// Node's `Promise.prototype.finally(onFinally)` semantics:
+///   - `onFinally()` is called with no arguments.
+///   - If it **throws**, the chained promise (`next`) rejects with the thrown
+///     value, OVERRIDING the upstream outcome.
+///   - If it returns a **Promise/thenable**, the chained promise waits for it:
+///       * cleanup fulfilled → settle `next` with the ORIGINAL outcome
+///         (the cleanup's fulfillment value is ignored).
+///       * cleanup rejected → reject `next` with the CLEANUP reason
+///         (overriding the upstream outcome).
+///   - Otherwise (non-thenable return / non-callable onFinally), settle `next`
+///     with the original outcome after one extra microtask hop (matching
+///     Node's `.finally()` microtask depth).
+///
+/// `orig` is the upstream value (fulfilled) or reason (rejected); `is_fulfilled`
+/// selects which.
+fn finally_wrapper_common(
+    closure: *const crate::closure::ClosureHeader,
+    orig: f64,
+    is_fulfilled: bool,
+) -> f64 {
     use crate::closure::{
-        js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr,
+        js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_f64,
+        js_closure_set_capture_ptr,
     };
 
     let on_finally = js_closure_get_capture_ptr(closure, 0) as *const crate::closure::ClosureHeader;
     let next = js_closure_get_capture_ptr(closure, 1) as *mut Promise;
 
-    // Call the user's finally callback (ignoring its return value).
-    if !on_finally.is_null() {
-        let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
-        crate::closure::js_closure_call1(on_finally, undef);
+    // Non-callable onFinally (e.g. `.finally(1)`): act like `.then(undefined,
+    // undefined)` — pass the original outcome through after one extra hop.
+    if on_finally.is_null() {
+        finally_settle_next_with_extra_hop(next, orig, is_fulfilled);
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
 
-    // Add one extra microtask tick before settling `next` by registering a
-    // passthrough closure on an already-resolved promise.  The runner will
-    // enqueue it, call it next iteration, and THEN `next` gets resolved.
+    // Call `onFinally()` under a dedicated try-frame so a throw from the
+    // callback rejects `next` (overriding the upstream outcome) instead of
+    // unwinding past us to the microtask runner's trap — whose `(*cur).next`
+    // is null here (js_promise_finally clears it), so a throw would otherwise
+    // be swallowed.
+    let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let trap_buf = crate::exception::js_try_push();
+    let jumped = unsafe { crate::ffi::setjmp::setjmp(trap_buf as *mut std::os::raw::c_int) };
+    if jumped != 0 {
+        // onFinally threw — reject `next` with the thrown value.
+        let exc = crate::exception::js_get_exception();
+        crate::exception::js_clear_exception();
+        crate::exception::js_try_end();
+        if !next.is_null() {
+            js_promise_reject(next, exc);
+        }
+        return undef;
+    }
+    let ret = crate::closure::js_closure_call1(on_finally, undef);
+    crate::exception::js_try_end();
+
+    // If onFinally returned a Promise/thenable, adopt it: wait for it before
+    // settling `next`. `js_assimilate_thenable` returns a native Promise for
+    // both real Promises and user thenables, or the value unchanged otherwise.
+    let cleanup = js_assimilate_thenable(ret);
+    if js_value_is_promise(cleanup) != 0 {
+        let inner = crate::value::js_nanbox_get_pointer(cleanup) as *mut Promise;
+        if !inner.is_null() {
+            // On cleanup fulfillment: settle `next` with the original outcome.
+            let on_ok = js_closure_alloc(finally_cleanup_fulfill as *const u8, 3);
+            js_closure_set_capture_ptr(on_ok, 0, next as i64);
+            js_closure_set_capture_f64(on_ok, 1, orig);
+            js_closure_set_capture_f64(
+                on_ok,
+                2,
+                f64::from_bits(if is_fulfilled {
+                    crate::value::TAG_TRUE
+                } else {
+                    crate::value::TAG_FALSE
+                }),
+            );
+            // On cleanup rejection: reject `next` with the cleanup reason.
+            let on_err = js_closure_alloc(finally_cleanup_reject as *const u8, 1);
+            js_closure_set_capture_ptr(on_err, 0, next as i64);
+            js_promise_then(inner, on_ok, on_err);
+            return undef;
+        }
+    }
+
+    // Plain (non-thenable) return value: pass the original outcome through
+    // after one extra microtask hop.
+    finally_settle_next_with_extra_hop(next, orig, is_fulfilled);
+    undef
+}
+
+/// Settle `next` with the original outcome after one extra microtask hop,
+/// matching Node's `.finally()` microtask depth.
+fn finally_settle_next_with_extra_hop(next: *mut Promise, orig: f64, is_fulfilled: bool) {
+    use crate::closure::{js_closure_alloc, js_closure_set_capture_f64, js_closure_set_capture_ptr};
+    if next.is_null() {
+        return;
+    }
+    let pass_fn = if is_fulfilled {
+        finally_passthrough_fulfill as *const u8
+    } else {
+        finally_passthrough_reject as *const u8
+    };
+    let pass = js_closure_alloc(pass_fn, 2);
+    js_closure_set_capture_ptr(pass, 0, next as i64);
+    js_closure_set_capture_f64(pass, 1, orig);
+    let undef_promise = js_promise_resolved(f64::from_bits(crate::value::TAG_UNDEFINED));
+    // js_promise_then's side-effect is enqueuing `pass` to run next iteration.
+    js_promise_then(undef_promise, pass, ptr::null());
+}
+
+/// Cleanup-fulfilled handler: settle `next` with the ORIGINAL outcome.
+/// Captures [next_promise_ptr (i64), orig (f64), is_fulfilled (TAG_TRUE/FALSE)].
+extern "C" fn finally_cleanup_fulfill(
+    closure: *const crate::closure::ClosureHeader,
+    _cleanup_value: f64,
+) -> f64 {
+    use crate::closure::{js_closure_get_capture_f64, js_closure_get_capture_ptr};
+    let next = js_closure_get_capture_ptr(closure, 0) as *mut Promise;
+    let orig = js_closure_get_capture_f64(closure, 1);
+    let is_fulfilled = js_closure_get_capture_f64(closure, 2).to_bits() == crate::value::TAG_TRUE;
     if !next.is_null() {
-        let pass = js_closure_alloc(finally_passthrough_fulfill as *const u8, 2);
-        js_closure_set_capture_ptr(pass, 0, next as i64);
-        crate::closure::js_closure_set_capture_f64(pass, 1, value);
-
-        let undef_promise = js_promise_resolved(f64::from_bits(crate::value::TAG_UNDEFINED));
-        // js_promise_then returns a new (discarded) promise; the side-effect
-        // is enqueuing `pass` to run in the next microtask iteration.
-        js_promise_then(undef_promise, pass, ptr::null());
+        if is_fulfilled {
+            js_promise_resolve(next, orig);
+        } else {
+            js_promise_reject(next, orig);
+        }
     }
-
-    // Return undefined.  Since promise.next is null (set in js_promise_finally),
-    // the runner will not try to resolve anything with this return value.
     f64::from_bits(crate::value::TAG_UNDEFINED)
 }
 
-/// Passthrough closure for the extra hop in finally_fulfill_wrapper.
+/// Cleanup-rejected handler: reject `next` with the CLEANUP reason (overrides
+/// the upstream outcome). Captures [next_promise_ptr (i64)].
+extern "C" fn finally_cleanup_reject(
+    closure: *const crate::closure::ClosureHeader,
+    cleanup_reason: f64,
+) -> f64 {
+    use crate::closure::js_closure_get_capture_ptr;
+    let next = js_closure_get_capture_ptr(closure, 0) as *mut Promise;
+    if !next.is_null() {
+        js_promise_reject(next, cleanup_reason);
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// Passthrough closure for the extra hop in the fulfilled path.
 /// Captures [next_promise_ptr (i64), value (f64)].
-/// Resolves `next` with `value`.
 extern "C" fn finally_passthrough_fulfill(
     closure: *const crate::closure::ClosureHeader,
     _: f64,
@@ -679,44 +803,8 @@ extern "C" fn finally_passthrough_fulfill(
     f64::from_bits(crate::value::TAG_UNDEFINED)
 }
 
-/// Rejected-path wrapper for `.finally()`.
-/// Captures [on_finally, next_promise].
-/// Called with the upstream rejection `reason`.
-/// Runs `on_finally()`, then rejects `next` with `reason` via ONE extra
-/// microtask hop.
-extern "C" fn finally_reject_wrapper(
-    closure: *const crate::closure::ClosureHeader,
-    reason: f64,
-) -> f64 {
-    use crate::closure::{
-        js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr,
-    };
-
-    let on_finally = js_closure_get_capture_ptr(closure, 0) as *const crate::closure::ClosureHeader;
-    let next = js_closure_get_capture_ptr(closure, 1) as *mut Promise;
-
-    // Call the user's finally callback (ignoring its return value).
-    if !on_finally.is_null() {
-        let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
-        crate::closure::js_closure_call1(on_finally, undef);
-    }
-
-    // Add one extra microtask tick before rejecting `next`.
-    if !next.is_null() {
-        let pass = js_closure_alloc(finally_passthrough_reject as *const u8, 2);
-        js_closure_set_capture_ptr(pass, 0, next as i64);
-        crate::closure::js_closure_set_capture_f64(pass, 1, reason);
-
-        let undef_promise = js_promise_resolved(f64::from_bits(crate::value::TAG_UNDEFINED));
-        js_promise_then(undef_promise, pass, ptr::null());
-    }
-
-    f64::from_bits(crate::value::TAG_UNDEFINED)
-}
-
-/// Passthrough closure for the extra hop in finally_reject_wrapper.
+/// Passthrough closure for the extra hop in the rejected path.
 /// Captures [next_promise_ptr (i64), reason (f64)].
-/// Rejects `next` with `reason`.
 extern "C" fn finally_passthrough_reject(
     closure: *const crate::closure::ClosureHeader,
     _: f64,

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -737,7 +737,9 @@ fn finally_wrapper_common(
 /// Settle `next` with the original outcome after one extra microtask hop,
 /// matching Node's `.finally()` microtask depth.
 fn finally_settle_next_with_extra_hop(next: *mut Promise, orig: f64, is_fulfilled: bool) {
-    use crate::closure::{js_closure_alloc, js_closure_set_capture_f64, js_closure_set_capture_ptr};
+    use crate::closure::{
+        js_closure_alloc, js_closure_set_capture_f64, js_closure_set_capture_ptr,
+    };
     if next.is_null() {
         return;
     }

--- a/test-files/test_gap_2823_2825_2822_promise_semantics.ts
+++ b/test-files/test_gap_2823_2825_2822_promise_semantics.ts
@@ -1,0 +1,95 @@
+// Promise semantics parity (#2823 identity, #2825 finally adoption,
+// #2822 iterable combinators).
+
+async function main() {
+  // ---- #2823: Promise.resolve identity ----
+  const fulfilled = Promise.resolve(1);
+  console.log("resolve-identity-fulfilled:", Promise.resolve(fulfilled) === fulfilled);
+
+  const pending = new Promise<number>(() => {});
+  console.log("resolve-identity-pending:", Promise.resolve(pending) === pending);
+
+  const thenable = { then(resolve: (v: number) => void) { resolve(42); } };
+  console.log("resolve-thenable-identity:", (Promise.resolve(thenable as any) as any) === thenable);
+
+  // ---- #2825: finally adoption ----
+  console.log("finally-ignored:", await Promise.resolve("v").finally(() => "ignored"));
+
+  const order: string[] = [];
+  await Promise.resolve("v")
+    .finally(() => new Promise<string>(resolve => setTimeout(() => {
+      order.push("cleanup");
+      resolve("x");
+    }, 1)))
+    .then(v => order.push("then:" + v));
+  console.log("finally-order:", JSON.stringify(order));
+
+  try {
+    await Promise.resolve("v").finally(() => Promise.reject("cleanup"));
+    console.log("finally-reject-promise: NO THROW");
+  } catch (e) {
+    console.log("finally-reject-promise:", e);
+  }
+
+  try {
+    await Promise.reject("orig").finally(() => Promise.reject("cleanup"));
+    console.log("finally-reject-override: NO THROW");
+  } catch (e) {
+    console.log("finally-reject-override:", e);
+  }
+
+  try {
+    await Promise.resolve("v").finally(() => { throw new Error("boom"); });
+    console.log("finally-throw: NO THROW");
+  } catch (e) {
+    console.log("finally-throw:", (e as Error).message);
+  }
+
+  console.log("finally-noncallable:", await Promise.resolve("v").finally(1 as any));
+
+  // ---- #2822: iterable combinators ----
+  console.log("all-set:", JSON.stringify(await Promise.all(new Set([Promise.resolve(1), 2]))));
+
+  const settled = await Promise.allSettled(new Set([Promise.resolve(1), Promise.reject("x")]));
+  console.log("allSettled-set:", JSON.stringify(settled.map(r => r.status)));
+
+  console.log("race-set:", await Promise.race(new Set([Promise.resolve("a")])));
+  console.log("any-set:", await Promise.any(new Set([Promise.reject("x"), Promise.resolve("b")])));
+
+  try {
+    await Promise.all(1 as any);
+    console.log("all-number: NO THROW");
+  } catch (e) {
+    console.log("all-number:", (e as Error).name, (e as Error).message);
+  }
+
+  try {
+    await Promise.all(undefined as any);
+    console.log("all-undefined: NO THROW");
+  } catch (e) {
+    console.log("all-undefined:", (e as Error).name, (e as Error).message);
+  }
+
+  try {
+    await Promise.race(1 as any);
+    console.log("race-number: NO THROW");
+  } catch (e) {
+    console.log("race-number:", (e as Error).name);
+  }
+
+  try {
+    await Promise.any(1 as any);
+    console.log("any-number: NO THROW");
+  } catch (e) {
+    console.log("any-number:", (e as Error).name);
+  }
+
+  try {
+    await Promise.any([]);
+    console.log("any-empty: NO THROW");
+  } catch (e) {
+    console.log("any-empty-errors:", (e as AggregateError).errors.length);
+  }
+}
+
+main();


### PR DESCRIPTION
Closes #2823
Closes #2825
Closes #2822

## Implementation

### #2823 — `Promise.resolve(p)` identity
`js_promise_resolved` (`promise/async_step.rs`) used to allocate a fresh wrapper Promise and chain it to the inner Promise even when the argument was already a native Promise. Now, when `js_value_is_promise(value)` is true (a `GC_TYPE_PROMISE` — Perry only ever constructs native `Promise`s, so the "constructor is Promise" check always holds), it returns the existing pointer directly. `Promise.resolve(p) === p` is now `true` for both fulfilled and pending promises. Non-Promise thenables still take the assimilation path.

### #2825 — `Promise.prototype.finally` cleanup adoption
Rewrote the `finally` wrappers (`promise/then.rs`) to implement Node's full contract:
- `onFinally()` is invoked under a dedicated `setjmp` try-frame so a throw rejects the chained promise with the thrown value (the microtask runner's trap can't, since `finally` nulls `promise.next`).
- A returned Promise/thenable is adopted via `js_assimilate_thenable` + `js_promise_then`: cleanup-fulfilled settles the chained promise with the original outcome; cleanup-rejected rejects it with the cleanup reason (overriding the upstream outcome).
- A non-thenable return / non-callable `onFinally` (e.g. `.finally(1)`) passes the original outcome through after one extra microtask hop, as before.

### #2822 — combinator iterable consumption
`Promise.all/race/allSettled/any` previously lowered `args[0]` by unboxing it as an `ArrayHeader*` (silently reinterpreting non-arrays) and returned a numeric stub for omitted args. Added iterable-accepting runtime entries `js_promise_{all,race,all_settled,any}_iterable(value: f64)` (`promise/combinators.rs`) that coerce any iterable (array, `Set`, `Map`, string, generator / object with `[Symbol.iterator]`, bare iterator object) to an array and reject with `TypeError: <x> is not iterable (cannot read property Symbol(Symbol.iterator))` otherwise. The codegen lowering (`lower_call/console_promise.rs`) now passes the boxed value (omitted arg becomes `undefined`, which rejects). New `#[no_mangle]` entries carry `#[used]` keepalive anchors and are declared in `runtime_decls/strings.rs` (#3320 dead-strip contract).

## Validation
- Gap test `test-files/test_gap_2823_2825_2822_promise_semantics.ts` is byte-identical to `node --experimental-strip-types` under the default auto-optimize compile.
- Keepalive anchors verified present (count == 1 each) in the auto-optimize `libperry_runtime.a`.
- `cargo test --release -p perry-runtime promise` — 33 passed, 0 failed.
- `cargo fmt --all -- --check` — clean.
- Regression: `test_edge_promises`, `test_issue_1013_promise_all_destructure`, `test_gap_try_finally_no_catch_rethrow`, `test_async_chain`, `test_gap_async_advanced` all stay byte-identical to Node.

## Out of scope (pre-existing, not regressed)
- Object-literal thenable assimilation (`await Promise.resolve({then(r){r(42)}})` yields the object, not `42`) — a documented limitation in `js_assimilate_thenable` (only class-vtable `then` is probed); present on `main` independent of this change.
- `Promise.any([]).name === "AggregateError"` reads `undefined` on `main` (the `errors.length === 0` part is correct); a separate AggregateError-name bug, unchanged by this PR.
