### PR TITLE
fix(bigint): coercion errors, numeric range, and operator semantics

### DIFF
--- a/crates/perry-codegen/src/expr/binary.rs
+++ b/crates/perry-codegen/src/expr/binary.rs
@@ -147,6 +147,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     BinaryOp::BitXor => Some("js_dynamic_bitxor"),
                     BinaryOp::Shl => Some("js_dynamic_shl"),
                     BinaryOp::Shr => Some("js_dynamic_shr"),
+                    // `bigint ** bigint` is a BigInt operation (RangeError on
+                    // negative exponent); `>>>` on any BigInt is a TypeError.
+                    // Both are routed through the dynamic helpers so the
+                    // numeric fallback only fires when neither side is a
+                    // BigInt at runtime (#2908).
+                    BinaryOp::Pow => Some("js_dynamic_pow"),
+                    BinaryOp::UShr => Some("js_dynamic_ushr"),
                     _ => None,
                 };
                 if let Some(fname) = helper {

--- a/crates/perry-codegen/src/expr/unary.rs
+++ b/crates/perry-codegen/src/expr/unary.rs
@@ -50,11 +50,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::Unary { op, operand } => {
             let numeric = is_numeric_expr(ctx, operand);
+            // `-<bigint>` must stay a BigInt (`typeof -1n === "bigint"`).
+            // `fneg` on a NaN-boxed BigInt flips the NaN payload's sign bit
+            // and produces a garbage number, so route negation through the
+            // runtime dynamic helper when the operand is statically bigint.
+            let is_big = matches!(op, UnaryOp::Neg) && is_bigint_expr(ctx, operand);
             let v = lower_expr(ctx, operand)?;
             let blk = ctx.block();
             match op {
                 UnaryOp::Neg => {
-                    if numeric {
+                    if is_big {
+                        Ok(blk.call(DOUBLE, "js_dynamic_neg", &[(DOUBLE, &v)]))
+                    } else if numeric {
                         Ok(blk.fneg(&v))
                     } else {
                         let coerced = blk.call(DOUBLE, "js_number_coerce", &[(DOUBLE, &v)]);

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -816,6 +816,10 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_dynamic_bitxor", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_dynamic_shl", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_dynamic_shr", DOUBLE, &[DOUBLE, DOUBLE]);
+    // #2908: `bigint ** bigint` (RangeError on negative exponent) and `>>>`
+    // (always TypeError for BigInt operands). Numeric fallback inside.
+    module.declare_function("js_dynamic_pow", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_dynamic_ushr", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_instanceof", DOUBLE, &[DOUBLE, I32]);
     // v0.5.749: dynamic instanceof — `value instanceof type` where type
     // is a runtime expression (function arg holding class ref).

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -60,8 +60,11 @@ pub(super) fn try_global_builtins(
                 if !args.is_empty() {
                     return Ok(Ok(Expr::BigIntCoerce(Box::new(args.remove(0)))));
                 } else {
-                    // BigInt() with no args returns 0n
-                    return Ok(Ok(Expr::BigInt("0".to_string())));
+                    // `BigInt()` with no args coerces `undefined`, which Node
+                    // rejects with `TypeError: Cannot convert undefined to a
+                    // BigInt` (#2754/#2907). Route through the coercion path
+                    // so the runtime throws instead of returning 0n.
+                    return Ok(Ok(Expr::BigIntCoerce(Box::new(Expr::Undefined))));
                 }
             }
             "String" => {

--- a/crates/perry-runtime/src/bigint.rs
+++ b/crates/perry-runtime/src/bigint.rs
@@ -15,6 +15,58 @@ const BIGINT_BITS: usize = BIGINT_LIMBS * 64;
 const ZERO_LIMBS: [u64; BIGINT_LIMBS] = [0; BIGINT_LIMBS];
 const DIVISION_BY_ZERO_MESSAGE: &[u8] = b"Division by zero";
 
+/// Throw a `TypeError` with the given message (matches Node's BigInt coercion
+/// and operator errors). Never returns.
+#[cold]
+fn throw_bigint_type_error(message: &str) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+/// Throw a `RangeError` with the given message. Never returns.
+#[cold]
+fn throw_bigint_range_error(message: &str) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_rangeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+/// Throw a `SyntaxError` with the given message. Never returns.
+#[cold]
+fn throw_bigint_syntax_error(message: &str) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_syntaxerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+/// Build a 1024-bit two's-complement limb array from a finite-integer f64.
+/// Node converts any finite integer Number to a BigInt of the same value,
+/// not just those that fit in i64. Caller must have already verified the
+/// value is finite and has no fractional part.
+fn limbs_from_integer_f64(value: f64) -> [u64; BIGINT_LIMBS] {
+    if value == 0.0 {
+        return ZERO_LIMBS;
+    }
+    let negative = value < 0.0;
+    let mut mag = value.abs();
+    // Decompose the magnitude into base-2^64 limbs, low limb first.
+    let mut limbs = ZERO_LIMBS;
+    let two_pow_64 = 18446744073709551616.0f64; // 2^64
+    let mut i = 0;
+    while mag >= 1.0 && i < BIGINT_LIMBS {
+        let limb = mag % two_pow_64;
+        limbs[i] = limb as u64;
+        mag = (mag / two_pow_64).floor();
+        i += 1;
+    }
+    if negative {
+        negate_limbs(&limbs)
+    } else {
+        limbs
+    }
+}
+
 /// Decode a 1024-bit two's-complement value into a host i64 if it fits.
 /// Layout: positive small → all upper limbs zero AND limb[0] high bit clear;
 /// negative small → all upper limbs `u64::MAX` AND limb[0] high bit set.
@@ -152,8 +204,19 @@ pub extern "C" fn js_bigint_from_i64(value: i64) -> *mut BigIntHeader {
     bigint_alloc_with_limbs(limbs)
 }
 
-/// Create a BigInt from an f64 value (BigInt() coercion)
-/// Converts f64 to i64 then to BigInt. Handles NaN-boxed values too.
+/// Create a BigInt from a JS value (the `BigInt(value)` coercion).
+///
+/// Matches Node/ECMAScript `ToBigInt` semantics (#2754, #2907):
+///   - `undefined` / `null`  → `TypeError`
+///   - `true` / `false`      → `1n` / `0n`
+///   - existing BigInt       → pass-through
+///   - Number (incl. int32)  → must be a finite integer, else `RangeError`;
+///                             the full integer value is preserved (not
+///                             truncated/saturated to i64)
+///   - string                → parsed; invalid syntax → `SyntaxError`
+///
+/// The argument arrives NaN-boxed, so a real Number is a plain f64 while
+/// booleans/null/undefined/strings/bigints carry Perry tag bits.
 #[no_mangle]
 pub extern "C" fn js_bigint_from_f64(value: f64) -> *mut BigIntHeader {
     use crate::value::JSValue;
@@ -162,6 +225,11 @@ pub extern "C" fn js_bigint_from_f64(value: f64) -> *mut BigIntHeader {
     // If already a BigInt (NaN-boxed), just return the pointer
     if jsval.is_bigint() {
         return jsval.as_bigint_ptr() as *mut BigIntHeader;
+    }
+
+    // Boolean: BigInt(true) === 1n, BigInt(false) === 0n.
+    if jsval.is_bool() {
+        return js_bigint_from_i64(if jsval.as_bool() { 1 } else { 0 });
     }
 
     // If it's an INT32 (NaN-boxed i32), extract and convert
@@ -187,98 +255,129 @@ pub extern "C" fn js_bigint_from_f64(value: f64) -> *mut BigIntHeader {
                 return result;
             }
         }
+        // Empty / unmaterializable string → 0n, matching `BigInt("")`.
         return js_bigint_from_i64(0);
     }
 
-    // If it's undefined or null, return 0 (JavaScript throws TypeError, but we're lenient)
-    if jsval.is_undefined() || jsval.is_null() {
-        return js_bigint_from_i64(0);
+    // undefined / null are not convertible — Node throws a TypeError.
+    if jsval.is_undefined() {
+        throw_bigint_type_error("Cannot convert undefined to a BigInt");
+    }
+    if jsval.is_null() {
+        throw_bigint_type_error("Cannot convert null to a BigInt");
     }
 
-    // Convert f64 to BigInt
-    let int_value = value as i64;
-    js_bigint_from_i64(int_value)
+    // Remaining case: a real Number. Node only converts finite integers;
+    // NaN, ±Infinity, and any value with a fractional part throw RangeError.
+    if !value.is_finite() || value.fract() != 0.0 {
+        let label = if value.is_nan() {
+            "NaN".to_string()
+        } else if value.is_infinite() {
+            if value > 0.0 {
+                "Infinity".to_string()
+            } else {
+                "-Infinity".to_string()
+            }
+        } else {
+            // Only finite non-integers reach here (e.g. 1.5). ECMAScript
+            // NumberToString switches to scientific notation outside
+            // [1e-6, 1e21); for the common fractional inputs Rust's `{}`
+            // already matches Node.
+            let abs = value.abs();
+            if !(1e-6..1e21).contains(&abs) {
+                format!("{:e}", value)
+            } else {
+                format!("{}", value)
+            }
+        };
+        throw_bigint_range_error(&format!(
+            "The number {label} cannot be converted to a BigInt because it is not an integer"
+        ));
+    }
+    bigint_alloc_with_limbs(limbs_from_integer_f64(value))
 }
 
-/// Create a BigInt from a string (decimal or hex with 0x prefix)
+/// Create a BigInt from a string (the `BigInt("…")` coercion path).
+///
+/// Matches ECMAScript `StringToBigInt` (#2907): leading/trailing whitespace
+/// is trimmed; an empty (or all-whitespace) string is `0n`; a decimal string
+/// may carry an optional `+`/`-` sign; the radix prefixes `0x`/`0X`, `0o`/`0O`,
+/// `0b`/`0B` are accepted (without a sign). Any other content — stray
+/// characters, a lone sign, a sign on a prefixed literal — throws a
+/// `SyntaxError` instead of silently dropping the invalid characters.
 #[no_mangle]
 pub extern "C" fn js_bigint_from_string(data: *const u8, len: u32) -> *mut BigIntHeader {
     unsafe {
         let bytes = std::slice::from_raw_parts(data, len as usize);
-        let s = std::str::from_utf8_unchecked(bytes);
-
-        // Fast path: decimal string that fits in i64. Postgres `int8`
-        // results, Node `Date.now()` timestamps, app IDs — the common
-        // BigInt input in real code is well under 2^63. For those we
-        // skip the per-digit 16-limb multiply (~300 u128 muls for a
-        // 20-char input) and let Rust's native str→i64 handle parsing
-        // in a single pass.
-        //
-        // `i64::from_str` returns Err on overflow / non-digit, and we
-        // fall through to the general path so hex, floats-of-ints, and
-        // arbitrary-precision still work exactly as before.
-        if !s.starts_with("0x") && !s.starts_with("0X") {
-            if let Ok(v) = s.parse::<i64>() {
-                return js_bigint_from_i64(v);
-            }
+        let raw = std::str::from_utf8_unchecked(bytes);
+        match parse_bigint_string(raw) {
+            Ok(limbs) => bigint_alloc_with_limbs(limbs),
+            Err(()) => throw_bigint_syntax_error(&format!("Cannot convert {raw} to a BigInt")),
         }
-
-        // Handle negative prefix
-        let (is_negative, s) = if s.starts_with('-') {
-            (true, &s[1..])
-        } else {
-            (false, s)
-        };
-
-        // Parse the string
-        let (is_hex, s) = if s.starts_with("0x") || s.starts_with("0X") {
-            (true, &s[2..])
-        } else {
-            (false, s)
-        };
-
-        let mut limbs = ZERO_LIMBS;
-
-        if is_hex {
-            // Parse hex string
-            let mut chars = s.chars().rev();
-            for limb in limbs.iter_mut() {
-                let mut value = 0u64;
-                for i in 0..16 {
-                    if let Some(c) = chars.next() {
-                        let digit = match c {
-                            '0'..='9' => c as u64 - '0' as u64,
-                            'a'..='f' => c as u64 - 'a' as u64 + 10,
-                            'A'..='F' => c as u64 - 'A' as u64 + 10,
-                            _ => continue,
-                        };
-                        value |= digit << (i * 4);
-                    } else {
-                        break;
-                    }
-                }
-                *limb = value;
-            }
-        } else {
-            // Parse decimal string using long multiplication
-            for c in s.chars() {
-                if let Some(digit) = c.to_digit(10) {
-                    // Multiply by 10 and add digit
-                    let mut carry = digit as u64;
-                    for limb in limbs.iter_mut() {
-                        let product = (*limb as u128) * 10 + carry as u128;
-                        *limb = product as u64;
-                        carry = (product >> 64) as u64;
-                    }
-                }
-            }
-        }
-
-        if is_negative && !limbs.iter().all(|&l| l == 0) {
-            limbs = negate_limbs(&limbs);
-        }
-        bigint_alloc_with_limbs(limbs)
     }
+}
+
+/// Parse a string per ECMAScript `StringToBigInt`. Returns the limb array on
+/// success, or `Err(())` for invalid BigInt syntax. The original (untrimmed)
+/// string is used by the caller to build Node's error message.
+fn parse_bigint_string(raw: &str) -> Result<[u64; BIGINT_LIMBS], ()> {
+    // ECMAScript trims StrWhiteSpace from both ends; the empty string is 0n.
+    let s = raw.trim();
+    if s.is_empty() {
+        return Ok(ZERO_LIMBS);
+    }
+
+    // Radix-prefixed forms do not allow a leading sign.
+    let lower_prefix = s.as_bytes().get(0..2).map(|p| {
+        let mut buf = [p[0], p[1]];
+        buf.make_ascii_lowercase();
+        buf
+    });
+    if let Some([b'0', tag]) = lower_prefix {
+        let radix = match tag {
+            b'x' => Some(16u32),
+            b'o' => Some(8u32),
+            b'b' => Some(2u32),
+            _ => None,
+        };
+        if let Some(radix) = radix {
+            let digits = &s[2..];
+            if digits.is_empty() {
+                return Err(());
+            }
+            return parse_radix_digits(digits, radix, false);
+        }
+    }
+
+    // Optional sign, then decimal digits only.
+    let (is_negative, digits) = match s.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, s.strip_prefix('+').unwrap_or(s)),
+    };
+    if digits.is_empty() {
+        return Err(());
+    }
+    parse_radix_digits(digits, 10, is_negative)
+}
+
+/// Parse `digits` in the given radix (2/8/10/16), rejecting any out-of-range
+/// character. Applies two's-complement negation when `is_negative`.
+fn parse_radix_digits(digits: &str, radix: u32, is_negative: bool) -> Result<[u64; BIGINT_LIMBS], ()> {
+    let mut limbs = ZERO_LIMBS;
+    let radix_u128 = radix as u128;
+    for c in digits.chars() {
+        let digit = c.to_digit(radix).ok_or(())?;
+        let mut carry = digit as u64;
+        for limb in limbs.iter_mut() {
+            let product = (*limb as u128) * radix_u128 + carry as u128;
+            *limb = product as u64;
+            carry = (product >> 64) as u64;
+        }
+    }
+    if is_negative && !limbs.iter().all(|&l| l == 0) {
+        limbs = negate_limbs(&limbs);
+    }
+    Ok(limbs)
 }
 
 /// Create a BigInt from a string with a given radix (for BN.js compatibility)
@@ -735,6 +834,12 @@ pub extern "C" fn js_bigint_pow(
 ) -> *mut BigIntHeader {
     let a_limbs = bigint_limbs_or_zero(a);
     let b_limbs = bigint_limbs_or_zero(b);
+
+    // ECMaScript: a negative BigInt exponent is a RangeError.
+    if is_negative(&b_limbs) {
+        throw_bigint_range_error("Exponent must be positive");
+    }
+
     // Get exponent as u64 (only lower 64 bits)
     let exp = b_limbs[0];
 
@@ -776,32 +881,19 @@ fn mul_limbs(a: &[u64; BIGINT_LIMBS], b: &[u64; BIGINT_LIMBS]) -> [u64; BIGINT_L
     result
 }
 
-/// Left shift BigInt by b bits (a << b)
-/// Note: b is interpreted as a u64 (only lower 64 bits are used)
-#[no_mangle]
-pub extern "C" fn js_bigint_shl(
-    a: *const BigIntHeader,
-    b: *const BigIntHeader,
-) -> *mut BigIntHeader {
-    let a_limbs = bigint_limbs_or_zero(a);
-    let b_limbs = bigint_limbs_or_zero(b);
-    let shift = b_limbs[0] as usize;
+/// Left-shift a limb array by `shift` bits (magnitude only).
+fn shl_limbs(a_limbs: &[u64; BIGINT_LIMBS], shift: usize) -> [u64; BIGINT_LIMBS] {
     if shift >= BIGINT_BITS {
-        return bigint_alloc_with_limbs(ZERO_LIMBS);
+        return ZERO_LIMBS;
     }
     let mut result = ZERO_LIMBS;
-
-    // Calculate full limb shifts and bit shifts within a limb
     let limb_shift = shift / 64;
     let bit_shift = (shift % 64) as u32;
-
     if bit_shift == 0 {
-        // Simple case: only limb-aligned shift
         for i in limb_shift..BIGINT_LIMBS {
             result[i] = a_limbs[i - limb_shift];
         }
     } else {
-        // General case: shift across limb boundaries
         for i in limb_shift..BIGINT_LIMBS {
             let src_idx = i - limb_shift;
             result[i] = a_limbs[src_idx] << bit_shift;
@@ -810,12 +902,79 @@ pub extern "C" fn js_bigint_shl(
             }
         }
     }
+    result
+}
 
+/// Arithmetic right-shift a limb array by `shift` bits (sign-extending).
+fn shr_limbs(a_limbs: &[u64; BIGINT_LIMBS], shift: usize) -> [u64; BIGINT_LIMBS] {
+    let neg = is_negative(a_limbs);
+    let fill: u64 = if neg { !0u64 } else { 0u64 };
+    if shift >= BIGINT_BITS {
+        return [fill; BIGINT_LIMBS];
+    }
+    let mut result = [fill; BIGINT_LIMBS];
+    let limb_shift = shift / 64;
+    let bit_shift = (shift % 64) as u32;
+    if bit_shift == 0 {
+        for i in 0..(BIGINT_LIMBS - limb_shift) {
+            result[i] = a_limbs[i + limb_shift];
+        }
+    } else {
+        for i in 0..(BIGINT_LIMBS - limb_shift) {
+            let src_idx = i + limb_shift;
+            result[i] = a_limbs[src_idx] >> bit_shift;
+            if src_idx + 1 < BIGINT_LIMBS {
+                result[i] |= a_limbs[src_idx + 1] << (64 - bit_shift);
+            } else {
+                result[i] |= fill << (64 - bit_shift);
+            }
+        }
+    }
+    result
+}
+
+/// Interpret a two's-complement shift count as a signed magnitude. Returns
+/// `(magnitude, count_is_negative)`. Counts beyond `BIGINT_BITS` saturate.
+fn shift_count(b_limbs: &[u64; BIGINT_LIMBS]) -> (usize, bool) {
+    if is_negative(b_limbs) {
+        let mag = negate_limbs(b_limbs);
+        // Only the low limb matters for any realistic shift; if any upper
+        // limb is set the count is enormous → saturate past BIGINT_BITS.
+        if mag[1..].iter().any(|&l| l != 0) {
+            (BIGINT_BITS, true)
+        } else {
+            (mag[0] as usize, true)
+        }
+    } else {
+        if b_limbs[1..].iter().any(|&l| l != 0) {
+            (BIGINT_BITS, false)
+        } else {
+            (b_limbs[0] as usize, false)
+        }
+    }
+}
+
+/// Left shift BigInt by b bits (a << b). A negative shift count reverses
+/// direction (`a << -n` === `a >> n`), matching ECMAScript.
+#[no_mangle]
+pub extern "C" fn js_bigint_shl(
+    a: *const BigIntHeader,
+    b: *const BigIntHeader,
+) -> *mut BigIntHeader {
+    let a_limbs = bigint_limbs_or_zero(a);
+    let b_limbs = bigint_limbs_or_zero(b);
+    let (shift, negative) = shift_count(&b_limbs);
+    let result = if negative {
+        shr_limbs(&a_limbs, shift)
+    } else {
+        shl_limbs(&a_limbs, shift)
+    };
     bigint_alloc_with_limbs(result)
 }
 
-/// Right shift BigInt by b bits (a >> b)
-/// Note: b is interpreted as a u64 (only lower 64 bits are used)
+/// Right shift BigInt by b bits (a >> b), arithmetic / sign-extending. A
+/// negative shift count reverses direction (`a >> -n` === `a << n`), matching
+/// ECMAScript.
 #[no_mangle]
 pub extern "C" fn js_bigint_shr(
     a: *const BigIntHeader,
@@ -823,41 +982,12 @@ pub extern "C" fn js_bigint_shr(
 ) -> *mut BigIntHeader {
     let a_limbs = bigint_limbs_or_zero(a);
     let b_limbs = bigint_limbs_or_zero(b);
-    let neg = is_negative(&a_limbs);
-    // Fill value for sign extension: 0xFF..FF for negative, 0x00..00 for positive
-    let fill: u64 = if neg { !0u64 } else { 0u64 };
-
-    let shift = b_limbs[0] as usize;
-    if shift >= BIGINT_BITS {
-        // Arithmetic: negative → all 1s (-1), positive → all 0s (0)
-        return bigint_alloc_with_limbs([fill; BIGINT_LIMBS]);
-    }
-
-    let mut result = [fill; BIGINT_LIMBS];
-
-    // Calculate full limb shifts and bit shifts within a limb
-    let limb_shift = shift / 64;
-    let bit_shift = (shift % 64) as u32;
-
-    if bit_shift == 0 {
-        // Simple case: only limb-aligned shift
-        for i in 0..(BIGINT_LIMBS - limb_shift) {
-            result[i] = a_limbs[i + limb_shift];
-        }
+    let (shift, negative) = shift_count(&b_limbs);
+    let result = if negative {
+        shl_limbs(&a_limbs, shift)
     } else {
-        // General case: shift across limb boundaries
-        for i in 0..(BIGINT_LIMBS - limb_shift) {
-            let src_idx = i + limb_shift;
-            result[i] = a_limbs[src_idx] >> bit_shift;
-            if src_idx + 1 < BIGINT_LIMBS {
-                result[i] |= a_limbs[src_idx + 1] << (64 - bit_shift);
-            } else {
-                // Top limb: sign-extend the vacated bits
-                result[i] |= fill << (64 - bit_shift);
-            }
-        }
-    }
-
+        shr_limbs(&a_limbs, shift)
+    };
     bigint_alloc_with_limbs(result)
 }
 

--- a/crates/perry-runtime/src/bigint.rs
+++ b/crates/perry-runtime/src/bigint.rs
@@ -362,7 +362,11 @@ fn parse_bigint_string(raw: &str) -> Result<[u64; BIGINT_LIMBS], ()> {
 
 /// Parse `digits` in the given radix (2/8/10/16), rejecting any out-of-range
 /// character. Applies two's-complement negation when `is_negative`.
-fn parse_radix_digits(digits: &str, radix: u32, is_negative: bool) -> Result<[u64; BIGINT_LIMBS], ()> {
+fn parse_radix_digits(
+    digits: &str,
+    radix: u32,
+    is_negative: bool,
+) -> Result<[u64; BIGINT_LIMBS], ()> {
     let mut limbs = ZERO_LIMBS;
     let radix_u128 = radix as u128;
     for c in digits.chars() {
@@ -1548,6 +1552,90 @@ mod tests {
         assert_eq!(d(-7, 2), -3);
         assert_eq!(d(7, -2), -3);
         assert_eq!(d(-7, -2), 3);
+    }
+
+    // -- #2754 / #2907: BigInt() coercion semantics --
+
+    #[test]
+    fn coerce_boolean_inputs() {
+        use crate::value::JSValue;
+        let t = js_bigint_from_f64(f64::from_bits(JSValue::bool(true).bits()));
+        assert_eq!(read_as_i64(t), 1);
+        let f = js_bigint_from_f64(f64::from_bits(JSValue::bool(false).bits()));
+        assert_eq!(read_as_i64(f), 0);
+    }
+
+    #[test]
+    fn coerce_finite_integer_number() {
+        // Plain f64 (real Number) integer → exact BigInt.
+        let b = js_bigint_from_f64(42.0);
+        assert_eq!(read_as_i64(b), 42);
+        let b = js_bigint_from_f64(-7.0);
+        assert_eq!(read_as_i64(b), -7);
+    }
+
+    #[test]
+    fn coerce_large_integer_number_preserved() {
+        // 2^60 fits in f64 exactly and exceeds nothing; verify the full
+        // value is preserved (not saturated/truncated).
+        let v = (1u64 << 60) as f64;
+        let b = js_bigint_from_f64(v);
+        assert_eq!(read_as_i64(b), 1i64 << 60);
+    }
+
+    // -- #2907: string parsing validation --
+
+    fn parse(s: &str) -> Result<i64, ()> {
+        parse_bigint_string(s).map(|limbs| fits_in_i64(&limbs).expect("fits"))
+    }
+
+    #[test]
+    fn parse_radix_prefixes_and_whitespace() {
+        assert_eq!(parse("0x10"), Ok(16));
+        assert_eq!(parse("0o17"), Ok(15));
+        assert_eq!(parse("0b101"), Ok(5));
+        assert_eq!(parse("  42  "), Ok(42));
+        assert_eq!(parse(""), Ok(0));
+        assert_eq!(parse("  "), Ok(0));
+        assert_eq!(parse("+5"), Ok(5));
+        assert_eq!(parse("-5"), Ok(-5));
+    }
+
+    #[test]
+    fn parse_invalid_strings_reject() {
+        assert_eq!(parse("bad"), Err(()));
+        assert_eq!(parse("12abc34"), Err(()));
+        assert_eq!(parse("0x"), Err(()));
+        assert_eq!(parse("0xG"), Err(()));
+        assert_eq!(parse("1_000"), Err(()));
+        assert_eq!(parse("+"), Err(()));
+    }
+
+    // -- #2908: shift direction-reversing + pow --
+
+    #[test]
+    fn shift_negative_count_reverses_direction() {
+        // 1n << -1n === 1n >> 1n === 0n
+        let one = js_bigint_from_i64(1);
+        let neg_one = js_bigint_from_i64(-1);
+        assert_eq!(read_as_i64(js_bigint_shl(one, neg_one)), 0);
+        // 8n >> -1n === 8n << 1n === 16n
+        let eight = js_bigint_from_i64(8);
+        assert_eq!(read_as_i64(js_bigint_shr(eight, neg_one)), 16);
+        // Sanity: positive counts still work.
+        let four = js_bigint_from_i64(4);
+        assert_eq!(read_as_i64(js_bigint_shl(one, four)), 16);
+        let two = js_bigint_from_i64(2);
+        assert_eq!(read_as_i64(js_bigint_shr(eight, two)), 2);
+    }
+
+    #[test]
+    fn pow_non_negative() {
+        let two = js_bigint_from_i64(2);
+        let three = js_bigint_from_i64(3);
+        assert_eq!(read_as_i64(js_bigint_pow(two, three)), 8);
+        let zero = js_bigint_from_i64(0);
+        assert_eq!(read_as_i64(js_bigint_pow(two, zero)), 1);
     }
 
     #[test]

--- a/crates/perry-runtime/src/gc/tests/runtime_roots.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots.rs
@@ -1041,7 +1041,13 @@ fn test_dynamic_string_add_roots_left_string_across_rhs_coercion_gc() {
 }
 
 #[test]
-fn test_dynamic_bigint_add_roots_left_bigint_across_rhs_coercion_gc() {
+fn test_dynamic_bigint_add_roots_both_bigint_across_gc() {
+    // #2908: a BigInt operator now requires BOTH operands to be BigInt
+    // (`1n + 1` throws TypeError instead of coercing). This test exercises
+    // the same GC-rooting guarantee — the left BigInt must survive a minor
+    // GC scheduled by the right operand's allocation — but with a second
+    // BigInt operand so the dynamic add takes the (now only legal) BigInt
+    // path instead of the removed mixed-coercion path.
     let _guard = CopyingNurseryTestGuard::new(0);
     let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
     register_runtime_handle_root_scanner_for_tests();
@@ -1061,12 +1067,15 @@ fn test_dynamic_bigint_add_roots_left_bigint_across_rhs_coercion_gc() {
         let left_scope = RuntimeHandleScope::new();
         let left_root = left_scope.root_bigint_ptr(left as *const crate::bigint::BigIntHeader);
 
+        let right = crate::bigint::js_bigint_from_i64(1);
+        let right_value = crate::value::js_nanbox_bigint(right as i64);
+
         force_next_general_arena_alloc_slow();
         trigger_guard.make_arena_trigger_due();
         let before = gc_collection_count();
-        let result = unsafe { op(left_value, 1.0) };
+        let result = unsafe { op(left_value, right_value) };
         let result_root = left_scope.root_nanbox_f64(result);
-        drain_scheduled_minor_gc(before, &format!("{name} rhs BigInt coercion"));
+        drain_scheduled_minor_gc(before, &format!("{name} both BigInt across GC"));
 
         let rooted_left = left_root.get_raw_const_ptr::<crate::bigint::BigIntHeader>();
         assert_eq!(crate::bigint::js_bigint_to_f64(rooted_left), 41.0);

--- a/crates/perry-runtime/src/value/dynamic_arith.rs
+++ b/crates/perry-runtime/src/value/dynamic_arith.rs
@@ -19,6 +19,34 @@ unsafe fn coerce_to_bigint_ptr(val: f64) -> *mut crate::bigint::BigIntHeader {
     }
 }
 
+/// Throw `TypeError: Cannot mix BigInt and other types, use explicit
+/// conversions`, matching Node when a BigInt operand is combined with a
+/// non-BigInt operand in an arithmetic / bitwise operation (#2908).
+#[cold]
+unsafe fn throw_mix_bigint() -> ! {
+    let msg = b"Cannot mix BigInt and other types, use explicit conversions";
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(js_nanbox_pointer(err as i64))
+}
+
+/// Enforce Node's rule that BigInt operators require *both* operands to be
+/// BigInt. Returns true when both are BigInt (proceed with the BigInt op),
+/// false when neither is (use the numeric path), and throws a TypeError when
+/// exactly one operand is a BigInt.
+#[inline]
+unsafe fn both_bigint_or_throw(a: f64, b: f64) -> bool {
+    let a_big = JSValue::from_bits(a.to_bits()).is_bigint();
+    let b_big = JSValue::from_bits(b.to_bits()).is_bigint();
+    if a_big && b_big {
+        true
+    } else if a_big || b_big {
+        throw_mix_bigint();
+    } else {
+        false
+    }
+}
+
 type BigIntBinaryOp = extern "C" fn(
     *const crate::bigint::BigIntHeader,
     *const crate::bigint::BigIntHeader,
@@ -60,9 +88,7 @@ unsafe fn dynamic_bigint_binary_op_from_handles<'scope>(
 /// Dynamic multiply: BigInt * BigInt if either operand is BigInt, else f64 * f64.
 #[no_mangle]
 pub unsafe extern "C" fn js_dynamic_mul(a: f64, b: f64) -> f64 {
-    let a_val = JSValue::from_bits(a.to_bits());
-    let b_val = JSValue::from_bits(b.to_bits());
-    if a_val.is_bigint() || b_val.is_bigint() {
+    if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_mul);
     }
     a * b
@@ -71,9 +97,7 @@ pub unsafe extern "C" fn js_dynamic_mul(a: f64, b: f64) -> f64 {
 /// Dynamic add: BigInt + BigInt if either operand is BigInt, else f64 + f64.
 #[no_mangle]
 pub unsafe extern "C" fn js_dynamic_add(a: f64, b: f64) -> f64 {
-    let a_val = JSValue::from_bits(a.to_bits());
-    let b_val = JSValue::from_bits(b.to_bits());
-    if a_val.is_bigint() || b_val.is_bigint() {
+    if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_add);
     }
     a + b
@@ -126,8 +150,10 @@ pub unsafe extern "C" fn js_dynamic_string_or_number_add(a: f64, b: f64) -> f64 
         return f64::from_bits(JSValue::string_ptr(result).bits());
     }
 
-    // BigInt: same as js_dynamic_add.
-    if a_val.is_bigint() || b_val.is_bigint() {
+    // BigInt: same as js_dynamic_add. Neither operand is a string here
+    // (the concat branch above already handled that), so a mixed
+    // BigInt/Number `+` throws TypeError just like Node.
+    if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op_from_handles(
             &scope,
             &a_handle,
@@ -154,9 +180,7 @@ pub unsafe extern "C" fn js_dynamic_string_or_number_add(a: f64, b: f64) -> f64 
 /// Dynamic subtract: BigInt - BigInt if either operand is BigInt, else f64 - f64.
 #[no_mangle]
 pub unsafe extern "C" fn js_dynamic_sub(a: f64, b: f64) -> f64 {
-    let a_val = JSValue::from_bits(a.to_bits());
-    let b_val = JSValue::from_bits(b.to_bits());
-    if a_val.is_bigint() || b_val.is_bigint() {
+    if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_sub);
     }
     a - b
@@ -165,9 +189,7 @@ pub unsafe extern "C" fn js_dynamic_sub(a: f64, b: f64) -> f64 {
 /// Dynamic divide: BigInt / BigInt if either operand is BigInt, else f64 / f64.
 #[no_mangle]
 pub unsafe extern "C" fn js_dynamic_div(a: f64, b: f64) -> f64 {
-    let a_val = JSValue::from_bits(a.to_bits());
-    let b_val = JSValue::from_bits(b.to_bits());
-    if a_val.is_bigint() || b_val.is_bigint() {
+    if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_div);
     }
     a / b
@@ -176,9 +198,7 @@ pub unsafe extern "C" fn js_dynamic_div(a: f64, b: f64) -> f64 {
 /// Dynamic modulo: BigInt % BigInt if either operand is BigInt, else f64 % f64.
 #[no_mangle]
 pub unsafe extern "C" fn js_dynamic_mod(a: f64, b: f64) -> f64 {
-    let a_val = JSValue::from_bits(a.to_bits());
-    let b_val = JSValue::from_bits(b.to_bits());
-    if a_val.is_bigint() || b_val.is_bigint() {
+    if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_mod);
     }
     // Float modulo: a - trunc(a / b) * b
@@ -203,9 +223,7 @@ pub unsafe extern "C" fn js_dynamic_neg(a: f64) -> f64 {
 /// Dynamic right shift: BigInt >> if either operand is BigInt, else i32 >> for numbers.
 #[no_mangle]
 pub unsafe extern "C" fn js_dynamic_shr(a: f64, b: f64) -> f64 {
-    let a_val = JSValue::from_bits(a.to_bits());
-    let b_val = JSValue::from_bits(b.to_bits());
-    if a_val.is_bigint() || b_val.is_bigint() {
+    if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_shr);
     }
     // JS ToInt32: f64 -> i64 -> i32 (wrapping), NOT f64 -> i32 (saturating).
@@ -218,9 +236,7 @@ pub unsafe extern "C" fn js_dynamic_shr(a: f64, b: f64) -> f64 {
 /// Dynamic left shift: BigInt << if either operand is BigInt, else i32 << for numbers.
 #[no_mangle]
 pub unsafe extern "C" fn js_dynamic_shl(a: f64, b: f64) -> f64 {
-    let a_val = JSValue::from_bits(a.to_bits());
-    let b_val = JSValue::from_bits(b.to_bits());
-    if a_val.is_bigint() || b_val.is_bigint() {
+    if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_shl);
     }
     // JS ToInt32: f64 -> i64 -> i32 (wrapping), NOT f64 -> i32 (saturating).
@@ -232,9 +248,7 @@ pub unsafe extern "C" fn js_dynamic_shl(a: f64, b: f64) -> f64 {
 /// Dynamic bitwise AND: BigInt & if either operand is BigInt, else i32 & for numbers.
 #[no_mangle]
 pub unsafe extern "C" fn js_dynamic_bitand(a: f64, b: f64) -> f64 {
-    let a_val = JSValue::from_bits(a.to_bits());
-    let b_val = JSValue::from_bits(b.to_bits());
-    if a_val.is_bigint() || b_val.is_bigint() {
+    if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_and);
     }
     // JS ToInt32: f64 -> i64 -> i32 (wrapping), NOT f64 -> i32 (saturating).
@@ -244,9 +258,7 @@ pub unsafe extern "C" fn js_dynamic_bitand(a: f64, b: f64) -> f64 {
 /// Dynamic bitwise OR: BigInt | if either operand is BigInt, else i32 | for numbers.
 #[no_mangle]
 pub unsafe extern "C" fn js_dynamic_bitor(a: f64, b: f64) -> f64 {
-    let a_val = JSValue::from_bits(a.to_bits());
-    let b_val = JSValue::from_bits(b.to_bits());
-    if a_val.is_bigint() || b_val.is_bigint() {
+    if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_or);
     }
     // JS ToInt32: f64 -> i64 -> i32 (wrapping), NOT f64 -> i32 (saturating).
@@ -256,11 +268,45 @@ pub unsafe extern "C" fn js_dynamic_bitor(a: f64, b: f64) -> f64 {
 /// Dynamic bitwise XOR: BigInt ^ if either operand is BigInt, else i32 ^ for numbers.
 #[no_mangle]
 pub unsafe extern "C" fn js_dynamic_bitxor(a: f64, b: f64) -> f64 {
-    let a_val = JSValue::from_bits(a.to_bits());
-    let b_val = JSValue::from_bits(b.to_bits());
-    if a_val.is_bigint() || b_val.is_bigint() {
+    if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_xor);
     }
     // JS ToInt32: f64 -> i64 -> i32 (wrapping), NOT f64 -> i32 (saturating).
     (((a as i64) as i32) ^ ((b as i64) as i32)) as f64
 }
+
+/// Dynamic exponentiation: `BigInt ** BigInt` when both operands are BigInt
+/// (#2908), else numeric `Math.pow`. A mixed BigInt/Number `**` throws
+/// TypeError; a negative BigInt exponent throws RangeError (handled inside
+/// `js_bigint_pow`).
+#[no_mangle]
+pub unsafe extern "C" fn js_dynamic_pow(a: f64, b: f64) -> f64 {
+    if both_bigint_or_throw(a, b) {
+        return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_pow);
+    }
+    crate::math::js_math_pow(a, b)
+}
+
+/// Dynamic unsigned right shift. BigInts have no `>>>` operator in
+/// ECMAScript, so any BigInt operand throws TypeError (#2908); otherwise
+/// numeric ToUint32 `>>>`.
+#[no_mangle]
+pub unsafe extern "C" fn js_dynamic_ushr(a: f64, b: f64) -> f64 {
+    let a_big = JSValue::from_bits(a.to_bits()).is_bigint();
+    let b_big = JSValue::from_bits(b.to_bits()).is_bigint();
+    if a_big || b_big {
+        let msg = b"BigInts have no unsigned right shift, use >> instead";
+        let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+        let err = crate::error::js_typeerror_new(s);
+        crate::exception::js_throw(js_nanbox_pointer(err as i64));
+    }
+    // JS ToUint32 then logical shift, count masked to 5 bits.
+    let ai = (a as i64) as u32;
+    let bi = ((b as i64) as i32 as u32) & 0x1f;
+    (ai >> bi) as f64
+}
+
+#[used]
+static KEEP_DYNAMIC_POW: unsafe extern "C" fn(f64, f64) -> f64 = js_dynamic_pow;
+#[used]
+static KEEP_DYNAMIC_USHR: unsafe extern "C" fn(f64, f64) -> f64 = js_dynamic_ushr;

--- a/test-files/test_gap_2754_2907_2908_bigint_semantics.ts
+++ b/test-files/test_gap_2754_2907_2908_bigint_semantics.ts
@@ -1,0 +1,47 @@
+// Gap test for #2754 / #2907 / #2908 — BigInt() coercion + operator semantics.
+// Each case prints err.name + ": " + err.message (or "ok <value>") so the
+// output is byte-comparable against `node --experimental-strip-types`.
+
+function run(label: string, fn: () => unknown): void {
+  try {
+    console.log(label + " ok " + String(fn()));
+  } catch (e) {
+    const err = e as Error;
+    console.log(label + " throw " + err.name + ": " + err.message);
+  }
+}
+
+// ---- BigInt() coercion (#2754 / #2907) ----
+run("BigInt()", () => BigInt());
+run("BigInt(undefined)", () => BigInt(undefined));
+run("BigInt(null)", () => BigInt(null as unknown as number));
+run("BigInt(1.5)", () => BigInt(1.5));
+run("BigInt(NaN)", () => BigInt(NaN));
+run("BigInt(Infinity)", () => BigInt(Infinity));
+run("BigInt(-Infinity)", () => BigInt(-Infinity));
+run("BigInt(42)", () => BigInt(42));
+run("BigInt(true)", () => BigInt(true));
+run("BigInt(false)", () => BigInt(false));
+run('BigInt("0x10")', () => BigInt("0x10"));
+run('BigInt("0o17")', () => BigInt("0o17"));
+run('BigInt("0b101")', () => BigInt("0b101"));
+run('BigInt("  42  ")', () => BigInt("  42  "));
+run('BigInt("")', () => BigInt(""));
+run('BigInt("bad")', () => BigInt("bad"));
+run('BigInt("12abc34")', () => BigInt("12abc34"));
+
+// ---- Operator semantics (#2908) ----
+run("1n + 1", () => (1n as bigint) + (1 as unknown as bigint));
+run("1n - 1", () => (1n as bigint) - (1 as unknown as bigint));
+run("1n * 2n", () => 1n * 2n);
+run("5n / 2n", () => 5n / 2n);
+run("5n % 2n", () => 5n % 2n);
+run("2n ** 3n", () => 2n ** 3n);
+run("2n ** -1n", () => 2n ** -1n);
+run("5n / 0n", () => 5n / 0n);
+run("5n % 0n", () => 5n % 0n);
+run("1n >>> 0n", () => (1n as bigint) >>> (0n as unknown as number));
+run("1n << -1n", () => 1n << -1n);
+run("8n >> -1n", () => 8n >> -1n);
+run("1n << 4n", () => 1n << 4n);
+run("256n >> 4n", () => 256n >> 4n);


### PR DESCRIPTION
Closes #2754
Closes #2907
Closes #2908

## Summary

Aligns Perry's `BigInt()` coercion and BigInt operator semantics with Node/ECMAScript. Previously Perry was lenient: invalid coercions returned `0n` or truncated, mixed BigInt/Number arithmetic silently coerced, and `**`/`>>>`/negative-shift edge cases were wrong. All three issues are coercion/operator semantics in the same area, so they are fixed together.

## Implementation

### `BigInt(value)` coercion (#2754 / #2907) — `crates/perry-runtime/src/bigint.rs`, `crates/perry-hir/src/lower/expr_call/globals.rs`
- `BigInt()` / `BigInt(undefined)` / `BigInt(null)` now throw `TypeError` (`Cannot convert undefined/null to a BigInt`). The no-arg form lowers to `BigIntCoerce(undefined)` instead of `0n`.
- Boolean inputs produce `1n` / `0n`.
- Non-integer / non-finite Numbers (`1.5`, `NaN`, `±Infinity`) throw `RangeError: The number <x> cannot be converted to a BigInt because it is not an integer`.
- Finite integer Numbers are converted to their full value via base-2^64 limb decomposition (no `i64` truncation/saturation; `BigInt(2**60)` is exact).
- `js_bigint_from_string` now implements ECMAScript `StringToBigInt`: trims whitespace, accepts `0x`/`0o`/`0b` prefixes and optional `+`/`-` sign on decimals, treats empty/whitespace-only as `0n`, and throws `SyntaxError: Cannot convert <s> to a BigInt` on any invalid character (e.g. `"bad"`, `"12abc34"`, `"1_000"`).

### Operator semantics (#2908) — `crates/perry-runtime/src/value/dynamic_arith.rs`, `crates/perry-runtime/src/bigint.rs`, `crates/perry-codegen/src/expr/{binary,unary}.rs`
- Mixed BigInt/Number arithmetic and bitwise ops throw `TypeError: Cannot mix BigInt and other types, use explicit conversions` (the dynamic helpers now require *both* operands to be BigInt; `+` still does string concat first, so `1n + "x"` works).
- `bigint / 0n` and `bigint % 0n` throw `RangeError` (unchanged).
- `bigint ** bigint` is now a BigInt op (new `js_dynamic_pow`, wired through `BinaryOp::Pow`); negative exponent throws `RangeError: Exponent must be positive`.
- `>>>` with any BigInt operand throws `TypeError: BigInts have no unsigned right shift, use >> instead` (new `js_dynamic_ushr`, wired through `BinaryOp::UShr`).
- Negative BigInt shift counts reverse direction (`1n << -1n` === `1n >> 1n`, `8n >> -1n` === `8n << 1n`) via a shared `shift_count` helper.
- Unary negation of a BigInt now keeps the BigInt tag (`typeof -1n === "bigint"`); previously `fneg` on the NaN-boxed payload produced a garbage Number, which also broke `2n ** -1n`.

## Validation
- New gap test `test-files/test_gap_2754_2907_2908_bigint_semantics.ts` (29 cases covering each issue) is byte-identical to `node --experimental-strip-types`, verified under the DEFAULT auto-optimize compile.
- New runtime unit tests in `bigint.rs` (boolean/integer/large-int coercion, string-parse accept/reject, shift direction-reversal, pow). `cargo test --release -p perry-runtime bigint` green.
- Existing `test_gap_bigint.ts` and `test_gap_typeof_instanceof.ts` remain byte-identical to Node.
- `cargo fmt --all -- --check` clean.
- Updated `test_dynamic_bigint_add_roots_*` GC-rooting test to use two BigInt operands (it previously asserted the now-removed mixed-coercion behavior; its GC-rooting intent is preserved).
