### PR TITLE
fix(util): implement util.toUSVString (#2514)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2666,6 +2666,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("util", "getSystemErrorMessage", false, None),
     method("util", "getSystemErrorMap", false, None),
     method("util", "parseEnv", false, None),
+    // #2514: util.toUSVString(value) → string with lone surrogates replaced.
+    method("util", "toUSVString", false, None),
     // `util.formatWithOptions(options, format[, ...args])` — identical to
     // `util.format` except the first arg is an `util.inspect` options bag
     // applied to any `%o`/`%O` placeholders. Required by the `debug` npm

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -1042,6 +1042,16 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    // #2514: util.toUSVString(value) → string with lone surrogates → U+FFFD.
+    NativeModSig {
+        module: "util",
+        has_receiver: false,
+        method: "toUSVString",
+        class_filter: None,
+        runtime: "js_util_to_usv_string",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     NativeModSig {
         module: "util",
         has_receiver: false,

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -145,6 +145,7 @@ pub mod ui_text_registry;
 pub mod util_parse_args;
 pub mod util_parse_env;
 pub mod util_promisify;
+pub mod util_usv;
 pub mod util_syserr;
 #[cfg(all(target_os = "watchos", feature = "watchos-game-loop"))]
 pub mod watchos_game_loop;

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -377,6 +377,7 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
             b"isDeepStrictEqual",
             b"promisify",
             b"stripVTControlCharacters",
+            b"toUSVString",
             b"types",
             b"parseArgs",
             b"TextDecoder",
@@ -1211,6 +1212,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("util", "inherits")
             | ("util", "isDeepStrictEqual")
             | ("util", "stripVTControlCharacters")
+            | ("util", "toUSVString")
             | ("zlib", "Deflate")
             | ("zlib", "DeflateRaw")
             | ("zlib", "Gzip")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -990,6 +990,8 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("util", "stripVTControlCharacters") => {
             crate::builtins::js_util_strip_vt_control_characters(arg(0))
         }
+        // #2514: util.toUSVString(value) → string with lone surrogates → U+FFFD.
+        ("util", "toUSVString") => crate::util_usv::js_util_to_usv_string(arg(0)),
         ("util", "promisify") => crate::util_promisify::js_util_promisify(arg(0)),
         ("util", "callbackify") => crate::util_promisify::js_util_callbackify(arg(0)),
         ("util", "deprecate") => crate::util_promisify::js_util_deprecate(arg(0), arg(1), arg(2)),

--- a/crates/perry-runtime/src/util_usv.rs
+++ b/crates/perry-runtime/src/util_usv.rs
@@ -1,0 +1,22 @@
+//! `util.toUSVString(value)` (#2514) — coerce `value` to a string, then replace
+//! each lone surrogate code unit with the Unicode replacement character U+FFFD.
+//!
+//! Perry stores lone surrogates (U+D800..U+DFFF) as WTF-8 bytes. Decoding those
+//! bytes back to a Rust `String` via `from_utf8_lossy` substitutes U+FFFD for
+//! each ill-formed sequence — which is exactly the USV-string scrubbing Node
+//! performs. So `ToString(value)` followed by a lossy round-trip yields Node's
+//! `toUSVString` result. Unlike `stripVTControlCharacters`, this coerces rather
+//! than throwing on non-string input (`toUSVString(123) === "123"`).
+
+use crate::url::{create_string_f64, string_from_header};
+
+/// `util.toUSVString(value)` → string with lone surrogates replaced by U+FFFD.
+#[no_mangle]
+pub extern "C" fn js_util_to_usv_string(value: f64) -> f64 {
+    // ToString(value): reuse the runtime's canonical coercion.
+    let str_ptr = crate::value::js_jsvalue_to_string(value);
+    // string_from_header decodes WTF-8 → String via from_utf8_lossy, mapping
+    // every lone surrogate to U+FFFD; re-intern the scrubbed bytes.
+    let scrubbed = string_from_header(str_ptr);
+    create_string_f64(&scrubbed)
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1782 entries across 88 modules
+// Coverage: 1783 entries across 88 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -2688,6 +2688,8 @@ declare module "util" {
   export function promisify(...args: any[]): any;
   /** stdlib */
   export function stripVTControlCharacters(...args: any[]): any;
+  /** stdlib */
+  export function toUSVString(...args: any[]): any;
 }
 
 declare module "util/types" {

--- a/test-files/test_gap_2514_tousvstring.ts
+++ b/test-files/test_gap_2514_tousvstring.ts
@@ -1,0 +1,13 @@
+// #2514 — util.toUSVString: coerce to string, replace lone surrogates with U+FFFD.
+import { toUSVString } from "node:util";
+
+console.log(typeof toUSVString);
+console.log(JSON.stringify(toUSVString("abc")));
+console.log(JSON.stringify(toUSVString("a\uD800b"))); // lone high surrogate -> U+FFFD
+console.log(JSON.stringify(toUSVString("a\uDC00b"))); // lone low surrogate  -> U+FFFD
+console.log(JSON.stringify(toUSVString("a😀b"))); // valid pair preserved
+console.log(JSON.stringify(toUSVString("café")));
+console.log(toUSVString("a\uD800b").charCodeAt(1)); // 65533 (U+FFFD)
+console.log(JSON.stringify(toUSVString(123 as unknown as string))); // coerces -> "123"
+console.log(JSON.stringify(toUSVString(undefined as unknown as string))); // -> "undefined"
+console.log(JSON.stringify(toUSVString(null as unknown as string))); // -> "null"


### PR DESCRIPTION
Implements `util.toUSVString` (part of #2514 — remaining `node:util` top-level helpers).

## Problem

`util.toUSVString` was entirely missing — no manifest entry, no callable-export whitelist entry, no dispatch arm, and no runtime implementation — so `typeof util.toUSVString === "undefined"` and any call failed.

## Fix

Full wiring, mirroring the existing `util.parseEnv` (#2514) path:

- **`util_usv.rs`** (new) — `js_util_to_usv_string`: `ToString(value)` via the runtime's canonical `js_jsvalue_to_string`, then decode the WTF-8 bytes back through `string_from_header` (which uses `from_utf8_lossy`, mapping every lone surrogate to U+FFFD) and re-intern. That lossy round-trip is exactly the USV-string scrubbing Node performs. Unlike `stripVTControlCharacters`, it coerces rather than throwing on non-string input.
- **`lib.rs`** — `pub mod util_usv;`
- **`native_module.rs`** — `b"toUSVString"` in the `util` callable-export whitelist + `("util", "toUSVString")` in the value-gate.
- **`native_module_dispatch.rs`** — dispatch arm next to `stripVTControlCharacters`.
- **`entries.rs`** — `method("util", "toUSVString", false, None)`.
- **`node_core.rs`** — `NativeModSig` row → `js_util_to_usv_string`.
- **`docs/api/perry.d.ts`** — regenerated via `scripts/regen_api_docs.sh` (single added method).

## Validation

`test-files/test_gap_2514_tousvstring.ts` is **byte-for-byte identical** to `node --experimental-strip-types`:

```
function
"abc"
"a�b"   // lone high surrogate -> U+FFFD
"a�b"   // lone low surrogate  -> U+FFFD
"a😀b"        // valid pair preserved
"café"
65533        // charCodeAt of U+FFFD
"123"        // number coerced
"undefined"  // undefined coerced
"null"       // null coerced
```

`cargo build --release -p perry-runtime -p perry-stdlib -p perry` clean; `cargo fmt --all -- --check` clean; api-docs regenerated (no drift).
