### PR TITLE
fix(collections): Map/Set/Weak constructors consume iterables and validate init

### DIFF
--- a/crates/perry-codegen/src/expr/misc_methods.rs
+++ b/crates/perry-codegen/src/expr/misc_methods.rs
@@ -59,12 +59,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 .call(DOUBLE, "js_math_f16round", &[(DOUBLE, &v)]))
         }
 
-        // -------- new Map([[k,v], ...]) — alloc empty map, ignore source --------
+        // -------- new Map(init) — consume any iterable + validate (#2770) --------
+        // Pass the NaN-boxed init value so the runtime can classify it by tag
+        // (number/symbol/object/iterable) and throw Node's exact TypeErrors for
+        // non-iterables / malformed entries instead of mis-reading an
+        // ArrayHeader.
         Expr::MapNewFromArray(arr_expr) => {
             let arr_box = lower_expr(ctx, arr_expr)?;
             let blk = ctx.block();
-            let arr_handle = unbox_to_i64(blk, &arr_box);
-            let handle = blk.call(I64, "js_map_from_array", &[(I64, &arr_handle)]);
+            let handle = blk.call(I64, "js_map_from_iterable", &[(DOUBLE, &arr_box)]);
             Ok(nanbox_pointer_inline(blk, &handle))
         }
 

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -301,6 +301,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_set_from_array", I64, &[I64]);
     module.declare_function("js_set_from_iterable", I64, &[DOUBLE]);
     module.declare_function("js_map_from_array", I64, &[I64]);
+    module.declare_function("js_map_from_iterable", I64, &[DOUBLE]);
     module.declare_function("js_object_has_property", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_fs_write_file_sync", I32, &[DOUBLE, DOUBLE]);
     module.declare_function(

--- a/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
@@ -414,8 +414,13 @@ pub(super) fn try_url_date_weakref_instance(
                 }
                 // WeakMap/WeakSet — route to dedicated runtime functions
                 // (NOT the regular Map/Set HIR variants) so reference-equality
-                // works for object keys. Primitive keys/values throw via
-                // js_weak_throw_primitive when the AST shows a bare literal.
+                // works for object keys. Primitive keys/values are rejected by
+                // the runtime helpers themselves (#2772): `js_weakmap_set` /
+                // `js_weakset_add` validate the key/value at runtime and throw
+                // Node's exact `Invalid value used as weak map key` /
+                // `Invalid value used in weak set`. This covers both literal
+                // and dynamic primitives uniformly, so no AST-literal fast path
+                // is needed here.
                 let make_extern_call = |name: &str, args: Vec<Expr>| -> Expr {
                     Expr::Call {
                         callee: Box::new(Expr::ExternFuncRef {
@@ -427,29 +432,11 @@ pub(super) fn try_url_date_weakref_instance(
                         type_args: Vec::new(),
                     }
                 };
-                let throw_primitive_expr = || -> Expr {
-                    Expr::Call {
-                        callee: Box::new(Expr::ExternFuncRef {
-                            name: "js_weak_throw_primitive".to_string(),
-                            param_types: Vec::new(),
-                            return_type: Type::Any,
-                        }),
-                        args: Vec::new(),
-                        type_args: Vec::new(),
-                    }
-                };
                 if ctx.weakmap_locals.contains(&recv_name) {
                     let map_id = ctx.lookup_local(&recv_name).unwrap_or(0);
                     let recv = Expr::LocalGet(map_id);
                     match method_name {
                         "set" if args.len() >= 2 => {
-                            let key_is_primitive_lit = matches!(
-                                call.args.first().map(|a| a.expr.as_ref()),
-                                Some(ast::Expr::Lit(_))
-                            );
-                            if key_is_primitive_lit {
-                                return Ok(Ok(throw_primitive_expr()));
-                            }
                             let mut iter = args.into_iter();
                             let key = iter.next().unwrap();
                             let value = iter.next().unwrap();
@@ -484,13 +471,6 @@ pub(super) fn try_url_date_weakref_instance(
                     let recv = Expr::LocalGet(set_id);
                     match method_name {
                         "add" if !args.is_empty() => {
-                            let value_is_primitive_lit = matches!(
-                                call.args.first().map(|a| a.expr.as_ref()),
-                                Some(ast::Expr::Lit(_))
-                            );
-                            if value_is_primitive_lit {
-                                return Ok(Ok(throw_primitive_expr()));
-                            }
                             return Ok(Ok(make_extern_call(
                                 "js_weakset_add",
                                 vec![recv, args.into_iter().next().unwrap()],

--- a/crates/perry-runtime/src/collection_iter.rs
+++ b/crates/perry-runtime/src/collection_iter.rs
@@ -1,0 +1,211 @@
+//! Shared iterable-consumption + validation for the `Map`/`Set`/`WeakMap`/
+//! `WeakSet` constructors (issues #2770/#2771/#2772).
+//!
+//! JS collection constructors run `AddEntriesFromIterable` / the Set
+//! constructor's iterable loop. Both require the init argument to be a real
+//! iterable: `null`/`undefined` mean "empty", and any other value that is
+//! not iterable throws
+//! `TypeError: <type> [<value> ]is not iterable (cannot read property
+//! Symbol(Symbol.iterator))` — matching Node exactly.
+//!
+//! This module centralizes (a) the iterability classification + Node error
+//! message, and (b) materializing the yielded values into a plain Array via
+//! the existing [`crate::array::js_for_of_to_array`] machinery (which already
+//! handles Array / String / Map / Set / custom `[Symbol.iterator]` objects).
+//! The collection-specific runtime helpers (`js_map_from_iterable`,
+//! `js_set_from_iterable`, `js_weakmap_init_iterable`, `js_weakset_init_iterable`)
+//! call into here so the throw-vs-empty-vs-consume decision lives in one place.
+
+use crate::array::ArrayHeader;
+use crate::value::{js_jsvalue_to_string, js_nanbox_get_pointer, JSValue, TAG_NULL, TAG_UNDEFINED};
+
+/// Outcome of classifying a constructor init argument.
+pub(crate) enum InitIter {
+    /// `null` / `undefined` — treat as empty init, no entries.
+    Empty,
+    /// An iterable; the yielded values have been materialized into this
+    /// (NaN-box-stripped) Array pointer.
+    Values(*mut ArrayHeader),
+}
+
+/// `typeof`-style word for a non-iterable value, used to build the Node
+/// "<type> is not iterable" message. `null`/`undefined` are handled by the
+/// caller (they never throw), so they are not produced here.
+fn typeof_word(value: f64) -> &'static str {
+    let jsv = JSValue::from_bits(value.to_bits());
+    if jsv.is_number() || jsv.is_int32() {
+        "number"
+    } else if jsv.is_bool() {
+        "boolean"
+    } else if jsv.is_bigint() {
+        "bigint"
+    } else if jsv.is_any_string() {
+        // Strings are iterable; never reaches the throw path. Kept for
+        // completeness.
+        "string"
+    } else {
+        let raw = js_nanbox_get_pointer(value);
+        if raw != 0 && crate::symbol::is_registered_symbol(raw as usize) {
+            "symbol"
+        } else if raw != 0 && crate::closure::is_closure_ptr(raw as usize) {
+            "function"
+        } else {
+            "object"
+        }
+    }
+}
+
+/// Build the Node TypeError message prefix for a non-iterable value.
+///
+/// Node prints the *value* only for `number` and `boolean` (`number 5`,
+/// `boolean true`); for `bigint`/`symbol`/`function`/`object` it prints just
+/// the type word.
+fn not_iterable_message(value: f64) -> String {
+    let word = typeof_word(value);
+    let with_value = match word {
+        "number" | "boolean" => {
+            let s_ptr = js_jsvalue_to_string(value);
+            if s_ptr.is_null() {
+                None
+            } else {
+                let s = unsafe {
+                    let byte_len = (*s_ptr).byte_len as usize;
+                    let data = (s_ptr as *const u8)
+                        .add(std::mem::size_of::<crate::string::StringHeader>());
+                    String::from_utf8_lossy(std::slice::from_raw_parts(data, byte_len)).into_owned()
+                };
+                Some(format!("{} {}", word, s))
+            }
+        }
+        _ => None,
+    };
+    let head = with_value.unwrap_or_else(|| word.to_string());
+    format!(
+        "{} is not iterable (cannot read property Symbol(Symbol.iterator))",
+        head
+    )
+}
+
+/// Throw the Node `TypeError: <type> is not iterable (...)` for a
+/// non-iterable constructor init value. Never returns.
+pub(crate) fn throw_not_iterable(value: f64) -> ! {
+    let msg = not_iterable_message(value);
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(msg_str);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+}
+
+/// True if `value` is a JS iterable (array, string, Map, Set, or any heap
+/// object carrying a callable `[Symbol.iterator]`). `null`/`undefined` are
+/// NOT iterable here (the caller handles them as empty before calling).
+fn is_iterable(value: f64) -> bool {
+    let jsv = JSValue::from_bits(value.to_bits());
+    if jsv.is_any_string() {
+        return true;
+    }
+    if crate::array::js_array_is_array(value).to_bits() == crate::value::TAG_TRUE {
+        return true;
+    }
+    let raw = js_nanbox_get_pointer(value);
+    if raw == 0 {
+        return false;
+    }
+    let addr = raw as usize;
+    if crate::map::is_registered_map(addr) || crate::set::is_registered_set(addr) {
+        return true;
+    }
+    // Generic object: iterable iff it exposes a callable `[Symbol.iterator]`.
+    if !crate::object::is_valid_obj_ptr(raw as *const u8) {
+        return false;
+    }
+    let iter_wk = crate::symbol::well_known_symbol("iterator");
+    if iter_wk.is_null() {
+        return false;
+    }
+    let sym_f64 = f64::from_bits(JSValue::pointer(iter_wk as *const u8).bits());
+    let iter_fn = unsafe { crate::symbol::js_object_get_symbol_property(value, sym_f64) };
+    if iter_fn.to_bits() == TAG_UNDEFINED {
+        return false;
+    }
+    let fn_raw = js_nanbox_get_pointer(iter_fn);
+    fn_raw != 0 && crate::closure::is_closure_ptr(fn_raw as usize)
+}
+
+/// True if a yielded value is a JS *object* (array, plain object, function,
+/// Map, Set, …) — i.e. anything `Type(v) === Object`. Primitives (number,
+/// boolean, string, bigint, symbol, null, undefined) are NOT entry objects,
+/// matching Node's `new Map([1])` / `new Map(['ab'])` throws.
+pub(crate) fn is_entry_object(value: f64) -> bool {
+    let jsv = JSValue::from_bits(value.to_bits());
+    if jsv.is_number()
+        || jsv.is_int32()
+        || jsv.is_bool()
+        || jsv.is_bigint()
+        || jsv.is_any_string()
+        || jsv.is_undefined()
+        || jsv.is_null()
+    {
+        return false;
+    }
+    let raw = js_nanbox_get_pointer(value);
+    if raw == 0 {
+        return false;
+    }
+    // Symbols are primitives despite being pointer-tagged.
+    !crate::symbol::is_registered_symbol(raw as usize)
+}
+
+/// Throw `TypeError: Iterator value <v> is not an entry object` (used by the
+/// Map / WeakMap constructors when a yielded value is not an object). Never
+/// returns.
+pub(crate) fn throw_not_entry_object(value: f64) -> ! {
+    let v_str = value_display(value);
+    let msg = format!("Iterator value {} is not an entry object", v_str);
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(msg_str);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+}
+
+/// Node's display string for a value embedded in a TypeError message
+/// (`Symbol(s)`, `5`, `ab`, `null`, `undefined`, `true`). Uses the standard
+/// `js_jsvalue_to_string` for everything except symbols, which it renders as
+/// `Symbol(<desc>)`.
+fn value_display(value: f64) -> String {
+    let raw = js_nanbox_get_pointer(value);
+    let s_ptr = if raw != 0 && crate::symbol::is_registered_symbol(raw as usize) {
+        // `js_symbol_to_string` already renders `Symbol(<desc>)`.
+        unsafe { crate::symbol::js_symbol_to_string(value) as *mut crate::string::StringHeader }
+    } else {
+        js_jsvalue_to_string(value)
+    };
+    if s_ptr.is_null() {
+        return String::new();
+    }
+    unsafe {
+        let byte_len = (*s_ptr).byte_len as usize;
+        let data = (s_ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+        String::from_utf8_lossy(std::slice::from_raw_parts(data, byte_len)).into_owned()
+    }
+}
+
+/// Classify a collection-constructor init argument:
+/// - `null`/`undefined` → [`InitIter::Empty`],
+/// - any iterable → materialize the yielded values into an Array
+///   ([`InitIter::Values`]),
+/// - anything else → throw the Node "not iterable" `TypeError`.
+///
+/// The returned Array pointer is NaN-box-stripped (a raw `*mut ArrayHeader`).
+pub(crate) fn classify_init(value: f64) -> InitIter {
+    let bits = value.to_bits();
+    if bits == TAG_UNDEFINED || bits == TAG_NULL {
+        return InitIter::Empty;
+    }
+    if !is_iterable(value) {
+        throw_not_iterable(value);
+    }
+    // `js_for_of_to_array` returns a NaN-boxed (POINTER_TAG) Array f64 whose
+    // elements are exactly what `for...of value` would yield.
+    let arr_f64 = crate::array::js_for_of_to_array(value);
+    let arr_ptr = js_nanbox_get_pointer(arr_f64) as *mut ArrayHeader;
+    InitIter::Values(arr_ptr)
+}

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -34,6 +34,7 @@ pub mod buffer;
 pub mod builtins;
 pub mod child_process;
 pub mod closure;
+pub mod collection_iter;
 pub mod color_parse;
 pub mod date;
 pub mod error;

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -1261,6 +1261,75 @@ pub extern "C" fn js_map_from_array(arr: *const crate::array::ArrayHeader) -> *m
     map_handle.get_raw_mut_ptr::<MapHeader>()
 }
 
+/// `new Map(init)` with full `AddEntriesFromIterable` semantics (issue #2770).
+///
+/// Takes the NaN-boxed init value (not a pre-unboxed array pointer) so it can
+/// classify the argument exactly like Node:
+/// - `null`/`undefined` → empty Map,
+/// - another Map / Set / Array / string / custom iterable → consume its
+///   yielded values,
+/// - non-iterable (number, boolean, bigint, symbol, function, plain object
+///   without `[Symbol.iterator]`) → throw
+///   `TypeError: <type> ... is not iterable (...)`.
+///
+/// Each yielded value must be an *object* (array or plain object). Its `[0]`
+/// and `[1]` properties become the entry key/value (missing → `undefined`),
+/// so `new Map([['k']])` and `new Map([[]])` keep entries with `undefined`
+/// components. A non-object yielded value throws
+/// `TypeError: Iterator value <v> is not an entry object`.
+///
+/// The `new Map(existingMap)` fast path is preserved via `js_for_of_to_array`
+/// (Maps materialize to their `[k, v]` pair arrays) inside `classify_init`.
+#[no_mangle]
+pub extern "C" fn js_map_from_iterable(value: f64) -> *mut MapHeader {
+    use crate::collection_iter::{classify_init, InitIter};
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let arr_ptr = match classify_init(value) {
+        InitIter::Empty => return js_map_alloc(4),
+        InitIter::Values(p) => p,
+    };
+    let arr_handle = if arr_ptr.is_null() {
+        None
+    } else {
+        Some(scope.root_raw_mut_ptr(arr_ptr))
+    };
+    let map = js_map_alloc(4);
+    let map_handle = scope.root_raw_mut_ptr(map);
+    let Some(arr_handle) = arr_handle.as_ref() else {
+        return map_handle.get_raw_mut_ptr::<MapHeader>();
+    };
+    let len = {
+        let arr = arr_handle.get_raw_const_ptr::<crate::array::ArrayHeader>();
+        crate::array::js_array_length(arr)
+    };
+    for i in 0..len {
+        let entry = {
+            let arr = arr_handle.get_raw_const_ptr::<crate::array::ArrayHeader>();
+            crate::array::js_array_get_f64(arr, i)
+        };
+        // Each yielded value must be an object (array or plain object).
+        if !crate::collection_iter::is_entry_object(entry) {
+            crate::collection_iter::throw_not_entry_object(entry);
+        }
+        let entry_bits = entry.to_bits() as i64;
+        let key = crate::object::js_object_get_index_polymorphic(entry_bits, 0.0);
+        let val = crate::object::js_object_get_index_polymorphic(entry_bits, 1.0);
+        let map = map_handle.get_raw_mut_ptr::<MapHeader>();
+        js_map_set(map, key, val);
+    }
+    map_handle.get_raw_mut_ptr::<MapHeader>()
+}
+
+// #2770: `js_map_from_iterable` is only invoked from generated LLVM IR
+// (codegen emits the `new Map(...)` call in
+// `perry-codegen/src/expr/misc_methods.rs`), so it has zero internal Rust
+// callers. The whole-program auto-optimize bitcode link would otherwise
+// internalize + dead-strip the `#[no_mangle]` export and break the default
+// compile path. The `#[used]` anchor pins it (see project_auto_optimize_keepalive).
+#[used]
+static KEEP_JS_MAP_FROM_ITERABLE: extern "C" fn(f64) -> *mut MapHeader = js_map_from_iterable;
+
 /// Iterate over map entries, calling a callback with (value, key, map) for each
 #[no_mangle]
 pub extern "C" fn js_map_foreach(map: *const MapHeader, callback: f64) {

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -792,79 +792,54 @@ pub extern "C" fn js_set_from_array(arr: *const crate::array::ArrayHeader) -> *m
 ///   adding each as a single-char string to the set (matches the JS
 ///   spec: `new Set("abc")` → `{"a", "b", "c"}`)
 /// - undefined / null → empty set (matches `new Set()` and `new Set(null)`)
-/// - anything else → empty set with no error (lenient — JS would throw
-///   `TypeError`, but blocking compilation for non-iterable inputs is
-///   worse than silently producing an empty set; followup as needed)
+/// - any other iterable (Map/Set/custom `[Symbol.iterator]`) → consume its
+///   yielded values
+/// - non-iterable number / boolean / bigint / symbol / function / plain
+///   object → throw `TypeError: <type> ... is not iterable (...)` (#2771)
 ///
 /// Used by codegen for `Expr::SetNewFromArray` so a single call site
 /// handles any iterable input shape — closes #421-related bug where
 /// `new Set("abc")` (hono's `regExpMetaChars` pattern) crashed because
-/// `js_set_from_array` blindly cast the StringHeader to ArrayHeader.
+/// `js_set_from_array` blindly cast the StringHeader to ArrayHeader, and
+/// #2771 (arbitrary iterables + TypeError on non-iterables).
 #[no_mangle]
 pub extern "C" fn js_set_from_iterable(value: f64) -> *mut SetHeader {
+    use crate::collection_iter::{classify_init, InitIter};
+
     let scope = crate::gc::RuntimeHandleScope::new();
-    let value_handle = scope.root_nanbox_f64(value);
-    let bits = value_handle.get_nanbox_u64();
-    let top16 = (bits >> 48) as u16;
-    // String literals (heap or SSO).
-    if top16 == 0x7FFF || top16 == 0x7FF9 {
-        let set = js_set_alloc(4);
-        let set_handle = scope.root_raw_mut_ptr(set);
-        maybe_force_helper_gc_for_test();
-        // Materialize SSO to a real heap StringHeader; cheap for heap strings.
-        let str_ptr = {
-            crate::value::js_get_string_pointer_unified(value_handle.get_nanbox_f64())
-                as *const crate::string::StringHeader
-        };
-        if str_ptr.is_null() {
-            return set_handle.get_raw_mut_ptr::<SetHeader>();
-        }
-        let bytes = unsafe {
-            let byte_len = (*str_ptr).byte_len as usize;
-            let data =
-                (str_ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
-            std::slice::from_raw_parts(data, byte_len).to_vec()
-        };
-        // UTF-8 codepoint iteration. Each codepoint becomes a single-
-        // codepoint string allocated via `js_string_from_bytes`, then
-        // added to the set as the NaN-boxed string handle.
-        let mut i = 0;
-        while i < bytes.len() {
-            let lead = bytes[i];
-            let codepoint_len = if lead < 0x80 {
-                1
-            } else if lead < 0xC0 {
-                // Continuation byte mid-sequence — shouldn't happen for
-                // well-formed UTF-8; skip one byte to avoid infinite loop.
-                1
-            } else if lead < 0xE0 {
-                2
-            } else if lead < 0xF0 {
-                3
-            } else {
-                4
-            };
-            let end = (i + codepoint_len).min(bytes.len());
-            let cp_bytes = &bytes[i..end];
-            let cp_str =
-                crate::string::js_string_from_bytes(cp_bytes.as_ptr(), cp_bytes.len() as u32);
-            let cp_value =
-                f64::from_bits(0x7FFF_0000_0000_0000 | (cp_str as u64 & 0x0000_FFFF_FFFF_FFFF));
-            let set = set_handle.get_raw_mut_ptr::<SetHeader>();
-            js_set_add(set, cp_value);
-            i = end;
-        }
+    // `classify_init` returns the materialized array of yielded values for any
+    // iterable (Array/String/Map/Set/custom iterator), an Empty marker for
+    // null/undefined, or throws the Node "not iterable" TypeError otherwise.
+    // For a Map it yields `[k, v]` pair arrays; for a String it yields
+    // single-codepoint strings — both match `[...new Set(x)]` in Node.
+    let arr_ptr = match classify_init(value) {
+        InitIter::Empty => return js_set_alloc(4),
+        InitIter::Values(p) => p,
+    };
+    let arr_handle = if arr_ptr.is_null() {
+        None
+    } else {
+        Some(scope.root_raw_mut_ptr(arr_ptr))
+    };
+    let set = js_set_alloc(4);
+    let set_handle = scope.root_raw_mut_ptr(set);
+    let Some(arr_handle) = arr_handle.as_ref() else {
         return set_handle.get_raw_mut_ptr::<SetHeader>();
+    };
+    maybe_force_helper_gc_for_test();
+    let len = {
+        let arr = arr_handle.get_raw_const_ptr::<crate::array::ArrayHeader>();
+        crate::array::js_array_length(arr)
+    };
+    for i in 0..len {
+        let element = {
+            let arr = arr_handle.get_raw_const_ptr::<crate::array::ArrayHeader>();
+            crate::array::js_array_get_f64(arr, i)
+        };
+        let set = set_handle.get_raw_mut_ptr::<SetHeader>();
+        js_set_add(set, element);
     }
-    // Pointer tag covers arrays + objects; we treat it as array (existing
-    // path). Non-array objects produce an empty-ish set since
-    // `js_array_length` reads bytes that happen to be at offset 0.
-    if top16 == 0x7FFD || (bits & 0xFFFF_0000_0000_0000) == 0 {
-        let arr_ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const crate::array::ArrayHeader;
-        return js_set_from_array(arr_ptr);
-    }
-    // undefined / null / number / etc. → empty set.
-    js_set_alloc(4)
+    set_handle.get_raw_mut_ptr::<SetHeader>()
 }
 
 /// Iterate over set elements, calling a callback with (value, value, set) for each

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -361,36 +361,60 @@ pub extern "C" fn js_weakmap_new() -> *mut ObjectHeader {
 
 #[no_mangle]
 pub extern "C" fn js_weakmap_init_iterable(map: f64, iterable: f64) -> f64 {
-    if crate::array::js_array_is_array(iterable).to_bits() != TAG_TRUE {
-        return map;
-    }
-    let arr_ptr = js_nanbox_get_pointer(iterable) as *const ArrayHeader;
+    use crate::collection_iter::{classify_init, InitIter};
+
+    // #2772: consume ANY iterable (Map/Set/custom), throw on non-iterables,
+    // require each yielded value to be an entry object, and require each key
+    // to be an object (`js_weakmap_set` validates the key).
+    let arr_ptr = match classify_init(iterable) {
+        InitIter::Empty => return map,
+        InitIter::Values(p) => p as *const ArrayHeader,
+    };
     if arr_ptr.is_null() {
         return map;
     }
     unsafe {
         let len = js_array_length(arr_ptr) as usize;
         for i in 0..len {
-            let pair = js_array_get_f64(arr_ptr, i as u32);
-            if crate::array::js_array_is_array(pair).to_bits() != TAG_TRUE {
-                continue;
+            let entry = js_array_get_f64(arr_ptr, i as u32);
+            if !crate::collection_iter::is_entry_object(entry) {
+                crate::collection_iter::throw_not_entry_object(entry);
             }
-            let pair_ptr = js_nanbox_get_pointer(pair) as *const ArrayHeader;
-            if pair_ptr.is_null() {
-                continue;
-            }
-            js_weakmap_set(
-                map,
-                js_array_get_f64(pair_ptr, 0),
-                js_array_get_f64(pair_ptr, 1),
-            );
+            let entry_bits = entry.to_bits() as i64;
+            let key = crate::object::js_object_get_index_polymorphic(entry_bits, 0.0);
+            let val = crate::object::js_object_get_index_polymorphic(entry_bits, 1.0);
+            js_weakmap_set(map, key, val);
         }
     }
     map
 }
 
+/// Throw `TypeError: Invalid value used as weak map key` (WeakMap key must be
+/// an object). Never returns.
+fn throw_invalid_weakmap_key() -> ! {
+    let msg = "Invalid value used as weak map key";
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(msg_str);
+    crate::exception::js_throw(f64::from_bits(JSValue::pointer(err as *const u8).bits()))
+}
+
+/// Throw `TypeError: Invalid value used in weak set` (WeakSet value must be an
+/// object). Never returns.
+fn throw_invalid_weakset_value() -> ! {
+    let msg = "Invalid value used in weak set";
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(msg_str);
+    crate::exception::js_throw(f64::from_bits(JSValue::pointer(err as *const u8).bits()))
+}
+
 #[no_mangle]
 pub extern "C" fn js_weakmap_set(map: f64, key: f64, value: f64) -> f64 {
+    // #2772: WeakMap keys must be objects. Validate at runtime so a primitive
+    // arriving through a variable / dynamic expression still throws (not only
+    // the AST-literal fast path in lowering).
+    if !crate::collection_iter::is_entry_object(key) {
+        throw_invalid_weakmap_key();
+    }
     let map_ptr = js_nanbox_get_pointer(map) as *mut ObjectHeader;
     if map_ptr.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
@@ -531,10 +555,14 @@ pub extern "C" fn js_weakset_new() -> *mut ObjectHeader {
 
 #[no_mangle]
 pub extern "C" fn js_weakset_init_iterable(set: f64, iterable: f64) -> f64 {
-    if crate::array::js_array_is_array(iterable).to_bits() != TAG_TRUE {
-        return set;
-    }
-    let arr_ptr = js_nanbox_get_pointer(iterable) as *const ArrayHeader;
+    use crate::collection_iter::{classify_init, InitIter};
+
+    // #2772: consume ANY iterable (Map/Set/custom), throw on non-iterables,
+    // and require each value to be an object (`js_weakset_add` validates).
+    let arr_ptr = match classify_init(iterable) {
+        InitIter::Empty => return set,
+        InitIter::Values(p) => p as *const ArrayHeader,
+    };
     if arr_ptr.is_null() {
         return set;
     }
@@ -549,6 +577,13 @@ pub extern "C" fn js_weakset_init_iterable(set: f64, iterable: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_weakset_add(set: f64, value: f64) -> f64 {
+    // #2772: WeakSet values must be objects — throw the WeakSet-specific
+    // message *before* delegating (js_weakmap_set throws the weak-map-key
+    // message, which is wrong for a Set). Validate at runtime so a primitive
+    // arriving through a variable/dynamic expression still throws.
+    if !crate::collection_iter::is_entry_object(value) {
+        throw_invalid_weakset_value();
+    }
     // Reuse js_weakmap_set with value as both key and value (matches JS Set spec).
     js_weakmap_set(set, value, value);
     set

--- a/test-files/test_gap_collections_2770_2771_2772.ts
+++ b/test-files/test_gap_collections_2770_2771_2772.ts
@@ -1,0 +1,93 @@
+// #2770/#2771/#2772 — Map/Set/WeakMap/WeakSet constructors consume any
+// iterable and validate init values; weak mutators reject primitives.
+
+function err(fn: () => void): string {
+  try {
+    fn();
+    return "no throw";
+  } catch (e: any) {
+    return e.name + ": " + e.message;
+  }
+}
+
+// ---- Map constructor (#2770) ----
+const m = new Map([
+  ["a", 1],
+  ["b", 2],
+]);
+console.log("map size", m.size, m.get("a"), m.get("b"));
+
+const mClone = new Map(m);
+console.log("map clone", mClone.size, mClone.get("a"));
+
+const mFromSet = new Map(new Set([["s", 3]]));
+console.log("map from set", mFromSet.size, mFromSet.get("s"));
+
+const mShort = new Map([["short"]]);
+console.log("map short", mShort.size, mShort.has("short"), mShort.get("short"));
+
+const mEmptyPair = new Map([[]]);
+console.log(
+  "map empty pair",
+  mEmptyPair.size,
+  mEmptyPair.has(undefined),
+  mEmptyPair.get(undefined),
+);
+
+console.log("map null", new Map(null).size);
+console.log("map undefined", new Map(undefined).size);
+
+console.log("map(5):", err(() => new Map(5 as any)));
+console.log("map({a:1}):", err(() => new Map({ a: 1 } as any)));
+console.log("map([1]):", err(() => new Map([1] as any)));
+
+// ---- Set constructor (#2771) ----
+console.log("set dedup", [...new Set([1, 2, 1])].join(","));
+console.log("set from set", [...new Set(new Set([3, 4]))].join(","));
+console.log("set from string", [...new Set("aba")].join(","));
+console.log(
+  "set from map",
+  [...new Set(new Map([[1, "a"], [2, "b"]]))].map((v: any) => v.join(":")).join(","),
+);
+console.log("set null", new Set(null).size);
+console.log("set undefined", new Set(undefined).size);
+console.log("set(5):", err(() => new Set(5 as any)));
+console.log("set({a:1}):", err(() => new Set({ a: 1 } as any)));
+
+// ---- WeakMap / WeakSet (#2772) ----
+const k1 = {};
+const k2 = {};
+
+console.log("weakmap arr", new WeakMap([[k1, "v1"]]).get(k1));
+console.log("weakmap from map", new WeakMap(new Map([[k2, "v2"]])).get(k2));
+console.log("weakset arr", new WeakSet([k1]).has(k1));
+console.log("weakset from set", new WeakSet(new Set([k2])).has(k2));
+
+// null / undefined init produce an empty but fully-functional collection.
+const wmNull = new WeakMap<any, any>(null);
+wmNull.set(k1, "n");
+console.log("weakmap null works", wmNull.get(k1));
+const wsUndef = new WeakSet<any>(undefined);
+wsUndef.add(k1);
+console.log("weakset undefined works", wsUndef.has(k1));
+
+console.log("weakmap(5):", err(() => new WeakMap(5 as any)));
+console.log("weakmap({a:1}):", err(() => new WeakMap({ a: 1 } as any)));
+console.log("weakmap([[1,x]]):", err(() => new WeakMap([[1, "x"]] as any)));
+console.log("weakmap([1]):", err(() => new WeakMap([1] as any)));
+console.log("weakset(5):", err(() => new WeakSet(5 as any)));
+console.log("weakset([1]):", err(() => new WeakSet([1] as any)));
+
+const wm = new WeakMap<any, any>();
+const ws = new WeakSet<any>();
+console.log("weakmap.set(1):", err(() => wm.set(1 as any, "x")));
+console.log("weakset.add(1):", err(() => ws.add(1 as any)));
+
+// dynamic-variable primitive (not an AST literal)
+const primKey: any = 7;
+console.log("weakmap.set(var):", err(() => wm.set(primKey, "y")));
+console.log("weakset.add(var):", err(() => ws.add(primKey)));
+
+console.log("weakmap.has(1)", new WeakMap<any, any>().has(1 as any));
+console.log("weakmap.delete(1)", new WeakMap<any, any>().delete(1 as any));
+console.log("weakset.has(1)", new WeakSet<any>().has(1 as any));


### PR DESCRIPTION
Closes #2770
Closes #2771
Closes #2772

## Implementation

`Map`/`Set`/`WeakMap`/`WeakSet` constructors now implement spec-faithful
`AddEntriesFromIterable` / Set-constructor iterable consumption, and the weak
mutators validate at runtime.

New shared module `crates/perry-runtime/src/collection_iter.rs`:
- `classify_init(value)` — `null`/`undefined` → empty; any iterable (Array,
  String, Map, Set, custom `[Symbol.iterator]`) → materialized value array via
  the existing `js_for_of_to_array`; everything else → throws Node's exact
  `TypeError: <type> [<value> ]is not iterable (cannot read property
  Symbol(Symbol.iterator))` (number/boolean print the value; bigint/symbol/
  function/object print just the type word).
- `is_entry_object` / `throw_not_entry_object` — Map/WeakMap require each
  yielded value to be an object, else `TypeError: Iterator value <v> is not an
  entry object`.

Per-collection wiring:
- **Map (#2770):** new `js_map_from_iterable(f64)` reads entry `[0]`/`[1]` via
  the polymorphic index getter (so `[['k']]` and `[[]]` keep `undefined`
  components); codegen passes the NaN-boxed init value (DOUBLE) instead of an
  unboxed `ArrayHeader`. `#[used]` keepalive anchor added (codegen-only symbol).
- **Set (#2771):** `js_set_from_iterable` rewritten to consume the materialized
  array and throw on non-iterables (no codegen change; it already took f64).
- **WeakMap/WeakSet (#2772):** `js_weakmap_init_iterable` /
  `js_weakset_init_iterable` consume arbitrary iterables + validate entries;
  `js_weakmap_set` / `js_weakset_add` validate keys/values at runtime and throw
  `Invalid value used as weak map key` / `Invalid value used in weak set`. The
  AST-literal-only primitive throw in HIR lowering was removed so literal and
  dynamic primitives are rejected uniformly with the correct distinct messages.

## Validation

- New gap test `test-files/test_gap_collections_2770_2771_2772.ts` is
  **byte-identical** to `node --experimental-strip-types` under the DEFAULT
  auto-optimize compile (covers iterable consumption, short/empty entries,
  null/undefined init, and every TypeError message above).
- `js_map_from_iterable` symbol confirmed present in the auto-optimize
  `libperry_runtime.a` (keepalive survives the whole-program bitcode link).
- `./scripts/check_file_size.sh` → OK; `cargo fmt --all -- --check` → clean.
- `cargo test -p perry-runtime` (896 collection/runtime tests pass; one
  unrelated GC-barrier ordering flake passes in isolation) and
  `cargo test -p perry-hir` (incl. `expr_variant_stable_hash_tags_are_unique`)
  green.
- Regression-checked 7 existing Map/Set/Weak test files
  (`test_gap_map_from_map`, `test_edge_map_set`, `test_gap_map_set_extended`,
  `test_gap_weakmap_dynamic`, `test_gap_for_of_untyped_map_set`,
  `test_gap_json_map_set`, `test_gap_map_set_entries_dispatch`) — all stay
  byte-identical to node.

## Note

`new WeakMap(null) instanceof WeakMap` returning `false` is a pre-existing,
orthogonal Perry gap (`instanceof WeakMap` is false even for `new WeakMap()`);
it is not regressed here. The constructor correctly produces a functional weak
collection for `null`/`undefined` init, so the gap test asserts that behavior
functionally (set/get/has) rather than via the unrelated `instanceof`.
