### PR TITLE
fix(buffer): expose Blob namespace and backing properties

### DIFF
--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -1532,9 +1532,17 @@ pub(crate) fn lower_var_decl_with_destructuring(
                         }
                     }
                     Expr::PropertyGet { object, property }
-                        if matches!(object.as_ref(), Expr::GlobalGet(_)) && property == "File" =>
+                        if matches!(object.as_ref(), Expr::GlobalGet(_))
+                            && matches!(property.as_str(), "Blob" | "File") =>
                     {
-                        ctx.register_let_class_alias(name.clone(), "File".to_string());
+                        ctx.register_let_class_alias(name.clone(), property.clone());
+                        ctx.uses_fetch = true;
+                    }
+                    Expr::PropertyGet { object, property }
+                        if matches!(object.as_ref(), Expr::NativeModuleRef(module) if module == "buffer")
+                            && matches!(property.as_str(), "Blob" | "File") =>
+                    {
+                        ctx.register_let_class_alias(name.clone(), property.clone());
                         ctx.uses_fetch = true;
                     }
                     // Issue #838: `var p = <ClassName>.prototype` records

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -860,7 +860,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 .unwrap_or_default();
             if ctx.lookup_class(&class_name).is_none() {
                 if let Some(resolved) = ctx.resolve_class_alias(&class_name) {
-                    if resolved == "File" {
+                    if matches!(resolved.as_str(), "Blob" | "File") {
                         ctx.uses_fetch = true;
                         return Ok(Expr::New {
                             class_name: resolved,
@@ -1001,7 +1001,19 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 {
                     return Ok(nonconstructable_builtin_throw_expr(property, args));
                 }
-                if matches!(object.as_ref(), Expr::GlobalGet(_)) && property == "File" {
+                if matches!(object.as_ref(), Expr::GlobalGet(_))
+                    && matches!(property.as_str(), "Blob" | "File")
+                {
+                    ctx.uses_fetch = true;
+                    return Ok(Expr::New {
+                        class_name: property.clone(),
+                        args,
+                        type_args: Vec::new(),
+                    });
+                }
+                if matches!(object.as_ref(), Expr::NativeModuleRef(module) if module == "buffer")
+                    && matches!(property.as_str(), "Blob" | "File")
+                {
                     ctx.uses_fetch = true;
                     return Ok(Expr::New {
                         class_name: property.clone(),

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -290,12 +290,56 @@ pub fn buffer_ab_alias(buf: usize) -> Option<usize> {
     BUFFER_AB_ALIAS.with(|m| m.borrow().get(&buf).copied())
 }
 
+/// Return the visible byte offset for a Buffer/Uint8Array view.
+pub fn buffer_byte_offset(buf: usize) -> u32 {
+    super::view::lookup(buf).map(|v| v.offset).unwrap_or(0)
+}
+
+/// Return a stable ArrayBuffer object for a Buffer-like value's `.buffer`.
+///
+/// Perry stores Buffer bytes inline in `BufferHeader`; Node exposes a separate
+/// backing ArrayBuffer object. Allocate that backing lazily, seed it with the
+/// current bytes, mark it as ArrayBuffer, and cache it so repeated `.buffer`
+/// and legacy `.parent` reads preserve identity.
+pub fn buffer_backing_array_buffer(buf: usize) -> usize {
+    if is_any_array_buffer(buf) {
+        return buf;
+    }
+    if let Some(alias) = buffer_ab_alias(buf) {
+        return alias;
+    }
+    if !is_registered_buffer(buf) {
+        return buf;
+    }
+
+    let src = buf as *const BufferHeader;
+    let len = unsafe { (*src).length };
+    let backing = buffer_alloc(len);
+    if backing.is_null() {
+        return buf;
+    }
+    unsafe {
+        (*backing).length = len;
+        if len > 0 {
+            std::ptr::copy_nonoverlapping(buffer_data(src), buffer_data_mut(backing), len as usize);
+        }
+    }
+    let alias = backing as usize;
+    mark_as_array_buffer(alias);
+    set_buffer_ab_alias(buf, alias);
+    alias
+}
+
 /// Collapse an alias chain to its root: if `buf` already aliases something,
 /// return that; otherwise return `buf` itself.  Callers use this to seed the
 /// alias on a fresh copy so chained `Buffer.from(Buffer.from(src))` keeps
 /// `===` identity with the original source.
 pub fn resolve_buffer_ab_alias(buf: usize) -> usize {
-    buffer_ab_alias(buf).unwrap_or(buf)
+    if is_any_array_buffer(buf) {
+        buf
+    } else {
+        buffer_backing_array_buffer(buf)
+    }
 }
 
 /// Allocate a buffer with the given capacity

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -29,12 +29,12 @@ pub use header::{BufferHeader, BUFFER_TYPE_ID, SMALL_BUF_THRESHOLD};
 
 // ---- Re-exports: allocation / registry helpers ----
 pub use header::{
-    asymmetric_key_meta, buffer_ab_alias, buffer_alloc, buffer_data, buffer_data_mut,
-    crypto_key_meta, is_any_array_buffer, is_array_buffer, is_data_view, is_registered_buffer,
-    is_secret_key, is_shared_array_buffer, is_uint8array_buffer, mark_as_array_buffer,
-    mark_as_asymmetric_key, mark_as_crypto_key, mark_as_data_view, mark_as_secret_key,
-    mark_as_shared_array_buffer, mark_as_uint8array, register_buffer, resolve_buffer_ab_alias,
-    set_buffer_ab_alias,
+    asymmetric_key_meta, buffer_ab_alias, buffer_alloc, buffer_backing_array_buffer,
+    buffer_byte_offset, buffer_data, buffer_data_mut, crypto_key_meta, is_any_array_buffer,
+    is_array_buffer, is_data_view, is_registered_buffer, is_secret_key, is_shared_array_buffer,
+    is_uint8array_buffer, mark_as_array_buffer, mark_as_asymmetric_key, mark_as_crypto_key,
+    mark_as_data_view, mark_as_secret_key, mark_as_shared_array_buffer, mark_as_uint8array,
+    register_buffer, resolve_buffer_ab_alias, set_buffer_ab_alias,
 };
 
 // ---- Re-exports: Buffer.from / alloc / concat (FFI) ----

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1629,6 +1629,9 @@ pub extern "C" fn js_object_get_field_by_name(
                     let b = obj as *const crate::buffer::BufferHeader;
                     return JSValue::number(crate::buffer::js_buffer_length(b) as f64);
                 }
+                if key_bytes == b"byteOffset" {
+                    return JSValue::number(crate::buffer::buffer_byte_offset(obj as usize) as f64);
+                }
                 if key_bytes == b"constructor" {
                     if crate::buffer::is_uint8array_buffer(obj as usize) {
                         let ctor =
@@ -1654,11 +1657,19 @@ pub extern "C" fn js_object_get_field_by_name(
                     }
                 }
                 if key_bytes == b"buffer" {
-                    // Issue #1225: a copied Buffer aliases its source's
-                    // ArrayBuffer identity so `Buffer.from(src).buffer ===
-                    // src.buffer` matches Node's pool-slab sharing.  Fresh
-                    // buffers without an entry fall back to their own pointer.
-                    let alias = crate::buffer::resolve_buffer_ab_alias(obj as usize);
+                    let alias = crate::buffer::buffer_backing_array_buffer(obj as usize);
+                    return JSValue::from_bits(
+                        crate::value::js_nanbox_pointer(alias as i64).to_bits(),
+                    );
+                }
+                if key_bytes == b"parent" {
+                    if crate::buffer::is_any_array_buffer(obj as usize)
+                        || crate::buffer::is_data_view(obj as usize)
+                        || crate::buffer::is_uint8array_buffer(obj as usize)
+                    {
+                        return JSValue::undefined();
+                    }
+                    let alias = crate::buffer::buffer_backing_array_buffer(obj as usize);
                     return JSValue::from_bits(
                         crate::value::js_nanbox_pointer(alias as i64).to_bits(),
                     );

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -2356,6 +2356,7 @@ pub(crate) unsafe fn get_native_module_constant(
         "fs.constants" => fs_const(property),
         "buffer" => match property {
             "Buffer" => Some(buffer_constructor_value()),
+            "Blob" => Some(js_get_global_this_builtin_value(b"Blob".as_ptr(), 4)),
             "File" => Some(js_get_global_this_builtin_value(b"File".as_ptr(), 4)),
             "constants" => Some(create_sub_namespace("buffer.constants")),
             // Match Node's common 64-bit max Buffer length value. Perry won't

--- a/crates/perry-runtime/src/value/dynamic_object.rs
+++ b/crates/perry-runtime/src/value/dynamic_object.rs
@@ -259,18 +259,20 @@ pub unsafe extern "C" fn js_dynamic_object_get_property(
                 return (*buf).length as f64;
             }
             "byteOffset" => {
-                return 0.0;
+                return crate::buffer::buffer_byte_offset(ptr as usize) as f64;
             }
             "buffer" => {
-                // Issue #1225: return the ArrayBuffer-identity alias when the
-                // buffer is a copy (so `src.buffer === Buffer.from(src).buffer`);
-                // otherwise return the buffer itself, matching the
-                // pre-aliasing behavior where Perry didn't separate
-                // ArrayBuffer from BufferHeader.
-                let alias = crate::buffer::resolve_buffer_ab_alias(ptr as usize);
-                if alias == ptr as usize {
-                    return obj_value;
+                let alias = crate::buffer::buffer_backing_array_buffer(ptr as usize);
+                return f64::from_bits(crate::value::js_nanbox_pointer(alias as i64).to_bits());
+            }
+            "parent" => {
+                if crate::buffer::is_any_array_buffer(ptr as usize)
+                    || crate::buffer::is_data_view(ptr as usize)
+                    || crate::buffer::is_uint8array_buffer(ptr as usize)
+                {
+                    return f64::from_bits(TAG_UNDEFINED);
                 }
+                let alias = crate::buffer::buffer_backing_array_buffer(ptr as usize);
                 return f64::from_bits(crate::value::js_nanbox_pointer(alias as i64).to_bits());
             }
             _ => {

--- a/test-parity/node-suite/buffer/blob-file/namespace-constructors.ts
+++ b/test-parity/node-suite/buffer/blob-file/namespace-constructors.ts
@@ -1,0 +1,17 @@
+import * as buffer from "node:buffer";
+
+const BlobCtor = buffer.Blob;
+console.log("BlobCtor typeof:", typeof BlobCtor);
+const blob = new BlobCtor(["hello"]);
+console.log("Blob size:", blob.size);
+console.log("Blob text:", await blob.text());
+
+const FileCtor = buffer.File;
+console.log("FileCtor typeof:", typeof FileCtor);
+const file = new FileCtor(["hello"], "greeting.txt", {
+  lastModified: 1700000000000,
+});
+console.log("File name:", file.name);
+console.log("File lastModified:", file.lastModified);
+console.log("File size:", file.size);
+console.log("File text:", await file.text());

--- a/test-parity/node-suite/buffer/properties/backing-properties.ts
+++ b/test-parity/node-suite/buffer/properties/backing-properties.ts
@@ -1,0 +1,19 @@
+import { Buffer } from "node:buffer";
+
+const fromArray = Buffer.from([0x10, 0x20, 0x30]);
+console.log(
+  "from buffer instanceof ArrayBuffer:",
+  fromArray.buffer instanceof ArrayBuffer,
+);
+console.log("from parent same as buffer:", fromArray.parent === fromArray.buffer);
+console.log(
+  "from parent instanceof ArrayBuffer:",
+  fromArray.parent instanceof ArrayBuffer,
+);
+
+const slow = Buffer.allocUnsafeSlow(4);
+slow.fill(0);
+console.log("slow byteOffset:", slow.byteOffset);
+console.log("slow parent same as buffer:", slow.parent === slow.buffer);
+console.log("slow parent typeof:", typeof slow.parent);
+console.log("slow parent instanceof ArrayBuffer:", slow.parent instanceof ArrayBuffer);


### PR DESCRIPTION
## Summary
- export `node:buffer`'s `Blob` namespace constructor alongside `File`
- lower `buffer.Blob` / `buffer.File` constructor aliases through the existing fetch-backed classes
- expose Buffer backing metadata for `.buffer`, `.parent`, and `.byteOffset` across dynamic and generic property reads
- add focused node-suite coverage for namespace constructors and backing properties

## Verification
- `cargo fmt --all`
- `cargo check -p perry-runtime -p perry-hir -p perry-codegen`
- `cargo build --release -p perry`
- `node --input-type=module < test-parity/node-suite/buffer/blob-file/namespace-constructors.ts`
- `node --input-type=module < test-parity/node-suite/buffer/properties/backing-properties.ts`
- `PERRY_ALLOW_UNIMPLEMENTED=1 ./target/release/perry test-parity/node-suite/buffer/blob-file/namespace-constructors.ts -o /tmp/perry_buffer_namespace_constructors && /tmp/perry_buffer_namespace_constructors`
- `PERRY_ALLOW_UNIMPLEMENTED=1 ./target/release/perry test-parity/node-suite/buffer/properties/backing-properties.ts -o /tmp/perry_buffer_backing_properties && /tmp/perry_buffer_backing_properties`

Note: this local Node v22.22.1 build reports `ERR_NO_TYPESCRIPT` for direct `.ts` execution with `--experimental-strip-types`, so the Node baselines above were run from stdin.

Closes #3385.
Closes #3386.
Part of #3387.