### PR TITLE
fix(util): implement util.toUSVString (#2514)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2762,6 +2762,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("util", "getSystemErrorMessage", false, None),
     method("util", "getSystemErrorMap", false, None),
     method("util", "parseEnv", false, None),
+    // #2514: util.toUSVString(value) → string with lone surrogates replaced.
+    method("util", "toUSVString", false, None),
     // `util.formatWithOptions(options, format[, ...args])` — identical to
     // `util.format` except the first arg is an `util.inspect` options bag
     // applied to any `%o`/`%O` placeholders. Required by the `debug` npm

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -1061,6 +1061,16 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    // #2514: util.toUSVString(value) → string with lone surrogates → U+FFFD.
+    NativeModSig {
+        module: "util",
+        has_receiver: false,
+        method: "toUSVString",
+        class_filter: None,
+        runtime: "js_util_to_usv_string",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     NativeModSig {
         module: "util",
         has_receiver: false,

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -147,6 +147,7 @@ pub mod util_parse_args;
 pub mod util_parse_env;
 pub mod util_promisify;
 pub mod util_syserr;
+pub mod util_usv;
 #[cfg(all(target_os = "watchos", feature = "watchos-game-loop"))]
 pub mod watchos_game_loop;
 pub mod weakref;

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -392,6 +392,7 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
             b"isDeepStrictEqual",
             b"promisify",
             b"stripVTControlCharacters",
+            b"toUSVString",
             b"types",
             b"parseArgs",
             b"TextDecoder",
@@ -1281,6 +1282,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("util", "inherits")
             | ("util", "isDeepStrictEqual")
             | ("util", "stripVTControlCharacters")
+            | ("util", "toUSVString")
             | ("zlib", "Deflate")
             | ("zlib", "DeflateRaw")
             | ("zlib", "Gzip")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -991,6 +991,8 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("util", "stripVTControlCharacters") => {
             crate::builtins::js_util_strip_vt_control_characters(arg(0))
         }
+        // #2514: util.toUSVString(value) → string with lone surrogates → U+FFFD.
+        ("util", "toUSVString") => crate::util_usv::js_util_to_usv_string(arg(0)),
         ("util", "promisify") => crate::util_promisify::js_util_promisify(arg(0)),
         ("util", "callbackify") => crate::util_promisify::js_util_callbackify(arg(0)),
         ("util", "deprecate") => crate::util_promisify::js_util_deprecate(arg(0), arg(1), arg(2)),

--- a/crates/perry-runtime/src/util_usv.rs
+++ b/crates/perry-runtime/src/util_usv.rs
@@ -1,0 +1,19 @@
+//! `util.toUSVString(value)` (#2514) — coerce `value` to a string, then replace
+//! each lone surrogate code unit with the Unicode replacement character U+FFFD.
+//!
+//! This is `ToString(value)` followed by the same lone-surrogate scrubbing that
+//! `String.prototype.toWellFormed` performs: Perry stores lone surrogates
+//! (U+D800..U+DFFF) as 3-byte WTF-8 sequences, and `js_string_to_well_formed`
+//! replaces each *whole* sequence with one U+FFFD (a byte-wise `from_utf8_lossy`
+//! would instead emit three). Unlike `stripVTControlCharacters`, `toUSVString`
+//! coerces rather than throwing on non-string input (`toUSVString(123) === "123"`).
+
+/// `util.toUSVString(value)` → string with lone surrogates replaced by U+FFFD.
+#[no_mangle]
+pub extern "C" fn js_util_to_usv_string(value: f64) -> f64 {
+    // ToString(value): reuse the runtime's canonical coercion (-> *mut StringHeader).
+    let str_ptr = crate::value::js_jsvalue_to_string(value);
+    // Replace each lone surrogate with a single U+FFFD (WTF-8-aware).
+    let well_formed = crate::string::js_string_to_well_formed(str_ptr);
+    f64::from_bits(crate::value::JSValue::string_ptr(well_formed).bits())
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1819 entries across 89 modules
+// Coverage: 1820 entries across 89 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -2729,6 +2729,8 @@ declare module "util" {
   export function promisify(...args: any[]): any;
   /** stdlib */
   export function stripVTControlCharacters(...args: any[]): any;
+  /** stdlib */
+  export function toUSVString(...args: any[]): any;
 }
 
 declare module "util/types" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1819 entries across 89 modules.
+Total: 1820 entries across 89 modules.
 
 ## Modules
 
@@ -2346,6 +2346,7 @@ Total: 1819 entries across 89 modules.
 - `parseEnv` — module
 - `promisify` — module
 - `stripVTControlCharacters` — module
+- `toUSVString` — module
 
 ### Properties
 

--- a/test-files/test_gap_2514_tousvstring.ts
+++ b/test-files/test_gap_2514_tousvstring.ts
@@ -1,0 +1,14 @@
+// #2514 — util.toUSVString: coerce to string, replace lone surrogates with U+FFFD.
+import { toUSVString } from "node:util";
+
+console.log(typeof toUSVString);
+console.log(JSON.stringify(toUSVString("abc")));
+console.log(JSON.stringify(toUSVString("a\uD800b"))); // lone high surrogate -> 1×U+FFFD
+console.log(JSON.stringify(toUSVString("a\uDC00b"))); // lone low surrogate  -> 1×U+FFFD
+console.log(toUSVString("a\uD800b").length); // 3 (one replacement unit)
+console.log(toUSVString("a\uD800b").charCodeAt(1)); // 65533
+console.log(JSON.stringify(toUSVString("a😀b"))); // valid pair preserved
+console.log(JSON.stringify(toUSVString("café")));
+console.log(JSON.stringify(toUSVString(123 as unknown as string))); // -> "123"
+console.log(JSON.stringify(toUSVString(undefined as unknown as string))); // -> "undefined"
+console.log(JSON.stringify(toUSVString(null as unknown as string))); // -> "null"


### PR DESCRIPTION
Implements `util.toUSVString` (part of #2514 — remaining `node:util` top-level helpers).

## Problem

`util.toUSVString` was entirely missing (no manifest entry, whitelist, dispatch, or runtime impl), so `typeof util.toUSVString === "undefined"` and any call failed.

## Fix

Full wiring, mirroring the existing `util.parseEnv` path:

- **`util_usv.rs`** (new) — `js_util_to_usv_string`: `ToString(value)` via `js_jsvalue_to_string`, then route the result through `js_string_to_well_formed`, which replaces each lone-surrogate WTF-8 sequence with a **single** U+FFFD (the same scrubbing `String.prototype.toWellFormed` does). Coerces rather than throwing on non-string input (`toUSVString(123) === "123"`).
- **`lib.rs`** — `pub mod util_usv;`
- **`native_module.rs`** — `b"toUSVString"` whitelist + `("util","toUSVString")` value-gate.
- **`native_module_dispatch.rs`** — dispatch arm.
- **`entries.rs`** — `method("util","toUSVString",false,None)`.
- **`node_core.rs`** — `NativeModSig` row to `js_util_to_usv_string`.
- **`docs/api/perry.d.ts` + `docs/src/api/reference.md`** — regenerated via `scripts/regen_api_docs.sh`.

Note: a naive `from_utf8_lossy` approach is wrong here — it emits 3 U+FFFD for a 3-byte WTF-8 surrogate. Reusing `js_string_to_well_formed` gives Node's one-per-surrogate result.

## Validation

`test-files/test_gap_2514_tousvstring.ts` is byte-for-byte identical to `node --experimental-strip-types` (lone high/low surrogate -> 1xU+FFFD, length 3, charCodeAt 65533, valid pair preserved, number/undefined/null coerced).

`cargo build --release -p perry-runtime -p perry-stdlib -p perry` clean; `cargo fmt --all -- --check` clean; api-docs regenerated (no drift).
