### PR TITLE
fix(timers): honor promise timer scheduling options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,6 +170,12 @@ jobs:
           # shared runner this has repeatedly terminated large test links with
           # SIGBUS. Use the system linker for the cargo-test gate.
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld"
+          # Keep test artifacts small enough for the shared runner disk. The
+          # cargo-test job does not need line tables, and debug info was enough
+          # to make later package archives hit ENOSPC after several package
+          # test builds accumulated in target/debug.
+          CARGO_PROFILE_TEST_DEBUG: "0"
+          CARGO_PROFILE_DEV_DEBUG: "0"
         run: |
           (
             while sleep 60; do
@@ -187,6 +193,7 @@ jobs:
           # flakes) and races the GC/threading tests into intermittent SIGSEGV.
           # Run perry-runtime single-threaded so the tests can't interfere.
           RUST_TEST_THREADS=1 cargo test -p perry-runtime
+          find target/debug/deps -maxdepth 1 -type f -perm -111 ! -name '*.so' -delete
           # The remaining workspace includes large `perry` / `perry-stdlib`
           # test binaries. Keep Cargo build jobs serialized so the runner
           # does not link several of those large test binaries at once, then
@@ -222,6 +229,7 @@ jobs:
             echo "::group::cargo test -p $package"
             cargo test -p "$package"
             echo "::endgroup::"
+            cargo clean -p "$package" || true
             find target/debug/deps -maxdepth 1 -type f -perm -111 ! -name '*.so' -delete
           done
 

--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -431,7 +431,7 @@ pub(super) fn compile_module_entry(
                 // don't need the full event loop.
                 for _ in 0..4 {
                     let _ = ctx.block().call(I32, "js_promise_run_microtasks", &[]);
-                    let _ = ctx.block().call(I32, "js_timer_tick", &[]);
+                    let _ = ctx.block().call(I32, "js_timer_tick_if_refed", &[]);
                     let _ = ctx.block().call(I32, "js_callback_timer_tick", &[]);
                     let _ = ctx.block().call(I32, "js_interval_timer_tick", &[]);
                 }
@@ -489,7 +489,7 @@ pub(super) fn compile_module_entry(
                 ctx.block()
                     .call_void("js_process_emit_before_exit", &[(DOUBLE, &zero_code)]);
                 let _ = ctx.block().call(I32, "js_promise_run_microtasks", &[]);
-                let _ = ctx.block().call(I32, "js_timer_tick", &[]);
+                let _ = ctx.block().call(I32, "js_timer_tick_if_refed", &[]);
                 let _ = ctx.block().call(I32, "js_callback_timer_tick", &[]);
                 let _ = ctx.block().call(I32, "js_interval_timer_tick", &[]);
                 ctx.block().ret(I32, "0");

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1578,6 +1578,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // Timer tick functions — called from the Await busy-wait loop so
     // `setTimeout(resolve, N)` inside a Promise executor actually fires.
     module.declare_function("js_timer_tick", I32, &[]);
+    module.declare_function("js_timer_tick_if_refed", I32, &[]);
     module.declare_function("js_callback_timer_tick", I32, &[]);
     module.declare_function("js_interval_timer_tick", I32, &[]);
     // Timer has-pending checks — called from the main event loop to

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -163,7 +163,7 @@ impl SH for Expr {
             Expr::ObjectGetOwnPropertySymbols(e) => { tag(h, 119); e.as_ref().hash(h); }
             Expr::SymbolNew(e) => { tag(h, 120); e.hash(h); }
             Expr::SymbolFor(e) => { tag(h, 121); e.as_ref().hash(h); }
-            Expr::RegExpEscape(e) => { tag(h, 12043); e.as_ref().hash(h); }
+            Expr::RegExpEscape(e) => { tag(h, 12045); e.as_ref().hash(h); }
             Expr::SymbolKeyFor(e) => { tag(h, 122); e.as_ref().hash(h); }
             Expr::SymbolDescription(e) => { tag(h, 123); e.as_ref().hash(h); }
             Expr::SymbolToString(e) => { tag(h, 124); e.as_ref().hash(h); }

--- a/crates/perry-runtime/src/node_submodules/timers.rs
+++ b/crates/perry-runtime/src/node_submodules/timers.rs
@@ -58,6 +58,25 @@ fn is_plain_object(value: f64) -> bool {
     gc_header.obj_type != crate::gc::GC_TYPE_ARRAY
 }
 
+fn options_ref(options: f64) -> bool {
+    let Some(value) = super::stream_promises::get_object_property(options, b"ref") else {
+        return true;
+    };
+    let jv = JSValue::from_bits(value.to_bits());
+    if jv.is_bool() {
+        return jv.as_bool();
+    }
+    let message = format!(
+        "The \"options.ref\" property must be of type boolean. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
+fn promise_timer(delay_ms: f64, value: f64, has_ref: bool) -> *mut crate::promise::Promise {
+    crate::timer::js_set_timeout_value_ref(delay_ms, value, has_ref as i32)
+}
+
 /// node:timers/promises.setTimeout(delay, value?) — a Promise that resolves
 /// with `value` (or undefined) after `delay` ms. Composes the existing
 /// promise-returning timer primitive; the closure dispatch pads a missing
@@ -72,6 +91,7 @@ pub(crate) extern "C" fn timers_promises_set_timeout(
     validate_delay(delay_ms);
     validate_options(options);
     let signal = super::stream_promises::options_signal(options);
+    let has_ref = options_ref(options);
     if let Some(signal) = signal {
         if super::stream_promises::signal_aborted(signal) {
             let reason = super::stream_promises::signal_reason(signal);
@@ -80,7 +100,7 @@ pub(crate) extern "C" fn timers_promises_set_timeout(
             );
         }
     }
-    let promise = crate::timer::js_set_timeout_value(delay_ms, value);
+    let promise = promise_timer(delay_ms, value, has_ref);
     if let Some(signal) = signal {
         super::stream_promises::register_abort_listener(signal, promise);
     }
@@ -88,8 +108,8 @@ pub(crate) extern "C" fn timers_promises_set_timeout(
 }
 
 /// node:timers/promises.setImmediate(value?, options?) — a Promise that
-/// resolves with `value` (or undefined) on a later turn. `options` is validated
-/// for type (#3067); honoring its `signal`/`ref` fields is tracked by #2603.
+/// resolves with `value` (or undefined) on a later turn and honors the same
+/// `signal` / `ref` option bag as the other timers/promises helpers.
 /// Refs #1213.
 pub(crate) extern "C" fn timers_promises_set_immediate(
     _closure: *const ClosureHeader,
@@ -97,7 +117,20 @@ pub(crate) extern "C" fn timers_promises_set_immediate(
     options: f64,
 ) -> f64 {
     validate_options(options);
-    let promise = crate::timer::js_set_timeout_value(0.0, value);
+    let signal = super::stream_promises::options_signal(options);
+    let has_ref = options_ref(options);
+    if let Some(signal) = signal {
+        if super::stream_promises::signal_aborted(signal) {
+            let reason = super::stream_promises::signal_reason(signal);
+            return crate::value::js_nanbox_pointer(
+                crate::promise::js_promise_rejected(reason) as i64
+            );
+        }
+    }
+    let promise = promise_timer(0.0, value, has_ref);
+    if let Some(signal) = signal {
+        super::stream_promises::register_abort_listener(signal, promise);
+    }
     crate::value::js_nanbox_pointer(promise as i64)
 }
 
@@ -110,7 +143,7 @@ pub(crate) extern "C" fn timers_promises_scheduler_wait(
 }
 
 pub(crate) extern "C" fn timers_promises_scheduler_yield(_closure: *const ClosureHeader) -> f64 {
-    let promise = crate::promise::js_promise_resolved(f64::from_bits(TAG_UNDEFINED));
+    let promise = promise_timer(0.0, f64::from_bits(TAG_UNDEFINED), true);
     crate::value::js_nanbox_pointer(promise as i64)
 }
 
@@ -147,6 +180,7 @@ extern "C" fn timers_promises_interval_next(closure: *const ClosureHeader) -> f6
     let signal = js_closure_get_capture_f64(closure, 1);
     let delay_ms = js_closure_get_capture_f64(closure, 2);
     let closed = js_closure_get_capture_f64(closure, 3);
+    let has_ref = js_closure_get_capture_f64(closure, 4) != 0.0;
     if closed != 0.0 {
         return boxed_ptr(crate::promise::js_promise_resolved(iter_result(
             f64::from_bits(TAG_UNDEFINED),
@@ -161,7 +195,7 @@ extern "C" fn timers_promises_interval_next(closure: *const ClosureHeader) -> f6
         return boxed_ptr(crate::promise::js_promise_rejected(reason) as *const u8);
     }
 
-    let promise = crate::timer::js_set_timeout_value(delay_ms, iter_result(value, false));
+    let promise = promise_timer(delay_ms, iter_result(value, false), has_ref);
     if !JSValue::from_bits(signal.to_bits()).is_undefined() {
         super::stream_promises::register_abort_listener(signal, promise);
     }
@@ -191,16 +225,20 @@ pub(crate) extern "C" fn timers_promises_set_interval(
     value: f64,
     options: f64,
 ) -> f64 {
+    validate_delay(delay_ms);
+    validate_options(options);
     let signal = super::stream_promises::options_signal(options)
         .unwrap_or_else(|| f64::from_bits(TAG_UNDEFINED));
+    let has_ref = options_ref(options);
     let obj = js_object_alloc(0, 4);
     let obj_value = boxed_ptr(obj as *const u8);
 
-    let next = js_closure_alloc(timers_promises_interval_next as *const u8, 4);
+    let next = js_closure_alloc(timers_promises_interval_next as *const u8, 5);
     js_closure_set_capture_f64(next, 0, value);
     js_closure_set_capture_f64(next, 1, signal);
     js_closure_set_capture_f64(next, 2, delay_ms);
     js_closure_set_capture_f64(next, 3, 0.0);
+    js_closure_set_capture_f64(next, 4, has_ref as i32 as f64);
     js_object_set_field_by_name(obj, string_key(b"next"), boxed_ptr(next as *const u8));
 
     let ret = js_closure_alloc(timers_promises_interval_return as *const u8, 1);

--- a/crates/perry-runtime/src/timer.rs
+++ b/crates/perry-runtime/src/timer.rs
@@ -17,6 +17,10 @@ use std::sync::{
 };
 use std::time::{Duration, Instant};
 
+extern "C" {
+    fn js_stdlib_has_active_handles() -> i32;
+}
+
 /// A scheduled timer
 struct Timer {
     /// When this timer should fire
@@ -25,6 +29,8 @@ struct Timer {
     promise: *mut Promise,
     /// The value to resolve with (typically undefined/0.0)
     value: f64,
+    /// Whether this promise timer should keep the event loop alive.
+    has_ref: bool,
 }
 
 // SAFETY: Promise pointers are only accessed from the pump thread
@@ -55,24 +61,26 @@ pub extern "C" fn js_timer_now() -> f64 {
 /// Returns the promise that will be resolved
 #[no_mangle]
 pub extern "C" fn js_set_timeout(delay_ms: f64) -> *mut Promise {
-    ensure_initialized();
-
-    let promise = js_promise_new();
-    let delay = Duration::from_millis(normalize_timer_delay(delay_ms));
-    let deadline = Instant::now() + delay;
-
-    TIMER_QUEUE.lock().unwrap().push(Timer {
-        deadline,
-        promise,
-        value: 0.0, // setTimeout resolves with undefined
-    });
-
-    promise
+    schedule_promise_timer(delay_ms, 0.0, true)
 }
 
 /// Schedule a timer with a specific resolve value
 #[no_mangle]
 pub extern "C" fn js_set_timeout_value(delay_ms: f64, value: f64) -> *mut Promise {
+    schedule_promise_timer(delay_ms, value, true)
+}
+
+/// Schedule a promise timer with explicit event-loop liveness.
+#[no_mangle]
+pub extern "C" fn js_set_timeout_value_ref(
+    delay_ms: f64,
+    value: f64,
+    has_ref: i32,
+) -> *mut Promise {
+    schedule_promise_timer(delay_ms, value, has_ref != 0)
+}
+
+fn schedule_promise_timer(delay_ms: f64, value: f64, has_ref: bool) -> *mut Promise {
     ensure_initialized();
 
     let promise = js_promise_new();
@@ -83,9 +91,28 @@ pub extern "C" fn js_set_timeout_value(delay_ms: f64, value: f64) -> *mut Promis
         deadline,
         promise,
         value,
+        has_ref,
     });
 
     promise
+}
+
+fn has_refed_promise_timer() -> bool {
+    TIMER_QUEUE
+        .lock()
+        .unwrap()
+        .iter()
+        .any(|timer| timer.has_ref)
+}
+
+fn other_event_sources_keep_loop_alive() -> bool {
+    js_callback_timer_has_pending() != 0
+        || js_interval_timer_has_pending() != 0
+        || unsafe { js_stdlib_has_active_handles() != 0 }
+}
+
+fn should_run_unref_promise_timers() -> bool {
+    has_refed_promise_timer() || other_event_sources_keep_loop_alive()
 }
 
 /// Process any expired timers, resolving their promises
@@ -93,6 +120,7 @@ pub extern "C" fn js_set_timeout_value(delay_ms: f64, value: f64) -> *mut Promis
 #[no_mangle]
 pub extern "C" fn js_timer_tick() -> i32 {
     let now = Instant::now();
+    let allow_unref = should_run_unref_promise_timers();
     let mut fired = 0;
 
     // Collect expired timers
@@ -101,7 +129,7 @@ pub extern "C" fn js_timer_tick() -> i32 {
         let mut expired = Vec::new();
         let mut i = 0;
         while i < queue.len() {
-            if queue[i].deadline <= now {
+            if queue[i].deadline <= now && (queue[i].has_ref || allow_unref) {
                 expired.push(queue.remove(i));
             } else {
                 i += 1;
@@ -128,22 +156,32 @@ pub extern "C" fn js_timer_tick() -> i32 {
 /// Check if there are any pending timers
 #[no_mangle]
 pub extern "C" fn js_timer_has_pending() -> i32 {
-    if TIMER_QUEUE.lock().unwrap().is_empty() {
-        0
-    } else {
+    if has_refed_promise_timer() {
         1
+    } else {
+        0
     }
+}
+
+/// Compatibility entry used by generated startup drains. `js_timer_tick`
+/// itself enforces promise timer liveness, so this wrapper keeps older
+/// generated call sites explicit without duplicating the policy.
+#[no_mangle]
+pub extern "C" fn js_timer_tick_if_refed() -> i32 {
+    js_timer_tick()
 }
 
 /// Get the time until the next timer fires (in ms), or -1 if no timers
 #[no_mangle]
 pub extern "C" fn js_timer_next_deadline() -> f64 {
     let now = Instant::now();
+    let allow_unref = should_run_unref_promise_timers();
 
     TIMER_QUEUE
         .lock()
         .unwrap()
         .iter()
+        .filter(|t| t.has_ref || allow_unref)
         .map(|t| {
             if t.deadline <= now {
                 0.0
@@ -1286,6 +1324,7 @@ pub(crate) fn test_seed_timer_scanner_roots(
         deadline,
         promise,
         value,
+        has_ref: true,
     });
     CALLBACK_TIMERS.lock().unwrap().push(CallbackTimer {
         id: TEST_CALLBACK_TIMER_ID,
@@ -1320,6 +1359,7 @@ pub(crate) fn test_seed_many_timeout_roots(values: &[f64]) {
             deadline,
             promise: std::ptr::null_mut(),
             value,
+            has_ref: true,
         });
     }
 }

--- a/test-parity/node-suite/timers/promises/ref-false-liveness.ts
+++ b/test-parity/node-suite/timers/promises/ref-false-liveness.ts
@@ -1,0 +1,21 @@
+import {
+  scheduler,
+  setImmediate,
+  setInterval,
+  setTimeout,
+} from "node:timers/promises";
+
+setTimeout(1000, "timeout", { ref: false }).then((value) =>
+  console.log("timeout resolved:", value)
+);
+setImmediate("immediate", { ref: false }).then((value) =>
+  console.log("immediate resolved:", value)
+);
+scheduler.wait(1000, { ref: false }).then(() => console.log("wait resolved"));
+
+const interval = setInterval(1000, "interval", { ref: false });
+interval.next().then((result) =>
+  console.log("interval resolved:", result.value, result.done)
+);
+
+console.log("scheduled");

--- a/test-parity/node-suite/timers/promises/ref-option-validation.ts
+++ b/test-parity/node-suite/timers/promises/ref-option-validation.ts
@@ -1,0 +1,23 @@
+import * as timers from "node:timers/promises";
+
+async function probe(label: string, fn: () => Promise<unknown>) {
+  try {
+    await fn();
+    console.log(label, "OK");
+  } catch (err: any) {
+    console.log(label, "THROW", err.name, err.code, err.message.split("\n")[0]);
+  }
+}
+
+await probe("setTimeout ref string", () =>
+  timers.setTimeout(1, undefined, { ref: "no" as any })
+);
+await probe("setImmediate ref number", () =>
+  timers.setImmediate(undefined, { ref: 0 as any })
+);
+await probe("setInterval ref object", () =>
+  timers.setInterval(1, undefined, { ref: {} as any }).next()
+);
+await probe("scheduler.wait ref string", () =>
+  timers.scheduler.wait(1, { ref: "no" as any })
+);

--- a/test-parity/node-suite/timers/promises/scheduler-yield-microtask-order.ts
+++ b/test-parity/node-suite/timers/promises/scheduler-yield-microtask-order.ts
@@ -1,0 +1,9 @@
+import { scheduler } from "node:timers/promises";
+
+const events: string[] = [];
+const yielded = scheduler.yield().then(() => events.push("yield"));
+Promise.resolve().then(() => events.push("micro"));
+events.push("sync");
+
+await yielded;
+console.log(events.join(","));

--- a/test-parity/node-suite/timers/promises/set-immediate-signal.ts
+++ b/test-parity/node-suite/timers/promises/set-immediate-signal.ts
@@ -1,0 +1,26 @@
+import { setImmediate } from "node:timers/promises";
+
+async function report(label: string, promise: Promise<unknown>) {
+  try {
+    console.log(label + ":", "resolved", await promise);
+  } catch (err: any) {
+    console.log(
+      label + ":",
+      err instanceof Error,
+      err.name,
+      err.code || "no-code",
+      typeof err.stack,
+    );
+  }
+}
+
+const already = new AbortController();
+already.abort();
+await report("already aborted", setImmediate("late", { signal: already.signal }));
+
+const pending = new AbortController();
+const promise = setImmediate("late", { signal: pending.signal });
+pending.abort();
+await report("aborted after scheduling", promise);
+
+console.log("resolved:", await setImmediate("value", { ref: true }));


### PR DESCRIPTION
Fixes #3413
Fixes #3225
Fixes #3224

## Summary
- defers `scheduler.yield()` settlement through the promise timer queue so queued microtasks run before the yield continuation
- honors `setImmediate(value, options.signal)` for already-aborted and later-aborted signals
- tracks `ref:false` on promise timers so fire-and-forget `setTimeout`, `setImmediate`, `setInterval().next()`, and `scheduler.wait()` do not keep the generated event loop alive
- validates `options.ref` as a boolean for the timers/promises helpers

## Scope
These issues share the `node:timers/promises` scheduling/options path, so they are batched as one PR. This avoids mixing in unrelated callback `node:timers` handle-shape work or broader event-loop rewrites.

## Tests Added
- `test-parity/node-suite/timers/promises/scheduler-yield-microtask-order.ts`
- `test-parity/node-suite/timers/promises/set-immediate-signal.ts`
- `test-parity/node-suite/timers/promises/ref-false-liveness.ts`
- `test-parity/node-suite/timers/promises/ref-option-validation.ts`

## Verification
Pre-fix focused parity runs failed for the new scheduler-yield ordering, setImmediate signal, and ref:false liveness fixtures. Post-fix commands run:

- `cargo check -p perry-runtime -p perry-codegen`
- `cargo check -p perry-codegen`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module timers/promises --filter scheduler-yield-microtask-order`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module timers/promises --filter set-immediate-signal`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module timers/promises --filter ref-false-liveness`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module timers/promises`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module timers`
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check && git diff --cached --check && git diff --check origin/main...HEAD`
- `./scripts/check_file_size.sh`

The full timers suite passes 86/86. The existing `timeout-value-and-ref` fixture remains a Node-side skip in the harness output.

## Known Limitations And Non-Goals
- This does not change callback `node:timers` handle `.ref()` / `.unref()` process-liveness semantics.
- This does not attempt broader event-loop rewrites or special top-level-await cancellation behavior for awaited unref promise timers.
