### PR TITLE
fix(hir): restore unique RegExpEscape stable-hash tag (main hotfix)

### DIFF
--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -163,7 +163,7 @@ impl SH for Expr {
             Expr::ObjectGetOwnPropertySymbols(e) => { tag(h, 119); e.as_ref().hash(h); }
             Expr::SymbolNew(e) => { tag(h, 120); e.hash(h); }
             Expr::SymbolFor(e) => { tag(h, 121); e.as_ref().hash(h); }
-            Expr::RegExpEscape(e) => { tag(h, 12045); e.as_ref().hash(h); }
+            Expr::RegExpEscape(e) => { tag(h, 12043); e.as_ref().hash(h); }
             Expr::SymbolKeyFor(e) => { tag(h, 122); e.as_ref().hash(h); }
             Expr::SymbolDescription(e) => { tag(h, 123); e.as_ref().hash(h); }
             Expr::SymbolToString(e) => { tag(h, 124); e.as_ref().hash(h); }


### PR DESCRIPTION
A merge mangled `RegExpEscape`'s stable-hash tag to 12045, colliding with `ReflectIsExtensible` (12045) and breaking `expr_variant_stable_hash_tags_are_unique` on main. Restores it to its original free slot 12043. One-line; `cargo test -p perry-hir` green locally. Admin-merging as a hotfix to unblock the red main.