### PR TITLE
fix(util): mirror toUSVString into sys alias — restores main (#2514)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2885,6 +2885,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("sys", "getSystemErrorName", false, None),
     method("sys", "getSystemErrorMessage", false, None),
     method("sys", "getSystemErrorMap", false, None),
+    method("sys", "toUSVString", false, None),
     method("sys", "parseEnv", false, None),
     method("sys", "formatWithOptions", false, None),
     method("sys", "promisify", false, None),


### PR DESCRIPTION
Restores `main` to green.

#3421 added `util.toUSVString` but not the matching `sys` alias entry, so `sys_alias_mirrors_util_manifest` (which asserts `node:sys` mirrors `node:util`'s manifest surface) fails on main — `sys` has one fewer entry than `util`.

This adds `method("sys", "toUSVString", false, None)` alongside the other `sys` util-mirror entries.

`cargo test -p perry-api-manifest --lib sys_alias` → passes (was failing on main). `cargo fmt --all -- --check` clean; api docs unchanged (sys alias isn't emitted to the .d.ts surface).
