### PR TITLE
fix(manifest): mirror util.toUSVString into sys alias (main hotfix)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2902,6 +2902,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("sys", "isDeepStrictEqual", false, None),
     method("sys", "parseArgs", false, None),
     method("sys", "stripVTControlCharacters", false, None),
+    method("sys", "toUSVString", false, None),
     class("sys", "TextEncoder"),
     class("sys", "TextDecoder"),
     property("sys", "types"),

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1820 entries across 89 modules
+// Coverage: 1821 entries across 89 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -2642,6 +2642,8 @@ declare module "sys" {
   export function promisify(...args: any[]): any;
   /** stdlib */
   export function stripVTControlCharacters(...args: any[]): any;
+  /** stdlib */
+  export function toUSVString(...args: any[]): any;
 }
 
 declare module "tls" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1820 entries across 89 modules.
+Total: 1821 entries across 89 modules.
 
 ## Modules
 
@@ -2266,6 +2266,7 @@ Total: 1820 entries across 89 modules.
 - `parseEnv` — module
 - `promisify` — module
 - `stripVTControlCharacters` — module
+- `toUSVString` — module
 
 ### Properties
 


### PR DESCRIPTION
PR #3421 added `util.toUSVString` but not the `node:sys` alias mirror, breaking `sys_alias_mirrors_util_manifest` on main (util 19 / sys 18). Adds the sys entry + regenerated api docs. `cargo test -p perry-api-manifest` green. Admin-merging as a hotfix to unblock red main.