### PR TITLE
fix(manifest): dedup sys.toUSVString (main hotfix)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2885,7 +2885,6 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("sys", "getSystemErrorName", false, None),
     method("sys", "getSystemErrorMessage", false, None),
     method("sys", "getSystemErrorMap", false, None),
-    method("sys", "toUSVString", false, None),
     method("sys", "parseEnv", false, None),
     method("sys", "formatWithOptions", false, None),
     method("sys", "promisify", false, None),


### PR DESCRIPTION
PR #3436 and #3439 both mirrored util.toUSVString into the sys alias, leaving a duplicate (sys 20 vs util 19) that re-broke sys_alias_mirrors_util_manifest. Removes the duplicate. Test green. Admin-merge to unblock main.