### PR TITLE
fix(util): dedup sys.toUSVString manifest entries — restores main

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2903,7 +2903,6 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("sys", "isDeepStrictEqual", false, None),
     method("sys", "parseArgs", false, None),
     method("sys", "stripVTControlCharacters", false, None),
-    method("sys", "toUSVString", false, None),
     class("sys", "TextEncoder"),
     class("sys", "TextDecoder"),
     property("sys", "types"),


### PR DESCRIPTION
Restores `main` to green.

`method("sys", "toUSVString")` ended up in `crates/perry-api-manifest/src/entries.rs` **three times** (#3436 plus parallel mirror fixes each added one). That made `node:sys` carry one more manifest entry than `node:util`, so:
- `sys_alias_mirrors_util_manifest` failed (`sys.len() != util.len()`), and
- `api-docs-drift` saw a duplicated `toUSVString` line in the regenerated reference.

This keeps exactly one `sys` mirror entry and regenerates the api docs.

`cargo test -p perry-api-manifest --lib` → 18 passed, 0 failed (was failing on main). `cargo fmt --all -- --check` clean. api-docs regenerated; a second regen produces no diff (zero drift).
