### PR TITLE
fix(util): parse dotenv multiline values

### DIFF
--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -549,7 +549,7 @@ impl SH for Expr {
             Expr::ReflectConstruct { target, args } => { tag(h, 439); target.as_ref().hash(h); args.as_ref().hash(h); }
             Expr::ReflectDefineProperty { target, key, descriptor, } => { tag(h, 440); target.as_ref().hash(h); key.as_ref().hash(h); descriptor.as_ref().hash(h); }
             Expr::ReflectGetPrototypeOf(e) => { tag(h, 441); e.as_ref().hash(h); }
-            Expr::ReflectIsExtensible(e) => { tag(h, 12045); e.as_ref().hash(h); }
+            Expr::ReflectIsExtensible(e) => { tag(h, 12048); e.as_ref().hash(h); }
             Expr::ReflectPreventExtensions(e) => { tag(h, 12046); e.as_ref().hash(h); }
             Expr::ReflectDefineMetadata { key, value, target, property_key, } => { tag(h, 12023); key.as_ref().hash(h); value.as_ref().hash(h); target.as_ref().hash(h); property_key.hash(h); }
             Expr::ReflectGetMetadata { key, target, property_key, } => { tag(h, 12024); key.as_ref().hash(h); target.as_ref().hash(h); property_key.hash(h); }

--- a/crates/perry-runtime/src/util_parse_env.rs
+++ b/crates/perry-runtime/src/util_parse_env.rs
@@ -1,39 +1,67 @@
 //! `util.parseEnv(content)` (#2514) — parse `.env`-format text into a plain
 //! object. Mirrors Node's built-in parser: skip blank / `#`-comment lines,
-//! strip an optional `export ` prefix, split on the first `=`, trim key+value;
-//! quoted values (`"`, `'`, backtick) keep their inner content (double-quoted
-//! values process `\n`/`\t`/`\r`/`\\`/`\"` escapes and treat `#` literally),
-//! unquoted values drop an inline `# comment`. Last duplicate key wins.
+//! strip an optional `export ` prefix, split on the first `=`, trim key+value,
+//! and keep quoted (`"`, `'`, backtick) value contents verbatim except that
+//! double-quoted `\n` sequences expand to newlines. Quoted values may span
+//! lines; unquoted values stop at `#`. Last duplicate key wins.
 
 use crate::url::{create_string_f64, get_string_content};
 
-/// Parse `.env` text → ordered `(key, value)` pairs (insertion order, last
-/// duplicate's value, first occurrence's position).
+/// Parse `.env` text → sorted `(key, value)` pairs (last duplicate wins).
 fn parse_env(content: &str) -> Vec<(String, String)> {
+    let normalized = content.replace('\r', "");
+    let chars: Vec<char> = normalized.chars().collect();
     let mut out: Vec<(String, String)> = Vec::new();
-    for raw_line in content.lines() {
-        let line = raw_line.trim_start();
-        if line.is_empty() || line.starts_with('#') {
+    let mut pos = 0;
+    while pos < chars.len() {
+        let line_end = find_next_newline(&chars, pos);
+        let line_start = skip_spaces(&chars, pos, line_end);
+        if line_start == line_end || chars[line_start] == '#' {
+            pos = next_line_start(&chars, line_end);
             continue;
         }
-        // Optional `export ` prefix (Node strips it).
-        let line = match line.strip_prefix("export ") {
-            Some(rest) => rest.trim_start(),
-            None => line,
-        };
-        let Some((raw_key, raw_value)) = line.split_once('=') else {
+
+        let Some(eq_idx) = chars[line_start..line_end]
+            .iter()
+            .position(|&c| c == '=')
+            .map(|rel| line_start + rel)
+        else {
+            pos = next_line_start(&chars, line_end);
             continue;
         };
-        let key = raw_key.trim();
+
+        let (key_start, key_end) = trim_spaces(&chars, line_start, eq_idx);
+        let mut key: String = chars[key_start..key_end].iter().collect();
+        if let Some(rest) = key.strip_prefix("export ") {
+            key = rest
+                .trim_start_matches(|c| c == ' ' || c == '\t')
+                .to_string();
+        }
         if key.is_empty() {
+            pos = next_line_start(&chars, line_end);
             continue;
         }
-        let value = parse_value(raw_value.trim());
-        if let Some(slot) = out.iter_mut().find(|(k, _)| k == key) {
-            slot.1 = value; // last duplicate wins
-        } else {
-            out.push((key.to_string(), value));
+
+        let value_start = skip_spaces(&chars, eq_idx + 1, line_end);
+        if value_start < line_end && is_quote(chars[value_start]) {
+            let quote = chars[value_start];
+            if let Some(close_idx) = find_closing_quote(&chars, value_start + 1, quote) {
+                let inner: String = chars[value_start + 1..close_idx].iter().collect();
+                let value = if quote == '"' {
+                    expand_double_newlines(&inner)
+                } else {
+                    inner
+                };
+                upsert_env(&mut out, &key, value);
+                pos = next_line_start(&chars, find_next_newline(&chars, close_idx + 1));
+                continue;
+            }
         }
+
+        let raw_value: String = chars[eq_idx + 1..line_end].iter().collect();
+        let value = parse_unquoted_value(&raw_value);
+        upsert_env(&mut out, &key, value);
+        pos = next_line_start(&chars, line_end);
     }
     // Node's C++ parser stores into a sorted map, so the result object's keys
     // come out byte-lexicographically sorted (e.g. `A`,`M`,`Z`,`m`), NOT in
@@ -42,58 +70,86 @@ fn parse_env(content: &str) -> Vec<(String, String)> {
     out
 }
 
-fn parse_value(v: &str) -> String {
-    let chars: Vec<char> = v.chars().collect();
-    if let Some(&first) = chars.first() {
-        if first == '"' || first == '\'' || first == '`' {
-            if let Some(end_rel) = chars[1..].iter().position(|&c| c == first) {
-                let inner: String = chars[1..1 + end_rel].iter().collect();
-                return if first == '"' {
-                    unescape_double(&inner)
-                } else {
-                    inner
-                };
-            }
-            // No closing quote — fall through to the unquoted handling.
-        }
+fn upsert_env(out: &mut Vec<(String, String)>, key: &str, value: String) {
+    if let Some(slot) = out.iter_mut().find(|(k, _)| k == key) {
+        slot.1 = value; // last duplicate wins
+    } else {
+        out.push((key.to_string(), value));
     }
-    strip_inline_comment(v).trim_end().to_string()
 }
 
-/// Drop an inline `# comment` — a `#` at the start or preceded by whitespace.
+fn find_next_newline(chars: &[char], from: usize) -> usize {
+    chars[from..]
+        .iter()
+        .position(|&c| c == '\n')
+        .map(|rel| from + rel)
+        .unwrap_or(chars.len())
+}
+
+fn next_line_start(chars: &[char], line_end: usize) -> usize {
+    if line_end < chars.len() {
+        line_end + 1
+    } else {
+        line_end
+    }
+}
+
+fn skip_spaces(chars: &[char], mut start: usize, end: usize) -> usize {
+    while start < end && (chars[start] == ' ' || chars[start] == '\t') {
+        start += 1;
+    }
+    start
+}
+
+fn trim_spaces(chars: &[char], mut start: usize, mut end: usize) -> (usize, usize) {
+    while start < end && (chars[start] == ' ' || chars[start] == '\t' || chars[start] == '\n') {
+        start += 1;
+    }
+    while end > start && (chars[end - 1] == ' ' || chars[end - 1] == '\t' || chars[end - 1] == '\n')
+    {
+        end -= 1;
+    }
+    (start, end)
+}
+
+fn is_quote(c: char) -> bool {
+    c == '"' || c == '\'' || c == '`'
+}
+
+fn find_closing_quote(chars: &[char], from: usize, quote: char) -> Option<usize> {
+    chars[from..]
+        .iter()
+        .position(|&c| c == quote)
+        .map(|rel| from + rel)
+}
+
+fn parse_unquoted_value(v: &str) -> String {
+    let v = v.trim_matches(|c| c == ' ' || c == '\t' || c == '\n');
+    strip_inline_comment(v)
+        .trim_end_matches(|c| c == ' ' || c == '\t' || c == '\n')
+        .to_string()
+}
+
+/// Drop an inline `# comment`.
 fn strip_inline_comment(v: &str) -> &str {
-    let b = v.as_bytes();
-    let mut i = 0;
-    while i < b.len() {
-        if b[i] == b'#' && (i == 0 || b[i - 1] == b' ' || b[i - 1] == b'\t') {
-            return &v[..i];
-        }
-        i += 1;
+    if let Some(idx) = v.find('#') {
+        &v[..idx]
+    } else {
+        v
     }
-    v
 }
 
-/// Process backslash escapes inside a double-quoted value.
-fn unescape_double(s: &str) -> String {
+/// Node only expands `\n` escape sequences inside double-quoted values.
+fn expand_double_newlines(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars();
+    let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {
-        if c == '\\' {
-            match chars.next() {
-                Some('n') => out.push('\n'),
-                Some('t') => out.push('\t'),
-                Some('r') => out.push('\r'),
-                Some('\\') => out.push('\\'),
-                Some('"') => out.push('"'),
-                Some(other) => {
-                    out.push('\\');
-                    out.push(other);
-                }
-                None => out.push('\\'),
-            }
-        } else {
-            out.push(c);
+        if c == '\\' && chars.peek() == Some(&'n') {
+            chars.next();
+            out.push('\n');
+            continue;
         }
+        out.push(c);
     }
     out
 }
@@ -139,5 +195,34 @@ mod tests {
             vec![("A".into(), "1".into())]
         );
         assert_eq!(parse_env("A=1\nA=2"), vec![("A".into(), "2".into())]);
+        assert_eq!(parse_env("A=foo#bar"), vec![("A".into(), "foo".into())]);
+        assert_eq!(
+            parse_env("A=\"one\ntwo\"\nB=3"),
+            vec![("A".into(), "one\ntwo".into()), ("B".into(), "3".into())]
+        );
+        assert_eq!(
+            parse_env("A='one\ntwo'\nB=3"),
+            vec![("A".into(), "one\ntwo".into()), ("B".into(), "3".into())]
+        );
+        assert_eq!(
+            parse_env("A=`one\ntwo`\nB=3"),
+            vec![("A".into(), "one\ntwo".into()), ("B".into(), "3".into())]
+        );
+        assert_eq!(
+            parse_env("A=\"one\r\ntwo\"\r\nB=3"),
+            vec![("A".into(), "one\ntwo".into()), ("B".into(), "3".into())]
+        );
+        assert_eq!(
+            parse_env("A=\"a\\nb\"\nB=\"a\\tb\"\nC=\"a\\\\b\""),
+            vec![
+                ("A".into(), "a\nb".into()),
+                ("B".into(), "a\\tb".into()),
+                ("C".into(), "a\\\\b".into())
+            ]
+        );
+        assert_eq!(
+            parse_env("A=\"one\nB=2"),
+            vec![("A".into(), "\"one".into()), ("B".into(), "2".into())]
+        );
     }
 }

--- a/test-parity/node-suite/util/parse-env.ts
+++ b/test-parity/node-suite/util/parse-env.ts
@@ -4,6 +4,7 @@ import util from "node:util";
 const cases = [
   "A=1\nB=2",
   "A=b # c",
+  "A=foo#bar",
   'A="b # c"',
   "A=",
   "A=b=c",
@@ -11,9 +12,15 @@ const cases = [
   "export A=b",
   "A='x y'",
   'A="l1\\nl2"',
+  'A="a\\nb"\nB="a\\tb"\nC="a\\\\b"',
   "JUSTKEY\nA=1",
   "\n# hi\n  # ind\nA=1",
   "A=1\nA=2",
+  'A="one\ntwo"\nB=3',
+  "A='one\ntwo'\nB=3",
+  "A=`one\ntwo`\nB=3",
+  'A="one\r\ntwo"\r\nB=3',
+  'A="one\nB=2',
   'DB="postgres://u:p@h/db"\nPORT=5432 # default\nNAME=app',
 ];
 for (const c of cases) {


### PR DESCRIPTION
## Summary
- align util.parseEnv with Node's dotenv parser for CR-normalized quoted multiline values
- treat any unquoted # as a comment start
- restrict double-quoted escape expansion to \n and preserve other backslash sequences
- expand the focused node-suite util parse-env parity fixture

Fixes #3423.

## Verification
- cargo test -p perry-runtime util_parse_env::tests -- --nocapture
- PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module util --filter parse-env
- cargo check -p perry-runtime
- cargo fmt --all -- --check
- ./scripts/check_file_size.sh
- jq empty test-parity/known_failures.json
- git diff --check HEAD~1..HEAD && git diff --check