### PR TITLE
fix(util): implement util.styleText (#2514)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2811,6 +2811,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("util", "parseEnv", false, None),
     // #2514: util.toUSVString(value) → string with lone surrogates replaced.
     method("util", "toUSVString", false, None),
+    // #2514: util.styleText(format, text[, options]) → ANSI-styled string.
+    method("util", "styleText", false, None),
     // `util.formatWithOptions(options, format[, ...args])` — identical to
     // `util.format` except the first arg is an `util.inspect` options bag
     // applied to any `%o`/`%O` placeholders. Required by the `debug` npm
@@ -2903,6 +2905,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("sys", "parseArgs", false, None),
     method("sys", "stripVTControlCharacters", false, None),
     method("sys", "toUSVString", false, None),
+    method("sys", "styleText", false, None),
     class("sys", "TextEncoder"),
     class("sys", "TextDecoder"),
     property("sys", "types"),

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -1071,6 +1071,16 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    // #2514: util.styleText(format, text[, options]) → ANSI-styled string.
+    NativeModSig {
+        module: "util",
+        has_receiver: false,
+        method: "styleText",
+        class_filter: None,
+        runtime: "js_util_style_text",
+        args: &[NA_F64, NA_F64, NA_F64],
+        ret: NR_F64,
+    },
     NativeModSig {
         module: "util",
         has_receiver: false,

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -146,6 +146,7 @@ pub mod ui_text_registry;
 pub mod util_parse_args;
 pub mod util_parse_env;
 pub mod util_promisify;
+pub mod util_styletext;
 pub mod util_syserr;
 pub mod util_usv;
 #[cfg(all(target_os = "watchos", feature = "watchos-game-loop"))]

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -415,6 +415,7 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
             b"isArray",
             b"isDeepStrictEqual",
             b"promisify",
+            b"styleText",
             b"stripVTControlCharacters",
             b"toUSVString",
             b"types",
@@ -1450,6 +1451,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("util", "deprecate")
             | ("util", "inherits")
             | ("util", "isDeepStrictEqual")
+            | ("util", "styleText")
             | ("util", "stripVTControlCharacters")
             | ("util", "toUSVString")
             | ("zlib", "Deflate")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -993,6 +993,8 @@ pub(crate) unsafe fn dispatch_native_module_method(
         }
         // #2514: util.toUSVString(value) → string with lone surrogates → U+FFFD.
         ("util", "toUSVString") => crate::util_usv::js_util_to_usv_string(arg(0)),
+        // #2514: util.styleText(format, text[, options]) → ANSI-wrapped string.
+        ("util", "styleText") => crate::util_styletext::js_util_style_text(arg(0), arg(1), arg(2)),
         ("util", "promisify") => crate::util_promisify::js_util_promisify(arg(0)),
         ("util", "callbackify") => crate::util_promisify::js_util_callbackify(arg(0)),
         ("util", "deprecate") => crate::util_promisify::js_util_deprecate(arg(0), arg(1), arg(2)),

--- a/crates/perry-runtime/src/util_styletext.rs
+++ b/crates/perry-runtime/src/util_styletext.rs
@@ -1,0 +1,169 @@
+//! `util.styleText(format, text[, options])` (#2514) — wrap `text` in the ANSI
+//! escape sequences for one or more named formats from `util.inspect.colors`.
+//!
+//! - `format` is a color/modifier name or an array of them. Each must be a known
+//!   format (or the special no-op `"none"`), else `ERR_INVALID_ARG_VALUE`.
+//! - `text` must be a string, else `ERR_INVALID_ARG_TYPE` (no coercion).
+//! - `options.validateStream` defaults to `true`: when the target stream (stdout)
+//!   does not support color (e.g. piped, or `NO_COLOR`), the text is returned
+//!   unstyled. `{ validateStream: false }` forces styling. Validation of
+//!   `format`/`text` happens regardless of whether styling is applied.
+//!
+//! For an array of formats the opening codes are emitted in order and the
+//! closing codes in reverse, matching Node:
+//! `styleText(["red","bold"],"X")` → `\x1b[31m\x1b[1mX\x1b[22m\x1b[39m`.
+
+use crate::url::{create_string_f64, get_string_content};
+use crate::value::{js_nanbox_get_pointer, JSValue, TAG_FALSE};
+
+/// `(name, open, close)` from Node's `util.inspect.colors`.
+const COLORS: &[(&str, u16, u16)] = &[
+    ("reset", 0, 0),
+    ("bold", 1, 22),
+    ("dim", 2, 22),
+    ("italic", 3, 23),
+    ("underline", 4, 24),
+    ("blink", 5, 25),
+    ("inverse", 7, 27),
+    ("hidden", 8, 28),
+    ("strikethrough", 9, 29),
+    ("doubleunderline", 21, 24),
+    ("black", 30, 39),
+    ("red", 31, 39),
+    ("green", 32, 39),
+    ("yellow", 33, 39),
+    ("blue", 34, 39),
+    ("magenta", 35, 39),
+    ("cyan", 36, 39),
+    ("white", 37, 39),
+    ("bgBlack", 40, 49),
+    ("bgRed", 41, 49),
+    ("bgGreen", 42, 49),
+    ("bgYellow", 43, 49),
+    ("bgBlue", 44, 49),
+    ("bgMagenta", 45, 49),
+    ("bgCyan", 46, 49),
+    ("bgWhite", 47, 49),
+    ("framed", 51, 54),
+    ("overlined", 53, 55),
+    ("gray", 90, 39),
+    ("redBright", 91, 39),
+    ("greenBright", 92, 39),
+    ("yellowBright", 93, 39),
+    ("blueBright", 94, 39),
+    ("magentaBright", 95, 39),
+    ("cyanBright", 96, 39),
+    ("whiteBright", 97, 39),
+    ("bgGray", 100, 49),
+    ("bgRedBright", 101, 49),
+    ("bgGreenBright", 102, 49),
+    ("bgYellowBright", 103, 49),
+    ("bgBlueBright", 104, 49),
+    ("bgMagentaBright", 105, 49),
+    ("bgCyanBright", 106, 49),
+    ("bgWhiteBright", 107, 49),
+];
+
+fn color_codes(name: &str) -> Option<(u16, u16)> {
+    COLORS
+        .iter()
+        .find(|(n, _, _)| *n == name)
+        .map(|(_, o, c)| (*o, *c))
+}
+
+fn is_string_f64(value: f64) -> bool {
+    JSValue::from_bits(value.to_bits()).is_any_string()
+}
+
+fn throw_invalid_format() -> ! {
+    crate::fs::validate::throw_type_error_with_code(
+        "The argument 'format' must be a string or an array of strings naming \
+         a recognized color or modifier.",
+        "ERR_INVALID_ARG_VALUE",
+    )
+}
+
+fn throw_invalid_text() -> ! {
+    crate::fs::validate::throw_type_error_with_code(
+        "The \"text\" argument must be of type string.",
+        "ERR_INVALID_ARG_TYPE",
+    )
+}
+
+/// Collect the format names from a `string | string[]` value, throwing
+/// `ERR_INVALID_ARG_VALUE` for anything else.
+fn collect_format_names(format: f64) -> Vec<String> {
+    if is_string_f64(format) {
+        return vec![get_string_content(format)];
+    }
+    // Array of strings?
+    if crate::array::js_array_is_array(format) != 0.0 {
+        let arr_ptr = js_nanbox_get_pointer(format) as *const crate::array::ArrayHeader;
+        let len = unsafe { crate::array::js_array_length(arr_ptr) };
+        let mut names = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            let el = unsafe { crate::array::js_array_get_f64(arr_ptr, i) };
+            if !is_string_f64(el) {
+                throw_invalid_format();
+            }
+            names.push(get_string_content(el));
+        }
+        return names;
+    }
+    throw_invalid_format();
+}
+
+/// Whether output should be styled: `validateStream:false` forces styling;
+/// otherwise only when stdout supports color (a TTY and `NO_COLOR` unset).
+fn should_style(options: f64) -> bool {
+    let opt_v = JSValue::from_bits(options.to_bits());
+    if opt_v.is_pointer() {
+        let key = b"validateStream";
+        let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+        let obj_ptr = js_nanbox_get_pointer(options) as *const crate::object::ObjectHeader;
+        let field = crate::object::js_object_get_field_by_name_f64(obj_ptr, key_ptr);
+        if field.to_bits() == TAG_FALSE {
+            return true; // validateStream:false → always style
+        }
+    }
+    // Default: style only if stdout (fd 1) supports color.
+    std::env::var_os("NO_COLOR").is_none() && crate::tty::is_tty_fd(1)
+}
+
+#[no_mangle]
+pub extern "C" fn js_util_style_text(format: f64, text: f64, options: f64) -> f64 {
+    // 1) Validate format (always, even when not styling).
+    let names = collect_format_names(format);
+    let mut pairs: Vec<(u16, u16)> = Vec::with_capacity(names.len());
+    for name in &names {
+        if name == "none" {
+            continue; // documented no-op format
+        }
+        match color_codes(name) {
+            Some(p) => pairs.push(p),
+            None => throw_invalid_format(),
+        }
+    }
+
+    // 2) Validate text (must be a string).
+    if !is_string_f64(text) {
+        throw_invalid_text();
+    }
+    let text_s = get_string_content(text);
+
+    // 3) Decide styling.
+    if pairs.is_empty() || !should_style(options) {
+        return create_string_f64(&text_s);
+    }
+
+    // 4) Wrap: opens in order, closes in reverse.
+    let mut out = String::with_capacity(text_s.len() + pairs.len() * 10);
+    for (open, _) in &pairs {
+        out.push_str(&format!("\u{1b}[{open}m"));
+    }
+    out.push_str(&text_s);
+    for (_, close) in pairs.iter().rev() {
+        out.push_str(&format!("\u{1b}[{close}m"));
+    }
+    create_string_f64(&out)
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1821 entries across 89 modules
+// Coverage: 1823 entries across 89 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -2643,6 +2643,8 @@ declare module "sys" {
   /** stdlib */
   export function stripVTControlCharacters(...args: any[]): any;
   /** stdlib */
+  export function styleText(...args: any[]): any;
+  /** stdlib */
   export function toUSVString(...args: any[]): any;
 }
 
@@ -2731,6 +2733,8 @@ declare module "util" {
   export function promisify(...args: any[]): any;
   /** stdlib */
   export function stripVTControlCharacters(...args: any[]): any;
+  /** stdlib */
+  export function styleText(...args: any[]): any;
   /** stdlib */
   export function toUSVString(...args: any[]): any;
 }

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1821 entries across 89 modules.
+Total: 1823 entries across 89 modules.
 
 ## Modules
 
@@ -2266,6 +2266,7 @@ Total: 1821 entries across 89 modules.
 - `parseEnv` — module
 - `promisify` — module
 - `stripVTControlCharacters` — module
+- `styleText` — module
 - `toUSVString` — module
 
 ### Properties
@@ -2347,6 +2348,7 @@ Total: 1821 entries across 89 modules.
 - `parseEnv` — module
 - `promisify` — module
 - `stripVTControlCharacters` — module
+- `styleText` — module
 - `toUSVString` — module
 
 ### Properties

--- a/test-files/test_gap_2514_styletext.ts
+++ b/test-files/test_gap_2514_styletext.ts
@@ -1,0 +1,20 @@
+// #2514 — util.styleText: wrap text in ANSI codes for named formats.
+// Uses {validateStream:false} so output is styled deterministically in a pipe.
+import { styleText } from "node:util";
+
+const o = { validateStream: false };
+console.log(typeof styleText);
+console.log(JSON.stringify(styleText("red", "X", o)));
+console.log(JSON.stringify(styleText("green", "ok", o)));
+console.log(JSON.stringify(styleText("bold", "b", o)));
+console.log(JSON.stringify(styleText("reset", "r", o)));
+console.log(JSON.stringify(styleText(["red", "bold"], "rb", o)));
+console.log(JSON.stringify(styleText(["bgBlue", "whiteBright", "underline"], "z", o)));
+console.log(JSON.stringify(styleText("none", "n", o)));
+console.log(JSON.stringify(styleText([], "e", o)));
+// default (piped, non-TTY) → unstyled
+console.log(JSON.stringify(styleText("red", "plain")));
+// errors
+try { styleText("notacolor", "x", o); } catch (e) { console.log("badfmt=" + (e as { code?: string }).code); }
+try { styleText("red", 5 as unknown as string, o); } catch (e) { console.log("badtext=" + (e as { code?: string }).code); }
+try { styleText(["red", "notacolor"], "x", o); } catch (e) { console.log("badarr=" + (e as { code?: string }).code); }


### PR DESCRIPTION
Implements `util.styleText` (part of #2514 — remaining `node:util` top-level helpers).

## Problem

`util.styleText` was entirely missing — no manifest entry, whitelist, dispatch, or runtime impl — so `typeof util.styleText === "undefined"`.

## Fix

Full wiring (7 edits), mirroring the existing `util.toUSVString`/`parseEnv` paths:

- **`util_styletext.rs`** (new) — `js_util_style_text(format, text, options)`. Embeds Node's 44-entry `util.inspect.colors` `(name, open, close)` table. `format` is a color/modifier name or an array of them (each validated; the documented `"none"` is a no-op); `text` must be a string. Array formats nest — opens in order, closes in reverse — matching Node exactly. `options.validateStream` defaults to `true`: when stdout isn't a color-capable TTY (e.g. piped, or `NO_COLOR`) the text is returned unstyled; `{ validateStream: false }` forces styling. Format/text validation happens regardless of styling.
- **`lib.rs`** — `pub mod util_styletext;`
- **`native_module.rs`** — `b"styleText"` whitelist + `("util","styleText")` value-gate.
- **`native_module_dispatch.rs`** — dispatch arm (3 args).
- **`entries.rs`** — `method("util","styleText",…)` **and** `method("sys","styleText",…)` (the `sys` alias must mirror `util` or `sys_alias_mirrors_util_manifest` fails).
- **`node_core.rs`** — `NativeModSig` (3× `NA_F64`) → `js_util_style_text`.
- **`docs/`** — regenerated.

## Validation

`test-files/test_gap_2514_styletext.ts` is **byte-for-byte identical** to `node --experimental-strip-types` (run with `{validateStream:false}` for deterministic styled output):

```
function
"[31mX[39m"                                  // red
"[32mok[39m"                                 // green
"[1mb[22m"                                   // bold
"[0mr[0m"                                    // reset
"[31m[1mrb[22m[39m"              // [red,bold] — closes reversed
"[44m[97m[4mz[24m[39m[49m"  // 3 formats nested
"n"                                                     // "none" → no-op
"e"                                                     // [] → unstyled
"plain"                                                 // default (piped/non-TTY) → unstyled
badfmt=ERR_INVALID_ARG_VALUE
badtext=ERR_INVALID_ARG_TYPE
badarr=ERR_INVALID_ARG_VALUE
```

`cargo build --release -p perry-runtime -p perry-stdlib -p perry` clean; `cargo test -p perry-api-manifest --lib sys_alias` passes; `cargo fmt --all -- --check` clean; api-docs regenerated (idempotent, no drift).
