### PR TITLE
fix(hir): resolve stable-hash Expr tag collision on 12045 (unblocks CI)

### DIFF
--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -549,7 +549,7 @@ impl SH for Expr {
             Expr::ReflectConstruct { target, args } => { tag(h, 439); target.as_ref().hash(h); args.as_ref().hash(h); }
             Expr::ReflectDefineProperty { target, key, descriptor, } => { tag(h, 440); target.as_ref().hash(h); key.as_ref().hash(h); descriptor.as_ref().hash(h); }
             Expr::ReflectGetPrototypeOf(e) => { tag(h, 441); e.as_ref().hash(h); }
-            Expr::ReflectIsExtensible(e) => { tag(h, 12045); e.as_ref().hash(h); }
+            Expr::ReflectIsExtensible(e) => { tag(h, 12048); e.as_ref().hash(h); }
             Expr::ReflectPreventExtensions(e) => { tag(h, 12046); e.as_ref().hash(h); }
             Expr::ReflectDefineMetadata { key, value, target, property_key, } => { tag(h, 12023); key.as_ref().hash(h); value.as_ref().hash(h); target.as_ref().hash(h); property_key.hash(h); }
             Expr::ReflectGetMetadata { key, target, property_key, } => { tag(h, 12024); key.as_ref().hash(h); target.as_ref().hash(h); property_key.hash(h); }


### PR DESCRIPTION
## Problem

`main` is currently RED on `stable_hash::tests::expr_variant_stable_hash_tags_are_unique`. Two HIR `Expr` variants both got assigned stable-hash tag **12045** via a merge race:

- `Expr::RegExpEscape` (#3409)
- `Expr::ReflectIsExtensible` (#3402)

Each PR's CI passed because the other variant wasn't on `main` yet at test time. With both merged, the uniqueness assertion fails — and since this is a workspace unit test, **every open PR's `cargo-test` now fails**, blocking the entire merge queue.

## Fix

Reassign `ReflectIsExtensible` from `12045` → `12048` (next free tag; 12046/12047 taken, 12048+ free). This matches the fix already present on PR #3445's branch, so no future conflict when that lands.

Verified locally: `cargo test -p perry-hir stable_hash` → 6 passed/0 failed; build + fmt clean.
