### PR TITLE
fix(util): implement styleText helper

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2833,6 +2833,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("util", "isDeepStrictEqual", false, None),
     method("util", "parseArgs", false, None),
     method("util", "stripVTControlCharacters", false, None),
+    method("util", "styleText", false, None),
     class("util", "TextEncoder"),
     class("util", "TextDecoder"),
     // util.types — Node's runtime type-introspection namespace. Required
@@ -2902,6 +2903,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("sys", "isDeepStrictEqual", false, None),
     method("sys", "parseArgs", false, None),
     method("sys", "stripVTControlCharacters", false, None),
+    method("sys", "styleText", false, None),
     method("sys", "toUSVString", false, None),
     class("sys", "TextEncoder"),
     class("sys", "TextDecoder"),

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -1023,6 +1023,15 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    NativeModSig {
+        module: "util",
+        has_receiver: false,
+        method: "styleText",
+        class_filter: None,
+        runtime: "js_util_style_text",
+        args: &[NA_F64, NA_F64, NA_F64],
+        ret: NR_F64,
+    },
     // #2514: util.getSystemErrorName/Message(errno) + getSystemErrorMap().
     NativeModSig {
         module: "util",

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -503,6 +503,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_util_inspect", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_util_is_deep_strict_equal", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_util_strip_vt_control_characters", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_util_style_text", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_util_promisify", DOUBLE, &[DOUBLE]);
     module.declare_function("js_util_callbackify", DOUBLE, &[DOUBLE]);
     module.declare_function("js_util_deprecate", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -146,6 +146,7 @@ pub mod ui_text_registry;
 pub mod util_parse_args;
 pub mod util_parse_env;
 pub mod util_promisify;
+pub mod util_style_text;
 pub mod util_syserr;
 pub mod util_usv;
 #[cfg(all(target_os = "watchos", feature = "watchos-game-loop"))]

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -416,6 +416,7 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
             b"isDeepStrictEqual",
             b"promisify",
             b"stripVTControlCharacters",
+            b"styleText",
             b"toUSVString",
             b"types",
             b"parseArgs",
@@ -865,36 +866,8 @@ fn util_inspect_colors() -> f64 {
         }
 
         let obj = js_object_alloc(0, 0);
-        for (name, open, close) in [
-            ("reset", 0, 0),
-            ("bold", 1, 22),
-            ("dim", 2, 22),
-            ("italic", 3, 23),
-            ("underline", 4, 24),
-            ("blink", 5, 25),
-            ("inverse", 7, 27),
-            ("hidden", 8, 28),
-            ("strikethrough", 9, 29),
-            ("black", 30, 39),
-            ("red", 31, 39),
-            ("green", 32, 39),
-            ("yellow", 33, 39),
-            ("blue", 34, 39),
-            ("magenta", 35, 39),
-            ("cyan", 36, 39),
-            ("white", 37, 39),
-            ("gray", 90, 39),
-            ("grey", 90, 39),
-            ("bgBlack", 40, 49),
-            ("bgRed", 41, 49),
-            ("bgGreen", 42, 49),
-            ("bgYellow", 43, 49),
-            ("bgBlue", 44, 49),
-            ("bgMagenta", 45, 49),
-            ("bgCyan", 46, 49),
-            ("bgWhite", 47, 49),
-        ] {
-            native_set_field(obj, name, native_color_tuple(open, close));
+        for style in crate::util_style_text::INSPECT_COLOR_STYLES {
+            native_set_field(obj, style.name, native_color_tuple(style.open, style.close));
         }
 
         let value = native_object_value(obj);
@@ -1451,6 +1424,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("util", "inherits")
             | ("util", "isDeepStrictEqual")
             | ("util", "stripVTControlCharacters")
+            | ("util", "styleText")
             | ("util", "toUSVString")
             | ("zlib", "Deflate")
             | ("zlib", "DeflateRaw")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -991,6 +991,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("util", "stripVTControlCharacters") => {
             crate::builtins::js_util_strip_vt_control_characters(arg(0))
         }
+        ("util", "styleText") => crate::util_style_text::js_util_style_text(arg(0), arg(1), arg(2)),
         // #2514: util.toUSVString(value) → string with lone surrogates → U+FFFD.
         ("util", "toUSVString") => crate::util_usv::js_util_to_usv_string(arg(0)),
         ("util", "promisify") => crate::util_promisify::js_util_promisify(arg(0)),

--- a/crates/perry-runtime/src/util_style_text.rs
+++ b/crates/perry-runtime/src/util_style_text.rs
@@ -1,0 +1,530 @@
+//! `util.styleText(format, text[, options])` ANSI formatting helper.
+//!
+//! Perry implements the Node-visible formatting contract for the built-in
+//! style names and the non-interactive color gate. Passing
+//! `{ validateStream: false }` forces ANSI output, which is the stable way
+//! tests and libraries request coloring independent of stdout TTY state.
+
+use crate::array::{js_array_get_f64, js_array_length, ArrayHeader};
+use crate::object::{js_object_get_field_by_name_f64, ObjectHeader};
+use crate::string::js_string_from_bytes;
+use crate::value::{JSValue, TAG_FALSE, TAG_TRUE, TAG_UNDEFINED};
+
+#[derive(Clone, Copy)]
+pub(crate) struct AnsiStyle {
+    pub name: &'static str,
+    pub open: i32,
+    pub close: i32,
+}
+
+pub(crate) const INSPECT_COLOR_STYLES: &[AnsiStyle] = &[
+    AnsiStyle {
+        name: "reset",
+        open: 0,
+        close: 0,
+    },
+    AnsiStyle {
+        name: "bold",
+        open: 1,
+        close: 22,
+    },
+    AnsiStyle {
+        name: "dim",
+        open: 2,
+        close: 22,
+    },
+    AnsiStyle {
+        name: "italic",
+        open: 3,
+        close: 23,
+    },
+    AnsiStyle {
+        name: "underline",
+        open: 4,
+        close: 24,
+    },
+    AnsiStyle {
+        name: "blink",
+        open: 5,
+        close: 25,
+    },
+    AnsiStyle {
+        name: "inverse",
+        open: 7,
+        close: 27,
+    },
+    AnsiStyle {
+        name: "hidden",
+        open: 8,
+        close: 28,
+    },
+    AnsiStyle {
+        name: "strikethrough",
+        open: 9,
+        close: 29,
+    },
+    AnsiStyle {
+        name: "doubleunderline",
+        open: 21,
+        close: 24,
+    },
+    AnsiStyle {
+        name: "black",
+        open: 30,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "red",
+        open: 31,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "green",
+        open: 32,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "yellow",
+        open: 33,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "blue",
+        open: 34,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "magenta",
+        open: 35,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "cyan",
+        open: 36,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "white",
+        open: 37,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "bgBlack",
+        open: 40,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgRed",
+        open: 41,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgGreen",
+        open: 42,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgYellow",
+        open: 43,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgBlue",
+        open: 44,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgMagenta",
+        open: 45,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgCyan",
+        open: 46,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgWhite",
+        open: 47,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "framed",
+        open: 51,
+        close: 54,
+    },
+    AnsiStyle {
+        name: "overlined",
+        open: 53,
+        close: 55,
+    },
+    AnsiStyle {
+        name: "gray",
+        open: 90,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "redBright",
+        open: 91,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "greenBright",
+        open: 92,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "yellowBright",
+        open: 93,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "blueBright",
+        open: 94,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "magentaBright",
+        open: 95,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "cyanBright",
+        open: 96,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "whiteBright",
+        open: 97,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "bgGray",
+        open: 100,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgRedBright",
+        open: 101,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgGreenBright",
+        open: 102,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgYellowBright",
+        open: 103,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgBlueBright",
+        open: 104,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgMagentaBright",
+        open: 105,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgCyanBright",
+        open: 106,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgWhiteBright",
+        open: 107,
+        close: 49,
+    },
+];
+
+const STYLE_ALIASES: &[AnsiStyle] = &[
+    AnsiStyle {
+        name: "grey",
+        open: 90,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "blackBright",
+        open: 90,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "bgGrey",
+        open: 100,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgBlackBright",
+        open: 100,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "faint",
+        open: 2,
+        close: 22,
+    },
+    AnsiStyle {
+        name: "crossedout",
+        open: 9,
+        close: 29,
+    },
+    AnsiStyle {
+        name: "strikeThrough",
+        open: 9,
+        close: 29,
+    },
+    AnsiStyle {
+        name: "crossedOut",
+        open: 9,
+        close: 29,
+    },
+    AnsiStyle {
+        name: "conceal",
+        open: 8,
+        close: 28,
+    },
+    AnsiStyle {
+        name: "swapColors",
+        open: 7,
+        close: 27,
+    },
+    AnsiStyle {
+        name: "swapcolors",
+        open: 7,
+        close: 27,
+    },
+    AnsiStyle {
+        name: "doubleUnderline",
+        open: 21,
+        close: 24,
+    },
+];
+
+const VALID_FORMATS_MESSAGE: &str = "'reset', 'bold', 'dim', 'italic', 'underline', 'blink', \
+    'inverse', 'hidden', 'strikethrough', 'doubleunderline', 'black', 'red', 'green', \
+    'yellow', 'blue', 'magenta', 'cyan', 'white', 'bgBlack', 'bgRed', 'bgGreen', \
+    'bgYellow', 'bgBlue', 'bgMagenta', 'bgCyan', 'bgWhite', 'framed', 'overlined', \
+    'gray', 'redBright', 'greenBright', 'yellowBright', 'blueBright', 'magentaBright', \
+    'cyanBright', 'whiteBright', 'bgGray', 'bgRedBright', 'bgGreenBright', \
+    'bgYellowBright', 'bgBlueBright', 'bgMagentaBright', 'bgCyanBright', \
+    'bgWhiteBright', 'grey', 'blackBright', 'bgGrey', 'bgBlackBright', 'faint', \
+    'crossedout', 'strikeThrough', 'crossedOut', 'conceal', 'swapColors', \
+    'swapcolors', 'doubleUnderline'";
+
+fn style_for(name: &str) -> Option<AnsiStyle> {
+    INSPECT_COLOR_STYLES
+        .iter()
+        .chain(STYLE_ALIASES.iter())
+        .find(|style| style.name == name)
+        .copied()
+}
+
+fn js_string_content(value: f64) -> Option<String> {
+    crate::builtins::jsvalue_string_content(value)
+}
+
+fn string_value(value: &str) -> f64 {
+    let ptr = js_string_from_bytes(value.as_ptr(), value.len() as u32);
+    f64::from_bits(JSValue::string_ptr(ptr).bits())
+}
+
+fn received_for_invalid_value(value: f64) -> String {
+    if let Some(s) = js_string_content(value) {
+        return format!("'{s}'");
+    }
+    let jsvalue = JSValue::from_bits(value.to_bits());
+    if jsvalue.is_int32() {
+        return jsvalue.as_int32().to_string();
+    }
+    if jsvalue.is_number() && value.is_finite() {
+        return value.to_string();
+    }
+    crate::fs::validate::describe_received(value)
+}
+
+fn throw_invalid_format(value: f64) -> ! {
+    let message = format!(
+        "The argument 'format' must be one of: {VALID_FORMATS_MESSAGE}. Received {}",
+        received_for_invalid_value(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE")
+}
+
+fn throw_invalid_text(value: f64) -> ! {
+    let message = format!(
+        "The \"text\" argument must be of type string. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn throw_invalid_options(value: f64) -> ! {
+    let message = format!(
+        "The \"options\" argument must be of type object. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn throw_invalid_validate_stream(value: f64) -> ! {
+    let message = format!(
+        "The \"options.validateStream\" property must be of type boolean. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn heap_ptr_with_gc_type(value: f64, expected_type: u8) -> Option<*const u8> {
+    let jsvalue = JSValue::from_bits(value.to_bits());
+    if !jsvalue.is_pointer() {
+        return None;
+    }
+    let ptr = jsvalue.as_pointer::<u8>();
+    if ptr.is_null()
+        || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000
+        || crate::closure::is_closure_ptr(ptr as usize)
+        || !crate::object::is_valid_obj_ptr(ptr)
+    {
+        return None;
+    }
+    let gc_header = unsafe { &*(ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader) };
+    if gc_header.obj_type == expected_type {
+        Some(ptr)
+    } else {
+        None
+    }
+}
+
+fn array_ptr(value: f64) -> Option<*const ArrayHeader> {
+    heap_ptr_with_gc_type(value, crate::gc::GC_TYPE_ARRAY).map(|ptr| ptr as *const ArrayHeader)
+}
+
+fn object_ptr(value: f64) -> Option<*const ObjectHeader> {
+    heap_ptr_with_gc_type(value, crate::gc::GC_TYPE_OBJECT).map(|ptr| ptr as *const ObjectHeader)
+}
+
+fn get_prop(obj: *const ObjectHeader, name: &[u8]) -> f64 {
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_get_field_by_name_f64(obj, key)
+}
+
+fn format_styles(format: f64) -> Vec<AnsiStyle> {
+    if let Some(name) = js_string_content(format) {
+        if name == "none" {
+            return Vec::new();
+        }
+        return vec![style_for(&name).unwrap_or_else(|| throw_invalid_format(format))];
+    }
+
+    if let Some(arr) = array_ptr(format) {
+        let mut styles = Vec::new();
+        for i in 0..js_array_length(arr) {
+            let item = js_array_get_f64(arr, i);
+            let Some(name) = js_string_content(item) else {
+                throw_invalid_format(item);
+            };
+            if name == "none" {
+                continue;
+            }
+            styles.push(style_for(&name).unwrap_or_else(|| throw_invalid_format(item)));
+        }
+        return styles;
+    }
+
+    throw_invalid_format(format)
+}
+
+fn should_style(options: f64) -> bool {
+    let jsvalue = JSValue::from_bits(options.to_bits());
+    let validate_stream = if jsvalue.is_undefined() {
+        true
+    } else {
+        let Some(obj) = object_ptr(options) else {
+            throw_invalid_options(options);
+        };
+        let validate_stream = get_prop(obj, b"validateStream");
+        match validate_stream.to_bits() {
+            TAG_UNDEFINED => true,
+            TAG_TRUE => true,
+            TAG_FALSE => false,
+            _ => throw_invalid_validate_stream(validate_stream),
+        }
+    };
+
+    if !validate_stream {
+        return true;
+    }
+    if let Some(force) = std::env::var_os("FORCE_COLOR") {
+        let force = force.to_string_lossy();
+        return !force.is_empty() && force != "0" && force.to_ascii_lowercase() != "false";
+    }
+    if std::env::var_os("NO_COLOR").is_some() || std::env::var_os("NODE_DISABLE_COLORS").is_some() {
+        return false;
+    }
+    crate::tty::is_tty_fd(1)
+}
+
+fn csi(code: i32) -> String {
+    format!("\x1b[{code}m")
+}
+
+fn text_with_inner_resets(text: &str, styles: &[AnsiStyle]) -> String {
+    let mut out = text.to_string();
+    let mut seen_closes: Vec<i32> = Vec::new();
+    for style in styles {
+        if seen_closes.contains(&style.close) {
+            continue;
+        }
+        seen_closes.push(style.close);
+        let close = csi(style.close);
+        let replacement = if style.close == 22 {
+            let mut reopened = close.clone();
+            for reopen in styles
+                .iter()
+                .rev()
+                .filter(|candidate| candidate.close == style.close)
+            {
+                reopened.push_str(&csi(reopen.open));
+            }
+            reopened
+        } else {
+            csi(style.open)
+        };
+        out = out.replace(&close, &replacement);
+    }
+    out
+}
+
+fn apply_styles(text: &str, styles: &[AnsiStyle]) -> String {
+    if styles.is_empty() {
+        return text.to_string();
+    }
+
+    let mut out = String::new();
+    for style in styles {
+        out.push_str(&csi(style.open));
+    }
+    out.push_str(&text_with_inner_resets(text, styles));
+    for style in styles.iter().rev() {
+        out.push_str(&csi(style.close));
+    }
+    out
+}
+
+#[no_mangle]
+pub extern "C" fn js_util_style_text(format: f64, text: f64, options: f64) -> f64 {
+    let styles = format_styles(format);
+    let Some(text) = js_string_content(text) else {
+        throw_invalid_text(text);
+    };
+
+    let out = if should_style(options) {
+        apply_styles(&text, &styles)
+    } else {
+        text
+    };
+    string_value(&out)
+}

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -659,7 +659,7 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 
 ### node:util
 
-**Gap APIs: 97** · Already covered: 8
+**Gap APIs: 96** · Already covered: 9
 
 #### Missing from Perry
 
@@ -672,7 +672,6 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 - `util.getSystemErrorMessage(err)`
 - `util.parseEnv(content)`
 - `util.stripVTControlCharacters(str)`
-- `util.styleText(format, text[, options])`
 - `util.toUSVString(string)`
 - `util.transferableAbortController()`
 - `util.transferableAbortSignal(signal)`

--- a/test-parity/node-suite/util/style-text/basic.ts
+++ b/test-parity/node-suite/util/style-text/basic.ts
@@ -1,0 +1,43 @@
+import { styleText } from "node:util";
+
+const forceColors = { validateStream: false };
+
+console.log("typeof", typeof styleText);
+
+for (const [label, format, text] of [
+  ["red", "red", "x"],
+  ["bold-green", ["bold", "green"], "ok"],
+  ["none", "none", "plain"],
+  ["reset", "reset", "plain"],
+  ["grey", "grey", "plain"],
+  ["bgGrey", "bgGrey", "plain"],
+  ["strikeThrough", "strikeThrough", "plain"],
+  ["swapColors", "swapColors", "plain"],
+  ["doubleUnderline", "doubleUnderline", "plain"],
+  ["overlined", "overlined", "plain"],
+  ["framed", "framed", "plain"],
+] as const) {
+  console.log(label, JSON.stringify(styleText(format as any, text, forceColors)));
+}
+
+console.log("default", JSON.stringify(styleText("red", "x")));
+console.log("inner-red-close", JSON.stringify(styleText("red", "a\u001b[39mb", forceColors)));
+console.log("inner-bold-close", JSON.stringify(styleText("bold", "a\u001b[22mb", forceColors)));
+
+function logThrow(label: string, fn: () => string) {
+  try {
+    console.log(label, "ok", JSON.stringify(fn()));
+  } catch (err) {
+    const e = err as Error & { code?: string };
+    console.log(label, "throw", e.name, e.code ?? "no-code", err instanceof TypeError);
+  }
+}
+
+logThrow("invalid-style", () => styleText("missing", "x", forceColors));
+logThrow("invalid-format-number", () => styleText(1 as any, "x", forceColors));
+logThrow("invalid-array-element", () => styleText(["red", 1] as any, "x", forceColors));
+logThrow("invalid-text", () => styleText("red", 1 as any, forceColors));
+logThrow("invalid-validateStream", () =>
+  styleText("red", "x", { validateStream: "no" } as any),
+);
+logThrow("null-options", () => styleText("red", "x", null as any));


### PR DESCRIPTION
## Summary
- Implements `util.styleText(format, text[, options])` as a callable `node:util` export.
- Adds Node-compatible ANSI open/close handling for string and array formats, including common aliases, `none`, inner reset reopening, and `{ validateStream: false }` forced-color behavior.
- Updates `util.inspect.colors`, native dispatch/codegen/manifest wiring, and the runtime parity gap docs.

## Issue
Closes #3424.

## Batching rationale
Single focused util formatting surface: one runtime helper plus the native-module/codegen/manifest rows needed to expose it consistently.

## Tests
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module util --filter style-text`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module util` (70/71; existing `node-suite/util/get-system-error` mismatch remains)
- `RUSTC_WRAPPER= cargo check -p perry-runtime -p perry-codegen -p perry-api-manifest -p perry-hir -p perry`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`

## Known limitations / non-goals
- Does not implement custom `options.stream` validation/color-depth probing beyond Perry's existing stdout/env color gate.
- Does not attempt to expand terminal color capability detection outside the parity-stable `validateStream: false` and environment/default paths.
