### PR TITLE
fix(assert): shape ifError assertion errors

### DIFF
--- a/crates/perry-runtime/src/object/assert.rs
+++ b/crates/perry-runtime/src/object/assert.rs
@@ -11,6 +11,10 @@ fn undefined_f64() -> f64 {
     f64::from_bits(crate::value::JSValue::undefined().bits())
 }
 
+fn null_f64() -> f64 {
+    f64::from_bits(crate::value::JSValue::null().bits())
+}
+
 fn string_f64(s: &str) -> f64 {
     let ptr = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
     f64::from_bits(crate::value::JSValue::string_ptr(ptr).bits())
@@ -33,19 +37,23 @@ fn is_null_or_undefined(value: f64) -> bool {
     jv.is_null() || jv.is_undefined()
 }
 
-fn is_error_value(value: f64) -> bool {
+fn gc_type_of(value: f64) -> Option<u8> {
     let jv = crate::value::JSValue::from_bits(value.to_bits());
     if !jv.is_pointer() {
-        return false;
+        return None;
     }
     let ptr = jv.as_pointer::<u8>();
     if ptr.is_null() || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
-        return false;
+        return None;
     }
     unsafe {
         let gc_header = ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-        (*gc_header).obj_type == crate::gc::GC_TYPE_ERROR
+        Some((*gc_header).obj_type)
     }
+}
+
+fn is_error_value(value: f64) -> bool {
+    gc_type_of(value) == Some(crate::gc::GC_TYPE_ERROR)
 }
 
 fn regexp_ptr(pattern: f64) -> Option<*const crate::regex::RegExpHeader> {
@@ -321,6 +329,44 @@ fn throw_assertion(
     crate::exception::js_throw(make_assertion_error(
         message, actual, expected, operator, generated,
     ))
+}
+
+fn if_error_value_message(value: f64) -> Option<String> {
+    match gc_type_of(value) {
+        Some(crate::gc::GC_TYPE_OBJECT | crate::gc::GC_TYPE_ARRAY | crate::gc::GC_TYPE_ERROR) => {}
+        _ => return None,
+    }
+
+    let message = read_property(value, "message");
+    if !crate::value::JSValue::from_bits(message.to_bits()).is_any_string() {
+        return None;
+    }
+
+    let message = value_to_string(message);
+    if !message.is_empty() {
+        return Some(message);
+    }
+
+    let name = read_property(value, "name");
+    if crate::value::JSValue::from_bits(name.to_bits()).is_any_string() {
+        let name = value_to_string(name);
+        if !name.is_empty() {
+            return Some(name);
+        }
+    }
+
+    Some(message)
+}
+
+fn inspected_value_to_string(value: f64) -> String {
+    let inspected = crate::builtins::js_util_inspect(value, undefined_f64());
+    value_to_string(inspected)
+}
+
+fn if_error_message(value: f64) -> String {
+    let value_message =
+        if_error_value_message(value).unwrap_or_else(|| inspected_value_to_string(value));
+    format!("ifError got unwanted exception: {value_message}")
 }
 
 fn promise_ptr_from_value(value: f64) -> Option<*mut crate::promise::Promise> {
@@ -963,11 +1009,5 @@ pub extern "C" fn js_assert_if_error(value: f64) -> f64 {
     if is_null_or_undefined(value) {
         return undefined_f64();
     }
-    throw_assertion(
-        format!("ifError got unwanted exception: {}", value_to_string(value)),
-        value,
-        undefined_f64(),
-        "ifError",
-        true,
-    )
+    throw_assertion(if_error_message(value), value, null_f64(), "ifError", false)
 }

--- a/test-parity/node-suite/assert/errors/if-error.ts
+++ b/test-parity/node-suite/assert/errors/if-error.ts
@@ -1,6 +1,31 @@
 import assert from "node:assert";
 
-assert.ifError(null);
-assert.ifError(undefined);
-try { assert.ifError(new Error("nested")); } catch (err) { console.log("if error Error:", (err as Error).name, (err as { code?: string }).code); }
-try { assert.ifError("problem"); } catch (err) { console.log("if error string:", (err as Error).name, (err as { code?: string }).code); }
+function probe(label, value) {
+  try {
+    const result = assert.ifError(value);
+    console.log(label, "OK", result);
+  } catch (err) {
+    console.log(
+      label,
+      "THROW",
+      err.name,
+      err.code,
+      JSON.stringify(String(err.message).split("\n")[0]),
+      "actual===value",
+      err.actual === value,
+      "expected",
+      err.expected,
+      "operator",
+      err.operator,
+      "generated",
+      err.generatedMessage,
+    );
+  }
+}
+
+probe("undefined", undefined);
+probe("null", null);
+probe("zero", 0);
+probe("false", false);
+probe("string", "boom");
+probe("error", new Error("boom"));


### PR DESCRIPTION
## Linked Issues
- Closes #3053

## Summary
- match assert.ifError AssertionError fields for non-nullish values
- use inspected primitive text for ifError messages while preserving Error.message text
- expand assert.ifError parity coverage for actual, expected, operator, and generatedMessage

## Why This Cut
- This is a single focused assert.ifError compatibility surface with one runtime entry point and one parity fixture.

## Tests
- cargo fmt --all -- --check
- git diff --check
- git diff --cached --check
- ./scripts/check_file_size.sh
- RUSTC_WRAPPER= cargo test -p perry-runtime assert --lib -- --test-threads=1
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/tmp/perry-node-compat-3-target cargo build --release -p perry -p perry-runtime -p perry-stdlib
- RUSTC_WRAPPER= CARGO_TARGET_DIR=/tmp/perry-node-compat-3-target PERRY_ALLOW_UNIMPLEMENTED=1 /tmp/perry-node-compat-3-target/release/perry test-parity/node-suite/assert/errors/if-error.ts -o /tmp/perry_assert_iferror_rebased
- diff -u <(node --input-type=module < test-parity/node-suite/assert/errors/if-error.ts) <(/tmp/perry_assert_iferror_rebased)

## Known Limitations / Non-goals
- Does not change broader assert diff formatting.
- Does not change AssertionError constructor/prototype behavior beyond assert.ifError output shape.