### PR TITLE
fix(fetch): expose Headers default iterator

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -50,6 +50,22 @@ use super::{
     TypedFeedbackKind,
 };
 
+fn is_headers_method_name(name: &str) -> bool {
+    matches!(
+        name,
+        "append"
+            | "delete"
+            | "entries"
+            | "forEach"
+            | "get"
+            | "getSetCookie"
+            | "has"
+            | "keys"
+            | "set"
+            | "values"
+    )
+}
+
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::PropertyGet { object, property }
@@ -1036,6 +1052,22 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             "write" | "close" | "abort" | "releaseLock"
                         )
                 );
+                if class_name == "Headers" && is_headers_method_name(property) {
+                    let recv_box = lower_expr(ctx, object)?;
+                    let key_idx = ctx.strings.intern(property);
+                    let key_handle_global =
+                        format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                    let blk = ctx.block();
+                    let obj_bits = blk.bitcast_double_to_i64(&recv_box);
+                    let key_box = blk.load(DOUBLE, &key_handle_global);
+                    let key_bits = blk.bitcast_double_to_i64(&key_box);
+                    let key_handle = blk.and(I64, &key_bits, POINTER_MASK_I64);
+                    return Ok(blk.call(
+                        DOUBLE,
+                        "js_object_get_field_by_name_f64",
+                        &[(I64, &obj_bits), (I64, &key_handle)],
+                    ));
+                }
                 if is_web_stream_method {
                     let recv_box = lower_expr(ctx, object)?;
                     let key_idx = ctx.strings.intern(property);

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -931,6 +931,15 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         object: Box::new(object_expr),
                         property: property_name,
                     });
+                } else if module_name == "Headers" && is_headers_method_name(&property_name) {
+                    // A bare Fetch Headers method read (`headers.entries`) is a
+                    // function value, not a zero-arg native call. The call form
+                    // (`headers.entries()`) is handled by expr_call lowering.
+                    let object_expr = lower_expr(ctx, &member.obj)?;
+                    return Ok(Expr::PropertyGet {
+                        object: Box::new(object_expr),
+                        property: property_name,
+                    });
                 } else if matches!(
                     module_name.as_str(),
                     "readable_stream"
@@ -1799,6 +1808,22 @@ fn is_console_instance_method_name(prop: &str) -> bool {
             | "profile"
             | "profileEnd"
             | "timeStamp"
+    )
+}
+
+fn is_headers_method_name(prop: &str) -> bool {
+    matches!(
+        prop,
+        "append"
+            | "delete"
+            | "entries"
+            | "forEach"
+            | "get"
+            | "getSetCookie"
+            | "has"
+            | "keys"
+            | "set"
+            | "values"
     )
 }
 

--- a/crates/perry-runtime/src/array/flat_clone.rs
+++ b/crates/perry-runtime/src/array/flat_clone.rs
@@ -234,6 +234,10 @@ pub extern "C" fn js_array_clone(src: *const ArrayHeader) -> *mut ArrayHeader {
         0
     };
 
+    if let Some(entries) = crate::array::entries_array_for_small_handle_id(raw_addr as i64) {
+        return entries;
+    }
+
     // Buffers allocated from the small-buffer slab do not carry a GC header.
     // Detect them before any GC-header probing below; otherwise arbitrary slab
     // bytes immediately before the BufferHeader can be misread as a String or

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -38,6 +38,9 @@ pub extern "C" fn js_for_of_to_array(val_f64: f64) -> f64 {
     use crate::value::{js_nanbox_pointer, JSValue};
 
     let jsv = JSValue::from_bits(val_f64.to_bits());
+    if let Some(entries) = entries_array_for_small_handle_value(val_f64) {
+        return js_nanbox_pointer(entries as i64);
+    }
 
     // Strings: iterate by code point. `is_any_string` covers both heap
     // STRING_TAG and inline SSO short strings. `js_get_string_pointer_unified`
@@ -107,6 +110,31 @@ pub extern "C" fn js_for_of_to_array(val_f64: f64) -> f64 {
             js_nanbox_pointer(arr as i64)
         }
     }
+}
+
+pub(crate) fn entries_array_for_small_handle_value(value: f64) -> Option<*mut ArrayHeader> {
+    let bits = value.to_bits();
+    if (bits >> 48) != 0x7FFD {
+        return None;
+    }
+    entries_array_for_small_handle_id((bits & crate::value::POINTER_MASK) as i64)
+}
+
+pub(crate) fn entries_array_for_small_handle_id(id: i64) -> Option<*mut ArrayHeader> {
+    if id <= 0 || id >= 0x100000 {
+        return None;
+    }
+    let dispatch = crate::object::handle_method_dispatch()?;
+    let prop = b"entries";
+    let entries = unsafe { dispatch(id, prop.as_ptr(), prop.len(), std::ptr::null(), 0) };
+    if entries.to_bits() == crate::value::TAG_UNDEFINED {
+        return None;
+    }
+    if js_array_is_array(entries).to_bits() != crate::value::TAG_TRUE {
+        return None;
+    }
+    let ptr = crate::value::js_nanbox_get_pointer(entries) as *mut ArrayHeader;
+    (!ptr.is_null()).then_some(ptr)
 }
 
 /// Thin wrappers so this module can reach the Map/Set materializers

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -63,7 +63,7 @@ pub use self::iterator::{js_for_of_to_array, js_iterator_to_array};
 // protocol instead of being appended as a single chunk.
 pub(crate) use self::iterator::{
     async_iterator_to_array_for_flat_map, call_symbol_async_iterator_for_flat_map,
-    has_iterator_next, sync_iterator_to_array_if_not_async,
+    entries_array_for_small_handle_id, has_iterator_next, sync_iterator_to_array_if_not_async,
 };
 pub use self::jsvalue_api::{
     js_array_from_jsvalue, js_array_get, js_array_get_jsvalue, js_array_push,

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -1148,6 +1148,27 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
             }
         }
     }
+    // Fetch `Headers` values are small pointer-tagged handles. Route the
+    // default iterator symbol to the same bound method as `headers.entries`.
+    if (bits >> 48) == 0x7FFD {
+        let id = (bits & 0x0000_FFFF_FFFF_FFFF) as i64;
+        if id > 0 && id < 0x100000 {
+            let iter_wk = well_known_symbol("iterator");
+            if !iter_wk.is_null() {
+                let iter_f64 =
+                    f64::from_bits(crate::value::JSValue::pointer(iter_wk as *const u8).bits());
+                if sym_key_from_f64(sym_f64) == sym_key_from_f64(iter_f64) {
+                    if let Some(dispatch) = crate::object::handle_property_dispatch() {
+                        let method = b"entries";
+                        let v = dispatch(id, method.as_ptr(), method.len());
+                        if v.to_bits() != TAG_UNDEFINED {
+                            return v;
+                        }
+                    }
+                }
+            }
+        }
+    }
     if let Some(v) = own_symbol_property(obj_f64, sym_f64) {
         return v;
     }

--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -17,6 +17,11 @@
 
 use super::*;
 
+lazy_static::lazy_static! {
+    static ref HEADERS_BOUND_METHOD_CACHE: Mutex<HashMap<(usize, &'static str), u64>> =
+        Mutex::new(HashMap::new());
+}
+
 // ----------------- Untyped property dispatch (refs #421) -----------------
 //
 // When user code accesses a property on a Web Fetch handle whose static type
@@ -314,19 +319,31 @@ pub fn dispatch_headers_property(headers_id: usize, prop: &str) -> Option<f64> {
         let guard = HEADERS_REGISTRY.lock().unwrap();
         guard.get(&headers_id)?;
     }
-    let name_bytes: &'static [u8] = match prop {
-        "append" => b"append",
-        "delete" => b"delete",
-        "entries" => b"entries",
-        "forEach" => b"forEach",
-        "get" => b"get",
-        "getSetCookie" => b"getSetCookie",
-        "has" => b"has",
-        "keys" => b"keys",
-        "set" => b"set",
-        "values" => b"values",
+    let (name, name_bytes): (&'static str, &'static [u8]) = match prop {
+        "append" => ("append", b"append"),
+        "delete" => ("delete", b"delete"),
+        "entries" => ("entries", b"entries"),
+        "forEach" => ("forEach", b"forEach"),
+        "get" => ("get", b"get"),
+        "getSetCookie" => ("getSetCookie", b"getSetCookie"),
+        "has" => ("has", b"has"),
+        "keys" => ("keys", b"keys"),
+        "set" => ("set", b"set"),
+        "values" => ("values", b"values"),
         _ => return None,
     };
+    Some(headers_bound_method(headers_id, name, name_bytes))
+}
+
+fn headers_bound_method(headers_id: usize, name: &'static str, name_bytes: &'static [u8]) -> f64 {
+    if let Some(bits) = HEADERS_BOUND_METHOD_CACHE
+        .lock()
+        .unwrap()
+        .get(&(headers_id, name))
+        .copied()
+    {
+        return f64::from_bits(bits);
+    }
     extern "C" {
         fn js_class_method_bind(
             instance: f64,
@@ -334,13 +351,19 @@ pub fn dispatch_headers_property(headers_id: usize, prop: &str) -> Option<f64> {
             method_name_len: usize,
         ) -> f64;
     }
-    Some(unsafe {
+    let value = unsafe {
         js_class_method_bind(
             handle_to_f64(headers_id),
             name_bytes.as_ptr(),
             name_bytes.len(),
         )
-    })
+    };
+    perry_runtime::gc::js_write_barrier_root_nanbox(value.to_bits());
+    HEADERS_BOUND_METHOD_CACHE
+        .lock()
+        .unwrap()
+        .insert((headers_id, name), value.to_bits());
+    value
 }
 
 /// Try to dispatch a method call on a Response handle. Returns `Some(result)`

--- a/test-parity/node-suite/fetch/headers/iterator.ts
+++ b/test-parity/node-suite/fetch/headers/iterator.ts
@@ -1,0 +1,17 @@
+const h = new Headers();
+h.append("b", "2");
+h.append("a", "1");
+
+console.log("iterator typeof:", typeof (h as any)[Symbol.iterator]);
+console.log("entries typeof:", typeof h.entries);
+console.log("iterator equals entries:", (h as any)[Symbol.iterator] === h.entries);
+
+const viaForOf: string[] = [];
+for (const [key, value] of h as any) {
+  viaForOf.push(`${key}=${value}`);
+}
+console.log("for-of:", viaForOf.join(","));
+
+console.log("spread:", JSON.stringify([...(h as any)]));
+console.log("array from:", JSON.stringify(Array.from(h as any)));
+console.log("entries:", JSON.stringify(Array.from(h.entries())));


### PR DESCRIPTION
Closes #3440.

## Summary
- maps Fetch `Headers[Symbol.iterator]` to the same cached bound method as `headers.entries`
- keeps typed `headers.entries` method value reads as property reads instead of accidental zero-arg native calls
- teaches generic `for...of`, spread, and `Array.from` materializers to consume small-handle `Headers` entries arrays safely
- adds parity coverage for direct symbol lookup, strict equality with `entries`, `for...of`, spread, `Array.from`, and explicit `entries()`

## Why This Cut
This issue is one coherent Fetch Headers iterator surface. The visible crash came from `Symbol.iterator`, but full Node parity also requires method-value identity and the generic iterator materialization paths to agree, so those pieces are batched here instead of landing as partial support.

## Tests
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module fetch --filter headers/iterator`
- `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module fetch`
- `RUSTC_WRAPPER= cargo check -p perry-runtime -p perry-stdlib -p perry-codegen -p perry-hir -p perry`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`

## Known Limitations / Non-goals
- Does not broaden Fetch Headers storage semantics beyond the existing sorted entries behavior.
- Does not introduce a general iterator object framework for every small-handle type.