### PR TITLE
fix(array): Array.from validation, concat variadic, Uint8Array.from/of

### DIFF
--- a/crates/perry-codegen-js/src/emit/exprs_more.rs
+++ b/crates/perry-codegen-js/src/emit/exprs_more.rs
@@ -1035,11 +1035,19 @@ impl JsEmitter {
                 self.emit_expr(val);
                 self.output.push(')');
             }
-            Expr::ArrayFromMapped { iterable, map_fn } => {
+            Expr::ArrayFromMapped {
+                iterable,
+                map_fn,
+                this_arg,
+            } => {
                 self.output.push_str("Array.from(");
                 self.emit_expr(iterable);
                 self.output.push_str(", ");
                 self.emit_expr(map_fn);
+                if let Some(t) = this_arg {
+                    self.output.push_str(", ");
+                    self.emit_expr(t);
+                }
                 self.output.push(')');
             }
 

--- a/crates/perry-codegen-wasm/src/emit/expr/arrays.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/arrays.rs
@@ -316,7 +316,9 @@ impl<'a> FuncEmitCtx<'a> {
                 self.emit_store_arg(func, 0, val);
                 self.emit_memcall(func, "array_from", 1);
             }
-            Expr::ArrayFromMapped { iterable, map_fn } => {
+            Expr::ArrayFromMapped {
+                iterable, map_fn, ..
+            } => {
                 self.emit_frame_begin(func, 2);
                 self.emit_store_arg(func, 0, iterable);
                 self.emit_store_arg(func, 1, map_fn);

--- a/crates/perry-codegen-wasm/src/emit/string_collection.rs
+++ b/crates/perry-codegen-wasm/src/emit/string_collection.rs
@@ -764,9 +764,16 @@ impl WasmModuleEmitter {
             Expr::ArrayEntries(array) | Expr::ArrayKeys(array) | Expr::ArrayValues(array) => {
                 self.collect_strings_in_expr(array);
             }
-            Expr::ArrayFromMapped { iterable, map_fn } => {
+            Expr::ArrayFromMapped {
+                iterable,
+                map_fn,
+                this_arg,
+            } => {
                 self.collect_strings_in_expr(iterable);
                 self.collect_strings_in_expr(map_fn);
+                if let Some(t) = this_arg {
+                    self.collect_strings_in_expr(t);
+                }
             }
             Expr::MapSet { map, key, value } => {
                 self.collect_strings_in_expr(map);

--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -712,8 +712,18 @@ pub fn check_escapes_in_expr(
             check_escapes_in_expr(registry, candidates, classes, escaped);
             check_escapes_in_expr(token, candidates, classes, escaped);
         }
-        Expr::ArrayFromMapped { iterable, map_fn }
-        | Expr::ObjectGroupBy {
+        Expr::ArrayFromMapped {
+            iterable,
+            map_fn,
+            this_arg,
+        } => {
+            check_escapes_in_expr(iterable, candidates, classes, escaped);
+            check_escapes_in_expr(map_fn, candidates, classes, escaped);
+            if let Some(t) = this_arg {
+                check_escapes_in_expr(t, candidates, classes, escaped);
+            }
+        }
+        Expr::ObjectGroupBy {
             items: iterable,
             key_fn: map_fn,
         }

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -523,8 +523,18 @@ fn collect_used_new_fields_in_expr(
             collect_used_new_fields_in_expr(registry, non_escaping_news, used);
             collect_used_new_fields_in_expr(token, non_escaping_news, used);
         }
-        Expr::ArrayFromMapped { iterable, map_fn }
-        | Expr::ObjectGroupBy {
+        Expr::ArrayFromMapped {
+            iterable,
+            map_fn,
+            this_arg,
+        } => {
+            collect_used_new_fields_in_expr(iterable, non_escaping_news, used);
+            collect_used_new_fields_in_expr(map_fn, non_escaping_news, used);
+            if let Some(t) = this_arg {
+                collect_used_new_fields_in_expr(t, non_escaping_news, used);
+            }
+        }
+        Expr::ObjectGroupBy {
             items: iterable,
             key_fn: map_fn,
         }

--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -1434,9 +1434,16 @@ pub fn collect_localset_ids_in_expr_filtered(
             walk(items, out);
             walk(key_fn, out);
         }
-        Expr::ArrayFromMapped { iterable, map_fn } => {
+        Expr::ArrayFromMapped {
+            iterable,
+            map_fn,
+            this_arg,
+        } => {
             walk(iterable, out);
             walk(map_fn, out);
+            if let Some(t) = this_arg {
+                walk(t, out);
+            }
         }
         Expr::RegExpTest { regex, string } | Expr::RegExpExec { regex, string } => {
             walk(regex, out);

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -646,9 +646,16 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
             walk(items, out);
             walk(key_fn, out);
         }
-        Expr::ArrayFromMapped { iterable, map_fn } => {
+        Expr::ArrayFromMapped {
+            iterable,
+            map_fn,
+            this_arg,
+        } => {
             walk(iterable, out);
             walk(map_fn, out);
+            if let Some(t) = this_arg {
+                walk(t, out);
+            }
         }
         Expr::RegExpTest { regex, string } | Expr::RegExpExec { regex, string } => {
             walk(regex, out);

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -317,10 +317,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // Array.from(iterable) — clone via js_array_clone which
         // handles arrays, Sets (→ js_set_to_array), Maps (→ entries).
         Expr::ArrayFrom(iter) => {
+            // #2773: `js_array_from_value` throws TypeError for null/undefined
+            // sources (and keeps number/boolean/symbol -> []) before delegating
+            // to the existing `js_array_clone` materialization. Pass the raw
+            // NaN-boxed value (NOT unboxed) so the tag bits survive.
             let iter_box = lower_expr(ctx, iter)?;
             let blk = ctx.block();
-            let iter_handle = unbox_to_i64(blk, &iter_box);
-            let result = blk.call(I64, "js_array_clone", &[(I64, &iter_handle)]);
+            let result = blk.call(I64, "js_array_from_value", &[(DOUBLE, &iter_box)]);
             Ok(nanbox_pointer_inline(blk, &result))
         }
 
@@ -372,17 +375,43 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             );
             Ok(ctx.block().bitcast_i64_to_double(&selected))
         }
-        Expr::ArrayFromMapped { iterable, map_fn } => {
+        Expr::ArrayFromMapped {
+            iterable,
+            map_fn,
+            this_arg,
+        } => {
+            // #2773: `js_array_from_mapped` throws for nullish sources, validates
+            // mapFn callability, calls mapFn(value, index) and binds the optional
+            // thisArg. All three args are passed raw NaN-boxed (DOUBLE).
             let iter_box = lower_expr(ctx, iterable)?;
             let cb_box = lower_expr(ctx, map_fn)?;
+            let this_box = match this_arg {
+                Some(t) => lower_expr(ctx, t)?,
+                None => double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)),
+            };
             let blk = ctx.block();
-            let iter_handle = unbox_to_i64(blk, &iter_box);
-            let arr = blk.call(I64, "js_array_clone", &[(I64, &iter_handle)]);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
-            let mapped = blk.call(I64, "js_array_map", &[(I64, &arr), (I64, &cb_handle)]);
+            let mapped = blk.call(
+                I64,
+                "js_array_from_mapped",
+                &[(DOUBLE, &iter_box), (DOUBLE, &cb_box), (DOUBLE, &this_box)],
+            );
             Ok(nanbox_pointer_inline(blk, &mapped))
         }
-        Expr::Uint8ArrayFrom(iter) => lower_expr(ctx, iter),
+        Expr::Uint8ArrayFrom(iter) => {
+            // #2774: materialize the source into a real Uint8Array (kind 1) so
+            // `Uint8Array.from(...)` / `Uint8Array.of(...)` produce typed arrays
+            // (with Uint8 truncation), not plain Arrays. Source nullish-throwing
+            // + materialization is reused from `js_array_from_value`.
+            let iter_box = lower_expr(ctx, iter)?;
+            let blk = ctx.block();
+            let arr = blk.call(I64, "js_array_from_value", &[(DOUBLE, &iter_box)]);
+            let ta = blk.call(
+                I64,
+                "js_typed_array_new_from_array",
+                &[(I32, "1"), (I64, &arr)],
+            );
+            Ok(nanbox_pointer_inline(blk, &ta))
+        }
 
         // -------- Object.values / Object.entries --------
         Expr::ObjectValues(obj) => {

--- a/crates/perry-codegen/src/lower_array_method.rs
+++ b/crates/perry-codegen/src/lower_array_method.rs
@@ -95,7 +95,7 @@ pub(crate) fn lower_array_method(
             Ok(nanbox_string_inline(blk, &result_handle))
         }
         "concat" => {
-            // arr.concat(other) — call js_array_concat_new (non-mutating).
+            // #2805: arr.concat(...args) — spec-complete, non-mutating, variadic.
             // Issue #637: pre-fix this called `js_array_concat` (mutating
             // — used internally by spread-into-array desugar) which wrote
             // `other`'s elements into `recv`'s storage. When `recv` was the
@@ -107,18 +107,35 @@ pub(crate) fn lower_array_method(
             // allocated keys_arrays of OTHER objects via GC reuse. The
             // user-visible `.concat()` is spec-non-mutating; route to the
             // dedicated non-mutating helper.
-            // For simplicity we only handle single-argument concat.
-            if args.len() != 1 {
-                return Ok(recv_box);
+            //
+            // Lower every argument into an alloca buffer of raw NaN-boxed
+            // doubles, then call `js_array_concat_variadic(recv, ptr, count)`
+            // which applies Symbol.isConcatSpreadable / array-like spreading
+            // and always returns a fresh array (receiver unchanged). Mirrors
+            // the `unshift` variadic pattern below.
+            let mut item_vals: Vec<String> = Vec::with_capacity(args.len());
+            for a in args {
+                item_vals.push(lower_expr(ctx, a)?);
             }
-            let other_box = lower_expr(ctx, &args[0])?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let other_handle = unbox_to_i64(blk, &other_box);
+            let n = item_vals.len();
+            let (buf_reg, count_str) = if n == 0 {
+                // No args: pass a null buffer + 0 count (concat() returns a copy).
+                ("null".to_string(), "0".to_string())
+            } else {
+                let buf_reg = blk.next_reg();
+                blk.emit_raw(format!("{} = alloca [{} x double]", buf_reg, n));
+                for (i, val) in item_vals.iter().enumerate() {
+                    let slot = blk.gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", i))]);
+                    blk.store(DOUBLE, val, &slot);
+                }
+                (buf_reg, format!("{}", n))
+            };
             let result = blk.call(
                 I64,
-                "js_array_concat_new",
-                &[(I64, &recv_handle), (I64, &other_handle)],
+                "js_array_concat_variadic",
+                &[(I64, &recv_handle), (PTR, &buf_reg), (I32, &count_str)],
             );
             Ok(nanbox_pointer_inline(blk, &result))
         }

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -117,6 +117,16 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     module.declare_function("js_array_set_length", VOID, &[I64, DOUBLE]);
     // Array.from() — js_array_clone handles arrays, Sets, and Maps.
     module.declare_function("js_array_clone", I64, &[I64]);
+    // #2773: Array.from(source) — throws TypeError for nullish sources, keeps
+    // number/boolean/symbol -> [], otherwise materializes via js_array_clone.
+    // Takes the raw NaN-boxed value so the tag bits survive.
+    module.declare_function("js_array_from_value", I64, &[DOUBLE]);
+    // #2773: Array.from(source, mapFn, thisArg?) — nullish-throw + mapFn
+    // callability validation + (value,index) mapped call with thisArg binding.
+    module.declare_function("js_array_from_mapped", I64, &[DOUBLE, DOUBLE, DOUBLE]);
+    // #2805: Array.prototype.concat(...args) — non-mutating, variadic, with
+    // Symbol.isConcatSpreadable handling. (recv_handle, args_ptr, count).
+    module.declare_function("js_array_concat_variadic", I64, &[I64, PTR, I32]);
     // Spread `[...x]` — wraps js_array_clone with a null/undefined
     // TypeError check so plain spread matches ECMA semantics.
     module.declare_function("js_array_clone_for_spread", I64, &[DOUBLE]);

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -1067,9 +1067,16 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
         Expr::ArrayIsArray(value) | Expr::ArrayFrom(value) => {
             collect_assigned_locals_expr(value, assigned);
         }
-        Expr::ArrayFromMapped { iterable, map_fn } => {
+        Expr::ArrayFromMapped {
+            iterable,
+            map_fn,
+            this_arg,
+        } => {
             collect_assigned_locals_expr(iterable, assigned);
             collect_assigned_locals_expr(map_fn, assigned);
+            if let Some(t) = this_arg {
+                collect_assigned_locals_expr(t, assigned);
+            }
         }
         Expr::RegExpTest { regex, string } => {
             collect_assigned_locals_expr(regex, assigned);

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1907,11 +1907,13 @@ pub enum Expr {
     /// else drives its `[Symbol.iterator]`. Without it the index loop read
     /// `.length` off a raw Map/Set handle (→ 0) and iterated zero times.
     ForOfToArray(Box<Expr>),
-    /// Array.from(iterable, mapFn) -> Array
+    /// Array.from(iterable, mapFn, thisArg?) -> Array
     /// Creates a new array by applying mapFn to each element of the iterable.
+    /// `this_arg` (#2773) binds `this` inside a non-arrow mapFn.
     ArrayFromMapped {
         iterable: Box<Expr>,
         map_fn: Box<Expr>,
+        this_arg: Option<Box<Expr>>,
     },
 
     // Global built-in functions

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -564,6 +564,19 @@ pub(super) fn try_native_module_methods(
                     match method_name {
                         "from" => {
                             let data = args.first().cloned().unwrap_or(Expr::Undefined);
+                            // #2774: `Uint8Array.from(src, mapFn, thisArg?)` — run
+                            // the mapped materialization first (which validates
+                            // mapFn + binds thisArg), then truncate to Uint8.
+                            if let Some(map_fn) = args.get(1).cloned() {
+                                let this_arg = args.get(2).cloned().map(Box::new);
+                                return Ok(Ok(Expr::Uint8ArrayFrom(Box::new(
+                                    Expr::ArrayFromMapped {
+                                        iterable: Box::new(data),
+                                        map_fn: Box::new(map_fn),
+                                        this_arg,
+                                    },
+                                ))));
+                            }
                             return Ok(Ok(Expr::Uint8ArrayFrom(Box::new(data))));
                         }
                         // Issue #871 (part 2): `Uint8Array.of(a, b, c, ...)` —
@@ -1104,9 +1117,13 @@ pub(super) fn try_native_module_methods(
                             // variant so codegen can handle Map/Set/Array sources
                             // uniformly (materialize + js_array_map).
                             if let Some(map_fn) = args.get(1).cloned() {
+                                // #2773: carry the optional thisArg (3rd arg) so
+                                // a non-arrow mapFn can bind `this`.
+                                let this_arg = args.get(2).cloned().map(Box::new);
                                 return Ok(Ok(Expr::ArrayFromMapped {
                                     iterable: Box::new(value),
                                     map_fn: Box::new(map_fn),
+                                    this_arg,
                                 }));
                             }
                             // Check if the source is a generator call — use iterator protocol

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -824,9 +824,16 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
             Expr::ArrayIsArray(Box::new(substitute_expr(value, substitutions)))
         }
         Expr::ArrayFrom(value) => Expr::ArrayFrom(Box::new(substitute_expr(value, substitutions))),
-        Expr::ArrayFromMapped { iterable, map_fn } => Expr::ArrayFromMapped {
+        Expr::ArrayFromMapped {
+            iterable,
+            map_fn,
+            this_arg,
+        } => Expr::ArrayFromMapped {
             iterable: Box::new(substitute_expr(iterable, substitutions)),
             map_fn: Box::new(substitute_expr(map_fn, substitutions)),
+            this_arg: this_arg
+                .as_ref()
+                .map(|t| Box::new(substitute_expr(t, substitutions))),
         },
 
         // Global built-in functions

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -506,7 +506,7 @@ impl SH for Expr {
             Expr::IteratorToArray(e) => { tag(h, 398); e.as_ref().hash(h); }
             Expr::GetIterator(e) => { tag(h, 11238); e.as_ref().hash(h); }
             Expr::ForOfToArray(e) => { tag(h, 11243); e.as_ref().hash(h); }
-            Expr::ArrayFromMapped { iterable, map_fn } => { tag(h, 399); iterable.as_ref().hash(h); map_fn.as_ref().hash(h); }
+            Expr::ArrayFromMapped { iterable, map_fn, this_arg } => { tag(h, 399); iterable.as_ref().hash(h); map_fn.as_ref().hash(h); this_arg.is_some().hash(h); if let Some(t) = this_arg { t.as_ref().hash(h); } }
             Expr::ParseInt { string, radix } => { tag(h, 400); string.as_ref().hash(h); radix.hash(h); }
             Expr::ParseFloat(e) => { tag(h, 401); e.as_ref().hash(h); }
             Expr::NumberCoerce(e) => { tag(h, 402); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -681,9 +681,16 @@ where
             f(items);
             f(key_fn);
         }
-        Expr::ArrayFromMapped { iterable, map_fn } => {
+        Expr::ArrayFromMapped {
+            iterable,
+            map_fn,
+            this_arg,
+        } => {
             f(iterable);
             f(map_fn);
+            if let Some(t) = this_arg {
+                f(t);
+            }
         }
 
         // ─── Three-child variants ─────────────────────────────────────────

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -682,9 +682,16 @@ where
             f(items);
             f(key_fn);
         }
-        Expr::ArrayFromMapped { iterable, map_fn } => {
+        Expr::ArrayFromMapped {
+            iterable,
+            map_fn,
+            this_arg,
+        } => {
             f(iterable);
             f(map_fn);
+            if let Some(t) = this_arg {
+                f(t);
+            }
         }
         Expr::IndexSet {
             object,

--- a/crates/perry-runtime/src/array/from_concat.rs
+++ b/crates/perry-runtime/src/array/from_concat.rs
@@ -1,0 +1,287 @@
+//! `Array.from` API-level validation + mapped-call semantics (#2773) and the
+//! spec-complete variadic, non-mutating `Array.prototype.concat` (#2805).
+//!
+//! These are the JS-API entry points. The low-level materialization helpers
+//! (`js_array_clone`, `js_array_from_arraylike`, ...) stay in their own
+//! modules; this module layers the spec validation (`TypeError` for nullish
+//! sources, callability checks, `Symbol.isConcatSpreadable`) on top of them.
+use super::{
+    clean_arr_ptr, js_array_alloc, js_array_clone, js_array_is_array, js_array_push_f64,
+    js_array_set_f64_extend, ArrayHeader,
+};
+use crate::closure::ClosureHeader;
+use crate::value::JSValue;
+
+const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
+
+/// Throw `TypeError: <receiver> is not iterable` (matches Node's wording for
+/// nullish `Array.from` / `Uint8Array.from` sources).
+#[cold]
+fn throw_not_iterable(receiver: &str) -> ! {
+    let msg = format!(
+        "{} is not iterable (cannot read property Symbol(Symbol.iterator))",
+        receiver
+    );
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err_ptr = crate::error::js_typeerror_new(msg_str);
+    let err_value = JSValue::pointer(err_ptr as *const u8).bits();
+    crate::exception::js_throw(f64::from_bits(err_value));
+}
+
+/// Throw `TypeError: <value> is not a function` for a non-callable mapFn,
+/// matching Node's `Array.from([1], 1)` → "number 1 is not a function".
+#[cold]
+fn throw_map_fn_not_callable(map_fn: f64) -> ! {
+    let value_str = {
+        let sp = crate::value::js_jsvalue_to_string(map_fn);
+        if sp.is_null() {
+            String::new()
+        } else {
+            unsafe {
+                let header = &*(sp as *const crate::string::StringHeader);
+                let bytes_ptr =
+                    (sp as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+                let slice = std::slice::from_raw_parts(bytes_ptr, header.byte_len as usize);
+                std::str::from_utf8(slice).unwrap_or("").to_string()
+            }
+        }
+    };
+    let jv = JSValue::from_bits(map_fn.to_bits());
+    let type_name = if jv.is_null() || jv.is_pointer() {
+        "object"
+    } else if map_fn.to_bits() >> 48 == 0x7FFF {
+        "string"
+    } else {
+        "number"
+    };
+    let msg = format!("{} {} is not a function", type_name, value_str);
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err_ptr = crate::error::js_typeerror_new(msg_str);
+    let err_value = JSValue::pointer(err_ptr as *const u8).bits();
+    crate::exception::js_throw(f64::from_bits(err_value));
+}
+
+/// `Array.from(source)` — the non-mapped form. Per ECMA-262 §23.1.2.1,
+/// `null`/`undefined` sources throw `TypeError` (they have no
+/// `Symbol.iterator`), while numbers/booleans/symbols are non-iterable
+/// non-objects that materialize to an empty array. All valid object/iterable
+/// sources delegate to the existing `js_array_clone` materialization (which
+/// covers arrays, sets, maps, strings, typed arrays, buffers, iterators, and
+/// array-likes).
+///
+/// Takes the raw NaN-boxed f64 value (NOT a pre-unboxed pointer) so it can
+/// inspect the tag bits before stripping.
+#[no_mangle]
+pub extern "C" fn js_array_from_value(boxed: f64) -> *mut ArrayHeader {
+    let bits = boxed.to_bits();
+    if bits == TAG_UNDEFINED {
+        throw_not_iterable("undefined");
+    }
+    if bits == TAG_NULL {
+        throw_not_iterable("object null");
+    }
+    // Numbers / booleans / strings handled inside js_array_clone:
+    //  - numbers/booleans aren't pointers → empty array.
+    //  - strings → per-codepoint materialization.
+    // Pointers (objects/arrays/iterables) materialize via js_array_clone.
+    let ptr_bits = if (bits >> 48) >= 0x7FF8 {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else {
+        bits as usize
+    };
+    js_array_clone(ptr_bits as *const ArrayHeader)
+}
+
+#[used]
+static KEEP_ARRAY_FROM_VALUE: extern "C" fn(f64) -> *mut ArrayHeader = js_array_from_value;
+
+/// `Array.from(source, mapFn, thisArg)` — the mapped form. Throws for nullish
+/// sources (like the non-mapped form), validates that `mapFn` is callable,
+/// then materializes the source and calls `mapFn(value, index)` for each
+/// element with `thisArg` bound as the function's `this`.
+///
+/// All three arguments are raw NaN-boxed f64 values. `this_arg` may be
+/// `undefined` (no binding).
+#[no_mangle]
+pub extern "C" fn js_array_from_mapped(
+    src_boxed: f64,
+    map_fn: f64,
+    this_arg: f64,
+) -> *mut ArrayHeader {
+    // Nullish source → TypeError (before validating mapFn, matching Node).
+    let bits = src_boxed.to_bits();
+    if bits == TAG_UNDEFINED {
+        throw_not_iterable("undefined");
+    }
+    if bits == TAG_NULL {
+        throw_not_iterable("object null");
+    }
+    let cb = resolve_callable(map_fn);
+    // Materialize the source (arrays, strings, iterables, array-likes, ...).
+    let ptr_bits = if (bits >> 48) >= 0x7FF8 {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else {
+        bits as usize
+    };
+    let src = js_array_clone(ptr_bits as *const ArrayHeader);
+    map_with_this(src, cb, this_arg)
+}
+
+#[used]
+static KEEP_ARRAY_FROM_MAPPED: extern "C" fn(f64, f64, f64) -> *mut ArrayHeader =
+    js_array_from_mapped;
+
+/// Validate a mapFn argument is callable, returning its `ClosureHeader*`.
+/// Throws `TypeError` for any non-callable value.
+fn resolve_callable(map_fn: f64) -> *const ClosureHeader {
+    let jv = JSValue::from_bits(map_fn.to_bits());
+    if jv.is_pointer() {
+        let ptr = jv.as_pointer::<ClosureHeader>();
+        if !ptr.is_null() && crate::closure::is_closure_ptr(ptr as usize) {
+            return ptr;
+        }
+    }
+    throw_map_fn_not_callable(map_fn);
+}
+
+/// Map `src` into a fresh array by calling `cb(value, index)` for each element
+/// with `this_arg` bound as the callback's `this`. Per ECMA-262 the mapFn
+/// receives exactly `(value, index)` (no array argument).
+fn map_with_this(
+    src: *mut ArrayHeader,
+    cb: *const ClosureHeader,
+    this_arg: f64,
+) -> *mut ArrayHeader {
+    let src = clean_arr_ptr(src);
+    if src.is_null() {
+        return js_array_alloc(0);
+    }
+    let prev_this = crate::object::js_implicit_this_set(this_arg);
+    let result = unsafe {
+        let length = (*src).length;
+        let src_elements = (src as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let result = js_array_alloc(length);
+        for i in 0..length as usize {
+            let element = *src_elements.add(i);
+            // mapFn receives (value, index) only.
+            let mapped = crate::closure::js_closure_call2(cb, element, i as f64);
+            js_array_set_f64_extend(result, i as u32, mapped);
+        }
+        (*result).length = length;
+        result
+    };
+    crate::object::js_implicit_this_set(prev_this);
+    result
+}
+
+/// `Array.prototype.concat(...args)` — spec-complete, non-mutating.
+///
+/// Returns a NEW array; the receiver is never mutated. Each argument is
+/// appended in order, spreading per ECMA-262 §23.1.3.1 / IsConcatSpreadable:
+///   - the receiver and array arguments spread by default,
+///   - an array with `Symbol.isConcatSpreadable === false` is a single element,
+///   - a non-array object with `Symbol.isConcatSpreadable === true` is spread
+///     as an array-like (`length` + indexed reads),
+///   - every other value (primitives, plain objects) is a single element.
+///
+/// `args_ptr` points at `count` raw NaN-boxed f64 argument values (alloca buffer
+/// built by codegen / passed straight from the dynamic dispatcher).
+#[no_mangle]
+pub extern "C" fn js_array_concat_variadic(
+    recv: *const ArrayHeader,
+    args_ptr: *const f64,
+    count: i32,
+) -> *mut ArrayHeader {
+    let result = js_array_alloc(0);
+    // The receiver itself is always spread (it's the array on which `.concat`
+    // was invoked). Materialize a clone to read its elements safely.
+    let result = append_spread_array(result, recv as *const ArrayHeader);
+    let mut result = result;
+    if !args_ptr.is_null() && count > 0 {
+        for i in 0..count as usize {
+            let value = unsafe { *args_ptr.add(i) };
+            result = append_concat_arg(result, value);
+        }
+    }
+    result
+}
+
+#[used]
+static KEEP_ARRAY_CONCAT_VARIADIC: extern "C" fn(
+    *const ArrayHeader,
+    *const f64,
+    i32,
+) -> *mut ArrayHeader = js_array_concat_variadic;
+
+/// Append a single concat argument to `result`, applying spreadability rules.
+fn append_concat_arg(result: *mut ArrayHeader, value: f64) -> *mut ArrayHeader {
+    let bits = value.to_bits();
+    let jv = JSValue::from_bits(bits);
+    if !jv.is_pointer() {
+        // Primitive (number / bool / undefined / null / string-by-tag): one element.
+        return js_array_push_f64(result, value);
+    }
+    let raw_addr = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
+
+    // Is the spreadable flag explicitly set?
+    let spreadable = read_concat_spreadable(value);
+
+    // Arrays (and set/map/typed-array/buffer that concat treats array-like via
+    // js_array_concat) spread by default, unless @@isConcatSpreadable === false.
+    let is_array = js_array_is_array(value).to_bits() == 0x7FFC_0000_0000_0004;
+    if is_array {
+        if spreadable == Some(false) {
+            return js_array_push_f64(result, value);
+        }
+        return append_spread_array(result, raw_addr as *const ArrayHeader);
+    }
+    // Non-array object explicitly marked spreadable → spread as array-like.
+    if spreadable == Some(true) {
+        let arr = unsafe {
+            super::js_array_from_arraylike(raw_addr as *const crate::object::ObjectHeader)
+        };
+        return append_spread_array(result, arr as *const ArrayHeader);
+    }
+    // Everything else (plain object, function, etc.) is a single element.
+    js_array_push_f64(result, value)
+}
+
+/// Read `value[Symbol.isConcatSpreadable]`. Returns `Some(true)`/`Some(false)`
+/// when the property is a defined boolean (using JS truthiness), or `None` when
+/// the property is absent/undefined (→ default behavior).
+fn read_concat_spreadable(value: f64) -> Option<bool> {
+    let sym = crate::symbol::well_known_symbol("isConcatSpreadable");
+    if sym.is_null() {
+        return None;
+    }
+    let sym_f64 = f64::from_bits(JSValue::pointer(sym as *const u8).bits());
+    let flag = unsafe { crate::symbol::js_object_get_symbol_property(value, sym_f64) };
+    let fbits = flag.to_bits();
+    if fbits == TAG_UNDEFINED {
+        return None;
+    }
+    Some(crate::value::js_is_truthy(flag) != 0)
+}
+
+/// Append every element of the (already-materializable) source array `src`
+/// into `result`, returning the (possibly reallocated) result. `src` is
+/// materialized via `js_array_clone` so sets/maps/typed-arrays/buffers spread
+/// to their element values, matching `[...x]`.
+fn append_spread_array(result: *mut ArrayHeader, src: *const ArrayHeader) -> *mut ArrayHeader {
+    let materialized = js_array_clone(src);
+    let materialized = clean_arr_ptr(materialized);
+    if materialized.is_null() {
+        return result;
+    }
+    unsafe {
+        let len = (*materialized).length;
+        let elems =
+            (materialized as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let mut out = result;
+        for i in 0..len as usize {
+            out = js_array_push_f64(out, *elems.add(i));
+        }
+        out
+    }
+}

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -2,6 +2,7 @@
 mod alloc;
 mod concat_reverse;
 mod flat_clone;
+mod from_concat;
 mod header;
 mod immutable;
 mod indexing;
@@ -31,6 +32,7 @@ pub use self::flat_clone::{
     js_array_clone, js_array_entries, js_array_flat, js_array_flat_depth, js_array_keys,
     js_array_values,
 };
+pub use self::from_concat::{js_array_concat_variadic, js_array_from_mapped, js_array_from_value};
 pub use self::header::{
     js_array_clear_numeric_layout, js_array_is_numeric_f64_layout,
     js_array_mark_numeric_f64_layout, js_array_note_numeric_write, js_tagged_template_register_raw,

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -460,7 +460,9 @@ unsafe fn dispatch_typed_array_method(
             } else {
                 f64::from_bits(crate::value::TAG_UNDEFINED)
             };
-            f64::from_bits(crate::typedarray::js_typed_array_copy_within(ta, target, start, end) as u64)
+            f64::from_bits(
+                crate::typedarray::js_typed_array_copy_within(ta, target, start, end) as u64,
+            )
         }
         "with" => {
             let idx = arg0();
@@ -1606,11 +1608,12 @@ pub unsafe extern "C" fn js_native_call_method(
                         let result = crate::array::js_array_flatMap(arr, cb_ptr);
                         return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
                     }
-                    "concat" if args_len >= 1 && !args_ptr.is_null() => {
-                        let arr = raw_ptr as *mut crate::array::ArrayHeader;
-                        let other_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
-                        let other_ptr = other_bits as *mut crate::array::ArrayHeader;
-                        let result = crate::array::js_array_concat(arr, other_ptr);
+                    "concat" => {
+                        // #2805: non-mutating, variadic concat with
+                        // Symbol.isConcatSpreadable handling.
+                        let arr = raw_ptr as *const crate::array::ArrayHeader;
+                        let result =
+                            crate::array::js_array_concat_variadic(arr, args_ptr, args_len as i32);
                         return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
                     }
                     "indexOf" if args_len >= 1 && !args_ptr.is_null() => {

--- a/test-files/test_gap_array_from_concat_2773_2805_2774.ts
+++ b/test-files/test_gap_array_from_concat_2773_2805_2774.ts
@@ -1,0 +1,80 @@
+// Gap test for #2773 (Array.from validation + mapped semantics),
+// #2805 (Array.prototype.concat variadic, non-mutating, isConcatSpreadable),
+// and #2774 (Uint8Array.from / Uint8Array.of produce typed arrays).
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+// ---- #2773: Array.from ----
+console.log(JSON.stringify(Array.from({ 0: "a", 2: "c", length: 3 })));
+console.log(JSON.stringify(Array.from("ab")));
+console.log(
+  JSON.stringify(
+    Array.from(
+      [10, 20],
+      function (value, index) {
+        return [this.mult * value, index].join(":");
+      },
+      { mult: 2 },
+    ),
+  ),
+);
+console.log(JSON.stringify(Array.from([1, 2], (value, index) => value + index)));
+
+try {
+  Array.from(null as any);
+} catch (e) {
+  console.log("from null: " + (e as Error).name);
+}
+try {
+  Array.from(undefined as any);
+} catch (e) {
+  console.log("from undefined: " + (e as Error).name);
+}
+try {
+  Array.from([1], 1 as any);
+} catch (e) {
+  console.log("from bad mapFn: " + (e as Error).name);
+}
+
+// ---- #2805: Array.prototype.concat ----
+console.log(JSON.stringify([1].concat([2, 3])));
+console.log(JSON.stringify([1].concat([2], [3, 4], 5)));
+console.log(JSON.stringify([1].concat()));
+{
+  const a = [1];
+  const out = a.concat([2]);
+  console.log(JSON.stringify([out, a, out === a]));
+}
+{
+  // Array with Symbol.isConcatSpreadable === false -> single element.
+  // (Set via defineProperty: bracket-assigning a Symbol key onto an Array
+  // is a separate, unrelated Perry index-set bug.)
+  const x: any = [2, 3];
+  Object.defineProperty(x, Symbol.isConcatSpreadable, { value: false });
+  console.log(JSON.stringify([1].concat(x)));
+}
+{
+  const x: any = { 0: "a", 1: "b", length: 2, [Symbol.isConcatSpreadable]: true };
+  console.log(JSON.stringify([1].concat(x)));
+}
+
+// ---- #2774: Uint8Array.from / .of ----
+{
+  const a = Uint8Array.from([1, 257, -1, 3.9]);
+  console.log(a.length, JSON.stringify([...a]));
+}
+{
+  const b = Uint8Array.of(1, 257, -1, 3.9);
+  console.log(b.length, JSON.stringify([...b]));
+}
+console.log(JSON.stringify([...Uint8Array.from("ABC", (c) => c.charCodeAt(0))]));
+console.log(
+  JSON.stringify([
+    ...Uint8Array.from(
+      [1, 2],
+      function (v, i) {
+        return v * this.mult + i;
+      },
+      { mult: 10 },
+    ),
+  ]),
+);


### PR DESCRIPTION
Closes #2773
Closes #2805
Closes #2774

## Implementation

All three issues are fixed primarily in the runtime (`crates/perry-runtime/src/array/from_concat.rs`, a new module) plus thin codegen plumbing. No new HIR `Expr` variant was added — the existing `ArrayFromMapped` struct variant gained one `this_arg: Option<Box<Expr>>` field (stable-hash tag 399 preserved).

### #2773 — `Array.from` validation + mapped semantics
- New `js_array_from_value(boxed)` throws `TypeError` for `null`/`undefined` sources, keeps `number`/`boolean`/`symbol` → `[]`, and delegates valid sources to the existing `js_array_clone` materialization. `Expr::ArrayFrom` codegen now calls it with the raw NaN-boxed value.
- New `js_array_from_mapped(src, mapFn, thisArg)` throws for nullish sources, validates `mapFn` is callable (else `TypeError: <type> <value> is not a function`), then calls `mapFn(value, index)` (two args only) with `thisArg` bound via `js_implicit_this_set`.
- Lowering now carries the optional 3rd `thisArg` arg into `ArrayFromMapped`.

### #2805 — `Array.prototype.concat` variadic, non-mutating
- New `js_array_concat_variadic(recv, args_ptr, count)` returns a fresh array, leaving the receiver unchanged. Arrays spread by default; `Symbol.isConcatSpreadable === false` makes an array a single element; a non-array object with `=== true` spreads as an array-like; everything else is a single element.
- Codegen lowers any-arity `concat` into an alloca buffer + the variadic helper (mirrors the `unshift` variadic pattern). The dynamic-dispatch path in `native_call_method.rs` now also routes through it (was the mutating `js_array_concat`).

### #2774 — `Uint8Array.from` / `Uint8Array.of`
- `Expr::Uint8ArrayFrom` codegen now materializes via `js_array_from_value` then calls `js_typed_array_new_from_array(KIND_UINT8, ...)`, producing a real typed array with Uint8 truncation (`257→1`, `-1→255`, `3.9→3`).
- `Uint8Array.from(src, mapFn, thisArg?)` is supported by lowering the mapped form first (reusing the #2773 path) before truncation.

## Validation

Gap test `test-files/test_gap_array_from_concat_2773_2805_2774.ts` is **byte-identical** to `node --experimental-strip-types` under the default auto-optimize compile (`diff` empty).

`cargo test --release -p perry-runtime array` (101 passed) and `cargo test -p perry-hir` (incl. `expr_variant_stable_hash_tags_are_unique`) green. `./scripts/check_file_size.sh` exit 0, `cargo fmt --all -- --check` clean. All codegen backends (`perry-codegen`, `-js`, `-wasm`) build.

Note: one separate, pre-existing bug surfaced (`arr[Symbol.x] = v` bracket-assigning a Symbol key onto an Array writes into slot 0 instead of the symbol side-table) — out of scope here; the gap test uses `Object.defineProperty` to set `Symbol.isConcatSpreadable`, which works correctly and exercises the concat logic.
