### PR TITLE
fix(collections): Map/Set insertion order, forEach semantics, real iterators

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -557,14 +557,19 @@ pub fn try_lower_property_get_method_call(
             // `undefined`. The runtime returns a real Array; we
             // NaN-box-pointer the result for downstream
             // `.length` / `forEach` / `Array.from` use.
+            // #2856: a value-level `.entries()`/`.keys()`/`.values()` call
+            // returns a real iterator OBJECT (`.next()`-bearing, not an
+            // Array). The eager Array materializers (`js_map_entries` etc.)
+            // are still used by the for-of/spread fast paths via the
+            // `Expr::MapEntries`/etc HIR variants.
             "entries" | "keys" | "values" if args.is_empty() => {
                 let m_box = lower_expr(ctx, object)?;
                 let blk = ctx.block();
                 let m_handle = unbox_to_i64(blk, &m_box);
                 let runtime_fn = match property.as_str() {
-                    "entries" => "js_map_entries",
-                    "keys" => "js_map_keys",
-                    "values" => "js_map_values",
+                    "entries" => "js_map_entries_iter_obj",
+                    "keys" => "js_map_keys_iter_obj",
+                    "values" => "js_map_values_iter_obj",
                     _ => unreachable!(),
                 };
                 let result = blk.call(I64, runtime_fn, &[(I64, &m_handle)]);
@@ -626,11 +631,20 @@ pub fn try_lower_property_get_method_call(
             // spread shapes. Pre-fix `new Set([1]).values()`
             // returned `undefined` because the HIR-level fold at
             // expr_call.rs only fires for `Expr::Ident` receivers.
-            "values" | "keys" if args.is_empty() => {
+            // #2856: value-level Set iterator methods return real iterator
+            // objects. `entries` was previously missing here and on the
+            // typed-Set HIR path; for Sets `entries` yields `[v, v]` pairs.
+            "values" | "keys" | "entries" if args.is_empty() => {
                 let s_box = lower_expr(ctx, object)?;
                 let blk = ctx.block();
                 let s_handle = unbox_to_i64(blk, &s_box);
-                let result = blk.call(I64, "js_set_to_array", &[(I64, &s_handle)]);
+                let runtime_fn = match property.as_str() {
+                    "values" => "js_set_values_iter_obj",
+                    "keys" => "js_set_keys_iter_obj",
+                    "entries" => "js_set_entries_iter_obj",
+                    _ => unreachable!(),
+                };
+                let result = blk.call(I64, runtime_fn, &[(I64, &s_handle)]);
                 return Ok(Some(crate::expr::nanbox_pointer_inline_pub(blk, &result)));
             }
             _ => {}
@@ -643,21 +657,45 @@ pub fn try_lower_property_get_method_call(
     // Route to the runtime forEach implementations which iterate
     // entries and call the callback via js_closure_call2.
     if property == "forEach" && !args.is_empty() {
+        // #2830: lower the optional `thisArg` (args[1]) and pass it through
+        // so the callback's `this` is bound; the runtime calls the callback
+        // with the full `(value, key, collection)` triple. Map.forEach
+        // returns `undefined`.
         if is_map_expr(ctx, object) {
             let m_box = lower_expr(ctx, object)?;
             let cb_box = lower_expr(ctx, &args[0])?;
+            let this_arg = if args.len() >= 2 {
+                lower_expr(ctx, &args[1])?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
             let blk = ctx.block();
             let m_handle = unbox_to_i64(blk, &m_box);
-            blk.call_void("js_map_foreach", &[(I64, &m_handle), (DOUBLE, &cb_box)]);
-            return Ok(Some(double_literal(0.0)));
+            blk.call_void(
+                "js_map_foreach",
+                &[(I64, &m_handle), (DOUBLE, &cb_box), (DOUBLE, &this_arg)],
+            );
+            return Ok(Some(double_literal(f64::from_bits(
+                crate::nanbox::TAG_UNDEFINED,
+            ))));
         }
         if is_set_expr(ctx, object) {
             let s_box = lower_expr(ctx, object)?;
             let cb_box = lower_expr(ctx, &args[0])?;
+            let this_arg = if args.len() >= 2 {
+                lower_expr(ctx, &args[1])?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
             let blk = ctx.block();
             let s_handle = unbox_to_i64(blk, &s_box);
-            blk.call_void("js_set_foreach", &[(I64, &s_handle), (DOUBLE, &cb_box)]);
-            return Ok(Some(double_literal(0.0)));
+            blk.call_void(
+                "js_set_foreach",
+                &[(I64, &s_handle), (DOUBLE, &cb_box), (DOUBLE, &this_arg)],
+            );
+            return Ok(Some(double_literal(f64::from_bits(
+                crate::nanbox::TAG_UNDEFINED,
+            ))));
         }
         // URLSearchParams.forEach((value, key, this) => …). The HIR
         // variant `Expr::UrlSearchParamsForEach` only fires when the

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -757,9 +757,18 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // would do. (Map ptr, entry idx) → key / value.
     module.declare_function("js_map_entry_key_at", DOUBLE, &[I64, I32]);
     module.declare_function("js_map_entry_value_at", DOUBLE, &[I64, I32]);
-    // Map/Set forEach: (collection_ptr, callback_nanboxed_f64) -> void
-    module.declare_function("js_map_foreach", VOID, &[I64, DOUBLE]);
-    module.declare_function("js_set_foreach", VOID, &[I64, DOUBLE]);
+    // Map/Set forEach: (collection_ptr, callback_nanboxed_f64, thisArg_f64) -> void (#2830)
+    module.declare_function("js_map_foreach", VOID, &[I64, DOUBLE, DOUBLE]);
+    module.declare_function("js_set_foreach", VOID, &[I64, DOUBLE, DOUBLE]);
+    // #2856: value-level Map/Set iterator methods return a real iterator
+    // OBJECT (raw ptr as i64; caller NaN-boxes), unlike the eager Array
+    // materializers above which still back the for-of/spread fast paths.
+    module.declare_function("js_map_entries_iter_obj", I64, &[I64]);
+    module.declare_function("js_map_keys_iter_obj", I64, &[I64]);
+    module.declare_function("js_map_values_iter_obj", I64, &[I64]);
+    module.declare_function("js_set_values_iter_obj", I64, &[I64]);
+    module.declare_function("js_set_keys_iter_obj", I64, &[I64]);
+    module.declare_function("js_set_entries_iter_obj", I64, &[I64]);
     // Set to array conversion (for Set iteration via for...of)
     module.declare_function("js_set_to_array", I64, &[I64]);
     // Direct element access for the `for (const x of set)` fast path —

--- a/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
@@ -606,43 +606,36 @@ pub(super) fn try_local_array_methods(
                                     Some(Type::Union(variants)) => variants.iter().any(ty_is_array),
                                     _ => false,
                                 };
+                                // #2856: Map/Set `entries`/`keys`/`values`
+                                // are NOT folded to the Array-materializing
+                                // `Map*`/`SetValues` HIR variants here. Those
+                                // variants are reserved for the for-of /
+                                // spread fast paths (which iterate the
+                                // collection directly); a *value-level* call
+                                // must return a real iterator OBJECT. Letting
+                                // these fall through to general dispatch routes
+                                // them to codegen's `is_map_expr`/`is_set_expr`
+                                // branch → `js_*_iter_obj`. The `is_map`/
+                                // `is_set` flags are still computed above so
+                                // the array fold below doesn't claim them.
+                                let _ = (is_map, is_set);
                                 match method_name {
                                     "entries" => {
-                                        if is_map {
-                                            return Ok(Ok(Expr::MapEntries(Box::new(
-                                                Expr::LocalGet(array_id),
-                                            ))));
-                                        }
-                                        if is_known_array {
+                                        if !is_map && !is_set && is_known_array {
                                             return Ok(Ok(Expr::ArrayEntries(Box::new(
                                                 Expr::LocalGet(array_id),
                                             ))));
                                         }
                                     }
                                     "keys" => {
-                                        if is_map {
-                                            return Ok(Ok(Expr::MapKeys(Box::new(
-                                                Expr::LocalGet(array_id),
-                                            ))));
-                                        }
-                                        if is_known_array {
+                                        if !is_map && !is_set && is_known_array {
                                             return Ok(Ok(Expr::ArrayKeys(Box::new(
                                                 Expr::LocalGet(array_id),
                                             ))));
                                         }
                                     }
                                     "values" => {
-                                        if is_map {
-                                            return Ok(Ok(Expr::MapValues(Box::new(
-                                                Expr::LocalGet(array_id),
-                                            ))));
-                                        }
-                                        if is_set {
-                                            return Ok(Ok(Expr::SetValues(Box::new(
-                                                Expr::LocalGet(array_id),
-                                            ))));
-                                        }
-                                        if is_known_array {
+                                        if !is_map && !is_set && is_known_array {
                                             return Ok(Ok(Expr::ArrayValues(Box::new(
                                                 Expr::LocalGet(array_id),
                                             ))));
@@ -650,8 +643,9 @@ pub(super) fn try_local_array_methods(
                                     }
                                     _ => unreachable!(),
                                 }
-                                // Fall through: receiver type unknown — let general
-                                // dispatch (js_native_call_method) inspect at runtime.
+                                // Fall through: Map/Set or unknown receiver —
+                                // general dispatch (codegen Map/Set branch or
+                                // runtime `js_native_call_method`) handles it.
                             }
                             // Map methods (only apply to actual Map/Set types)
                             "set" => {

--- a/crates/perry-runtime/src/array/flat_clone.rs
+++ b/crates/perry-runtime/src/array/flat_clone.rs
@@ -317,7 +317,13 @@ pub extern "C" fn js_array_clone(src: *const ArrayHeader) -> *mut ArrayHeader {
             // (the runtime array-iterator class id / a stored `.next` closure).
             unsafe {
                 let iter_f64 = crate::value::js_nanbox_pointer(raw_addr as i64);
-                let is_array_iterator = (*obj).class_id == ARRAY_ITERATOR_CLASS_ID;
+                // #2856: Map/Set iterator objects dispatch `.next()` /
+                // `[Symbol.iterator]()` via class id (no stored symbol prop or
+                // `.next` field), so detect them here so `[...m.entries()]` /
+                // `Array.from(s.values())` drive the iterator protocol.
+                let is_array_iterator = (*obj).class_id == ARRAY_ITERATOR_CLASS_ID
+                    || (*obj).class_id == crate::collection_iter_object::MAP_ITERATOR_CLASS_ID
+                    || (*obj).class_id == crate::collection_iter_object::SET_ITERATOR_CLASS_ID;
                 let is_iterable = is_array_iterator || {
                     let iter_sym = crate::symbol::well_known_symbol("iterator");
                     if iter_sym.is_null() {

--- a/crates/perry-runtime/src/collection_iter_object.rs
+++ b/crates/perry-runtime/src/collection_iter_object.rs
@@ -1,0 +1,234 @@
+//! Real Map/Set iterator objects (#2856).
+//!
+//! Node's `Map.prototype.{entries,keys,values}` and
+//! `Set.prototype.{entries,keys,values}` return iterator OBJECTS — not
+//! arrays. Each is `Array.isArray(...) === false`, exposes a `.next()`
+//! method returning `{ value, done }`, is iterable via `Symbol.iterator`,
+//! and is recognized by `util.types.isMapIterator()` / `isSetIterator()`.
+//!
+//! Representation mirrors `array/iter_object.rs`: a regular `ObjectHeader`
+//! with a dedicated class id. Field 0 holds the backing Map/Set (NaN-boxed
+//! pointer, so the object scanner keeps it alive), field 1 the cursor
+//! index, field 2 the iterator kind. The collection is read LIVE at each
+//! `.next()` via `js_map_entry_key_at` / `js_map_entry_value_at` /
+//! `js_set_value_at`, so insertion-order-after-delete (#2831) is honored.
+//!
+//! Dispatch lives in `object/native_call_method.rs` via the class-id check
+//! next to the array iterator one; `flat_clone.rs` detects the class id so
+//! `[...m.entries()]` / `Array.from(s.values())` drive `.next()`.
+
+use crate::map::MapHeader;
+use crate::object::{js_object_alloc, js_object_get_field, js_object_set_field, ObjectHeader};
+use crate::set::SetHeader;
+use crate::value::{js_nanbox_get_pointer, js_nanbox_pointer, JSValue, TAG_UNDEFINED};
+
+/// Class id reserved for Map iterators. Sits just past the array iterator
+/// id (0xFFFF0006) in the 0xFFFF prefix reserved for runtime-defined
+/// classes.
+pub const MAP_ITERATOR_CLASS_ID: u32 = 0xFFFF_0007;
+/// Class id reserved for Set iterators.
+pub const SET_ITERATOR_CLASS_ID: u32 = 0xFFFF_0008;
+
+/// Iterator kind tags — matches the i32 stored in field 2.
+const KIND_KEYS: i32 = 1;
+const KIND_VALUES: i32 = 0;
+const KIND_ENTRIES: i32 = 2;
+
+/// `true` when `addr` carries a Map iterator object's class id.
+pub fn is_map_iterator_addr(addr: usize) -> bool {
+    iterator_class_id(addr) == Some(MAP_ITERATOR_CLASS_ID)
+}
+
+/// `true` when `addr` carries a Set iterator object's class id.
+pub fn is_set_iterator_addr(addr: usize) -> bool {
+    iterator_class_id(addr) == Some(SET_ITERATOR_CLASS_ID)
+}
+
+fn iterator_class_id(addr: usize) -> Option<u32> {
+    if addr < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return None;
+    }
+    unsafe {
+        let gc_header = (addr - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        if (*gc_header).obj_type != crate::gc::GC_TYPE_OBJECT {
+            return None;
+        }
+        Some((*(addr as *const ObjectHeader)).class_id)
+    }
+}
+
+unsafe fn alloc_iterator(class_id: u32, coll_nanboxed: f64, kind: i32) -> f64 {
+    let obj = js_object_alloc(class_id, 3);
+    // Field 0: backing collection (NaN-boxed pointer so the GC scanner keeps it).
+    js_object_set_field(obj, 0, JSValue::from_bits(coll_nanboxed.to_bits()));
+    // Field 1: cursor index, starts at 0.
+    js_object_set_field(obj, 1, JSValue::number(0.0));
+    // Field 2: iterator kind.
+    js_object_set_field(obj, 2, JSValue::number(kind as f64));
+    js_nanbox_pointer(obj as i64)
+}
+
+/// Build a fresh Map iterator object for `map` (raw pointer) of the given
+/// kind. Returns the RAW iterator-object pointer as i64 (caller NaN-boxes).
+unsafe fn map_iter_obj_raw(map: *const MapHeader, kind: i32) -> i64 {
+    if map.is_null() {
+        return 0;
+    }
+    let nanboxed = alloc_iterator(MAP_ITERATOR_CLASS_ID, js_nanbox_pointer(map as i64), kind);
+    js_nanbox_get_pointer(nanboxed)
+}
+
+unsafe fn set_iter_obj_raw(set: *const SetHeader, kind: i32) -> i64 {
+    if set.is_null() {
+        return 0;
+    }
+    let nanboxed = alloc_iterator(SET_ITERATOR_CLASS_ID, js_nanbox_pointer(set as i64), kind);
+    js_nanbox_get_pointer(nanboxed)
+}
+
+// ---------------------------------------------------------------------------
+// C-ABI entry points for codegen / runtime dispatch. Each takes a RAW
+// Map/Set pointer (the handle from `unbox_to_i64`) and returns the RAW
+// iterator-object pointer as i64; the caller NaN-boxes it.
+
+#[no_mangle]
+pub extern "C" fn js_map_entries_iter_obj(map: *const MapHeader) -> i64 {
+    unsafe { map_iter_obj_raw(map, KIND_ENTRIES) }
+}
+
+#[no_mangle]
+pub extern "C" fn js_map_keys_iter_obj(map: *const MapHeader) -> i64 {
+    unsafe { map_iter_obj_raw(map, KIND_KEYS) }
+}
+
+#[no_mangle]
+pub extern "C" fn js_map_values_iter_obj(map: *const MapHeader) -> i64 {
+    unsafe { map_iter_obj_raw(map, KIND_VALUES) }
+}
+
+#[no_mangle]
+pub extern "C" fn js_set_values_iter_obj(set: *const SetHeader) -> i64 {
+    unsafe { set_iter_obj_raw(set, KIND_VALUES) }
+}
+
+#[no_mangle]
+pub extern "C" fn js_set_keys_iter_obj(set: *const SetHeader) -> i64 {
+    unsafe { set_iter_obj_raw(set, KIND_KEYS) }
+}
+
+#[no_mangle]
+pub extern "C" fn js_set_entries_iter_obj(set: *const SetHeader) -> i64 {
+    unsafe { set_iter_obj_raw(set, KIND_ENTRIES) }
+}
+
+// These are only invoked from generated LLVM IR (codegen emits the
+// `.entries()`/`.keys()`/`.values()` call), so they have zero internal
+// Rust callers. The whole-program auto-optimize bitcode link would
+// otherwise internalize + dead-strip the `#[no_mangle]` exports and break
+// the default compile path (see project_auto_optimize_keepalive).
+#[used]
+static KEEP_MAP_ENTRIES_ITER: extern "C" fn(*const MapHeader) -> i64 = js_map_entries_iter_obj;
+#[used]
+static KEEP_MAP_KEYS_ITER: extern "C" fn(*const MapHeader) -> i64 = js_map_keys_iter_obj;
+#[used]
+static KEEP_MAP_VALUES_ITER: extern "C" fn(*const MapHeader) -> i64 = js_map_values_iter_obj;
+#[used]
+static KEEP_SET_VALUES_ITER: extern "C" fn(*const SetHeader) -> i64 = js_set_values_iter_obj;
+#[used]
+static KEEP_SET_KEYS_ITER: extern "C" fn(*const SetHeader) -> i64 = js_set_keys_iter_obj;
+#[used]
+static KEEP_SET_ENTRIES_ITER: extern "C" fn(*const SetHeader) -> i64 = js_set_entries_iter_obj;
+
+/// Build the `{ value, done }` iterator-result object. Mirrors
+/// `array/iter_object.rs::make_iter_result`.
+unsafe fn make_iter_result(value: JSValue, done: bool) -> f64 {
+    let obj = js_object_alloc(0, 2);
+
+    // keys array so destructuring + property reads find named slots.
+    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+    let done_key = crate::string::js_string_from_bytes(b"done".as_ptr(), 4);
+    let keys = crate::array::js_array_alloc(2);
+    crate::array::js_array_push(keys, JSValue::string_ptr(value_key));
+    crate::array::js_array_push(keys, JSValue::string_ptr(done_key));
+    crate::object::js_object_set_keys(obj, keys);
+
+    js_object_set_field(obj, 0, value);
+    js_object_set_field(obj, 1, JSValue::bool(done));
+    js_nanbox_pointer(obj as i64)
+}
+
+/// `[key, value]` pair array for Map entries / Set entries (`[v, v]`).
+unsafe fn make_pair_array(a: f64, b: f64) -> f64 {
+    let pair = crate::array::js_array_alloc(2);
+    crate::array::store_array_slot(pair, 0, a.to_bits());
+    crate::array::store_array_slot(pair, 1, b.to_bits());
+    (*pair).length = 2;
+    crate::array::rebuild_array_layout_exact(pair);
+    js_nanbox_pointer(pair as i64)
+}
+
+/// Dispatch `.next()` / `[Symbol.iterator]()` on a Map iterator object.
+pub unsafe fn dispatch_map_iterator_method(iter_obj: *mut ObjectHeader, method_name: &str) -> f64 {
+    match method_name {
+        "next" => {
+            let backing = f64::from_bits(js_object_get_field(iter_obj, 0).bits());
+            let map = js_nanbox_get_pointer(backing) as *const MapHeader;
+            let idx = f64::from_bits(js_object_get_field(iter_obj, 1).bits()) as u32;
+            let kind = f64::from_bits(js_object_get_field(iter_obj, 2).bits()) as i32;
+
+            let size = crate::map::js_map_size(map);
+            if map.is_null() || idx >= size {
+                return make_iter_result(JSValue::undefined(), true);
+            }
+            // Advance the cursor before computing the value.
+            js_object_set_field(iter_obj, 1, JSValue::number((idx + 1) as f64));
+
+            let value = match kind {
+                KIND_KEYS => {
+                    JSValue::from_bits(crate::map::js_map_entry_key_at(map, idx).to_bits())
+                }
+                KIND_VALUES => {
+                    JSValue::from_bits(crate::map::js_map_entry_value_at(map, idx).to_bits())
+                }
+                _ => {
+                    let key = crate::map::js_map_entry_key_at(map, idx);
+                    let val = crate::map::js_map_entry_value_at(map, idx);
+                    JSValue::from_bits(make_pair_array(key, val).to_bits())
+                }
+            };
+            make_iter_result(value, false)
+        }
+        "Symbol.iterator" | "@@iterator" => js_nanbox_pointer(iter_obj as i64),
+        "return" | "throw" => make_iter_result(JSValue::undefined(), true),
+        _ => f64::from_bits(TAG_UNDEFINED),
+    }
+}
+
+/// Dispatch `.next()` / `[Symbol.iterator]()` on a Set iterator object.
+pub unsafe fn dispatch_set_iterator_method(iter_obj: *mut ObjectHeader, method_name: &str) -> f64 {
+    match method_name {
+        "next" => {
+            let backing = f64::from_bits(js_object_get_field(iter_obj, 0).bits());
+            let set = js_nanbox_get_pointer(backing) as *const SetHeader;
+            let idx = f64::from_bits(js_object_get_field(iter_obj, 1).bits()) as u32;
+            let kind = f64::from_bits(js_object_get_field(iter_obj, 2).bits()) as i32;
+
+            let size = crate::set::js_set_size(set);
+            if set.is_null() || idx >= size {
+                return make_iter_result(JSValue::undefined(), true);
+            }
+            js_object_set_field(iter_obj, 1, JSValue::number((idx + 1) as f64));
+
+            let elem = crate::set::js_set_value_at(set, idx);
+            let value = match kind {
+                // For Sets, keys === values; entries yields [v, v] pairs.
+                KIND_ENTRIES => JSValue::from_bits(make_pair_array(elem, elem).to_bits()),
+                _ => JSValue::from_bits(elem.to_bits()),
+            };
+            make_iter_result(value, false)
+        }
+        "Symbol.iterator" | "@@iterator" => js_nanbox_pointer(iter_obj as i64),
+        "return" | "throw" => make_iter_result(JSValue::undefined(), true),
+        _ => f64::from_bits(TAG_UNDEFINED),
+    }
+}

--- a/crates/perry-runtime/src/gc/tests/runtime_roots/callback_scanners.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots/callback_scanners.rs
@@ -16,7 +16,11 @@ fn test_map_set_foreach_runtime_handles_survive_callback_copied_minor_gc() {
     crate::map::js_map_set(map, 2.0, test_string_value(b"map-foreach-b"));
     TEST_FOREACH_FORCE_MINOR_VISITS.with(|visits| visits.set(0));
     let before_map = gc_collection_count();
-    crate::map::js_map_foreach(map, callback_handle.get_nanbox_f64());
+    crate::map::js_map_foreach(
+        map,
+        callback_handle.get_nanbox_f64(),
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+    );
     assert!(
         gc_collection_count() > before_map,
         "Map.forEach callback should force copied-minor GC during JS re-entry"
@@ -31,7 +35,11 @@ fn test_map_set_foreach_runtime_handles_survive_callback_copied_minor_gc() {
     crate::set::js_set_add(set, test_string_value(b"set-foreach-b"));
     TEST_FOREACH_FORCE_MINOR_VISITS.with(|visits| visits.set(0));
     let before_set = gc_collection_count();
-    crate::set::js_set_foreach(set, callback_handle.get_nanbox_f64());
+    crate::set::js_set_foreach(
+        set,
+        callback_handle.get_nanbox_f64(),
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+    );
     assert!(
         gc_collection_count() > before_set,
         "Set.forEach callback should force copied-minor GC during JS re-entry"

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -35,6 +35,7 @@ pub mod builtins;
 pub mod child_process;
 pub mod closure;
 pub mod collection_iter;
+pub mod collection_iter_object;
 pub mod color_parse;
 pub mod date;
 pub mod error;

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -877,98 +877,81 @@ pub extern "C" fn js_map_delete(map: *mut MapHeader, key: f64) -> i32 {
         let size = (*map).size;
         let entries = entries_ptr_mut(map);
 
-        // Capture the swapped-in key (if any) before writing, so we can
-        // patch its position in the side-table after the swap-and-pop.
-        let mut swapped_key: Option<f64> = None;
-        if (idx as u32) < size - 1 {
-            let last_key = ptr::read(entries.add(((size - 1) as usize) * 2));
-            let last_value = ptr::read(entries.add(((size - 1) as usize) * 2 + 1));
-            let key_slot = entries.add((idx as usize) * 2);
-            let value_slot = entries.add((idx as usize) * 2 + 1);
-            // GC_STORE_AUDIT(EXTERNAL_BARRIERED): map swap-remove slots use the shared external-slot helper.
+        // #2831: preserve insertion order. JS Map iteration must keep the
+        // relative order of surviving entries after a delete (and a
+        // delete-then-re-add appends at the end). The previous swap-and-pop
+        // moved the last entry into the hole, reordering iteration. Shift
+        // every entry after `idx` down by one slot instead.
+        for i in (idx as usize)..(size as usize - 1) {
+            let next_key = ptr::read(entries.add((i + 1) * 2));
+            let next_value = ptr::read(entries.add((i + 1) * 2 + 1));
+            // GC_STORE_AUDIT(EXTERNAL_BARRIERED): map compaction slots use the shared external-slot helper.
             crate::gc::runtime_store_external_jsvalue_slot(
                 map as usize,
-                key_slot as usize,
-                last_key.to_bits(),
+                entries.add(i * 2) as usize,
+                next_key.to_bits(),
             );
             crate::gc::runtime_store_external_jsvalue_slot(
                 map as usize,
-                value_slot as usize,
-                last_value.to_bits(),
+                entries.add(i * 2 + 1) as usize,
+                next_value.to_bits(),
             );
-            swapped_key = Some(last_key);
         }
 
         (*map).size = size - 1;
 
-        // Update side-table: drop the deleted key (if it was indexed),
-        // and if we swap-popped, patch the swapped key's stored index.
-        let key_bits = key.to_bits();
-        let swapped_bits = swapped_key.map(|f| f.to_bits());
-        if is_safe_numeric_key(key_bits) || swapped_bits.map(is_safe_numeric_key).unwrap_or(false) {
-            MAP_INDEX.with(|midx| {
-                let mut midx = midx.borrow_mut();
-                if let Some(slot) = midx.get_mut(&(map as usize)) {
-                    if is_safe_numeric_key(key_bits) {
-                        slot.remove(&NumericKey(key_bits));
-                    }
-                    if let Some(sb) = swapped_bits {
-                        if is_safe_numeric_key(sb) {
-                            if let Some(entry) = slot.get_mut(&NumericKey(sb)) {
-                                *entry = idx as u32;
-                            }
-                        }
-                    }
-                }
-            });
-        }
-
-        // Mirror string-key index maintenance: drop the deleted key from
-        // its bucket; on swap-pop, rewrite the swapped key's stored
-        // index from `size-1` to `idx`.
-        let key_str_h = if is_string_like(key_bits) {
-            string_content_hash(key_bits)
-        } else {
-            None
-        };
-        let swapped_str_h = swapped_bits.and_then(|sb| {
-            if is_string_like(sb) {
-                string_content_hash(sb)
-            } else {
-                None
-            }
-        });
-        if key_str_h.is_some() || swapped_str_h.is_some() {
-            MAP_STRING_INDEX.with(|sidx| {
-                let mut sidx = sidx.borrow_mut();
-                if let Some(slot) = sidx.get_mut(&(map as usize)) {
-                    if let Some(h) = key_str_h {
-                        // Drop the deleted-key index from its bucket.
-                        let drop_idx = idx as u32;
-                        if let Some(bucket) = slot.get_mut(&h) {
-                            bucket.retain(|&i| i != drop_idx);
-                            if bucket.is_empty() {
-                                slot.remove(&h);
-                            }
-                        }
-                    }
-                    if let Some(h) = swapped_str_h {
-                        // Rewrite the swapped key's stored index.
-                        let old_idx = (size - 1) as u32;
-                        let new_idx = idx as u32;
-                        if let Some(bucket) = slot.get_mut(&h) {
-                            for entry in bucket.iter_mut() {
-                                if *entry == old_idx {
-                                    *entry = new_idx;
-                                }
-                            }
-                        }
-                    }
-                }
-            });
-        }
+        // The shift changes the entry index of every surviving key at or
+        // after `idx`, so the O(1) lookup side-tables can't be patched in
+        // place cheaply — rebuild them from the compacted buffer. Small
+        // maps don't use the side-table fast path (linear scan under
+        // SIDE_TABLE_THRESHOLD), so this only matters for large maps where
+        // a full rebuild is still O(size) like the shift itself.
+        rebuild_map_index(map);
         1
     }
+}
+
+/// Rebuild the numeric + string lookup side-tables for `map` from its
+/// current compacted entries buffer. Used after an order-preserving
+/// `delete` shifts entry indexes (#2831).
+unsafe fn rebuild_map_index(map: *mut MapHeader) {
+    if map.is_null() {
+        return;
+    }
+    let size = (*map).size as usize;
+    let capacity = (*map).capacity as usize;
+    if size > capacity || size > 16_000_000 || (*map).entries.is_null() {
+        return;
+    }
+    let entries = entries_ptr(map);
+    MAP_INDEX.with(|idx| {
+        let mut idx = idx.borrow_mut();
+        let slot = idx
+            .entry(map as usize)
+            .or_insert_with(crate::fast_hash::new_ptr_hash_map);
+        slot.clear();
+        for i in 0..size {
+            let key_bits = ptr::read(entries.add(i * 2)).to_bits();
+            if is_safe_numeric_key(key_bits) {
+                slot.insert(NumericKey(key_bits), i as u32);
+            }
+        }
+    });
+    MAP_STRING_INDEX.with(|idx| {
+        let mut idx = idx.borrow_mut();
+        let slot = idx
+            .entry(map as usize)
+            .or_insert_with(std::collections::HashMap::new);
+        slot.clear();
+        for i in 0..size {
+            let key_bits = ptr::read(entries.add(i * 2)).to_bits();
+            if is_string_like(key_bits) {
+                if let Some(h) = string_content_hash(key_bits) {
+                    slot.entry(h).or_insert_with(Vec::new).push(i as u32);
+                }
+            }
+        }
+    });
 }
 
 /// Clear all entries from the map
@@ -1330,9 +1313,12 @@ pub extern "C" fn js_map_from_iterable(value: f64) -> *mut MapHeader {
 #[used]
 static KEEP_JS_MAP_FROM_ITERABLE: extern "C" fn(f64) -> *mut MapHeader = js_map_from_iterable;
 
-/// Iterate over map entries, calling a callback with (value, key, map) for each
+/// `Map.prototype.forEach(callback, thisArg)` — calls `callback` with the
+/// full `(value, key, map)` argument triple (#2830) and binds `thisArg` as
+/// the callback's `this` for non-arrow functions. `this_arg` is `undefined`
+/// when omitted at the call site.
 #[no_mangle]
-pub extern "C" fn js_map_foreach(map: *const MapHeader, callback: f64) {
+pub extern "C" fn js_map_foreach(map: *const MapHeader, callback: f64, this_arg: f64) {
     let map = clean_map_ptr(map);
     if map.is_null() {
         return;
@@ -1340,14 +1326,13 @@ pub extern "C" fn js_map_foreach(map: *const MapHeader, callback: f64) {
     let scope = crate::gc::RuntimeHandleScope::new();
     let map_handle = scope.root_raw_const_ptr(map);
     let callback_handle = scope.root_nanbox_f64(callback);
+    let this_handle = scope.root_nanbox_f64(this_arg);
     unsafe {
         let map = map_handle.get_raw_const_ptr::<MapHeader>();
         let size = (*map).size as usize;
-
-        // Extract the closure pointer from the NaN-boxed callback.
-        // The callback may be NaN-boxed with POINTER_TAG (0x7FFD) or
-        // passed as a raw pointer (i64 bitcast to f64). Mask off the
-        // upper 16 bits to get the real 48-bit pointer.
+        // The collection itself is the third callback argument and the
+        // identity user code compares `self === m` against.
+        let map_value = crate::value::js_nanbox_pointer(map as i64);
 
         for i in 0..size {
             let map = map_handle.get_raw_const_ptr::<MapHeader>();
@@ -1357,10 +1342,15 @@ pub extern "C" fn js_map_foreach(map: *const MapHeader, callback: f64) {
             let entries = entries_ptr(map);
             let key = ptr::read(entries.add(i * 2));
             let value = ptr::read(entries.add(i * 2 + 1));
-            let closure_ptr = (callback_handle.get_nanbox_u64() & 0x0000_FFFF_FFFF_FFFF)
-                as *const crate::closure::ClosureHeader;
-            // Call closure with (value, key) - Map.forEach callback signature
-            crate::closure::js_closure_call2(closure_ptr, value, key);
+            let args = [value, key, map_value];
+            let cb = callback_handle.get_nanbox_f64();
+            let this_v = this_handle.get_nanbox_f64();
+            // Bind `thisArg` for the duration of the call (matches the
+            // URLSearchParams.forEach pattern); `js_native_call_value`
+            // dispatches the NaN-boxed callback with the full arg vector.
+            let prev_this = crate::object::js_implicit_this_set(this_v);
+            let _ = crate::closure::js_native_call_value(cb, args.as_ptr(), args.len());
+            crate::object::js_implicit_this_set(prev_this);
         }
     }
 }

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2190,6 +2190,34 @@ pub extern "C" fn js_object_get_field_by_name(
             }
         }
 
+        // #2856: a property READ (not a call) of `next` on a Map/Set
+        // iterator object must yield a callable (so `typeof it.next ===
+        // "function"` and `const n = it.next; n()` work). The iterators
+        // dispatch via class id and store no `next` field, so bind the
+        // method to the receiver. Also bind the self-iterator methods.
+        if !key.is_null()
+            && ((*obj).class_id == crate::collection_iter_object::MAP_ITERATOR_CLASS_ID
+                || (*obj).class_id == crate::collection_iter_object::SET_ITERATOR_CLASS_ID)
+        {
+            let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+            let key_len = (*key).byte_len as usize;
+            let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
+            let bind_name: Option<&'static [u8]> = match key_bytes {
+                b"next" => Some(b"next"),
+                b"return" => Some(b"return"),
+                b"throw" => Some(b"throw"),
+                b"@@iterator" => Some(b"@@iterator"),
+                _ => None,
+            };
+            if let Some(name) = bind_name {
+                let this_f64 =
+                    f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+                let result = js_class_method_bind(this_f64, name.as_ptr(), name.len());
+                return JSValue::from_bits(result.to_bits());
+            }
+            return JSValue::undefined();
+        }
+
         // Issue #649: native-module sub-namespace property access.
         // `fs.constants.F_OK` lowers to `PropertyGet { PropertyGet { fs,
         // "constants" }, "F_OK" }` — the inner expression's runtime value

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -460,7 +460,9 @@ unsafe fn dispatch_typed_array_method(
             } else {
                 f64::from_bits(crate::value::TAG_UNDEFINED)
             };
-            f64::from_bits(crate::typedarray::js_typed_array_copy_within(ta, target, start, end) as u64)
+            f64::from_bits(
+                crate::typedarray::js_typed_array_copy_within(ta, target, start, end) as u64,
+            )
         }
         "with" => {
             let idx = arg0();
@@ -1760,6 +1762,22 @@ pub unsafe extern "C" fn js_native_call_method(
                     method_name,
                 );
             }
+            // #2856: Map/Set iterators returned from a value-level
+            // `m.entries()`/`.keys()`/`.values()` / `s.entries()` etc. carry
+            // dedicated class ids so `.next()` lands in the matching iterator
+            // dispatcher (mirroring the array iterator above).
+            if (*obj).class_id == crate::collection_iter_object::MAP_ITERATOR_CLASS_ID {
+                return crate::collection_iter_object::dispatch_map_iterator_method(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                );
+            }
+            if (*obj).class_id == crate::collection_iter_object::SET_ITERATOR_CLASS_ID {
+                return crate::collection_iter_object::dispatch_set_iterator_method(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                );
+            }
 
             // Scan object fields for a callable property (closure stored via IndexSet)
             let keys = (*obj).keys_array;
@@ -2036,17 +2054,32 @@ pub unsafe extern "C" fn js_native_call_method(
                         f64::from_bits(crate::value::TAG_UNDEFINED)
                     }
                     "size" => crate::map::js_map_size(map) as f64,
+                    // #2856: value-level iterator methods return real iterator
+                    // OBJECTS (not arrays), dispatched via class id.
                     "entries" => f64::from_bits(
-                        JSValue::pointer(crate::map::js_map_entries(map) as *mut u8).bits(),
+                        JSValue::pointer(
+                            crate::collection_iter_object::js_map_entries_iter_obj(map) as *mut u8,
+                        )
+                        .bits(),
                     ),
                     "keys" => f64::from_bits(
-                        JSValue::pointer(crate::map::js_map_keys(map) as *mut u8).bits(),
+                        JSValue::pointer(
+                            crate::collection_iter_object::js_map_keys_iter_obj(map) as *mut u8
+                        )
+                        .bits(),
                     ),
                     "values" => f64::from_bits(
-                        JSValue::pointer(crate::map::js_map_values(map) as *mut u8).bits(),
+                        JSValue::pointer(
+                            crate::collection_iter_object::js_map_values_iter_obj(map) as *mut u8,
+                        )
+                        .bits(),
                     ),
                     "forEach" if !args.is_empty() => {
-                        crate::map::js_map_foreach(map, args[0]);
+                        let this_arg = args
+                            .get(1)
+                            .copied()
+                            .unwrap_or(f64::from_bits(crate::value::TAG_UNDEFINED));
+                        crate::map::js_map_foreach(map, args[0], this_arg);
                         f64::from_bits(crate::value::TAG_UNDEFINED)
                     }
                     _ => f64::from_bits(crate::value::TAG_UNDEFINED),
@@ -2077,6 +2110,30 @@ pub unsafe extern "C" fn js_native_call_method(
                         f64::from_bits(crate::value::TAG_UNDEFINED)
                     }
                     "size" => crate::set::js_set_size(set) as f64,
+                    // #2856: dynamic Set iterator methods previously fell
+                    // through to `undefined` (only add/has/delete/clear/size
+                    // were handled). Return real iterator objects; `entries`
+                    // yields `[v, v]` pairs.
+                    "values" | "keys" => f64::from_bits(
+                        JSValue::pointer(
+                            crate::collection_iter_object::js_set_values_iter_obj(set) as *mut u8,
+                        )
+                        .bits(),
+                    ),
+                    "entries" => f64::from_bits(
+                        JSValue::pointer(
+                            crate::collection_iter_object::js_set_entries_iter_obj(set) as *mut u8,
+                        )
+                        .bits(),
+                    ),
+                    "forEach" if !args.is_empty() => {
+                        let this_arg = args
+                            .get(1)
+                            .copied()
+                            .unwrap_or(f64::from_bits(crate::value::TAG_UNDEFINED));
+                        crate::set::js_set_foreach(set, args[0], this_arg);
+                        f64::from_bits(crate::value::TAG_UNDEFINED)
+                    }
                     _ => f64::from_bits(crate::value::TAG_UNDEFINED),
                 };
             }
@@ -2121,6 +2178,19 @@ pub unsafe extern "C" fn js_native_call_method(
             // #321: same array-iterator class-id check as the NaN-boxed path.
             if (*obj).class_id == crate::array::ARRAY_ITERATOR_CLASS_ID {
                 return crate::array::dispatch_array_iterator_method(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                );
+            }
+            // #2856: same Map/Set-iterator class-id checks as the NaN-boxed path.
+            if (*obj).class_id == crate::collection_iter_object::MAP_ITERATOR_CLASS_ID {
+                return crate::collection_iter_object::dispatch_map_iterator_method(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                );
+            }
+            if (*obj).class_id == crate::collection_iter_object::SET_ITERATOR_CLASS_ID {
+                return crate::collection_iter_object::dispatch_set_iterator_method(
                     obj as *mut ObjectHeader,
                     method_name,
                 );

--- a/crates/perry-runtime/src/object/util_types.rs
+++ b/crates/perry-runtime/src/object/util_types.rs
@@ -294,10 +294,21 @@ pub extern "C" fn js_util_types_is_proxy(value: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_util_types_is_map_iterator(value: f64) -> f64 {
-    nanbox_bool(crate::map::is_registered_map_iterator(jsvalue_addr(value)))
+    let addr = jsvalue_addr(value);
+    // #2856: real Map iterator objects carry a dedicated class id. The
+    // legacy side-table marker on materialized arrays is kept as a fallback
+    // for any path that still produces a marked array.
+    nanbox_bool(
+        crate::collection_iter_object::is_map_iterator_addr(addr)
+            || crate::map::is_registered_map_iterator(addr),
+    )
 }
 
 #[no_mangle]
 pub extern "C" fn js_util_types_is_set_iterator(value: f64) -> f64 {
-    nanbox_bool(crate::set::is_registered_set_iterator(jsvalue_addr(value)))
+    let addr = jsvalue_addr(value);
+    nanbox_bool(
+        crate::collection_iter_object::is_set_iterator_addr(addr)
+            || crate::set::is_registered_set_iterator(addr),
+    )
 }

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -643,34 +643,26 @@ pub extern "C" fn js_set_delete(set: *mut SetHeader, value: f64) -> i32 {
         let size = (*set).size;
         let elements = elements_ptr_mut(set);
 
-        // Update the hash index: remove the deleted value,
-        // and if we swap-remove, update the swapped element's index.
-        SET_INDEX.with(|sidx| {
-            let mut sidx = sidx.borrow_mut();
-            if let Some(map) = sidx.get_mut(&(set as usize)) {
-                map.remove(&JSValueKey(value));
-                if (idx as u32) < size - 1 {
-                    let last_value = ptr::read(elements.add((size - 1) as usize));
-                    // Update the last element's index to the position of the deleted element
-                    if let Some(entry) = map.get_mut(&JSValueKey(last_value)) {
-                        *entry = idx as u32;
-                    }
-                }
-            }
-        });
-
-        // If not the last element, swap with the last element
-        if (idx as u32) < size - 1 {
-            let last_value = ptr::read(elements.add((size - 1) as usize));
-            // GC_STORE_AUDIT(EXTERNAL_BARRIERED): Set swap-remove stores through the shared external-slot helper.
+        // #2831: preserve insertion order. The previous swap-remove moved
+        // the last element into the hole, reordering iteration. Shift every
+        // element after `idx` down by one slot instead so survivors keep
+        // their relative order (and a delete-then-re-add appends at the end).
+        for i in (idx as usize)..(size as usize - 1) {
+            let next_value = ptr::read(elements.add(i + 1));
+            // GC_STORE_AUDIT(EXTERNAL_BARRIERED): Set compaction stores through the shared external-slot helper.
             crate::gc::runtime_store_external_jsvalue_slot(
                 set as usize,
-                elements.add(idx as usize) as usize,
-                last_value.to_bits(),
+                elements.add(i) as usize,
+                next_value.to_bits(),
             );
         }
 
         (*set).size = size - 1;
+
+        // The shift changes the stored index of every surviving element at
+        // or after `idx`, so rebuild the O(1) lookup index from the
+        // compacted buffer.
+        rebuild_set_index(set);
         1
     }
 }
@@ -842,10 +834,12 @@ pub extern "C" fn js_set_from_iterable(value: f64) -> *mut SetHeader {
     set_handle.get_raw_mut_ptr::<SetHeader>()
 }
 
-/// Iterate over set elements, calling a callback with (value, value, set) for each
-/// Matches JS Set.forEach signature where key===value (so we pass value twice).
+/// `Set.prototype.forEach(callback, thisArg)` — calls `callback` with
+/// `(value, value, set)` (key === value for Sets, #2830) and binds
+/// `thisArg` as the callback's `this`. `this_arg` is `undefined` when
+/// omitted at the call site.
 #[no_mangle]
-pub extern "C" fn js_set_foreach(set: *const SetHeader, callback: f64) {
+pub extern "C" fn js_set_foreach(set: *const SetHeader, callback: f64, this_arg: f64) {
     let set = clean_set_ptr(set);
     if set.is_null() {
         return;
@@ -853,15 +847,15 @@ pub extern "C" fn js_set_foreach(set: *const SetHeader, callback: f64) {
     let scope = crate::gc::RuntimeHandleScope::new();
     let set_handle = scope.root_raw_const_ptr(set);
     let callback_handle = scope.root_nanbox_f64(callback);
+    let this_handle = scope.root_nanbox_f64(this_arg);
     unsafe {
         let set = set_handle.get_raw_const_ptr::<SetHeader>();
         let size = (*set).size as usize;
         if size == 0 {
             return;
         }
-
-        // Extract the closure pointer from the NaN-boxed callback.
-        // Mask off the upper 16 bits (NaN-box tag) to get the real pointer.
+        // The Set itself is the third callback argument / `self === s`.
+        let set_value = crate::value::js_nanbox_pointer(set as i64);
 
         for i in 0..size {
             let set = set_handle.get_raw_const_ptr::<SetHeader>();
@@ -870,10 +864,12 @@ pub extern "C" fn js_set_foreach(set: *const SetHeader, callback: f64) {
             }
             let elements = elements_ptr(set);
             let value = ptr::read(elements.add(i));
-            let closure_ptr = (callback_handle.get_nanbox_u64() & 0x0000_FFFF_FFFF_FFFF)
-                as *const crate::closure::ClosureHeader;
-            // Call closure with (value, value) - Set.forEach callback gets (value, value) in JS
-            crate::closure::js_closure_call2(closure_ptr, value, value);
+            let args = [value, value, set_value];
+            let cb = callback_handle.get_nanbox_f64();
+            let this_v = this_handle.get_nanbox_f64();
+            let prev_this = crate::object::js_implicit_this_set(this_v);
+            let _ = crate::closure::js_native_call_value(cb, args.as_ptr(), args.len());
+            crate::object::js_implicit_this_set(prev_this);
         }
     }
 }

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -1273,6 +1273,35 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
             }
         }
     }
+    // #2856: `Map.prototype[Symbol.iterator]` aliases `entries`, and
+    // `Set.prototype[Symbol.iterator]` aliases `values`. Bind the matching
+    // method so `m[Symbol.iterator]()` returns a real iterator object (and
+    // `Symbol.iterator in m` / `typeof m[Symbol.iterator]` are correct).
+    if raw_addr >= 0x10000 {
+        let iter_wk = well_known_symbol("iterator");
+        if !iter_wk.is_null() {
+            let iter_f64 =
+                f64::from_bits(crate::value::JSValue::pointer(iter_wk as *const u8).bits());
+            if sym_key_from_f64(sym_f64) == sym_key_from_f64(iter_f64) {
+                if crate::map::is_registered_map(raw_addr) {
+                    let mname = b"entries";
+                    return crate::object::js_class_method_bind(
+                        obj_f64,
+                        mname.as_ptr(),
+                        mname.len(),
+                    );
+                }
+                if crate::set::is_registered_set(raw_addr) {
+                    let mname = b"values";
+                    return crate::object::js_class_method_bind(
+                        obj_f64,
+                        mname.as_ptr(),
+                        mname.len(),
+                    );
+                }
+            }
+        }
+    }
     // #1758: a POINTER class-object whose OWN symbol props miss may inherit
     // the symbol through its class_id prototype chain. (The SYMBOL_PROPERTIES
     // lock is released above before recursing into the resolver, which takes

--- a/test-files/test_gap_mapset_iter_2831_2830_2856.ts
+++ b/test-files/test_gap_mapset_iter_2831_2830_2856.ts
@@ -1,0 +1,62 @@
+// #2831: insertion order preserved after delete (+ re-add appends at end)
+console.log("set del first:", JSON.stringify(Array.from((() => {
+  const s = new Set([1, 2, 3]);
+  s.delete(1);
+  return s;
+})())));
+console.log("set del mid:", JSON.stringify(Array.from((() => {
+  const s = new Set([1, 2, 3, 4]);
+  s.delete(2);
+  return s;
+})())));
+console.log("map del mid:", JSON.stringify(Array.from((() => {
+  const m = new Map([[1, "a"], [2, "b"], [3, "c"], [4, "d"]]);
+  m.delete(2);
+  return m.keys();
+})())));
+console.log("map del readd:", JSON.stringify(Array.from((() => {
+  const m = new Map([[1, "a"], [2, "b"]]);
+  m.delete(1);
+  m.set(1, "z");
+  return m.entries();
+})())));
+
+// #2830: forEach arg arity (value, key, collection) + thisArg + undefined return
+const m = new Map([["k", "v"]]);
+const ctx = { tag: "ctx" };
+const out: unknown[] = [];
+const ret = m.forEach(function (this: any, value, key, self) {
+  out.push(this.tag, value, key, self === m);
+}, ctx);
+console.log("map forEach:", JSON.stringify(out), ret === undefined);
+
+const s = new Set(["x"]);
+const out2: unknown[] = [];
+s.forEach(function (this: any, value, key, self) {
+  out2.push(this.tag, value, key, self === s);
+}, ctx);
+console.log("set forEach:", JSON.stringify(out2));
+
+// #2856: real iterator objects
+import { types } from "node:util";
+const mk = new Map([[1, "a"], [2, "b"]]).keys();
+console.log("map keys array:", Array.isArray(mk));
+console.log("map keys next type:", typeof (mk as any).next);
+console.log("map keys util:", types.isMapIterator(mk));
+console.log("map keys next:", JSON.stringify((mk as any).next()), JSON.stringify((mk as any).next()));
+
+const se = new Set(["x", "y"]).entries();
+console.log("set entries array:", Array.isArray(se));
+console.log("set entries next type:", typeof (se as any).next);
+console.log("set entries util:", types.isSetIterator(se));
+console.log("set entries next:", JSON.stringify((se as any).next()), JSON.stringify((se as any).next()));
+
+// default iterators
+console.log("map default:", new Map([[1, "a"]])[Symbol.iterator]().next().value.join(":"));
+console.log("set default:", new Set(["x"])[Symbol.iterator]().next().value);
+
+// spread + for-of of iterator results
+console.log("spread map entries:", JSON.stringify([...new Map([[1, "a"], [2, "b"]]).entries()]));
+const keysOut: number[] = [];
+for (const k of new Set([10, 20, 30]).keys()) keysOut.push(k);
+console.log("for-of set keys:", JSON.stringify(keysOut));


### PR DESCRIPTION
Closes #2831
Closes #2830
Closes #2856

## Implementation

Pure-runtime + codegen-dispatch fix for three Map/Set parity gaps. **No new HIR variants.**

### #2831 — insertion order after delete
`js_map_delete` / `js_set_delete` used swap-and-pop, which moved the last
entry into the deleted slot and reordered iteration. Both now shift the
surviving entries after the hole down by one slot, preserving insertion
order (and re-add appends at the end). The shift invalidates the O(1)
lookup side-tables' stored indexes, so they are rebuilt from the compacted
buffer (`rebuild_map_index` added in `map.rs`; `rebuild_set_index` reused
in `set.rs`).

### #2830 — forEach callback semantics
`js_map_foreach` / `js_set_foreach` now take a third `thisArg` parameter and
call the callback with the full triple — `(value, key, map)` for Map,
`(value, value, set)` for Set — via `js_native_call_value` wrapped in
`js_implicit_this_set(thisArg)` (the same pattern as
`URLSearchParams.forEach`). The codegen branch lowers the optional `args[1]`
thisArg and returns `undefined` (was `0.0`). The dynamic
`js_native_call_method` Map/Set arm forwards `args[1]` too.

### #2856 — real Map/Set iterator objects
New `collection_iter_object.rs` module (modeled on `array/iter_object.rs`):
a real iterator OBJECT with dedicated class ids (`MAP_ITERATOR_CLASS_ID =
0xFFFF_0007`, `SET_ITERATOR_CLASS_ID = 0xFFFF_0008`). Fields hold the
backing collection (NaN-boxed so the GC scanner keeps it), a cursor, and the
kind. `.next()` reads the collection LIVE per step, so it composes with the
#2831 order fix, and returns `{ value, done }`.

- Value-level `.entries()`/`.keys()`/`.values()` (and Set `.entries()`, which
  was previously missing on the typed-Set path) now lower to
  `js_*_iter_obj` instead of the eager array materializers. The
  `Expr::MapEntries`/`MapKeys`/`MapValues`/`SetValues` HIR variants still
  return arrays — they back the for-of / spread fast paths that iterate the
  collection directly, so those are untouched.
- The HIR Ident-fold (`local_array_methods.rs`) no longer folds Map/Set
  iterator methods to the array variants; they fall through to the codegen
  `is_map_expr`/`is_set_expr` dispatch.
- Dispatch (`.next()`/`[Symbol.iterator]()`) added to
  `native_call_method.rs` (NaN-boxed + raw-pointer paths), class-id detected
  in `flat_clone.rs` so `[...m.entries()]` / `Array.from(s.values())` drive
  the iterator protocol, and a property-GET arm in `field_get_set.rs` so
  `typeof it.next === "function"`.
- `Map.prototype[Symbol.iterator]` aliases `entries`, `Set.prototype[Symbol
  .iterator]` aliases `values` (bound via `js_class_method_bind` in
  `symbol.rs`).
- `util.types.isMapIterator` / `isSetIterator` now class-id based (legacy
  array-marker kept as fallback).

`#[used]` keepalive anchors pin the six codegen-only `js_*_iter_obj`
exports against the auto-optimize whole-program dead-strip.

## Validation

New gap test `test-files/test_gap_mapset_iter_2831_2830_2856.ts` is
**byte-identical** to `node --experimental-strip-types` under the DEFAULT
auto-optimize compile (delete-then-insert order; forEach arg arity + thisArg
+ undefined return; `[...map.entries()]`; `for (const k of set.keys())`;
iterator `.next()` `{value,done}` shape; `Array.isArray` false; `typeof
.next` function; `util.types.is{Map,Set}Iterator`; default `[Symbol
.iterator]()`).

- `cargo build --release` clean (cold).
- `cargo test --release -p perry-runtime` — 915 passed.
- `cargo test --release -p perry-hir` — green (incl.
  `expr_variant_stable_hash_tags_are_unique`; no HIR variant added).
- `cargo test --release -p perry-codegen` — green.
- `./scripts/check_file_size.sh` exit 0; `cargo fmt --all -- --check` clean.
- No regressions across the Map/Set/iterator gap-test corpus (the one diff,
  `test_gap_global_apis`, is a pre-existing `atob`/`btoa` latin1 issue
  unrelated to this change).
