### PR TITLE
fix(util): implement setTraceSigInt (#2514)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2816,6 +2816,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("util", "parseEnv", false, None),
     // #2514: util.toUSVString(value) → string with lone surrogates replaced.
     method("util", "toUSVString", false, None),
+    method("util", "setTraceSigInt", false, None),
     // `util.formatWithOptions(options, format[, ...args])` — identical to
     // `util.format` except the first arg is an `util.inspect` options bag
     // applied to any `%o`/`%O` placeholders. Required by the `debug` npm
@@ -2915,6 +2916,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("sys", "stripVTControlCharacters", false, None),
     method("sys", "styleText", false, None),
     method("sys", "toUSVString", false, None),
+    method("sys", "setTraceSigInt", false, None),
     class("sys", "TextEncoder"),
     class("sys", "TextDecoder"),
     property("sys", "types"),

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -1125,6 +1125,16 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    // #2514: util.setTraceSigInt(enable) → validate boolean, return undefined.
+    NativeModSig {
+        module: "util",
+        has_receiver: false,
+        method: "setTraceSigInt",
+        class_filter: None,
+        runtime: "js_util_set_trace_sig_int",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     NativeModSig {
         module: "util",
         has_receiver: false,

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -149,6 +149,7 @@ pub mod util_call_sites;
 pub mod util_parse_args;
 pub mod util_parse_env;
 pub mod util_promisify;
+pub mod util_settracesigint;
 pub mod util_style_text;
 pub mod util_syserr;
 pub mod util_usv;

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -421,6 +421,7 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
             b"stripVTControlCharacters",
             b"styleText",
             b"toUSVString",
+            b"setTraceSigInt",
             b"types",
             b"parseArgs",
             b"TextDecoder",
@@ -1436,6 +1437,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("util", "stripVTControlCharacters")
             | ("util", "styleText")
             | ("util", "toUSVString")
+            | ("util", "setTraceSigInt")
             | ("zlib", "Deflate")
             | ("zlib", "DeflateRaw")
             | ("zlib", "Gzip")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1002,6 +1002,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("util", "styleText") => crate::util_style_text::js_util_style_text(arg(0), arg(1), arg(2)),
         // #2514: util.toUSVString(value) → string with lone surrogates → U+FFFD.
         ("util", "toUSVString") => crate::util_usv::js_util_to_usv_string(arg(0)),
+        ("util", "setTraceSigInt") => crate::util_settracesigint::js_util_set_trace_sig_int(arg(0)),
         ("util", "promisify") => crate::util_promisify::js_util_promisify(arg(0)),
         ("util", "callbackify") => crate::util_promisify::js_util_callbackify(arg(0)),
         ("util", "deprecate") => crate::util_promisify::js_util_deprecate(arg(0), arg(1), arg(2)),

--- a/crates/perry-runtime/src/util_settracesigint.rs
+++ b/crates/perry-runtime/src/util_settracesigint.rs
@@ -1,0 +1,20 @@
+//! `util.setTraceSigInt(enable)` (#2514) — toggle printing a JS stack trace on
+//! SIGINT. `enable` must be a boolean (else `ERR_INVALID_ARG_TYPE`); the call
+//! returns `undefined`.
+//!
+//! Perry does not install a SIGINT stack-trace handler, so this validates the
+//! argument and is otherwise a no-op — matching Node's observable contract
+//! (boolean in, `undefined` out, throw on non-boolean).
+
+use crate::value::{JSValue, TAG_UNDEFINED};
+
+#[no_mangle]
+pub extern "C" fn js_util_set_trace_sig_int(enable: f64) -> f64 {
+    if !JSValue::from_bits(enable.to_bits()).is_bool() {
+        crate::fs::validate::throw_type_error_with_code(
+            "The \"enable\" argument must be of type boolean.",
+            "ERR_INVALID_ARG_TYPE",
+        );
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1833 entries across 89 modules
+// Coverage: 1835 entries across 89 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -2647,6 +2647,8 @@ declare module "sys" {
   /** stdlib */
   export function promisify(...args: any[]): any;
   /** stdlib */
+  export function setTraceSigInt(...args: any[]): any;
+  /** stdlib */
   export function stripVTControlCharacters(...args: any[]): any;
   /** stdlib */
   export function styleText(...args: any[]): any;
@@ -2747,6 +2749,8 @@ declare module "util" {
   export function parseEnv(...args: any[]): any;
   /** stdlib */
   export function promisify(...args: any[]): any;
+  /** stdlib */
+  export function setTraceSigInt(...args: any[]): any;
   /** stdlib */
   export function stripVTControlCharacters(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1833 entries across 89 modules.
+Total: 1835 entries across 89 modules.
 
 ## Modules
 
@@ -2268,6 +2268,7 @@ Total: 1833 entries across 89 modules.
 - `parseArgs` — module
 - `parseEnv` — module
 - `promisify` — module
+- `setTraceSigInt` — module
 - `stripVTControlCharacters` — module
 - `styleText` — module
 - `toUSVString` — module
@@ -2355,6 +2356,7 @@ Total: 1833 entries across 89 modules.
 - `parseArgs` — module
 - `parseEnv` — module
 - `promisify` — module
+- `setTraceSigInt` — module
 - `stripVTControlCharacters` — module
 - `styleText` — module
 - `toUSVString` — module

--- a/test-files/test_gap_2514_settracesigint.ts
+++ b/test-files/test_gap_2514_settracesigint.ts
@@ -1,0 +1,16 @@
+// #2514 — util.setTraceSigInt(enable): boolean → undefined; non-boolean throws.
+import { setTraceSigInt } from "node:util";
+
+console.log(typeof setTraceSigInt);
+console.log(String(setTraceSigInt(true)));
+console.log(String(setTraceSigInt(false)));
+try {
+  setTraceSigInt("x" as unknown as boolean);
+} catch (e) {
+  console.log("badtype=" + (e as { code?: string }).code);
+}
+try {
+  setTraceSigInt(1 as unknown as boolean);
+} catch (e) {
+  console.log("badnum=" + (e as { code?: string }).code);
+}


### PR DESCRIPTION
Implements `util.setTraceSigInt(enable)` (part of #2514).

## Behavior

`enable` must be a boolean (else `ERR_INVALID_ARG_TYPE`); the call returns `undefined`. Perry does not install a SIGINT stack-trace handler, so this validates the argument and is otherwise a no-op — matching Node's observable contract (boolean in, `undefined` out, throw on non-boolean).

## Wiring

New `crates/perry-runtime/src/util_settracesigint.rs` (`js_util_set_trace_sig_int`), plus standard `node:util` helper wiring: `lib.rs` module, `native_module.rs` whitelist + value-gate, dispatch arm, manifest `method("util",…)` and `method("sys",…)`, and a `NativeModSig` row. Docs regenerated.

## Validation

`test-files/test_gap_2514_settracesigint.ts` is byte-for-byte identical to `node --experimental-strip-types`: `typeof === "function"`, `setTraceSigInt(true)`/`(false)` → `undefined`, and `ERR_INVALID_ARG_TYPE` for a string and a number argument.

`cargo build --release -p perry-runtime -p perry-stdlib -p perry` clean; `cargo test -p perry-api-manifest --lib sys_alias_mirrors_util_manifest` passes; `cargo fmt --all -- --check` clean; api docs regenerate idempotently.
