### PR TITLE
fix(number/string): toString radix validation, String.at code units, tagged-template freeze

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -151,6 +151,10 @@ pub fn try_lower_property_get_method_call(
             .unwrap_or(false);
         if !has_user_to_string {
             let v = lower_expr(ctx, object)?;
+            // Always lower the raw arg value too: for a Number/BigInt receiver
+            // the string is the radix (ToNumber-coerced at runtime, #2864), not
+            // an encoding. Disambiguation is by receiver type at runtime.
+            let arg_box = lower_expr(ctx, &args[0])?;
             let enc_tag_i32 = if let Expr::String(s) = &args[0] {
                 let lower = s.to_ascii_lowercase();
                 let tag: i32 = match lower.as_str() {
@@ -165,15 +169,14 @@ pub fn try_lower_property_get_method_call(
                 };
                 tag.to_string()
             } else {
-                let enc_box = lower_expr(ctx, &args[0])?;
                 let blk = ctx.block();
-                blk.call(I32, "js_encoding_tag_from_value", &[(DOUBLE, &enc_box)])
+                blk.call(I32, "js_encoding_tag_from_value", &[(DOUBLE, &arg_box)])
             };
             let blk = ctx.block();
             let handle = blk.call(
                 I64,
-                "js_value_to_string_with_encoding",
-                &[(DOUBLE, &v), (I32, &enc_tag_i32)],
+                "js_value_to_string_with_encoding_or_radix",
+                &[(DOUBLE, &v), (I32, &enc_tag_i32), (DOUBLE, &arg_box)],
             );
             return Ok(Some(nanbox_string_inline(blk, &handle)));
         }
@@ -205,13 +208,16 @@ pub fn try_lower_property_get_method_call(
             .unwrap_or(false);
         if !has_user_to_string {
             let v = lower_expr(ctx, object)?;
-            let radix_d = lower_expr(ctx, &args[0])?;
+            // Pass the *raw* NaN-boxed radix value (not an `fptosi` i32). The
+            // runtime performs ECMAScript ToNumber/ToInteger coercion and
+            // `RangeError` validation on it (#2864); an `fptosi` here would
+            // silently collapse NaN/Infinity/string radices to 0 or garbage.
+            let radix_v = lower_expr(ctx, &args[0])?;
             let blk = ctx.block();
-            let radix_i32 = blk.fptosi(DOUBLE, &radix_d, I32);
             let handle = blk.call(
                 I64,
                 "js_jsvalue_to_string_radix",
-                &[(DOUBLE, &v), (I32, &radix_i32)],
+                &[(DOUBLE, &v), (DOUBLE, &radix_v)],
             );
             return Ok(Some(nanbox_string_inline(blk, &handle)));
         }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -467,7 +467,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_string_replace_all_string", I64, &[I64, I64, I64]);
     module.declare_function("js_string_equals", I32, &[I64, I64]);
     module.declare_function("js_string_compare", I32, &[I64, I64]);
-    module.declare_function("js_jsvalue_to_string_radix", I64, &[DOUBLE, I32]);
+    module.declare_function("js_jsvalue_to_string_radix", I64, &[DOUBLE, DOUBLE]);
     module.declare_function("js_math_random", DOUBLE, &[]);
     // WebAssembly host runtime (issue #76). All take/return NaN-boxed
     // doubles (JSValues). Implementations live in
@@ -955,6 +955,13 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // Universal `.toString(encoding)` dispatch — branches on
     // is_registered_buffer at runtime, falls back to js_jsvalue_to_string.
     module.declare_function("js_value_to_string_with_encoding", I64, &[DOUBLE, I32]);
+    // Buffer-encoding OR number/bigint-radix dispatch (#2864): the string arg
+    // is ambiguous, so pass both the pre-parsed encoding tag and the raw arg.
+    module.declare_function(
+        "js_value_to_string_with_encoding_or_radix",
+        I64,
+        &[DOUBLE, I32, DOUBLE],
+    );
     module.declare_function("js_fs_unlink_sync", I32, &[DOUBLE]);
     module.declare_function("js_object_values", I64, &[I64]);
     module.declare_function("js_object_values_value", I64, &[DOUBLE]);

--- a/crates/perry-runtime/src/buffer/encode.rs
+++ b/crates/perry-runtime/src/buffer/encode.rs
@@ -185,6 +185,48 @@ pub extern "C" fn js_value_to_string_with_encoding(value: f64, enc_tag: i32) -> 
     crate::value::js_jsvalue_to_string(value)
 }
 
+/// `value.toString(arg)` where `arg` is statically a *string* and `value` is
+/// NOT statically a string/array. The arg is ambiguous: for a `Buffer`
+/// receiver it is an encoding name; for a `Number`/`BigInt` receiver it is the
+/// radix (ECMAScript coerces a string radix via ToNumber — `(255).toString("16")`
+/// === `"ff"`, #2864). We can only disambiguate at runtime by the receiver's
+/// type, so codegen passes both the pre-parsed encoding `enc_tag` and the raw
+/// NaN-boxed `arg` value. Buffers use the encoding; numbers/bigints use the
+/// radix; everything else falls back to plain stringification.
+#[no_mangle]
+pub extern "C" fn js_value_to_string_with_encoding_or_radix(
+    value: f64,
+    enc_tag: i32,
+    arg: f64,
+) -> *mut StringHeader {
+    let bits = value.to_bits();
+    let top16 = bits >> 48;
+    let ptr_addr = if top16 >= 0x7FF8 {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else if top16 == 0 && bits >= 0x1000 {
+        bits as usize
+    } else {
+        0
+    };
+    if ptr_addr != 0 && is_registered_buffer(ptr_addr) {
+        return js_buffer_to_string(ptr_addr as *const BufferHeader, enc_tag);
+    }
+    // Non-buffer: a Number or BigInt receiver treats the string arg as a radix.
+    let jsval = crate::value::JSValue::from_bits(bits);
+    if jsval.is_number() || jsval.is_int32() || jsval.is_bigint() {
+        return crate::value::js_jsvalue_to_string_radix(value, arg);
+    }
+    crate::value::js_jsvalue_to_string(value)
+}
+
+/// Keepalive anchor: `js_value_to_string_with_encoding_or_radix` is emitted
+/// only from generated `.o`, so the auto-optimize whole-program LLVM rebuild
+/// would internalize + dead-strip it without a `#[used]` reference (see
+/// project_auto_optimize_keepalive_3320).
+#[used]
+static KEEP_VALUE_TO_STRING_ENCODING_OR_RADIX: extern "C" fn(f64, i32, f64) -> *mut StringHeader =
+    js_value_to_string_with_encoding_or_radix;
+
 /// Print a buffer in Node.js `<Buffer xx xx ...>` format to stdout
 #[no_mangle]
 pub extern "C" fn js_buffer_print(buf_ptr: *const BufferHeader) {

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -796,12 +796,16 @@ pub unsafe extern "C" fn js_native_call_method(
                 return crate::bigint::js_bigint_to_f64(bigint_ptr);
             }
             "toString" => {
-                let result_ptr = if args_len > 0 && !args_ptr.is_null() {
-                    let radix_f64 = *args_ptr;
-                    let radix = radix_f64 as i32;
-                    crate::bigint::js_bigint_to_string_radix(bigint_ptr, radix)
+                // #2864: ToNumber/ToInteger-coerce + validate the radix
+                // (RangeError for out-of-range), `None`/no-arg → decimal.
+                let radix = if args_len > 0 && !args_ptr.is_null() {
+                    crate::value::coerce_validate_radix(*args_ptr)
                 } else {
-                    crate::bigint::js_bigint_to_string(bigint_ptr)
+                    None
+                };
+                let result_ptr = match radix {
+                    Some(r) => crate::bigint::js_bigint_to_string_radix(bigint_ptr, r),
+                    None => crate::bigint::js_bigint_to_string(bigint_ptr),
                 };
                 return f64::from_bits(JSValue::string_ptr(result_ptr).bits());
             }

--- a/crates/perry-runtime/src/string/char_ops.rs
+++ b/crates/perry-runtime/src/string/char_ops.rs
@@ -216,20 +216,16 @@ pub extern "C" fn js_string_at(s: *const StringHeader, index: i32) -> f64 {
     if resolved < 0 || resolved >= len {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
-    // Decode the UTF-16 code unit at `resolved`. If it's a high surrogate followed
-    // by a low surrogate, decode the pair; otherwise the unit is the code point.
+    // #2948: `at()` is UTF-16 *code-unit* based, exactly like `charAt`/`[i]` —
+    // NOT code-point based like `codePointAt`. For an astral char stored as a
+    // surrogate pair, each index returns the lone surrogate code unit (Node:
+    // `"😀".at(0).charCodeAt(0) === 0xd83d`), it does NOT decode the pair.
     let unit = utf16[resolved as usize];
-    let cp: u32 = if (0xD800..=0xDBFF).contains(&unit) && (resolved + 1) < len {
-        let next = utf16[(resolved + 1) as usize];
-        if (0xDC00..=0xDFFF).contains(&next) {
-            0x10000 + ((unit as u32 - 0xD800) << 10) + (next as u32 - 0xDC00)
-        } else {
-            unit as u32
-        }
-    } else {
-        unit as u32
-    };
-    let ch = char::from_u32(cp).unwrap_or('\u{FFFD}');
+    // Encode the single code unit. A lone surrogate (0xD800..=0xDFFF) is not a
+    // valid Rust `char`, so it materializes as U+FFFD — the documented WTF-8 /
+    // lone-surrogate categorical gap (same shim as `fromCharCode`). BMP units
+    // round-trip exactly.
+    let ch = char::from_u32(unit as u32).unwrap_or('\u{FFFD}');
     let mut buf = [0u8; 4];
     let encoded = ch.encode_utf8(&mut buf);
     let ptr = js_string_from_bytes(encoded.as_ptr(), encoded.len() as u32);

--- a/crates/perry-runtime/src/value/mod.rs
+++ b/crates/perry-runtime/src/value/mod.rs
@@ -105,6 +105,7 @@ pub use dynamic_arith::{
 pub use dyn_index::{js_dyn_index_get, js_dyn_index_set, js_is_undefined_or_bare_nan};
 
 // ----- to-string conversion helpers -----
+pub(crate) use to_string::coerce_validate_radix;
 pub use to_string::{js_ensure_string_ptr, js_jsvalue_to_string, js_jsvalue_to_string_radix};
 
 // ----- Equality, comparison, SameValueZero, dynamic string equality -----

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -329,14 +329,212 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
     }
 }
 
-/// Convert a NaN-boxed f64 value to a string with the given radix.
-/// Handles BigInt (uses bigint_to_string_radix), numbers, strings, etc.
+/// ECMAScript `ToNumber` for a radix argument value (NaN-boxed f64). Numbers
+/// pass through; strings are parsed with `Number()` semantics (trim + full
+/// numeric parse, NOT `parseFloat` prefix parse — `"16px"` → NaN); booleans →
+/// 0/1; null → 0; undefined → NaN (signals "use the default radix 10").
+/// Returns NaN for anything that does not coerce to a finite number.
+unsafe fn radix_arg_to_number(radix_value: f64) -> f64 {
+    let jsval = JSValue::from_bits(radix_value.to_bits());
+    if jsval.is_int32() {
+        jsval.as_int32() as f64
+    } else if jsval.is_bool() {
+        if jsval.as_bool() {
+            1.0
+        } else {
+            0.0
+        }
+    } else if jsval.is_null() {
+        0.0
+    } else if jsval.is_undefined() {
+        // Signals the "no radix supplied" / default path.
+        f64::NAN
+    } else if jsval.is_any_string() {
+        let s_ptr = js_jsvalue_to_string(radix_value);
+        if s_ptr.is_null() {
+            return f64::NAN;
+        }
+        let len = (*s_ptr).byte_len as usize;
+        let data = (s_ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+        let bytes = std::slice::from_raw_parts(data, len);
+        let trimmed = std::str::from_utf8(bytes).unwrap_or("").trim();
+        if trimmed.is_empty() {
+            // `Number("")` === 0
+            0.0
+        } else {
+            trimmed.parse::<f64>().unwrap_or(f64::NAN)
+        }
+    } else {
+        // Plain f64 number (or some other heap pointer that does not coerce
+        // to a finite radix — treat as NaN so it triggers RangeError).
+        if jsval.is_number() {
+            radix_value
+        } else {
+            f64::NAN
+        }
+    }
+}
+
+/// Coerce + validate a radix argument per ECMAScript `Number.prototype.toString`
+/// (and `BigInt.prototype.toString`). Returns the validated integer radix in
+/// `2..=36`, or `None` when the argument was `undefined` (caller uses the
+/// default radix 10). Throws (diverges via `js_throw`) with a `RangeError` for
+/// any other out-of-range / non-coercible value, matching Node.
+pub(crate) unsafe fn coerce_validate_radix(radix_value: f64) -> Option<i32> {
+    let n = radix_arg_to_number(radix_value);
+    if n.is_nan() {
+        // `undefined` → default radix (None); everything else NaN → RangeError.
+        if JSValue::from_bits(radix_value.to_bits()).is_undefined() {
+            return None;
+        }
+        throw_radix_range_error();
+    }
+    // ToInteger: truncate toward zero.
+    let r = n.trunc();
+    if !(2.0..=36.0).contains(&r) {
+        throw_radix_range_error();
+    }
+    Some(r as i32)
+}
+
+fn throw_radix_range_error() -> ! {
+    let message = b"toString() radix must be between 2 and 36";
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_rangeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+/// V8-style `DoubleToRadixCString`: render a finite, non-integer f64 in
+/// `radix` (2..=36) producing the shortest digit sequence that round-trips
+/// back to the same double. Mirrors ECMAScript `Number::toString` for
+/// non-decimal radices, including the fractional part (`(10.5).toString(2)`
+/// === `"1010.1"`). Assumes `radix` is already validated.
+fn double_to_radix_string(value: f64, radix: u32) -> String {
+    debug_assert!((2..=36).contains(&radix));
+    const CHARS: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+
+    let negative = value < 0.0;
+    let abs = value.abs();
+
+    // Split into integer and fractional parts.
+    let mut integer = abs.floor();
+    let mut fraction = abs - integer;
+
+    // `delta` is half the distance to the next representable double, the
+    // tolerance used to decide when enough fractional digits have been
+    // emitted to uniquely identify `value` (shortest round-trip).
+    let mut delta = 0.5 * (next_double(abs) - abs);
+    delta = next_double(0.0).max(delta);
+
+    let mut frac_buf = String::new();
+    if fraction >= delta {
+        frac_buf.push('.');
+        loop {
+            // Shift up by the radix.
+            fraction *= radix as f64;
+            delta *= radix as f64;
+            // Extract the digit.
+            let digit = fraction.floor() as usize;
+            frac_buf.push(CHARS[digit] as char);
+            fraction -= digit as f64;
+            if fraction >= 0.5 && fraction > delta {
+                // Round up: carry into the already-emitted digits.
+                if fraction + delta > 1.0 {
+                    // Propagate the carry through fraction digits, possibly
+                    // into the integer part.
+                    loop {
+                        // Pop the last char; if it was '.', carry into integer.
+                        let last = frac_buf.pop();
+                        match last {
+                            None => {
+                                integer += 1.0;
+                                break;
+                            }
+                            Some('.') => {
+                                frac_buf.push('.');
+                                integer += 1.0;
+                                break;
+                            }
+                            Some(c) => {
+                                let idx = CHARS.iter().position(|&b| b as char == c).unwrap();
+                                if idx + 1 < radix as usize {
+                                    frac_buf.push(CHARS[idx + 1] as char);
+                                    break;
+                                }
+                                // Was the max digit (e.g. 'f' in hex): becomes
+                                // '0' and the carry continues leftward.
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+            if fraction < delta {
+                break;
+            }
+        }
+        // A trailing '.' with no fraction digits (carry consumed all) is junk.
+        if frac_buf == "." {
+            frac_buf.clear();
+        }
+    }
+
+    // Integer part: repeated division. `integer` may have grown via carry.
+    let mut int_buf = String::new();
+    if integer == 0.0 {
+        int_buf.push('0');
+    } else {
+        while integer >= 1.0 {
+            let remainder = (integer % radix as f64) as usize;
+            int_buf.push(CHARS[remainder] as char);
+            integer = (integer / radix as f64).floor();
+        }
+    }
+    let int_part: String = int_buf.chars().rev().collect();
+
+    let mut result = String::new();
+    if negative {
+        result.push('-');
+    }
+    result.push_str(&int_part);
+    result.push_str(&frac_buf);
+    result
+}
+
+/// Smallest representable double strictly greater than `x` (for finite `x`).
+fn next_double(x: f64) -> f64 {
+    if x.is_nan() || x == f64::INFINITY {
+        return x;
+    }
+    let bits = x.to_bits();
+    let next = if x >= 0.0 {
+        bits + 1
+    } else if bits == (1u64 << 63) {
+        // -0.0 → smallest positive subnormal
+        1
+    } else {
+        bits - 1
+    };
+    f64::from_bits(next)
+}
+
+/// Convert a NaN-boxed f64 value to a string with the given radix argument.
+/// `radix_value` is the *raw* NaN-boxed radix argument (number/string/bool/
+/// undefined); it is ToNumber/ToInteger-coerced and validated to `2..=36`
+/// here, throwing `RangeError` for out-of-range values (#2864). Handles
+/// BigInt (uses bigint_to_string_radix), numbers, strings, etc.
 #[no_mangle]
 pub extern "C" fn js_jsvalue_to_string_radix(
     value: f64,
-    radix: i32,
+    radix_value: f64,
 ) -> *mut crate::string::StringHeader {
     let jsval = JSValue::from_bits(value.to_bits());
+
+    // Coerce + validate the radix once up front. `None` → default radix 10.
+    let radix = match unsafe { coerce_validate_radix(radix_value) } {
+        Some(r) => r,
+        None => 10,
+    };
 
     if jsval.is_bigint() {
         let ptr = jsval.as_bigint_ptr();
@@ -345,33 +543,11 @@ pub extern "C" fn js_jsvalue_to_string_radix(
         jsval.as_string_ptr() as *mut crate::string::StringHeader
     } else if jsval.is_int32() {
         let n = jsval.as_int32();
-        let s = if radix == 16 {
-            format!("{:x}", n)
-        } else if radix == 10 || radix == 0 {
-            n.to_string()
-        } else {
-            // General radix conversion
-            let mut result = String::new();
-            let mut val = if n < 0 { -(n as i64) as u64 } else { n as u64 };
-            let r = radix as u64;
-            if val == 0 {
-                return crate::string::js_string_from_bytes(b"0".as_ptr(), 1);
-            }
-            while val > 0 {
-                let digit = (val % r) as u8;
-                result.push(if digit < 10 {
-                    (b'0' + digit) as char
-                } else {
-                    (b'a' + digit - 10) as char
-                });
-                val /= r;
-            }
-            if n < 0 {
-                result.push('-');
-            }
-            let s: String = result.chars().rev().collect();
+        if radix == 10 {
+            let s = n.to_string();
             return crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
-        };
+        }
+        let s = double_to_radix_string(n as f64, radix as u32);
         crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32)
     } else {
         // Regular f64 number
@@ -386,42 +562,10 @@ pub extern "C" fn js_jsvalue_to_string_radix(
                 return crate::string::js_string_from_bytes(b"-Infinity".as_ptr(), 9);
             }
         }
-        if radix == 10 || radix == 0 {
+        if radix == 10 {
             return crate::string::js_number_to_string(value);
         }
-        // For hex and other radixes, convert via integer
-        let n_i64 = n as i64;
-        let s = if radix == 16 {
-            if n_i64 < 0 {
-                format!("-{:x}", -n_i64)
-            } else {
-                format!("{:x}", n_i64)
-            }
-        } else {
-            let mut result = String::new();
-            let mut val = if n_i64 < 0 {
-                (-n_i64) as u64
-            } else {
-                n_i64 as u64
-            };
-            let r = radix as u64;
-            if val == 0 {
-                return crate::string::js_string_from_bytes(b"0".as_ptr(), 1);
-            }
-            while val > 0 {
-                let digit = (val % r) as u8;
-                result.push(if digit < 10 {
-                    (b'0' + digit) as char
-                } else {
-                    (b'a' + digit - 10) as char
-                });
-                val /= r;
-            }
-            if n_i64 < 0 {
-                result.push('-');
-            }
-            result.chars().rev().collect()
-        };
+        let s = double_to_radix_string(n, radix as u32);
         crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32)
     }
 }
@@ -488,6 +632,66 @@ mod error_subclass_tostring_tests {
                 Some("hi")
             );
             assert_eq!(object_field_to_owned_string(obj, b"missing"), None);
+        }
+    }
+}
+
+#[cfg(test)]
+mod radix_tostring_tests {
+    use super::*;
+
+    #[test]
+    fn integer_radix_formatting() {
+        assert_eq!(double_to_radix_string(255.0, 16), "ff");
+        assert_eq!(double_to_radix_string(10.0, 2), "1010");
+        assert_eq!(double_to_radix_string(255.0, 2), "11111111");
+        assert_eq!(double_to_radix_string(-255.0, 16), "-ff");
+        assert_eq!(double_to_radix_string(0.0, 2), "0");
+        assert_eq!(double_to_radix_string(35.0, 36), "z");
+    }
+
+    #[test]
+    fn fractional_radix_formatting_matches_v8() {
+        // Terminating fractions.
+        assert_eq!(double_to_radix_string(10.5, 2), "1010.1");
+        assert_eq!(double_to_radix_string(10.5, 16), "a.8");
+        assert_eq!(double_to_radix_string(10.5, 36), "a.i");
+        assert_eq!(double_to_radix_string(-10.5, 2), "-1010.1");
+        assert_eq!(double_to_radix_string(255.5, 16), "ff.8");
+        assert_eq!(double_to_radix_string(1.5, 2), "1.1");
+        assert_eq!(double_to_radix_string(100.25, 2), "1100100.01");
+        // Repeating fraction — shortest round-trip (matches Node v25).
+        assert_eq!(
+            double_to_radix_string(0.1, 2),
+            "0.0001100110011001100110011001100110011001100110011001101"
+        );
+    }
+
+    #[test]
+    fn coerce_validate_radix_semantics() {
+        unsafe {
+            // undefined → None (default radix path).
+            assert_eq!(
+                coerce_validate_radix(f64::from_bits(crate::value::TAG_UNDEFINED)),
+                None
+            );
+            // Plain number radices.
+            assert_eq!(coerce_validate_radix(16.0), Some(16));
+            assert_eq!(coerce_validate_radix(2.0), Some(2));
+            assert_eq!(coerce_validate_radix(36.0), Some(36));
+            // ToInteger truncation.
+            assert_eq!(coerce_validate_radix(2.9), Some(2));
+            // int32-boxed radix.
+            assert_eq!(
+                coerce_validate_radix(f64::from_bits(JSValue::int32(16).bits())),
+                Some(16)
+            );
+            // String radix coerces via ToNumber.
+            let s = crate::string::js_string_from_bytes(b"16".as_ptr(), 2);
+            assert_eq!(
+                coerce_validate_radix(crate::value::js_nanbox_string(s as i64)),
+                Some(16)
+            );
         }
     }
 }

--- a/test-files/test_gap_number_string_2864_2948_2855.ts
+++ b/test-files/test_gap_number_string_2864_2948_2855.ts
@@ -1,0 +1,60 @@
+// Gap test for #2864 (Number/BigInt toString radix validation + formatting)
+// and #2948 (String.prototype.at returns UTF-16 code units, not code points).
+//
+// #2855 (tagged-template caching + freeze) was DROPPED from this PR: it
+// requires per-call-site identity (codegen site-ids) plus making array
+// element writes honor the frozen flag — broad multi-subsystem infra.
+
+// ---- #2864: Number.prototype.toString(radix) ----
+console.log((255).toString(16)); // ff
+console.log((10).toString(2)); // 1010
+console.log((255).toString(2)); // 11111111
+console.log((10.5).toString(2)); // 1010.1
+console.log((10.5).toString(16)); // a.8
+console.log((10.5).toString(36)); // a.i
+console.log((255).toString(2.9)); // 11111111 (radix truncated to 2)
+console.log((-255).toString(16)); // -ff
+console.log((-10.5).toString(2)); // -1010.1
+console.log((255).toString("16")); // ff (radix string-coerced)
+
+// ---- #2864: BigInt.prototype.toString(radix) ----
+console.log((255n).toString(2)); // 11111111
+console.log((255n).toString(16)); // ff
+console.log((255n).toString("16")); // ff
+
+// ---- #2864: invalid radices throw RangeError (Number) ----
+for (const r of [1, 37, 0, NaN, Infinity, "bad"]) {
+  try {
+    (255).toString(r as any);
+  } catch (e: any) {
+    console.log("num", e.name);
+  }
+}
+
+// ---- #2864: invalid radices throw RangeError (BigInt) ----
+for (const r of [1, 37, 0, NaN, Infinity, "bad"]) {
+  try {
+    (255n).toString(r as any);
+  } catch (e: any) {
+    console.log("big", e.name);
+  }
+}
+
+// ---- #2948: String.prototype.at is UTF-16 code-unit based ----
+const s = "\u{1F600}"; // astral char stored as a surrogate pair
+console.log("len", s.length); // 2
+// at() returns a single code unit, so its .length is 1 (NOT the whole 2-unit
+// emoji that the old code-point-decoding behavior returned). The exact lone
+// surrogate code unit value (0xd83d) is the documented WTF-8 categorical gap,
+// so we assert the code-unit *count* rather than charCodeAt here.
+console.log("at0len", s.at(0)!.length); // 1
+console.log("at1len", s.at(1)!.length); // 1
+console.log("atneg1len", s.at(-1)!.length); // 1
+console.log("atOOB", s.at(5)); // undefined
+// codePointAt keeps full code-point semantics as the contrast.
+console.log("cp0", s.codePointAt(0)!.toString(16)); // 1f600
+
+// at() on a plain BMP string behaves like charAt with negative index support.
+console.log("abc.at1", "abc".at(1)); // b
+console.log("abc.at-1", "abc".at(-1)); // c
+console.log("abc.at5", "abc".at(5)); // undefined


### PR DESCRIPTION
## Summary

Closes #2864
Closes #2948

Two pure-runtime + thin-codegen TypeScript-parity fixes for Number/String small-semantics. #2855 (tagged-template caching/freeze) was assessed and dropped — see below.

## #2864 — Number/BigInt toString(radix) validation + formatting

- The radix argument is now ToNumber/ToInteger-coerced and validated to `2..=36`, throwing `RangeError` for `1`, `37`, `0`, `NaN`, `Infinity`, and non-numeric strings like `"bad"` — matching Node, instead of silently formatting in base 10. `undefined` keeps the default radix 10.
- Codegen now passes the **raw NaN-boxed radix value** to `js_jsvalue_to_string_radix(value, radix_value)` (signature `(DOUBLE, DOUBLE)`), not an `fptosi`-truncated i32 — so `NaN`/`Infinity`/string radices are observable rather than collapsed to 0/garbage.
- Non-decimal radices now render the **fractional part** via a V8-style `DoubleToRadixCString` (shortest round-trip): `(10.5).toString(2) === "1010.1"`, `(10.5).toString(16) === "a.8"`, `(0.1).toString(2)` matches Node's full digit sequence.
- BigInt `toString(radix)` shares the same `coerce_validate_radix` path in `native_call_method.rs`.
- String radices (`(255).toString("16") === "ff"`) are disambiguated from `Buffer.prototype.toString(encoding)` at runtime by receiver type via a new `js_value_to_string_with_encoding_or_radix` helper (the static codegen branch can't tell a Buffer receiver from a Number receiver when the arg is a string).

## #2948 — String.prototype.at returns UTF-16 code units

`js_string_at` no longer decodes a high+low surrogate pair into a single code point; it returns the single UTF-16 code unit at the index, exactly like `charAt`/`[i]`. `"😀".at(0)` is now a 1-code-unit string, not the whole emoji. `codePointAt` keeps its code-point semantics as the contrast.

Note: the **exact lone-surrogate code unit value** (`charCodeAt(0) === 0xd83d`) is the documented WTF-8 / lone-surrogate categorical gap — Perry materializes a lone surrogate as U+FFFD. The gap test therefore asserts the code-unit **count** (`.at(0).length === 1`) rather than the surrogate value; the semantic fix (code-unit indexing, not code-point) is complete.

## #2855 — DROPPED

Tagged-template caching/freeze requires per-call-site object identity (codegen must allocate the cooked/raw arrays once per site and reuse them) **and** making array element-write paths honor the `OBJ_FLAG_FROZEN` flag (today only object field writes check it; array index writes don't). That is broad multi-subsystem infra, so per the "correct 2-issue PR beats a broken 3-issue one" guidance it is out of scope here.

## Implementation

- `crates/perry-runtime/src/value/to_string.rs`: `radix_arg_to_number` (ToNumber), `coerce_validate_radix` (ToInteger + RangeError), `double_to_radix_string` (V8 shortest fractional), rewritten `js_jsvalue_to_string_radix(value, radix_value)`.
- `crates/perry-runtime/src/object/native_call_method.rs`: BigInt `toString` uses `coerce_validate_radix`.
- `crates/perry-runtime/src/buffer/encode.rs`: new `js_value_to_string_with_encoding_or_radix` + `#[used]` keepalive anchor.
- `crates/perry-runtime/src/string/char_ops.rs`: `js_string_at` code-unit semantics.
- `crates/perry-codegen/src/lower_call/property_get.rs` + `runtime_decls/strings.rs`: pass raw radix; route string-arg toString through the encoding-or-radix helper.

No new HIR variant added.

## Validation

- `test-files/test_gap_number_string_2864_2948_2855.ts` is **byte-identical** to `node --experimental-strip-types` under the DEFAULT auto-optimize compile (radix formatting, RangeError throws for Number and BigInt, string radices, negative/fractional, `at()` code units, `codePointAt` contrast).
- `cargo test --release -p perry-runtime` (918 passed) including new `radix_tostring_tests` (integer/fractional formatting + coercion).
- `cargo test --release -p perry-hir` green.
- `./scripts/check_file_size.sh` and `cargo fmt --all -- --check` clean.
- Buffer.toString(encoding) regression-checked (hex/base64/utf8, literal + variable arg) — identical to Node.
