### PR TITLE
fix(array): dynamic toReversed/toSorted/toSpliced, toLocaleString, fromAsync

### DIFF
--- a/crates/perry-codegen/src/lower_array_method.rs
+++ b/crates/perry-codegen/src/lower_array_method.rs
@@ -808,7 +808,20 @@ pub(crate) fn lower_array_method(
         // `.next().value` was then `undefined` (same class of bug as #800's
         // `lastIndexOf`). Route through the runtime's generic dispatch so the
         // `ARRAY_ITERATOR_CLASS_ID` check reaches `dispatch_array_iterator_method`.
-        "next" | "return" | "throw" => {
+        // #2808: `Array.prototype.toLocaleString` has no static HIR fold, so a
+        // typed / `as any` array receiver reaches this codegen path. The old
+        // catch-all returned the receiver unchanged (so `JSON.stringify` saw
+        // the array, not the joined locale string). Route through the runtime
+        // dispatch tower, which walks elements and calls each element's own
+        // `toLocaleString(locales, options)`.
+        //
+        // #2803 defensive: `toReversed` / `toSorted` / `toSpliced` normally fold
+        // to dedicated `Expr::ArrayTo*` nodes upstream, but if that fold ever
+        // bails for an `any`-typed receiver they would otherwise hit the
+        // receiver-returning catch-all below. Dispatching them dynamically here
+        // keeps the immutable-copy semantics (the runtime arms added in #2803).
+        "next" | "return" | "throw" | "toLocaleString" | "toReversed" | "toSorted"
+        | "toSpliced" => {
             let mut lowered_args = Vec::with_capacity(args.len());
             for a in args {
                 lowered_args.push(lower_expr(ctx, a)?);

--- a/crates/perry-hir/src/lower/expr_call/static_receiver.rs
+++ b/crates/perry-hir/src/lower/expr_call/static_receiver.rs
@@ -22,6 +22,33 @@ pub(super) fn static_receiver_class(
     ctx: &LoweringContext,
     obj: &ast::Expr,
 ) -> Option<&'static str> {
+    // #2808: an array receiver is definitely NOT a Date. Detect array literals,
+    // `as` / const-assertion casts wrapping any of the above, and locals typed
+    // as `T[]` / tuple, so `(arr as any).toLocaleString()` (and toString/etc.)
+    // skip the ambiguous Date arms and fall through to generic dynamic
+    // dispatch, where the runtime Array.prototype.toLocaleString lives.
+    {
+        // Peel `as`/`as const`/parens to inspect the underlying receiver shape.
+        let mut cur = obj;
+        loop {
+            match cur {
+                ast::Expr::TsAs(ts_as) => cur = ts_as.expr.as_ref(),
+                ast::Expr::TsConstAssertion(c) => cur = c.expr.as_ref(),
+                ast::Expr::Paren(p) => cur = p.expr.as_ref(),
+                _ => break,
+            }
+        }
+        if matches!(cur, ast::Expr::Array(_)) {
+            return Some("Array");
+        }
+        if let ast::Expr::Ident(ident) = cur {
+            if let Some(ty) = ctx.lookup_local_type(ident.sym.as_ref()) {
+                if matches!(ty, Type::Array(_) | Type::Tuple(_)) {
+                    return Some("Array");
+                }
+            }
+        }
+    }
     if let ast::Expr::New(new_expr) = obj {
         if let ast::Expr::Ident(ident) = new_expr.callee.as_ref() {
             return match ident.sym.as_ref() {

--- a/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
@@ -110,6 +110,7 @@ pub(super) fn try_url_date_weakref_instance(
                 | Some("Buffer")
                 | Some("Uint8Array")
                 | Some("Uint8ClampedArray")
+                | Some("Array")
         );
         // Methods we treat as Date-only when the receiver is unambiguously
         // Date or unknown (current behavior). `toString` / `toJSON` etc.

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -714,3 +714,69 @@ static KEEP_ARRAY_JOIN_VALUE: extern "C" fn(
     *const ArrayHeader,
     f64,
 ) -> *mut crate::string::StringHeader = js_array_join_value;
+
+/// `arr.toLocaleString(locales?, options?)` (#2808).
+///
+/// Per the ECMAScript `Array.prototype.toLocaleString` algorithm: walk the
+/// array from `0` to `length - 1`, render `null` / `undefined` elements as the
+/// empty string, and for every other element call its own
+/// `toLocaleString(locales, options)` method, stringify the result, and join
+/// the per-element strings with `","` separators. `locales` / `options` are
+/// forwarded verbatim to each element method (omitted args are passed as
+/// `undefined`).
+#[no_mangle]
+pub extern "C" fn js_array_to_locale_string(
+    arr: *const ArrayHeader,
+    locales: f64,
+    options: f64,
+) -> *mut crate::string::StringHeader {
+    let arr = clean_arr_ptr(arr);
+    if arr.is_null() {
+        return crate::string::js_string_from_bytes(b"".as_ptr(), 0);
+    }
+    let len = unsafe { (*arr).length as usize };
+    // Forward (locales, options) to each element's toLocaleString. Both are
+    // always passed (undefined when omitted by the caller) so element methods
+    // that branch on `arguments.length` still observe two slots, matching V8.
+    let elem_args: [f64; 2] = [locales, options];
+    let method = b"toLocaleString";
+    let mut out = String::new();
+    for i in 0..len {
+        if i > 0 {
+            out.push(',');
+        }
+        let elem = js_array_get(arr, i as u32);
+        if elem.is_null() || elem.is_undefined() {
+            // Nullish / hole -> empty field.
+            continue;
+        }
+        let elem_f64 = f64::from_bits(elem.bits());
+        let result = unsafe {
+            crate::object::js_native_call_method(
+                elem_f64,
+                method.as_ptr() as *const i8,
+                method.len(),
+                elem_args.as_ptr(),
+                elem_args.len(),
+            )
+        };
+        let sp = crate::value::js_jsvalue_to_string(result);
+        if !sp.is_null() {
+            unsafe {
+                let header = &*(sp as *const crate::string::StringHeader);
+                let bytes_ptr =
+                    (sp as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+                let slice = std::slice::from_raw_parts(bytes_ptr, header.byte_len as usize);
+                out.push_str(std::str::from_utf8(slice).unwrap_or(""));
+            }
+        }
+    }
+    crate::string::js_string_from_bytes(out.as_ptr(), out.len() as u32)
+}
+
+#[used]
+static KEEP_ARRAY_TO_LOCALE_STRING: extern "C" fn(
+    *const ArrayHeader,
+    f64,
+    f64,
+) -> *mut crate::string::StringHeader = js_array_to_locale_string;

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -54,7 +54,7 @@ pub use self::iter_methods::{
     js_array_at, js_array_every, js_array_filter, js_array_find, js_array_findIndex,
     js_array_find_last, js_array_find_last_index, js_array_flatMap, js_array_forEach,
     js_array_join, js_array_join_value, js_array_map, js_array_map_discard, js_array_reduce,
-    js_array_some,
+    js_array_some, js_array_to_locale_string,
 };
 pub use self::iter_object::{
     array_entries_iter, array_keys_iter, array_values_iter, dispatch_array_iterator_method,

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -277,6 +277,22 @@ pub(crate) unsafe fn js_object_default_to_locale_string(receiver: f64) -> f64 {
     if jsval.is_undefined() || jsval.is_null() {
         throw_object_to_locale_string_nullish_receiver();
     }
+    // #2808: numbers use `Number.prototype.toLocaleString` (thousands
+    // separators), so a number element / receiver formats as `1,000.5` rather
+    // than the bare `toString` form. Locale/option-aware grouping is not yet
+    // modeled — the default-locale grouping matches Node's en-US output for
+    // the common integer/decimal cases.
+    if jsval.is_number() {
+        let s = crate::date::js_number_to_locale_string(jsval.as_number());
+        return f64::from_bits(JSValue::string_ptr(s).bits());
+    }
+    // #2808: a Date value uses `Date.prototype.toLocaleString` (date+time
+    // rendering) rather than `[object Date]`.
+    if crate::date::is_date_value(receiver) {
+        let ts = crate::date::date_cell_timestamp(receiver);
+        let s = crate::date::js_date_to_locale_string(ts);
+        return f64::from_bits(JSValue::string_ptr(s).bits());
+    }
     if !jsval.is_pointer() {
         return js_native_call_method(
             receiver,

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1726,6 +1726,81 @@ pub unsafe extern "C" fn js_native_call_method(
                     "entries" => {
                         return crate::array::array_entries_iter(object);
                     }
+                    // #2803: ES2023 immutable methods reaching the dynamic
+                    // dispatch tower (`(arr as any).toSorted()`, computed
+                    // `arr[m]()`, chained-call receivers that escape the HIR
+                    // fold). Each returns a NEW array and leaves the receiver
+                    // unchanged, mirroring the static codegen helpers.
+                    "toReversed" => {
+                        let arr = raw_ptr as *const crate::array::ArrayHeader;
+                        let result = crate::array::js_array_to_reversed(arr);
+                        return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
+                    }
+                    "toSorted" => {
+                        let arr = raw_ptr as *const crate::array::ArrayHeader;
+                        // #2796: validate comparator (function | undefined);
+                        // a null/undefined comparator routes to the default
+                        // (string) sort inside js_array_to_sorted_with_comparator.
+                        let cmp_ptr = if args_len >= 1 && !args_ptr.is_null() {
+                            crate::array::js_validate_array_comparator(*args_ptr)
+                                as *const crate::closure::ClosureHeader
+                        } else {
+                            std::ptr::null()
+                        };
+                        let result = crate::array::js_array_to_sorted_with_comparator(arr, cmp_ptr);
+                        return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
+                    }
+                    "toSpliced" => {
+                        let arr = raw_ptr as *const crate::array::ArrayHeader;
+                        // Per spec / #2794: toSpliced() inserts/deletes nothing,
+                        // toSpliced(start) deletes through the end. NaN-coercion
+                        // for the f64 start/deleteCount is handled in the helper.
+                        let start = if args_len >= 1 { *args_ptr } else { 0.0 };
+                        let delete_count = if args_len == 0 {
+                            0.0
+                        } else if args_len == 1 {
+                            f64::INFINITY
+                        } else {
+                            *args_ptr.add(1)
+                        };
+                        let items: Vec<f64> = if args_len > 2 && !args_ptr.is_null() {
+                            std::slice::from_raw_parts(args_ptr.add(2), args_len - 2).to_vec()
+                        } else {
+                            Vec::new()
+                        };
+                        let items_ptr = if items.is_empty() {
+                            std::ptr::null()
+                        } else {
+                            items.as_ptr()
+                        };
+                        let result = crate::array::js_array_to_spliced(
+                            arr,
+                            start,
+                            delete_count,
+                            items_ptr,
+                            items.len() as u32,
+                        );
+                        return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
+                    }
+                    // #2808: Array.prototype.toLocaleString — calls each
+                    // non-nullish element's own toLocaleString(locales, options),
+                    // renders nullish/hole elements as empty fields, and joins
+                    // with commas. Routed here for any-typed / computed receivers.
+                    "toLocaleString" => {
+                        let arr = raw_ptr as *const crate::array::ArrayHeader;
+                        let locales = if args_len >= 1 && !args_ptr.is_null() {
+                            *args_ptr
+                        } else {
+                            f64::from_bits(crate::value::TAG_UNDEFINED)
+                        };
+                        let options = if args_len >= 2 && !args_ptr.is_null() {
+                            *args_ptr.add(1)
+                        } else {
+                            f64::from_bits(crate::value::TAG_UNDEFINED)
+                        };
+                        let s = crate::array::js_array_to_locale_string(arr, locales, options);
+                        return f64::from_bits(JSValue::string_ptr(s).bits());
+                    }
                     _ => {} // not a handled array method — fall through to object dispatch
                 }
             }

--- a/test-files/test_gap_array_dyndispatch_2803_2808_2791.ts
+++ b/test-files/test_gap_array_dyndispatch_2803_2808_2791.ts
@@ -1,0 +1,89 @@
+// Gap test: Array dynamic dispatch completeness (#2803, #2808).
+//
+// Exercises ES2023 immutable methods (toReversed / toSorted / toSpliced) and
+// toLocaleString through DYNAMIC dispatch — `(arr as any).method()` and the
+// computed `arr[m]()` form — so the runtime dispatch tower handles them, not
+// just the static codegen fast paths. Output must be byte-identical to
+// `node --experimental-strip-types`.
+
+// --- #2803: toReversed / toSorted / toSpliced via `as any` ---
+const base = [3, 1, 2];
+
+{
+  const a = base.slice();
+  const out = (a as any).toReversed();
+  console.log("toReversed: " + JSON.stringify([out, a, out === a]));
+}
+{
+  const a = base.slice();
+  const out = (a as any).toSorted();
+  console.log("toSorted default: " + JSON.stringify([out, a, out === a]));
+}
+{
+  const a = base.slice();
+  const out = (a as any).toSorted((x: number, y: number) => x - y);
+  console.log("toSorted comparator: " + JSON.stringify([out, a, out === a]));
+}
+{
+  const a = [1, 2, 3, 4];
+  const out = (a as any).toSpliced(1, 2, 9);
+  console.log("toSpliced: " + JSON.stringify([out, a, out === a]));
+}
+{
+  // toSpliced(start) deletes through the end.
+  const a = [1, 2, 3, 4];
+  const out = (a as any).toSpliced(2);
+  console.log("toSpliced start-only: " + JSON.stringify([out, a]));
+}
+
+// --- #2803 via computed-key dispatch `arr[m]()` ---
+{
+  const a = [5, 1, 4, 2, 3];
+  const m = "toSorted";
+  const out = (a as any)[m]((x: number, y: number) => x - y);
+  console.log("computed toSorted: " + JSON.stringify(out));
+}
+{
+  const a = [10, 20, 30];
+  const m = "toReversed";
+  const out = (a as any)[m]();
+  console.log("computed toReversed: " + JSON.stringify(out));
+}
+
+// --- #2808: Array.prototype.toLocaleString element dispatch ---
+const obj = {
+  toLocaleString(locales: any, options: any) {
+    return `obj:${locales}:${options && options.tag}`;
+  },
+};
+{
+  const r = ([1, null, undefined, "x"] as any).toLocaleString();
+  console.log("toLocaleString plain: " + JSON.stringify(r));
+}
+{
+  const r = ([obj] as any).toLocaleString("xx-YY", { tag: "opt" });
+  console.log("toLocaleString forwarded: " + JSON.stringify(r));
+}
+{
+  const r = ([1, 2, 3] as any).toLocaleString();
+  console.log("toLocaleString numbers: " + JSON.stringify(r));
+}
+{
+  // empty array -> empty string
+  const r = ([] as any).toLocaleString();
+  console.log("toLocaleString empty: " + JSON.stringify(r));
+}
+{
+  // number element with locale: grouping separators.
+  const r = ([1000.5] as any).toLocaleString("en-US");
+  console.log("toLocaleString number locale: " + JSON.stringify(r));
+}
+{
+  // Date element dispatches to Date.prototype.toLocaleString (the element's
+  // own method is invoked, producing a date+time string rather than
+  // "[object Date]"). The exact wall-clock value tracks the host timezone, so
+  // assert the dispatch shape (a non-empty, comma-bearing string) rather than
+  // a fixed instant to keep the test deterministic across timezones.
+  const r = ([new Date(Date.UTC(2020, 0, 2))] as any).toLocaleString();
+  console.log("toLocaleString date dispatched: " + (r.length > 0 && r.includes(",")));
+}


### PR DESCRIPTION
Closes #2803
Closes #2808

## Implementation

### #2803 — dynamic `toReversed` / `toSorted` / `toSpliced`
Added generic Array branches to the runtime dispatch tower
(`crates/perry-runtime/src/object/native_call_method.rs`) so these ES2023
immutable methods work when they reach dynamic dispatch — computed
`arr[m]()` and any-typed receivers that escape the static HIR fold:

- `toReversed()` → `js_array_to_reversed`
- `toSorted(compareFn?)` → validates the comparator (`js_validate_array_comparator`,
  #2796) and routes through `js_array_to_sorted_with_comparator` (null/undefined
  comparator falls back to the default string sort).
- `toSpliced(start?, deleteCount?, ...items)` → `js_array_to_spliced` with the
  spec omitted-argument semantics (no args deletes nothing; `start`-only deletes
  through the end, #2794).

Each returns a new array and leaves the receiver unchanged.

Also added a codegen routing arm in `lower_array_method.rs`: these three names
already fold to dedicated `Expr::ArrayTo*` nodes for statically-typed receivers,
but if that fold ever bails for an `any`-typed array literal they now dispatch
through `js_native_call_method` instead of the receiver-returning catch-all.

### #2808 — `Array.prototype.toLocaleString` element dispatch
- New runtime helper `js_array_to_locale_string` (`array/iter_methods.rs`):
  walks the array, renders nullish/hole elements as empty fields, calls each
  remaining element's own `toLocaleString(locales, options)` via the dispatch
  tower, stringifies, and joins with commas. `locales`/`options` are forwarded
  to every element method.
- Routed `Array.prototype.toLocaleString` through this helper at both the
  runtime dynamic-dispatch arm and the `lower_array_method` codegen path (the
  method has no static HIR fold, so a typed/`as any` array receiver previously
  hit the catch-all and returned the receiver unchanged).
- Extended `static_receiver_class` to classify array receivers (array literals,
  `as`/const-assertion casts over them, and `T[]`/tuple-typed locals) as
  `Some("Array")` so the ambiguous Date-method arms skip arrays and let
  `toLocaleString` / `toString` fall through to generic dispatch.
- Improved the primitive `toLocaleString` fallback (`js_object_default_to_locale_string`)
  to route number elements through `Number.prototype.toLocaleString` (grouping
  separators) and Date elements through `Date.prototype.toLocaleString` rather
  than emitting `[object Object]`.

### Dropped: #2791 (`Array.fromAsync` mapFn/thisArg/invalid-input)
Deferred. A correct fix requires broad async infrastructure: threading `mapFn`
through the `Promise.all`-backed array path with a per-element await of the
mapped result, binding `thisArg` as `this` across the recursive `.next()`
closure chain, and Node-compatible synchronous rejection for non-callable
`mapFn` / nullish input. This is more than a pure-runtime dispatch change and
is out of scope for this PR.

## Validation
- Gap test `test-files/test_gap_array_dyndispatch_2803_2808_2791.ts` is
  byte-identical to `node --experimental-strip-types` under the default
  auto-optimize compile. Covers `(arr as any).toReversed/toSorted/toSpliced`,
  computed `arr[m]()`, `toSpliced(start)`-only, and `toLocaleString` over
  nullish/custom-object/number/date elements plus the empty array.
- No new HIR `Expr` variant added.
- Guards green: `./scripts/check_file_size.sh`, `cargo fmt --all -- --check`,
  `cargo test --release -p perry-runtime array` (101 passed),
  `cargo test --release -p perry-hir` (132 passed, including
  `expr_variant_stable_hash_tags_are_unique`).
- No API-manifest entries added; no api-docs regen required.
