### PR TITLE
fix(url): validate Node URL helper inputs

### DIFF
--- a/crates/perry-runtime/src/url/node_compat.rs
+++ b/crates/perry-runtime/src/url/node_compat.rs
@@ -50,6 +50,50 @@ fn throw_url_type_error_with_code(message: &str, code: &'static str) -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
+fn is_js_string_value(value: f64) -> bool {
+    crate::value::JSValue::from_bits(value.to_bits()).is_any_string()
+}
+
+fn string_from_js_value(value: f64) -> String {
+    let ptr = crate::value::js_get_string_pointer_unified(value) as *mut crate::StringHeader;
+    string_from_header(ptr)
+}
+
+fn url_received(value: f64) -> String {
+    if crate::buffer::js_buffer_is_buffer(value.to_bits() as i64) == 1 {
+        return "an instance of Buffer".to_string();
+    }
+    if unsafe { crate::symbol::js_is_symbol(value) != 0 } {
+        let ptr = unsafe { crate::symbol::js_symbol_to_string(value) } as *const StringHeader;
+        return format!(
+            "type symbol ({})",
+            string_from_header(ptr as *mut StringHeader)
+        );
+    }
+    crate::fs::validate::describe_received(value)
+}
+
+fn throw_invalid_url_arg(value: f64, url_instance_allowed: bool) -> ! {
+    let expected = if url_instance_allowed {
+        "string or an instance of URL"
+    } else {
+        "string"
+    };
+    let message = format!(
+        "The \"path\" argument must be of type {expected}. Received {}",
+        url_received(value)
+    );
+    throw_url_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn throw_invalid_legacy_url_arg(value: f64) -> ! {
+    let message = format!(
+        "The \"url\" argument must be of type string. Received {}",
+        url_received(value)
+    );
+    throw_url_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
 fn hex_nibble(b: u8) -> Option<u8> {
     match b {
         b'0'..=b'9' => Some(b - b'0'),
@@ -94,13 +138,16 @@ fn decode_file_url_pathname(pathname: &str) -> String {
 /// and `fileURLToPathBuffer` (raw bytes). Returns the decoded path bytes,
 /// throwing the same scheme/host/encoded-slash errors as Node.
 fn file_url_to_path_bytes(url_f64: f64) -> Vec<u8> {
-    let url_string = object_from_f64(url_f64)
-        .map(|obj| object_prop_string(obj, "href"))
-        .unwrap_or_else(|| {
-            let ptr =
-                crate::value::js_get_string_pointer_unified(url_f64) as *mut crate::StringHeader;
-            string_from_header(ptr)
-        });
+    let url_string = if is_js_string_value(url_f64) {
+        string_from_js_value(url_f64)
+    } else if let Some(obj) = object_from_f64(url_f64) {
+        if !is_url_object_shape(obj) {
+            throw_invalid_url_arg(url_f64, true);
+        }
+        object_prop_string(obj, "href")
+    } else {
+        throw_invalid_url_arg(url_f64, true);
+    };
 
     let Some(after_scheme) = url_string.strip_prefix("file:") else {
         throw_url_type_error_with_code("The URL must be of scheme file", "ERR_INVALID_URL_SCHEME");
@@ -159,6 +206,9 @@ pub extern "C" fn js_url_file_url_to_path_buffer(url_f64: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_url_path_to_file_url(path_f64: f64) -> f64 {
+    if !is_js_string_value(path_f64) {
+        throw_invalid_url_arg(path_f64, false);
+    }
     let path = get_string_content(path_f64);
     let path = crate::path::resolve_posix_str(&path);
     let mut encoded = String::new();
@@ -372,10 +422,12 @@ pub extern "C" fn js_url_legacy_parse(
     parse_query_string: f64,
     slashes_denote_host: f64,
 ) -> f64 {
+    if !is_js_string_value(input) {
+        throw_invalid_legacy_url_arg(input);
+    }
     let s = get_string_content(input);
     let (protocol, mut host, mut hostname, mut port, mut pathname, search, hash) = parse_url(&s);
-    let bool_true_bits = 0x7FFC_0000_0000_0004u64;
-    let slashes_host = slashes_denote_host.to_bits() == bool_true_bits;
+    let slashes_host = crate::value::js_is_truthy(slashes_denote_host) != 0;
     let protocol_is_null = protocol.is_empty() && slashes_host && s.starts_with("//");
 
     if protocol_is_null {
@@ -421,7 +473,7 @@ pub extern "C" fn js_url_legacy_parse(
             rest
         };
     }
-    let parse_qs = parse_query_string.to_bits() == bool_true_bits;
+    let parse_qs = crate::value::js_is_truthy(parse_query_string) != 0;
     let query = if parse_qs {
         let mut map = serde_json::Map::new();
         let raw = search.strip_prefix('?').unwrap_or(&search);
@@ -454,6 +506,12 @@ pub extern "C" fn js_url_legacy_parse(
 
 #[no_mangle]
 pub extern "C" fn js_url_legacy_resolve(from: f64, to: f64) -> f64 {
+    if !is_js_string_value(from) {
+        throw_invalid_legacy_url_arg(from);
+    }
+    if !is_js_string_value(to) {
+        throw_invalid_legacy_url_arg(to);
+    }
     let from_s = get_string_content(from);
     let to_s = get_string_content(to);
     let resolved = if to_s.starts_with('/') && !is_valid_absolute_url(&from_s) {

--- a/test-parity/node-suite/url/module/file-url-input-validation.ts
+++ b/test-parity/node-suite/url/module/file-url-input-validation.ts
@@ -1,0 +1,38 @@
+import { fileURLToPath, fileURLToPathBuffer, pathToFileURL } from "node:url";
+
+function show(label: string, fn: () => unknown) {
+  try {
+    const value = fn();
+    console.log(label + ":", String(value));
+  } catch (err: any) {
+    console.log(label + ":", err?.name, err?.code || "no-code", err?.message);
+  }
+}
+
+const invalidFileInputs = [
+  ["number", 123],
+  ["null", null],
+  ["buffer", Buffer.from("file:///tmp/a")],
+  ["plain-object", { href: "file:///tmp/a" }],
+] as any[];
+
+for (const [label, value] of invalidFileInputs) {
+  show("fileURLToPath " + label, () => fileURLToPath(value));
+}
+
+for (const [label, value] of invalidFileInputs) {
+  show("fileURLToPathBuffer " + label, () => fileURLToPathBuffer(value));
+}
+
+console.log("fileURLToPath URL:", fileURLToPath(new URL("file:///tmp/a%20b")));
+console.log("fileURLToPathBuffer bytes:", fileURLToPathBuffer("file:///tmp/a%FF").toString("hex"));
+
+for (const [label, value] of [
+  ["number", 123],
+  ["buffer", Buffer.from("/tmp/a")],
+  ["symbol", Symbol("x")],
+] as any[]) {
+  show("pathToFileURL " + label, () => pathToFileURL(value));
+}
+
+console.log("pathToFileURL valid:", pathToFileURL("/tmp/a b").href);

--- a/test-parity/node-suite/url/module/legacy-parse-resolve-validation.ts
+++ b/test-parity/node-suite/url/module/legacy-parse-resolve-validation.ts
@@ -1,0 +1,23 @@
+import * as url from "node:url";
+
+function show(label: string, fn: () => unknown) {
+  try {
+    const value = fn();
+    console.log(label + ":", String(value));
+  } catch (err: any) {
+    console.log(label + ":", err?.name, err?.code || "no-code", err?.message);
+  }
+}
+
+show("parse number", () => url.parse(123 as any));
+show("parse null", () => url.parse(null as any));
+
+const parsedTruthy = url.parse("//example.com/a?x=1", "yes" as any, "no" as any);
+console.log("parse truthy host:", parsedTruthy.host);
+console.log("parse truthy protocol:", parsedTruthy.protocol === null ? "null" : parsedTruthy.protocol);
+console.log("parse truthy query x:", (parsedTruthy.query as any).x);
+
+show("resolve from-number", () => url.resolve(123 as any, "/x"));
+show("resolve to-number", () => url.resolve("http://example.com/a", 123 as any));
+show("resolve from-symbol", () => url.resolve(Symbol("x") as any, "/x"));
+console.log("resolve valid:", url.resolve("http://example.com/a/b", "../c"));


### PR DESCRIPTION
## Summary

Fixes #3060
Fixes #3062

This PR tightens Node-compatible validation for the `node:url` helper surface:

- `fileURLToPath()` and `fileURLToPathBuffer()` now accept only strings or real URL instances before file-scheme parsing.
- `pathToFileURL()` now rejects non-string inputs with `ERR_INVALID_ARG_TYPE`.
- Legacy `url.parse()` and `url.resolve()` now reject non-string URL arguments with Node-shaped errors.
- Legacy `url.parse()` now treats `parseQueryString` and `slashesDenoteHost` with normal JS truthiness instead of exact boolean identity.

## Why These Issues Are Batched

Both issues cover argument validation in the same `node:url` runtime implementation and parity-test area. Handling them together keeps the error-shape helpers and coverage in one coherent PR without crossing into unrelated URL behavior.

## Tests Added

- `test-parity/node-suite/url/module/file-url-input-validation.ts`
- `test-parity/node-suite/url/module/legacy-parse-resolve-validation.ts`

## Verification

- `cargo check -p perry-runtime`
- `cargo check -p perry-runtime -p perry`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module url/module --filter file-url-input-validation`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module url/module --filter legacy-parse-resolve-validation`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module url/module`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module url`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known Limitations / Non-Goals

- Does not change `urlToHttpOptions()` field copying or validation behavior (#2976).
- Does not change URLSearchParams form-encoding behavior (#2978).
- Does not change WHATWG URL coercion beyond the helper and legacy validation paths listed above.
