### PR TITLE
fix(object): hasOwnProperty/propertyIsEnumerable own-key checks, ToObject in inspection statics

### DIFF
--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -119,6 +119,12 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_typed_array_find_last_index", DOUBLE, &[I64, I64]);
     // Object introspection / mutation (Agent A's accessor-descriptor work).
     module.declare_function("js_object_has_own", DOUBLE, &[DOUBLE, DOUBLE]);
+    // #2891: Object.prototype.propertyIsEnumerable.call(obj, key).
+    module.declare_function(
+        "js_object_property_is_enumerable",
+        DOUBLE,
+        &[DOUBLE, DOUBLE],
+    );
     // Issue #620: own-property override probe used by class-method dispatch.
     // Returns the stored value if `name` is in obj's own keys_array (data
     // property only — no vtable getter walk), else TAG_UNDEFINED. Lets

--- a/crates/perry-hir/src/lower/expr_call/post_args_dispatch.rs
+++ b/crates/perry-hir/src/lower/expr_call/post_args_dispatch.rs
@@ -107,18 +107,26 @@ pub(super) fn try_object_has_own_call(
                         if let (ast::MemberProp::Ident(mid_prop), ast::Expr::Ident(mid_obj)) =
                             (&mid.prop, mid.obj.as_ref())
                         {
-                            if mid_obj.sym.as_ref() == "Object"
-                                && mid_prop.sym.as_ref() == "hasOwnProperty"
-                            {
-                                return Ok(Expr::Call {
-                                    callee: Box::new(Expr::ExternFuncRef {
-                                        name: "js_object_has_own".to_string(),
-                                        param_types: Vec::new(),
-                                        return_type: Type::Any,
-                                    }),
-                                    args,
-                                    type_args: Vec::new(),
-                                });
+                            if mid_obj.sym.as_ref() == "Object" {
+                                let runtime_fn = match mid_prop.sym.as_ref() {
+                                    "hasOwnProperty" => Some("js_object_has_own"),
+                                    // #2891: Object.propertyIsEnumerable.call(obj, key)
+                                    "propertyIsEnumerable" => {
+                                        Some("js_object_property_is_enumerable")
+                                    }
+                                    _ => None,
+                                };
+                                if let Some(runtime_fn) = runtime_fn {
+                                    return Ok(Expr::Call {
+                                        callee: Box::new(Expr::ExternFuncRef {
+                                            name: runtime_fn.to_string(),
+                                            param_types: Vec::new(),
+                                            return_type: Type::Any,
+                                        }),
+                                        args,
+                                        type_args: Vec::new(),
+                                    });
+                                }
                             }
                         }
                     }
@@ -158,6 +166,10 @@ pub(super) fn try_object_prototype_call(
                             let runtime_fn = match (mid_prop.sym.as_ref(), args.len()) {
                                 ("toString", 1) => Some("js_object_to_string"),
                                 ("hasOwnProperty", 2) => Some("js_object_has_own"),
+                                // #2891: Object.prototype.propertyIsEnumerable.call(obj, key)
+                                ("propertyIsEnumerable", 2) => {
+                                    Some("js_object_property_is_enumerable")
+                                }
                                 _ => None,
                             };
                             if let Some(runtime_fn) = runtime_fn {

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -16,6 +16,20 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
     const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
     const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
     unsafe {
+        // #2818: ToObject(null/undefined) throws TypeError, matching Node.
+        let obj_jv = crate::JSValue::from_bits(obj_value.to_bits());
+        if obj_jv.is_null() || obj_jv.is_undefined() {
+            super::has_own_helpers::throw_to_object_nullish_type_error();
+        }
+
+        // #2818: string primitives box to String objects whose own
+        // properties are the index keys "0".."len-1" (writable:false,
+        // enumerable:true, configurable:false) plus "length"
+        // (writable:false, enumerable:false, configurable:false).
+        if obj_jv.is_any_string() {
+            return string_primitive_descriptor(obj_value, key_value);
+        }
+
         if let Some(class_id) = class_ref_id(obj_value) {
             let method_name = metadata_key_to_string(key_value);
             if let Some(method_name) = method_name {
@@ -245,11 +259,85 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
     }
 }
 
+/// Build a `{ value, writable, enumerable, configurable }` data descriptor
+/// object. Shared by the string-primitive descriptor path (#2818).
+unsafe fn build_data_descriptor(
+    value: f64,
+    writable: bool,
+    enumerable: bool,
+    configurable: bool,
+) -> f64 {
+    const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
+    const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
+    let bf = |b: bool| f64::from_bits(if b { TAG_TRUE } else { TAG_FALSE });
+    let packed = b"value\0writable\0enumerable\0configurable";
+    let desc = js_object_alloc_with_shape(0x0D_E5_C0, 4, packed.as_ptr(), packed.len() as u32);
+    let header_size = std::mem::size_of::<ObjectHeader>();
+    let fields = (desc as *mut u8).add(header_size) as *mut f64;
+    // GC_STORE_AUDIT(INIT): descriptor object is freshly allocated; layout is rebuilt before publication.
+    *fields = value;
+    *fields.add(1) = bf(writable);
+    *fields.add(2) = bf(enumerable);
+    *fields.add(3) = bf(configurable);
+    super::rebuild_object_field_layout(desc, 4);
+    f64::from_bits((desc as u64) | 0x7FFD_0000_0000_0000)
+}
+
+/// #2818: own-property descriptor for a string primitive receiver. Index keys
+/// in range yield the single-char value descriptor (writable:false,
+/// enumerable:true, configurable:false); "length" yields the length value
+/// descriptor (writable:false, enumerable:false, configurable:false). Any
+/// other key is absent → undefined.
+unsafe fn string_primitive_descriptor(str_value: f64, key_value: f64) -> f64 {
+    let key_str = crate::builtins::js_string_coerce(key_value);
+    if key_str.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let name_ptr = (key_str as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    let name_len = (*key_str).byte_len as usize;
+    let name = match std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)) {
+        Ok(s) => s,
+        Err(_) => return f64::from_bits(crate::value::TAG_UNDEFINED),
+    };
+
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let (sptr, sblen) = match crate::string::str_bytes_from_jsvalue(str_value, &mut scratch) {
+        Some((p, b)) if !p.is_null() => (p, b),
+        _ => return f64::from_bits(crate::value::TAG_UNDEFINED),
+    };
+    let utf16_len = crate::string::compute_utf16_len(sptr, sblen);
+
+    if name == "length" {
+        return build_data_descriptor(utf16_len as f64, false, false, false);
+    }
+
+    if let Some(index) = super::canonical_array_index(name) {
+        if index < utf16_len {
+            // Materialize the single UTF-16 unit at `index` as a 1-char string.
+            let bytes = std::slice::from_raw_parts(sptr, sblen as usize);
+            let s = std::str::from_utf8(bytes).unwrap_or("");
+            if let Some(ch) = s.chars().nth(index as usize) {
+                let mut buf = [0u8; 4];
+                let cs = ch.encode_utf8(&mut buf);
+                let cstr = crate::string::js_string_from_bytes(cs.as_ptr(), cs.len() as u32);
+                let char_val = f64::from_bits(JSValue::string_ptr(cstr).bits());
+                return build_data_descriptor(char_val, false, true, false);
+            }
+        }
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
 /// Object.getOwnPropertyNames(obj) — returns all own property names (including non-enumerable).
 /// Takes a NaN-boxed f64 object pointer, returns a NaN-boxed f64 array pointer.
 #[no_mangle]
 pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
     unsafe {
+        // #2818: ToObject(null/undefined) throws TypeError, matching Node.
+        let obj_jv = crate::JSValue::from_bits(obj_value.to_bits());
+        if obj_jv.is_null() || obj_jv.is_undefined() {
+            super::has_own_helpers::throw_to_object_nullish_type_error();
+        }
         if let Some(class_id) = class_ref_id(obj_value) {
             let mut names: Vec<String> = vec!["constructor".to_string()];
             if let Ok(registry) = CLASS_VTABLE_REGISTRY.read() {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -485,6 +485,10 @@ pub extern "C" fn js_object_set_keys(obj: *mut ObjectHeader, keys_array: *mut Ar
 #[no_mangle]
 pub extern "C" fn js_object_keys_value(value: f64) -> *mut ArrayHeader {
     let jv = JSValue::from_bits(value.to_bits());
+    // #2818: ToObject(null/undefined) throws TypeError, matching Node.
+    if jv.is_null() || jv.is_undefined() {
+        super::has_own_helpers::throw_to_object_nullish_type_error();
+    }
     if jv.is_any_string() {
         let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
         let len = match crate::string::str_bytes_from_jsvalue(value, &mut scratch) {
@@ -535,6 +539,10 @@ fn for_each_string_char<F: FnMut(u32, f64)>(value: f64, mut emit: F) -> Option<u
 #[no_mangle]
 pub extern "C" fn js_object_values_value(value: f64) -> *mut ArrayHeader {
     let jv = JSValue::from_bits(value.to_bits());
+    // #2818: ToObject(null/undefined) throws TypeError, matching Node.
+    if jv.is_null() || jv.is_undefined() {
+        super::has_own_helpers::throw_to_object_nullish_type_error();
+    }
     if jv.is_any_string() {
         let arr = crate::array::js_array_alloc(1);
         let mut out = arr;
@@ -560,6 +568,10 @@ pub extern "C" fn js_object_values_value(value: f64) -> *mut ArrayHeader {
 #[no_mangle]
 pub extern "C" fn js_object_entries_value(value: f64) -> *mut ArrayHeader {
     let jv = JSValue::from_bits(value.to_bits());
+    // #2818: ToObject(null/undefined) throws TypeError, matching Node.
+    if jv.is_null() || jv.is_undefined() {
+        super::has_own_helpers::throw_to_object_nullish_type_error();
+    }
     if jv.is_any_string() {
         let outer = crate::array::js_array_alloc(1);
         let mut out = outer;

--- a/crates/perry-runtime/src/object/has_own_helpers.rs
+++ b/crates/perry-runtime/src/object/has_own_helpers.rs
@@ -1,6 +1,6 @@
 //! Helpers for `Object.hasOwn` ToObject and primitive own-key handling.
 
-pub(super) fn throw_to_object_nullish_type_error() -> ! {
+pub(crate) fn throw_to_object_nullish_type_error() -> ! {
     let message = "Cannot convert undefined or null to object";
     let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
     let err = crate::error::js_typeerror_new(msg);

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -36,7 +36,7 @@ mod field_get_set;
 mod field_set_by_name;
 mod global_this;
 mod groupby;
-mod has_own_helpers;
+pub(crate) mod has_own_helpers;
 mod instanceof;
 mod native_call_method;
 mod native_module;

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -542,6 +542,67 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
     }
 }
 
+/// `Object.prototype.propertyIsEnumerable.call(obj, key)` (#2891) — true iff
+/// `key` is an OWN property of `obj` whose descriptor is enumerable. Inherited
+/// and absent keys return false. Nullish receivers throw `TypeError` per
+/// ToObject. Mirrors the ordinary-method branch in `native_call_method.rs`
+/// (which handles `obj.propertyIsEnumerable(key)`); this entry point is what
+/// the syntactic `.call` shapes lower to.
+#[no_mangle]
+pub extern "C" fn js_object_property_is_enumerable(obj_value: f64, key_value: f64) -> f64 {
+    const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
+    const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
+    unsafe {
+        let obj_jv = crate::JSValue::from_bits(obj_value.to_bits());
+        if obj_jv.is_null() || obj_jv.is_undefined() {
+            super::has_own_helpers::throw_to_object_nullish_type_error();
+        }
+
+        let key_str = crate::builtins::js_string_coerce(key_value);
+        if key_str.is_null() {
+            return f64::from_bits(TAG_FALSE);
+        }
+
+        // String primitives: index keys in range are enumerable own props;
+        // "length" is a non-enumerable own prop; everything else absent.
+        if obj_jv.is_any_string() {
+            let present =
+                super::has_own_helpers::string_primitive_own_key_present(obj_value, key_str);
+            if !present {
+                return f64::from_bits(TAG_FALSE);
+            }
+            let name_ptr = (key_str as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+            let name_len = (*key_str).byte_len as usize;
+            let is_length = std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len))
+                .map(|s| s == "length")
+                .unwrap_or(false);
+            return f64::from_bits(if is_length { TAG_FALSE } else { TAG_TRUE });
+        }
+
+        let obj = extract_obj_ptr(obj_value);
+        if obj.is_null() || (obj as usize) < 0x10000 || !is_valid_obj_ptr(obj as *const u8) {
+            return f64::from_bits(TAG_FALSE);
+        }
+        if !own_key_present(obj, key_str) {
+            return f64::from_bits(TAG_FALSE);
+        }
+        let name_ptr = (key_str as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let name_len = (*key_str).byte_len as usize;
+        let key_name = match std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)) {
+            Ok(s) => s,
+            Err(_) => return f64::from_bits(TAG_FALSE),
+        };
+        let enumerable = super::get_property_attrs(obj as usize, key_name)
+            .map(|attrs| attrs.enumerable())
+            .unwrap_or(true);
+        f64::from_bits(if enumerable { TAG_TRUE } else { TAG_FALSE })
+    }
+}
+
+#[used]
+static KEEP_PROPERTY_IS_ENUMERABLE: extern "C" fn(f64, f64) -> f64 =
+    js_object_property_is_enumerable;
+
 /// Helper: extract object pointer from NaN-boxed f64. Returns null on failure.
 pub(crate) unsafe fn extract_obj_ptr(value: f64) -> *mut ObjectHeader {
     let jsval = crate::JSValue::from_bits(value.to_bits());

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -1463,6 +1463,12 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
 /// with POINTER_TAG before handing the result to user code.
 #[no_mangle]
 pub unsafe extern "C" fn js_object_get_own_property_symbols(obj_f64: f64) -> i64 {
+    // #2818: ToObject(null/undefined) throws TypeError, matching Node. Other
+    // primitives box successfully and enumerate no own symbols (empty array).
+    let jv = crate::JSValue::from_bits(obj_f64.to_bits());
+    if jv.is_null() || jv.is_undefined() {
+        crate::object::has_own_helpers::throw_to_object_nullish_type_error();
+    }
     let obj_key = obj_key_from_f64(obj_f64);
     if obj_key == 0 {
         return crate::array::js_array_alloc(0) as i64;

--- a/test-files/test_gap_object_inspect_2892_2891_2818.ts
+++ b/test-files/test_gap_object_inspect_2892_2891_2818.ts
@@ -1,0 +1,51 @@
+// #2892 hasOwnProperty own-key checks
+const proto = { inherited: 1 };
+const obj = Object.create(proto);
+(obj as any).own = 2;
+
+console.log(obj.hasOwnProperty("own"));
+console.log(obj.hasOwnProperty("inherited"));
+console.log(obj.hasOwnProperty("absent"));
+console.log(Object.prototype.hasOwnProperty.call(obj, "inherited"));
+
+// #2891 propertyIsEnumerable honors enumerable bit
+const p2 = { inherited: 1 };
+const o2 = Object.create(p2);
+Object.defineProperty(o2, "hidden", { value: 2, enumerable: false });
+Object.defineProperty(o2, "visible", { value: 3, enumerable: true });
+console.log(o2.propertyIsEnumerable("visible"));
+console.log(o2.propertyIsEnumerable("hidden"));
+console.log(o2.propertyIsEnumerable("inherited"));
+console.log(Object.prototype.propertyIsEnumerable.call(o2, "hidden"));
+
+// #2818 ToObject in inspection statics
+console.log(Object.keys("abc"));
+console.log(Object.values("ab"));
+console.log(Object.entries("ab"));
+console.log(Object.getOwnPropertyNames("ab"));
+console.log(Object.getOwnPropertyDescriptor("ab", "0"));
+console.log(Object.getOwnPropertyDescriptor("ab", "length")!.value);
+console.log(Object.keys(7 as any));
+console.log(Object.getOwnPropertyDescriptor(7 as any, "x"));
+const sd = Object.getOwnPropertyDescriptors("ab");
+console.log(Object.keys(sd));
+console.log(sd["1"].value, sd["1"].enumerable, sd["length"].value);
+console.log(Object.getOwnPropertySymbols("ab").length);
+console.log(Object.propertyIsEnumerable.call({ a: 1 }, "a"));
+
+function throwsType(fn: () => void): string {
+  try {
+    fn();
+    return "no throw";
+  } catch (e) {
+    return e instanceof TypeError ? "TypeError" : "other";
+  }
+}
+
+console.log(throwsType(() => Object.keys(null as any)));
+console.log(throwsType(() => Object.values(undefined as any)));
+console.log(throwsType(() => Object.entries(null as any)));
+console.log(throwsType(() => Object.getOwnPropertyNames(null as any)));
+console.log(throwsType(() => Object.getOwnPropertySymbols(undefined as any)));
+console.log(throwsType(() => Object.getOwnPropertyDescriptor(null as any, "x")));
+console.log(throwsType(() => Object.getOwnPropertyDescriptors(undefined as any)));


### PR DESCRIPTION
Closes #2892
Closes #2891
Closes #2818

## Implementation

Pure-runtime object property-inspection parity. No new HIR variant (existing ExternFuncRef reused), no file split needed.

### #2892 hasOwnProperty own-key checks
Already correct on main for ObjectHeader receivers: native_call_method.rs's hasOwnProperty arm walks own_key_present and returns false for inherited/absent keys. Covered by the gap test (own true, inherited/absent false, Object.prototype.hasOwnProperty.call false).

### #2891 propertyIsEnumerable honors the enumerable bit
The ordinary obj.propertyIsEnumerable(key) dispatch already consulted descriptor attributes, but the syntactic .call forms (Object.prototype.propertyIsEnumerable.call / Object.propertyIsEnumerable.call) fell through to reading an undefined property and returned undefined instead of a boolean.
- New runtime FFI js_object_property_is_enumerable(obj, key) (object/object_ops.rs): ToObject-nullish throw, string-primitive index/length handling, own-key + enumerable-attr lookup; mirrors the existing method-dispatch branch. #[used] keepalive anchor added (auto-optimize dead-strip protection).
- HIR rewrites in expr_call/post_args_dispatch.rs route both .call shapes to it.
- Declared in codegen runtime_decls/strings_part2.rs.

### #2818 ToObject in inspection statics
- js_object_keys_value / values / entries (field_get_set.rs): throw TypeError on null/undefined (was empty array).
- js_object_get_own_property_names (descriptors.rs): throw on null/undefined.
- js_object_get_own_property_descriptor (descriptors.rs): throw on null/undefined; new string-primitive branch producing index descriptors {value, writable:false, enumerable:true, configurable:false} and the length descriptor {value, writable:false, enumerable:false, configurable:false} via a shared build_data_descriptor helper.
- js_object_get_own_property_descriptors: inherits both behaviors (delegates to names + per-key descriptor).
- js_object_get_own_property_symbols (symbol.rs): throw on null/undefined; other primitives still box to an empty array.
- Promoted has_own_helpers::throw_to_object_nullish_type_error to pub(crate) so symbol.rs can reuse it.

## Validation

test-files/test_gap_object_inspect_2892_2891_2818.ts is byte-identical to node --experimental-strip-types under the DEFAULT auto-optimize compile. Covers hasOwnProperty own/inherited/absent + .call; propertyIsEnumerable visible/hidden/inherited + .call; Object.keys("abc") = ['0','1','2'], values/entries/getOwnPropertyNames/getOwnPropertyDescriptor on strings (index + length), getOwnPropertyDescriptors/getOwnPropertySymbols on strings, Object.keys(7) = [], and TypeError for all nullish statics.

Guards: cargo fmt --all -- --check clean, scripts/check_file_size.sh exit 0 (object_ops.rs 1890 lines), cargo test -p perry-hir green (no new variant), cargo test -p perry-runtime object green single-threaded.

Note: text_encoding_stream_globals_construct_readable_writable_shape flaps under parallel test execution; confirmed it also fails on clean origin/main (pre-existing parallel-ordering flake, unrelated to this change).
