### PR TITLE
fix(regexp): flag/pattern validation and flag property getters

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2167,8 +2167,20 @@ pub extern "C" fn js_object_get_field_by_name(
                     b"multiline" => {
                         return JSValue::bool((*re).multiline);
                     }
-                    b"sticky" | b"unicode" | b"dotAll" | b"hasIndices" => {
-                        return JSValue::bool(false);
+                    // #2828: route the remaining observable flags to the
+                    // header fields populated by `js_regexp_new` instead of
+                    // unconditionally returning `false`.
+                    b"sticky" => {
+                        return JSValue::bool((*re).sticky);
+                    }
+                    b"unicode" => {
+                        return JSValue::bool((*re).unicode);
+                    }
+                    b"dotAll" => {
+                        return JSValue::bool((*re).dot_all);
+                    }
+                    b"hasIndices" => {
+                        return JSValue::bool((*re).has_indices);
                     }
                     _ => return JSValue::undefined(),
                 }

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -71,13 +71,19 @@ fn get_or_compile_regex(pattern: &str, flags: &str) -> Arc<Regex> {
         let translated = js_regex_to_rust(pattern);
         let case_insensitive = flags.contains('i');
         let multiline = flags.contains('m');
-        let regex_pattern = if case_insensitive || multiline {
+        // #2828: the `s` (dotAll) flag maps directly onto the Rust `regex`
+        // crate's `(?s)` inline mode, so `.` matches newlines.
+        let dot_all = flags.contains('s');
+        let regex_pattern = if case_insensitive || multiline || dot_all {
             let mut prefix = String::from("(?");
             if case_insensitive {
                 prefix.push('i');
             }
             if multiline {
                 prefix.push('m');
+            }
+            if dot_all {
+                prefix.push('s');
             }
             prefix.push(')');
             format!("{}{}", prefix, translated)
@@ -124,6 +130,13 @@ pub struct RegExpHeader {
     pub case_insensitive: bool,
     pub global: bool,
     pub multiline: bool,
+    /// #2828: additional observable flags. `sticky`/`unicode`/`has_indices`
+    /// are exposed via getters (matching behavior is scoped — see notes in
+    /// `js_regexp_new`); `dot_all` IS honored at compile time via `(?s)`.
+    pub sticky: bool,
+    pub dot_all: bool,
+    pub unicode: bool,
+    pub has_indices: bool,
     /// lastIndex for global/sticky regexes (byte offset into the string for stateful exec)
     pub last_index: u32,
 }
@@ -232,6 +245,53 @@ fn js_regex_to_rust(pattern: &str) -> String {
     result
 }
 
+/// Throw a `SyntaxError` with the given message and never return.
+fn throw_regexp_syntax_error(message: &str) -> ! {
+    let msg = js_string_from_str(message);
+    let err = crate::error::js_syntaxerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+/// #2829: validate a RegExp flags string the way the spec's
+/// `RegExpInitialize` does — each flag must be one of `dgimsuvy` and must not
+/// repeat. Returns the flags in canonical (sorted) order, or throws a
+/// `SyntaxError` mirroring Node's "Invalid flags supplied to RegExp
+/// constructor '<flags>'" message.
+///
+/// Note: the `v` flag (unicodeSets) is accepted as a valid flag for parity but
+/// its set-notation matching semantics are not implemented (the regex crate
+/// has no equivalent); it behaves like an ordinary unicode pattern.
+fn validate_and_canonicalize_flags(flags: &str) -> String {
+    // Spec order of the flag bits: d g i m s u v y.
+    const FLAG_ORDER: &[char] = &['d', 'g', 'i', 'm', 's', 'u', 'v', 'y'];
+    let mut seen = [false; 8];
+    for ch in flags.chars() {
+        match FLAG_ORDER.iter().position(|&f| f == ch) {
+            Some(idx) => {
+                if seen[idx] {
+                    throw_regexp_syntax_error(&format!(
+                        "Invalid flags supplied to RegExp constructor '{}'",
+                        flags
+                    ));
+                }
+                seen[idx] = true;
+            }
+            None => {
+                throw_regexp_syntax_error(&format!(
+                    "Invalid flags supplied to RegExp constructor '{}'",
+                    flags
+                ));
+            }
+        }
+    }
+    FLAG_ORDER
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| seen[*i])
+        .map(|(_, c)| *c)
+        .collect()
+}
+
 /// Create a new RegExp from pattern and flags strings
 /// Returns a pointer to RegExpHeader
 ///
@@ -248,15 +308,41 @@ pub extern "C" fn js_regexp_new(
     } else {
         ""
     };
-    let flags_str = if is_valid_ptr(flags) {
+    let raw_flags_str = if is_valid_ptr(flags) {
         string_as_str(flags)
     } else {
         ""
     };
 
+    // #2829: reject duplicate/unknown flags (SyntaxError) and store the
+    // canonical sorted form so `.flags` reflects Node's ordering.
+    let canonical_flags = validate_and_canonicalize_flags(raw_flags_str);
+    let flags_str = canonical_flags.as_str();
+
     let case_insensitive = flags_str.contains('i');
     let global = flags_str.contains('g');
     let multiline = flags_str.contains('m');
+    let sticky = flags_str.contains('y');
+    let dot_all = flags_str.contains('s');
+    let unicode = flags_str.contains('u') || flags_str.contains('v');
+    let has_indices = flags_str.contains('d');
+
+    // #2829: reject invalid pattern syntax with a SyntaxError. A pattern the
+    // `regex` crate rejects is only a real error if `fancy-regex` (which
+    // covers the full JS feature set: lookbehind/lookahead/backreferences)
+    // ALSO rejects it — otherwise it is a valid JS pattern we route through
+    // the fancy fallback. `get_or_compile_regex` populates FANCY_CACHE when
+    // the regex crate fails but fancy-regex succeeds; check both here.
+    {
+        let translated = js_regex_to_rust(pattern_str);
+        if regex::Regex::new(&translated).is_err() && fancy_regex::Regex::new(&translated).is_err()
+        {
+            throw_regexp_syntax_error(&format!(
+                "Invalid regular expression: /{}/: invalid pattern",
+                pattern_str
+            ));
+        }
+    }
 
     // Get or compile the regex from the cache. The returned Arc is stored
     // in the cache indefinitely, so the raw pointer we extract stays valid
@@ -269,6 +355,11 @@ pub extern "C" fn js_regexp_new(
     // leaked every header, which was a 64-byte-per-call leak on top of the
     // (now-fixed) regex object leak.
     let header_size = std::mem::size_of::<RegExpHeader>();
+    // Materialize the canonical flags into a fresh StringHeader so that
+    // `flags_ptr`-keyed lookups (FANCY_CACHE, lookup_fancy_regex) and the
+    // GC-survivable source table all agree on the canonical form, and the
+    // header never holds the caller's possibly-temporary input flags.
+    let canonical_flags_ptr = js_string_from_str(flags_str);
     unsafe {
         let raw = crate::gc::gc_malloc(header_size, crate::gc::GC_TYPE_OBJECT);
         if raw.is_null() {
@@ -278,10 +369,14 @@ pub extern "C" fn js_regexp_new(
 
         (*ptr).regex_ptr = regex_ptr;
         (*ptr).pattern_ptr = pattern;
-        (*ptr).flags_ptr = flags;
+        (*ptr).flags_ptr = canonical_flags_ptr;
         (*ptr).case_insensitive = case_insensitive;
         (*ptr).global = global;
         (*ptr).multiline = multiline;
+        (*ptr).sticky = sticky;
+        (*ptr).dot_all = dot_all;
+        (*ptr).unicode = unicode;
+        (*ptr).has_indices = has_indices;
         (*ptr).last_index = 0;
 
         // Record the pointer so that js_string_split can detect

--- a/test-files/test_gap_regexp_flags_2829_2828.ts
+++ b/test-files/test_gap_regexp_flags_2829_2828.ts
@@ -1,0 +1,49 @@
+// Gap test for #2829 (RegExp flag/pattern validation + canonical .flags) and
+// #2828 (sticky/dotAll/unicode/hasIndices flag getters).
+//
+// Scope note: the Rust `regex` crate cannot implement true sticky (`y`)
+// MATCHING or `d` (hasIndices) match.indices, so this test only asserts the
+// flag GETTER properties for `y`/`u`/`d`, the canonical `.flags` ordering,
+// constructor flag/pattern validation, and `s` (dotAll) match behavior (which
+// maps onto the regex crate's `(?s)` mode).
+
+// --- Canonical .flags ordering -------------------------------------------
+const re = /x/gimsuy;
+console.log(re.flags);
+console.log(re.global, re.ignoreCase, re.multiline, re.sticky, re.dotAll, re.unicode);
+console.log(re.source);
+
+// Per-flag isolation
+console.log(/a/g.flags, /a/g.global, /a/g.sticky);
+console.log(/a/y.flags, /a/y.sticky, /a/y.global);
+console.log(/a/s.flags, /a/s.dotAll);
+console.log(/a/u.flags, /a/u.unicode);
+console.log(/a/d.flags, /a/d.hasIndices);
+console.log(/a/i.flags, /a/i.ignoreCase);
+console.log(/a/m.flags, /a/m.multiline);
+console.log(/a/.flags, /a/.global, /a/.sticky, /a/.dotAll, /a/.unicode, /a/.hasIndices);
+
+// new RegExp canonicalizes flag order too
+console.log(new RegExp("a", "yusimg").flags);
+console.log(new RegExp("a", "mig").flags);
+
+// --- dotAll matching behavior (regex crate (?s)) -------------------------
+console.log(/a.b/s.test("a\nb"));
+console.log(/a.b/.test("a\nb"));
+
+// --- Constructor validation throws SyntaxError ---------------------------
+function expectSyntaxError(fn: () => void): boolean {
+  try {
+    fn();
+    return false;
+  } catch (e) {
+    return e instanceof SyntaxError;
+  }
+}
+
+console.log(expectSyntaxError(() => new RegExp("x", "gg")));   // duplicate flag
+console.log(expectSyntaxError(() => new RegExp("x", "Q")));    // invalid flag
+console.log(expectSyntaxError(() => new RegExp("(", "")));     // invalid pattern
+console.log(expectSyntaxError(() => new RegExp("x", "gimg"))); // duplicate among many
+console.log(expectSyntaxError(() => RegExp("x", "z")));        // bare call invalid flag
+console.log(expectSyntaxError(() => new RegExp("x", "gim")));  // valid → false


### PR DESCRIPTION
Closes #2829
Closes #2828

## Implementation

All work is in the runtime (no new HIR variant, no new codegen-emitted FFI).

**#2829 — constructor flag/pattern validation + canonical `.flags`** (`crates/perry-runtime/src/regex.rs`):
- `validate_and_canonicalize_flags()` runs in `js_regexp_new` (the single chokepoint for both `/lit/flags`, `new RegExp(p, f)`, and bare `RegExp(p, f)`). Each flag must be one of `dgimsuvy` and must not repeat; a duplicate or unknown flag throws `SyntaxError` with Node's `Invalid flags supplied to RegExp constructor '<flags>'` message. The returned flags are in canonical (spec-bit) order.
- The header's `flags_ptr` is now a freshly materialized canonical-flags `StringHeader`, and the GC-survivable source table stores the canonical form, so `.flags` reflects Node's ordering (e.g. `"yusimg"` → `"gimsuy"`, `"mig"` → `"gim"`).
- Invalid pattern syntax throws `SyntaxError`: a pattern is only rejected when BOTH the `regex` crate and `fancy-regex` (which covers lookbehind/lookahead/backreferences) fail to compile, so valid-JS-but-regex-crate-unsupported patterns still route through the existing fancy fallback rather than erroring.

**#2828 — sticky/dotAll/unicode/hasIndices flag getters**:
- Added `sticky`/`dot_all`/`unicode`/`has_indices` bools to `RegExpHeader`, populated in `js_regexp_new`.
- `js_object_get_field_by_name` (`object/field_get_set.rs`) now routes `.sticky`/`.unicode`/`.dotAll`/`.hasIndices` to those header fields instead of unconditionally returning `false`.
- `dotAll` (`s`) is honored at match time by translating to the regex crate's `(?s)` inline mode, so `/a.b/s.test("a\nb")` is `true`.

## Validation

`test-files/test_gap_regexp_flags_2829_2828.ts` compiled under the DEFAULT auto-optimize flow and run is **byte-identical** to `node --experimental-strip-types` (`diff` reports IDENTICAL). Covers canonical `.flags`, every per-flag getter, dotAll matching, and the four required SyntaxError cases (duplicate flag, invalid flag, invalid pattern, bare-call invalid flag) plus a valid-flags negative case.

Guards green: `./scripts/check_file_size.sh` (exit 0), `cargo fmt --all -- --check` (clean), `cargo test --release -p perry-runtime` (regex suite passes), `cargo test --release -p perry-hir` (passes).

## Scope / dropped sub-behaviors

The Rust `regex` crate cannot implement two flag behaviors, so these are intentionally NOT claimed (the gap test does not assert them):
- **`y` (sticky) matching**: the crate has no anchored-at-`lastIndex` sticky mode. The `.sticky` getter is exposed; sticky exec semantics are unchanged.
- **`d` (hasIndices) `match.indices`**: the crate exposes no indices array. The `.hasIndices` getter is exposed; no `indices` is added to exec results.
- **`v` (unicodeSets)** is accepted as a valid flag for parity and reflected via `.unicode`, but set-notation matching is not implemented.
