### PR TITLE
fix(typedarray): implement Uint8Array base64/hex conversion APIs

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -3177,6 +3177,10 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("buffer", "of", false, None),
     method("buffer", "concat", false, None),
     method("buffer", "copyBytesFrom", false, None),
+    // #2901: TC39 `Uint8Array.fromBase64` / `fromHex` static factories,
+    // routed through the buffer module (Uint8Array ≡ Buffer in Perry).
+    method("buffer", "fromBase64", false, None),
+    method("buffer", "fromHex", false, None),
     method("buffer", "isBuffer", false, None),
     method("buffer", "isEncoding", false, None),
     method("buffer", "byteLength", false, None),

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -1468,6 +1468,27 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_F64, NA_F64, NA_F64],
         ret: NR_PTR,
     },
+    // #2901: TC39 `Uint8Array.fromBase64(str, opts)` / `fromHex(str)`.
+    // Routed via the buffer module (Uint8Array ≡ Buffer in Perry); the
+    // runtime decodes strictly into a fresh BufferHeader.
+    NativeModSig {
+        module: "buffer",
+        has_receiver: false,
+        method: "fromBase64",
+        class_filter: None,
+        runtime: "js_u8_from_base64",
+        args: &[NA_STR, NA_F64],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "buffer",
+        has_receiver: false,
+        method: "fromHex",
+        class_filter: None,
+        runtime: "js_u8_from_hex",
+        args: &[NA_STR],
+        ret: NR_PTR,
+    },
     NativeModSig {
         module: "buffer",
         has_receiver: false,

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -1164,6 +1164,25 @@ pub(super) fn try_module_static_methods(
                 }
             }
 
+            // #2901: TC39 `Uint8Array.fromBase64(str, opts)` / `fromHex(str)`
+            // static factories. Perry aliases Uint8Array → Buffer; route these
+            // through the buffer native-module dispatch table (no new HIR
+            // variant) so the runtime decodes into a fresh BufferHeader.
+            if obj_name == "Uint8Array" {
+                if let ast::MemberProp::Ident(method_ident) = &member.prop {
+                    let method_name = method_ident.sym.as_ref();
+                    if matches!(method_name, "fromBase64" | "fromHex") {
+                        return Ok(Ok(Expr::NativeMethodCall {
+                            module: "buffer".to_string(),
+                            class_name: None,
+                            object: None,
+                            method: method_name.to_string(),
+                            args,
+                        }));
+                    }
+                }
+            }
+
             // Check for child_process named imports (execSync, spawnSync, spawn, exec)
             let is_child_process_module =
                 ctx.lookup_builtin_module_alias(obj_name) == Some("child_process");

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -22,6 +22,7 @@ mod mutate;
 mod numeric;
 mod query;
 mod transcode;
+mod u8_codec;
 pub mod validate;
 mod view;
 
@@ -58,6 +59,12 @@ pub use query::{
 pub use encode::{
     buffer_to_array, js_buffer_length, js_buffer_print, js_buffer_to_string,
     js_buffer_to_string_range, js_value_to_string_with_encoding,
+};
+
+// ---- Re-exports: TC39 Uint8Array base64/hex codecs (#2901) ----
+pub use u8_codec::{
+    js_u8_from_base64, js_u8_from_hex, js_u8_set_from_base64, js_u8_set_from_hex, js_u8_to_base64,
+    js_u8_to_hex,
 };
 
 // ---- Re-exports: indexed access / slice / Uint8Array.set ----

--- a/crates/perry-runtime/src/buffer/u8_codec.rs
+++ b/crates/perry-runtime/src/buffer/u8_codec.rs
@@ -1,0 +1,576 @@
+//! TC39 Uint8Array base64/hex conversion APIs (issue #2901).
+//!
+//! Implements the instance methods `toBase64({alphabet, omitPadding})`,
+//! `toHex()`, `setFromBase64(str, {alphabet, lastChunkHandling})`,
+//! `setFromHex(str)` and the static factories `Uint8Array.fromBase64` /
+//! `Uint8Array.fromHex`. Perry aliases `Uint8Array` to its `Buffer`
+//! representation (#2447), so the receiver of the instance methods is a
+//! `BufferHeader` and the static factories return a fresh `BufferHeader`.
+//!
+//! These differ from the existing permissive Buffer hex/base64 codecs
+//! (`coding.rs`) in that TC39 mandates *strict* validation: an invalid
+//! character or an odd-length hex string throws a `SyntaxError`, and the
+//! base64 alphabet is selected explicitly (standard `+/` vs. url `-_`)
+//! rather than accepting both. Interior/trailing ASCII whitespace is
+//! tolerated in base64 input.
+
+use super::header::{buffer_alloc, buffer_data, buffer_data_mut, BufferHeader};
+use crate::object::{js_object_alloc, js_object_set_field_by_name};
+use crate::string::{js_string_alloc_ascii_uninit, js_string_from_ascii_bytes, StringHeader};
+use crate::value::JSValue;
+
+const STD_ENCODE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const URL_ENCODE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+const HEX_ENCODE: &[u8; 16] = b"0123456789abcdef";
+
+/// 0..=63 valid, 255 invalid. Standard alphabet (`+` = 62, `/` = 63).
+const STD_DECODE: [u8; 256] = build_b64_decode(false);
+/// Url-safe alphabet (`-` = 62, `_` = 63).
+const URL_DECODE: [u8; 256] = build_b64_decode(true);
+
+const fn build_b64_decode(url: bool) -> [u8; 256] {
+    let mut t = [255u8; 256];
+    let mut i = 0u8;
+    while i < 26 {
+        t[(b'A' + i) as usize] = i;
+        t[(b'a' + i) as usize] = i + 26;
+        i += 1;
+    }
+    let mut i = 0u8;
+    while i < 10 {
+        t[(b'0' + i) as usize] = i + 52;
+        i += 1;
+    }
+    if url {
+        t[b'-' as usize] = 62;
+        t[b'_' as usize] = 63;
+    } else {
+        t[b'+' as usize] = 62;
+        t[b'/' as usize] = 63;
+    }
+    t
+}
+
+const HEX_DECODE: [u8; 256] = {
+    let mut t = [255u8; 256];
+    let mut i = 0u8;
+    while i < 10 {
+        t[(b'0' + i) as usize] = i;
+        i += 1;
+    }
+    let mut i = 0u8;
+    while i < 6 {
+        t[(b'a' + i) as usize] = 10 + i;
+        t[(b'A' + i) as usize] = 10 + i;
+        i += 1;
+    }
+    t
+};
+
+#[inline]
+fn is_b64_whitespace(b: u8) -> bool {
+    matches!(b, b' ' | b'\t' | b'\n' | b'\r' | 0x0c)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: unbox pointers, read input strings, throw, build result objects.
+// ---------------------------------------------------------------------------
+
+#[inline]
+fn unbox_ptr(raw: u64) -> usize {
+    let top16 = raw >> 48;
+    if top16 >= 0x7FF8 {
+        (raw & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else {
+        raw as usize
+    }
+}
+
+unsafe fn buffer_from_addr(addr: usize) -> *mut BufferHeader {
+    unbox_ptr(addr as u64) as *mut BufferHeader
+}
+
+/// Read the bytes of a `StringHeader` (passed as an i64 handle, possibly
+/// NaN-boxed). Returns `None` when the handle is null.
+unsafe fn string_bytes<'a>(str_handle: i64) -> Option<&'a [u8]> {
+    let addr = unbox_ptr(str_handle as u64);
+    if addr < 0x1000 {
+        return None;
+    }
+    let hdr = addr as *const StringHeader;
+    let bytes = (hdr as *const u8).add(std::mem::size_of::<StringHeader>());
+    Some(std::slice::from_raw_parts(bytes, (*hdr).byte_len as usize))
+}
+
+fn throw_syntax(message: &[u8]) -> ! {
+    let s = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_syntaxerror_new(s);
+    crate::exception::js_throw(f64::from_bits(JSValue::pointer(err as *mut u8).bits()))
+}
+
+fn throw_type(message: &[u8]) -> ! {
+    let s = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(f64::from_bits(JSValue::pointer(err as *mut u8).bits()))
+}
+
+/// Build a `{ read, written }` result object as Node returns for `setFrom*`.
+unsafe fn read_written_object(read: usize, written: usize) -> f64 {
+    let obj = js_object_alloc(0, 2);
+    let read_key = crate::string::js_string_from_bytes(b"read".as_ptr(), 4);
+    js_object_set_field_by_name(obj, read_key, read as f64);
+    let written_key = crate::string::js_string_from_bytes(b"written".as_ptr(), 7);
+    js_object_set_field_by_name(obj, written_key, written as f64);
+    f64::from_bits(JSValue::pointer(obj as *mut u8).bits())
+}
+
+/// Read the `alphabet` option ("base64" | "base64url") from an options object.
+/// Returns true when base64url is requested. Non-object / missing → false.
+unsafe fn opt_is_base64url(opts_bits: f64) -> bool {
+    match opt_string_field(opts_bits, b"alphabet") {
+        Some(s) => s == "base64url",
+        None => false,
+    }
+}
+
+unsafe fn opt_omit_padding(opts_bits: f64) -> bool {
+    let raw = opts_bits.to_bits();
+    if (raw >> 48) as u16 != 0x7FFD {
+        return false;
+    }
+    let obj = (raw & 0x0000_FFFF_FFFF_FFFF) as *const crate::object::ObjectHeader;
+    if (obj as usize) < 0x1000 {
+        return false;
+    }
+    let key = crate::string::js_string_from_bytes(b"omitPadding".as_ptr(), 11);
+    let val = crate::object::js_object_get_field_by_name(obj, key);
+    crate::value::js_is_truthy(f64::from_bits(val.bits())) != 0
+}
+
+/// `lastChunkHandling`: 0 = loose (default), 1 = strict, 2 = stop-before-partial.
+unsafe fn opt_last_chunk_handling(opts_bits: f64) -> u8 {
+    match opt_string_field(opts_bits, b"lastChunkHandling") {
+        Some(s) if s == "strict" => 1,
+        Some(s) if s == "stop-before-partial" => 2,
+        _ => 0,
+    }
+}
+
+unsafe fn opt_string_field(opts_bits: f64, name: &[u8]) -> Option<String> {
+    let raw = opts_bits.to_bits();
+    if (raw >> 48) as u16 != 0x7FFD {
+        return None;
+    }
+    let obj = (raw & 0x0000_FFFF_FFFF_FFFF) as *const crate::object::ObjectHeader;
+    if (obj as usize) < 0x1000 {
+        return None;
+    }
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let val = crate::object::js_object_get_field_by_name(obj, key);
+    let vbits = val.bits();
+    if (vbits >> 48) as u16 != 0x7FFF {
+        return None;
+    }
+    let ptr = (vbits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+    if ptr.is_null() {
+        return None;
+    }
+    let bytes = std::slice::from_raw_parts(
+        (ptr as *const u8).add(std::mem::size_of::<StringHeader>()),
+        (*ptr).byte_len as usize,
+    );
+    std::str::from_utf8(bytes).ok().map(str::to_string)
+}
+
+// ---------------------------------------------------------------------------
+// Encoders.
+// ---------------------------------------------------------------------------
+
+fn hex_encode(bytes: &[u8]) -> *mut StringHeader {
+    let out_len = bytes.len() * 2;
+    if out_len == 0 {
+        return js_string_from_ascii_bytes(std::ptr::null(), 0);
+    }
+    let (hdr, dst) = js_string_alloc_ascii_uninit(out_len as u32);
+    unsafe {
+        for (i, &b) in bytes.iter().enumerate() {
+            *dst.add(i * 2) = *HEX_ENCODE.get_unchecked((b >> 4) as usize);
+            *dst.add(i * 2 + 1) = *HEX_ENCODE.get_unchecked((b & 0xF) as usize);
+        }
+    }
+    hdr
+}
+
+fn base64_encode(bytes: &[u8], url: bool, omit_padding: bool) -> *mut StringHeader {
+    let table = if url { URL_ENCODE } else { STD_ENCODE };
+    let rem = bytes.len() % 3;
+    let full_groups = bytes.len() / 3;
+    let tail_len = match rem {
+        0 => 0,
+        _ => {
+            if omit_padding {
+                rem + 1 // 1 byte -> 2 chars, 2 bytes -> 3 chars
+            } else {
+                4
+            }
+        }
+    };
+    let out_len = full_groups * 4 + tail_len;
+    if out_len == 0 {
+        return js_string_from_ascii_bytes(std::ptr::null(), 0);
+    }
+    let (hdr, dst) = js_string_alloc_ascii_uninit(out_len as u32);
+    unsafe {
+        let mut i = 0usize;
+        let mut o = 0usize;
+        let triple_end = bytes.len() - rem;
+        while i < triple_end {
+            let a = *bytes.get_unchecked(i) as u32;
+            let b = *bytes.get_unchecked(i + 1) as u32;
+            let c = *bytes.get_unchecked(i + 2) as u32;
+            let n = (a << 16) | (b << 8) | c;
+            *dst.add(o) = *table.get_unchecked((n >> 18) as usize);
+            *dst.add(o + 1) = *table.get_unchecked(((n >> 12) & 0x3F) as usize);
+            *dst.add(o + 2) = *table.get_unchecked(((n >> 6) & 0x3F) as usize);
+            *dst.add(o + 3) = *table.get_unchecked((n & 0x3F) as usize);
+            i += 3;
+            o += 4;
+        }
+        if rem == 1 {
+            let a = *bytes.get_unchecked(i) as u32;
+            let n = a << 16;
+            *dst.add(o) = *table.get_unchecked((n >> 18) as usize);
+            *dst.add(o + 1) = *table.get_unchecked(((n >> 12) & 0x3F) as usize);
+            if !omit_padding {
+                *dst.add(o + 2) = b'=';
+                *dst.add(o + 3) = b'=';
+            }
+        } else if rem == 2 {
+            let a = *bytes.get_unchecked(i) as u32;
+            let b = *bytes.get_unchecked(i + 1) as u32;
+            let n = (a << 16) | (b << 8);
+            *dst.add(o) = *table.get_unchecked((n >> 18) as usize);
+            *dst.add(o + 1) = *table.get_unchecked(((n >> 12) & 0x3F) as usize);
+            *dst.add(o + 2) = *table.get_unchecked(((n >> 6) & 0x3F) as usize);
+            if !omit_padding {
+                *dst.add(o + 3) = b'=';
+            }
+        }
+    }
+    hdr
+}
+
+// ---------------------------------------------------------------------------
+// Strict decoders (write into a caller-provided slice, bounded by `max`).
+// ---------------------------------------------------------------------------
+
+struct DecodeResult {
+    read: usize,    // bytes consumed from the input string
+    written: usize, // bytes written to the output
+}
+
+/// Strict TC39 hex decode. Throws SyntaxError on odd length or invalid char.
+/// Writes up to `dst.len()` bytes; returns chars-read / bytes-written.
+fn hex_decode_strict(input: &[u8], dst: &mut [u8]) -> DecodeResult {
+    if input.len() % 2 != 0 {
+        throw_syntax(b"Input string must contain hex characters in even length");
+    }
+    let mut written = 0usize;
+    let mut read = 0usize;
+    let mut i = 0usize;
+    while i + 2 <= input.len() {
+        let hi = HEX_DECODE[input[i] as usize];
+        let lo = HEX_DECODE[input[i + 1] as usize];
+        if hi == 255 || lo == 255 {
+            throw_syntax(b"Input string must contain only hex characters");
+        }
+        if written >= dst.len() {
+            break;
+        }
+        dst[written] = (hi << 4) | lo;
+        written += 1;
+        read += 2;
+        i += 2;
+    }
+    DecodeResult { read, written }
+}
+
+/// Strict TC39 base64 decode bounded by `dst.len()`.
+///
+/// `bounded` controls the partial-final-chunk behavior for `setFromBase64`:
+/// when true, a final group whose decoded bytes would overflow `dst` is not
+/// written at all (matching Node's chunk-boundary `{read, written}`).
+fn base64_decode_strict(
+    input: &[u8],
+    url: bool,
+    last_chunk: u8,
+    dst: &mut [u8],
+    bounded: bool,
+) -> DecodeResult {
+    let table = if url { &URL_DECODE } else { &STD_DECODE };
+    // Collect the 6-bit values of significant characters, tracking input
+    // offsets so `read` reflects characters consumed from the source string.
+    let mut written = 0usize;
+    // Sextet accumulator for the current 4-char group.
+    let mut group: [u8; 4] = [0; 4];
+    let mut group_len = 0usize;
+    // Offset just past the last fully-consumed group.
+    let mut last_group_end = 0usize;
+    let mut i = 0usize;
+    let mut saw_padding = false;
+    let mut pad_count = 0usize;
+
+    while i < input.len() {
+        let b = input[i];
+        i += 1;
+        if is_b64_whitespace(b) {
+            continue;
+        }
+        if b == b'=' {
+            saw_padding = true;
+            pad_count += 1;
+            // Padding only valid in the last group (group_len 2 or 3).
+            if group_len < 2 || pad_count > 2 {
+                throw_syntax(b"Invalid base64 padding");
+            }
+            if (group_len == 2 && pad_count == 2) || group_len == 3 {
+                // Group complete with padding; flush the final partial group.
+                break;
+            }
+            continue;
+        }
+        if saw_padding {
+            throw_syntax(b"Found a character after end of padding");
+        }
+        let v = table[b as usize];
+        if v == 255 {
+            throw_syntax(b"Found a character that cannot be part of a valid base64 string.");
+        }
+        group[group_len] = v;
+        group_len += 1;
+        if group_len == 4 {
+            // Emit a full 3-byte group if it fits.
+            let out = [
+                (group[0] << 2) | (group[1] >> 4),
+                (group[1] << 4) | (group[2] >> 2),
+                (group[2] << 6) | group[3],
+            ];
+            if written + 3 > dst.len() {
+                if bounded {
+                    // Stop before this group; do not consume it.
+                    return DecodeResult {
+                        read: last_group_end,
+                        written,
+                    };
+                }
+                // Unbounded (fromBase64): dst is sized exactly, so this is
+                // unreachable, but be defensive.
+                let room = dst.len() - written;
+                dst[written..].copy_from_slice(&out[..room]);
+                written += room;
+                last_group_end = i;
+                return DecodeResult {
+                    read: last_group_end,
+                    written,
+                };
+            }
+            dst[written] = out[0];
+            dst[written + 1] = out[1];
+            dst[written + 2] = out[2];
+            written += 3;
+            group_len = 0;
+            last_group_end = i;
+        }
+    }
+
+    // Handle the trailing partial group (group_len 1..=3, or padded).
+    if group_len == 0 {
+        return DecodeResult {
+            read: last_group_end,
+            written,
+        };
+    }
+    if group_len == 1 {
+        // A single trailing sextet can't form a byte.
+        if last_chunk == 1 {
+            throw_syntax(
+                b"The base64 input terminates with a single character, excluding padding (=).",
+            );
+        }
+        // loose / stop-before-partial: drop it.
+        return DecodeResult {
+            read: last_group_end,
+            written,
+        };
+    }
+    // group_len is 2 or 3.
+    if last_chunk == 2 && !saw_padding {
+        // stop-before-partial: leave the partial chunk unconsumed.
+        return DecodeResult {
+            read: last_group_end,
+            written,
+        };
+    }
+    if last_chunk == 1 && !saw_padding {
+        throw_syntax(b"Missing padding character in base64 string");
+    }
+    let produced = group_len - 1; // 2 sextets -> 1 byte, 3 sextets -> 2 bytes
+    let out = [
+        (group[0] << 2) | (group[1] >> 4),
+        (group[1] << 4) | (group[2] >> 2),
+    ];
+    if last_chunk == 1 {
+        // strict: the unused trailing bits must be zero.
+        let extra_bits_zero = if group_len == 2 {
+            (group[1] & 0x0F) == 0
+        } else {
+            (group[2] & 0x03) == 0
+        };
+        if !extra_bits_zero {
+            throw_syntax(b"The base64 input contains non-zero bits after the final character");
+        }
+    }
+    let room = dst.len().saturating_sub(written);
+    let to_write = produced.min(room);
+    if bounded && to_write < produced {
+        // Final partial group doesn't fully fit; write nothing more.
+        return DecodeResult {
+            read: last_group_end,
+            written,
+        };
+    }
+    dst[written..written + to_write].copy_from_slice(&out[..to_write]);
+    written += to_write;
+    DecodeResult { read: i, written }
+}
+
+/// Count the decoded byte length of a (validated) base64 string for the
+/// unbounded `fromBase64` allocation. We over-allocate to the maximum and
+/// trim afterwards, so a cheap upper bound suffices.
+fn base64_max_bytes(input: &[u8]) -> usize {
+    input.len().saturating_mul(3) / 4 + 3
+}
+
+// ---------------------------------------------------------------------------
+// Public FFI entry points.
+// ---------------------------------------------------------------------------
+
+/// `Uint8Array.prototype.toBase64({ alphabet?, omitPadding? })`.
+#[no_mangle]
+pub extern "C" fn js_u8_to_base64(addr: i64, opts_bits: f64) -> *mut StringHeader {
+    unsafe {
+        let buf = buffer_from_addr(addr as usize);
+        if buf.is_null() || (buf as usize) < 0x1000 {
+            return js_string_from_ascii_bytes(std::ptr::null(), 0);
+        }
+        let len = (*buf).length as usize;
+        let bytes = std::slice::from_raw_parts(buffer_data(buf), len);
+        let url = opt_is_base64url(opts_bits);
+        let omit = opt_omit_padding(opts_bits);
+        base64_encode(bytes, url, omit)
+    }
+}
+
+/// `Uint8Array.prototype.toHex()`.
+#[no_mangle]
+pub extern "C" fn js_u8_to_hex(addr: i64) -> *mut StringHeader {
+    unsafe {
+        let buf = buffer_from_addr(addr as usize);
+        if buf.is_null() || (buf as usize) < 0x1000 {
+            return js_string_from_ascii_bytes(std::ptr::null(), 0);
+        }
+        let len = (*buf).length as usize;
+        let bytes = std::slice::from_raw_parts(buffer_data(buf), len);
+        hex_encode(bytes)
+    }
+}
+
+/// `Uint8Array.fromBase64(str, { alphabet?, lastChunkHandling? })`.
+#[no_mangle]
+pub extern "C" fn js_u8_from_base64(str_handle: i64, opts_bits: f64) -> *mut BufferHeader {
+    unsafe {
+        let Some(input) = string_bytes(str_handle) else {
+            throw_type(b"input argument must be a string");
+        };
+        let url = opt_is_base64url(opts_bits);
+        let last_chunk = opt_last_chunk_handling(opts_bits);
+        let max = base64_max_bytes(input);
+        let buf = buffer_alloc(max as u32);
+        let dst = std::slice::from_raw_parts_mut(buffer_data_mut(buf), max);
+        let res = base64_decode_strict(input, url, last_chunk, dst, false);
+        (*buf).length = res.written as u32;
+        buf
+    }
+}
+
+/// `Uint8Array.fromHex(str)`.
+#[no_mangle]
+pub extern "C" fn js_u8_from_hex(str_handle: i64) -> *mut BufferHeader {
+    unsafe {
+        let Some(input) = string_bytes(str_handle) else {
+            throw_type(b"input argument must be a string");
+        };
+        let max = input.len() / 2;
+        let buf = buffer_alloc(max as u32);
+        let dst = std::slice::from_raw_parts_mut(buffer_data_mut(buf), max);
+        let res = hex_decode_strict(input, dst);
+        (*buf).length = res.written as u32;
+        buf
+    }
+}
+
+/// `Uint8Array.prototype.setFromBase64(str, { alphabet?, lastChunkHandling? })`.
+/// Returns `{ read, written }`.
+#[no_mangle]
+pub extern "C" fn js_u8_set_from_base64(addr: i64, str_handle: i64, opts_bits: f64) -> f64 {
+    unsafe {
+        let buf = buffer_from_addr(addr as usize);
+        if buf.is_null() || (buf as usize) < 0x1000 {
+            return read_written_object(0, 0);
+        }
+        let Some(input) = string_bytes(str_handle) else {
+            throw_type(b"input argument must be a string");
+        };
+        let url = opt_is_base64url(opts_bits);
+        let last_chunk = opt_last_chunk_handling(opts_bits);
+        let cap = (*buf).length as usize;
+        let dst = std::slice::from_raw_parts_mut(buffer_data_mut(buf), cap);
+        let res = base64_decode_strict(input, url, last_chunk, dst, true);
+        read_written_object(res.read, res.written)
+    }
+}
+
+/// `Uint8Array.prototype.setFromHex(str)`. Returns `{ read, written }`.
+#[no_mangle]
+pub extern "C" fn js_u8_set_from_hex(addr: i64, str_handle: i64) -> f64 {
+    unsafe {
+        let buf = buffer_from_addr(addr as usize);
+        if buf.is_null() || (buf as usize) < 0x1000 {
+            return read_written_object(0, 0);
+        }
+        let Some(input) = string_bytes(str_handle) else {
+            throw_type(b"input argument must be a string");
+        };
+        let cap = (*buf).length as usize;
+        let dst = std::slice::from_raw_parts_mut(buffer_data_mut(buf), cap);
+        let res = hex_decode_strict(input, dst);
+        read_written_object(res.read, res.written)
+    }
+}
+
+// Keepalive anchors: these `#[no_mangle]` symbols are only referenced from
+// generated `.o` files, so the auto-optimize whole-program-LLVM bitcode
+// rebuild would dead-strip them without an `#[used]` reference. See
+// project_auto_optimize_keepalive_3320.
+#[used]
+static KEEP_U8_TO_BASE64: extern "C" fn(i64, f64) -> *mut StringHeader = js_u8_to_base64;
+#[used]
+static KEEP_U8_TO_HEX: extern "C" fn(i64) -> *mut StringHeader = js_u8_to_hex;
+#[used]
+static KEEP_U8_FROM_BASE64: extern "C" fn(i64, f64) -> *mut BufferHeader = js_u8_from_base64;
+#[used]
+static KEEP_U8_FROM_HEX: extern "C" fn(i64) -> *mut BufferHeader = js_u8_from_hex;
+#[used]
+static KEEP_U8_SET_FROM_BASE64: extern "C" fn(i64, i64, f64) -> f64 = js_u8_set_from_base64;
+#[used]
+static KEEP_U8_SET_FROM_HEX: extern "C" fn(i64, i64) -> f64 = js_u8_set_from_hex;

--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -155,6 +155,11 @@ pub fn is_buffer_method_name(name: &str) -> bool {
             | "writeUintLE"
             | "writeIntBE"
             | "writeIntLE"
+            // #2901: TC39 Uint8Array base64/hex instance conversion APIs.
+            | "toBase64"
+            | "toHex"
+            | "setFromBase64"
+            | "setFromHex"
             // #2879: typed-array mutators that reach buffer dispatch for the
             // Uint8Array/Buffer shape.
             | "copyWithin"
@@ -376,6 +381,26 @@ pub unsafe fn dispatch_buffer_method(
                 crate::buffer::js_buffer_to_string(buf_ptr, enc)
             };
             f64::from_bits(JSValue::string_ptr(str_ptr).bits())
+        }
+        // TC39 Uint8Array base64/hex conversion APIs (#2901). Perry aliases
+        // Uint8Array → Buffer, so these instance methods reach buffer dispatch.
+        "toBase64" => {
+            let opts = arg_or_zero(0);
+            let s = crate::buffer::js_u8_to_base64(addr as i64, opts);
+            f64::from_bits(JSValue::string_ptr(s).bits())
+        }
+        "toHex" => {
+            let s = crate::buffer::js_u8_to_hex(addr as i64);
+            f64::from_bits(JSValue::string_ptr(s).bits())
+        }
+        "setFromBase64" => {
+            let str_handle = arg_or_zero(0).to_bits() as i64;
+            let opts = arg_or_zero(1);
+            crate::buffer::js_u8_set_from_base64(addr as i64, str_handle, opts)
+        }
+        "setFromHex" => {
+            let str_handle = arg_or_zero(0).to_bits() as i64;
+            crate::buffer::js_u8_set_from_hex(addr as i64, str_handle)
         }
         "inspect" => {
             crate::builtins::js_util_inspect(buf_f64, f64::from_bits(crate::value::TAG_UNDEFINED))

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1835 entries across 89 modules
+// Coverage: 1837 entries across 89 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -256,6 +256,10 @@ declare module "buffer" {
   export function copyBytesFrom(...args: any[]): any;
   /** stdlib */
   export function from(...args: any[]): any;
+  /** stdlib */
+  export function fromBase64(...args: any[]): any;
+  /** stdlib */
+  export function fromHex(...args: any[]): any;
   /** stdlib */
   export function isAscii(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1835 entries across 89 modules.
+Total: 1837 entries across 89 modules.
 
 ## Modules
 
@@ -271,6 +271,8 @@ Total: 1835 entries across 89 modules.
 - `concat` — module
 - `copyBytesFrom` — module
 - `from` — module
+- `fromBase64` — module
+- `fromHex` — module
 - `isAscii` — module
 - `isBuffer` — module
 - `isEncoding` — module

--- a/test-files/test_gap_u8_base64_hex_2901.ts
+++ b/test-files/test_gap_u8_base64_hex_2901.ts
@@ -1,0 +1,56 @@
+// #2901: TC39 Uint8Array base64/hex conversion APIs.
+
+// Instance toBase64 / toHex round-trips.
+console.log(new Uint8Array([72, 105]).toBase64());
+console.log(new Uint8Array([72, 105]).toHex());
+console.log(new Uint8Array([1, 2, 3]).toBase64());
+console.log(new Uint8Array([1, 2]).toBase64());
+console.log(new Uint8Array([255, 16, 0]).toHex());
+
+// base64url alphabet + omitPadding.
+console.log(new Uint8Array([251, 255, 190]).toBase64({ alphabet: "base64url" }));
+console.log(new Uint8Array([1, 2]).toBase64({ alphabet: "base64url" }));
+console.log(new Uint8Array([1, 2]).toBase64({ omitPadding: true }));
+console.log(new Uint8Array([1, 2]).toBase64({ alphabet: "base64url", omitPadding: true }));
+
+// Static fromBase64 / fromHex.
+const a = Uint8Array.fromBase64("SGk=");
+console.log(JSON.stringify([...a]));
+const b = Uint8Array.fromBase64("AQID");
+console.log(JSON.stringify([...b]));
+const c = Uint8Array.fromHex("4869");
+console.log(JSON.stringify([...c]));
+const d = Uint8Array.fromHex("0aff");
+console.log(JSON.stringify([...d]));
+
+// base64url decode.
+console.log(JSON.stringify([...Uint8Array.fromBase64("-_--", { alphabet: "base64url" })]));
+
+// Empty inputs.
+console.log(JSON.stringify([...Uint8Array.fromBase64("")]));
+console.log(JSON.stringify([...Uint8Array.fromHex("")]));
+
+// Whitespace tolerance.
+console.log(JSON.stringify([...Uint8Array.fromBase64("AQ ID")]));
+
+// setFromBase64 / setFromHex partial writes.
+const c1 = new Uint8Array(4);
+const r1 = c1.setFromBase64("AQIDBAU=");
+console.log(JSON.stringify([...c1]), JSON.stringify(r1));
+
+const c2 = new Uint8Array(5);
+const r2 = c2.setFromBase64("AQIDBAU=");
+console.log(JSON.stringify([...c2]), JSON.stringify(r2));
+
+const d1 = new Uint8Array(3);
+const r3 = d1.setFromHex("0aff10aa");
+console.log(JSON.stringify([...d1]), JSON.stringify(r3));
+
+const d2 = new Uint8Array(2);
+const r4 = d2.setFromHex("0aff10");
+console.log(JSON.stringify([...d2]), JSON.stringify(r4));
+
+// Full round-trip.
+const orig = new Uint8Array([0, 1, 2, 250, 251, 255]);
+console.log(JSON.stringify([...Uint8Array.fromBase64(orig.toBase64())]));
+console.log(JSON.stringify([...Uint8Array.fromHex(orig.toHex())]));


### PR DESCRIPTION
Closes #2901

## Implementation

Implements the TC39 Uint8Array-base64 proposal surface that Node v25 exposes:

- Instance: `toBase64({ alphabet, omitPadding })`, `toHex()`, `setFromBase64(str, { alphabet, lastChunkHandling })`, `setFromHex(str)`
- Static: `Uint8Array.fromBase64(str, { alphabet, lastChunkHandling })`, `Uint8Array.fromHex(str)`

Perry aliases `Uint8Array` to its `Buffer` representation (#2447), so:

- New strict TC39 codecs live in `crates/perry-runtime/src/buffer/u8_codec.rs`. Unlike the permissive Buffer codecs (`coding.rs`), these enforce TC39 validation: explicit alphabet selection (standard `+/` vs. url `-_`), `SyntaxError` on invalid characters / odd-length hex / bad padding, interior/trailing whitespace tolerance, and the three `lastChunkHandling` modes (loose / strict / stop-before-partial). `setFrom*` honor the chunk-boundary bounded-write semantics and return `{ read, written }`.
- Instance methods dispatch through the existing `dispatch_buffer_method` (runtime), and are added to `is_buffer_method_name` so method-as-value reads resolve to callables.
- Statics route through an `Expr::NativeMethodCall` against the `buffer` module — **no new HIR variant** — wired via two `NativeModSig` rows in the codegen dispatch table plus matching API-manifest entries (api-docs regenerated).
- New `#[no_mangle]` runtime entry points carry `#[used]` keepalive anchors so the auto-optimize whole-program-LLVM rebuild does not dead-strip them.

## Validation

- Gap test `test-files/test_gap_u8_base64_hex_2901.ts` is **byte-identical** to `node --experimental-strip-types` under the default auto-optimize compile (round-trips, base64url, omitPadding, partial `setFrom*` writes, whitespace, empty inputs).
- Error-path parity verified directly against Node: invalid hex/base64 and `lastChunkHandling:"strict"` all throw `SyntaxError` with matching messages; `stop-before-partial` matches.
- Guards green: `cargo fmt --all -- --check`, `./scripts/check_file_size.sh`, `cargo test -p perry-hir` (stable-hash uniqueness — no new variant), `cargo test -p perry-runtime` (buffer), `cargo test -p perry-codegen` (manifest consistency).

`setFromBase64` / `setFromHex` are implemented (not deferred).
