### PR TITLE
fix(set): implement ES Set composition methods (union/intersection/difference/...)

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -653,6 +653,44 @@ pub fn try_lower_property_get_method_call(
                 let result = blk.call(I64, runtime_fn, &[(I64, &s_handle)]);
                 return Ok(Some(crate::expr::nanbox_pointer_inline_pub(blk, &result)));
             }
+            // #2872: ES2024 Set composition methods. union/intersection/
+            // difference/symmetricDifference take a set-like `other` and
+            // return a NEW Set; isSubsetOf/isSupersetOf/isDisjointFrom return
+            // a boolean. The runtime fns receive the receiver as an I64 set
+            // handle and `other` as a NaN-boxed f64.
+            "union" | "intersection" | "difference" | "symmetricDifference" if args.len() == 1 => {
+                let s_box = lower_expr(ctx, object)?;
+                let other_box = lower_expr(ctx, &args[0])?;
+                let blk = ctx.block();
+                let s_handle = unbox_to_i64(blk, &s_box);
+                let runtime_fn = match property.as_str() {
+                    "union" => "js_set_union",
+                    "intersection" => "js_set_intersection",
+                    "difference" => "js_set_difference",
+                    "symmetricDifference" => "js_set_symmetric_difference",
+                    _ => unreachable!(),
+                };
+                let result = blk.call(I64, runtime_fn, &[(I64, &s_handle), (DOUBLE, &other_box)]);
+                return Ok(Some(crate::expr::nanbox_pointer_inline_pub(blk, &result)));
+            }
+            "isSubsetOf" | "isSupersetOf" | "isDisjointFrom" if args.len() == 1 => {
+                let s_box = lower_expr(ctx, object)?;
+                let other_box = lower_expr(ctx, &args[0])?;
+                let blk = ctx.block();
+                let s_handle = unbox_to_i64(blk, &s_box);
+                let runtime_fn = match property.as_str() {
+                    "isSubsetOf" => "js_set_is_subset_of",
+                    "isSupersetOf" => "js_set_is_superset_of",
+                    "isDisjointFrom" => "js_set_is_disjoint_from",
+                    _ => unreachable!(),
+                };
+                let i32_v = blk.call(
+                    crate::types::I32,
+                    runtime_fn,
+                    &[(I64, &s_handle), (DOUBLE, &other_box)],
+                );
+                return Ok(Some(crate::expr::i32_bool_to_nanbox(blk, &i32_v)));
+            }
             _ => {}
         }
     }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -437,6 +437,14 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_set_has", I32, &[I64, DOUBLE]);
     module.declare_function("js_set_delete", I32, &[I64, DOUBLE]);
     module.declare_function("js_set_size", I32, &[I64]);
+    // #2872: ES2024 Set composition methods.
+    module.declare_function("js_set_union", I64, &[I64, DOUBLE]);
+    module.declare_function("js_set_intersection", I64, &[I64, DOUBLE]);
+    module.declare_function("js_set_difference", I64, &[I64, DOUBLE]);
+    module.declare_function("js_set_symmetric_difference", I64, &[I64, DOUBLE]);
+    module.declare_function("js_set_is_subset_of", I32, &[I64, DOUBLE]);
+    module.declare_function("js_set_is_superset_of", I32, &[I64, DOUBLE]);
+    module.declare_function("js_set_is_disjoint_from", I32, &[I64, DOUBLE]);
     module.declare_function("js_string_to_lower_case", I64, &[I64]);
     module.declare_function("js_string_to_upper_case", I64, &[I64]);
     // Locale-aware casing + locales validation (#2781). The locales arg is a

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -2230,6 +2230,36 @@ pub unsafe extern "C" fn js_native_call_method(
                         crate::set::js_set_foreach(set, args[0], this_arg);
                         f64::from_bits(crate::value::TAG_UNDEFINED)
                     }
+                    // #2872: ES2024 Set composition methods. union/intersection/
+                    // difference/symmetricDifference return a new Set; the
+                    // is* predicates return a boolean.
+                    "union" if !args.is_empty() => f64::from_bits(
+                        JSValue::pointer(crate::set::js_set_union(set, args[0]) as *mut u8).bits(),
+                    ),
+                    "intersection" if !args.is_empty() => f64::from_bits(
+                        JSValue::pointer(crate::set::js_set_intersection(set, args[0]) as *mut u8)
+                            .bits(),
+                    ),
+                    "difference" if !args.is_empty() => f64::from_bits(
+                        JSValue::pointer(crate::set::js_set_difference(set, args[0]) as *mut u8)
+                            .bits(),
+                    ),
+                    "symmetricDifference" if !args.is_empty() => f64::from_bits(
+                        JSValue::pointer(
+                            crate::set::js_set_symmetric_difference(set, args[0]) as *mut u8
+                        )
+                        .bits(),
+                    ),
+                    "isSubsetOf" if !args.is_empty() => f64::from_bits(
+                        JSValue::bool(crate::set::js_set_is_subset_of(set, args[0]) != 0).bits(),
+                    ),
+                    "isSupersetOf" if !args.is_empty() => f64::from_bits(
+                        JSValue::bool(crate::set::js_set_is_superset_of(set, args[0]) != 0).bits(),
+                    ),
+                    "isDisjointFrom" if !args.is_empty() => f64::from_bits(
+                        JSValue::bool(crate::set::js_set_is_disjoint_from(set, args[0]) != 0)
+                            .bits(),
+                    ),
                     _ => f64::from_bits(crate::value::TAG_UNDEFINED),
                 };
             }

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -874,6 +874,311 @@ pub extern "C" fn js_set_foreach(set: *const SetHeader, callback: f64, this_arg:
     }
 }
 
+// =====================================================================
+// ES2024 Set composition methods (TC39 Set-methods proposal, Node 22+).
+// #2872: union / intersection / difference / symmetricDifference return a
+// NEW Set; isSubsetOf / isSupersetOf / isDisjointFrom return a boolean.
+//
+// All four set-returning methods preserve insertion order per spec:
+// `union` is `this` elements followed by `other`'s new elements;
+// `intersection` / `difference` keep `this`'s order; `symmetricDifference`
+// is `this`'s leftover elements followed by `other`'s leftover elements.
+//
+// The `other` argument is received as a NaN-boxed value (f64). For the
+// scoped basic behavior (#2872) it is expected to be a real Set; we
+// recover its pointer via `clean_set_ptr` (which masks the NaN-box tag).
+// =====================================================================
+
+/// Recover a `*const SetHeader` from a NaN-boxed `other` argument. Returns
+/// null if the value isn't a registered Set (callers treat null as empty).
+unsafe fn other_set_ptr(other: f64) -> *const SetHeader {
+    let raw = other.to_bits() as *const SetHeader;
+    let cleaned = clean_set_ptr(raw);
+    if cleaned.is_null() {
+        return ptr::null();
+    }
+    if is_registered_set(cleaned as usize) {
+        cleaned
+    } else {
+        ptr::null()
+    }
+}
+
+/// `Set.prototype.union(other)` — new Set with elements of both sets,
+/// `this`'s elements first (insertion order) then `other`'s new elements.
+#[no_mangle]
+pub extern "C" fn js_set_union(set: *const SetHeader, other: f64) -> *mut SetHeader {
+    let set = clean_set_ptr(set);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let result = js_set_alloc(4);
+    let result_handle = scope.root_raw_mut_ptr(result);
+    let set_handle = if set.is_null() {
+        None
+    } else {
+        Some(scope.root_raw_const_ptr(set))
+    };
+    let other_handle = unsafe {
+        let o = other_set_ptr(other);
+        if o.is_null() {
+            None
+        } else {
+            Some(scope.root_raw_const_ptr(o))
+        }
+    };
+    unsafe {
+        if let Some(ref h) = set_handle {
+            let s = h.get_raw_const_ptr::<SetHeader>();
+            for i in 0..(*s).size as usize {
+                let s = h.get_raw_const_ptr::<SetHeader>();
+                let v = ptr::read(elements_ptr(s).add(i));
+                js_set_add(result_handle.get_raw_mut_ptr::<SetHeader>(), v);
+            }
+        }
+        if let Some(ref h) = other_handle {
+            let o = h.get_raw_const_ptr::<SetHeader>();
+            for i in 0..(*o).size as usize {
+                let o = h.get_raw_const_ptr::<SetHeader>();
+                let v = ptr::read(elements_ptr(o).add(i));
+                js_set_add(result_handle.get_raw_mut_ptr::<SetHeader>(), v);
+            }
+        }
+    }
+    result_handle.get_raw_mut_ptr::<SetHeader>()
+}
+
+/// `Set.prototype.intersection(other)` — new Set with elements present in
+/// both sets, keeping `this`'s insertion order.
+#[no_mangle]
+pub extern "C" fn js_set_intersection(set: *const SetHeader, other: f64) -> *mut SetHeader {
+    let set = clean_set_ptr(set);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let result = js_set_alloc(4);
+    let result_handle = scope.root_raw_mut_ptr(result);
+    if set.is_null() {
+        return result_handle.get_raw_mut_ptr::<SetHeader>();
+    }
+    let set_handle = scope.root_raw_const_ptr(set);
+    let other = unsafe { other_set_ptr(other) };
+    let other_handle = if other.is_null() {
+        None
+    } else {
+        Some(scope.root_raw_const_ptr(other))
+    };
+    unsafe {
+        let s = set_handle.get_raw_const_ptr::<SetHeader>();
+        for i in 0..(*s).size as usize {
+            let s = set_handle.get_raw_const_ptr::<SetHeader>();
+            let v = ptr::read(elements_ptr(s).add(i));
+            let in_other = match other_handle {
+                Some(ref h) => {
+                    let o = h.get_raw_const_ptr::<SetHeader>();
+                    js_set_has(o, v) != 0
+                }
+                None => false,
+            };
+            if in_other {
+                js_set_add(result_handle.get_raw_mut_ptr::<SetHeader>(), v);
+            }
+        }
+    }
+    result_handle.get_raw_mut_ptr::<SetHeader>()
+}
+
+/// `Set.prototype.difference(other)` — new Set with elements of `this` that
+/// are NOT in `other`, keeping `this`'s insertion order.
+#[no_mangle]
+pub extern "C" fn js_set_difference(set: *const SetHeader, other: f64) -> *mut SetHeader {
+    let set = clean_set_ptr(set);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let result = js_set_alloc(4);
+    let result_handle = scope.root_raw_mut_ptr(result);
+    if set.is_null() {
+        return result_handle.get_raw_mut_ptr::<SetHeader>();
+    }
+    let set_handle = scope.root_raw_const_ptr(set);
+    let other = unsafe { other_set_ptr(other) };
+    let other_handle = if other.is_null() {
+        None
+    } else {
+        Some(scope.root_raw_const_ptr(other))
+    };
+    unsafe {
+        let s = set_handle.get_raw_const_ptr::<SetHeader>();
+        for i in 0..(*s).size as usize {
+            let s = set_handle.get_raw_const_ptr::<SetHeader>();
+            let v = ptr::read(elements_ptr(s).add(i));
+            let in_other = match other_handle {
+                Some(ref h) => {
+                    let o = h.get_raw_const_ptr::<SetHeader>();
+                    js_set_has(o, v) != 0
+                }
+                None => false,
+            };
+            if !in_other {
+                js_set_add(result_handle.get_raw_mut_ptr::<SetHeader>(), v);
+            }
+        }
+    }
+    result_handle.get_raw_mut_ptr::<SetHeader>()
+}
+
+/// `Set.prototype.symmetricDifference(other)` — new Set with elements in
+/// exactly one of the sets. `this`'s leftover elements (not in `other`)
+/// first, then `other`'s leftover elements (not in `this`).
+#[no_mangle]
+pub extern "C" fn js_set_symmetric_difference(set: *const SetHeader, other: f64) -> *mut SetHeader {
+    let set = clean_set_ptr(set);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let result = js_set_alloc(4);
+    let result_handle = scope.root_raw_mut_ptr(result);
+    let set_handle = if set.is_null() {
+        None
+    } else {
+        Some(scope.root_raw_const_ptr(set))
+    };
+    let other = unsafe { other_set_ptr(other) };
+    let other_handle = if other.is_null() {
+        None
+    } else {
+        Some(scope.root_raw_const_ptr(other))
+    };
+    unsafe {
+        // `this` elements not in `other`.
+        if let Some(ref sh) = set_handle {
+            let s = sh.get_raw_const_ptr::<SetHeader>();
+            for i in 0..(*s).size as usize {
+                let s = sh.get_raw_const_ptr::<SetHeader>();
+                let v = ptr::read(elements_ptr(s).add(i));
+                let in_other = match other_handle {
+                    Some(ref h) => {
+                        let o = h.get_raw_const_ptr::<SetHeader>();
+                        js_set_has(o, v) != 0
+                    }
+                    None => false,
+                };
+                if !in_other {
+                    js_set_add(result_handle.get_raw_mut_ptr::<SetHeader>(), v);
+                }
+            }
+        }
+        // `other` elements not in `this`.
+        if let Some(ref oh) = other_handle {
+            let o = oh.get_raw_const_ptr::<SetHeader>();
+            for i in 0..(*o).size as usize {
+                let o = oh.get_raw_const_ptr::<SetHeader>();
+                let v = ptr::read(elements_ptr(o).add(i));
+                let in_set = match set_handle {
+                    Some(ref h) => {
+                        let s = h.get_raw_const_ptr::<SetHeader>();
+                        js_set_has(s, v) != 0
+                    }
+                    None => false,
+                };
+                if !in_set {
+                    js_set_add(result_handle.get_raw_mut_ptr::<SetHeader>(), v);
+                }
+            }
+        }
+    }
+    result_handle.get_raw_mut_ptr::<SetHeader>()
+}
+
+/// `Set.prototype.isSubsetOf(other)` — true if every element of `this` is
+/// also in `other`. Returns 1/0.
+#[no_mangle]
+pub extern "C" fn js_set_is_subset_of(set: *const SetHeader, other: f64) -> i32 {
+    let set = clean_set_ptr(set);
+    if set.is_null() {
+        return 1; // empty set is a subset of anything
+    }
+    unsafe {
+        let other = other_set_ptr(other);
+        let size = (*set).size as usize;
+        if other.is_null() {
+            return (size == 0) as i32;
+        }
+        let elements = elements_ptr(set);
+        for i in 0..size {
+            let v = ptr::read(elements.add(i));
+            if js_set_has(other, v) == 0 {
+                return 0;
+            }
+        }
+        1
+    }
+}
+
+/// `Set.prototype.isSupersetOf(other)` — true if every element of `other`
+/// is also in `this`. Returns 1/0.
+#[no_mangle]
+pub extern "C" fn js_set_is_superset_of(set: *const SetHeader, other: f64) -> i32 {
+    let set = clean_set_ptr(set);
+    unsafe {
+        let other = other_set_ptr(other);
+        if other.is_null() {
+            return 1; // every set is a superset of an empty other
+        }
+        let osize = (*other).size as usize;
+        if set.is_null() {
+            return (osize == 0) as i32;
+        }
+        let oelements = elements_ptr(other);
+        for i in 0..osize {
+            let v = ptr::read(oelements.add(i));
+            if js_set_has(set, v) == 0 {
+                return 0;
+            }
+        }
+        1
+    }
+}
+
+/// `Set.prototype.isDisjointFrom(other)` — true if the sets share no
+/// elements. Returns 1/0.
+#[no_mangle]
+pub extern "C" fn js_set_is_disjoint_from(set: *const SetHeader, other: f64) -> i32 {
+    let set = clean_set_ptr(set);
+    if set.is_null() {
+        return 1;
+    }
+    unsafe {
+        let other = other_set_ptr(other);
+        if other.is_null() {
+            return 1;
+        }
+        let size = (*set).size as usize;
+        let elements = elements_ptr(set);
+        for i in 0..size {
+            let v = ptr::read(elements.add(i));
+            if js_set_has(other, v) != 0 {
+                return 0;
+            }
+        }
+        1
+    }
+}
+
+// #2872: keepalive anchors so the auto-optimize whole-program-LLVM-bitcode
+// rebuild doesn't dead-strip these codegen-only `#[no_mangle]` entry points
+// (see project_auto_optimize_keepalive_3320 / PR #3320).
+#[used]
+static KEEP_SET_UNION: extern "C" fn(*const SetHeader, f64) -> *mut SetHeader = js_set_union;
+#[used]
+static KEEP_SET_INTERSECTION: extern "C" fn(*const SetHeader, f64) -> *mut SetHeader =
+    js_set_intersection;
+#[used]
+static KEEP_SET_DIFFERENCE: extern "C" fn(*const SetHeader, f64) -> *mut SetHeader =
+    js_set_difference;
+#[used]
+static KEEP_SET_SYMDIFF: extern "C" fn(*const SetHeader, f64) -> *mut SetHeader =
+    js_set_symmetric_difference;
+#[used]
+static KEEP_SET_IS_SUBSET: extern "C" fn(*const SetHeader, f64) -> i32 = js_set_is_subset_of;
+#[used]
+static KEEP_SET_IS_SUPERSET: extern "C" fn(*const SetHeader, f64) -> i32 = js_set_is_superset_of;
+#[used]
+static KEEP_SET_IS_DISJOINT: extern "C" fn(*const SetHeader, f64) -> i32 = js_set_is_disjoint_from;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -891,6 +1196,93 @@ mod tests {
         assert_eq!(js_set_has(set, 3.0), 1);
         assert_eq!(js_set_has(set, 4.0), 0);
         assert_eq!(js_set_has(set, 0.0), 0);
+    }
+
+    // #2872: helper to pass a Set pointer as the NaN-boxed `other` argument.
+    // A raw heap pointer (top16 == 0) is returned unchanged by `clean_set_ptr`,
+    // so reinterpreting the pointer bits as f64 round-trips through
+    // `other_set_ptr`.
+    fn as_other(set: *mut SetHeader) -> f64 {
+        f64::from_bits(set as u64)
+    }
+
+    fn collect(set: *const SetHeader) -> Vec<f64> {
+        unsafe {
+            let size = (*set).size as usize;
+            (0..size).map(|i| *(elements_ptr(set).add(i))).collect()
+        }
+    }
+
+    #[test]
+    fn test_set_union() {
+        let a = js_set_alloc(4);
+        js_set_add(a, 1.0);
+        js_set_add(a, 2.0);
+        let b = js_set_alloc(4);
+        js_set_add(b, 2.0);
+        js_set_add(b, 3.0);
+        let u = js_set_union(a, as_other(b));
+        assert_eq!(collect(u), vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn test_set_intersection() {
+        let a = js_set_alloc(4);
+        js_set_add(a, 1.0);
+        js_set_add(a, 2.0);
+        let b = js_set_alloc(4);
+        js_set_add(b, 2.0);
+        js_set_add(b, 3.0);
+        let r = js_set_intersection(a, as_other(b));
+        assert_eq!(collect(r), vec![2.0]);
+    }
+
+    #[test]
+    fn test_set_difference() {
+        let a = js_set_alloc(4);
+        js_set_add(a, 1.0);
+        js_set_add(a, 2.0);
+        let b = js_set_alloc(4);
+        js_set_add(b, 2.0);
+        js_set_add(b, 3.0);
+        let r = js_set_difference(a, as_other(b));
+        assert_eq!(collect(r), vec![1.0]);
+    }
+
+    #[test]
+    fn test_set_symmetric_difference() {
+        let a = js_set_alloc(4);
+        js_set_add(a, 1.0);
+        js_set_add(a, 2.0);
+        let b = js_set_alloc(4);
+        js_set_add(b, 2.0);
+        js_set_add(b, 3.0);
+        let r = js_set_symmetric_difference(a, as_other(b));
+        // `a` leftovers (1) then `b` leftovers (3) — insertion order.
+        assert_eq!(collect(r), vec![1.0, 3.0]);
+    }
+
+    #[test]
+    fn test_set_predicates() {
+        let a = js_set_alloc(4);
+        js_set_add(a, 1.0);
+        js_set_add(a, 2.0);
+
+        let superset = js_set_alloc(4);
+        js_set_add(superset, 1.0);
+        js_set_add(superset, 2.0);
+        js_set_add(superset, 3.0);
+        assert_eq!(js_set_is_subset_of(a, as_other(superset)), 1);
+        assert_eq!(js_set_is_superset_of(a, as_other(superset)), 0);
+
+        let one = js_set_alloc(4);
+        js_set_add(one, 1.0);
+        assert_eq!(js_set_is_superset_of(a, as_other(one)), 1);
+
+        let disjoint = js_set_alloc(4);
+        js_set_add(disjoint, 4.0);
+        assert_eq!(js_set_is_disjoint_from(a, as_other(disjoint)), 1);
+        assert_eq!(js_set_is_disjoint_from(a, as_other(superset)), 0);
     }
 
     #[test]

--- a/test-files/test_gap_set_composition_2872.ts
+++ b/test-files/test_gap_set_composition_2872.ts
@@ -1,0 +1,20 @@
+// #2872: ES2024 Set composition methods (TC39 Set-methods proposal, Node 22+).
+const a = new Set<number>([1, 2]);
+const b = new Set<number>([2, 3]);
+console.log([...a.union(b)]);
+console.log([...a.intersection(b)]);
+console.log([...a.difference(b)]);
+console.log([...a.symmetricDifference(b)]);
+console.log(a.isSubsetOf(new Set<number>([1, 2, 3])));
+console.log(a.isSupersetOf(new Set<number>([1])));
+console.log(a.isDisjointFrom(new Set<number>([4])));
+
+const s1 = new Set<string>(["a", "b", "c"]);
+const s2 = new Set<string>(["b", "c", "d"]);
+console.log([...s1.union(s2)]);
+console.log([...s1.intersection(s2)]);
+console.log([...s1.difference(s2)]);
+console.log([...s1.symmetricDifference(s2)]);
+console.log(s1.isSubsetOf(s2));
+console.log(s1.isSupersetOf(new Set<string>(["a"])));
+console.log(s1.isDisjointFrom(new Set<string>(["x", "y"])));


### PR DESCRIPTION
Closes #2872

## Implementation

Implements the ES2024 / TC39 Set-methods proposal (shipping in Node 22+) on `Set.prototype`:

- `union(other)`, `intersection(other)`, `difference(other)`, `symmetricDifference(other)` — return a NEW Set
- `isSubsetOf(other)`, `isSupersetOf(other)`, `isDisjointFrom(other)` — return a boolean

All four set-returning methods preserve spec insertion order: `union` = `this` elements then `other`'s new elements; `intersection`/`difference` keep `this`'s order; `symmetricDifference` = `this`'s leftovers then `other`'s leftovers.

No new HIR variant — these reuse the existing Set method dispatch:

- **Runtime** (`crates/perry-runtime/src/set.rs`): seven new `#[no_mangle]` fns (`js_set_union`, `js_set_intersection`, `js_set_difference`, `js_set_symmetric_difference`, `js_set_is_subset_of`, `js_set_is_superset_of`, `js_set_is_disjoint_from`) plus `#[used]` keepalive anchors (so the auto-optimize whole-program-LLVM-bitcode rebuild does not dead-strip these codegen-only symbols — see PR #3320). The `other` argument is recovered as a registered Set via `clean_set_ptr` + `is_registered_set`.
- **Codegen typed path** (`crates/perry-codegen/src/lower_call/property_get.rs`): added the seven methods to the `is_set_expr` dispatch block.
- **Dynamic dispatch** (`crates/perry-runtime/src/object/native_call_method.rs`): added the seven methods to the registered-Set method match.
- **Runtime decls** (`crates/perry-codegen/src/runtime_decls/strings.rs`): declared the seven FFI signatures.

Scope is basic Set-to-Set behavior per the issue; arbitrary set-like objects and TypeError cases are explicit follow-ups.

## Validation

- Gap test `test-files/test_gap_set_composition_2872.ts` (all 7 methods over two number Sets and two string Sets, printing `[...result]` for the set-returning ones and the booleans for the predicates) compiles under the DEFAULT auto-optimize flow and is **byte-identical** to `node --experimental-strip-types` (`diff` → IDENTICAL).
- Added 5 unit tests in `set.rs` (union/intersection/difference/symmetricDifference/predicates). `cargo test --release -p perry-runtime` (25 set tests) and `cargo test --release -p perry-hir` both pass.
- `cargo fmt --all -- --check` clean; `./scripts/check_file_size.sh` exit 0.
