### PR TITLE
fix(runtime): JSON.rawJSON/isRawJSON + instanceof RHS TypeError

### DIFF
--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -358,6 +358,8 @@ pub fn check_escapes_in_expr(
         | Expr::Uint8ArrayFrom(operand)
         | Expr::JsonParse(operand)
         | Expr::JsonStringify(operand)
+        | Expr::JsonRawJson(operand)
+        | Expr::JsonIsRawJson(operand)
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)
         | Expr::ForOfToArray(operand)

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -247,6 +247,8 @@ fn collect_used_new_fields_in_expr(
         | Expr::Uint8ArrayFrom(operand)
         | Expr::JsonParse(operand)
         | Expr::JsonStringify(operand)
+        | Expr::JsonRawJson(operand)
+        | Expr::JsonIsRawJson(operand)
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)
         | Expr::ForOfToArray(operand)

--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -1136,6 +1136,8 @@ pub fn collect_localset_ids_in_expr_filtered(
         | Expr::Uint8ArrayNew(Some(operand))
         | Expr::Uint8ArrayLength(operand)
         | Expr::JsonParse(operand)
+        | Expr::JsonRawJson(operand)
+        | Expr::JsonIsRawJson(operand)
         | Expr::MathSqrt(operand)
         | Expr::MathFloor(operand)
         | Expr::MathCeil(operand)

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -241,6 +241,8 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         | Expr::Uint8ArrayNew(Some(operand))
         | Expr::Uint8ArrayLength(operand)
         | Expr::JsonParse(operand)
+        | Expr::JsonRawJson(operand)
+        | Expr::JsonIsRawJson(operand)
         | Expr::MathSqrt(operand)
         | Expr::MathFloor(operand)
         | Expr::MathCeil(operand)

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -1012,6 +1012,19 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let result_i64 = blk.call(I64, "js_json_parse", &[(I64, &s_handle)]);
             Ok(blk.bitcast_i64_to_double(&result_i64))
         }
+        // -------- JSON.rawJSON / JSON.isRawJSON (#2900) --------
+        // Both runtime helpers take and return a NaN-boxed f64, so the text /
+        // value operand passes straight through.
+        Expr::JsonRawJson(text) => {
+            let s_box = lower_expr(ctx, text)?;
+            let blk = ctx.block();
+            Ok(blk.call(DOUBLE, "js_json_raw_json", &[(DOUBLE, &s_box)]))
+        }
+        Expr::JsonIsRawJson(value) => {
+            let v_box = lower_expr(ctx, value)?;
+            let blk = ctx.block();
+            Ok(blk.call(DOUBLE, "js_json_is_raw_json", &[(DOUBLE, &v_box)]))
+        }
         // Issue #179 typed-parse, Step 1b: when `<T>` is
         // `Array<Object{fields}>`, emit a packed-keys rodata constant
         // and route through `js_json_parse_typed_array`. Any other

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1512,6 +1512,8 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::PathBasenameExt(..)
         | Expr::PathParse(..)
         | Expr::JsonParse(..)
+        | Expr::JsonRawJson(..)
+        | Expr::JsonIsRawJson(..)
         | Expr::JsonParseTyped { .. }
         | Expr::JsonParseReviver { .. }
         | Expr::JsonParseWithReviver(..) => instance_misc1::lower(ctx, expr),

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1021,6 +1021,10 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // JSON.parse returns JSValue (u64) via integer register on ARM64,
     // not f64. Use I64 return + bitcast to avoid ABI mismatch crash.
     module.declare_function("js_json_parse", I64, &[I64]);
+    // #2900: JSON.rawJSON(text) / JSON.isRawJSON(value). Both take and return
+    // a NaN-boxed f64 (the wrapper object pointer / a boolean).
+    module.declare_function("js_json_raw_json", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_json_is_raw_json", DOUBLE, &[DOUBLE]);
     // JSON.parse(text) shim that returns `null` for a null `text_ptr`
     // instead of throwing. Used by NR_OBJ_FROM_JSON_STR dispatch rows
     // (e.g. `jwt.verify` on bad signature) — see issue #927.

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -660,7 +660,10 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
             collect_assigned_locals_expr(set, assigned);
         }
         // JSON operations
-        Expr::JsonParse(expr) | Expr::JsonStringify(expr) => {
+        Expr::JsonParse(expr)
+        | Expr::JsonStringify(expr)
+        | Expr::JsonRawJson(expr)
+        | Expr::JsonIsRawJson(expr) => {
             collect_assigned_locals_expr(expr, assigned);
         }
         // Math operations

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -674,6 +674,10 @@ pub enum Expr {
         space: Box<Expr>,
     },
     JsonStringifyFull(Box<Expr>, Box<Expr>, Box<Expr>),
+    /// `JSON.rawJSON(text)` (#2900) -> raw-JSON wrapper object.
+    JsonRawJson(Box<Expr>),
+    /// `JSON.isRawJSON(value)` (#2900) -> boolean.
+    JsonIsRawJson(Box<Expr>),
 
     // Math operations
     MathFloor(Box<Expr>),            // Math.floor(x) -> number

--- a/crates/perry-hir/src/js_transform/imports.rs
+++ b/crates/perry-hir/src/js_transform/imports.rs
@@ -976,7 +976,7 @@ pub fn transform_expr(
         Expr::PathDirname(e) | Expr::PathBasename(e) | Expr::PathExtname(e) | Expr::PathResolve(e) | Expr::PathIsAbsolute(e) | Expr::PathToNamespacedPath(e) => {
             transform_expr(e, js_imports, extern_func_to_js, local_name_to_js, tracker);
         }
-        Expr::JsonParse(e) | Expr::JsonStringify(e) => {
+        Expr::JsonParse(e) | Expr::JsonStringify(e) | Expr::JsonRawJson(e) | Expr::JsonIsRawJson(e) => {
             transform_expr(e, js_imports, extern_func_to_js, local_name_to_js, tracker);
         }
         Expr::MathFloor(e) | Expr::MathCeil(e) | Expr::MathRound(e) | Expr::MathAbs(e) | Expr::MathSqrt(e) => {

--- a/crates/perry-hir/src/lower/array_fold.rs
+++ b/crates/perry-hir/src/lower/array_fold.rs
@@ -263,7 +263,7 @@ pub(crate) fn is_known_math_static_method(name: &str) -> bool {
 
 /// Names of `JSON.<name>` static functions Perry's runtime implements.
 pub(crate) fn is_known_json_static_method(name: &str) -> bool {
-    matches!(name, "parse" | "stringify")
+    matches!(name, "parse" | "stringify" | "rawJSON" | "isRawJSON")
 }
 
 /// Names of `Number.<name>` static functions Perry's runtime implements.

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -345,6 +345,18 @@ pub(super) fn try_module_static_methods(
                                 )));
                             }
                         }
+                        "rawJSON" => {
+                            // #2900: `JSON.rawJSON(text)` -> raw-JSON wrapper.
+                            if let Some(text) = args.into_iter().next() {
+                                return Ok(Ok(Expr::JsonRawJson(Box::new(text))));
+                            }
+                        }
+                        "isRawJSON" => {
+                            // #2900: `JSON.isRawJSON(value)` -> boolean.
+                            if let Some(value) = args.into_iter().next() {
+                                return Ok(Ok(Expr::JsonIsRawJson(Box::new(value))));
+                            }
+                        }
                         _ => {} // Fall through to generic handling
                     }
                 }

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -347,13 +347,15 @@ pub(super) fn try_module_static_methods(
                         }
                         "rawJSON" => {
                             // #2900: `JSON.rawJSON(text)` -> raw-JSON wrapper.
-                            if let Some(text) = args.into_iter().next() {
+                            if !args.is_empty() {
+                                let text = args.into_iter().next().unwrap();
                                 return Ok(Ok(Expr::JsonRawJson(Box::new(text))));
                             }
                         }
                         "isRawJSON" => {
                             // #2900: `JSON.isRawJSON(value)` -> boolean.
-                            if let Some(value) = args.into_iter().next() {
+                            if !args.is_empty() {
+                                let value = args.into_iter().next().unwrap();
                                 return Ok(Ok(Expr::JsonIsRawJson(Box::new(value))));
                             }
                         }

--- a/crates/perry-hir/src/monomorph/driver.rs
+++ b/crates/perry-hir/src/monomorph/driver.rs
@@ -515,7 +515,10 @@ fn collect_instantiations_in_expr(
             collect_instantiations_in_expr(set, ctx, module, idx);
         }
         // JSON operations
-        Expr::JsonParse(expr) | Expr::JsonStringify(expr) => {
+        Expr::JsonParse(expr)
+        | Expr::JsonStringify(expr)
+        | Expr::JsonRawJson(expr)
+        | Expr::JsonIsRawJson(expr) => {
             collect_instantiations_in_expr(expr, ctx, module, idx);
         }
         // Math operations

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -665,6 +665,10 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
         Expr::JsonStringify(expr) => {
             Expr::JsonStringify(Box::new(substitute_expr(expr, substitutions)))
         }
+        Expr::JsonRawJson(expr) => Expr::JsonRawJson(Box::new(substitute_expr(expr, substitutions))),
+        Expr::JsonIsRawJson(expr) => {
+            Expr::JsonIsRawJson(Box::new(substitute_expr(expr, substitutions)))
+        }
 
         // Math operations
         Expr::MathFloor(expr) => Expr::MathFloor(Box::new(substitute_expr(expr, substitutions))),

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -665,7 +665,9 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
         Expr::JsonStringify(expr) => {
             Expr::JsonStringify(Box::new(substitute_expr(expr, substitutions)))
         }
-        Expr::JsonRawJson(expr) => Expr::JsonRawJson(Box::new(substitute_expr(expr, substitutions))),
+        Expr::JsonRawJson(expr) => {
+            Expr::JsonRawJson(Box::new(substitute_expr(expr, substitutions)))
+        }
         Expr::JsonIsRawJson(expr) => {
             Expr::JsonIsRawJson(Box::new(substitute_expr(expr, substitutions)))
         }

--- a/crates/perry-hir/src/monomorph/update_call_sites.rs
+++ b/crates/perry-hir/src/monomorph/update_call_sites.rs
@@ -447,7 +447,10 @@ fn update_call_sites_in_expr(
             update_call_sites_in_expr(set, ctx, lookup);
         }
         // JSON operations
-        Expr::JsonParse(expr) | Expr::JsonStringify(expr) => {
+        Expr::JsonParse(expr)
+        | Expr::JsonStringify(expr)
+        | Expr::JsonRawJson(expr)
+        | Expr::JsonIsRawJson(expr) => {
             update_call_sites_in_expr(expr, ctx, lookup);
         }
         // Math operations

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -183,6 +183,8 @@ impl SH for Expr {
             Expr::JsonStringify(e) => { tag(h, 138); e.as_ref().hash(h); }
             Expr::JsonStringifyPretty { value, replacer, space, } => { tag(h, 139); value.as_ref().hash(h); replacer.hash(h); space.as_ref().hash(h); }
             Expr::JsonStringifyFull(a, b, c) => { tag(h, 140); a.as_ref().hash(h); b.as_ref().hash(h); c.as_ref().hash(h); }
+            Expr::JsonRawJson(e) => { tag(h, 12130); e.as_ref().hash(h); }
+            Expr::JsonIsRawJson(e) => { tag(h, 12131); e.as_ref().hash(h); }
             Expr::MathFloor(e) => { tag(h, 141); e.as_ref().hash(h); }
             Expr::MathCeil(e) => { tag(h, 142); e.as_ref().hash(h); }
             Expr::MathRound(e) => { tag(h, 143); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -159,6 +159,8 @@ where
         | Expr::RegExpLastIndex(v)
         | Expr::JsonParse(v)
         | Expr::JsonStringify(v)
+        | Expr::JsonRawJson(v)
+        | Expr::JsonIsRawJson(v)
         | Expr::JsonParseTyped { text: v, .. }
         | Expr::MathFloor(v)
         | Expr::MathCeil(v)

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -160,6 +160,8 @@ where
         | Expr::RegExpLastIndex(v)
         | Expr::JsonParse(v)
         | Expr::JsonStringify(v)
+        | Expr::JsonRawJson(v)
+        | Expr::JsonIsRawJson(v)
         | Expr::JsonParseTyped { text: v, .. }
         | Expr::MathFloor(v)
         | Expr::MathCeil(v)

--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -23,6 +23,7 @@ use std::cell::RefCell;
 
 mod parse_api;
 mod parser;
+mod raw_json;
 mod replacer;
 mod reviver;
 mod simd;
@@ -34,6 +35,7 @@ mod stringify_api;
 pub use parse_api::{
     js_json_parse, js_json_parse_or_null, js_json_parse_result, js_json_parse_typed_array,
 };
+pub use raw_json::{js_json_is_raw_json, js_json_raw_json};
 pub use replacer::{js_json_stringify_full, js_json_stringify_with_replacer};
 pub use reviver::js_json_parse_with_reviver;
 pub use stringify_api::{
@@ -57,6 +59,8 @@ pub(crate) use parse_api::test_json_parse_direct;
 pub(crate) use parse_api::{try_parse_via_tape, TapeMode};
 #[allow(unused_imports)]
 pub(crate) use parser::{DirectParser, ObjectShapeHint};
+#[allow(unused_imports)]
+pub(crate) use raw_json::{ptr_is_raw_json_wrapper, raw_json_text_bytes, RAW_JSON_CLASS_ID};
 #[cfg(test)]
 pub(crate) use reviver::test_apply_reviver_for_value;
 #[allow(unused_imports)]

--- a/crates/perry-runtime/src/json/raw_json.rs
+++ b/crates/perry-runtime/src/json/raw_json.rs
@@ -1,0 +1,176 @@
+//! `JSON.rawJSON(text)` / `JSON.isRawJSON(value)` (#2900).
+//!
+//! `JSON.rawJSON(text)` validates `text` as a single JSON *scalar* (number,
+//! string, `true`, `false`, or `null` — no surrounding whitespace, no object
+//! or array) and returns a wrapper object that `JSON.stringify` emits
+//! verbatim. The wrapper carries:
+//!   - a `rawJSON` own property holding the original text (Node exposes this
+//!     so `wrapper.rawJSON === text`), and
+//!   - a reserved `class_id` (`RAW_JSON_CLASS_ID`) so detection survives GC
+//!     moves without a pointer side-table.
+//!
+//! `JSON.isRawJSON(value)` returns `true` iff `value` is such a wrapper.
+//!
+//! The stringify traversal (`stringify_value` / `stringify_value_depth`)
+//! checks `class_id == RAW_JSON_CLASS_ID` before the generic object path and
+//! writes the stored text directly into the output buffer.
+
+use crate::{js_string_from_bytes, JSValue, ObjectHeader, StringHeader};
+
+/// Reserved class id stamped onto raw-JSON wrapper objects. Kept distinct
+/// from every other reserved id used by `instanceof` / typeof so it can't be
+/// confused with a real user class or built-in.
+pub(crate) const RAW_JSON_CLASS_ID: u32 = 0xFFFF_00A0;
+
+/// True if `text` is an acceptable argument to `JSON.rawJSON` per Node: a
+/// single JSON scalar with no leading/trailing whitespace, and not an object
+/// or array. Empty strings and bare identifiers (`NaN`, `undefined`) are
+/// rejected.
+fn is_valid_raw_json_text(text: &str) -> bool {
+    // Node rejects any surrounding whitespace and empty input.
+    if text.is_empty() || text != text.trim() {
+        return false;
+    }
+    // Object / array literals are rejected — only scalars are allowed.
+    let first = text.as_bytes()[0];
+    if first == b'{' || first == b'[' {
+        return false;
+    }
+    // Must be valid JSON that parses to a scalar.
+    match serde_json::from_str::<serde_json::Value>(text) {
+        Ok(serde_json::Value::Object(_)) | Ok(serde_json::Value::Array(_)) => false,
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}
+
+/// If `value` is a raw-JSON wrapper, return its stored text bytes.
+pub(crate) unsafe fn raw_json_text_bytes(ptr: *const u8) -> Option<&'static [u8]> {
+    let obj = ptr as *const ObjectHeader;
+    if obj.is_null() {
+        return None;
+    }
+    if (*obj).class_id != RAW_JSON_CLASS_ID {
+        return None;
+    }
+    let key = raw_json_key();
+    let val = crate::object::js_object_get_field_by_name_f64(obj, key);
+    let bits = val.to_bits();
+    let tag = bits & 0xFFFF_0000_0000_0000;
+    if tag == crate::value::STRING_TAG {
+        let str_ptr = (bits & crate::value::POINTER_MASK) as *const StringHeader;
+        if str_ptr.is_null() {
+            return None;
+        }
+        let len = (*str_ptr).byte_len as usize;
+        let data = (str_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        return Some(std::slice::from_raw_parts(data, len));
+    }
+    None
+}
+
+/// Whether the value at `ptr` is a raw-JSON wrapper object (used by stringify
+/// and `js_json_is_raw_json`).
+pub(crate) unsafe fn ptr_is_raw_json_wrapper(ptr: *const u8) -> bool {
+    let obj = ptr as *const ObjectHeader;
+    !obj.is_null() && (*obj).class_id == RAW_JSON_CLASS_ID
+}
+
+/// Cached `"rawJSON"` key string used for the wrapper's own property.
+fn raw_json_key() -> *const StringHeader {
+    use std::cell::Cell;
+    thread_local! {
+        static KEY: Cell<*mut StringHeader> = const { Cell::new(std::ptr::null_mut()) };
+    }
+    KEY.with(|c| {
+        let p = c.get();
+        if !p.is_null() {
+            return p as *const StringHeader;
+        }
+        let np = js_string_from_bytes(b"rawJSON".as_ptr(), 7);
+        c.set(np);
+        np as *const StringHeader
+    })
+}
+
+/// `JSON.rawJSON(text)` — validate and wrap. Throws `SyntaxError` for invalid
+/// input (non-scalar, surrounding whitespace, empty, etc.).
+///
+/// Returns a NaN-boxed pointer to the wrapper object.
+#[no_mangle]
+pub unsafe extern "C" fn js_json_raw_json(text: f64) -> f64 {
+    let bits = text.to_bits();
+    let s: String = {
+        let tag = bits & 0xFFFF_0000_0000_0000;
+        if tag == crate::value::STRING_TAG {
+            let str_ptr = (bits & crate::value::POINTER_MASK) as *const StringHeader;
+            match super::stringify_api::string_from_header(str_ptr) {
+                Some(s) => s,
+                None => String::new(),
+            }
+        } else if tag == crate::value::SHORT_STRING_TAG {
+            let jv = JSValue::from_bits(bits);
+            let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+            let n = jv.short_string_to_buf(&mut scratch);
+            String::from_utf8_lossy(&scratch[..n]).into_owned()
+        } else {
+            // Non-string argument: Node coerces via ToString. Fall back to the
+            // runtime string-conversion so e.g. a number argument behaves like
+            // its decimal text. (Most call sites pass a string literal.)
+            let sp = crate::js_jsvalue_to_string(text);
+            super::stringify_api::string_from_header(sp).unwrap_or_default()
+        }
+    };
+
+    if !is_valid_raw_json_text(&s) {
+        throw_raw_json_syntax_error();
+    }
+
+    let obj = crate::object::js_object_alloc_null_proto(RAW_JSON_CLASS_ID, 1);
+    let text_str = js_string_from_bytes(s.as_ptr(), s.len() as u32);
+    let key = raw_json_key();
+    crate::object::js_object_set_field_by_name(
+        obj,
+        key,
+        f64::from_bits(JSValue::string_ptr(text_str).bits()),
+    );
+    f64::from_bits(JSValue::object_ptr(obj as *mut u8).bits())
+}
+
+/// `JSON.isRawJSON(value)` — returns a NaN-boxed boolean.
+#[no_mangle]
+pub unsafe extern "C" fn js_json_is_raw_json(value: f64) -> f64 {
+    let true_val = f64::from_bits(crate::value::TAG_TRUE);
+    let false_val = f64::from_bits(crate::value::TAG_FALSE);
+    let bits = value.to_bits();
+    let tag = bits & 0xFFFF_0000_0000_0000;
+    // Only POINTER_TAG heap objects can be wrappers.
+    if tag != crate::value::POINTER_TAG {
+        return false_val;
+    }
+    let ptr = (bits & crate::value::POINTER_MASK) as *const u8;
+    if ptr.is_null() || (ptr as usize) < 0x100000 {
+        return false_val;
+    }
+    if ptr_is_raw_json_wrapper(ptr) {
+        true_val
+    } else {
+        false_val
+    }
+}
+
+#[cold]
+fn throw_raw_json_syntax_error() -> ! {
+    let msg = b"Invalid value for JSON.rawJSON";
+    let s = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_syntaxerror_new(s);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+// Keepalive anchors: these `#[no_mangle]` entry points are called only from
+// generated `.o`; the auto-optimize whole-program bitcode rebuild would
+// otherwise dead-strip them (see project_auto_optimize_keepalive_3320).
+#[used]
+static KEEP_RAW_JSON: unsafe extern "C" fn(f64) -> f64 = js_json_raw_json;
+#[used]
+static KEEP_IS_RAW_JSON: unsafe extern "C" fn(f64) -> f64 = js_json_is_raw_json;

--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -497,6 +497,13 @@ pub(crate) unsafe fn stringify_value_pretty(
             stringify_buffer_pretty(ptr, buf, indent, depth);
             return;
         }
+        // #2900: raw-JSON wrapper — emit stored text verbatim (pretty-print
+        // output never indents a scalar, so no indentation is applied here
+        // either).
+        if let Some(raw) = super::raw_json_text_bytes(ptr) {
+            buf.push_str(std::str::from_utf8(raw).unwrap_or("null"));
+            return;
+        }
         if matches!(
             gc_obj_type(ptr),
             crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET | crate::gc::GC_TYPE_ERROR

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -1412,10 +1412,18 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
     let template = if len >= 2 {
         let first_bits = (*elements).to_bits();
         let tag = first_bits & 0xFFFF_0000_0000_0000;
+        let first_ptr = if tag == POINTER_TAG {
+            (first_bits & POINTER_MASK) as *const u8
+        } else {
+            first_bits as *const u8
+        };
         if (tag == POINTER_TAG || is_raw_pointer(first_bits))
             // #2089: a Date element is a small `DateCell`, not an object with a
             // `keys_array` — don't build an object-shape template from it.
             && !crate::date::is_date_cell_addr((first_bits & POINTER_MASK) as usize)
+            // #2900: a raw-JSON wrapper must emit its stored text verbatim, not
+            // be templated as a `{"rawJSON":...}` object.
+            && !(first_ptr as usize >= 0x1000 && super::ptr_is_raw_json_wrapper(first_ptr))
         {
             build_shape_prefix_template(first_bits)
         } else {
@@ -1498,6 +1506,11 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
                 } else {
                     buf.push_str("null");
                 }
+                continue;
+            }
+            // #2900: raw-JSON wrapper element — emit stored text verbatim.
+            if let Some(raw) = super::raw_json_text_bytes(elem_ptr) {
+                buf.push_str(std::str::from_utf8(raw).unwrap_or("null"));
                 continue;
             }
             // Issue #639: Buffer/Uint8Array detection BEFORE gc_obj_type — see

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -517,6 +517,15 @@ pub(crate) unsafe fn stringify_value(value: f64, type_hint: u32, buf: &mut Strin
             }
             return;
         }
+        // #2900: a `JSON.rawJSON(text)` wrapper emits its stored text verbatim
+        // (no quoting, no re-escaping) — at the root, as an object field, or as
+        // an array element. Detect via the reserved class id before the
+        // generic object path so the wrapper's `rawJSON` own property is never
+        // serialized as `{"rawJSON":...}`.
+        if let Some(raw) = super::raw_json_text_bytes(ptr) {
+            buf.push_str(std::str::from_utf8(raw).unwrap_or("null"));
+            return;
+        }
         if type_hint == TYPE_OBJECT {
             stringify_object(ptr, buf);
             return;
@@ -718,6 +727,12 @@ pub(crate) unsafe fn stringify_value_depth(
             } else {
                 buf.push_str("null");
             }
+            return;
+        }
+        // #2900: raw-JSON wrapper — emit stored text verbatim. See the matching
+        // branch in `stringify_value`.
+        if let Some(raw) = super::raw_json_text_bytes(ptr) {
+            buf.push_str(std::str::from_utf8(raw).unwrap_or("null"));
             return;
         }
         if type_hint == TYPE_OBJECT {

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -107,7 +107,74 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
     if synthetic_cid != 0 {
         return js_instanceof(value, synthetic_cid);
     }
-    f64::from_bits(TAG_FALSE)
+    // #2909: nothing recognized the RHS as a constructor/class. Per the
+    // ECMAScript `InstanceofOperator`, the right operand must be an object
+    // (and ultimately callable / have a `Symbol.hasInstance`); a primitive
+    // or non-callable RHS is a `TypeError`, not a silent `false`. Match
+    // Node's two distinct messages:
+    //   - primitive RHS (number/string/bool/null/undefined/bigint/symbol):
+    //       "Right-hand side of 'instanceof' is not an object"
+    //   - object-but-non-callable RHS ({}, [], Map, …):
+    //       "Right-hand side of 'instanceof' is not callable"
+    // (Callable RHS values never reach here — they resolve to a synthetic
+    // class id above — so we don't need to model the arrow-`.prototype`
+    // case at this site.)
+    throw_invalid_instanceof_rhs(type_ref)
+}
+
+#[cold]
+fn throw_invalid_instanceof_rhs(type_ref: f64) -> ! {
+    if rhs_is_object_value(type_ref) {
+        throw_type_error(b"Right-hand side of 'instanceof' is not callable");
+    }
+    throw_type_error(b"Right-hand side of 'instanceof' is not an object");
+}
+
+/// Whether `value` is a (non-callable) object for the purposes of the
+/// `instanceof` RHS check: any heap pointer (plain object, array, Map, Set,
+/// Date, RegExp, Buffer/typed-array, etc.). Primitives — including `null`,
+/// `undefined`, numbers, strings, booleans, bigints — are not objects.
+fn rhs_is_object_value(value: f64) -> bool {
+    let bits = value.to_bits();
+    let jsval = crate::JSValue::from_bits(bits);
+    if jsval.is_null()
+        || jsval.is_undefined()
+        || jsval.is_bool()
+        || jsval.is_any_string()
+        || jsval.is_int32()
+        || jsval.is_bigint()
+    {
+        return false;
+    }
+    if jsval.is_pointer() {
+        let ptr = (bits & crate::value::POINTER_MASK) as usize;
+        // Symbols are primitives; small registry handles aren't real objects
+        // here either, but they're still object-typed in JS (`typeof` is
+        // "object"), so a "not callable" message is the right one for them.
+        if ptr >= 0x100000 && crate::symbol::is_registered_symbol(ptr) {
+            return false;
+        }
+        return true;
+    }
+    // Raw bitcast pointers (typed arrays / buffers / arrays) — these are
+    // objects too.
+    let top16 = bits >> 48;
+    if top16 == 0 && bits >= 0x1000 {
+        let addr = bits as usize;
+        return crate::buffer::is_registered_buffer(addr)
+            || crate::set::is_registered_set(addr)
+            || crate::map::is_registered_map(addr)
+            || crate::typedarray::lookup_typed_array_kind(addr).is_some()
+            || addr >= crate::gc::GC_HEADER_SIZE;
+    }
+    false
+}
+
+#[cold]
+fn throw_type_error(message: &[u8]) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
 fn is_event_emitter_instance_value(value: f64) -> bool {

--- a/test-files/test_gap_json_instanceof_2900_2909.ts
+++ b/test-files/test_gap_json_instanceof_2900_2909.ts
@@ -1,0 +1,41 @@
+// #2900 JSON.rawJSON / JSON.isRawJSON, #2909 instanceof RHS TypeError.
+
+// --- JSON.rawJSON / JSON.isRawJSON ---
+console.log(typeof JSON.rawJSON, typeof JSON.isRawJSON);
+
+const one = JSON.rawJSON("123");
+console.log(JSON.isRawJSON(one));
+console.log(one.rawJSON);
+console.log(JSON.stringify(one));
+console.log(JSON.stringify({ a: JSON.rawJSON("123") }));
+console.log(JSON.stringify({ a: JSON.rawJSON("123") }) === '{"a":123}');
+console.log(JSON.isRawJSON(JSON.rawJSON("1")) === true);
+console.log(JSON.isRawJSON({}));
+console.log(JSON.isRawJSON({}) === false);
+console.log(JSON.stringify([JSON.rawJSON("1"), JSON.rawJSON("true"), JSON.rawJSON("null")]));
+console.log(JSON.stringify({ n: JSON.rawJSON("3.14"), s: JSON.rawJSON("\"hi\"") }));
+
+// --- instanceof RHS TypeError (#2909) ---
+class Ctor {}
+const c = new Ctor();
+console.log(c instanceof Ctor);
+console.log(new Date() instanceof Date);
+
+function check(label: string, fn: () => unknown): void {
+  try {
+    const r = fn();
+    console.log(label, "ok", r);
+  } catch (e) {
+    const err = e as Error;
+    console.log(label, "throw", err.name, err.message);
+  }
+}
+
+const five: any = 5;
+const u: any = undefined;
+const str: any = "x";
+const nul: any = null;
+check("{} instanceof 5", () => ({} as any) instanceof five);
+check("{} instanceof undefined", () => ({} as any) instanceof u);
+check("{} instanceof string", () => ({} as any) instanceof str);
+check("{} instanceof null", () => ({} as any) instanceof nul);


### PR DESCRIPTION
Closes #2900
Closes #2909

## Implementation

### #2900 — `JSON.rawJSON` / `JSON.isRawJSON`
- New runtime module `crates/perry-runtime/src/json/raw_json.rs`:
  - `js_json_raw_json(text)` validates the argument as a single JSON *scalar*
    (number / string / `true` / `false` / `null`, no surrounding whitespace,
    no object or array — matching Node) and returns a null-proto wrapper object
    stamped with a reserved `class_id` (`0xFFFF00A0`) plus a `rawJSON` own
    property holding the original text. Invalid input throws `SyntaxError`.
  - `js_json_is_raw_json(value)` returns a NaN-boxed boolean by checking the
    reserved class id (GC-move-safe — no pointer side-table).
- `JSON.stringify` emits the wrapper's stored text verbatim at every position:
  root value, object field, and array element. Intercepts added to
  `stringify_value`, `stringify_value_depth`, `stringify_array_depth`'s
  per-element path (plus the shape-template guard so an array of wrappers isn't
  templated as `{"rawJSON":...}`), and `stringify_value_pretty`.
- `typeof JSON.rawJSON` / `typeof JSON.isRawJSON` now report `"function"`
  (added to `is_known_json_static_method`).
- HIR: two new single-child `Expr` variants `JsonRawJson` / `JsonIsRawJson`
  (mirroring `JsonParse`), lowered from `JSON.rawJSON(...)` / `JSON.isRawJSON(...)`
  in `module_static.rs`, with stable-hash tags 12130 / 12131. Codegen lowers
  both to the new runtime FFIs (NaN-boxed `f64` in/out). Keepalive `#[used]`
  anchors retain the FFIs through the auto-optimize bitcode rebuild.

### #2909 — `instanceof` RHS `TypeError`
- `js_instanceof_dynamic` previously returned `false` defensively when no
  recognized constructor/class shape matched the RHS. It now throws, matching
  Node:
  - primitive RHS (number / string / boolean / `null` / `undefined` / bigint /
    symbol): `TypeError: Right-hand side of 'instanceof' is not an object`
  - object-but-non-callable RHS (`{}`, `[]`, Map, …):
    `TypeError: Right-hand side of 'instanceof' is not callable`
- Callable RHS values never reach this fall-through (they resolve to a synthetic
  class id earlier), so valid class / Error subclass / built-in / Buffer /
  stream / function-constructor `instanceof` checks are unaffected — verified no
  boolean-returning case changed.

## Validation
- Gap test `test-files/test_gap_json_instanceof_2900_2909.ts` is **byte-identical**
  to `node --experimental-strip-types` under the default (auto-optimize) compile,
  covering `JSON.stringify({a: JSON.rawJSON("123")}) === '{"a":123}'`,
  `JSON.isRawJSON(JSON.rawJSON("1")) === true`, `JSON.isRawJSON({}) === false`,
  raw-JSON in arrays/nested objects, `typeof`, valid `x instanceof Ctor` /
  `new Date() instanceof Date`, and number/undefined/string/null RHS throws.
- `./scripts/check_file_size.sh` (OK), `cargo fmt --all -- --check` (clean),
  `cargo test -p perry-hir` (incl. `expr_variant_stable_hash_tags_are_unique`),
  `cargo test -p perry-runtime` (json + object/instanceof pass; one unrelated
  flaky GC barrier test passes in isolation).
