### PR TITLE
fix(runtime): Function.prototype.bind semantics + String.replace callback args

### DIFF
--- a/crates/perry-runtime/src/closure/dispatch.rs
+++ b/crates/perry-runtime/src/closure/dispatch.rs
@@ -274,7 +274,7 @@ pub fn get_valid_func_ptr(closure: *const ClosureHeader) -> *const u8 {
     if func_ptr == BOUND_METHOD_FUNC_PTR {
         return func_ptr;
     }
-    // BOUND_FUNCTION_FUNC_PTR (0xBADD_B1ND) is the Function.prototype.bind
+    // BOUND_FUNCTION_FUNC_PTR (0xBADD_B12D) is the Function.prototype.bind
     // sentinel — like BOUND_METHOD_FUNC_PTR it's not a real code address, so
     // pass it through here and let the call sites route to
     // dispatch_bound_function (#2840).

--- a/crates/perry-runtime/src/closure/dispatch.rs
+++ b/crates/perry-runtime/src/closure/dispatch.rs
@@ -22,6 +22,117 @@ pub unsafe fn dispatch_bound_method(closure: *const ClosureHeader, args: &[f64])
     )
 }
 
+/// Dispatch a `Function.prototype.bind` result (BOUND_FUNCTION_FUNC_PTR
+/// sentinel). Reads the bound target/this/partial-args from the closure
+/// captures, prepends the bound args to the call-time args, sets
+/// `IMPLICIT_THIS` to the bound receiver, and invokes the target closure.
+/// Refs #2840.
+#[inline]
+pub unsafe fn dispatch_bound_function(closure: *const ClosureHeader, args: &[f64]) -> f64 {
+    let target = js_closure_get_capture_f64(closure, 0);
+    let bound_this = js_closure_get_capture_f64(closure, 1);
+    let bound_args_ptr = js_closure_get_capture_ptr(closure, 2) as *const crate::array::ArrayHeader;
+
+    // Collect the partial-applied (bound) leading args, then append the
+    // call-time args. `g = f.bind(obj, 2); g(3)` calls `f` with `(2, 3)`.
+    let mut combined: Vec<f64> = Vec::with_capacity(args.len() + 4);
+    if !bound_args_ptr.is_null() {
+        let n = crate::array::js_array_length(bound_args_ptr) as usize;
+        for i in 0..n {
+            combined.push(crate::array::js_array_get_f64(bound_args_ptr, i as u32));
+        }
+    }
+    combined.extend_from_slice(args);
+
+    let prev_this = crate::object::js_implicit_this_set(bound_this);
+    let (call_ptr, call_len) = if combined.is_empty() {
+        (std::ptr::null::<f64>(), 0usize)
+    } else {
+        (combined.as_ptr(), combined.len())
+    };
+    let result = js_native_call_value(target, call_ptr, call_len);
+    crate::object::js_implicit_this_set(prev_this);
+    result
+}
+
+/// `Function.prototype.bind(thisArg, ...boundArgs)` — create a distinct bound
+/// function closure. Captures the target closure value, the bound `this`, and
+/// the partial-applied leading args (as a JS array). The returned closure uses
+/// the BOUND_FUNCTION_FUNC_PTR sentinel; `js_closure_callN` /
+/// `js_native_call_value` route it through `dispatch_bound_function`.
+///
+/// `.name` is set to `"bound " + target.name` and `.length` to
+/// `max(0, target.length - boundArgs.length)`, matching Node. Refs #2840.
+#[no_mangle]
+pub unsafe extern "C" fn js_function_bind(
+    target_value: f64,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
+    use crate::value::JSValue;
+
+    let target_jv = JSValue::from_bits(target_value.to_bits());
+    // Only closures can be bound; non-callable receivers fall back to
+    // returning the receiver unchanged (the prior conservative behavior).
+    if !target_jv.is_pointer() {
+        return target_value;
+    }
+    let target_closure = target_jv.as_pointer::<ClosureHeader>();
+    if target_closure.is_null() || (*target_closure).type_tag != CLOSURE_MAGIC {
+        return target_value;
+    }
+
+    let bound_this = if args_len >= 1 && !args_ptr.is_null() {
+        *args_ptr
+    } else {
+        f64::from_bits(crate::value::TAG_UNDEFINED)
+    };
+    let bound_arg_count = args_len.saturating_sub(1);
+
+    // Build the partial-args array (NaN-boxed values copied as-is).
+    let bound_args_arr: *mut crate::array::ArrayHeader = if bound_arg_count > 0 {
+        let arr = crate::array::js_array_alloc(bound_arg_count as u32);
+        let mut cur = arr;
+        for i in 0..bound_arg_count {
+            cur = crate::array::js_array_push_f64(cur, *args_ptr.add(1 + i));
+        }
+        cur
+    } else {
+        std::ptr::null_mut()
+    };
+
+    // Allocate the bound closure with 3 capture slots.
+    let bound = crate::closure::js_closure_alloc(BOUND_FUNCTION_FUNC_PTR, 3);
+    js_closure_set_capture_f64(bound, 0, target_value);
+    js_closure_set_capture_f64(bound, 1, bound_this);
+    js_closure_set_capture_ptr(bound, 2, bound_args_arr as i64);
+
+    // Spec `.length` = max(0, target.length - boundArgs.length).
+    let target_len = crate::closure::closure_arity(target_closure).unwrap_or(0);
+    let bound_len = target_len.saturating_sub(bound_arg_count as u32);
+    crate::object::set_builtin_closure_length(bound as usize, bound_len);
+
+    // Spec `.name` = "bound " + target.name.
+    let target_name = crate::builtins::function_name_for_ptr((*target_closure).func_ptr as usize)
+        .unwrap_or_default();
+    let bound_name = format!("bound {target_name}");
+    let name_ptr =
+        crate::string::js_string_from_bytes(bound_name.as_ptr(), bound_name.len() as u32);
+    let name_value = f64::from_bits(JSValue::string_ptr(name_ptr).bits());
+    crate::closure::closure_set_dynamic_prop(bound as usize, "name", name_value);
+
+    crate::gc::runtime_write_barrier_root_heap_word(bound as u64);
+    f64::from_bits(JSValue::pointer(bound as *mut u8).bits())
+}
+
+/// Keepalive anchor for the `js_function_bind` symbol. The auto-optimize
+/// whole-program LLVM rebuild dead-strips `#[no_mangle]` fns that are only
+/// referenced from generated `.o` / other crates; this `#[used]` static
+/// survives the bitcode pipeline. See project_auto_optimize_keepalive_3320.
+#[used]
+static KEEP_JS_FUNCTION_BIND: unsafe extern "C" fn(f64, *const f64, usize) -> f64 =
+    js_function_bind;
+
 /// Issue #648: calling a value that isn't a function (most commonly the
 /// result of a property lookup that returned undefined, e.g.
 /// `obj.missingFn()`) must throw a TypeError that user code can catch via
@@ -163,6 +274,13 @@ pub fn get_valid_func_ptr(closure: *const ClosureHeader) -> *const u8 {
     if func_ptr == BOUND_METHOD_FUNC_PTR {
         return func_ptr;
     }
+    // BOUND_FUNCTION_FUNC_PTR (0xBADD_B1ND) is the Function.prototype.bind
+    // sentinel — like BOUND_METHOD_FUNC_PTR it's not a real code address, so
+    // pass it through here and let the call sites route to
+    // dispatch_bound_function (#2840).
+    if func_ptr == BOUND_FUNCTION_FUNC_PTR {
+        return func_ptr;
+    }
     // Validate func_ptr is in a reasonable code address range.
     // macOS ARM64: .text starts at 0x100000000, typically < 0x400000000
     // Windows x86_64: typically 0x7FF7_xxxx_xxxx (ASLR), so we allow up to 0x8000_0000_0000
@@ -189,6 +307,7 @@ pub extern "C" fn js_closure_call0(closure: *const ClosureHeader) -> f64 {
     }
     match resolve_strategy(func_ptr) {
         DispatchStrategy::BoundMethod => unsafe { dispatch_bound_method(closure, &[]) },
+        DispatchStrategy::BoundFunction => unsafe { dispatch_bound_function(closure, &[]) },
         DispatchStrategy::Rest(fixed_arity, synth) => unsafe {
             dispatch_rest_bundled(closure, func_ptr, &[], fixed_arity, synth)
         },
@@ -212,6 +331,7 @@ pub extern "C" fn js_closure_call1(closure: *const ClosureHeader, arg0: f64) -> 
     }
     match resolve_strategy(func_ptr) {
         DispatchStrategy::BoundMethod => unsafe { dispatch_bound_method(closure, &[arg0]) },
+        DispatchStrategy::BoundFunction => unsafe { dispatch_bound_function(closure, &[arg0]) },
         DispatchStrategy::Rest(fixed_arity, synth) => unsafe {
             dispatch_rest_bundled(closure, func_ptr, &[arg0], fixed_arity, synth)
         },
@@ -239,7 +359,10 @@ pub(crate) fn resolve_call2_direct(
     closure: *const ClosureHeader,
 ) -> Option<extern "C" fn(*const ClosureHeader, f64, f64) -> f64> {
     let func_ptr = get_valid_func_ptr(closure);
-    if func_ptr.is_null() || func_ptr == BOUND_METHOD_FUNC_PTR {
+    if func_ptr.is_null()
+        || func_ptr == BOUND_METHOD_FUNC_PTR
+        || func_ptr == BOUND_FUNCTION_FUNC_PTR
+    {
         return None;
     }
     if lookup_closure_rest(func_ptr).is_some() {
@@ -262,6 +385,9 @@ pub extern "C" fn js_closure_call2(closure: *const ClosureHeader, arg0: f64, arg
     }
     match resolve_strategy(func_ptr) {
         DispatchStrategy::BoundMethod => unsafe { dispatch_bound_method(closure, &[arg0, arg1]) },
+        DispatchStrategy::BoundFunction => unsafe {
+            dispatch_bound_function(closure, &[arg0, arg1])
+        },
         DispatchStrategy::Rest(fixed_arity, synth) => unsafe {
             dispatch_rest_bundled(closure, func_ptr, &[arg0, arg1], fixed_arity, synth)
         },
@@ -291,6 +417,9 @@ pub extern "C" fn js_closure_call3(
     match resolve_strategy(func_ptr) {
         DispatchStrategy::BoundMethod => unsafe {
             dispatch_bound_method(closure, &[arg0, arg1, arg2])
+        },
+        DispatchStrategy::BoundFunction => unsafe {
+            dispatch_bound_function(closure, &[arg0, arg1, arg2])
         },
         DispatchStrategy::Rest(fixed_arity, synth) => unsafe {
             dispatch_rest_bundled(closure, func_ptr, &[arg0, arg1, arg2], fixed_arity, synth)
@@ -322,6 +451,9 @@ pub extern "C" fn js_closure_call4(
     match resolve_strategy(func_ptr) {
         DispatchStrategy::BoundMethod => unsafe {
             dispatch_bound_method(closure, &[arg0, arg1, arg2, arg3])
+        },
+        DispatchStrategy::BoundFunction => unsafe {
+            dispatch_bound_function(closure, &[arg0, arg1, arg2, arg3])
         },
         DispatchStrategy::Rest(fixed_arity, synth) => unsafe {
             dispatch_rest_bundled(
@@ -359,6 +491,9 @@ pub extern "C" fn js_closure_call5(
     }
     if func_ptr == BOUND_METHOD_FUNC_PTR {
         return unsafe { dispatch_bound_method(closure, &[arg0, arg1, arg2, arg3, arg4]) };
+    }
+    if func_ptr == BOUND_FUNCTION_FUNC_PTR {
+        return unsafe { dispatch_bound_function(closure, &[arg0, arg1, arg2, arg3, arg4]) };
     }
     if let Some((fixed_arity, synth)) = lookup_closure_rest_full(func_ptr) {
         return unsafe {
@@ -400,6 +535,9 @@ pub extern "C" fn js_closure_call6(
     }
     if func_ptr == BOUND_METHOD_FUNC_PTR {
         return unsafe { dispatch_bound_method(closure, &[arg0, arg1, arg2, arg3, arg4, arg5]) };
+    }
+    if func_ptr == BOUND_FUNCTION_FUNC_PTR {
+        return unsafe { dispatch_bound_function(closure, &[arg0, arg1, arg2, arg3, arg4, arg5]) };
     }
     if let Some((fixed_arity, synth)) = lookup_closure_rest_full(func_ptr) {
         return unsafe {
@@ -450,6 +588,11 @@ pub extern "C" fn js_closure_call7(
             dispatch_bound_method(closure, &[arg0, arg1, arg2, arg3, arg4, arg5, arg6])
         };
     }
+    if func_ptr == BOUND_FUNCTION_FUNC_PTR {
+        return unsafe {
+            dispatch_bound_function(closure, &[arg0, arg1, arg2, arg3, arg4, arg5, arg6])
+        };
+    }
     let func: extern "C" fn(*const ClosureHeader, f64, f64, f64, f64, f64, f64, f64) -> f64 =
         unsafe { std::mem::transmute(func_ptr) };
     func(closure, arg0, arg1, arg2, arg3, arg4, arg5, arg6)
@@ -475,6 +618,11 @@ pub extern "C" fn js_closure_call8(
     if func_ptr == BOUND_METHOD_FUNC_PTR {
         return unsafe {
             dispatch_bound_method(closure, &[arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7])
+        };
+    }
+    if func_ptr == BOUND_FUNCTION_FUNC_PTR {
+        return unsafe {
+            dispatch_bound_function(closure, &[arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7])
         };
     }
     let func: extern "C" fn(*const ClosureHeader, f64, f64, f64, f64, f64, f64, f64, f64) -> f64 =
@@ -503,6 +651,14 @@ pub extern "C" fn js_closure_call9(
     if func_ptr == BOUND_METHOD_FUNC_PTR {
         return unsafe {
             dispatch_bound_method(
+                closure,
+                &[arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8],
+            )
+        };
+    }
+    if func_ptr == BOUND_FUNCTION_FUNC_PTR {
+        return unsafe {
+            dispatch_bound_function(
                 closure,
                 &[arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8],
             )
@@ -547,6 +703,14 @@ pub extern "C" fn js_closure_call10(
     if func_ptr == BOUND_METHOD_FUNC_PTR {
         return unsafe {
             dispatch_bound_method(
+                closure,
+                &[arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9],
+            )
+        };
+    }
+    if func_ptr == BOUND_FUNCTION_FUNC_PTR {
+        return unsafe {
+            dispatch_bound_function(
                 closure,
                 &[arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9],
             )
@@ -600,6 +764,16 @@ pub extern "C" fn js_closure_call11(
             )
         };
     }
+    if func_ptr == BOUND_FUNCTION_FUNC_PTR {
+        return unsafe {
+            dispatch_bound_function(
+                closure,
+                &[
+                    arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10,
+                ],
+            )
+        };
+    }
     let func: extern "C" fn(
         *const ClosureHeader,
         f64,
@@ -643,6 +817,16 @@ pub extern "C" fn js_closure_call12(
     if func_ptr == BOUND_METHOD_FUNC_PTR {
         return unsafe {
             dispatch_bound_method(
+                closure,
+                &[
+                    arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
+                ],
+            )
+        };
+    }
+    if func_ptr == BOUND_FUNCTION_FUNC_PTR {
+        return unsafe {
+            dispatch_bound_function(
                 closure,
                 &[
                     arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
@@ -702,6 +886,16 @@ pub extern "C" fn js_closure_call13(
             )
         };
     }
+    if func_ptr == BOUND_FUNCTION_FUNC_PTR {
+        return unsafe {
+            dispatch_bound_function(
+                closure,
+                &[
+                    arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12,
+                ],
+            )
+        };
+    }
     let func: extern "C" fn(
         *const ClosureHeader,
         f64,
@@ -749,6 +943,17 @@ pub extern "C" fn js_closure_call14(
     if func_ptr == BOUND_METHOD_FUNC_PTR {
         return unsafe {
             dispatch_bound_method(
+                closure,
+                &[
+                    arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
+                    arg12, arg13,
+                ],
+            )
+        };
+    }
+    if func_ptr == BOUND_FUNCTION_FUNC_PTR {
+        return unsafe {
+            dispatch_bound_function(
                 closure,
                 &[
                     arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
@@ -815,6 +1020,17 @@ pub extern "C" fn js_closure_call15(
             )
         };
     }
+    if func_ptr == BOUND_FUNCTION_FUNC_PTR {
+        return unsafe {
+            dispatch_bound_function(
+                closure,
+                &[
+                    arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
+                    arg12, arg13, arg14,
+                ],
+            )
+        };
+    }
     let func: extern "C" fn(
         *const ClosureHeader,
         f64,
@@ -867,6 +1083,17 @@ pub extern "C" fn js_closure_call16(
     if func_ptr == BOUND_METHOD_FUNC_PTR {
         return unsafe {
             dispatch_bound_method(
+                closure,
+                &[
+                    arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
+                    arg12, arg13, arg14, arg15,
+                ],
+            )
+        };
+    }
+    if func_ptr == BOUND_FUNCTION_FUNC_PTR {
+        return unsafe {
+            dispatch_bound_function(
                 closure,
                 &[
                     arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,

--- a/crates/perry-runtime/src/closure/mod.rs
+++ b/crates/perry-runtime/src/closure/mod.rs
@@ -30,16 +30,17 @@ pub use registry::{
     js_register_closure_async_function, js_register_closure_generator_function,
     js_register_closure_rest, js_register_closure_synthetic_arguments, lookup_closure_arity,
     lookup_closure_rest, lookup_closure_rest_full, real_capture_count, resolve_strategy,
-    DispatchStrategy, BOUND_METHOD_FUNC_PTR, CAPTURES_THIS_FLAG, CLOSURE_MAGIC,
+    DispatchStrategy, BOUND_FUNCTION_FUNC_PTR, BOUND_METHOD_FUNC_PTR, CAPTURES_THIS_FLAG,
+    CLOSURE_MAGIC,
 };
 
 pub use dispatch::{
-    clean_closure_ptr, dispatch_bound_method, get_valid_func_ptr, js_closure_call0,
-    js_closure_call1, js_closure_call10, js_closure_call11, js_closure_call12, js_closure_call13,
-    js_closure_call14, js_closure_call15, js_closure_call16, js_closure_call2, js_closure_call3,
-    js_closure_call4, js_closure_call5, js_closure_call6, js_closure_call7, js_closure_call8,
-    js_closure_call9, js_closure_call_apply_with_spread, js_closure_call_array,
-    js_native_call_value, throw_not_callable,
+    clean_closure_ptr, dispatch_bound_function, dispatch_bound_method, get_valid_func_ptr,
+    js_closure_call0, js_closure_call1, js_closure_call10, js_closure_call11, js_closure_call12,
+    js_closure_call13, js_closure_call14, js_closure_call15, js_closure_call16, js_closure_call2,
+    js_closure_call3, js_closure_call4, js_closure_call5, js_closure_call6, js_closure_call7,
+    js_closure_call8, js_closure_call9, js_closure_call_apply_with_spread, js_closure_call_array,
+    js_function_bind, js_native_call_value, throw_not_callable,
 };
 pub(crate) use dispatch::{reset_throw_not_callable_counter, resolve_call2_direct};
 

--- a/crates/perry-runtime/src/closure/registry.rs
+++ b/crates/perry-runtime/src/closure/registry.rs
@@ -84,6 +84,9 @@ pub enum DispatchStrategy {
     /// Bound-method receiver pretending to be a closure (BOUND_METHOD_FUNC_PTR
     /// sentinel). Dispatch via `dispatch_bound_method`.
     BoundMethod,
+    /// `Function.prototype.bind` result (BOUND_FUNCTION_FUNC_PTR sentinel).
+    /// Dispatch via `dispatch_bound_function`.
+    BoundFunction,
     /// Closure body has a rest param at the given fixed_arity index.
     /// Dispatch via `dispatch_rest_bundled`. The bool flag is true when
     /// the rest param is the synthesized `arguments` array (HIR-injected
@@ -141,6 +144,12 @@ fn resolve_strategy_slow(func_ptr: *const u8) -> DispatchStrategy {
             c.borrow_mut().insert(key, DispatchStrategy::BoundMethod);
         });
         return DispatchStrategy::BoundMethod;
+    }
+    if func_ptr == BOUND_FUNCTION_FUNC_PTR {
+        DISPATCH_CACHE.with(|c| {
+            c.borrow_mut().insert(key, DispatchStrategy::BoundFunction);
+        });
+        return DispatchStrategy::BoundFunction;
     }
     let strategy = if let Some((fixed_arity, synthetic)) = lookup_closure_rest_full(func_ptr) {
         DispatchStrategy::Rest(fixed_arity, synthetic)
@@ -544,6 +553,19 @@ pub unsafe fn dispatch_with_arity(
 /// When js_closure_callN detects this, it extracts captures and dispatches via js_native_call_method.
 /// Captures layout: [0] = namespace_obj (f64), [1] = method_name_ptr (i64), [2] = method_name_len (i64)
 pub const BOUND_METHOD_FUNC_PTR: *const u8 = 0xBADD_DEAD_u64 as *const u8;
+
+/// Sentinel func_ptr value indicating this closure is a `Function.prototype.bind`
+/// result: a bound function with a fixed `this`, prepended partial args, and an
+/// adjusted `.name` / `.length`. When `js_closure_callN` (or `js_native_call_value`)
+/// detects this sentinel it dispatches via `dispatch_bound_function`, which
+/// prepends the bound args, sets `IMPLICIT_THIS` to the bound receiver, and calls
+/// the target closure.
+///
+/// Captures layout:
+///   [0] = target closure value (f64, NaN-boxed)
+///   [1] = bound `this` value (f64)
+///   [2] = bound-args JS Array pointer (i64; 0 when no partial args)
+pub const BOUND_FUNCTION_FUNC_PTR: *const u8 = 0xBADD_B1ND_u64 as *const u8;
 
 /// Flag stored in the high bit of capture_count to indicate that capture slot 0
 /// holds `this` (i.e., this closure is an object literal method that captures `this`).

--- a/crates/perry-runtime/src/closure/registry.rs
+++ b/crates/perry-runtime/src/closure/registry.rs
@@ -565,7 +565,7 @@ pub const BOUND_METHOD_FUNC_PTR: *const u8 = 0xBADD_DEAD_u64 as *const u8;
 ///   [0] = target closure value (f64, NaN-boxed)
 ///   [1] = bound `this` value (f64)
 ///   [2] = bound-args JS Array pointer (i64; 0 when no partial args)
-pub const BOUND_FUNCTION_FUNC_PTR: *const u8 = 0xBADD_B1ND_u64 as *const u8;
+pub const BOUND_FUNCTION_FUNC_PTR: *const u8 = 0xBADD_B12D_u64 as *const u8;
 
 /// Flag stored in the high bit of capture_count to indicate that capture slot 0
 /// holds `this` (i.e., this closure is an object literal method that captures `this`).

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1229,9 +1229,37 @@ pub unsafe extern "C" fn js_native_call_method(
                 }
                 "replace" | "replaceAll" => {
                     // Two-arg shape: (pattern, replacement). pattern can be a
-                    // string OR a RegExp; replacement is a string. Function
-                    // replacements aren't supported here yet — they need
-                    // closure dispatch and aren't on hono's hot path.
+                    // string OR a RegExp; replacement is a string OR a function.
+                    // Function replacements over a RegExp pattern route to the
+                    // regex-fn helpers (#2867) so dynamically-dispatched
+                    // `str.replace(re, fn)` observes Node's callback argument
+                    // shape `(match, p1, ..., offset, string, groups?)`.
+                    if let (Some(pat_val), Some(repl_val)) = (arg_at(0), arg_at(1)) {
+                        let pat_jsv = JSValue::from_bits(pat_val.to_bits());
+                        let repl_jsv = JSValue::from_bits(repl_val.to_bits());
+                        if pat_jsv.is_pointer() && repl_jsv.is_pointer() {
+                            let repl_raw = (repl_val.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize;
+                            if crate::closure::is_closure_ptr(repl_raw) {
+                                let regex_ptr = pat_jsv.as_pointer::<crate::regex::RegExpHeader>();
+                                if !regex_ptr.is_null() {
+                                    let r = if method_name == "replaceAll" {
+                                        crate::regex::js_string_replace_all_regex_fn(
+                                            receiver_string(),
+                                            regex_ptr,
+                                            repl_val,
+                                        )
+                                    } else {
+                                        crate::regex::js_string_replace_regex_fn(
+                                            receiver_string(),
+                                            regex_ptr,
+                                            repl_val,
+                                        )
+                                    };
+                                    return f64::from_bits(JSValue::string_ptr(r).bits());
+                                }
+                            }
+                        }
+                    }
                     let pat_handle = root_string_arg_handle(&root_scope, &arg_handles, 0);
                     let repl_handle = root_string_arg_handle(&root_scope, &arg_handles, 1);
                     let pat_str = || {
@@ -2373,11 +2401,16 @@ pub unsafe extern "C" fn js_native_call_method(
 
     // Handle common method calls
     match method_name {
-        // Function.prototype.bind - returns the same function for native closures
-        // This is a simplification - real bind() creates a new function with bound 'this'
+        // Function.prototype.bind(thisArg, ...boundArgs) — create a distinct
+        // bound function with a fixed `this`, prepended partial args, and an
+        // adjusted `.name`/`.length` (#2840). For closure receivers route to
+        // the runtime bind helper; non-closure receivers fall back to the
+        // prior conservative behavior of returning the receiver unchanged.
         "bind" => {
-            // For native closures, we return the function as-is
-            // The 'this' binding is handled at the call site
+            let raw_ptr = (object.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize;
+            if jsval.is_pointer() && crate::closure::is_closure_ptr(raw_ptr) {
+                return crate::closure::js_function_bind(object, args_ptr, args_len);
+            }
             return object;
         }
 

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -1382,9 +1382,15 @@ pub extern "C" fn js_regexp_set_last_index(re: *mut RegExpHeader, value: f64) {
     }
 }
 
-/// string.replace(regex, replacerFn) — replace with a callback function
-/// The callback receives (match, p1, p2, ..., offset, string)
-/// We simplify to (match, ...groups, offset) since the full string is rarely needed.
+/// string.replace(regex, replacerFn) — replace with a callback function.
+///
+/// The callback receives the full ECMAScript argument list (#2867):
+///   `(match, p1, p2, ..., offset, string, groups?)`
+/// i.e. the whole match, then every capture group (undefined for
+/// non-participating groups), then the 0-based offset of the match in the
+/// input, then the whole input string, and finally — only when the pattern
+/// has named capture groups — a `groups` object mapping each name to its
+/// captured substring.
 #[no_mangle]
 pub extern "C" fn js_string_replace_regex_fn(
     s: *const StringHeader,
@@ -1424,47 +1430,78 @@ pub extern "C" fn js_string_replace_regex_fn(
             }
         };
 
+        // Does the pattern declare any named capture groups? If so we pass a
+        // trailing `groups` object to the callback (matching Node). Computed
+        // once outside the match loop.
+        let has_named_groups = regex.capture_names().any(|n| n.is_some());
+
         for caps in &captures_iter {
             let full_match = caps.get(0).unwrap();
             result.push_str(&str_data[last_end..full_match.start()]);
 
-            // Calculate char offset for the offset parameter
+            // Calculate char offset for the offset parameter.
             let char_offset = str_data[..full_match.start()].chars().count();
 
-            // Call the closure with (match, ...groups, offset)
-            // We need to use the appropriate js_closure_callN function
-            let match_str = js_string_from_str(full_match.as_str());
-            let match_nanboxed = js_nanbox_string(match_str as i64);
+            // Build the full ECMAScript callback argument list:
+            //   (match, p1, ..., pN, offset, string, groups?)
+            // Root every NaN-boxed value as we go so a GC triggered by a
+            // subsequent string/object/array allocation (or by the callback
+            // dispatch itself) can't reclaim earlier arguments.
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let mut arg_handles: Vec<crate::gc::RuntimeHandle<'_>> = Vec::new();
 
+            let match_nanboxed = js_nanbox_string(js_string_from_str(full_match.as_str()) as i64);
+            arg_handles.push(scope.root_nanbox_f64(match_nanboxed));
+
+            // Capture groups 1..=N (undefined for non-participating groups).
             let num_groups = caps.len() - 1; // exclude full match
-            let ret = if num_groups == 0 {
-                // Call with (match, offset)
-                let offset_f64 = char_offset as f64;
-                crate::closure::js_closure_call2(closure_ptr, match_nanboxed, offset_f64)
-            } else if num_groups == 1 {
-                // Call with (match, p1, offset)
-                let p1 = if let Some(m) = caps.get(1) {
+            for gi in 1..=num_groups {
+                let group_val = if let Some(m) = caps.get(gi) {
                     js_nanbox_string(js_string_from_str(m.as_str()) as i64)
                 } else {
                     f64::from_bits(TAG_UNDEFINED)
                 };
-                let offset_f64 = char_offset as f64;
-                crate::closure::js_closure_call3(closure_ptr, match_nanboxed, p1, offset_f64)
-            } else {
-                // For 2+ groups, call with (match, p1, p2, offset)
-                let p1 = if let Some(m) = caps.get(1) {
-                    js_nanbox_string(js_string_from_str(m.as_str()) as i64)
-                } else {
-                    f64::from_bits(TAG_UNDEFINED)
-                };
-                let p2 = if let Some(m) = caps.get(2) {
-                    js_nanbox_string(js_string_from_str(m.as_str()) as i64)
-                } else {
-                    f64::from_bits(TAG_UNDEFINED)
-                };
-                let offset_f64 = char_offset as f64;
-                crate::closure::js_closure_call4(closure_ptr, match_nanboxed, p1, p2, offset_f64)
-            };
+                arg_handles.push(scope.root_nanbox_f64(group_val));
+            }
+
+            // offset (number) then the whole input string.
+            arg_handles.push(scope.root_nanbox_f64(char_offset as f64));
+            let string_nanboxed = js_nanbox_string(js_string_from_str(str_data) as i64);
+            arg_handles.push(scope.root_nanbox_f64(string_nanboxed));
+
+            // groups object (only when the pattern has named captures).
+            if has_named_groups {
+                let groups_obj = crate::object::js_object_alloc(0, 0);
+                let groups_handle = scope.root_raw_mut_ptr(groups_obj);
+                let group_names: Vec<(&str, Option<regex::Match>)> = regex
+                    .capture_names()
+                    .enumerate()
+                    .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
+                    .collect();
+                for (name, m) in &group_names {
+                    let val = if let Some(m) = m {
+                        js_nanbox_string(js_string_from_str(m.as_str()) as i64)
+                    } else {
+                        f64::from_bits(TAG_UNDEFINED)
+                    };
+                    let key_ptr =
+                        crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                    let groups_obj = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+                    crate::object::js_object_set_field_by_name(groups_obj, key_ptr, val);
+                }
+                // The groups object handle is a POINTER_TAG raw root — its
+                // refreshed nanbox value is exactly the `groups` callback arg.
+                arg_handles.push(groups_handle);
+            }
+
+            let call_args: Vec<f64> = arg_handles.iter().map(|h| h.get_nanbox_f64()).collect();
+            let callback_value =
+                f64::from_bits(crate::value::JSValue::pointer(closure_ptr as *mut u8).bits());
+            let ret = crate::closure::js_native_call_value(
+                callback_value,
+                call_args.as_ptr(),
+                call_args.len(),
+            );
 
             // Convert the NaN-boxed return value to a string. Issue #833:
             // the previous tag-discriminated decode only handled STRING_TAG

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -1489,9 +1489,12 @@ pub extern "C" fn js_string_replace_regex_fn(
                     let groups_obj = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
                     crate::object::js_object_set_field_by_name(groups_obj, key_ptr, val);
                 }
-                // The groups object handle is a POINTER_TAG raw root — its
-                // refreshed nanbox value is exactly the `groups` callback arg.
-                arg_handles.push(groups_handle);
+                // Re-root the (possibly-moved) groups object as a NaN-boxed
+                // pointer value so it lands in the uniform `arg_handles` list
+                // alongside the other NaN-boxed callback args.
+                let groups_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+                let groups_value = crate::value::js_nanbox_pointer(groups_ptr as i64);
+                arg_handles.push(scope.root_nanbox_f64(groups_value));
             }
 
             let call_args: Vec<f64> = arg_handles.iter().map(|h| h.get_nanbox_f64()).collect();

--- a/test-files/test_gap_bind_replace_2840_2867.ts
+++ b/test-files/test_gap_bind_replace_2840_2867.ts
@@ -29,7 +29,7 @@ console.log("bind multi-partial length:", a3.length); // 1
 
 // --- #2867: String.replace regex callback arguments ---
 
-function argsFor(pattern: RegExp, input: string) {
+function argsFor(label: string, pattern: RegExp, input: string) {
   let seen: string[] = [];
   input.replace(pattern, function (...args: any[]) {
     seen = args.map((v) =>
@@ -37,12 +37,12 @@ function argsFor(pattern: RegExp, input: string) {
     );
     return "x";
   });
-  console.log(String(pattern), seen.length, seen.join("|"));
+  console.log(label, seen.length, seen.join("|"));
 }
 
-argsFor(/b/, "abc"); // /b/ 3 b|1|abc
-argsFor(/(a)(b)(c)/, "abc"); // /(a)(b)(c)/ 6 abc|a|b|c|0|abc
-argsFor(/(?<word>\w+)-(?<num>\d+)/, "abc-123"); // 6 abc-123|abc|123|0|abc-123|{"word":"abc","num":"123"}
+argsFor("no-capture", /b/, "abc"); // no-capture 3 b|1|abc
+argsFor("captures", /(a)(b)(c)/, "abc"); // captures 6 abc|a|b|c|0|abc
+argsFor("named", /(?<word>\w+)-(?<num>\d+)/, "abc-123"); // named 6 abc-123|abc|123|0|abc-123|{"word":"abc","num":"123"}
 
 // Global flag still calls the callback per match with the full arg list.
 const out = "abcabc".replace(/(a)(b)/g, (m, p1, p2, off, str) => {

--- a/test-files/test_gap_bind_replace_2840_2867.ts
+++ b/test-files/test_gap_bind_replace_2840_2867.ts
@@ -1,0 +1,51 @@
+// Gap test for #2840 (Function.prototype.bind) and #2867 (String.replace callback args).
+
+// --- #2840: Function.prototype.bind ---
+
+function f(this: any, a: number, b: number) {
+  return [this.x, a, b];
+}
+const g = f.bind({ x: 1 }, 2);
+console.log("bind this+partial:", JSON.stringify(g(3))); // [1,2,3]
+console.log("bind distinct:", g !== f); // true
+console.log("bind length:", g.length); // 1
+console.log("bind name:", g.name); // bound f
+
+// bind with no partial args
+function h(this: any, a: number) {
+  return this.y + a;
+}
+const hb = h.bind({ y: 10 });
+console.log("bind no-partial:", hb(5)); // 15
+console.log("bind no-partial length:", hb.length); // 1
+
+// bind with multiple partial args
+function add3(a: number, b: number, c: number) {
+  return a + b + c;
+}
+const a3 = add3.bind(null, 1, 2);
+console.log("bind multi-partial:", a3(3)); // 6
+console.log("bind multi-partial length:", a3.length); // 1
+
+// --- #2867: String.replace regex callback arguments ---
+
+function argsFor(pattern: RegExp, input: string) {
+  let seen: string[] = [];
+  input.replace(pattern, function (...args: any[]) {
+    seen = args.map((v) =>
+      typeof v === "object" && v !== null ? JSON.stringify(v) : String(v),
+    );
+    return "x";
+  });
+  console.log(String(pattern), seen.length, seen.join("|"));
+}
+
+argsFor(/b/, "abc"); // /b/ 3 b|1|abc
+argsFor(/(a)(b)(c)/, "abc"); // /(a)(b)(c)/ 6 abc|a|b|c|0|abc
+argsFor(/(?<word>\w+)-(?<num>\d+)/, "abc-123"); // 6 abc-123|abc|123|0|abc-123|{"word":"abc","num":"123"}
+
+// Global flag still calls the callback per match with the full arg list.
+const out = "abcabc".replace(/(a)(b)/g, (m, p1, p2, off, str) => {
+  return `[${m}:${p1}:${p2}:${off}:${str}]`;
+});
+console.log("replace global:", out);


### PR DESCRIPTION
Closes #2840
Closes #2867

## Implementation

### #2840 — real `Function.prototype.bind` semantics (runtime)

Replaced the `"bind"` arm in `object/native_call_method.rs` (which returned the
receiver unchanged) with a real bound-function builder.

- New `BOUND_FUNCTION_FUNC_PTR` sentinel (`0xBADD_B12D`) in `closure/registry.rs`,
  mirroring the existing `BOUND_METHOD_FUNC_PTR` pattern, plus a
  `DispatchStrategy::BoundFunction` strategy variant.
- New `js_function_bind(target, args_ptr, args_len)` in `closure/dispatch.rs`
  allocates a bound closure capturing `[0]=target closure value`,
  `[1]=bound this`, `[2]=partial-args JS array`. It sets:
  - `.length` = `max(0, target.length - boundArgs.length)` via the existing
    per-closure `set_builtin_closure_length` side table.
  - `.name` = `"bound " + target.name` via the closure dynamic-prop table.
    Both are read by the existing `field_get_set.rs` closure property path, so
    `g.length` / `g.name` work with no codegen changes.
- New `dispatch_bound_function` prepends the bound args to the call-time args,
  sets `IMPLICIT_THIS` to the bound receiver, and forwards to
  `js_native_call_value`. It is wired into every `js_closure_callN`
  (0–16, both the `match resolve_strategy` and explicit-sentinel forms),
  `get_valid_func_ptr` (sentinel passthrough), and `resolve_call2_direct`.
- `#[used] KEEP_JS_FUNCTION_BIND` keepalive anchor so the auto-optimize
  whole-program bitcode rebuild doesn't dead-strip the `#[no_mangle]` symbol.
  Verified the symbol survives in the auto-optimized `libperry_runtime.a`.

`g === f` is false (distinct closure), `this`, partial args, `.name`, and
`.length` all match Node.

**Scope note:** `new`-target forwarding for bound *constructors*
(`const o = new B(...)` where `B = C.bind(...)`) is **not** included — it needs
the closure-as-constructor path to recognise the sentinel and forward to the
target's class-id/prototype machinery, which is broader infra than this
runtime-only change. The common bind cases (bound `this` + partial args +
`.name`/`.length`) are complete. Constructor-`new` forwarding can be a follow-up.

### #2867 — `String.replace` regex callback arguments (runtime)

`regex.rs::js_string_replace_regex_fn` previously called the replacer with a
truncated `(match, p1?, p2?, offset)` and dropped captures past `p2`, the input
string, and named `groups`. It now builds the full ECMAScript argument list
`(match, p1, ..., pN, offset, string, groups?)` and dispatches via
`js_native_call_value` (variadic), rooting each NaN-boxed arg in a
`RuntimeHandleScope`. The `groups` object is built only when the pattern has
named captures. The dynamic/any-typed `replace`/`replaceAll` path in
`native_call_method.rs` now also routes RegExp + function replacements to the
regex-fn helpers, so dynamically-dispatched `str.replace(re, fn)` observes the
same callback shape.

## Validation

`test-files/test_gap_bind_replace_2840_2867.ts` is **byte-identical** to
`node --experimental-strip-types` under the DEFAULT auto-optimize compile,
covering: `f.bind(obj, 1)(2)` this+partial args, bound `.name`/`.length`,
no-partial and multi-partial bind, and `replace` callback arg order for
no-capture / positional-capture / named-capture / global cases.

- `./scripts/check_file_size.sh` — OK (exit 0)
- `cargo fmt --all -- --check` — clean
- `cargo test --release -p perry-runtime` — 918 passed, 0 failed
- `cargo test --release -p perry-hir` — passed (no HIR variant added)

No new HIR `Expr` variant; no stable-hash tag needed. Runtime-only change.
