### PR TITLE
fix(stream): execute compose pipelines

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -694,15 +694,10 @@ extern "C" fn ns_unshift1(closure: *const ClosureHeader, chunk: f64) -> f64 {
 }
 
 /// `readable.compose(stream)` (#1539): the instance-method form of
-/// `stream.compose`. Retained-chunk Readables can eagerly compose through a
-/// single Transform/PassThrough so downstream iterator helpers still see a
-/// readable chunk snapshot; unsupported forms keep the historical shape stub.
+/// `stream.compose`, routed through the shared compose builder so the same
+/// data-flow and error handling paths cover module and prototype calls.
 extern "C" fn ns_compose1(closure: *const ClosureHeader, arg: f64) -> f64 {
-    let source = this_value(closure);
-    if let Some(composed) = compose_readable_snapshot(source, arg) {
-        return composed;
-    }
-    js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
+    build_node_stream_compose(vec![this_value(closure), arg])
 }
 
 extern "C" fn ns_pipe2(closure: *const ClosureHeader, dest: f64, options: f64) -> f64 {

--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -969,12 +969,8 @@ pub extern "C" fn js_node_stream_duplex_from_options(body: f64, _opts: f64) -> f
     node_stream_duplex_from_source_chunks(body)
 }
 
-/// #1539: `stream.compose(...streams)` chains a sequence of streams
-/// into one composite Duplex (data flows through them in order). Perry
-/// now handles Node's single-source fast path by returning a Duplex
-/// wrapper whose readable side drains the source snapshot, and the
-/// single-Transform stage form by returning the stage itself. Multi-stage
-/// composition remains tracked separately.
+/// #1539: `stream.compose(...streams)` chains a sequence of streams or
+/// callable stages into one composite Duplex.
 #[no_mangle]
 pub extern "C" fn js_node_stream_compose(args: *const crate::array::ArrayHeader) -> f64 {
     js_node_stream_compose_args(args)
@@ -983,22 +979,7 @@ pub extern "C" fn js_node_stream_compose(args: *const crate::array::ArrayHeader)
 /// Variadic `stream.compose(...)` entry used by bound native-module property
 /// reads and by direct named imports through codegen's packed varargs ABI.
 pub extern "C" fn js_node_stream_compose_args(args: *const crate::array::ArrayHeader) -> f64 {
-    let args = pipeline_args(args);
-    if args.is_empty() {
-        throw_pipeline_missing_streams();
-    }
-    if args.len() == 1 {
-        if is_transform_stream(args[0]) {
-            return args[0];
-        }
-        return node_stream_duplex_from_source_chunks(args[0]);
-    }
-    if args.len() == 2 {
-        if let Some(readable) = compose_readable_snapshot(args[0], args[1]) {
-            return node_stream_duplex_from_source_chunks(readable);
-        }
-    }
-    js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
+    build_node_stream_compose(pipeline_args(args))
 }
 
 pub(super) fn add_finished_once_listeners(

--- a/crates/perry-runtime/src/node_stream_dispatch.rs
+++ b/crates/perry-runtime/src/node_stream_dispatch.rs
@@ -160,6 +160,12 @@ pub(super) fn register_stub_arities() {
     register(pipeline_success_callback as *const u8, 0);
     register(pipeline_error_callback as *const u8, 1);
     register(pipeline_close_callback as *const u8, 0);
+    register(compose_stage_error_callback as *const u8, 1);
+    register(compose_source_data_callback as *const u8, 1);
+    register(compose_source_end_callback as *const u8, 0);
+    register(compose_source_error_callback as *const u8, 1);
+    register(compose_duplex_write_callback as *const u8, 3);
+    register(compose_duplex_final_callback as *const u8, 1);
     register(ns_write3 as *const u8, 3);
     register(ns_end3 as *const u8, 3);
     register(ns_cork0 as *const u8, 0);

--- a/crates/perry-runtime/src/node_stream_iter_helpers.rs
+++ b/crates/perry-runtime/src/node_stream_iter_helpers.rs
@@ -244,66 +244,6 @@ pub(super) fn prepare_readable_for_iteration(stream: f64) {
     drain_iter_helper_microtasks();
 }
 
-pub(super) fn extend_compose_output_chunks(
-    mut out: *mut crate::array::ArrayHeader,
-    stage: f64,
-    chunks: f64,
-) -> *mut crate::array::ArrayHeader {
-    if !readable_object_mode(stage) {
-        let mut bytes = Vec::new();
-        append_chunk_bytes(chunks, &mut bytes, 0);
-        if !bytes.is_empty() {
-            out = crate::array::js_array_push_f64(out, buffer_value_from_bytes(&bytes));
-        }
-        return out;
-    }
-
-    if is_array_like_value(chunks) {
-        extend_with_array(out, raw_ptr_from_value(chunks) as *const _)
-    } else {
-        crate::array::js_array_push_f64(out, chunks)
-    }
-}
-
-pub(super) fn compose_readable_snapshot(source: f64, stage: f64) -> Option<f64> {
-    prepare_readable_for_iteration(source);
-    let arr = readable_chunks_array(source);
-    if arr.is_null() || !is_transform_stream(stage) {
-        return None;
-    }
-
-    let mut out = crate::array::js_array_alloc(0);
-    if has_truthy_hidden(stage, hidden_transform_passthrough_key()) {
-        out = extend_compose_output_chunks(out, stage, box_pointer(arr as *const u8));
-    } else {
-        transform_hidden_callback(stage)?;
-        clear_readable_buffer(stage);
-        let len = crate::array::js_array_length(arr);
-        for i in 0..len {
-            let chunk = crate::array::js_array_get_f64(arr, i);
-            let _ = write_writable_chunk(
-                stage,
-                chunk,
-                f64::from_bits(TAG_UNDEFINED),
-                f64::from_bits(TAG_UNDEFINED),
-            );
-            if let Some(err) = readable_hidden_error(stage) {
-                let result = readable_from_chunks(out);
-                propagate_stream_state(source, f64::from_bits(TAG_UNDEFINED), result);
-                set_hidden_value(result, hidden_error_key(), err);
-                return Some(result);
-            }
-        }
-        if let Some(chunks) = readable_hidden_chunks(stage) {
-            out = extend_compose_output_chunks(out, stage, chunks);
-        }
-    }
-
-    let result = readable_from_chunks(out);
-    propagate_stream_state(source, f64::from_bits(TAG_UNDEFINED), result);
-    Some(result)
-}
-
 /// Resolve a callback result that may be a Promise (an async mapper /
 /// predicate) by driving Perry's await pump until it settles, then
 /// reading the fulfilled value or preserving the rejection reason.

--- a/crates/perry-runtime/src/node_stream_pipeline.rs
+++ b/crates/perry-runtime/src/node_stream_pipeline.rs
@@ -287,30 +287,7 @@ pub(super) fn pipeline_single_chunk(value: f64) -> f64 {
 
 pub(super) fn settle_pipeline_value(value: f64) -> Result<f64, f64> {
     let value = crate::promise::adapt_foreign_promise_value(value);
-    if crate::promise::js_value_is_promise(value) == 0 {
-        return Ok(value);
-    }
-    let promise = crate::value::js_nanbox_get_pointer(value) as *mut crate::promise::Promise;
-    if promise.is_null() {
-        return Ok(value);
-    }
-    for _ in 0..100_000 {
-        unsafe {
-            if (*promise).state != crate::promise::PromiseState::Pending {
-                break;
-            }
-        }
-        if crate::promise::js_promise_run_microtasks() == 0 {
-            break;
-        }
-    }
-    unsafe {
-        match (*promise).state {
-            crate::promise::PromiseState::Fulfilled => Ok((*promise).value),
-            crate::promise::PromiseState::Rejected => Err((*promise).reason),
-            crate::promise::PromiseState::Pending => Ok(value),
-        }
-    }
+    settle_result(value)
 }
 
 pub(super) fn catch_pipeline_throw(call: impl FnOnce() -> f64) -> Result<f64, f64> {
@@ -604,6 +581,468 @@ pub(super) fn start_pipeline_readable(stream: f64) {
     if stream_hidden_ended(stream) || has_truthy_hidden(stream, hidden_end_emitted_key()) {
         end_pipe_destinations(stream);
     }
+}
+
+fn compose_stage_values(stages: f64) -> Vec<f64> {
+    if !is_array_like_value(stages) {
+        return Vec::new();
+    }
+    pipeline_chunks_vec(stages)
+}
+
+fn compose_source_iterator(value: f64) -> Option<f64> {
+    get_hidden_value(value, hidden_key(READABLE_SOURCE_ITERATOR_KEY))
+}
+
+fn compose_first_arg_is_source(value: f64) -> bool {
+    if is_callable_value(value) {
+        return false;
+    }
+    if is_pipeline_stream(value) {
+        return get_hidden_value(value, hidden_writable_flag_key()).is_none()
+            || readable_hidden_chunks(value).is_some()
+            || compose_source_iterator(value).is_some();
+    }
+    !matches!(value.to_bits(), TAG_NULL | TAG_UNDEFINED)
+        && !is_non_iterable_primitive_for_readable_from(value)
+}
+
+fn normalize_compose_source(value: f64) -> f64 {
+    if is_pipeline_stream(value) {
+        value
+    } else {
+        js_node_stream_readable_from(value)
+    }
+}
+
+fn drain_compose_stream_stage(stage: f64) {
+    for _ in 0..10_000 {
+        let pending_write = writable_length(stage) > 0.0;
+        let pending_flush = has_truthy_hidden(stage, hidden_transform_finishing_key());
+        let ran = crate::event_pump::perry_poll();
+        if !pending_write && !pending_flush && ran == 0 {
+            break;
+        }
+        if !pending_write && !pending_flush && ran == 0 && crate::event_pump::perry_has_work() == 0
+        {
+            break;
+        }
+        if (pending_write || pending_flush) && ran == 0 && crate::event_pump::perry_has_work() != 0
+        {
+            crate::event_pump::js_wait_for_event();
+        }
+        if writable_length(stage) == 0.0
+            && !has_truthy_hidden(stage, hidden_transform_finishing_key())
+            && crate::event_pump::perry_has_work() == 0
+        {
+            break;
+        }
+    }
+}
+
+fn compose_empty_chunks() -> f64 {
+    pipeline_empty_chunks()
+}
+
+fn compose_copy_chunks(chunks: f64) -> f64 {
+    let values = pipeline_chunks_vec(chunks);
+    let mut out = crate::array::js_array_alloc(values.len() as u32);
+    for value in values {
+        out = crate::array::js_array_push_f64(out, value);
+    }
+    box_pointer(out as *const u8)
+}
+
+fn compose_is_buffer_chunk(chunk: f64) -> bool {
+    crate::buffer::js_buffer_is_buffer(chunk.to_bits() as i64) == 1
+}
+
+fn compose_coalesce_stage_output(stage: f64, chunks: f64) -> f64 {
+    if !pipeline_should_coalesce_chunks(stage) {
+        return chunks;
+    }
+    let values = pipeline_chunks_vec(chunks);
+    if values.len() <= 1 {
+        return chunks;
+    }
+    if values.iter().all(|chunk| compose_is_buffer_chunk(*chunk)) {
+        let mut arr = crate::array::js_array_alloc(values.len() as u32);
+        for value in values {
+            arr = crate::array::js_array_push_f64(arr, value);
+        }
+        let joined = crate::buffer::js_buffer_concat(arr as *const crate::array::ArrayHeader);
+        return pipeline_single_chunk(box_pointer(joined as *const u8));
+    }
+    if values.iter().any(|chunk| compose_is_buffer_chunk(*chunk)) {
+        return chunks;
+    }
+    pipeline_coalesce_chunks(chunks)
+}
+
+fn compose_take_stage_output(stage: f64) -> Result<f64, f64> {
+    drain_compose_stream_stage(stage);
+    if let Some(err) = readable_hidden_error(stage) {
+        return Err(err);
+    }
+    let mut chunks = readable_hidden_chunks(stage)
+        .map(compose_copy_chunks)
+        .unwrap_or_else(compose_empty_chunks);
+    chunks = compose_coalesce_stage_output(stage, chunks);
+    clear_readable_buffer(stage);
+    clear_pending_readable_chunks(stage);
+    if let Some(err) = readable_hidden_error(stage) {
+        Err(err)
+    } else {
+        Ok(chunks)
+    }
+}
+
+fn compose_process_stream_stage(stage: f64, chunks: f64, end_stage: bool) -> Result<f64, f64> {
+    clear_readable_buffer(stage);
+    clear_pending_readable_chunks(stage);
+    for chunk in pipeline_chunks_vec(chunks) {
+        catch_pipeline_throw(|| {
+            write_writable_chunk(
+                stage,
+                chunk,
+                f64::from_bits(TAG_UNDEFINED),
+                f64::from_bits(TAG_UNDEFINED),
+            )
+        })?;
+        drain_compose_stream_stage(stage);
+        if let Some(err) = readable_hidden_error(stage) {
+            return Err(err);
+        }
+    }
+    if end_stage {
+        catch_pipeline_throw(|| {
+            finish_stream_with_args(
+                stage,
+                f64::from_bits(TAG_UNDEFINED),
+                f64::from_bits(TAG_UNDEFINED),
+                f64::from_bits(TAG_UNDEFINED),
+            );
+            f64::from_bits(TAG_UNDEFINED)
+        })?;
+        drain_compose_stream_stage(stage);
+        if let Some(err) = readable_hidden_error(stage) {
+            return Err(err);
+        }
+    }
+    compose_take_stage_output(stage)
+}
+
+fn compose_process_callable_stage(stage: f64, chunks: f64) -> Result<f64, f64> {
+    call_pipeline_function_stage(stage, chunks).and_then(collect_pipeline_chunks)
+}
+
+fn compose_process_stages(stages: &[f64], input: f64, end_stages: bool) -> Result<f64, f64> {
+    let mut chunks = input;
+    for stage in stages {
+        if is_callable_value(*stage) {
+            chunks = compose_process_callable_stage(*stage, chunks)?;
+            continue;
+        }
+        if is_pipeline_stream(*stage) {
+            chunks = compose_process_stream_stage(*stage, chunks, end_stages)?;
+            continue;
+        }
+        chunks = collect_pipeline_chunks(*stage)?;
+    }
+    Ok(chunks)
+}
+
+fn compose_push_output(composite: f64, chunks: f64) -> Result<(), f64> {
+    for chunk in pipeline_chunks_vec(chunks) {
+        let _ = push_chunk(composite, chunk);
+        if let Some(err) = readable_hidden_error(composite) {
+            return Err(err);
+        }
+    }
+    Ok(())
+}
+
+fn compose_destroy_stage_list(stages: f64, err: f64) {
+    for stage in compose_stage_values(stages) {
+        if is_pipeline_stream(stage) {
+            destroy_stream(stage, err);
+        }
+    }
+}
+
+fn fail_composed_duplex(composite: f64, source: f64, stages: f64, err: f64) {
+    if stream_destroyed(composite) {
+        return;
+    }
+    compose_destroy_stage_list(stages, err);
+    if is_pipeline_stream(source) {
+        destroy_stream(source, err);
+    }
+    destroy_stream(composite, err);
+}
+
+pub(super) extern "C" fn compose_stage_error_callback(
+    closure: *const ClosureHeader,
+    err: f64,
+) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let composite = js_closure_get_capture_f64(closure, 0);
+    let source = js_closure_get_capture_f64(closure, 1);
+    let stages = js_closure_get_capture_f64(closure, 2);
+    fail_composed_duplex(composite, source, stages, err);
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+pub(super) extern "C" fn compose_source_data_callback(
+    closure: *const ClosureHeader,
+    chunk: f64,
+) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let composite = js_closure_get_capture_f64(closure, 0);
+    if stream_destroyed(composite) {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let _ = write_writable_chunk(
+        composite,
+        chunk,
+        f64::from_bits(TAG_UNDEFINED),
+        f64::from_bits(TAG_UNDEFINED),
+    );
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+pub(super) extern "C" fn compose_source_end_callback(closure: *const ClosureHeader) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let composite = js_closure_get_capture_f64(closure, 0);
+    if !stream_destroyed(composite) {
+        finish_stream_with_args(
+            composite,
+            f64::from_bits(TAG_UNDEFINED),
+            f64::from_bits(TAG_UNDEFINED),
+            f64::from_bits(TAG_UNDEFINED),
+        );
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+pub(super) extern "C" fn compose_source_error_callback(
+    closure: *const ClosureHeader,
+    err: f64,
+) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let composite = js_closure_get_capture_f64(closure, 0);
+    let source = js_closure_get_capture_f64(closure, 1);
+    let stages = js_closure_get_capture_f64(closure, 2);
+    fail_composed_duplex(composite, source, stages, err);
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+pub(super) extern "C" fn compose_duplex_write_callback(
+    closure: *const ClosureHeader,
+    chunk: f64,
+    _encoding: f64,
+    cb: f64,
+) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let composite = js_closure_get_capture_f64(closure, 0);
+    let stages_value = js_closure_get_capture_f64(closure, 1);
+    let source = js_closure_get_capture_f64(closure, 2);
+    let stages = compose_stage_values(stages_value);
+    let result = compose_process_stages(&stages, pipeline_single_chunk(chunk), false)
+        .and_then(|chunks| compose_push_output(composite, chunks));
+    match result {
+        Ok(()) => call_listener_args(composite, cb, &[]),
+        Err(err) => {
+            fail_composed_duplex(composite, source, stages_value, err);
+            call_listener_args(composite, cb, &[err])
+        }
+    };
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+pub(super) extern "C" fn compose_duplex_final_callback(
+    closure: *const ClosureHeader,
+    cb: f64,
+) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let composite = js_closure_get_capture_f64(closure, 0);
+    let stages_value = js_closure_get_capture_f64(closure, 1);
+    let source = js_closure_get_capture_f64(closure, 2);
+    set_hidden_value(composite, hidden_ended_key(), f64::from_bits(TAG_FALSE));
+    set_visible_readable(composite, true);
+    let stages = compose_stage_values(stages_value);
+    let result = compose_process_stages(&stages, compose_empty_chunks(), true)
+        .and_then(|chunks| compose_push_output(composite, chunks));
+    match result {
+        Ok(()) => {
+            schedule_readable_end(composite);
+            call_listener_args(composite, cb, &[]);
+        }
+        Err(err) => {
+            fail_composed_duplex(composite, source, stages_value, err);
+            call_listener_args(composite, cb, &[err]);
+        }
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+fn install_compose_stage_error_listeners(composite: f64, source: f64, stages: f64) {
+    let error_event = string_value(b"error");
+    for stage in compose_stage_values(stages) {
+        if !is_pipeline_stream(stage) {
+            continue;
+        }
+        let listener = js_closure_alloc(compose_stage_error_callback as *const u8, 3);
+        js_closure_set_capture_f64(listener, 0, composite);
+        js_closure_set_capture_f64(listener, 1, source);
+        js_closure_set_capture_f64(listener, 2, stages);
+        add_stream_listener_for_event(stage, error_event, box_pointer(listener as *const u8));
+    }
+}
+
+fn install_compose_source_listeners(composite: f64, source: f64, stages: f64) {
+    if !is_pipeline_stream(source) {
+        return;
+    }
+    let data = js_closure_alloc(compose_source_data_callback as *const u8, 1);
+    js_closure_set_capture_f64(data, 0, composite);
+    add_stream_listener_for_event(
+        source,
+        string_value(b"data"),
+        box_pointer(data as *const u8),
+    );
+
+    let end = js_closure_alloc(compose_source_end_callback as *const u8, 1);
+    js_closure_set_capture_f64(end, 0, composite);
+    add_stream_listener_for_event(source, string_value(b"end"), box_pointer(end as *const u8));
+
+    let error = js_closure_alloc(compose_source_error_callback as *const u8, 3);
+    js_closure_set_capture_f64(error, 0, composite);
+    js_closure_set_capture_f64(error, 1, source);
+    js_closure_set_capture_f64(error, 2, stages);
+    add_stream_listener_for_event(
+        source,
+        string_value(b"error"),
+        box_pointer(error as *const u8),
+    );
+
+    start_pipeline_readable(source);
+}
+
+fn install_composed_duplex_callbacks(composite: f64, stages: f64, source: f64, writable: bool) {
+    let raw = raw_ptr_from_value(composite);
+    if raw < 0x10000 {
+        return;
+    }
+    let obj = raw as *mut ObjectHeader;
+    let write = js_closure_alloc(compose_duplex_write_callback as *const u8, 3);
+    js_closure_set_capture_f64(write, 0, composite);
+    js_closure_set_capture_f64(write, 1, stages);
+    js_closure_set_capture_f64(write, 2, source);
+    js_object_set_field_by_name(obj, hidden_write_key(), box_pointer(write as *const u8));
+
+    let final_cb = js_closure_alloc(compose_duplex_final_callback as *const u8, 3);
+    js_closure_set_capture_f64(final_cb, 0, composite);
+    js_closure_set_capture_f64(final_cb, 1, stages);
+    js_closure_set_capture_f64(final_cb, 2, source);
+    js_object_set_field_by_name(
+        obj,
+        hidden_writable_final_key(),
+        box_pointer(final_cb as *const u8),
+    );
+
+    set_hidden_value(
+        composite,
+        hidden_key(b"writableCustomSink"),
+        f64::from_bits(TAG_TRUE),
+    );
+    if !writable {
+        set_visible_writable(composite, false);
+    }
+}
+
+fn compose_source_has_snapshot(source: f64) -> bool {
+    readable_hidden_chunks(source).is_some() || compose_source_iterator(source).is_some()
+}
+
+fn prime_composed_duplex_from_source(composite: f64, source: f64, stages: f64) -> bool {
+    prepare_readable_for_iteration(source);
+    let chunks = match collect_pipeline_chunks(source) {
+        Ok(chunks) => chunks,
+        Err(err) => {
+            fail_composed_duplex(composite, source, stages, err);
+            return true;
+        }
+    };
+    let stage_values = compose_stage_values(stages);
+    match compose_process_stages(&stage_values, chunks, true)
+        .and_then(|chunks| compose_push_output(composite, chunks))
+    {
+        Ok(()) => {
+            schedule_readable_end(composite);
+        }
+        Err(err) => {
+            fail_composed_duplex(composite, source, stages, err);
+        }
+    }
+    true
+}
+
+fn new_composed_duplex(stages: &[f64], source: Option<f64>, writable: bool) -> f64 {
+    let composite = js_node_stream_duplex_new(readable_from_options(f64::from_bits(TAG_UNDEFINED)));
+    let stages_value = pipeline_stage_array(stages);
+    let source_value = source.unwrap_or_else(|| f64::from_bits(TAG_UNDEFINED));
+    install_composed_duplex_callbacks(composite, stages_value, source_value, writable);
+    if let Some(source) = source {
+        if !compose_source_has_snapshot(source) {
+            install_compose_stage_error_listeners(composite, source_value, stages_value);
+            install_compose_source_listeners(composite, source, stages_value);
+        } else {
+            prime_composed_duplex_from_source(composite, source, stages_value);
+            if !stream_destroyed(composite) {
+                install_compose_stage_error_listeners(composite, source_value, stages_value);
+            }
+        }
+    } else {
+        install_compose_stage_error_listeners(composite, source_value, stages_value);
+    }
+    composite
+}
+
+pub(super) fn build_node_stream_compose(args: Vec<f64>) -> f64 {
+    if args.is_empty() {
+        throw_pipeline_missing_streams();
+    }
+    if args.len() == 1 {
+        let only = args[0];
+        if is_transform_stream(only) {
+            return only;
+        }
+        if compose_first_arg_is_source(only) {
+            let source = normalize_compose_source(only);
+            return new_composed_duplex(&[], Some(source), false);
+        }
+        return new_composed_duplex(&args, None, true);
+    }
+
+    if compose_first_arg_is_source(args[0]) {
+        let source = normalize_compose_source(args[0]);
+        return new_composed_duplex(&args[1..], Some(source), true);
+    }
+
+    new_composed_duplex(&args, None, true)
 }
 
 #[cold]

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -128,54 +128,6 @@
     "category": "ci-env",
     "reason": "Tracked in #1634 (parity CI environment fixtures). Ramda npm-package fixture failure on Linux CI; observed on #1038's CI run pre-merge. Companion to the existing test_ramda_user_import skip in the compile-smoke list \u2014 the parity harness can't npm-install ramda. File a CI-side fixture issue if/when this matters for sweep coverage."
   },
-  "node-suite/stream/compose/multiple-transforms": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: stream.compose() composite Duplex doesn't forward data through the chain, so the joined output never arrives. Shape sub-tests pass; reopened #1539 for pipeline execution."
-  },
-  "node-suite/stream/compose/with-async-fn": {
-    "issue": "1539",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: stream.compose(asyncGenerator) doesn't run the async stage / forward data. Reopened #1539 for pipeline execution."
-  },
-  "node-suite/stream/compose/single-sync-fn": {
-    "issue": "1531",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream: compose(readable, asyncGenFn) \u2014 fails to compile (single-fn compose form not yet wired). Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/compose/compose-array-form": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: compose(src, transform, sink) \u2014 spread-arg form does not produce a working pipeline. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/compose/error-mid-chain": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: compose() \u2014 error in middle transform does not propagate to composite 'error' event. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/compose/async-handler-promise": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: compose(src, asyncGenWithAwait) \u2014 async-await handler not iterated correctly. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/compose/async-iter-handler-rejection": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: compose() async-gen handler throw \u2014 composite does not emit 'error'. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/compose/error-propagates-to-source": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: compose() error does not destroy source. Flips to PASS when #1531 lands."
-  },
   "node-suite/stream/web/abort-during-pipeto": {
     "issue": "1545",
     "added": "2026-05-24",
@@ -205,23 +157,5 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream/web: cancel() during pull \u2014 read() does not resolve {done:true}. Flips to PASS when #1545 lands."
-  },
-  "node-suite/stream/compose/three-stages-order": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: compose(src,t1,t2) \u2014 output transformation order wrong. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/compose/two-stage-error-stops": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: compose 2-stage err \u2014 composite 'error' event not fired. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/compose/with-passthrough-mid": {
-    "issue": "1531",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream: compose(src, t1, PassThrough, t2) \u2014 chain produces wrong output. Flips to PASS when #1531 lands."
   }
 }


### PR DESCRIPTION
## Summary
- Route `stream.compose()` and `Readable.prototype.compose()` through one shared compose builder.
- Execute composed classic stream pipelines across stream, callable, sync iterable, and async iterable stages.
- Propagate stage/source errors through the composite Duplex and remove passing compose fixtures from known failures.

## Verification
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/stream/compose/multiple-transforms.ts` -> `joined: A!B!`
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/stream/compose/error-mid-chain.ts` -> `err received: mid-chain-fail`
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/stream/compose/single-sync-fn.ts` -> `composed: A,B,C`
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/stream/compose/composite-end-event.ts` -> `end fired: true`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module stream/compose` -> 21 pass, 0 parity failures, 0 compile failures; `sync-generator` skipped because Node v25.9.0 itself throws for that fixture
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module stream/readable --filter compose` -> 4 pass, 0 parity failures, 0 compile failures
- `cargo test -p perry-runtime compose -- --nocapture` -> 2 passed
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib` -> pass
- `cargo fmt --all -- --check` -> pass
- `git diff --check origin/main...HEAD` -> pass
- `jq empty test-parity/known_failures.json` -> pass
- `./scripts/check_file_size.sh` -> pass

## Non-Goals
- No `node:stream/web`, web adapter, or `node:stream/promises` semantic changes.
- No public API signature changes.

Closes #3232
Closes #3233
Closes #3234
Closes #3235