### PR TITLE
fix(process): validate usage snapshots and exit codes

### DIFF
--- a/crates/perry-codegen-js/src/emit/exprs.rs
+++ b/crates/perry-codegen-js/src/emit/exprs.rs
@@ -476,8 +476,12 @@ impl JsEmitter {
             Expr::ProcessMemoryUsage => {
                 self.output.push_str("(typeof process !== 'undefined' ? process.memoryUsage() : {rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0})");
             }
-            Expr::ProcessThreadCpuUsage => {
-                self.output.push_str("(typeof process !== 'undefined' && typeof process.threadCpuUsage === 'function' ? process.threadCpuUsage() : {user: 0, system: 0})");
+            Expr::ProcessThreadCpuUsage(prior) => {
+                self.output.push_str("(typeof process !== 'undefined' && typeof process.threadCpuUsage === 'function' ? process.threadCpuUsage(");
+                if let Some(prior) = prior {
+                    self.emit_expr(prior);
+                }
+                self.output.push_str(") : {user: 0, system: 0})");
             }
             Expr::ProcessAvailableMemory => {
                 self.output.push_str("(typeof process !== 'undefined' && typeof process.availableMemory === 'function' ? process.availableMemory() : 0)");

--- a/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
@@ -91,7 +91,7 @@ impl<'a> FuncEmitCtx<'a> {
             }
             Expr::ProcessUptime
             | Expr::ProcessMemoryUsage
-            | Expr::ProcessThreadCpuUsage
+            | Expr::ProcessThreadCpuUsage(_)
             | Expr::ProcessAvailableMemory
             | Expr::ProcessConstrainedMemory
             | Expr::ProcessPosixCredential(_)

--- a/crates/perry-codegen/src/collectors/escape_objects.rs
+++ b/crates/perry-codegen/src/collectors/escape_objects.rs
@@ -429,9 +429,10 @@ pub fn check_object_literal_escapes_in_expr(
         | Expr::IterResultGetValue | Expr::IterResultGetDone
         // Process leaf intrinsics
         | Expr::ProcessCwd | Expr::ProcessUptime | Expr::ProcessArgv
-        | Expr::ProcessMemoryUsage | Expr::ProcessThreadCpuUsage
+        | Expr::ProcessMemoryUsage
         | Expr::ProcessAvailableMemory | Expr::ProcessConstrainedMemory
         | Expr::ProcessPosixCredential(_)
+        | Expr::ProcessThreadCpuUsage(_)
         | Expr::ProcessCpuUsage(_)
         | Expr::ProcessResourceUsage | Expr::ProcessActiveResourcesInfo
         | Expr::ProcessPid | Expr::ProcessPpid

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1723,7 +1723,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::OsMachine => string_regex_proc::lower(ctx, expr),
         Expr::OsVersion
         | Expr::ProcessMemoryUsage
-        | Expr::ProcessThreadCpuUsage
+        | Expr::ProcessThreadCpuUsage(..)
         | Expr::ProcessAvailableMemory
         | Expr::ProcessConstrainedMemory
         | Expr::ProcessPosixCredential(..)

--- a/crates/perry-codegen/src/expr/os_uri_dates.rs
+++ b/crates/perry-codegen/src/expr/os_uri_dates.rs
@@ -115,10 +115,19 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // Runtime returns an already NaN-boxed pointer (f64).
             Ok(ctx.block().call(DOUBLE, "js_process_memory_usage", &[]))
         }
-        Expr::ProcessThreadCpuUsage => {
+        Expr::ProcessThreadCpuUsage(prior) => {
             // Runtime returns an already NaN-boxed pointer (f64) for
             // { user, system }.
-            Ok(ctx.block().call(DOUBLE, "js_process_thread_cpu_usage", &[]))
+            let prior_val = if let Some(e) = prior {
+                lower_expr(ctx, e)?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_process_thread_cpu_usage",
+                &[(DOUBLE, &prior_val)],
+            ))
         }
         Expr::ProcessAvailableMemory => {
             Ok(ctx.block().call(DOUBLE, "js_process_available_memory", &[]))

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -588,7 +588,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_version", I64, &[]);
     module.declare_function("js_process_versions", DOUBLE, &[]);
     module.declare_function("js_process_memory_usage", DOUBLE, &[]);
-    module.declare_function("js_process_thread_cpu_usage", DOUBLE, &[]);
+    module.declare_function("js_process_thread_cpu_usage", DOUBLE, &[DOUBLE]);
     module.declare_function("js_process_available_memory", DOUBLE, &[]);
     module.declare_function("js_process_constrained_memory", DOUBLE, &[]);
     module.declare_function("js_process_getuid", DOUBLE, &[]);

--- a/crates/perry-hir/src/audit.rs
+++ b/crates/perry-hir/src/audit.rs
@@ -269,7 +269,7 @@ fn specialized_stdlib_call(expr: &Expr) -> Option<(&'static str, &'static str)> 
         Expr::ProcessArgv => ("process", "argv"),
         Expr::ProcessAbort => ("process", "abort"),
         Expr::ProcessUmask(_) => ("process", "umask"),
-        Expr::ProcessThreadCpuUsage => ("process", "threadCpuUsage"),
+        Expr::ProcessThreadCpuUsage(_) => ("process", "threadCpuUsage"),
         Expr::ProcessAvailableMemory => ("process", "availableMemory"),
         Expr::ProcessConstrainedMemory => ("process", "constrainedMemory"),
         Expr::ProcessPosixCredential(crate::ir::PosixCredentialKind::Uid) => ("process", "getuid"),

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -493,8 +493,8 @@ pub enum Expr {
     ProcessExit(Option<Box<Expr>>), // process.exit(code?) -> never; None means code 0
     ProcessAbort,                   // process.abort() -> never; raises SIGABRT
     ProcessUmask(Option<Box<Expr>>), // process.umask(mask?) -> number; no-arg reads, arg sets and returns previous
-    ProcessThreadCpuUsage,           // process.threadCpuUsage() -> { user, system } microseconds
-    ProcessAvailableMemory,          // process.availableMemory() -> number (free memory bytes)
+    ProcessThreadCpuUsage(Option<Box<Expr>>), // process.threadCpuUsage(prior?) -> { user, system } microseconds
+    ProcessAvailableMemory, // process.availableMemory() -> number (free memory bytes)
     ProcessConstrainedMemory, // process.constrainedMemory() -> number (OS limit, 0 if unconstrained)
     ProcessPosixCredential(super::PosixCredentialKind), // process.{getuid,geteuid,getgid,getegid}() (#1408)
     ProcessEmitWarning(Vec<Expr>), // process.emitWarning(warning[, type, code, ctor]) -> undefined (#1375)

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -246,11 +246,16 @@ pub(super) fn try_native_module_methods(
                             return Ok(Ok(Expr::ProcessUmask(mask)));
                         }
                         "threadCpuUsage" => {
-                            // process.threadCpuUsage() — CPU time used by
+                            // process.threadCpuUsage(prior?) — CPU time used by
                             // the current thread, as { user, system } in
-                            // microseconds. Ignores any arguments (Node
-                            // accepts none).
-                            return Ok(Ok(Expr::ProcessThreadCpuUsage));
+                            // microseconds. If prior is given, returns the
+                            // diff (clamped to >= 0).
+                            let prior = if !args.is_empty() {
+                                Some(Box::new(args.into_iter().next().unwrap()))
+                            } else {
+                                None
+                            };
+                            return Ok(Ok(Expr::ProcessThreadCpuUsage(prior)));
                         }
                         "availableMemory" => {
                             // process.availableMemory() — free system memory

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -332,7 +332,11 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
             mask.as_ref()
                 .map(|e| Box::new(substitute_expr(e, substitutions))),
         ),
-        Expr::ProcessThreadCpuUsage => Expr::ProcessThreadCpuUsage,
+        Expr::ProcessThreadCpuUsage(prior) => Expr::ProcessThreadCpuUsage(
+            prior
+                .as_ref()
+                .map(|e| Box::new(substitute_expr(e, substitutions))),
+        ),
         Expr::ProcessAvailableMemory => Expr::ProcessAvailableMemory,
         Expr::ProcessConstrainedMemory => Expr::ProcessConstrainedMemory,
         Expr::ProcessPosixCredential(k) => Expr::ProcessPosixCredential(*k),

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -92,7 +92,7 @@ impl SH for Expr {
             Expr::ProcessExit(e) => { tag(h, 69); e.hash(h); }
             Expr::ProcessAbort => tag(h, 11224),
             Expr::ProcessUmask(e) => { tag(h, 11225); e.hash(h); }
-            Expr::ProcessThreadCpuUsage => tag(h, 11226),
+            Expr::ProcessThreadCpuUsage(e) => { tag(h, 11226); e.hash(h); }
             Expr::ProcessAvailableMemory => tag(h, 11227),
             Expr::ProcessConstrainedMemory => tag(h, 11228),
             Expr::ProcessPosixCredential(k) => { tag(h, 11229); (*k as u8).hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -47,7 +47,6 @@ where
         | Expr::ProcessStdout
         | Expr::ProcessStderr
         | Expr::ProcessAbort
-        | Expr::ProcessThreadCpuUsage
         | Expr::ProcessAvailableMemory
         | Expr::ProcessConstrainedMemory
         | Expr::ProcessPosixCredential(_)
@@ -1209,6 +1208,11 @@ where
             }
         }
         Expr::ProcessCpuUsage(opt) => {
+            if let Some(v) = opt {
+                f(v);
+            }
+        }
+        Expr::ProcessThreadCpuUsage(opt) => {
             if let Some(v) = opt {
                 f(v);
             }

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -48,7 +48,6 @@ where
         | Expr::ProcessStdout
         | Expr::ProcessStderr
         | Expr::ProcessAbort
-        | Expr::ProcessThreadCpuUsage
         | Expr::ProcessAvailableMemory
         | Expr::ProcessConstrainedMemory
         | Expr::ProcessPosixCredential(_)
@@ -1190,6 +1189,11 @@ where
             }
         }
         Expr::ProcessCpuUsage(opt) => {
+            if let Some(v) = opt {
+                f(v);
+            }
+        }
+        Expr::ProcessThreadCpuUsage(opt) => {
             if let Some(v) = opt {
                 f(v);
             }

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -726,7 +726,7 @@ struct ProcessListener {
 struct ProcessEmitter {
     events: HashMap<String, Vec<ProcessListener>>,
     event_order: Vec<String>,
-    max_listeners: i32,
+    max_listeners: f64,
 }
 
 impl ProcessEmitter {
@@ -734,7 +734,7 @@ impl ProcessEmitter {
         Self {
             events: HashMap::new(),
             event_order: Vec::new(),
-            max_listeners: 10,
+            max_listeners: 10.0,
         }
     }
 
@@ -774,6 +774,16 @@ fn read_event_name(event_ptr: *const StringHeader) -> Option<String> {
 }
 
 fn process_namespace_value() -> f64 {
+    let global = crate::object::js_get_global_this();
+    let jv = crate::value::JSValue::from_bits(global.to_bits());
+    if jv.is_pointer() {
+        let obj = jv.as_pointer::<ObjectHeader>();
+        let key = js_string_from_bytes(b"process".as_ptr(), "process".len() as u32);
+        let value = crate::object::js_object_get_field_by_name_f64(obj, key);
+        if value.to_bits() != crate::value::TAG_UNDEFINED {
+            return value;
+        }
+    }
     crate::object::js_create_native_module_namespace(b"process".as_ptr(), "process".len())
 }
 
@@ -1041,17 +1051,40 @@ pub extern "C" fn js_process_event_names() -> *mut ArrayHeader {
 
 #[no_mangle]
 pub extern "C" fn js_process_set_max_listeners(value: f64) -> f64 {
-    if value.is_finite() && value >= 0.0 {
-        PROCESS_EMITTER.with(|emitter| {
-            emitter.borrow_mut().max_listeners = value as i32;
-        });
-    }
+    let value = validate_process_max_listeners(value);
+    PROCESS_EMITTER.with(|emitter| {
+        emitter.borrow_mut().max_listeners = value;
+    });
     process_namespace_value()
 }
 
 #[no_mangle]
 pub extern "C" fn js_process_get_max_listeners() -> f64 {
-    PROCESS_EMITTER.with(|emitter| emitter.borrow().max_listeners as f64)
+    PROCESS_EMITTER.with(|emitter| emitter.borrow().max_listeners)
+}
+
+fn validate_process_max_listeners(value: f64) -> f64 {
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if !crate::fs::validate::is_numeric(jv) {
+        let message = format!(
+            "The \"setMaxListeners\" argument must be of type number. Received {}",
+            crate::fs::validate::describe_received(value)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    let number = if jv.is_int32() {
+        jv.as_int32() as f64
+    } else {
+        jv.as_number()
+    };
+    if number.is_nan() || number < 0.0 {
+        let message = format!(
+            "The value of \"setMaxListeners\" is out of range. It must be >= 0. Received {}",
+            crate::process::format_number_for_node_message(number)
+        );
+        crate::fs::validate::throw_range_error_with_code(&message);
+    }
+    number
 }
 
 pub fn scan_process_event_listener_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -9,25 +9,7 @@ use crate::value::JSValue;
 /// during async event loop drain and V8 isolate destruction.
 #[no_mangle]
 pub extern "C" fn js_process_exit(code: f64) {
-    // #2013 — `process.exit('foo')` throws TypeError ERR_INVALID_ARG_TYPE
-    // in Node (the exit code must be a number, null, or undefined). The
-    // numeric default of `1` for NaN/Infinity in the pre-fix code only
-    // matters for the inferred numeric-coerce path; keep that fallback
-    // for the (degenerate) numeric NaN/Infinity case so existing call
-    // sites that pass a parsed-out number aren't surprised.
-    let jv = JSValue::from_bits(code.to_bits());
-    if !jv.is_undefined() && !jv.is_null() && !crate::fs::validate::is_numeric(jv) {
-        let message = format!(
-            "The \"code\" argument must be of type number or null. Received {}",
-            crate::fs::validate::describe_received(code)
-        );
-        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
-    }
-    let exit_code = if code.is_nan() || code.is_infinite() {
-        1 // Default to 1 for invalid codes
-    } else {
-        code as i32
-    };
+    let exit_code = validate_process_exit_code(code);
     // Use _exit() instead of std::process::exit() to avoid SIGILL during cleanup.
     // std::process::exit() runs atexit handlers and C++ destructors which can trigger
     // illegal instructions when exception handler state (jmp_buf), GC roots, or
@@ -47,6 +29,67 @@ pub extern "C" fn js_process_exit(code: f64) {
     }
     #[cfg(not(any(unix, windows)))]
     std::process::exit(exit_code);
+}
+
+fn validate_process_exit_code(code: f64) -> i32 {
+    let jv = JSValue::from_bits(code.to_bits());
+    if jv.is_undefined() || jv.is_null() {
+        return 0;
+    }
+
+    let number = if crate::fs::validate::is_numeric(jv) {
+        js_number_from_value(jv)
+    } else if jv.is_any_string() {
+        parse_exit_code_string(code).unwrap_or_else(|| {
+            let message = format!(
+                "The \"code\" argument must be of type number. Received {}",
+                crate::fs::validate::describe_received(code)
+            );
+            crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+        })
+    } else {
+        let message = format!(
+            "The \"code\" argument must be of type number. Received {}",
+            crate::fs::validate::describe_received(code)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    };
+
+    if !number.is_finite() || number.trunc() != number {
+        let message = format!(
+            "The value of \"code\" is out of range. It must be an integer. Received {}",
+            format_number_for_node_message(number)
+        );
+        crate::fs::validate::throw_range_error_with_code(&message);
+    }
+
+    number as i32
+}
+
+fn parse_exit_code_string(value: f64) -> Option<f64> {
+    let ptr = crate::value::js_get_string_pointer_unified(value) as *const StringHeader;
+    if ptr.is_null() {
+        return None;
+    }
+    let text = unsafe {
+        let len = (*ptr).byte_len as usize;
+        let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned()
+    };
+    if text.is_empty() {
+        return None;
+    }
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Some(0.0);
+    }
+    if let Some(hex) = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+    {
+        return i64::from_str_radix(hex, 16).ok().map(|n| n as f64);
+    }
+    trimmed.parse::<f64>().ok()
 }
 
 /// process.abort() -> never. Raises SIGABRT (no clean shutdown). Matches
@@ -884,21 +927,8 @@ pub extern "C" fn js_process_active_resources_info() -> f64 {
 /// Non-unix targets return `{ user: 0, system: 0 }`.
 #[no_mangle]
 pub extern "C" fn js_process_cpu_usage(prior: f64) -> f64 {
-    // #2013 — Node throws TypeError ERR_INVALID_ARG_TYPE when `prior`
-    // is supplied but isn't an object (e.g. `process.cpuUsage('abc')`).
-    // Undefined / null fall through to the no-prior baseline read.
-    let prior_jv = JSValue::from_bits(prior.to_bits());
-    if !prior_jv.is_undefined() && !prior_jv.is_null() && !prior_jv.is_pointer() {
-        let message = format!(
-            "The \"prevValue\" argument must be of type object. Received {}",
-            crate::fs::validate::describe_received(prior)
-        );
-        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
-    }
     let (mut user_us, mut system_us) = read_process_cpu_micros();
-    let undef_bits = crate::value::TAG_UNDEFINED;
-    if prior.to_bits() != undef_bits && !prior_jv.is_null() {
-        let (prev_user, prev_system) = extract_cpu_pair(prior);
+    if let Some((prev_user, prev_system)) = extract_cpu_pair(prior) {
         user_us = (user_us - prev_user).max(0.0);
         system_us = (system_us - prev_system).max(0.0);
     }
@@ -928,28 +958,85 @@ fn read_process_cpu_micros() -> (f64, f64) {
     (0.0, 0.0)
 }
 
-/// Read `.user` and `.system` (numbers, microseconds) from a JS object
-/// — used by `js_process_cpu_usage` to compute diffs. Missing fields
-/// or non-numeric values count as 0.
-fn extract_cpu_pair(value: f64) -> (f64, f64) {
+/// Read and validate `.user` / `.system` previous CPU counters. Node treats
+/// `undefined` and `null` as no prior sample, but any supplied object must
+/// carry finite, non-negative numeric fields.
+fn extract_cpu_pair(value: f64) -> Option<(f64, f64)> {
+    let obj_ptr = validate_cpu_prev_object(value)?;
+    Some((
+        validate_cpu_prev_field(obj_ptr, "user"),
+        validate_cpu_prev_field(obj_ptr, "system"),
+    ))
+}
+
+fn validate_cpu_prev_object(value: f64) -> Option<*mut crate::object::ObjectHeader> {
     let jv = crate::value::JSValue::from_bits(value.to_bits());
-    if !jv.is_pointer() {
-        return (0.0, 0.0);
+    if jv.is_undefined() || jv.is_null() {
+        return None;
+    }
+    if !jv.is_pointer() || is_array_nanbox_value(value) {
+        let message = format!(
+            "The \"prevValue\" argument must be of type object. Received {}",
+            crate::fs::validate::describe_received(value)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
     }
     let obj_ptr = jv.as_pointer::<u8>() as *mut crate::object::ObjectHeader;
     if obj_ptr.is_null() {
-        return (0.0, 0.0);
+        let message = "The \"prevValue\" argument must be of type object. Received null";
+        crate::fs::validate::throw_type_error_with_code(message, "ERR_INVALID_ARG_TYPE");
     }
-    let get_num = |name: &str| -> f64 {
-        let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
-        let v = crate::object::js_object_get_field_by_name_f64(obj_ptr, key);
-        if v.is_nan() {
-            0.0
+    Some(obj_ptr)
+}
+
+fn validate_cpu_prev_field(obj_ptr: *mut crate::object::ObjectHeader, name: &str) -> f64 {
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let value = crate::object::js_object_get_field_by_name_f64(obj_ptr, key);
+    let jv = JSValue::from_bits(value.to_bits());
+    if !crate::fs::validate::is_numeric(jv) {
+        let message = format!(
+            "The \"prevValue.{name}\" property must be of type number. Received {}",
+            crate::fs::validate::describe_received(value)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    let number = js_number_from_value(jv);
+    if !number.is_finite() || number < 0.0 {
+        let message = format!(
+            "The property 'prevValue.{name}' is invalid. Received {}",
+            format_number_for_node_message(number)
+        );
+        crate::fs::validate::throw_range_error_named(&message, "ERR_INVALID_ARG_VALUE");
+    }
+    number
+}
+
+fn js_number_from_value(value: JSValue) -> f64 {
+    if value.is_int32() {
+        value.as_int32() as f64
+    } else {
+        value.as_number()
+    }
+}
+
+fn is_array_nanbox_value(value: f64) -> bool {
+    crate::array::js_array_is_array(value).to_bits() == crate::value::TAG_TRUE
+}
+
+pub(crate) fn format_number_for_node_message(value: f64) -> String {
+    if value.is_nan() {
+        "NaN".to_string()
+    } else if value.is_infinite() {
+        if value.is_sign_negative() {
+            "-Infinity".to_string()
         } else {
-            v
+            "Infinity".to_string()
         }
-    };
-    (get_num("user"), get_num("system"))
+    } else if value.fract() == 0.0 && value.abs() < 1e21 {
+        format!("{}", value as i64)
+    } else {
+        format!("{}", value)
+    }
 }
 
 /// process.emitWarning(warning[, type, code, ctor]) -> undefined.
@@ -1351,13 +1438,17 @@ pub extern "C" fn js_process_env() -> f64 {
     boxed
 }
 
-/// process.threadCpuUsage() -> object { user, system } in microseconds.
+/// process.threadCpuUsage(previousValue?) -> object { user, system } in microseconds.
 /// CPU time consumed by the current thread. Uses CLOCK_THREAD_CPUTIME_ID
 /// (available on macOS 10.12+ and Linux). Platforms without the clock get
 /// 0.0 for both fields.
 #[no_mangle]
-pub extern "C" fn js_process_thread_cpu_usage() -> f64 {
-    let (user_us, system_us) = read_thread_cpu_micros();
+pub extern "C" fn js_process_thread_cpu_usage(prior: f64) -> f64 {
+    let (mut user_us, mut system_us) = read_thread_cpu_micros();
+    if let Some((prev_user, prev_system)) = extract_cpu_pair(prior) {
+        user_us = (user_us - prev_user).max(0.0);
+        system_us = (system_us - prev_system).max(0.0);
+    }
 
     let obj = crate::object::js_object_alloc(0, 2);
     let set_field = |name: &str, value: f64| {

--- a/test-parity/node-suite/process/cpu/cpu-usage-validation.ts
+++ b/test-parity/node-suite/process/cpu/cpu-usage-validation.ts
@@ -1,0 +1,18 @@
+function probe(label: string, fn: () => unknown): void {
+  try {
+    console.log(label, "OK", fn());
+  } catch (err: any) {
+    console.log(label, "THROW", err.name, err.code, err.message.split("\n")[0]);
+  }
+}
+
+const baseline = process.cpuUsage();
+const delta = process.cpuUsage(baseline);
+console.log("cpu delta shape:", typeof delta.user, typeof delta.system, delta.user >= 0, delta.system >= 0);
+console.log("cpu nullish:", typeof process.cpuUsage(undefined).user, typeof process.cpuUsage(null).system);
+
+probe("cpu empty object", () => process.cpuUsage({} as any));
+probe("cpu array", () => process.cpuUsage([] as any));
+probe("cpu string fields", () => process.cpuUsage({ user: "1", system: "2" } as any));
+probe("cpu nan field", () => process.cpuUsage({ user: NaN, system: Infinity } as any));
+probe("cpu negative field", () => process.cpuUsage({ user: -1, system: 0 } as any));

--- a/test-parity/node-suite/process/cpu/thread-cpu-usage-previous.ts
+++ b/test-parity/node-suite/process/cpu/thread-cpu-usage-previous.ts
@@ -1,0 +1,21 @@
+function probe(label: string, fn: () => unknown): void {
+  try {
+    console.log(label, "OK", fn());
+  } catch (err: any) {
+    console.log(label, "THROW", err.name, err.code, err.message.split("\n")[0]);
+  }
+}
+
+const first = process.threadCpuUsage();
+for (let i = 0; i < 100000; i++) {
+  // Burn a tiny amount of CPU so the delta path is exercised without relying
+  // on a specific microsecond count.
+}
+const delta = process.threadCpuUsage(first);
+console.log("thread delta shape:", typeof delta.user, typeof delta.system, delta.user >= 0, delta.system >= 0);
+console.log("thread nullish:", typeof process.threadCpuUsage(undefined).user, typeof process.threadCpuUsage(null).system);
+
+probe("thread number", () => process.threadCpuUsage(123 as any));
+probe("thread array", () => process.threadCpuUsage([] as any));
+probe("thread missing field", () => process.threadCpuUsage({ user: 1 } as any));
+probe("thread negative field", () => process.threadCpuUsage({ user: -1, system: 0 } as any));

--- a/test-parity/node-suite/process/events/max-listeners-validation.ts
+++ b/test-parity/node-suite/process/events/max-listeners-validation.ts
@@ -1,0 +1,18 @@
+function probe(label: string, fn: () => unknown): void {
+  try {
+    console.log(label, "OK", fn());
+  } catch (err: any) {
+    console.log(label, "THROW", err.name, err.code, err.message.split("\n")[0]);
+  }
+}
+
+for (const value of [0, 1, 1.5, Infinity]) {
+  probe(`max ${String(value)}`, () => {
+    const ret = process.setMaxListeners(value);
+    return `${ret === process},${String(process.getMaxListeners())}`;
+  });
+}
+
+for (const value of [-1, NaN, "5", null, undefined]) {
+  probe(`max ${String(value)}`, () => process.setMaxListeners(value as any));
+}

--- a/test-parity/node-suite/process/methods/exit-validation.ts
+++ b/test-parity/node-suite/process/methods/exit-validation.ts
@@ -1,0 +1,16 @@
+function probe(label: string, fn: () => unknown): void {
+  try {
+    console.log(label, "OK", fn());
+  } catch (err: any) {
+    console.log(label, "THROW", err.name, err.code, err.message.split("\n")[0]);
+  }
+}
+
+probe("exit string fractional", () => process.exit("2.5" as any));
+probe("exit string text", () => process.exit("abc" as any));
+probe("exit boolean", () => process.exit(true as any));
+probe("exit fractional", () => process.exit(1.9 as any));
+probe("exit nan", () => process.exit(NaN as any));
+probe("exit infinity", () => process.exit(Infinity as any));
+
+process.exit("0" as any);


### PR DESCRIPTION
## Summary

Closes #3040
Closes #2927
Closes #3041
Closes #3049

- validate `process.cpuUsage(previousValue)` objects like Node, including array/non-object rejection, required numeric `user`/`system`, and finite non-negative counters
- add `process.threadCpuUsage(previousValue)` lowering/codegen/runtime support with the same previous-value validation and delta calculation
- align `process.exit(code)` validation for numeric strings, fractional values, `NaN`/`Infinity`, and non-number inputs
- validate `process.setMaxListeners(n)`, preserve fractional/`Infinity` listener limits, and return the real `process` object for chaining

## Why Batched

These issues all sit in `node:process` validation/readback behavior, share the same parity harness surface, and reuse the same runtime helpers for Node-style numeric/error formatting.

## Tests Added

- `test-parity/node-suite/process/cpu/cpu-usage-validation.ts`
- `test-parity/node-suite/process/cpu/thread-cpu-usage-previous.ts`
- `test-parity/node-suite/process/events/max-listeners-validation.ts`
- `test-parity/node-suite/process/methods/exit-validation.ts`

## Verification

Using Node v25.9.0 on `PATH` for parity expected output:

- `./run_parity_tests.sh --suite node-suite --module process --filter validation` - 4 pass, 0 fail
- `./run_parity_tests.sh --suite node-suite --module process/cpu --filter thread-cpu-usage-previous` - 1 pass, 0 fail
- `./run_parity_tests.sh --suite node-suite --module process/cpu` - 5 pass, 0 fail
- `./run_parity_tests.sh --suite node-suite --module process/events` - 8 pass, 0 fail
- `./run_parity_tests.sh --suite node-suite --module process/methods` - 12 pass, 0 fail
- `cargo check -p perry-runtime -p perry-hir -p perry-codegen -p perry`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`

## Known Limitations

`process.threadCpuUsage()` keeps Perry's current per-thread CPU split behavior: available thread CPU time is reported as `user` with `system: 0` on supported platforms. This PR adds previous-value support and validation around that existing measurement.

## Non-Goals

- no `process.hrtime()` changes
- no UID/GID/umask validation changes
- no generic EventEmitter refactor
- no `known_failures.json` edits