### PR TITLE
fix(path/string): path.format/relative arg validation + String.includes position

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -500,12 +500,22 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     let result = blk.call(I64, fn_name, &[(I64, &h)]);
                     Ok(nanbox_string_inline(blk, &result))
                 }
-                PathWin32Method::BasenameExt
-                | PathWin32Method::Relative
-                | PathWin32Method::ResolveJoin => {
+                PathWin32Method::Relative => {
+                    // #2995: validate both operands are strings (throwing
+                    // ERR_INVALID_ARG_TYPE on a non-string) before computing
+                    // the relative path. Pass the NaN-boxed doubles so the
+                    // runtime can inspect their type.
+                    let blk = ctx.block();
+                    let result = blk.call(
+                        I64,
+                        "js_path_win32_relative_checked",
+                        &[(DOUBLE, &lowered[0]), (DOUBLE, &lowered[1])],
+                    );
+                    Ok(nanbox_string_inline(blk, &result))
+                }
+                PathWin32Method::BasenameExt | PathWin32Method::ResolveJoin => {
                     let fn_name = match method {
                         PathWin32Method::BasenameExt => "js_path_win32_basename_ext",
-                        PathWin32Method::Relative => "js_path_win32_relative",
                         PathWin32Method::ResolveJoin => "js_path_win32_resolve_join",
                         _ => unreachable!(),
                     };
@@ -654,15 +664,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_string_inline(blk, &result))
         }
         Expr::PathRelative(from, to) => {
+            // #2995: validate both operands are strings before computing the
+            // relative path. The checked entry point inspects the NaN-boxed
+            // doubles and throws ERR_INVALID_ARG_TYPE for non-strings.
             let f_box = lower_expr(ctx, from)?;
             let t_box = lower_expr(ctx, to)?;
             let blk = ctx.block();
-            let f_handle = unbox_to_i64(blk, &f_box);
-            let t_handle = unbox_to_i64(blk, &t_box);
             let result = blk.call(
                 I64,
-                "js_path_relative",
-                &[(I64, &f_handle), (I64, &t_handle)],
+                "js_path_relative_checked",
+                &[(DOUBLE, &f_box), (DOUBLE, &t_box)],
             );
             Ok(nanbox_string_inline(blk, &result))
         }

--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -749,8 +749,12 @@ pub(crate) fn lower_string_method(
             Ok(i32_bool_to_nanbox(blk, &result_i32))
         }
         "includes" => {
-            // str.includes(sub) -> boolean. Implemented as
-            // js_string_index_of(str, sub) != -1, then NaN-tagged.
+            // str.includes(sub, position?) -> boolean. Implemented as
+            // js_string_index_of_from(str, sub, position) != -1, then
+            // NaN-tagged. #2812: the optional `position` argument must be
+            // honored (search starts there), matching the dynamic dispatch
+            // path. Negative/NaN clamp to 0 and Infinity saturates past the
+            // end inside js_string_index_of_from.
             if args.is_empty() || args.len() > 2 {
                 bail!(
                     "perry-codegen: String.includes expects 1 or 2 args, got {}",
@@ -758,10 +762,13 @@ pub(crate) fn lower_string_method(
                 );
             }
             let needle_box = lower_expr(ctx, &args[0])?;
-            // Optional fromIndex param is ignored for the boolean form.
-            if args.len() == 2 {
-                let _ = lower_expr(ctx, &args[1])?;
-            }
+            // Preserve evaluation of the second argument for side effects and
+            // use it as the start index when present.
+            let pos_d = if args.len() == 2 {
+                Some(lower_expr(ctx, &args[1])?)
+            } else {
+                None
+            };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
             let method_id = regexp_search_method_id(property);
@@ -770,10 +777,16 @@ pub(crate) fn lower_string_method(
                 "js_string_search_value_to_string",
                 &[(DOUBLE, &needle_box), (I32, &method_id)],
             );
+            let from_i32 = match pos_d {
+                // Use the runtime ToIntegerOrInfinity helper rather than a raw
+                // `fptosi`, which is undefined for Infinity/NaN.
+                Some(pos_d) => blk.call(I32, "js_string_position_to_index", &[(DOUBLE, &pos_d)]),
+                None => "0".to_string(),
+            };
             let idx_i32 = blk.call(
                 I32,
-                "js_string_index_of",
-                &[(I64, &recv_handle), (I64, &needle_handle)],
+                "js_string_index_of_from",
+                &[(I64, &recv_handle), (I64, &needle_handle), (I32, &from_i32)],
             );
             // includes := indexOf != -1
             let neg_one = "-1".to_string();

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -52,6 +52,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // - js_string_ends_with(s, suffix) -> i32
     module.declare_function("js_string_index_of", I32, &[I64, I64]);
     module.declare_function("js_string_index_of_from", I32, &[I64, I64, I32]);
+    // #2812: ToIntegerOrInfinity for String.includes(search, position).
+    module.declare_function("js_string_position_to_index", I32, &[DOUBLE]);
     module.declare_function("js_string_slice", I64, &[I64, I32, I32]);
     module.declare_function("js_string_substring", I64, &[I64, I32, I32]);
     // Legacy substr(start, length); length sentinel i32::MIN = omitted (#2897).
@@ -999,6 +1001,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_path_win32_parse", I64, &[I64]);
     module.declare_function("js_path_win32_format", I64, &[DOUBLE]);
     module.declare_function("js_path_win32_relative", I64, &[I64, I64]);
+    module.declare_function("js_path_win32_relative_checked", I64, &[DOUBLE, DOUBLE]);
     module.declare_function("js_path_win32_resolve", I64, &[I64]);
     module.declare_function("js_path_win32_resolve_join", I64, &[I64, I64]);
     module.declare_function("js_path_win32_to_namespaced_path", I64, &[I64]);
@@ -1009,6 +1012,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_path_dirname", I64, &[I64]);
     module.declare_function("js_path_resolve", I64, &[I64]);
     module.declare_function("js_path_relative", I64, &[I64, I64]);
+    module.declare_function("js_path_relative_checked", I64, &[DOUBLE, DOUBLE]);
     module.declare_function("js_path_to_namespaced_path", I64, &[I64]);
     module.declare_function("js_path_to_namespaced_path_value", DOUBLE, &[DOUBLE]);
     module.declare_function("js_path_matches_glob", I32, &[I64, I64]);

--- a/crates/perry-runtime/src/path.rs
+++ b/crates/perry-runtime/src/path.rs
@@ -579,6 +579,53 @@ pub extern "C" fn js_path_normalize(path_ptr: *const StringHeader) -> *mut Strin
     string_to_js(&normalize_str(&path_str))
 }
 
+/// Validate that a `path.relative` operand is a string, materializing it to a
+/// heap `StringHeader`. Throws `TypeError [ERR_INVALID_ARG_TYPE]` naming the
+/// offending argument (`from` / `to`) for non-string values, matching Node.
+fn require_relative_arg(value: f64, arg_name: &str) -> *const StringHeader {
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if jv.is_any_string() {
+        let ptr = js_string_materialize_to_heap(value);
+        if !ptr.is_null() {
+            return ptr;
+        }
+    }
+    let message = format!(
+        "The \"{}\" argument must be of type string. Received {}",
+        arg_name,
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+/// Validating entry point for the compiled `path.relative(from, to)` fast path.
+/// Both operands arrive NaN-boxed so their type can be checked before the
+/// underlying string-only helper is invoked (#2995).
+#[no_mangle]
+pub extern "C" fn js_path_relative_checked(from_f64: f64, to_f64: f64) -> *mut StringHeader {
+    let from = require_relative_arg(from_f64, "from");
+    let to = require_relative_arg(to_f64, "to");
+    js_path_relative(from, to)
+}
+
+/// `path.win32.relative(from, to)` validating entry point — see
+/// [`js_path_relative_checked`].
+#[no_mangle]
+pub extern "C" fn js_path_win32_relative_checked(from_f64: f64, to_f64: f64) -> *mut StringHeader {
+    let from = require_relative_arg(from_f64, "from");
+    let to = require_relative_arg(to_f64, "to");
+    js_path_win32_relative(from, to)
+}
+
+/// Keepalive anchors: these are emitted only from generated code, so the
+/// whole-program auto-optimize bitcode pass would otherwise dead-strip them.
+#[used]
+static KEEP_PATH_RELATIVE_CHECKED: extern "C" fn(f64, f64) -> *mut StringHeader =
+    js_path_relative_checked;
+#[used]
+static KEEP_PATH_WIN32_RELATIVE_CHECKED: extern "C" fn(f64, f64) -> *mut StringHeader =
+    js_path_win32_relative_checked;
+
 #[no_mangle]
 pub extern "C" fn js_path_relative(
     from_ptr: *const StringHeader,
@@ -655,69 +702,112 @@ pub extern "C" fn js_path_parse(path_ptr: *const StringHeader) -> *mut crate::ob
     obj
 }
 
+/// Throw `TypeError [ERR_INVALID_ARG_TYPE]` for a `path.format` descriptor that
+/// is not an object (Node validates the top-level `pathObject` argument).
+fn throw_invalid_path_object(value: f64) -> ! {
+    let message = format!(
+        "The \"pathObject\" argument must be of type object. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+/// A single descriptor field read from a `path.format` argument: its
+/// Node-`ToString`-coerced text and whether the raw value is truthy.
+/// Node's `_format` uses `pathObject.field || ''`, so falsy fields (including
+/// `0`, `false`, `null`, `""`) contribute nothing.
+struct FormatField {
+    coerced: String,
+    truthy: bool,
+}
+
+/// Read a descriptor field by name and coerce it the way Node does (template
+/// literal / `||` semantics): truthy values are stringified via the standard
+/// `ToString`, falsy values become empty.
+fn read_format_field(obj_ptr: *mut crate::object::ObjectHeader, name: &str) -> FormatField {
+    use crate::object::js_object_get_field_by_name;
+    let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let val = js_object_get_field_by_name(obj_ptr, key_ptr);
+    let raw = f64::from_bits(val.bits());
+    if crate::value::js_is_truthy(raw) == 0 {
+        return FormatField {
+            coerced: String::new(),
+            truthy: false,
+        };
+    }
+    let s_ptr = crate::value::js_jsvalue_to_string(raw);
+    let coerced = unsafe { string_from_header(s_ptr) }.unwrap_or_default();
+    FormatField {
+        coerced,
+        truthy: true,
+    }
+}
+
+/// Shared `path.format` implementation for both posix (`sep = '/'`) and win32
+/// (`sep = '\\'`). Mirrors Node's `_format`:
+/// `dir = pathObject.dir || pathObject.root; base = pathObject.base ||
+/// `${name||''}${formatExt(ext)}`; if (!dir) return base; return dir ===
+/// pathObject.root ? dir+base : dir+sep+base;`
+fn format_descriptor(obj_f64: f64, sep: char) -> String {
+    use crate::value::js_nanbox_get_pointer;
+
+    let jv = crate::value::JSValue::from_bits(obj_f64.to_bits());
+    // Node: typeof pathObject !== 'object' || pathObject === null throws.
+    // Objects and arrays are POINTER_TAG values; strings/numbers/bool/null/
+    // undefined are not.
+    if !jv.is_pointer() {
+        throw_invalid_path_object(obj_f64);
+    }
+    let obj_ptr = js_nanbox_get_pointer(obj_f64) as *mut crate::object::ObjectHeader;
+    if obj_ptr.is_null() {
+        throw_invalid_path_object(obj_f64);
+    }
+
+    let dir_f = read_format_field(obj_ptr, "dir");
+    let root_f = read_format_field(obj_ptr, "root");
+    let base_f = read_format_field(obj_ptr, "base");
+    let name_f = read_format_field(obj_ptr, "name");
+    let ext_f = read_format_field(obj_ptr, "ext");
+
+    // formatExt: ensure a leading dot when ext is truthy.
+    let ext = if ext_f.truthy && !ext_f.coerced.starts_with('.') {
+        format!(".{}", ext_f.coerced)
+    } else {
+        ext_f.coerced.clone()
+    };
+
+    // base = pathObject.base || `${name||''}${formatExt(ext)}`
+    let base = if base_f.truthy {
+        base_f.coerced.clone()
+    } else {
+        format!("{}{}", name_f.coerced, ext)
+    };
+
+    // dir = pathObject.dir || pathObject.root
+    let (dir, dir_from_root) = if dir_f.truthy {
+        (dir_f.coerced.clone(), false)
+    } else {
+        (root_f.coerced.clone(), true)
+    };
+
+    if dir.is_empty() {
+        return base;
+    }
+
+    // dir === pathObject.root ? dir+base : dir+sep+base. dir equals root when
+    // it fell through to root, or when the (string) dir and root values match.
+    let no_sep = dir_from_root || (dir_f.truthy && root_f.truthy && dir == root_f.coerced);
+    if no_sep {
+        format!("{dir}{base}")
+    } else {
+        format!("{dir}{sep}{base}")
+    }
+}
+
 /// Build a path from a `{ dir, base, root, name, ext }` descriptor.
 #[no_mangle]
 pub extern "C" fn js_path_format(obj_f64: f64) -> *mut StringHeader {
-    use crate::object::js_object_get_field_by_name;
-    use crate::value::js_nanbox_get_pointer;
-
-    // Extract object pointer
-    let obj_ptr = js_nanbox_get_pointer(obj_f64) as *mut crate::object::ObjectHeader;
-    if obj_ptr.is_null() {
-        return string_to_js("");
-    }
-
-    // Helper: read a string field by name (returns "" if undefined/missing)
-    let get_str = |name: &str| -> String {
-        let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-        let val = js_object_get_field_by_name(obj_ptr, key_ptr);
-        if val.is_undefined() {
-            return String::new();
-        }
-        let ptr = val.as_string_ptr();
-        unsafe { string_from_header(ptr) }.unwrap_or_default()
-    };
-
-    let dir = get_str("dir");
-    let root = get_str("root");
-    let base = get_str("base");
-    let name = get_str("name");
-    let mut ext = get_str("ext");
-    // Node inserts the separator dot when `ext` is provided without
-    // one: path.format({ name: "file", ext: "txt" }) === "file.txt".
-    if !ext.is_empty() && !ext.starts_with('.') {
-        ext.insert(0, '.');
-    }
-    let has_tail = !base.is_empty() || !name.is_empty() || !ext.is_empty();
-
-    // dir takes precedence over root; name+ext fallback when base missing
-    let mut result = if !dir.is_empty() {
-        let mut s = dir.clone();
-        // Node always inserts a separator between dir and base, even when
-        // dir already ends with `/`. If there is no tail, keep dir as-is
-        // (path.format(path.parse("/")) === "/").
-        if has_tail {
-            s.push('/');
-        }
-        s
-    } else if !root.is_empty() {
-        let mut s = root.clone();
-        if !s.ends_with('/') {
-            s.push('/');
-        }
-        s
-    } else {
-        String::new()
-    };
-
-    if !base.is_empty() {
-        result.push_str(&base);
-    } else {
-        result.push_str(&name);
-        result.push_str(&ext);
-    }
-
-    string_to_js(&result)
+    string_to_js(&format_descriptor(obj_f64, '/'))
 }
 
 #[no_mangle]
@@ -1190,54 +1280,7 @@ pub extern "C" fn js_path_win32_parse(
 /// version but emits backslash separators.
 #[no_mangle]
 pub extern "C" fn js_path_win32_format(obj_f64: f64) -> *mut StringHeader {
-    use crate::object::js_object_get_field_by_name;
-    use crate::value::js_nanbox_get_pointer;
-
-    let obj_ptr = js_nanbox_get_pointer(obj_f64) as *mut crate::object::ObjectHeader;
-    if obj_ptr.is_null() {
-        return string_to_js("");
-    }
-    let get_str = |name: &str| -> String {
-        let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-        let val = js_object_get_field_by_name(obj_ptr, key_ptr);
-        if val.is_undefined() {
-            return String::new();
-        }
-        let ptr = val.as_string_ptr();
-        unsafe { string_from_header(ptr) }.unwrap_or_default()
-    };
-    let dir = get_str("dir");
-    let root = get_str("root");
-    let base = get_str("base");
-    let name = get_str("name");
-    let mut ext = get_str("ext");
-    if !ext.is_empty() && !ext.starts_with('.') {
-        ext.insert(0, '.');
-    }
-    let has_tail = !base.is_empty() || !name.is_empty() || !ext.is_empty();
-
-    let mut result = if !dir.is_empty() {
-        let mut s = dir.clone();
-        if has_tail && !s.ends_with('\\') && !s.ends_with('/') {
-            s.push('\\');
-        }
-        s
-    } else if !root.is_empty() {
-        let mut s = root.clone();
-        if !s.ends_with('\\') && !s.ends_with('/') {
-            s.push('\\');
-        }
-        s
-    } else {
-        String::new()
-    };
-    if !base.is_empty() {
-        result.push_str(&base);
-    } else {
-        result.push_str(&name);
-        result.push_str(&ext);
-    }
-    string_to_js(&result)
+    string_to_js(&format_descriptor(obj_f64, '\\'))
 }
 
 fn current_dir_as_win32() -> Option<String> {

--- a/crates/perry-runtime/src/string/slice_ops.rs
+++ b/crates/perry-runtime/src/string/slice_ops.rs
@@ -292,6 +292,42 @@ pub extern "C" fn js_string_index_of_from(
     }
 }
 
+/// Convert a `position` argument (a NaN-boxed double) into an `i32` start
+/// index using JS `ToIntegerOrInfinity` + clamp semantics, as used by
+/// `String.prototype.includes(search, position)`:
+/// `NaN`/`-Infinity` → 0, `+Infinity` → `i32::MAX` (past the end → no match),
+/// otherwise truncate toward zero and saturate into `i32` range. This avoids
+/// LLVM `fptosi`'s undefined result on non-finite inputs and matches Node's
+/// behavior (`"ababa".includes("a", Infinity) === false`).
+#[no_mangle]
+pub extern "C" fn js_string_position_to_index(pos_f64: f64) -> i32 {
+    // The typed `includes` lowering passes a raw numeric double here.
+    let n = pos_f64;
+    if n.is_nan() {
+        return 0;
+    }
+    if n == f64::INFINITY {
+        return i32::MAX;
+    }
+    if n == f64::NEG_INFINITY {
+        return 0;
+    }
+    let truncated = n.trunc();
+    if truncated >= i32::MAX as f64 {
+        i32::MAX
+    } else if truncated <= i32::MIN as f64 {
+        i32::MIN
+    } else {
+        truncated as i32
+    }
+}
+
+// `#[used]` keepalive: `js_string_position_to_index` is reached only from
+// generated `.o`, so the auto-optimize whole-program bitcode pass would
+// otherwise dead-strip it.
+#[used]
+static KEEP_POSITION_TO_INDEX: extern "C" fn(f64) -> i32 = js_string_position_to_index;
+
 /// Find the last index of a substring (-1 if not found).
 /// Returns the UTF-16 code unit offset of the LAST occurrence, or -1 if not found.
 /// An empty needle returns the string's UTF-16 length.

--- a/test-files/test_gap_path_includes_2992_2995_2812.ts
+++ b/test-files/test_gap_path_includes_2992_2995_2812.ts
@@ -1,0 +1,57 @@
+import path from "node:path";
+
+// #2992 — path.format top-level argument validation + field coercion
+console.log("=== format validation ===");
+for (const value of [null, undefined, 1, "x"]) {
+  try {
+    const r = path.format(value as any);
+    console.log("ok", JSON.stringify(r));
+  } catch (err: any) {
+    console.log(err.name, err.message, err.code);
+  }
+}
+
+console.log("=== format coercion ===");
+console.log(JSON.stringify(path.format({ dir: 1, base: "b" } as any)));
+console.log(JSON.stringify(path.format({ dir: "/d", base: 1 } as any)));
+console.log(JSON.stringify(path.format({ root: 1, name: "n", ext: "e" } as any)));
+console.log(JSON.stringify(path.win32.format({ dir: 1, base: "b" } as any)));
+console.log(JSON.stringify(path.win32.format({ dir: "/d", base: 1 } as any)));
+console.log(JSON.stringify(path.format({ dir: "/d", base: "b" })));
+console.log(JSON.stringify(path.format({ root: "/", base: "b" })));
+console.log(JSON.stringify(path.format({ name: "file", ext: "txt" })));
+console.log(JSON.stringify(path.format({ base: 0 } as any)));
+console.log(JSON.stringify(path.win32.format({ dir: "C:\\a\\b", base: "c.js" } as any)));
+
+// #2995 — path.relative argument validation
+console.log("=== relative validation ===");
+const relCases: any[] = [[1, "x"], ["x", 1], [null, "x"], ["x", undefined]];
+for (const args of relCases) {
+  try {
+    const r = path.relative(args[0], args[1]);
+    console.log("ok", JSON.stringify(r));
+  } catch (err: any) {
+    console.log(err.name, err.message, err.code);
+  }
+}
+console.log("=== relative win32 validation ===");
+for (const args of relCases) {
+  try {
+    const r = path.win32.relative(args[0], args[1]);
+    console.log("ok", JSON.stringify(r));
+  } catch (err: any) {
+    console.log(err.name, err.message, err.code);
+  }
+}
+
+// #2812 — String.prototype.includes(position)
+console.log("=== includes position ===");
+const s = "ababa";
+console.log(s.includes("a"));
+console.log(s.includes("a", 1));
+console.log(s.includes("a", 5));
+console.log(s.includes("a", -10));
+console.log(s.includes("a", Infinity));
+console.log(s.includes("a", NaN));
+console.log(s.includes("b", 2));
+console.log(s.includes("x", 0));


### PR DESCRIPTION
Closes #2992
Closes #2995
Closes #2812

## Implementation

### #2992 — path.format argument validation + field coercion
`js_path_format` / `js_path_win32_format` (`crates/perry-runtime/src/path.rs`) now reimplement Node's `_format` exactly via a shared `format_descriptor(obj_f64, sep)` helper:
- The top-level `pathObject` is validated: a non-object (`null`, `undefined`, number, string, ...) throws `TypeError [ERR_INVALID_ARG_TYPE]` with the `"pathObject" argument must be of type object` message.
- Descriptor fields (`dir`, `root`, `base`, `name`, `ext`) are read with Node's `||` semantics: truthy values are ToString-coerced (`js_jsvalue_to_string`), falsy values (`0`, `false`, `null`, `""`) contribute nothing. Fixes the bug where a numeric `dir` was dropped (`{dir:1, base:"b"}` returned `"b"` instead of `"1/b"`).
- Separator handling matches Node precisely: `dir = pathObject.dir || pathObject.root`; the separator is omitted only when `dir === pathObject.root`. Removes the old dedup hacks that diverged from Node.

The top-level object handle already reached the runtime as a NaN-boxed `f64`, so no codegen change was needed for `format`.

### #2995 — path.relative argument validation on the compiled path
Added validating entry points `js_path_relative_checked(from_f64, to_f64)` / `js_path_win32_relative_checked` that receive the NaN-boxed operands, validate each is a string (throwing `TypeError [ERR_INVALID_ARG_TYPE]` naming `from` / `to`), then forward to the existing string-only helpers. The compiled lowerings (`Expr::PathRelative` in `arrays_finds.rs`/`instance_misc1.rs`, and `PathWin32Method::Relative` split out of its shared arm) now pass the doubles to these checked wrappers instead of silently unboxing invalid pointers to `""`.

### #2812 — honor position in String.prototype.includes
The typed `includes` lowering (`crates/perry-codegen/src/lower_string_method.rs`) now routes the optional second argument through the new `js_string_position_to_index` runtime helper (JS ToIntegerOrInfinity + clamp: `NaN`/`-Infinity` -> 0, `+Infinity` -> `i32::MAX`, otherwise truncate/saturate) and calls `js_string_index_of_from` instead of `js_string_index_of`. This avoids LLVM `fptosi`'s undefined result on non-finite inputs and matches Node (`"ababa".includes("a", Infinity) === false`). The second argument is still evaluated for side effects.

New codegen-emitted `#[no_mangle]` fns (`js_path_relative_checked`, `js_path_win32_relative_checked`, `js_string_position_to_index`) have `#[used]` keepalive anchors + `runtime_decls` declarations so the auto-optimize whole-program bitcode pass does not dead-strip them.

No new HIR variant added.

## Validation
- New gap test `test-files/test_gap_path_includes_2992_2995_2812.ts` is byte-identical to `node --experimental-strip-types` under the DEFAULT auto-optimize compile (covers all issue repro cases incl. err.name/message/code for throws).
- `#[used]` anchors verified present in the freshly-rebuilt `libperry_runtime.a` (each symbol count == 1).
- `./scripts/check_file_size.sh` -> OK. `cargo fmt --all -- --check` -> clean.
- `cargo test --release -p perry-runtime` (path/string modules) and `cargo test --release -p perry-hir` -> green.
