### PR TITLE
fix(reflect): receiver-aware get, apply thisArg, construct newTarget, has chain, ownKeys symbols, setPrototypeOf failure

### DIFF
--- a/crates/perry-codegen-js/src/emit/exprs_more.rs
+++ b/crates/perry-codegen-js/src/emit/exprs_more.rs
@@ -1524,11 +1524,17 @@ impl JsEmitter {
             Expr::ProxyRevoke(_) => {
                 self.output.push_str("undefined");
             }
-            Expr::ReflectGet { target, key } => {
+            Expr::ReflectGet {
+                target,
+                key,
+                receiver,
+            } => {
                 self.output.push_str("Reflect.get(");
                 self.emit_expr(target);
                 self.output.push_str(", ");
                 self.emit_expr(key);
+                self.output.push_str(", ");
+                self.emit_expr(receiver);
                 self.output.push(')');
             }
             Expr::ReflectSet { target, key, value } => {
@@ -1595,6 +1601,13 @@ impl JsEmitter {
             Expr::ReflectGetPrototypeOf(target) => {
                 self.output.push_str("Reflect.getPrototypeOf(");
                 self.emit_expr(target);
+                self.output.push(')');
+            }
+            Expr::ReflectSetPrototypeOf { target, proto } => {
+                self.output.push_str("Reflect.setPrototypeOf(");
+                self.emit_expr(target);
+                self.output.push_str(", ");
+                self.emit_expr(proto);
                 self.output.push(')');
             }
             Expr::ReflectIsExtensible(target) => {

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1860,6 +1860,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ReflectConstruct { .. }
         | Expr::ReflectDefineProperty { .. }
         | Expr::ReflectGetPrototypeOf(..)
+        | Expr::ReflectSetPrototypeOf { .. }
         | Expr::ReflectIsExtensible(..)
         | Expr::ReflectPreventExtensions(..)
         | Expr::ReflectDefineMetadata { .. }

--- a/crates/perry-codegen/src/expr/proxy_reflect.rs
+++ b/crates/perry-codegen/src/expr/proxy_reflect.rs
@@ -126,12 +126,22 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             ctx.block().call_void("js_proxy_revoke", &[(DOUBLE, &p)]);
             Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
         }
-        Expr::ReflectGet { target, key } => {
+        Expr::ReflectGet {
+            target,
+            key,
+            receiver,
+        } => {
+            // #2766: pass the optional receiver through; the runtime defaults
+            // an `undefined` receiver to the target and binds it as `this` for
+            // accessor getters.
             let t = lower_expr(ctx, target)?;
             let k = lower_expr(ctx, key)?;
-            Ok(ctx
-                .block()
-                .call(DOUBLE, "js_reflect_get", &[(DOUBLE, &t), (DOUBLE, &k)]))
+            let r = lower_expr(ctx, receiver)?;
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_reflect_get",
+                &[(DOUBLE, &t), (DOUBLE, &k), (DOUBLE, &r)],
+            ))
         }
         Expr::ReflectSet { target, key, value } => {
             let t = lower_expr(ctx, target)?;
@@ -199,6 +209,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 DOUBLE,
                 "js_reflect_define_property",
                 &[(DOUBLE, &t), (DOUBLE, &k), (DOUBLE, &d)],
+            ))
+        }
+        Expr::ReflectSetPrototypeOf { target, proto } => {
+            // #2761: Reflect-specific boolean result (false on rejected change)
+            // + TypeError on bad args, distinct from Object.setPrototypeOf.
+            let t = lower_expr(ctx, target)?;
+            let p = lower_expr(ctx, proto)?;
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_reflect_set_prototype_of",
+                &[(DOUBLE, &t), (DOUBLE, &p)],
             ))
         }
         Expr::ReflectGetPrototypeOf(target) => {

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -243,7 +243,7 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     module.declare_function("js_proxy_delete", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_proxy_apply", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_proxy_construct", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
-    module.declare_function("js_reflect_get", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_reflect_get", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_reflect_set", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_reflect_has", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_reflect_delete", DOUBLE, &[DOUBLE, DOUBLE]);
@@ -255,6 +255,7 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
         &[DOUBLE, DOUBLE, DOUBLE],
     );
     module.declare_function("js_reflect_get_prototype_of", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_reflect_set_prototype_of", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_reflect_is_extensible", DOUBLE, &[DOUBLE]);
     module.declare_function("js_reflect_prevent_extensions", DOUBLE, &[DOUBLE]);
     module.declare_function(

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -2097,6 +2097,9 @@ pub enum Expr {
     ReflectGet {
         target: Box<Expr>,
         key: Box<Expr>,
+        /// #2766: optional `receiver` argument (the `this` binding for accessor
+        /// getters). Lowering supplies `target` when the call omits it.
+        receiver: Box<Expr>,
     },
     ReflectSet {
         target: Box<Expr>,
@@ -2127,6 +2130,13 @@ pub enum Expr {
         descriptor: Box<Expr>,
     },
     ReflectGetPrototypeOf(Box<Expr>),
+    /// #2761: `Reflect.setPrototypeOf(target, proto)` — returns a boolean
+    /// (false when rejected), unlike `Object.setPrototypeOf` which returns the
+    /// object. Lowered separately so it can report failure / throw on bad args.
+    ReflectSetPrototypeOf {
+        target: Box<Expr>,
+        proto: Box<Expr>,
+    },
     // #2762: Reflect.isExtensible / Reflect.preventExtensions have
     // Reflect-specific semantics (boolean result, TypeError on non-object)
     // distinct from the Object.* helpers, so they use dedicated variants.

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -909,9 +909,14 @@ pub(super) fn try_native_module_methods(
                             let mut it = args.into_iter();
                             let target = it.next().unwrap_or(Expr::Undefined);
                             let key = it.next().unwrap_or(Expr::Undefined);
+                            // #2766: optional `receiver` (3rd arg) used as the
+                            // `this` binding for accessor getters. Default to
+                            // `undefined` — the runtime substitutes `target`.
+                            let receiver = it.next().unwrap_or(Expr::Undefined);
                             return Ok(Ok(Expr::ReflectGet {
                                 target: Box::new(target),
                                 key: Box::new(key),
+                                receiver: Box::new(receiver),
                             }));
                         }
                         "set" => {
@@ -1070,7 +1075,18 @@ pub(super) fn try_native_module_methods(
                                 property_key,
                             }));
                         }
-                        "setPrototypeOf" => return Ok(Ok(Expr::Bool(true))),
+                        "setPrototypeOf" => {
+                            // #2761: Reflect-specific — boolean result (false on
+                            // rejected change) + TypeError on bad args, distinct
+                            // from Object.setPrototypeOf (returns the object).
+                            let mut it = args.into_iter();
+                            let target = it.next().unwrap_or(Expr::Undefined);
+                            let proto = it.next().unwrap_or(Expr::Undefined);
+                            return Ok(Ok(Expr::ReflectSetPrototypeOf {
+                                target: Box::new(target),
+                                proto: Box::new(proto),
+                            }));
+                        }
                         "isExtensible" => {
                             // #2762: Reflect-specific semantics (boolean +
                             // TypeError on non-object), NOT Object.isExtensible.

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -543,7 +543,7 @@ impl SH for Expr {
             Expr::ProxyConstruct { proxy, args } => { tag(h, 430); proxy.as_ref().hash(h); args.hash(h); }
             Expr::ProxyRevocable { target, handler } => { tag(h, 431); target.as_ref().hash(h); handler.as_ref().hash(h); }
             Expr::ProxyRevoke(e) => { tag(h, 432); e.as_ref().hash(h); }
-            Expr::ReflectGet { target, key } => { tag(h, 433); target.as_ref().hash(h); key.as_ref().hash(h); }
+            Expr::ReflectGet { target, key, receiver } => { tag(h, 433); target.as_ref().hash(h); key.as_ref().hash(h); receiver.as_ref().hash(h); }
             Expr::ReflectSet { target, key, value } => { tag(h, 434); target.as_ref().hash(h); key.as_ref().hash(h); value.as_ref().hash(h); }
             Expr::ReflectHas { target, key } => { tag(h, 435); target.as_ref().hash(h); key.as_ref().hash(h); }
             Expr::ReflectDelete { target, key } => { tag(h, 436); target.as_ref().hash(h); key.as_ref().hash(h); }
@@ -552,6 +552,7 @@ impl SH for Expr {
             Expr::ReflectConstruct { target, args } => { tag(h, 439); target.as_ref().hash(h); args.as_ref().hash(h); }
             Expr::ReflectDefineProperty { target, key, descriptor, } => { tag(h, 440); target.as_ref().hash(h); key.as_ref().hash(h); descriptor.as_ref().hash(h); }
             Expr::ReflectGetPrototypeOf(e) => { tag(h, 441); e.as_ref().hash(h); }
+            Expr::ReflectSetPrototypeOf { target, proto } => { tag(h, 12230); target.as_ref().hash(h); proto.as_ref().hash(h); }
             Expr::ReflectIsExtensible(e) => { tag(h, 12048); e.as_ref().hash(h); }
             Expr::ReflectPreventExtensions(e) => { tag(h, 12046); e.as_ref().hash(h); }
             Expr::ReflectDefineMetadata { key, value, target, property_key, } => { tag(h, 12023); key.as_ref().hash(h); value.as_ref().hash(h); target.as_ref().hash(h); property_key.hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1544,9 +1544,16 @@ where
                 f(a);
             }
         }
-        Expr::ReflectGet { target, key }
-        | Expr::ReflectHas { target, key }
-        | Expr::ReflectDelete { target, key } => {
+        Expr::ReflectGet {
+            target,
+            key,
+            receiver,
+        } => {
+            f(target);
+            f(key);
+            f(receiver);
+        }
+        Expr::ReflectHas { target, key } | Expr::ReflectDelete { target, key } => {
             f(target);
             f(key);
         }
@@ -1554,6 +1561,10 @@ where
             f(target);
             f(key);
             f(value);
+        }
+        Expr::ReflectSetPrototypeOf { target, proto } => {
+            f(target);
+            f(proto);
         }
         Expr::ReflectApply {
             func,

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1515,9 +1515,16 @@ where
                 f(a);
             }
         }
-        Expr::ReflectGet { target, key }
-        | Expr::ReflectHas { target, key }
-        | Expr::ReflectDelete { target, key } => {
+        Expr::ReflectGet {
+            target,
+            key,
+            receiver,
+        } => {
+            f(target);
+            f(key);
+            f(receiver);
+        }
+        Expr::ReflectHas { target, key } | Expr::ReflectDelete { target, key } => {
             f(target);
             f(key);
         }
@@ -1525,6 +1532,10 @@ where
             f(target);
             f(key);
             f(value);
+        }
+        Expr::ReflectSetPrototypeOf { target, proto } => {
+            f(target);
+            f(proto);
         }
         Expr::ReflectApply {
             func,

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -509,6 +509,43 @@ pub(crate) fn get_accessor_descriptor(obj: usize, key: &str) -> Option<AccessorD
     ACCESSOR_DESCRIPTORS.with(|m| m.borrow().get(&(obj, key.to_string())).copied())
 }
 
+/// #2766: resolve an accessor *getter* closure for `(value, key)` if one is
+/// installed (e.g. an object-literal `get x() {…}` or
+/// `Object.defineProperty(obj, k, { get })`). Returns the NaN-boxed getter
+/// closure bits, or `0` when no getter exists. Used by `Reflect.get(target,
+/// key, receiver)` so it can rebind the getter's `this` to the receiver before
+/// invoking it. Returns `None` (rather than reading the field) when there is no
+/// accessor at all, so the caller falls back to an ordinary field read.
+pub(crate) fn reflect_getter_closure_bits(value: f64, key: f64) -> Option<u64> {
+    if !ACCESSORS_IN_USE.with(|c| c.get()) {
+        return None;
+    }
+    let obj = unsafe { extract_obj_ptr(value) };
+    if obj.is_null() {
+        return None;
+    }
+    let key_str = crate::builtins::js_string_coerce(key);
+    if key_str.is_null() {
+        return None;
+    }
+    let name = unsafe {
+        let name_ptr = (key_str as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let name_len = (*key_str).byte_len as usize;
+        match std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)) {
+            Ok(s) => s.to_string(),
+            Err(_) => return None,
+        }
+    };
+    let acc = get_accessor_descriptor(obj as usize, &name)?;
+    if acc.get != 0 {
+        Some(acc.get)
+    } else {
+        // Accessor exists but has no getter → reading yields undefined; signal
+        // that via 0 so the caller returns undefined rather than a field read.
+        Some(0)
+    }
+}
+
 /// Store an accessor descriptor for (obj, key).
 pub(crate) fn set_accessor_descriptor(obj: usize, key: String, acc: AccessorDescriptor) {
     ACCESSORS_IN_USE.with(|c| c.set(true));

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -287,6 +287,112 @@ fn reflect_non_object_typeerror(op: &str) -> f64 {
     crate::exception::js_throw(boxed);
 }
 
+/// Throw a `TypeError` with an arbitrary message. Does not return.
+fn throw_type_error(msg: &str) -> f64 {
+    let msg_handle = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(msg_handle);
+    let boxed = f64::from_bits(POINTER_TAG | ((err as u64) & POINTER_MASK));
+    crate::exception::js_throw(boxed)
+}
+
+/// Is `value` a Reflect-acceptable object? Heap objects, class refs (callable
+/// constructors), and proxies all count. Primitives / null / undefined do not.
+fn reflect_value_is_object(value: f64) -> bool {
+    if lookup(value).is_some() {
+        return true;
+    }
+    if crate::object::js_value_is_heap_object(value) {
+        return true;
+    }
+    // Class refs (INT32-tagged constructors) are callable objects.
+    (value.to_bits() >> 48) == 0x7FFE
+}
+
+/// `CreateListFromArrayLike(value)` — collect indexed `0..length` properties of
+/// an array-like object into an owned `Vec<f64>`. Throws `TypeError` for a
+/// non-object `value`, matching Node's `CreateListFromArrayLike called on
+/// non-object`. Plain Arrays use the fast array accessors; any other object
+/// reads `.length` then `[0]..[length-1]` via the field getter.
+fn create_list_from_array_like(value: f64) -> Vec<f64> {
+    // Fast path: a real Array.
+    let bits = value.to_bits();
+    let top16 = bits >> 48;
+    let is_pointer = top16 == 0x7FFD || (top16 == 0 && bits > 0x10000);
+    if is_pointer {
+        let ptr = (bits & POINTER_MASK) as usize;
+        if ptr >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+            unsafe {
+                let gc =
+                    (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+                if (*gc).obj_type == crate::gc::GC_TYPE_ARRAY {
+                    let arr = ptr as *const crate::array::ArrayHeader;
+                    let len = crate::array::js_array_length(arr) as usize;
+                    let mut out = Vec::with_capacity(len);
+                    for i in 0..len {
+                        let v = crate::array::js_array_get(arr, i as u32);
+                        out.push(f64::from_bits(v.bits()));
+                    }
+                    return out;
+                }
+            }
+        }
+    }
+    if !reflect_value_is_object(value) {
+        throw_type_error("CreateListFromArrayLike called on non-object");
+    }
+    // General array-like object: read `.length`, then `[0]..[length-1]`.
+    let len_key = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
+    let len_val = {
+        let obj_ptr = extract_pointer(value.to_bits()) as *const crate::ObjectHeader;
+        if obj_ptr.is_null() {
+            f64::from_bits(TAG_UNDEFINED)
+        } else {
+            crate::object::js_object_get_field_by_name_f64(obj_ptr, len_key)
+        }
+    };
+    let len_f = f64::from_bits(len_val.to_bits());
+    let len = if len_f.is_finite() && len_f > 0.0 {
+        len_f as usize
+    } else {
+        0
+    };
+    let mut out = Vec::with_capacity(len);
+    let obj_ptr = extract_pointer(value.to_bits()) as *const crate::ObjectHeader;
+    for i in 0..len {
+        let idx_str = i.to_string();
+        let key = crate::string::js_string_from_bytes(idx_str.as_ptr(), idx_str.len() as u32);
+        let v = crate::object::js_object_get_field_by_name_f64(obj_ptr, key);
+        out.push(v);
+    }
+    out
+}
+
+/// Invoke a callable `f64` value with the supplied positional args and an
+/// explicit `thisArg` binding, throwing `TypeError` if `f` is not callable.
+/// Used by `Reflect.apply`. `thisArg` flows through `IMPLICIT_THIS` so free
+/// functions reading `this` observe it.
+fn call_with_this_and_args(f: f64, this_arg: f64, args: &[f64]) -> f64 {
+    let closure = closure_from(f);
+    if closure.is_null() {
+        return throw_type_error("Reflect.apply target is not a function");
+    }
+    let prev = crate::object::js_implicit_this_set(this_arg);
+    let a = |i: usize| -> f64 {
+        args.get(i)
+            .copied()
+            .unwrap_or(f64::from_bits(TAG_UNDEFINED))
+    };
+    let result = match args.len() {
+        0 => js_closure_call0(closure),
+        1 => js_closure_call1(closure, a(0)),
+        2 => js_closure_call2(closure, a(0), a(1)),
+        3 => js_closure_call3(closure, a(0), a(1), a(2)),
+        _ => crate::closure::js_closure_call4(closure, a(0), a(1), a(2), a(3)),
+    };
+    crate::object::js_implicit_this_set(prev);
+    result
+}
+
 /// Detect the runtime's "null object" sentinel returned by
 /// `js_native_call_method` when a method lookup falls off the end.
 /// Matches the static `NULL_OBJECT_BYTES` in `object.rs` — we treat
@@ -622,14 +728,59 @@ pub extern "C" fn js_proxy_construct(proxy_boxed: f64, args_array: f64, _new_tar
 
 // ---- Reflect.* helpers (direct wrappers, not proxy-specific) -----
 
-/// `Reflect.get(target, key)` — when `target` is not a proxy, falls through
-/// to the regular field getter.
+/// `Reflect.get(target, key, receiver)` (#2766).
+///
+/// - throws `TypeError` for a non-object target,
+/// - uses `receiver` as the `this` binding for accessor getters,
+/// - dispatches proxy `get` traps (forwarding `(target, key)` to the existing
+///   proxy path; the three-argument trap receiver is out of scope — Perry's
+///   proxy traps are two-argument).
+///
+/// `receiver` is the optional third argument; codegen passes `target` when the
+/// call site omits it (matching the spec default), and `undefined` is treated
+/// as "use target".
 #[no_mangle]
-pub extern "C" fn js_reflect_get(target: f64, key: f64) -> f64 {
+pub extern "C" fn js_reflect_get(target: f64, key: f64, receiver: f64) -> f64 {
     if lookup(target).is_some() {
         return js_proxy_get(target, key);
     }
-    target_get(target, key)
+    if !reflect_value_is_object(target) {
+        return reflect_non_object_typeerror("get");
+    }
+    // Default receiver to target when undefined.
+    let recv = if receiver.to_bits() == TAG_UNDEFINED {
+        target
+    } else {
+        receiver
+    };
+    // #2766: if `key` resolves to an accessor *getter* on `target`, rebind its
+    // `this` to the receiver and invoke it — object-literal getters capture
+    // `this` in a reserved closure slot (not `IMPLICIT_THIS`), so plain
+    // forwarding would read the target's fields, not the receiver's. When the
+    // receiver equals the target we can skip the clone and use the ordinary
+    // read.
+    if recv.to_bits() != target.to_bits() {
+        if let Some(getter_bits) = crate::object::reflect_getter_closure_bits(target, key) {
+            if getter_bits == 0 {
+                // Accessor with no getter → undefined.
+                return f64::from_bits(TAG_UNDEFINED);
+            }
+            let rebound = crate::closure::clone_closure_rebind_this(getter_bits, recv);
+            let closure = closure_from(f64::from_bits(rebound));
+            if !closure.is_null() {
+                // Also set IMPLICIT_THIS for free-function getters that read
+                // `this` from the implicit-this fallback rather than a slot.
+                let prev = crate::object::js_implicit_this_set(recv);
+                let result = js_closure_call0(closure);
+                crate::object::js_implicit_this_set(prev);
+                return result;
+            }
+        }
+    }
+    let prev = crate::object::js_implicit_this_set(recv);
+    let result = target_get(target, key);
+    crate::object::js_implicit_this_set(prev);
+    result
 }
 
 /// `Reflect.set(target, key, value)` — returns the boolean result of the
@@ -643,13 +794,39 @@ pub extern "C" fn js_reflect_set(target: f64, key: f64, value: f64) -> f64 {
     reflect_ordinary_set(target, key, value)
 }
 
-/// `Reflect.has(target, key)` — bool.
+/// `Reflect.has(target, key)` (#2764) — `[[HasProperty]]` semantics:
+///
+/// - throws `TypeError` for a non-object target,
+/// - walks the recorded ordinary prototype chain (e.g. `Object.create(proto)`),
+/// - dispatches to a proxy `has` trap (with `ToBoolean` coercion).
 #[no_mangle]
 pub extern "C" fn js_reflect_has(target: f64, key: f64) -> f64 {
     if lookup(target).is_some() {
-        return js_proxy_has(target, key);
+        let trap_result = js_proxy_has(target, key);
+        // #2764: normalize the trap result with ToBoolean.
+        return coerce_trap_bool(trap_result);
     }
-    crate::object::js_object_has_property(target, key)
+    if !reflect_value_is_object(target) {
+        return reflect_non_object_typeerror("has");
+    }
+    // Own + (for class refs / closures) internal lookup.
+    let own = crate::object::js_object_has_property(target, key);
+    if own.to_bits() == TAG_TRUE {
+        return own;
+    }
+    // #2764: `[[HasProperty]]` must also see inherited properties. Perry's
+    // `js_object_has_property` only checks own keys, but the ordinary field
+    // getter DOES walk the (Object.create / setPrototypeOf-recorded) prototype
+    // chain. So probe via a field read: a non-`undefined` result means the
+    // property resolves somewhere on the chain. (A genuinely
+    // present-but-`undefined` inherited value is indistinguishable here, which
+    // matches the own-undefined behavior of `js_object_has_property` and is
+    // acceptable for the inherited case.)
+    let inherited = target_get(target, key);
+    if inherited.to_bits() != TAG_UNDEFINED {
+        return nanbox_bool(true);
+    }
+    nanbox_bool(false)
 }
 
 /// `Reflect.deleteProperty(target, key)` — returns the boolean delete result
@@ -663,20 +840,75 @@ pub extern "C" fn js_reflect_delete(target: f64, key: f64) -> f64 {
     reflect_ordinary_delete(target, key)
 }
 
-/// `Reflect.ownKeys(target)` — forward to getOwnPropertyNames.
+/// `Reflect.ownKeys(target)` (#2763) — returns string own-property names
+/// followed by own symbol keys (Node order: integer-index then insertion-order
+/// string keys, then symbols). Throws `TypeError` for a non-object target.
+///
+/// Proxy `ownKeys` traps are out of scope (Perry has no `ownKeys` trap
+/// dispatch); a proxy target falls through to its registered target's keys.
 #[no_mangle]
 pub extern "C" fn js_reflect_own_keys(target: f64) -> f64 {
-    crate::object::js_object_get_own_property_names(target)
+    // Resolve a proxy to its target so we enumerate real keys.
+    let real = if let Some(id) = lookup(target) {
+        PROXIES.with(|p| {
+            p.borrow()
+                .get(id as usize)
+                .and_then(|o| o.as_ref())
+                .map(|e| e.target)
+                .unwrap_or(f64::from_bits(TAG_UNDEFINED))
+        })
+    } else {
+        target
+    };
+    if !reflect_value_is_object(real) {
+        return reflect_non_object_typeerror("ownKeys");
+    }
+    // String own names (this fn already throws for null/undefined; we've
+    // validated above for the other primitives).
+    let names = crate::object::js_object_get_own_property_names(real);
+    let names_ptr = (names.to_bits() & POINTER_MASK) as *mut crate::array::ArrayHeader;
+    if names_ptr.is_null() {
+        return names;
+    }
+    // Append own symbol keys (#2763).
+    let syms_raw = unsafe { crate::symbol::js_object_get_own_property_symbols(real) };
+    let syms_ptr = syms_raw as *const crate::array::ArrayHeader;
+    if !syms_ptr.is_null() {
+        let sym_count = crate::array::js_array_length(syms_ptr) as usize;
+        let mut out = names_ptr;
+        for i in 0..sym_count {
+            let sym = crate::array::js_array_get(syms_ptr, i as u32);
+            out = crate::array::js_array_push_f64(out, f64::from_bits(sym.bits()));
+        }
+        return f64::from_bits(POINTER_TAG | ((out as u64) & POINTER_MASK));
+    }
+    names
 }
 
-/// `Reflect.apply(fn, thisArg, argsArray)` — call fn unpacking args.
+/// `Reflect.apply(fn, thisArg, argumentsList)` (#2767).
+///
+/// - throws `TypeError` for a non-callable target,
+/// - implements `CreateListFromArrayLike(argumentsList)` (throws for a
+///   non-object `argumentsList`, reads `0..length` from any array-like),
+/// - binds `thisArg` for the call.
+///
+/// Proxy targets still dispatch to `js_proxy_apply` (which forwards the
+/// already-constructed `args_array`). Proxy `apply` trap result fidelity for
+/// an `undefined` trap return is out of scope here — Perry's proxy-apply path
+/// keeps a pragmatic fallback (see `js_proxy_apply`).
 #[no_mangle]
 pub extern "C" fn js_reflect_apply(f: f64, this_arg: f64, args_array: f64) -> f64 {
     // If `f` is a proxy with apply trap, dispatch through it.
     if lookup(f).is_some() {
         return js_proxy_apply(f, this_arg, args_array);
     }
-    call_with_args_array(f, args_array)
+    // Non-callable target → TypeError (before evaluating argumentsList,
+    // matching Node which reports the function check first).
+    if !is_callable(f) {
+        return throw_type_error("Reflect.apply target is not a function");
+    }
+    let args = create_list_from_array_like(args_array);
+    call_with_this_and_args(f, this_arg, &args)
 }
 
 /// `Reflect.defineProperty(obj, key, descriptor)` — returns `false` when the
@@ -805,6 +1037,57 @@ pub extern "C" fn js_reflect_prevent_extensions(target: f64) -> f64 {
         return reflect_non_object_typeerror("preventExtensions");
     }
     crate::object::js_object_prevent_extensions(target);
+    nanbox_bool(true)
+}
+
+/// `Reflect.setPrototypeOf(target, proto)` (#2761).
+///
+/// Returns a boolean: `true` when the prototype change is applied, `false`
+/// when it is rejected (target is non-extensible and the proto actually
+/// changes). Throws `TypeError` for a non-object target or a proto that is
+/// neither an object nor `null`.
+///
+/// Proxy `setPrototypeOf` traps are out of scope (no trap dispatch); a proxy
+/// target reports `true` after recording the change on its underlying target.
+#[no_mangle]
+pub extern "C" fn js_reflect_set_prototype_of(target: f64, proto: f64) -> f64 {
+    // Resolve a proxy to its underlying target.
+    let real = if let Some(id) = lookup(target) {
+        PROXIES.with(|p| {
+            p.borrow()
+                .get(id as usize)
+                .and_then(|o| o.as_ref())
+                .map(|e| e.target)
+                .unwrap_or(f64::from_bits(TAG_UNDEFINED))
+        })
+    } else {
+        target
+    };
+
+    // Target must be an object.
+    if !reflect_value_is_object(real) {
+        return reflect_non_object_typeerror("setPrototypeOf");
+    }
+
+    // Proto must be an object or null.
+    let proto_bits = proto.to_bits();
+    let proto_ok = proto_bits == TAG_NULL || reflect_value_is_object(proto);
+    if !proto_ok {
+        return throw_type_error("Object prototype may only be an Object or null");
+    }
+
+    // #2761: a non-extensible target rejects a *changing* prototype. If the
+    // current prototype already equals `proto`, the no-op set still succeeds.
+    if crate::object::obj_value_no_extend(real) {
+        let current = crate::object::js_object_get_prototype_of(real);
+        if current.to_bits() != proto_bits {
+            return nanbox_bool(false);
+        }
+        return nanbox_bool(true);
+    }
+
+    // Apply via the shared Object-side helper (records in the side-table).
+    crate::object::js_object_set_prototype_of(real, proto);
     nanbox_bool(true)
 }
 
@@ -1108,3 +1391,19 @@ static KEEP_PROXY_REVOCABLE: extern "C" fn(f64, f64) -> f64 = js_proxy_revocable
 static KEEP_REFLECT_IS_EXTENSIBLE: extern "C" fn(f64) -> f64 = js_reflect_is_extensible;
 #[used]
 static KEEP_REFLECT_PREVENT_EXTENSIONS: extern "C" fn(f64) -> f64 = js_reflect_prevent_extensions;
+
+// #2761: retention anchor for `Reflect.setPrototypeOf` (codegen-only callsite).
+#[used]
+static KEEP_REFLECT_SET_PROTOTYPE_OF: extern "C" fn(f64, f64) -> f64 = js_reflect_set_prototype_of;
+
+// #2763/#2764/#2766/#2767: retention anchors for the Reflect entry points
+// whose only callsites are codegen-emitted. `js_reflect_get` gained a third
+// `receiver` arg (#2766) and must keep its new signature retained.
+#[used]
+static KEEP_REFLECT_GET: extern "C" fn(f64, f64, f64) -> f64 = js_reflect_get;
+#[used]
+static KEEP_REFLECT_HAS: extern "C" fn(f64, f64) -> f64 = js_reflect_has;
+#[used]
+static KEEP_REFLECT_OWN_KEYS: extern "C" fn(f64) -> f64 = js_reflect_own_keys;
+#[used]
+static KEEP_REFLECT_APPLY: extern "C" fn(f64, f64, f64) -> f64 = js_reflect_apply;

--- a/test-files/test_gap_reflect_semantics2.ts
+++ b/test-files/test_gap_reflect_semantics2.ts
@@ -1,0 +1,101 @@
+// Reflect non-proxy semantics, batch 2:
+//   #2766 Reflect.get honors receiver (accessor `this`) + non-object TypeError
+//   #2767 Reflect.apply uses thisArg + array-like argumentsList + TypeErrors
+//   #2764 Reflect.has uses [[HasProperty]] (prototype chain) + non-object TypeError
+//   #2763 Reflect.ownKeys includes symbol keys + non-object TypeError
+//   #2761 Reflect.setPrototypeOf reports rejected changes (false) + bad-arg TypeError
+//
+// Proxy trap dispatch for these operations is out of scope (Perry lacks
+// three-argument get traps / ownKeys traps / setPrototypeOf traps), so this
+// test asserts only the ordinary-object behavior implemented here.
+
+// --- #2766 Reflect.get receiver + accessor getter ---
+const base = { marker: "base", get value() { return this.marker; } };
+const recv = { marker: "recvval" };
+console.log("get1:", Reflect.get(base, "value", recv)); // receiver's marker
+console.log("get2:", Reflect.get({ x: 1 }, "x"));
+console.log("get3:", Reflect.get({}, "missing"));
+try {
+  Reflect.get(1 as any, "x");
+  console.log("get4: noThrow");
+} catch (e) {
+  console.log("get4:", e instanceof TypeError);
+}
+
+// --- #2767 Reflect.apply ---
+function withThis(a: any, b: any) {
+  return [(this as any) && (this as any).marker, a, b].join(":");
+}
+console.log("apply1:", Reflect.apply(withThis, { marker: "ctx" }, ["a", "b"]));
+// array-like argumentsList
+console.log(
+  "apply2:",
+  Reflect.apply(function (a: any, b: any) { return a + b; }, null, {
+    0: 2,
+    1: 3,
+    length: 2,
+  } as any),
+);
+try {
+  Reflect.apply(1 as any, null, []);
+  console.log("apply3: noThrow");
+} catch (e) {
+  console.log("apply3:", e instanceof TypeError);
+}
+try {
+  Reflect.apply(function () {}, null, null as any);
+  console.log("apply4: noThrow");
+} catch (e) {
+  console.log("apply4:", e instanceof TypeError);
+}
+
+// --- #2764 Reflect.has (prototype chain) ---
+const hasProto = { inherited: 1 };
+const hasObj: any = Object.create(hasProto);
+hasObj.own = 2;
+console.log("has1:", Reflect.has(hasObj, "own"));
+console.log("has2:", Reflect.has(hasObj, "inherited"));
+console.log("has3:", Reflect.has(hasObj, "missing"));
+try {
+  Reflect.has(1 as any, "x");
+  console.log("has4: noThrow");
+} catch (e) {
+  console.log("has4:", e instanceof TypeError);
+}
+
+// --- #2763 Reflect.ownKeys (symbols) ---
+const sym = Symbol("s");
+const keysObj: any = {};
+keysObj.visible = 2;
+keysObj[sym] = 3;
+console.log(
+  "ownkeys1:",
+  Reflect.ownKeys(keysObj)
+    .map((k) => (typeof k === "symbol" ? String(k) : k))
+    .join(","),
+);
+try {
+  Reflect.ownKeys(1 as any);
+  console.log("ownkeys2: noThrow");
+} catch (e) {
+  console.log("ownkeys2:", e instanceof TypeError);
+}
+
+// --- #2761 Reflect.setPrototypeOf (failure reporting) ---
+const spOk: any = {};
+console.log("setproto1:", Reflect.setPrototypeOf(spOk, { p: 1 }));
+const spNonExt: any = {};
+Object.preventExtensions(spNonExt);
+console.log("setproto2:", Reflect.setPrototypeOf(spNonExt, { p: 1 }));
+try {
+  Reflect.setPrototypeOf(1 as any, {});
+  console.log("setproto3: noThrow");
+} catch (e) {
+  console.log("setproto3:", e instanceof TypeError);
+}
+try {
+  Reflect.setPrototypeOf({}, 1 as any);
+  console.log("setproto4: noThrow");
+} catch (e) {
+  console.log("setproto4:", e instanceof TypeError);
+}


### PR DESCRIPTION
Implements correct Node non-proxy semantics for six Reflect operations. Each behavior is asserted byte-for-byte against node --experimental-strip-types in test-files/test_gap_reflect_semantics2.ts under the default auto-optimize compile.

Closes #2766
Closes #2767
Closes #2764
Closes #2763
Closes #2761

## Implementation

- #2766 Reflect.get(target, key, receiver): carry the optional receiver through HIR (ReflectGet gains a receiver field), codegen, and runtime. When key resolves to an accessor getter, the getter's this is rebound to the receiver via clone_closure_rebind_this (object-literal getters capture this in a reserved closure slot, so plain forwarding would read the target's fields). Throws TypeError for a non-object target.
- #2767 Reflect.apply(fn, thisArg, argumentsList): binds thisArg (through IMPLICIT_THIS), implements CreateListFromArrayLike (real Arrays via fast accessors, any other object via .length + indexed reads), throws TypeError for a non-callable target and for a non-object argumentsList.
- #2764 Reflect.has(target, key): full HasProperty - own check plus a prototype-chain probe (via the inherited field read, which already walks Object.create/setPrototypeOf chains), TypeError on a non-object target, and ToBoolean normalization of proxy has trap results.
- #2763 Reflect.ownKeys(target): returns string own-property names followed by own symbol keys, TypeError on a non-object target.
- #2761 Reflect.setPrototypeOf(target, proto): new ReflectSetPrototypeOf HIR variant (was hard-coded to Expr::Bool(true)). Returns a boolean (false when a non-extensible target rejects a changing prototype), throws TypeError for a non-object target or a proto that is neither object nor null. Shares the Object-side js_object_set_prototype_of side-table helper.

## Dropped

- #2768 Reflect.construct newTarget: dropped. Honoring newTarget, array-like args, and constructor errors requires a real runtime construct-from-value path (constructing an arbitrary function/class value with a custom prototype), which Perry does not have today - non-proxy Reflect.construct only works through the compile-time fold to new ClassName(...). Left unchanged rather than ship a broken partial.
- Proxy three-argument get traps, ownKeys traps, and setPrototypeOf traps are out of scope (Perry's proxy traps are two-argument with no ownKeys/setPrototypeOf dispatch). The ordinary-object behavior is implemented; proxy targets fall through to their underlying target.

## Validation

- test-files/test_gap_reflect_semantics2.ts is byte-identical to Node v25 (get-with-receiver+getter, apply thisArg+array-like+TypeErrors, has-on-inherited+TypeError, ownKeys-with-Symbol+TypeError, setPrototypeOf-on-preventExtensions'd to false + bad-arg TypeErrors).
- Regression: test_gap_proxy_reflect.ts and test_gap_reflect_2756_2762.ts stay byte-identical to Node.
- cargo test -p perry-hir (incl. expr_variant_stable_hash_tags_are_unique) and cargo test -p perry-runtime green.
- ./scripts/check_file_size.sh and cargo fmt --all -- --check clean.
- New Expr::ReflectSetPrototypeOf uses stable-hash tag 12230. Retention #[used] anchors added for the codegen-only reflect entry points; verified each symbol survives the auto-optimize whole-program bitcode rebuild.

## HIR

- New variant Expr::ReflectSetPrototypeOf { target, proto } (tag 12230).
- New field receiver on the existing Expr::ReflectGet.
