### PR TITLE
fix(util): validate system error helpers

### DIFF
--- a/crates/perry-runtime/src/util_syserr.rs
+++ b/crates/perry-runtime/src/util_syserr.rs
@@ -18,6 +18,8 @@
 use crate::url::create_string_f64;
 use crate::value::JSValue;
 
+const MAX_SAFE_INTEGER: f64 = 9_007_199_254_740_991.0;
+
 /// errno-backed libuv codes: `(libc errno value, name, libuv message)`.
 #[cfg(unix)]
 fn errno_backed() -> Vec<(i32, &'static str, &'static str)> {
@@ -139,6 +141,9 @@ fn errno_backed() -> Vec<(i32, &'static str, &'static str)> {
     #[cfg(target_os = "linux")]
     {
         t.push((libc::ENODATA, "ENODATA", "no data available"));
+        t.push((libc::EUNATCH, "EUNATCH", "protocol driver not attached"));
+        t.push((libc::EREMOTEIO, "EREMOTEIO", "remote I/O error"));
+        t.push((libc::ENONET, "ENONET", "machine is not on the network"));
     }
     t
 }
@@ -169,8 +174,13 @@ fn uv_internal() -> &'static [(i32, &'static str, &'static str)] {
         (-3011, "EAI_SOCKTYPE", "socket type not supported"),
         (-3013, "EAI_BADHINTS", "invalid value for hints"),
         (-3014, "EAI_PROTOCOL", "resolved protocol is unknown"),
+        #[cfg(not(target_os = "macos"))]
+        (-4028, "EFTYPE", "inappropriate file type or format"),
+        #[cfg(not(target_os = "linux"))]
         (-4023, "EUNATCH", "protocol driver not attached"),
+        #[cfg(not(target_os = "linux"))]
         (-4030, "EREMOTEIO", "remote I/O error"),
+        #[cfg(not(target_os = "linux"))]
         (-4056, "ENONET", "machine is not on the network"),
         (-4080, "ECHARSET", "invalid Unicode character"),
         (-4094, "UNKNOWN", "unknown error"),
@@ -178,15 +188,81 @@ fn uv_internal() -> &'static [(i32, &'static str, &'static str)] {
     ]
 }
 
-/// Coerce a JS value to the libuv-style code integer Node would receive.
+fn group_decimal_digits(digits: &str) -> String {
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    let first = digits.len() % 3;
+    if first != 0 {
+        out.push_str(&digits[..first]);
+        if digits.len() > first {
+            out.push('_');
+        }
+    }
+    for (idx, chunk) in digits[first..].as_bytes().chunks(3).enumerate() {
+        if idx > 0 {
+            out.push('_');
+        }
+        out.push_str(std::str::from_utf8(chunk).unwrap_or_default());
+    }
+    out
+}
+
+fn format_out_of_range_number(n: f64) -> String {
+    if n.is_nan() {
+        return "NaN".to_string();
+    }
+    if n.is_infinite() {
+        return if n.is_sign_negative() {
+            "-Infinity"
+        } else {
+            "Infinity"
+        }
+        .to_string();
+    }
+    if n.fract() == 0.0 && n.abs() <= i64::MAX as f64 {
+        let sign = if n.is_sign_negative() { "-" } else { "" };
+        let digits = format!("{}", n.abs() as i64);
+        if n.abs() > MAX_SAFE_INTEGER {
+            return format!("{sign}{}", group_decimal_digits(&digits));
+        }
+        return format!("{sign}{digits}");
+    }
+    format!("{n}")
+}
+
+fn throw_invalid_err_type(value: f64) -> ! {
+    let message = format!(
+        "The \"err\" argument must be of type number. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn throw_err_out_of_range(n: f64) -> ! {
+    let message = format!(
+        "The value of \"err\" is out of range. It must be a negative integer. Received {}",
+        format_out_of_range_number(n)
+    );
+    crate::fs::validate::throw_range_error_named(&message, "ERR_OUT_OF_RANGE")
+}
+
+/// Validate a JS value as the negative safe-integer libuv code Node accepts.
 fn code_of(value: f64) -> i64 {
     let jsval = JSValue::from_bits(value.to_bits());
     if jsval.is_int32() {
-        jsval.as_int32() as i64
-    } else if value.is_finite() {
-        value as i64
+        let n = jsval.as_int32() as f64;
+        if n < 0.0 {
+            return jsval.as_int32() as i64;
+        }
+        throw_err_out_of_range(n);
+    }
+    if !crate::fs::validate::is_numeric(jsval) {
+        throw_invalid_err_type(value);
+    }
+    let n = jsval.as_number();
+    if n.is_finite() && n < 0.0 && n.fract() == 0.0 && n.abs() <= MAX_SAFE_INTEGER {
+        n as i64
     } else {
-        0
+        throw_err_out_of_range(n);
     }
 }
 
@@ -282,5 +358,38 @@ mod tests {
         assert_eq!(system_error_message(-3008.0), "unknown node or service");
         // unmapped:
         assert_eq!(system_error_name(-999999.0), "Unknown system error -999999");
+    }
+
+    #[test]
+    fn range_number_format_matches_node() {
+        assert_eq!(format_out_of_range_number(f64::NAN), "NaN");
+        assert_eq!(format_out_of_range_number(f64::INFINITY), "Infinity");
+        assert_eq!(
+            format_out_of_range_number(-9_007_199_254_740_992.0),
+            "-9_007_199_254_740_992"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_libuv_aliases_match_node_map() {
+        let entry_count = errno_backed().len() + uv_internal().len();
+        assert_eq!(entry_count, 85);
+        assert_eq!(lookup(-4028).map(|(name, _)| name), Some("EFTYPE"));
+        assert_eq!(
+            lookup(-(libc::EUNATCH as i64)).map(|(name, _)| name),
+            Some("EUNATCH")
+        );
+        assert_eq!(
+            lookup(-(libc::EREMOTEIO as i64)).map(|(name, _)| name),
+            Some("EREMOTEIO")
+        );
+        assert_eq!(
+            lookup(-(libc::ENONET as i64)).map(|(name, _)| name),
+            Some("ENONET")
+        );
+        assert_eq!(lookup(-4023), None);
+        assert_eq!(lookup(-4030), None);
+        assert_eq!(lookup(-4056), None);
     }
 }

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -7,10 +7,10 @@ This document is a structured gap analysis comparing the public Node.js + Bun ru
 | Category | Modules | Gap APIs | Verified-covered |
 |----------|---------|----------|------------------|
 | Whole-module gaps (zero coverage) | 18 | 472 | n/a |
-| Partial-module gaps | 29 | 1646 | 371 |
+| Partial-module gaps | 29 | 1643 | 374 |
 | Web-global gaps | — | 282 | 107 |
 | Bun-only gaps (out of scope) | — | 394 | n/a |
-| **Total true gaps** |  | **2400** |  |
+| **Total true gaps** |  | **2397** |  |
 
 **Top modules by remaining true gaps (Node + Web):**
 
@@ -19,7 +19,7 @@ This document is a structured gap analysis comparing the public Node.js + Bun ru
 - `node:fs` — 139
 - `node:crypto` — 128
 - `node:process (and global `process`)` — 101
-- `node:util` — 95
+- `node:util` — 92
 - `node:http2` — 97
 - `node:test (and node:test/reporters, node:test/mock)` — 93
 - `node:http` — 89
@@ -646,16 +646,13 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 
 ### node:util
 
-**Gap APIs: 92** · Already covered: 10
+**Gap APIs: 89** · Already covered: 13
 
 #### Missing from Perry
 
 - `util.debuglog(section[, callback])`
 - `util.debug(section)`
 - `util.formatWithOptions(inspectOptions, format[, ...args])`
-- `util.getSystemErrorName(err)`
-- `util.getSystemErrorMap()`
-- `util.getSystemErrorMessage(err)`
 - `util.parseEnv(content)`
 - `util.stripVTControlCharacters(str)`
 - `util.toUSVString(string)`
@@ -703,6 +700,9 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 | `util.deprecate(fn, msg[, code[, options]])` | `manifest:util.deprecate` |
 | `util.format(format[, ...args])` | `manifest:util.format` |
 | `util.getCallSites([frameCount][, options])` | `manifest:util.getCallSites` |
+| `util.getSystemErrorName(err)` | `manifest:util.getSystemErrorName` |
+| `util.getSystemErrorMap()` | `manifest:util.getSystemErrorMap` |
+| `util.getSystemErrorMessage(err)` | `manifest:util.getSystemErrorMessage` |
 | `util.inherits(constructor, superConstructor)` | `manifest:util.inherits` |
 | `util.inspect(object[, options])` | `manifest:util.inspect` |
 | `util.isDeepStrictEqual(val1, val2[, options])` | `manifest:util.isDeepStrictEqual` |

--- a/test-parity/node-suite/util/get-system-error.ts
+++ b/test-parity/node-suite/util/get-system-error.ts
@@ -16,6 +16,45 @@ console.log("map size:", m.size);
 console.log("map -2:", JSON.stringify(m.get(-2)));
 console.log("map -9:", JSON.stringify(m.get(-9)));
 console.log("map -4094:", JSON.stringify(m.get(-4094)));
+console.log("map has -4028:", m.has(-4028));
+console.log("map has -4023:", m.has(-4023));
+console.log("map has -4030:", m.has(-4030));
+console.log("map has -4056:", m.has(-4056));
 
 import { getSystemErrorName } from "node:util";
 console.log("named -28:", getSystemErrorName(-28));
+
+function probe(fnName, fn, value, label) {
+  try {
+    console.log("probe", fnName, label, "=>", JSON.stringify(fn(value)));
+  } catch (e) {
+    console.log(
+      "probe",
+      fnName,
+      label,
+      "THROW",
+      e.name,
+      e.code,
+      JSON.stringify(e.message.split("\n")[0]),
+    );
+  }
+}
+
+for (const [fnName, fn] of [
+  ["getSystemErrorName", util.getSystemErrorName],
+  ["getSystemErrorMessage", util.getSystemErrorMessage],
+]) {
+  probe(fnName, fn, undefined, "undefined");
+  probe(fnName, fn, null, "null");
+  probe(fnName, fn, "-2", "string");
+  probe(fnName, fn, -2, "valid");
+  probe(fnName, fn, -2.1, "fraction");
+  probe(fnName, fn, 2, "positive");
+  probe(fnName, fn, 0, "zero");
+  probe(fnName, fn, Infinity, "infinity");
+  probe(fnName, fn, NaN, "nan");
+  probe(fnName, fn, Number.MIN_SAFE_INTEGER - 1, "unsafe");
+  probe(fnName, fn, 1n, "bigint");
+  probe(fnName, fn, {}, "object");
+  probe(fnName, fn, true, "boolean");
+}


### PR DESCRIPTION
## Summary
- validate `util.getSystemErrorName(err)` and `util.getSystemErrorMessage(err)` inputs with Node-shaped `ERR_INVALID_ARG_TYPE` / `ERR_OUT_OF_RANGE` behavior
- require negative safe-integer error codes before libuv lookup, including unsafe integer range formatting
- align the Linux libuv error map entries so `getSystemErrorMap()` has Node's 85-entry shape and the expected `EFTYPE` / `EUNATCH` / `EREMOTEIO` / `ENONET` keys
- update the util parity gap counts for the covered system-error helpers

## Issues
Closes #3022
Refs #2514

## Why This Cut
The validation gap and the existing `node-suite/util/get-system-error` map-size mismatch share the same `util_syserr` lookup path and one deterministic parity fixture. The broader #2514 tracker remains open for unrelated util helpers.

## Tests Added
- expanded `test-parity/node-suite/util/get-system-error.ts` with invalid input validation, unsafe integer handling, and Linux libuv alias/map-size probes
- added focused `util_syserr` Rust unit coverage for range-number formatting and Linux libuv alias entries

## Verification
- pre-fix expanded fixture failed on the expected output mismatch: `test-parity/reports/parity_report_20260531_005655.json`
- post-fix/rebase focused fixture passed 1/1: `test-parity/reports/parity_report_20260531_011354.json`
- post-fix/rebase full util suite passed 74/74: `test-parity/reports/parity_report_20260531_011516.json`
- `TMPDIR="$PWD/target/tmp" RUSTC_WRAPPER= cargo test -p perry-runtime util_syserr` passed with existing warnings
- `TMPDIR="$PWD/target/tmp" CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo check -p perry-runtime -p perry-codegen -p perry-api-manifest` passed with existing warnings
- `cargo fmt --all -- --check`
- `git diff --check HEAD`
- `./scripts/check_file_size.sh`

## Known Limitations
- This does not close the broad #2514 tracker; remaining unrelated util helper APIs are still tracked there.
- Platform-specific libuv alias coverage is asserted for the Linux parity environment used by the suite.

## Non-goals
- No changes to `util.debuglog`, `util.diff`, `util.parseEnv`, MIME helpers, or other `node:util` APIs.
