### PR TITLE
fix(fetch): Response status/statusText + Request method validation

### DIFF
--- a/crates/perry-ext-fetch/src/lib.rs
+++ b/crates/perry-ext-fetch/src/lib.rs
@@ -27,6 +27,14 @@ use perry_ffi::{
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+// Web Fetch constructor validation helpers (#2640 / #2643) — split out to
+// keep lib.rs under the 2,000-line lint gate.
+mod validation;
+use validation::{
+    is_forbidden_method, is_null_body_status, is_valid_status_text, normalize_method,
+    throw_range_error, throw_type_error,
+};
+
 const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
 const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
@@ -1070,13 +1078,34 @@ pub unsafe extern "C" fn js_response_new(
     status_text_ptr: *const StringHeader,
     headers_handle: f64,
 ) -> f64 {
-    let body = read_str(body_ptr).unwrap_or_default().into_bytes();
+    let body_opt = read_str(body_ptr);
+    let body_present = body_opt.is_some();
+    let body = body_opt.unwrap_or_default().into_bytes();
+    // NaN/0.0 are the codegen "no status field" sentinels → default 200.
+    // Otherwise truncate toward zero + range-check 200..=599 (#2640).
     let status = if status.is_nan() || status == 0.0 {
         200
     } else {
-        status as u16
+        let truncated = status.trunc();
+        if !(200.0..=599.0).contains(&truncated) {
+            throw_range_error("init[\"status\"] must be in the range of 200 to 599, inclusive.");
+        }
+        truncated as u16
     };
-    let status_text = read_str(status_text_ptr).unwrap_or_else(|| "OK".to_string());
+    let status_text = match read_str(status_text_ptr) {
+        Some(s) => {
+            if !is_valid_status_text(&s) {
+                throw_type_error("Invalid statusText");
+            }
+            s
+        }
+        None => String::new(),
+    };
+    if body_present && is_null_body_status(status) {
+        throw_type_error(&format!(
+            "Response constructor: Invalid response status code {status}"
+        ));
+    }
     let headers_id = handle_id(headers_handle);
     let headers = if headers_id != 0 {
         HEADERS_HANDLES
@@ -1441,11 +1470,8 @@ pub extern "C" fn js_blob_stream(handle: f64) -> f64 {
 // ── Request ───────────────────────────────────────────────────────
 
 /// `new Request(url, init)` — stores url/method/body. The `headers_handle`
-/// arg matches perry-stdlib's 4-arg shape (declared in
-/// `crates/perry-codegen/src/runtime_decls.rs:1064`); it's currently ignored
-/// at the storage level (perry-ext-fetch's RequestData has no headers field
-/// yet), but accepting the arg keeps the ABI in sync with codegen so the f64
-/// arg lands in the right register.
+/// arg matches perry-stdlib's shape so the f64 arg lands in the right
+/// register (declared in `crates/perry-codegen/src/runtime_decls.rs:1064`).
 ///
 /// # Safety
 /// All string pointers must be null or Perry-runtime `StringHeader`s;
@@ -1468,10 +1494,17 @@ pub unsafe extern "C" fn js_request_new(
     signal: f64,
 ) -> f64 {
     let url = read_str(url_ptr).unwrap_or_default();
-    let method = read_str(method_ptr)
-        .unwrap_or_else(|| "GET".to_string())
-        .to_ascii_uppercase();
+    let raw_method = read_str(method_ptr).unwrap_or_else(|| "GET".to_string());
+    // Forbidden methods rejected case-insensitively; message keeps the
+    // caller's original casing (Node parity). #2643
+    if is_forbidden_method(&raw_method.to_ascii_uppercase()) {
+        throw_type_error(&format!("'{raw_method}' HTTP method is unsupported."));
+    }
+    let method = normalize_method(&raw_method);
     let body = read_str(body_ptr);
+    if body.is_some() && (method == "GET" || method == "HEAD") {
+        throw_type_error("Request with GET/HEAD method cannot have body.");
+    }
     let headers_id = handle_id(headers_handle);
     let headers = if headers_id != 0 {
         HEADERS_HANDLES

--- a/crates/perry-ext-fetch/src/validation.rs
+++ b/crates/perry-ext-fetch/src/validation.rs
@@ -1,0 +1,61 @@
+//! Web Fetch constructor validation helpers shared by the Response and
+//! Request constructors (`js_response_new` / `js_request_new`). Mirrors the
+//! WHATWG fetch spec rules Node enforces; refs #2640 (Response status /
+//! statusText validation + empty-string default) and #2643 (Request method
+//! normalization + forbidden methods + GET/HEAD body rejection).
+
+use perry_ffi::{alloc_string, JsValue, StringHeader};
+
+// Web Fetch constructor validation throws real TypeError / RangeError
+// objects. perry-ffi doesn't re-export the runtime error/throw entry
+// points, but with the `runtime-link` feature the `#[no_mangle]` symbols
+// from perry-runtime are present in the final link, so we declare them
+// here. (Mirrors perry-stdlib's `throw_fetch_type_error`, which reaches
+// them through the `perry_runtime::` path.)
+extern "C" {
+    fn js_typeerror_new(message: *mut StringHeader) -> *mut u8;
+    fn js_rangeerror_new(message: *mut StringHeader) -> *mut u8;
+    fn js_throw(value: f64) -> !;
+}
+
+pub(crate) unsafe fn throw_type_error(msg: &str) -> ! {
+    let m = alloc_string(msg).as_raw();
+    let err = js_typeerror_new(m);
+    js_throw(f64::from_bits(JsValue::from_object_ptr(err).bits()));
+}
+
+pub(crate) unsafe fn throw_range_error(msg: &str) -> ! {
+    let m = alloc_string(msg).as_raw();
+    let err = js_rangeerror_new(m);
+    js_throw(f64::from_bits(JsValue::from_object_ptr(err).bits()));
+}
+
+/// Web Fetch reason-phrase validation (HTTP token rules). A valid
+/// `statusText` byte is HTAB (0x09), SP (0x20), VCHAR (0x21..=0x7E),
+/// or obs-text (0x80..=0xFF). Anything else (e.g. a newline) is invalid.
+pub(crate) fn is_valid_status_text(s: &str) -> bool {
+    s.bytes()
+        .all(|b| b == 0x09 || b == 0x20 || (0x21..=0x7E).contains(&b) || b >= 0x80)
+}
+
+/// Web Fetch null-body status codes — a Response with one of these may
+/// not carry a body.
+pub(crate) fn is_null_body_status(status: u16) -> bool {
+    matches!(status, 101 | 103 | 204 | 205 | 304)
+}
+
+/// Web Fetch forbidden request methods — rejected by the Request ctor.
+pub(crate) fn is_forbidden_method(method_upper: &str) -> bool {
+    matches!(method_upper, "CONNECT" | "TRACE" | "TRACK")
+}
+
+/// Methods that Node/WHATWG normalize to canonical uppercase when given
+/// case-insensitively. PATCH and any extension method keep their original
+/// casing (Node parity: `patch` stays `patch`).
+pub(crate) fn normalize_method(raw: &str) -> String {
+    let upper = raw.to_ascii_uppercase();
+    match upper.as_str() {
+        "DELETE" | "GET" | "HEAD" | "OPTIONS" | "POST" | "PUT" => upper,
+        _ => raw.to_string(),
+    }
+}

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -28,6 +28,13 @@ pub use dispatch::*;
 mod body_metadata;
 pub use body_metadata::*;
 
+// Web Fetch constructor validation helpers (#2640 / #2643) — split out to
+// keep this file under the 2,000-line lint gate.
+mod validation;
+use validation::{
+    is_forbidden_method, is_null_body_status, is_valid_status_text, normalize_method,
+};
+
 // Response handle storage
 lazy_static::lazy_static! {
     static ref FETCH_RESPONSES: Mutex<HashMap<usize, FetchResponse>> = Mutex::new(HashMap::new());
@@ -183,6 +190,12 @@ unsafe fn reject_fetch_type_error(promise: *mut perry_runtime::Promise, msg: &st
 
 unsafe fn throw_fetch_type_error(msg: &str) -> ! {
     perry_runtime::exception::js_throw(f64::from_bits(fetch_type_error_bits(msg)))
+}
+
+unsafe fn throw_fetch_range_error(msg: &str) -> ! {
+    let msg_str = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = perry_runtime::error::js_rangeerror_new(msg_str);
+    perry_runtime::exception::js_throw(f64::from_bits(JSValue::pointer(err as *const u8).bits()))
 }
 
 fn tagged_bool(value: bool) -> f64 {
@@ -1186,13 +1199,37 @@ pub unsafe extern "C" fn js_response_new(
     let body_present = body_opt.is_some();
     let body_str = body_opt.unwrap_or_default();
     let body = body_str.into_bytes();
+    // NaN / 0.0 are the codegen "no status field" sentinels. Node defaults
+    // missing status to 200; any explicit value is truncated toward zero
+    // then range-checked against 200..=599 (199.9 → RangeError, 599.9 →
+    // 599). Refs #2640.
     let status_u16 = if status.is_nan() || status == 0.0 {
         200
     } else {
-        status as u16
+        let truncated = status.trunc();
+        if !(200.0..=599.0).contains(&truncated) {
+            throw_fetch_range_error(
+                "init[\"status\"] must be in the range of 200 to 599, inclusive.",
+            );
+        }
+        truncated as u16
     };
-    let status_text = string_from_header(status_text_ptr)
-        .unwrap_or_else(|| canonical_reason(status_u16).to_string());
+    // Node defaults statusText to the empty string (NOT the canonical
+    // reason phrase) and validates the reason-phrase token. Refs #2640.
+    let status_text = match string_from_header(status_text_ptr) {
+        Some(s) => {
+            if !is_valid_status_text(&s) {
+                throw_fetch_type_error("Invalid statusText");
+            }
+            s
+        }
+        None => String::new(),
+    };
+    if body_present && is_null_body_status(status_u16) {
+        throw_fetch_type_error(&format!(
+            "Response constructor: Invalid response status code {status_u16}"
+        ));
+    }
     let headers_id = handle_id(headers_handle);
     let headers = if headers_id != 0 {
         HEADERS_REGISTRY
@@ -1680,10 +1717,18 @@ pub unsafe extern "C" fn js_request_new(
     signal: f64,
 ) -> f64 {
     let url = string_from_header(url_ptr).unwrap_or_default();
-    let method = string_from_header(method_ptr)
-        .unwrap_or_else(|| "GET".to_string())
-        .to_ascii_uppercase();
+    let raw_method = string_from_header(method_ptr).unwrap_or_else(|| "GET".to_string());
+    // Forbidden methods are rejected case-insensitively; the error message
+    // preserves the caller's original casing (Node parity). Refs #2643.
+    if is_forbidden_method(&raw_method.to_ascii_uppercase()) {
+        throw_fetch_type_error(&format!("'{raw_method}' HTTP method is unsupported."));
+    }
+    let method = normalize_method(&raw_method);
     let body = string_from_header(body_ptr);
+    // GET/HEAD requests may not carry a body (WHATWG fetch). Refs #2643.
+    if body.is_some() && (method == "GET" || method == "HEAD") {
+        throw_fetch_type_error("Request with GET/HEAD method cannot have body.");
+    }
     let headers_id_in = handle_id(headers_handle);
     let headers = if headers_id_in != 0 {
         HEADERS_REGISTRY

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -32,7 +32,8 @@ pub use body_metadata::*;
 // keep this file under the 2,000-line lint gate.
 mod validation;
 use validation::{
-    is_forbidden_method, is_null_body_status, is_valid_status_text, normalize_method,
+    canonical_reason, is_forbidden_method, is_null_body_status, is_valid_status_text,
+    normalize_method,
 };
 
 // Response handle storage
@@ -1248,23 +1249,6 @@ pub unsafe extern "C" fn js_response_new(
         body,
         body_present,
     ))
-}
-
-fn canonical_reason(status: u16) -> &'static str {
-    match status {
-        200 => "OK",
-        201 => "Created",
-        204 => "No Content",
-        301 => "Moved Permanently",
-        302 => "Found",
-        304 => "Not Modified",
-        400 => "Bad Request",
-        401 => "Unauthorized",
-        403 => "Forbidden",
-        404 => "Not Found",
-        500 => "Internal Server Error",
-        _ => "",
-    }
 }
 
 /// response.headers — returns a Headers handle (f64). Lazily allocates a Headers entry

--- a/crates/perry-stdlib/src/fetch/validation.rs
+++ b/crates/perry-stdlib/src/fetch/validation.rs
@@ -1,0 +1,35 @@
+//! Web Fetch constructor validation helpers shared by the Response and
+//! Request constructors (`js_response_new` / `js_request_new`). Mirrors the
+//! WHATWG fetch spec rules Node enforces; refs #2640 (Response status /
+//! statusText validation + empty-string default) and #2643 (Request method
+//! normalization + forbidden methods + GET/HEAD body rejection).
+
+/// Web Fetch reason-phrase validation (HTTP token rules). A valid
+/// `statusText` byte is HTAB (0x09), SP (0x20), VCHAR (0x21..=0x7E),
+/// or obs-text (0x80..=0xFF). Anything else (e.g. a newline) is invalid.
+pub(crate) fn is_valid_status_text(s: &str) -> bool {
+    s.bytes()
+        .all(|b| b == 0x09 || b == 0x20 || (0x21..=0x7E).contains(&b) || b >= 0x80)
+}
+
+/// Web Fetch null-body status codes — a Response with one of these may
+/// not carry a body.
+pub(crate) fn is_null_body_status(status: u16) -> bool {
+    matches!(status, 101 | 103 | 204 | 205 | 304)
+}
+
+/// Web Fetch forbidden request methods — rejected by the Request ctor.
+pub(crate) fn is_forbidden_method(method_upper: &str) -> bool {
+    matches!(method_upper, "CONNECT" | "TRACE" | "TRACK")
+}
+
+/// Methods that Node/WHATWG normalize to canonical uppercase when given
+/// case-insensitively. PATCH and any extension method keep their original
+/// casing (Node parity: `patch` stays `patch`).
+pub(crate) fn normalize_method(raw: &str) -> String {
+    let upper = raw.to_ascii_uppercase();
+    match upper.as_str() {
+        "DELETE" | "GET" | "HEAD" | "OPTIONS" | "POST" | "PUT" => upper,
+        _ => raw.to_string(),
+    }
+}

--- a/crates/perry-stdlib/src/fetch/validation.rs
+++ b/crates/perry-stdlib/src/fetch/validation.rs
@@ -33,3 +33,20 @@ pub(crate) fn normalize_method(raw: &str) -> String {
         _ => raw.to_string(),
     }
 }
+
+pub(crate) fn canonical_reason(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        201 => "Created",
+        204 => "No Content",
+        301 => "Moved Permanently",
+        302 => "Found",
+        304 => "Not Modified",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        403 => "Forbidden",
+        404 => "Not Found",
+        500 => "Internal Server Error",
+        _ => "",
+    }
+}

--- a/test-files/test_gap_fetch_reqresp_2640_2643.ts
+++ b/test-files/test_gap_fetch_reqresp_2640_2643.ts
@@ -1,0 +1,92 @@
+// Gap test for #2640 (Response status/statusText validation + default)
+// and #2643 (Request method normalization + GET/HEAD body rejection).
+// Compared byte-for-byte against `node --experimental-strip-types`.
+//
+// Uses object literals at each `new Response`/`new Request` call site (the
+// path the issues report). The runtime-object init path (e.g. a loop var)
+// is a separate, pre-existing constructor-lowering gap.
+
+function respErr(fn: () => void): void {
+  try {
+    fn();
+    console.log("no throw");
+  } catch (e: any) {
+    console.log("respErr " + e.name + " " + e.message.split("\n")[0]);
+  }
+}
+
+function methodErr(fn: () => void): void {
+  try {
+    fn();
+    console.log("no throw");
+  } catch (e: any) {
+    console.log("err " + e.name + " " + e.message.split("\n")[0]);
+  }
+}
+
+// --- #2640: Response default statusText + valid init ---
+const r0 = new Response("x");
+console.log("default statusText: " + JSON.stringify(r0.statusText));
+console.log("default status: " + r0.status);
+
+const r1 = new Response("x", {});
+console.log("empty-init statusText: " + JSON.stringify(r1.statusText));
+
+const r2 = new Response("x", {
+  status: 201,
+  statusText: "Created-ish",
+  headers: { "x-test": "yes" },
+});
+console.log(
+  "valid init: " +
+    r2.status +
+    " " +
+    JSON.stringify(r2.statusText) +
+    " " +
+    r2.headers.get("x-test") +
+    " " +
+    r2.ok,
+);
+
+const r3 = new Response(null, { status: 204 });
+console.log("null-body 204: " + r3.status + " " + JSON.stringify(r3.statusText));
+
+// --- #2640: Response invalid init throws ---
+respErr(() => {
+  new Response("x", { status: 99 });
+});
+respErr(() => {
+  new Response("x", { status: 600 });
+});
+respErr(() => {
+  new Response("x", { statusText: "bad\nline" });
+});
+respErr(() => {
+  new Response("x", { status: 204 });
+});
+
+// --- #2643: Request method normalization ---
+console.log("method post => " + new Request("http://example.com", { method: "post" }).method);
+console.log("method PATCH => " + new Request("http://example.com", { method: "PATCH" }).method);
+console.log("method custom => " + new Request("http://example.com", { method: "custom" }).method);
+
+// --- #2643: forbidden methods throw ---
+methodErr(() => {
+  new Request("http://example.com", { method: "connect" });
+});
+methodErr(() => {
+  new Request("http://example.com", { method: "TRACE" });
+});
+methodErr(() => {
+  new Request("http://example.com", { method: "TRACK" });
+});
+
+// --- #2643: GET/HEAD body rejection + POST body kept ---
+methodErr(() => {
+  new Request("http://example.com", { method: "GET", body: "x" });
+});
+methodErr(() => {
+  new Request("http://example.com", { method: "HEAD", body: "x" });
+});
+const rp = new Request("http://example.com", { method: "POST", body: "x" });
+console.log("body POST => " + rp.method);


### PR DESCRIPTION
Closes #2640
Closes #2643

## Implementation

Web Fetch `new Response(...)` / `new Request(...)` constructors now apply the WHATWG validation Node enforces. Fixed in **both** fetch backends (`perry-stdlib/src/fetch/mod.rs` and `perry-ext-fetch/src/lib.rs` — `uses_fetch` routes inline construction through perry-ext-fetch, but both ship the ctors).

### Response (#2640)
- Default `statusText` is now the empty string `""` (was the canonical reason / `"OK"`), matching Node.
- `status` is truncated toward zero then range-checked against `200..=599`; out-of-range throws `RangeError: init["status"] must be in the range of 200 to 599, inclusive.` (NaN/0 remain the codegen "no status field" sentinel → default 200).
- `statusText` is validated against the HTTP reason-phrase token rules (HTAB / SP / VCHAR / obs-text); an invalid byte (e.g. a newline) throws `TypeError: Invalid statusText`.
- A body-bearing response with a null-body status (101/103/204/205/304) throws `TypeError: Response constructor: Invalid response status code <code>`. `new Response(null, { status: 204 })` is still allowed (body presence is tracked via the null `*StringHeader`).

### Request (#2643)
- Standard methods are normalized to uppercase (`post` → `POST`). `PATCH` and extension methods (e.g. `custom`) keep their original casing, matching Node (`patch` stays `patch`).
- Forbidden methods `CONNECT` / `TRACE` / `TRACK` are rejected case-insensitively with `TypeError: '<original-casing>' HTTP method is unsupported.`
- `GET` / `HEAD` requests carrying a body throw `TypeError: Request with GET/HEAD method cannot have body.`

Shared validation helpers were extracted into a new `validation.rs` sibling module in each crate to keep the touched files under the 2000-line lint gate.

No new HIR variant. Errors are thrown via the existing runtime `js_typeerror_new` / `js_rangeerror_new` / `js_throw` entry points (perry-stdlib reaches them through `perry_runtime::`; perry-ext-fetch declares them as externs, present under the `runtime-link` feature).

## Validation

New gap test `test-files/test_gap_fetch_reqresp_2640_2643.ts` is **byte-identical** to `node --experimental-strip-types` under the DEFAULT auto-optimize compile, covering every repro from both issues (default/empty-init statusText, valid init, null-body 204, status 99/600 RangeError, newline-statusText TypeError, body+204 TypeError, `post`/`PATCH`/`custom` normalization, CONNECT/TRACE/TRACK rejection, GET/HEAD body rejection, POST body kept).

Other checks: `./scripts/check_file_size.sh` exit 0, `cargo fmt --all -- --check` clean, `cargo test -p perry-hir` (6 passed), `cargo test -p perry-stdlib` (81 passed), `cargo test -p perry-ext-fetch` ok. Existing `test_gap_fetch_response.ts` remains byte-identical (no regression from the empty-statusText default).

The gap test uses object-literal init at each call site (the path the issues report). The runtime-object init path (e.g. a loop variable) is a separate pre-existing constructor-lowering gap where Request init fields are dropped — out of scope here.
