### PR TITLE
fix(runtime): global Iterator + iterator helper methods

### DIFF
--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -355,6 +355,7 @@ pub fn check_escapes_in_expr(
         | Expr::MathMinSpread(operand)
         | Expr::MathMaxSpread(operand)
         | Expr::ArrayFrom(operand)
+        | Expr::IteratorFrom(operand)
         | Expr::Uint8ArrayFrom(operand)
         | Expr::JsonParse(operand)
         | Expr::JsonStringify(operand)

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -244,6 +244,7 @@ fn collect_used_new_fields_in_expr(
         | Expr::MathMinSpread(operand)
         | Expr::MathMaxSpread(operand)
         | Expr::ArrayFrom(operand)
+        | Expr::IteratorFrom(operand)
         | Expr::Uint8ArrayFrom(operand)
         | Expr::JsonParse(operand)
         | Expr::JsonStringify(operand)

--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -1107,6 +1107,7 @@ pub fn collect_localset_ids_in_expr_filtered(
         | Expr::SetSize(operand)
         | Expr::SetClear(operand)
         | Expr::ArrayFrom(operand)
+        | Expr::IteratorFrom(operand)
         | Expr::Uint8ArrayFrom(operand)
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -212,6 +212,7 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         | Expr::SetSize(operand)
         | Expr::SetClear(operand)
         | Expr::ArrayFrom(operand)
+        | Expr::IteratorFrom(operand)
         | Expr::Uint8ArrayFrom(operand)
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -329,6 +329,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_pointer_inline(blk, &result))
         }
 
+        // #2874: `Iterator.from(x)` — wrap any iterable in a lazy
+        // iterator-helper object. `js_iterator_from` returns an already
+        // NaN-boxed pointer (f64), so return it directly.
+        Expr::IteratorFrom(iter) => {
+            let iter_box = lower_expr(ctx, iter)?;
+            let blk = ctx.block();
+            Ok(blk.call(DOUBLE, "js_iterator_from", &[(DOUBLE, &iter_box)]))
+        }
+
         // Tagged-template strings literal — build cooked array, build raw
         // array, register the (cooked, raw) pair so subsequent `.raw`
         // reads resolve via `js_template_raw`, return the cooked array.

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1483,6 +1483,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::Delete(..)
         | Expr::Sequence(..)
         | Expr::ArrayFrom(..)
+        | Expr::IteratorFrom(..)
         | Expr::TaggedTemplateStrings { .. }
         | Expr::TemplateRaw(..)
         | Expr::ArrayFromMapped { .. }

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -121,6 +121,9 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // number/boolean/symbol -> [], otherwise materializes via js_array_clone.
     // Takes the raw NaN-boxed value so the tag bits survive.
     module.declare_function("js_array_from_value", I64, &[DOUBLE]);
+    // #2874: Iterator.from(x) — wrap any iterable in a lazy iterator-helper
+    // object. Returns an already NaN-boxed pointer (DOUBLE).
+    module.declare_function("js_iterator_from", DOUBLE, &[DOUBLE]);
     // #2773: Array.from(source, mapFn, thisArg?) — nullish-throw + mapFn
     // callability validation + (value,index) mapped call with thisArg binding.
     module.declare_function("js_array_from_mapped", I64, &[DOUBLE, DOUBLE, DOUBLE]);

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1879,6 +1879,13 @@ pub enum Expr {
     /// Creates a new array from an iterable (e.g., Map.entries(), Map.keys(), another array)
     ArrayFrom(Box<Expr>),
 
+    /// `Iterator.from(iterable)` (#2874) — wrap any iterable/iterator in a lazy
+    /// iterator-helper object exposing `.map`/`.filter`/`.take`/`.drop`/
+    /// `.flatMap`/`.toArray`/`.forEach`/`.reduce`/`.some`/`.every`/`.find`.
+    /// The helper methods themselves dispatch at runtime through
+    /// `js_native_call_method` (no dedicated HIR variant).
+    IteratorFrom(Box<Expr>),
+
     /// Tagged-template strings literal — codegen builds the cooked-strings
     /// array AND a parallel raw-strings array, registers the (cooked, raw)
     /// pair via `js_tagged_template_register_raw`, and returns the cooked

--- a/crates/perry-hir/src/lower/array_fold.rs
+++ b/crates/perry-hir/src/lower/array_fold.rs
@@ -300,6 +300,8 @@ pub(crate) fn is_known_namespace_static_function(obj_name: &str, prop_name: &str
         // `util.types.isArrayBufferView` predicate at call sites). The bare
         // value-read must report typeof "function".
         "ArrayBuffer" => prop_name == "isView",
+        // #2874: `Iterator.from` is a real static function in Node 22+.
+        "Iterator" => prop_name == "from",
         "Response" => matches!(prop_name, "json" | "redirect" | "error"),
         _ => false,
     }

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -101,6 +101,42 @@ fn chain_roots_at_stream(expr: &ast::Expr) -> bool {
     }
 }
 
+/// #2874: does this expression's method chain originate from
+/// `Iterator.from(...)` (optionally through lazy helpers `map`/`filter`/
+/// `take`/`drop`/`flatMap`)? Such a chain yields a lazy iterator-helper
+/// OBJECT, not an array, so it must NOT be folded into `Expr::Array<Method>`
+/// ops — `js_array_map` would read garbage out of the helper's header. Keep it
+/// on dynamic dispatch so `dispatch_iterator_helper_method` runs. Mirrors
+/// `chain_roots_at_stream`; AST-only (no type info), so it catches the common
+/// inline-chain form.
+fn chain_roots_at_iterator_from(expr: &ast::Expr) -> bool {
+    let expr = unwrap_transparent_expr(expr);
+    let ast::Expr::Call(call) = expr else {
+        return false;
+    };
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return false;
+    };
+    let ast::Expr::Member(m) = callee.as_ref() else {
+        return false;
+    };
+    let ast::MemberProp::Ident(prop) = &m.prop else {
+        return false;
+    };
+    match prop.sym.as_ref() {
+        // The static factory `Iterator.from(x)` is the root.
+        "from" => matches!(
+            unwrap_transparent_expr(m.obj.as_ref()),
+            ast::Expr::Ident(i) if i.sym.as_ref() == "Iterator"
+        ),
+        // Lazy helpers preserve the helper — recurse into the receiver.
+        "map" | "filter" | "take" | "drop" | "flatMap" => {
+            chain_roots_at_iterator_from(&m.obj)
+        }
+        _ => false,
+    }
+}
+
 use super::super::{
     extract_typed_parse_source_order, is_generator_call_expr, is_widget_modifier_name, lower_expr,
     resolve_typed_parse_ty, LoweringContext,
@@ -351,7 +387,9 @@ pub(super) fn try_array_only_methods(
                 // transforms return a Readable, not an array, so `js_array_map`
                 // would read garbage out of the stream object's header. Bail to
                 // dynamic dispatch so the runtime's iterator-helper stubs run.
-                let recv_is_class = recv_is_class || chain_roots_at_stream(member_obj);
+                let recv_is_class = recv_is_class
+                    || chain_roots_at_stream(member_obj)
+                    || chain_roots_at_iterator_from(member_obj);
                 match method_name {
                     "reduce" if !args.is_empty() && !recv_is_class => {
                         let array_expr = lower_expr(ctx, &member.obj)?;

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -130,9 +130,7 @@ fn chain_roots_at_iterator_from(expr: &ast::Expr) -> bool {
             ast::Expr::Ident(i) if i.sym.as_ref() == "Iterator"
         ),
         // Lazy helpers preserve the helper — recurse into the receiver.
-        "map" | "filter" | "take" | "drop" | "flatMap" => {
-            chain_roots_at_iterator_from(&m.obj)
-        }
+        "map" | "filter" | "take" | "drop" | "flatMap" => chain_roots_at_iterator_from(&m.obj),
         _ => false,
     }
 }

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1372,3 +1372,52 @@ pub(super) fn try_bare_regexp_call(
     }
     Ok(None)
 }
+
+/// #2874: `Iterator.from(x)` — wrap an iterable in a lazy iterator-helper
+/// object. Only fires when `Iterator` is the global (not a local/func/import).
+/// The produced helper's `.map`/`.filter`/`.take`/etc. dispatch at runtime via
+/// `js_native_call_method`, so no further HIR variants are needed.
+pub(super) fn try_iterator_from(
+    ctx: &mut LoweringContext,
+    call: &ast::CallExpr,
+    has_spread: bool,
+) -> Result<Option<Expr>> {
+    if has_spread {
+        return Ok(None);
+    }
+    let ast::Callee::Expr(callee_expr) = &call.callee else {
+        return Ok(None);
+    };
+    let mut callee = callee_expr.as_ref();
+    while let ast::Expr::Paren(p) = callee {
+        callee = p.expr.as_ref();
+    }
+    let ast::Expr::Member(member) = callee else {
+        return Ok(None);
+    };
+    let ast::MemberProp::Ident(prop) = &member.prop else {
+        return Ok(None);
+    };
+    if prop.sym.as_ref() != "from" {
+        return Ok(None);
+    }
+    let mut obj = member.obj.as_ref();
+    while let ast::Expr::Paren(p) = obj {
+        obj = p.expr.as_ref();
+    }
+    let ast::Expr::Ident(obj_ident) = obj else {
+        return Ok(None);
+    };
+    if obj_ident.sym.as_ref() != "Iterator"
+        || ctx.lookup_local("Iterator").is_some()
+        || ctx.lookup_func("Iterator").is_some()
+    {
+        return Ok(None);
+    }
+    let arg = if call.args.is_empty() {
+        Expr::Undefined
+    } else {
+        lower_expr(ctx, &call.args[0].expr)?
+    };
+    Ok(Some(Expr::IteratorFrom(Box::new(arg))))
+}

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -59,7 +59,7 @@ use imported_array_methods::try_imported_array_methods;
 use inline_array_methods::try_inline_array_methods;
 use intrinsics::{
     check_eval_function_call, try_bare_regexp_call, try_builtin_prototype_method_apply_call,
-    try_embed_wasm, try_function_return_this, try_iife_call_rewrite,
+    try_embed_wasm, try_function_return_this, try_iife_call_rewrite, try_iterator_from,
     try_namespace_static_method_apply_call_bind, try_native_arena_intrinsics,
     try_native_arena_public_api, try_native_memory_public_api, try_native_module_method_apply_call,
     try_pod_layout_constants, try_precompile, try_require_literal_bail,
@@ -205,6 +205,10 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
     // runtime-unknown bucket; otherwise logs + falls through.
     check_eval_function_call(ctx, call)?;
     if let Some(expr) = try_bare_regexp_call(ctx, call, has_spread)? {
+        return Ok(expr);
+    }
+    // #2874: `Iterator.from(x)` — wrap an iterable in a lazy iterator-helper.
+    if let Some(expr) = try_iterator_from(ctx, call, has_spread)? {
         return Ok(expr);
     }
 

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -589,6 +589,14 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                     if id.sym.as_ref() == "Function" && ctx.lookup_local("Function").is_none() {
                         return Ok(Expr::String("function".to_string()));
                     }
+                    // #2874: global `Iterator` (TC39 iterator-helpers) is a
+                    // constructor function in Node 22+.
+                    if id.sym.as_ref() == "Iterator"
+                        && ctx.lookup_local("Iterator").is_none()
+                        && ctx.lookup_func("Iterator").is_none()
+                    {
+                        return Ok(Expr::String("function".to_string()));
+                    }
                     // #1454: global timer builtins (+ fetch) are functions, but
                     // a bare read lowers to an ExternFuncRef whose typeof reads
                     // "boolean". Fold to "function" (gc is excluded — it's

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -505,6 +505,7 @@ impl SH for Expr {
             Expr::ObjectRest { object, exclude_keys, } => { tag(h, 395); object.as_ref().hash(h); exclude_keys.hash(h); }
             Expr::ArrayIsArray(e) => { tag(h, 396); e.as_ref().hash(h); }
             Expr::ArrayFrom(e) => { tag(h, 397); e.as_ref().hash(h); }
+            Expr::IteratorFrom(e) => { tag(h, 12270); e.as_ref().hash(h); }
             Expr::IteratorToArray(e) => { tag(h, 398); e.as_ref().hash(h); }
             Expr::GetIterator(e) => { tag(h, 11238); e.as_ref().hash(h); }
             Expr::ForOfToArray(e) => { tag(h, 11243); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -233,6 +233,7 @@ where
         | Expr::StaticPluginResolve(v)
         | Expr::ArrayIsArray(v)
         | Expr::ArrayFrom(v)
+        | Expr::IteratorFrom(v)
         | Expr::IteratorToArray(v)
         | Expr::GetIterator(v)
         | Expr::ForOfToArray(v)

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -234,6 +234,7 @@ where
         | Expr::StaticPluginResolve(v)
         | Expr::ArrayIsArray(v)
         | Expr::ArrayFrom(v)
+        | Expr::IteratorFrom(v)
         | Expr::IteratorToArray(v)
         | Expr::GetIterator(v)
         | Expr::ForOfToArray(v)

--- a/crates/perry-runtime/src/array/flat_clone.rs
+++ b/crates/perry-runtime/src/array/flat_clone.rs
@@ -327,7 +327,11 @@ pub extern "C" fn js_array_clone(src: *const ArrayHeader) -> *mut ArrayHeader {
                 // `Array.from(s.values())` drive the iterator protocol.
                 let is_array_iterator = (*obj).class_id == ARRAY_ITERATOR_CLASS_ID
                     || (*obj).class_id == crate::collection_iter_object::MAP_ITERATOR_CLASS_ID
-                    || (*obj).class_id == crate::collection_iter_object::SET_ITERATOR_CLASS_ID;
+                    || (*obj).class_id == crate::collection_iter_object::SET_ITERATOR_CLASS_ID
+                    // #2874: lazy iterator-helper objects (`Iterator.from(x).map(f)`)
+                    // dispatch `.next()` via class id, so `[...it]` / `Array.from(it)`
+                    // must drive the iterator protocol.
+                    || (*obj).class_id == crate::iterator_helpers::ITERATOR_HELPER_CLASS_ID;
                 let is_iterable = is_array_iterator || {
                     let iter_sym = crate::symbol::well_known_symbol("iterator");
                     if iter_sym.is_null() {

--- a/crates/perry-runtime/src/iterator_helpers.rs
+++ b/crates/perry-runtime/src/iterator_helpers.rs
@@ -304,6 +304,63 @@ unsafe fn helper_to_array(obj: *mut ObjectHeader) -> f64 {
     js_nanbox_pointer(arr as i64)
 }
 
+/// Is `name` one of the iterator-helper method names?
+pub fn is_iterator_helper_method(name: &str) -> bool {
+    matches!(
+        name,
+        "map"
+            | "filter"
+            | "take"
+            | "drop"
+            | "flatMap"
+            | "toArray"
+            | "forEach"
+            | "reduce"
+            | "some"
+            | "every"
+            | "find"
+    )
+}
+
+/// #2874: when a method call lands on a RAW iterator object (a generator, a
+/// Map/Set/array iterator, or any `{ next() }`) for an iterator-helper method
+/// it doesn't define as an own property, Node resolves it on
+/// `Iterator.prototype`. Wrap the iterator in an identity helper and dispatch
+/// there. Returns `Some(result)` when handled, `None` to fall through.
+///
+/// `has_own` reports whether `obj` defines `method_name` as an own callable
+/// field (in which case the user's own method wins and we must NOT intercept).
+pub unsafe fn maybe_dispatch_helper_on_iterator(
+    obj: *mut ObjectHeader,
+    method_name: &str,
+    args_ptr: *const f64,
+    args_len: usize,
+    has_own_field: bool,
+) -> Option<f64> {
+    if has_own_field || !is_iterator_helper_method(method_name) {
+        return None;
+    }
+    // Only intercept genuine iterators: those exposing a callable `.next`.
+    let next_key = js_string_from_bytes(b"next".as_ptr(), 4);
+    let next_val = js_object_get_field_by_name(obj, next_key);
+    if next_val.is_undefined() {
+        return None;
+    }
+    let next_ptr = js_nanbox_get_pointer(f64::from_bits(next_val.bits())) as *const ClosureHeader;
+    if next_ptr.is_null() || !is_closure_ptr(next_ptr as usize) {
+        return None;
+    }
+    let self_f64 = js_nanbox_pointer(obj as i64);
+    let wrapped = js_iterator_from(self_f64);
+    let wrapped_ptr = js_nanbox_get_pointer(wrapped) as *mut ObjectHeader;
+    Some(dispatch_iterator_helper_method(
+        wrapped_ptr,
+        method_name,
+        args_ptr,
+        args_len,
+    ))
+}
+
 /// Dispatch a method call on a helper iterator object. `args_ptr`/`args_len`
 /// carry the NaN-boxed call arguments.
 pub unsafe fn dispatch_iterator_helper_method(
@@ -335,12 +392,20 @@ pub unsafe fn dispatch_iterator_helper_method(
         "take" => {
             let n = JSValue::from_bits(arg0.to_bits()).to_number();
             let count = if n.is_nan() { 0.0 } else { n.max(0.0).floor() };
-            alloc_helper(OP_TAKE, self_f64, f64::from_bits(JSValue::number(count).bits()))
+            alloc_helper(
+                OP_TAKE,
+                self_f64,
+                f64::from_bits(JSValue::number(count).bits()),
+            )
         }
         "drop" => {
             let n = JSValue::from_bits(arg0.to_bits()).to_number();
             let count = if n.is_nan() { 0.0 } else { n.max(0.0).floor() };
-            alloc_helper(OP_DROP, self_f64, f64::from_bits(JSValue::number(count).bits()))
+            alloc_helper(
+                OP_DROP,
+                self_f64,
+                f64::from_bits(JSValue::number(count).bits()),
+            )
         }
         // Terminal helpers — drain.
         "toArray" => helper_to_array(obj),

--- a/crates/perry-runtime/src/iterator_helpers.rs
+++ b/crates/perry-runtime/src/iterator_helpers.rs
@@ -1,0 +1,426 @@
+//! Global `Iterator` helper objects (TC39 Iterator-helpers proposal, Node 22+;
+//! issue #2874).
+//!
+//! Node exposes a global `Iterator` (typeof `"function"`) with a static
+//! `Iterator.from(x)` and lazy helper methods on the iterator prototype:
+//! `.map`, `.filter`, `.take`, `.drop`, `.flatMap`, `.toArray`, `.forEach`,
+//! `.reduce`, `.some`, `.every`, `.find`. They operate LAZILY on any
+//! synchronous iterator — generators, the Map/Set/array iterator objects Perry
+//! already builds, or a bare `{ next() }` object.
+//!
+//! Representation mirrors `collection_iter_object.rs`: a regular `ObjectHeader`
+//! with a dedicated class id (`ITERATOR_HELPER_CLASS_ID`). Fields:
+//!   - field 0: source iterator (NaN-boxed; kept alive by the object scanner)
+//!   - field 1: op kind (number; see `OP_*` below)
+//!   - field 2: callback closure (NaN-boxed) for map/filter/flatMap, or the
+//!     numeric limit/count for take/drop
+//!   - field 3: mutable state — remaining count for take, drop-counter for
+//!     drop, an inner sub-iterator for flatMap (NaN-boxed pointer or 0).
+//!
+//! Each `.next()` pulls lazily from the source via [`iterator_step`], which
+//! drives the generic `.next()` protocol on ANY iterator object (stored-closure
+//! `next` field OR class-id method dispatch). Lazy chaining means `.take(2)` on
+//! an infinite generator terminates. Terminal methods (`toArray`/`forEach`/
+//! `reduce`/`some`/`every`/`find`) drain the chain.
+//!
+//! Dispatch lives in `object/native_call_method.rs` via the class-id check next
+//! to the Map/Set iterator ones.
+
+use crate::closure::{is_closure_ptr, js_closure_call1, js_closure_call2, ClosureHeader};
+use crate::object::{
+    js_object_alloc, js_object_get_field, js_object_get_field_by_name, js_object_set_field,
+    ObjectHeader,
+};
+use crate::string::js_string_from_bytes;
+use crate::value::{js_nanbox_get_pointer, js_nanbox_pointer, JSValue, TAG_TRUE, TAG_UNDEFINED};
+
+/// Class id reserved for lazy iterator-helper objects. Sits just past the
+/// Set iterator id (0xFFFF0008).
+pub const ITERATOR_HELPER_CLASS_ID: u32 = 0xFFFF_0009;
+
+// Op kinds stored in field 1.
+const OP_IDENTITY: i32 = 0; // `Iterator.from(x)` — yields the source unchanged.
+const OP_MAP: i32 = 1;
+const OP_FILTER: i32 = 2;
+const OP_TAKE: i32 = 3;
+const OP_DROP: i32 = 4;
+const OP_FLATMAP: i32 = 5;
+
+pub fn is_iterator_helper_addr(addr: usize) -> bool {
+    if addr < 0x1000 || (addr as u64) >> 48 != 0 {
+        return false;
+    }
+    unsafe {
+        let gc_header =
+            (addr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        if (*gc_header).obj_type != crate::gc::GC_TYPE_OBJECT {
+            return false;
+        }
+        (*(addr as *const ObjectHeader)).class_id == ITERATOR_HELPER_CLASS_ID
+    }
+}
+
+/// Build the `{ value, done }` iterator-result object. Mirrors
+/// `collection_iter_object.rs::make_iter_result`.
+unsafe fn make_iter_result(value: JSValue, done: bool) -> f64 {
+    let obj = js_object_alloc(0, 2);
+    let value_key = js_string_from_bytes(b"value".as_ptr(), 5);
+    let done_key = js_string_from_bytes(b"done".as_ptr(), 4);
+    let keys = crate::array::js_array_alloc(2);
+    crate::array::js_array_push(keys, JSValue::string_ptr(value_key));
+    crate::array::js_array_push(keys, JSValue::string_ptr(done_key));
+    crate::object::js_object_set_keys(obj, keys);
+    js_object_set_field(obj, 0, value);
+    js_object_set_field(
+        obj,
+        1,
+        if done {
+            JSValue::from_bits(TAG_TRUE)
+        } else {
+            JSValue::from_bits(crate::value::TAG_FALSE)
+        },
+    );
+    js_nanbox_pointer(obj as i64)
+}
+
+/// Drive one `.next()` step on ANY iterator object. Returns `(value, done)`.
+/// Mirrors the dual dispatch in `array/iterator.rs::js_iterator_to_array`:
+/// prefer a stored `next` closure FIELD (generators / bare `{next}` objects),
+/// else fall back to class-id method dispatch (array / Map / Set / helper
+/// iterators).
+unsafe fn iterator_step(iter_f64: f64) -> (f64, bool) {
+    let iter_ptr = js_nanbox_get_pointer(iter_f64);
+    if iter_ptr == 0 {
+        return (f64::from_bits(TAG_UNDEFINED), true);
+    }
+    let iter_obj = iter_ptr as *const ObjectHeader;
+
+    let next_key = js_string_from_bytes(b"next".as_ptr(), 4);
+    let next_val = js_object_get_field_by_name(iter_obj, next_key);
+    let next_ptr = if next_val.is_undefined() {
+        std::ptr::null::<ClosureHeader>()
+    } else {
+        js_nanbox_get_pointer(f64::from_bits(next_val.bits())) as *const ClosureHeader
+    };
+    let use_field = !next_ptr.is_null() && is_closure_ptr(next_ptr as usize);
+
+    let result_f64 = if use_field {
+        js_closure_call1(next_ptr, f64::from_bits(TAG_UNDEFINED))
+    } else {
+        crate::object::js_native_call_method(
+            iter_f64,
+            b"next".as_ptr() as *const i8,
+            4,
+            std::ptr::null(),
+            0,
+        )
+    };
+
+    let result_ptr = js_nanbox_get_pointer(result_f64);
+    if result_ptr == 0 {
+        return (f64::from_bits(TAG_UNDEFINED), true);
+    }
+    let result_obj = result_ptr as *const ObjectHeader;
+    let done_key = js_string_from_bytes(b"done".as_ptr(), 4);
+    let value_key = js_string_from_bytes(b"value".as_ptr(), 5);
+    let done_val = js_object_get_field_by_name(result_obj, done_key);
+    let done = crate::value::js_is_truthy(f64::from_bits(done_val.bits())) != 0;
+    let val = js_object_get_field_by_name(result_obj, value_key);
+    (f64::from_bits(val.bits()), done)
+}
+
+/// Get the iterator of an iterable value (array / generator / Map/Set iterator
+/// object / anything with `[Symbol.iterator]` or a `.next`). Reuses
+/// `js_get_iterator`, which already returns the value unchanged when it is
+/// itself an iterator object.
+unsafe fn get_iterator(val_f64: f64) -> f64 {
+    crate::symbol::js_get_iterator(val_f64)
+}
+
+/// Extract a closure pointer from a NaN-boxed value, or null.
+unsafe fn closure_ptr(val_f64: f64) -> *const ClosureHeader {
+    let p = js_nanbox_get_pointer(val_f64) as *const ClosureHeader;
+    if !p.is_null() && is_closure_ptr(p as usize) {
+        p
+    } else {
+        std::ptr::null()
+    }
+}
+
+unsafe fn alloc_helper(op: i32, source: f64, arg: f64) -> f64 {
+    let obj = js_object_alloc(ITERATOR_HELPER_CLASS_ID, 4);
+    js_object_set_field(obj, 0, JSValue::from_bits(source.to_bits()));
+    js_object_set_field(obj, 1, JSValue::number(op as f64));
+    js_object_set_field(obj, 2, JSValue::from_bits(arg.to_bits()));
+    // Field 3: mutable state. take/drop seed it from the count; flatMap seeds
+    // the inner sub-iterator slot to 0 (none yet).
+    let state = match op {
+        OP_TAKE | OP_DROP => arg,
+        _ => f64::from_bits(TAG_UNDEFINED),
+    };
+    js_object_set_field(obj, 3, JSValue::from_bits(state.to_bits()));
+    js_nanbox_pointer(obj as i64)
+}
+
+/// `Iterator.from(x)` — wrap any iterable/iterator in an identity helper so the
+/// helper methods are available. Returns a NaN-boxed pointer.
+#[no_mangle]
+pub extern "C" fn js_iterator_from(val_f64: f64) -> f64 {
+    unsafe {
+        let source = get_iterator(val_f64);
+        // If the source is already one of our helper objects, hand it back
+        // unchanged (Node returns the iterator itself when it already inherits
+        // from Iterator.prototype).
+        let p = js_nanbox_get_pointer(source);
+        if p != 0 && is_iterator_helper_addr(p as usize) {
+            return source;
+        }
+        alloc_helper(OP_IDENTITY, source, f64::from_bits(TAG_UNDEFINED))
+    }
+}
+
+#[used]
+static KEEP_ITERATOR_FROM: extern "C" fn(f64) -> f64 = js_iterator_from;
+
+/// `.next()` on a helper iterator object. Pulls lazily from the source per the
+/// op kind.
+unsafe fn helper_next(obj: *mut ObjectHeader) -> f64 {
+    let source = f64::from_bits(js_object_get_field(obj, 0).bits());
+    let op = f64::from_bits(js_object_get_field(obj, 1).bits()) as i32;
+    let arg = f64::from_bits(js_object_get_field(obj, 2).bits());
+
+    match op {
+        OP_IDENTITY => {
+            let (v, done) = iterator_step(source);
+            make_iter_result(JSValue::from_bits(v.to_bits()), done)
+        }
+        OP_MAP => {
+            let cb = closure_ptr(arg);
+            let (v, done) = iterator_step(source);
+            if done {
+                return make_iter_result(JSValue::undefined(), true);
+            }
+            let mapped = if cb.is_null() {
+                v
+            } else {
+                js_closure_call1(cb, v)
+            };
+            make_iter_result(JSValue::from_bits(mapped.to_bits()), false)
+        }
+        OP_FILTER => {
+            let cb = closure_ptr(arg);
+            loop {
+                let (v, done) = iterator_step(source);
+                if done {
+                    return make_iter_result(JSValue::undefined(), true);
+                }
+                let keep = if cb.is_null() {
+                    true
+                } else {
+                    crate::value::js_is_truthy(js_closure_call1(cb, v)) != 0
+                };
+                if keep {
+                    return make_iter_result(JSValue::from_bits(v.to_bits()), false);
+                }
+            }
+        }
+        OP_TAKE => {
+            let remaining = f64::from_bits(js_object_get_field(obj, 3).bits());
+            if !(remaining > 0.0) {
+                return make_iter_result(JSValue::undefined(), true);
+            }
+            js_object_set_field(obj, 3, JSValue::number(remaining - 1.0));
+            let (v, done) = iterator_step(source);
+            if done {
+                return make_iter_result(JSValue::undefined(), true);
+            }
+            make_iter_result(JSValue::from_bits(v.to_bits()), false)
+        }
+        OP_DROP => {
+            // Drop the first N (once), then passthrough.
+            let mut to_drop = f64::from_bits(js_object_get_field(obj, 3).bits());
+            while to_drop > 0.0 {
+                let (_v, done) = iterator_step(source);
+                if done {
+                    js_object_set_field(obj, 3, JSValue::number(0.0));
+                    return make_iter_result(JSValue::undefined(), true);
+                }
+                to_drop -= 1.0;
+            }
+            js_object_set_field(obj, 3, JSValue::number(0.0));
+            let (v, done) = iterator_step(source);
+            make_iter_result(JSValue::from_bits(v.to_bits()), done)
+        }
+        OP_FLATMAP => {
+            let cb = closure_ptr(arg);
+            loop {
+                // Drain the current inner sub-iterator first.
+                let inner = f64::from_bits(js_object_get_field(obj, 3).bits());
+                let inner_ptr = js_nanbox_get_pointer(inner);
+                if inner_ptr != 0 {
+                    let (v, done) = iterator_step(inner);
+                    if !done {
+                        return make_iter_result(JSValue::from_bits(v.to_bits()), false);
+                    }
+                    // Inner exhausted — clear and pull the next outer value.
+                    js_object_set_field(obj, 3, JSValue::from_bits(TAG_UNDEFINED));
+                }
+                let (v, done) = iterator_step(source);
+                if done {
+                    return make_iter_result(JSValue::undefined(), true);
+                }
+                let produced = if cb.is_null() {
+                    v
+                } else {
+                    js_closure_call1(cb, v)
+                };
+                // Per spec each produced value must itself be iterable; wrap it.
+                let inner_iter = get_iterator(produced);
+                js_object_set_field(obj, 3, JSValue::from_bits(inner_iter.to_bits()));
+            }
+        }
+        _ => make_iter_result(JSValue::undefined(), true),
+    }
+}
+
+/// Drain the helper iterator fully into a `*mut ArrayHeader` (NaN-box yourself).
+unsafe fn helper_to_array(obj: *mut ObjectHeader) -> f64 {
+    let mut arr = crate::array::js_array_alloc(8);
+    for _ in 0..100_000_000usize {
+        let res = helper_next(obj);
+        let res_ptr = js_nanbox_get_pointer(res);
+        if res_ptr == 0 {
+            break;
+        }
+        let done = crate::value::js_is_truthy(f64::from_bits(
+            js_object_get_field(res_ptr as *mut ObjectHeader, 1).bits(),
+        )) != 0;
+        if done {
+            break;
+        }
+        let v = f64::from_bits(js_object_get_field(res_ptr as *mut ObjectHeader, 0).bits());
+        arr = crate::array::js_array_push_f64(arr, v);
+    }
+    js_nanbox_pointer(arr as i64)
+}
+
+/// Dispatch a method call on a helper iterator object. `args_ptr`/`args_len`
+/// carry the NaN-boxed call arguments.
+pub unsafe fn dispatch_iterator_helper_method(
+    obj: *mut ObjectHeader,
+    method_name: &str,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
+    let self_f64 = js_nanbox_pointer(obj as i64);
+    let arg0 = if args_len >= 1 && !args_ptr.is_null() {
+        *args_ptr
+    } else {
+        f64::from_bits(TAG_UNDEFINED)
+    };
+    let arg1 = if args_len >= 2 && !args_ptr.is_null() {
+        *args_ptr.add(1)
+    } else {
+        f64::from_bits(TAG_UNDEFINED)
+    };
+
+    match method_name {
+        "next" => helper_next(obj),
+        "Symbol.iterator" | "@@iterator" => self_f64,
+        "return" | "throw" => make_iter_result(JSValue::undefined(), true),
+        // Lazy helpers — return a new helper wrapping `self`.
+        "map" => alloc_helper(OP_MAP, self_f64, arg0),
+        "filter" => alloc_helper(OP_FILTER, self_f64, arg0),
+        "flatMap" => alloc_helper(OP_FLATMAP, self_f64, arg0),
+        "take" => {
+            let n = JSValue::from_bits(arg0.to_bits()).to_number();
+            let count = if n.is_nan() { 0.0 } else { n.max(0.0).floor() };
+            alloc_helper(OP_TAKE, self_f64, f64::from_bits(JSValue::number(count).bits()))
+        }
+        "drop" => {
+            let n = JSValue::from_bits(arg0.to_bits()).to_number();
+            let count = if n.is_nan() { 0.0 } else { n.max(0.0).floor() };
+            alloc_helper(OP_DROP, self_f64, f64::from_bits(JSValue::number(count).bits()))
+        }
+        // Terminal helpers — drain.
+        "toArray" => helper_to_array(obj),
+        "forEach" => {
+            let cb = closure_ptr(arg0);
+            let mut i = 0.0f64;
+            loop {
+                let (v, done) = iterator_step(self_f64);
+                if done {
+                    break;
+                }
+                if !cb.is_null() {
+                    js_closure_call2(cb, v, f64::from_bits(JSValue::number(i).bits()));
+                }
+                i += 1.0;
+            }
+            f64::from_bits(TAG_UNDEFINED)
+        }
+        "reduce" => {
+            let cb = closure_ptr(arg0);
+            let has_init = args_len >= 2;
+            let mut acc = arg1;
+            let mut started = has_init;
+            loop {
+                let (v, done) = iterator_step(self_f64);
+                if done {
+                    break;
+                }
+                if !started {
+                    acc = v;
+                    started = true;
+                    continue;
+                }
+                if !cb.is_null() {
+                    acc = js_closure_call2(cb, acc, v);
+                }
+            }
+            if !started {
+                // No init + empty iterator → TypeError in spec; return undefined
+                // (Perry avoids throwing from this internal helper).
+                return f64::from_bits(TAG_UNDEFINED);
+            }
+            acc
+        }
+        "some" => {
+            let cb = closure_ptr(arg0);
+            loop {
+                let (v, done) = iterator_step(self_f64);
+                if done {
+                    return f64::from_bits(crate::value::TAG_FALSE);
+                }
+                if !cb.is_null() && crate::value::js_is_truthy(js_closure_call1(cb, v)) != 0 {
+                    return f64::from_bits(TAG_TRUE);
+                }
+            }
+        }
+        "every" => {
+            let cb = closure_ptr(arg0);
+            loop {
+                let (v, done) = iterator_step(self_f64);
+                if done {
+                    return f64::from_bits(TAG_TRUE);
+                }
+                if !cb.is_null() && crate::value::js_is_truthy(js_closure_call1(cb, v)) == 0 {
+                    return f64::from_bits(crate::value::TAG_FALSE);
+                }
+            }
+        }
+        "find" => {
+            let cb = closure_ptr(arg0);
+            loop {
+                let (v, done) = iterator_step(self_f64);
+                if done {
+                    return f64::from_bits(TAG_UNDEFINED);
+                }
+                if !cb.is_null() && crate::value::js_is_truthy(js_closure_call1(cb, v)) != 0 {
+                    return f64::from_bits(v.to_bits());
+                }
+            }
+        }
+        _ => f64::from_bits(TAG_UNDEFINED),
+    }
+}

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -48,6 +48,7 @@ pub mod ffi;
 pub mod frame;
 pub mod fs;
 pub mod gc;
+pub mod iterator_helpers;
 pub mod map;
 pub mod math;
 pub mod native_abi;

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1902,6 +1902,17 @@ pub unsafe extern "C" fn js_native_call_method(
                     method_name,
                 );
             }
+            // #2874: lazy iterator-helper objects (`Iterator.from(x)` and the
+            // chain it produces: `.map`/`.filter`/`.take`/`.drop`/`.flatMap`/
+            // `.toArray`/`.forEach`/`.reduce`/`.some`/`.every`/`.find`/`.next`).
+            if (*obj).class_id == crate::iterator_helpers::ITERATOR_HELPER_CLASS_ID {
+                return crate::iterator_helpers::dispatch_iterator_helper_method(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                    args_ptr,
+                    args_len,
+                );
+            }
 
             // Scan object fields for a callable property (closure stored via IndexSet)
             let keys = (*obj).keys_array;
@@ -2347,6 +2358,15 @@ pub unsafe extern "C" fn js_native_call_method(
                 return crate::collection_iter_object::dispatch_set_iterator_method(
                     obj as *mut ObjectHeader,
                     method_name,
+                );
+            }
+            // #2874: lazy iterator-helper objects, same as the NaN-boxed path.
+            if (*obj).class_id == crate::iterator_helpers::ITERATOR_HELPER_CLASS_ID {
+                return crate::iterator_helpers::dispatch_iterator_helper_method(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                    args_ptr,
+                    args_len,
                 );
             }
 

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1914,6 +1914,35 @@ pub unsafe extern "C" fn js_native_call_method(
                 );
             }
 
+            // #2874: an iterator-helper method (`map`/`filter`/`take`/…) on a
+            // RAW iterator object — a generator, the runtime array/Map/Set
+            // iterators, or any `{ next() }`. Node resolves these on
+            // `Iterator.prototype`; wrap the iterator in an identity helper and
+            // dispatch there. Skipped when the object defines the name as an own
+            // callable field (the user's own method wins). Runs before the
+            // own-field scan so the cheap has-own check below stays in sync.
+            if crate::iterator_helpers::is_iterator_helper_method(method_name) {
+                let has_own = {
+                    let mk = crate::string::js_string_from_bytes(
+                        method_name.as_ptr(),
+                        method_name.len() as u32,
+                    );
+                    let fv = js_object_get_field_by_name(obj as *const _, mk);
+                    let fp =
+                        crate::value::js_nanbox_get_pointer(f64::from_bits(fv.bits())) as usize;
+                    !fv.is_undefined() && crate::closure::is_closure_ptr(fp)
+                };
+                if let Some(result) = crate::iterator_helpers::maybe_dispatch_helper_on_iterator(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                    args_ptr,
+                    args_len,
+                    has_own,
+                ) {
+                    return result;
+                }
+            }
+
             // Scan object fields for a callable property (closure stored via IndexSet)
             let keys = (*obj).keys_array;
             if !keys.is_null() {

--- a/test-files/test_gap_iterator_helpers_2874.ts
+++ b/test-files/test_gap_iterator_helpers_2874.ts
@@ -1,0 +1,51 @@
+// #2874: global Iterator + iterator helper methods (TC39 iterator-helpers).
+
+function* gen() {
+  yield 1;
+  yield 2;
+  yield 3;
+}
+
+// typeof surface
+console.log(typeof Iterator);
+console.log(typeof Iterator.from);
+
+// Iterator.from + toArray
+console.log(Iterator.from([1, 2, 3]).toArray());
+
+// map over a generator, spread the result
+console.log([...gen().map((x) => x * 2)]);
+
+// filter
+console.log(Iterator.from([1, 2, 3]).filter((x) => x > 1).toArray());
+
+// chained map + filter + spread
+console.log([...Iterator.from([1, 2, 3, 4]).map((x) => x * 2).filter((x) => x > 4)]);
+
+// take
+console.log(Iterator.from([1, 2, 3, 4, 5]).take(2).toArray());
+
+// drop
+console.log(Iterator.from([1, 2, 3, 4, 5]).drop(1).toArray());
+
+// take after a lazy chain over a generator
+console.log([...gen().filter((x) => x >= 2).take(1)]);
+
+// reduce
+console.log(Iterator.from([1, 2, 3]).reduce((a, b) => a + b, 0));
+console.log(Iterator.from([1, 2, 3, 4]).reduce((a, b) => a + b));
+
+// some / every / find
+console.log(Iterator.from([1, 2, 3]).some((x) => x === 2));
+console.log(Iterator.from([1, 2, 3]).every((x) => x > 0));
+console.log(Iterator.from([1, 2, 3]).find((x) => x > 1));
+
+// flatMap
+console.log(Iterator.from([1, 2]).flatMap((x) => [x, x * 10]).toArray());
+
+// forEach
+let sum = 0;
+Iterator.from([1, 2, 3]).forEach((x) => {
+  sum += x;
+});
+console.log(sum);


### PR DESCRIPTION
Closes #2874

## Implementation

Adds the TC39 Iterator-helpers surface (Node 22+): a global `Iterator`
(typeof `"function"`), `Iterator.from(x)`, and the lazy iterator-helper methods
that operate on **any** synchronous iterator — generators, the Map/Set/array
iterator objects Perry already builds, and bare `{ next() }` objects.

**New runtime module** `crates/perry-runtime/src/iterator_helpers.rs`:
- A lazy iterator-helper object (`ITERATOR_HELPER_CLASS_ID = 0xFFFF_0009`),
  fields = `{ source iterator, op-kind, callback/count, mutable state }`.
- `iterator_step()` drives the generic `.next()` protocol on any iterator
  (stored-closure `next` field OR class-id method dispatch — same dual path as
  `js_iterator_to_array`), so chains compose over generators and the existing
  Map/Set/array iterator objects.
- `js_iterator_from(x)` (`#[no_mangle]` + `#[used]` keepalive anchor) wraps an
  iterable in an identity helper.
- `dispatch_iterator_helper_method()` handles `next`/`Symbol.iterator`/`return`/
  `throw` plus the helpers: lazy `map`/`filter`/`take`/`drop`/`flatMap` return a
  new helper wrapping `self`; terminal `toArray`/`forEach`/`reduce`/`some`/
  `every`/`find` drain the chain. Laziness means `.take(n)` terminates on an
  infinite generator.
- `maybe_dispatch_helper_on_iterator()` lets a helper method called on a RAW
  iterator (e.g. `gen().map(f)`) resolve as if on `Iterator.prototype` — only
  when the object exposes a callable `.next` and does not define the method as
  an own field (the user's own method always wins).

**Dispatch wiring**: class-id checks in `object/native_call_method.rs` (both the
NaN-boxed and raw-pointer paths) and `array/flat_clone.rs` so `[...it]` /
`Array.from(it)` drive the iterator protocol.

**HIR/codegen**: one new variant `Expr::IteratorFrom` (stable-hash tag 12270)
lowered from `Iterator.from(x)` in `try_iterator_from`; codegen emits
`js_iterator_from`. The helper *methods* need no HIR variants — they dispatch at
runtime through `js_native_call_method`. `chain_roots_at_iterator_from` mirrors
the existing `chain_roots_at_stream` guard so a chained `Iterator.from(x).map().
filter()` stays on dynamic dispatch instead of being mis-folded to
`Expr::ArrayMap`. `typeof Iterator` and `typeof Iterator.from` fold to
`"function"`.

Nothing dropped — all helpers from the issue are implemented, lazily.

## Validation

Gap test `test-files/test_gap_iterator_helpers_2874.ts` (typeof surface,
`Iterator.from(...).toArray()`, `[...gen().map()]`, filter, chained map+filter,
take, drop, take-over-lazy-generator-chain, reduce with/without init, some/every/
find, flatMap, forEach) is **byte-identical** to
`node --experimental-strip-types` under the DEFAULT auto-optimize compile.

Regression-checked: plain `arr.map/filter`, a custom class with its own `.map`,
and `[...map.keys()]` are unchanged vs node.

Guards green: `cargo test -p perry-runtime` (925), `cargo test -p perry-hir`
(incl. `expr_variant_stable_hash_tags_are_unique`), `./scripts/check_file_size.sh`,
`cargo fmt --all -- --check`.
