### PR TITLE
fix(node): expose namespace alias gaps

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -576,6 +576,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         TypeSpec::Any,
     ),
     method_sig("net", "Socket", false, None, &[], TypeSpec::Any),
+    method_sig("net", "Stream", false, None, &[], TypeSpec::Any),
     method_sig(
         "net",
         "_normalizeArgs",
@@ -604,6 +605,17 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("net", "destroy", true, Some("Socket")),
     method("net", "on", true, Some("Socket")),
     method("net", "upgradeToTLS", true, Some("Socket")),
+    method("timers", "setTimeout", false, None),
+    method("timers", "clearTimeout", false, None),
+    method("timers", "setImmediate", false, None),
+    method("timers", "clearImmediate", false, None),
+    method("timers", "setInterval", false, None),
+    method("timers", "clearInterval", false, None),
+    property("timers", "promises"),
+    method("timers/promises", "setTimeout", false, None),
+    method("timers/promises", "setImmediate", false, None),
+    method("timers/promises", "setInterval", false, None),
+    property("timers/promises", "scheduler"),
     // Issue #1852 — chainable no-op `net.Socket` option setters. Perry's
     // TCP transport doesn't model Nagle/keep-alive/idle-timeout or read
     // back-pressure yet, but the methods must be callable (and return the
@@ -1483,6 +1495,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // by axios for stream wiring. Values are resolved at runtime by
     // `get_native_module_constant` in `perry-runtime/src/object.rs`.
     property("zlib", "constants"),
+    property("zlib", "codes"),
     class("zlib", "Deflate"),
     class("zlib", "DeflateRaw"),
     class("zlib", "Gzip"),
@@ -2617,6 +2630,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     class("ws", "WebSocketServer"),
     class("ws", "WebSocket"),
     class("net", "Socket"),
+    class("net", "Stream"),
     class("net", "Server"),
     class("ioredis", "Redis"),
     class("mysql2/promise", "Pool"),

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -918,6 +918,19 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         object: Box::new(object_expr),
                         property: property_name,
                     });
+                } else if module_name == "net"
+                    && matches!(class_name.as_str(), "Socket" | "Stream")
+                    && is_net_socket_method_name(&property_name)
+                {
+                    // `new net.Socket().write` / `net.Stream().destroy` are
+                    // method-value reads, not zero-arg native calls. Keep the
+                    // PropertyGet shape so runtime handle-property dispatch
+                    // can bind a callable to the socket handle.
+                    let object_expr = lower_expr(ctx, &member.obj)?;
+                    return Ok(Expr::PropertyGet {
+                        object: Box::new(object_expr),
+                        property: property_name,
+                    });
                 } else if module_name == "console"
                     && class_name == "Console"
                     && is_console_instance_method_name(&property_name)
@@ -1786,6 +1799,40 @@ fn is_classic_stream_method_name(prop: &str) -> bool {
             | "removeAllListeners"
             | "setMaxListeners"
             | "getMaxListeners"
+    )
+}
+
+fn is_net_socket_method_name(prop: &str) -> bool {
+    matches!(
+        prop,
+        "connect"
+            | "write"
+            | "end"
+            | "destroy"
+            | "on"
+            | "addListener"
+            | "once"
+            | "off"
+            | "removeListener"
+            | "removeAllListeners"
+            | "listenerCount"
+            | "eventNames"
+            | "listeners"
+            | "rawListeners"
+            | "address"
+            | "resetAndDestroy"
+            | "setNoDelay"
+            | "setKeepAlive"
+            | "setTimeout"
+            | "setEncoding"
+            | "pause"
+            | "resume"
+            | "ref"
+            | "unref"
+            | "cork"
+            | "uncork"
+            | "setDefaultEncoding"
+            | "upgradeToTLS"
     )
 }
 

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -71,12 +71,12 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
     // instance so subsequent method calls dispatch correctly.
     if let ast::Expr::Member(member) = callee_expr {
         if let (ast::Expr::Ident(obj_ident), ast::MemberProp::Ident(prop_ident)) =
-            (member.obj.as_ref(), &member.prop)
+            (peel_new_callee(member.obj.as_ref()), &member.prop)
         {
             let obj_name = obj_ident.sym.as_ref();
             let is_net_module =
                 obj_name == "net" || ctx.lookup_builtin_module_alias(obj_name) == Some("net");
-            if is_net_module && matches!(prop_ident.sym.as_ref(), "Socket" | "Server") {
+            if is_net_module && matches!(prop_ident.sym.as_ref(), "Socket" | "Stream" | "Server") {
                 let args = new_expr
                     .args
                     .as_ref()
@@ -87,11 +87,16 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                     })
                     .transpose()?
                     .unwrap_or_default();
+                let method = if prop_ident.sym.as_ref() == "Stream" {
+                    "Socket"
+                } else {
+                    prop_ident.sym.as_ref()
+                };
                 return Ok(Expr::NativeMethodCall {
                     module: "net".to_string(),
                     class_name: None,
                     object: None,
-                    method: prop_ident.sym.to_string(),
+                    method: method.to_string(),
                     args,
                 });
             }

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -396,28 +396,47 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                 // falls through to `class_id = 0` — every dynamic
                 // instanceof returns false. Drizzle's `is(value, type)`
                 // chain depends on this. Refs #420 / #618 followup.
-                let ty_expr = if let ast::Expr::Ident(ident) = bin.right.as_ref() {
-                    let name = ident.sym.as_ref();
-                    // A local holding a class ref (drizzle's `is(value, type)`),
-                    // OR a top-level ES5 function constructor (`function Foo(){…}`
-                    // used as `x instanceof Foo`). The latter has no class entry,
-                    // so without a dynamic value codegen resolves `ty = "Foo"` to
-                    // class_id 0 and instanceof always returns false — which makes
-                    // the ubiquitous `if (!(this instanceof Foo)) return new Foo()`
-                    // guard recurse forever. Lower the function to its value and
-                    // route through `js_instanceof_dynamic`, which derives the same
-                    // `synthetic_class_id_for_function` that `new Foo()` stamps onto
-                    // the instance (see js_new_function_construct).
-                    if ctx.lookup_local(name).is_some() || ctx.lookup_func(name).is_some() {
-                        match lower_expr(ctx, &bin.right) {
-                            Ok(e) => Some(Box::new(e)),
-                            Err(_) => None,
+                let ty_expr = match bin.right.as_ref() {
+                    ast::Expr::Ident(ident) => {
+                        let name = ident.sym.as_ref();
+                        // A local holding a class ref (drizzle's `is(value, type)`),
+                        // OR a top-level ES5 function constructor (`function Foo(){…}`
+                        // used as `x instanceof Foo`). The latter has no class entry,
+                        // so without a dynamic value codegen resolves `ty = "Foo"` to
+                        // class_id 0 and instanceof always returns false — which makes
+                        // the ubiquitous `if (!(this instanceof Foo)) return new Foo()`
+                        // guard recurse forever. Lower the function to its value and
+                        // route through `js_instanceof_dynamic`, which derives the same
+                        // `synthetic_class_id_for_function` that `new Foo()` stamps onto
+                        // the instance (see js_new_function_construct).
+                        if ctx.lookup_local(name).is_some() || ctx.lookup_func(name).is_some() {
+                            match lower_expr(ctx, &bin.right) {
+                                Ok(e) => Some(Box::new(e)),
+                                Err(_) => None,
+                            }
+                        } else {
+                            None
                         }
-                    } else {
-                        None
                     }
-                } else {
-                    None
+                    ast::Expr::Member(member) => {
+                        let native_module = if let ast::Expr::Ident(obj_ident) = member.obj.as_ref()
+                        {
+                            let obj_name = obj_ident.sym.as_ref();
+                            ctx.lookup_builtin_module_alias(obj_name).is_some()
+                                || matches!(ctx.lookup_native_module(obj_name), Some((_, None)))
+                        } else {
+                            false
+                        };
+                        if native_module {
+                            match lower_expr(ctx, &bin.right) {
+                                Ok(e) => Some(Box::new(e)),
+                                Err(_) => None,
+                            }
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
                 };
                 return Ok(Expr::InstanceOf { expr, ty, ty_expr });
             }

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -897,6 +897,12 @@ fn ensure_namespace_singleton(submod: &'static SubmoduleSpec) -> *mut ObjectHead
             crate::object::js_object_set_field_by_name(obj, name_header, value);
         }
     }
+    if submod.key == "timers" {
+        let value = crate::object::timers_promises_parent_namespace();
+        let name = b"promises";
+        let name_header = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        crate::object::js_object_set_field_by_name(obj, name_header, value);
+    }
     if submod.key == "trace_events" {
         let default_obj = js_object_alloc(0, submod.exports.len() as u32);
         for spec in submod.exports {
@@ -1077,6 +1083,9 @@ pub unsafe extern "C" fn js_node_submodule_export_as_function(
         let obj = ensure_namespace_singleton(submod);
         return f64::from_bits(JSValue::pointer(obj as *const u8).bits());
     }
+    if submod.key == "timers" && name == "promises" {
+        return crate::object::timers_promises_parent_namespace();
+    }
     if let Some(value) = special_export_value(submod.key, name) {
         return value;
     }
@@ -1142,6 +1151,9 @@ pub unsafe extern "C" fn js_node_submodule_namespace_member(
     if submod.key == "test_reporters" && name == "default" {
         let obj = ensure_namespace_singleton(submod);
         return f64::from_bits(JSValue::pointer(obj as *const u8).bits());
+    }
+    if submod.key == "timers" && name == "promises" {
+        return crate::object::timers_promises_parent_namespace();
     }
     if let Some(value) = special_export_value(submod.key, name) {
         return value;

--- a/crates/perry-runtime/src/object/class_handles.rs
+++ b/crates/perry-runtime/src/object/class_handles.rs
@@ -52,6 +52,10 @@ pub type StreamHandleKindProbeFn = unsafe extern "C" fn(id: usize) -> u8;
 /// as heap objects.
 pub type EventEmitterHandleProbeFn = unsafe extern "C" fn(handle: i64) -> bool;
 
+/// Probe for stdlib `net.Socket` handles. Socket instances are represented as
+/// pointer-tagged small integer handles, not heap objects with class ids.
+pub type NetSocketHandleProbeFn = unsafe extern "C" fn(handle: i64) -> bool;
+
 /// Narrow registration hook for runtime code that needs to attach an
 /// EventEmitter listener without routing through the generic handle dispatcher.
 pub type EventEmitterOnFn = unsafe extern "C" fn(
@@ -71,6 +75,7 @@ static HANDLE_PROPERTY_SET_DISPATCH_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::nul
 static STREAM_HANDLE_PROBE_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 static STREAM_HANDLE_KIND_PROBE_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 static EVENT_EMITTER_HANDLE_PROBE_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
+static NET_SOCKET_HANDLE_PROBE_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 static EVENT_EMITTER_ON_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 
 #[inline]
@@ -156,6 +161,21 @@ pub fn event_emitter_handle_probe() -> Option<EventEmitterHandleProbeFn> {
 #[no_mangle]
 pub unsafe extern "C" fn js_register_event_emitter_handle_probe(f: EventEmitterHandleProbeFn) {
     EVENT_EMITTER_HANDLE_PROBE_PTR.store(f as *mut (), Ordering::Release);
+}
+
+#[inline]
+pub fn net_socket_handle_probe() -> Option<NetSocketHandleProbeFn> {
+    let p = NET_SOCKET_HANDLE_PROBE_PTR.load(Ordering::Acquire);
+    if p.is_null() {
+        None
+    } else {
+        Some(unsafe { std::mem::transmute::<*mut (), NetSocketHandleProbeFn>(p) })
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_register_net_socket_handle_probe(f: NetSocketHandleProbeFn) {
+    NET_SOCKET_HANDLE_PROBE_PTR.store(f as *mut (), Ordering::Release);
 }
 
 #[inline]

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -15,9 +15,10 @@ pub use super::class_handles::{
     handle_property_set_dispatch, js_register_event_emitter_handle_probe,
     js_register_event_emitter_on, js_register_handle_method_dispatch,
     js_register_handle_property_dispatch, js_register_handle_property_set_dispatch,
-    js_register_stream_handle_kind_probe, js_register_stream_handle_probe,
-    stream_handle_kind_probe, stream_handle_probe, EventEmitterHandleProbeFn, EventEmitterOnFn,
-    HandleMethodDispatchFn, HandlePropertyDispatchFn, HandlePropertySetDispatchFn,
+    js_register_net_socket_handle_probe, js_register_stream_handle_kind_probe,
+    js_register_stream_handle_probe, net_socket_handle_probe, stream_handle_kind_probe,
+    stream_handle_probe, EventEmitterHandleProbeFn, EventEmitterOnFn, HandleMethodDispatchFn,
+    HandlePropertyDispatchFn, HandlePropertySetDispatchFn, NetSocketHandleProbeFn,
     StreamHandleKindProbeFn, StreamHandleProbeFn,
 };
 use super::*;

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -9,6 +9,20 @@ use super::*;
 const CLASS_ID_EVENT_EMITTER: u32 = 0xFFFF0076;
 const CLASS_ID_PROMISE: u32 = 0xFFFF0027;
 
+fn small_native_handle_id(value: f64) -> Option<i64> {
+    let bits = value.to_bits();
+    if (bits & crate::value::TAG_MASK) == crate::value::POINTER_TAG {
+        let raw = (bits & crate::value::POINTER_MASK) as i64;
+        if raw > 0 && raw < 0x100000 {
+            return Some(raw);
+        }
+    }
+    if value.is_finite() && value > 0.0 && value.fract() == 0.0 && value < 0x100000 as f64 {
+        return Some(value as i64);
+    }
+    None
+}
+
 /// v0.5.749: dynamic instanceof — `value instanceof type` where the
 /// type is a runtime value (function arg holding a class ref). Extracts
 /// the class_id from the INT32 NaN-tag (top16=0x7FFE) and dispatches to
@@ -56,6 +70,16 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
             && crate::tty::is_tty_stream_instance(value, method.as_str())
         {
             return f64::from_bits(crate::value::TAG_TRUE);
+        }
+        if module == "net" && method == "Socket" {
+            if let (Some(handle), Some(probe)) = (
+                small_native_handle_id(value),
+                crate::object::net_socket_handle_probe(),
+            ) {
+                if unsafe { probe(handle) } {
+                    return f64::from_bits(crate::value::TAG_TRUE);
+                }
+            }
         }
         if module == "console"
             && method == "Console"

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -17,6 +17,8 @@ thread_local! {
     static UTIL_INSPECT_DEFAULT_OPTIONS: Cell<u64> = const { Cell::new(0) };
     static UTIL_INSPECT_STYLES: Cell<u64> = const { Cell::new(0) };
     static UTIL_INSPECT_COLORS: Cell<u64> = const { Cell::new(0) };
+    static TIMERS_PROMISES_PARENT_NAMESPACE: Cell<u64> = const { Cell::new(0) };
+    static ZLIB_CODES_OBJECT: Cell<u64> = const { Cell::new(0) };
     static NATIVE_MODULE_NAMESPACES: RefCell<HashMap<String, u64>> =
         RefCell::new(HashMap::new());
 }
@@ -50,6 +52,20 @@ pub fn scan_native_callable_export_roots_mut(visitor: &mut crate::gc::RuntimeRoo
         }
     });
     UTIL_INSPECT_COLORS.with(|slot| {
+        let mut value_bits = slot.get();
+        if value_bits != 0 {
+            visitor.visit_nanbox_u64_slot(&mut value_bits);
+            slot.set(value_bits);
+        }
+    });
+    TIMERS_PROMISES_PARENT_NAMESPACE.with(|slot| {
+        let mut value_bits = slot.get();
+        if value_bits != 0 {
+            visitor.visit_nanbox_u64_slot(&mut value_bits);
+            slot.set(value_bits);
+        }
+    });
+    ZLIB_CODES_OBJECT.with(|slot| {
         let mut value_bits = slot.get();
         if value_bits != 0 {
             visitor.visit_nanbox_u64_slot(&mut value_bits);
@@ -440,11 +456,23 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
             b"isIPv6",
             b"Server",
             b"Socket",
+            b"Stream",
             b"getDefaultAutoSelectFamily",
             b"setDefaultAutoSelectFamily",
             b"getDefaultAutoSelectFamilyAttemptTimeout",
             b"setDefaultAutoSelectFamilyAttemptTimeout",
         ]),
+        "timers" => Some(&[
+            b"setTimeout",
+            b"clearTimeout",
+            b"setImmediate",
+            b"clearImmediate",
+            b"setInterval",
+            b"clearInterval",
+            b"promises",
+        ]),
+        "timers/promises" => Some(&[b"setTimeout", b"setImmediate", b"setInterval", b"scheduler"]),
+        "zlib" => Some(&[b"codes"]),
         _ => None,
     }
 }
@@ -452,7 +480,13 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
 fn should_cache_native_module_namespace(module_name: &str) -> bool {
     matches!(
         module_name,
-        "assert/strict" | "constants" | "util" | "util.types" | "path.posix" | "path.win32"
+        "assert/strict"
+            | "constants"
+            | "util"
+            | "util.types"
+            | "path.posix"
+            | "path.win32"
+            | "timers/promises"
     )
 }
 
@@ -877,6 +911,58 @@ fn util_inspect_colors() -> f64 {
         }
 
         let value = native_object_value(obj);
+        slot.set(value.to_bits());
+        crate::gc::runtime_write_barrier_root_nanbox(value.to_bits());
+        value
+    })
+}
+
+fn zlib_codes_object() -> f64 {
+    const ZLIB_RETURN_CODES: &[(&str, i32)] = &[
+        ("Z_OK", 0),
+        ("Z_STREAM_END", 1),
+        ("Z_NEED_DICT", 2),
+        ("Z_ERRNO", -1),
+        ("Z_STREAM_ERROR", -2),
+        ("Z_DATA_ERROR", -3),
+        ("Z_MEM_ERROR", -4),
+        ("Z_BUF_ERROR", -5),
+        ("Z_VERSION_ERROR", -6),
+    ];
+
+    ZLIB_CODES_OBJECT.with(|slot| {
+        let bits = slot.get();
+        if bits != 0 {
+            return f64::from_bits(bits);
+        }
+
+        let obj = js_object_alloc(0, 0);
+        for (name, value) in ZLIB_RETURN_CODES.iter().take(3) {
+            native_set_field(obj, &value.to_string(), native_string_value(name));
+        }
+        for (name, value) in ZLIB_RETURN_CODES {
+            native_set_field(obj, name, *value as f64);
+        }
+        for (name, value) in ZLIB_RETURN_CODES.iter().skip(3) {
+            native_set_field(obj, &value.to_string(), native_string_value(name));
+        }
+
+        let value = native_object_value(obj);
+        slot.set(value.to_bits());
+        crate::gc::runtime_write_barrier_root_nanbox(value.to_bits());
+        value
+    })
+}
+
+pub(crate) fn timers_promises_parent_namespace() -> f64 {
+    TIMERS_PROMISES_PARENT_NAMESPACE.with(|slot| {
+        let bits = slot.get();
+        if bits != 0 {
+            return f64::from_bits(bits);
+        }
+
+        let module_name = "timers/promises";
+        let value = js_create_native_module_namespace(module_name.as_ptr(), module_name.len());
         slot.set(value.to_bits());
         crate::gc::runtime_write_barrier_root_nanbox(value.to_bits());
         value
@@ -2615,6 +2701,33 @@ pub(crate) unsafe fn get_native_module_constant(
             }),
             _ => None,
         },
+        "net" => match property {
+            "Stream" => Some(bound_native_callable_export_value("net", "Socket")),
+            _ => None,
+        },
+        "timers" => match property {
+            "promises" => Some(timers_promises_parent_namespace()),
+            _ => None,
+        },
+        "timers/promises" => match property {
+            "setTimeout" | "setImmediate" | "setInterval" => Some(unsafe {
+                crate::node_submodules::js_node_submodule_namespace_member(
+                    b"timers_promises".as_ptr(),
+                    "timers_promises".len() as u32,
+                    property.as_ptr(),
+                    property.len() as u32,
+                )
+            }),
+            "scheduler" => Some(unsafe {
+                crate::node_submodules::js_node_submodule_namespace_member(
+                    b"timers_promises".as_ptr(),
+                    "timers_promises".len() as u32,
+                    b"scheduler".as_ptr(),
+                    "scheduler".len() as u32,
+                )
+            }),
+            _ => None,
+        },
         "crypto" => match property {
             "constants" => Some(create_sub_namespace("crypto.constants")),
             "Certificate" => Some(create_sub_namespace("crypto.Certificate")),
@@ -2667,6 +2780,7 @@ pub(crate) unsafe fn get_native_module_constant(
         // Node also exposes directly on `require('node:zlib')`.
         "zlib" => match property {
             "constants" => Some(create_sub_namespace("zlib.constants")),
+            "codes" => Some(zlib_codes_object()),
             _ => zlib_const(property),
         },
         "zlib.constants" => zlib_const(property),

--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -3,11 +3,10 @@
 use super::*;
 
 /// Tag-aware dynamic index dispatch for `obj[key]` where `obj` has unknown
-/// static type. Issue #514. Strings → js_string_char_at; everything else
-/// uses the same `raw_ptr + 8 + idx*8` direct-read offset hack the existing
-/// IndexGet fallback uses (which happens to be load-bearing for
-/// Object-with-numeric-keys + TypedArrays). LAZY_ARRAY / FORWARDED arrays
-/// route through `js_array_get_f64` to chase the materialized chain.
+/// static type. Issue #514. Strings → js_string_char_at; objects stringify
+/// numeric keys (`obj[0]` is `obj["0"]`), while arrays/buffers keep numeric
+/// element reads. LAZY_ARRAY / FORWARDED arrays route through
+/// `js_array_get_f64` to chase the materialized chain.
 #[no_mangle]
 pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
     let bits = value.to_bits();
@@ -82,9 +81,6 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
     } else {
         index as i32
     };
-    if idx_i32 < 0 {
-        return f64::from_bits(TAG_UNDEFINED);
-    }
     // Registry-backed Buffer (`Buffer.from(...)`, `js_buffer_alloc`, the
     // `'data'`-event chunk an http/net listener receives). These carry NO
     // GcHeader (see `crates/perry-runtime/src/buffer.rs` — "Buffers carry
@@ -100,6 +96,9 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
     // way the working accessors do (`js_buffer_get` → `buffer_data()`).
     // Node semantics: in-range → the byte (0..255); out-of-range → undefined.
     if crate::buffer::is_registered_buffer(raw_ptr) {
+        if idx_i32 < 0 {
+            return f64::from_bits(TAG_UNDEFINED);
+        }
         let buf = raw_ptr as *const crate::buffer::BufferHeader;
         let len = unsafe { (*buf).length };
         if (idx_i32 as u32) >= len {
@@ -117,6 +116,9 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
         if obj_type == crate::gc::GC_TYPE_LAZY_ARRAY
             || (gc_flags & crate::gc::GC_FLAG_FORWARDED) != 0
         {
+            if idx_i32 < 0 {
+                return f64::from_bits(TAG_UNDEFINED);
+            }
             let arr = raw_ptr as *const crate::array::ArrayHeader;
             return crate::array::js_array_get_f64(arr, idx_i32 as u32);
         }
@@ -131,12 +133,30 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
         // `undefined`. The narrow gate (GC_TYPE_ARRAY) keeps object
         // numeric-key fast path unchanged.
         if obj_type == crate::gc::GC_TYPE_ARRAY {
+            if idx_i32 < 0 {
+                return f64::from_bits(TAG_UNDEFINED);
+            }
             let arr = raw_ptr as *const crate::array::ArrayHeader;
             let length = unsafe { (*arr).length };
             if (idx_i32 as u32) >= length {
                 return f64::from_bits(TAG_UNDEFINED);
             }
         }
+        if obj_type == crate::gc::GC_TYPE_OBJECT || obj_type == crate::gc::GC_TYPE_CLOSURE {
+            let s = if index == (idx_i32 as f64) {
+                idx_i32.to_string()
+            } else {
+                format!("{}", index)
+            };
+            let key = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+            return crate::object::js_object_get_field_by_name_f64(
+                raw_ptr as *const crate::object::ObjectHeader,
+                key,
+            );
+        }
+    }
+    if idx_i32 < 0 {
+        return f64::from_bits(TAG_UNDEFINED);
     }
     let elem_addr = raw_ptr.wrapping_add(8 + (idx_i32 as usize) * 8);
     let v = unsafe { *(elem_addr as *const f64) };

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -11,8 +11,6 @@ use perry_runtime::StringHeader;
 type EventEmitterOn = unsafe extern "C" fn(i64, *const StringHeader, i64) -> i64;
 
 /// Dispatch a method call on a handle-based object.
-/// Called from perry-runtime's js_native_call_method when it detects a handle
-/// (pointer value < 0x100000, indicating an integer handle, not a real heap pointer).
 #[no_mangle]
 pub unsafe extern "C" fn js_handle_method_dispatch(
     handle: i64,
@@ -971,10 +969,6 @@ unsafe fn dispatch_external_net_socket(handle: i64, method: &str, args: &[f64]) 
     fn unbox_to_i64(v: f64) -> i64 {
         (v.to_bits() & 0x0000_FFFF_FFFF_FFFF) as i64
     }
-    // Pack a raw i64 handle back as a NaN-boxed POINTER_TAG f64 — the
-    // shape every chainable Socket method returns so subsequent
-    // `.on(...)` / `.write(...)` calls dispatch through the same
-    // small-handle range check at the top of `js_native_call_method`.
     fn nanbox_handle(h: i64) -> f64 {
         f64::from_bits(0x7FFD_0000_0000_0000u64 | (h as u64 & 0x0000_FFFF_FFFF_FFFF))
     }
@@ -1118,7 +1112,6 @@ unsafe fn dispatch_external_net_socket(handle: i64, method: &str, args: &[f64]) 
 }
 
 /// Dispatch a property access on a handle-based object.
-/// Called from perry-runtime's js_dynamic_object_get_property when it detects a handle.
 #[no_mangle]
 pub unsafe extern "C" fn js_handle_property_dispatch(
     handle: i64,
@@ -1152,6 +1145,10 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
         && crate::streams::js_stream_handle_is_registered(handle as usize)
     {
         return crate::streams::dispatch_stream_property(handle as f64, property_name);
+    }
+
+    if let Some(value) = super::net_socket_bridge::bind_net_socket_property(handle, property_name) {
+        return value;
     }
 
     // zlib Transform streams: `typeof createGzip().write` must read
@@ -1954,6 +1951,7 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
     js_register_event_emitter_handle_probe(event_emitter_probe);
     #[cfg(feature = "bundled-events")]
     js_register_event_emitter_on(crate::events::js_event_emitter_on);
+    super::net_socket_bridge::register_net_socket_handle_probe();
     // #1577: route captured-then-called `crypto.*` methods (which reach the
     // runtime's native-module dispatch) back to the stdlib crypto impls.
     perry_runtime::js_set_native_crypto_dispatch(crate::crypto::js_crypto_native_dispatch);

--- a/crates/perry-stdlib/src/common/mod.rs
+++ b/crates/perry-stdlib/src/common/mod.rs
@@ -8,6 +8,7 @@ pub mod handle;
 #[cfg(feature = "async-runtime")]
 pub mod async_bridge;
 pub mod dispatch;
+mod net_socket_bridge;
 
 #[cfg(feature = "async-runtime")]
 pub use async_bridge::*;

--- a/crates/perry-stdlib/src/common/net_socket_bridge.rs
+++ b/crates/perry-stdlib/src/common/net_socket_bridge.rs
@@ -1,0 +1,143 @@
+#[inline]
+fn nanbox_small_handle(handle: i64) -> f64 {
+    f64::from_bits(0x7FFD_0000_0000_0000u64 | (handle as u64 & 0x0000_FFFF_FFFF_FFFF))
+}
+
+#[inline]
+unsafe fn bind_class_method(handle: i64, name_bytes: &'static [u8]) -> f64 {
+    extern "C" {
+        fn js_class_method_bind(
+            instance: f64,
+            method_name_ptr: *const u8,
+            method_name_len: usize,
+        ) -> f64;
+    }
+    js_class_method_bind(
+        nanbox_small_handle(handle),
+        name_bytes.as_ptr(),
+        name_bytes.len(),
+    )
+}
+
+#[cfg(all(
+    feature = "bundled-net",
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+fn bundled_socket_method_name(property_name: &str) -> Option<&'static [u8]> {
+    match property_name {
+        "connect" => Some(b"connect"),
+        "write" => Some(b"write"),
+        "end" => Some(b"end"),
+        "destroy" => Some(b"destroy"),
+        "on" => Some(b"on"),
+        "upgradeToTLS" => Some(b"upgradeToTLS"),
+        _ => None,
+    }
+}
+
+#[cfg(all(
+    not(feature = "bundled-net"),
+    feature = "external-net-pump",
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+fn external_socket_method_name(property_name: &str) -> Option<&'static [u8]> {
+    match property_name {
+        "connect" => Some(b"connect"),
+        "write" => Some(b"write"),
+        "end" => Some(b"end"),
+        "destroy" => Some(b"destroy"),
+        "on" => Some(b"on"),
+        "addListener" => Some(b"addListener"),
+        "once" => Some(b"once"),
+        "off" => Some(b"off"),
+        "removeListener" => Some(b"removeListener"),
+        "removeAllListeners" => Some(b"removeAllListeners"),
+        "listenerCount" => Some(b"listenerCount"),
+        "eventNames" => Some(b"eventNames"),
+        "listeners" => Some(b"listeners"),
+        "rawListeners" => Some(b"rawListeners"),
+        "address" => Some(b"address"),
+        "resetAndDestroy" => Some(b"resetAndDestroy"),
+        "setNoDelay" => Some(b"setNoDelay"),
+        "setKeepAlive" => Some(b"setKeepAlive"),
+        "setTimeout" => Some(b"setTimeout"),
+        "setEncoding" => Some(b"setEncoding"),
+        "pause" => Some(b"pause"),
+        "resume" => Some(b"resume"),
+        "ref" => Some(b"ref"),
+        "unref" => Some(b"unref"),
+        "cork" => Some(b"cork"),
+        "uncork" => Some(b"uncork"),
+        "setDefaultEncoding" => Some(b"setDefaultEncoding"),
+        "upgradeToTLS" => Some(b"upgradeToTLS"),
+        _ => None,
+    }
+}
+
+pub(super) unsafe fn bind_net_socket_property(handle: i64, property_name: &str) -> Option<f64> {
+    #[cfg(all(
+        feature = "bundled-net",
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
+    if crate::net::is_net_socket_handle(handle) {
+        if let Some(name_bytes) = bundled_socket_method_name(property_name) {
+            return Some(bind_class_method(handle, name_bytes));
+        }
+    }
+
+    #[cfg(all(
+        not(feature = "bundled-net"),
+        feature = "external-net-pump",
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
+    {
+        extern "C" {
+            fn js_ext_net_is_socket_handle(handle: i64) -> i32;
+        }
+        if js_ext_net_is_socket_handle(handle) != 0 {
+            if let Some(name_bytes) = external_socket_method_name(property_name) {
+                return Some(bind_class_method(handle, name_bytes));
+            }
+        }
+    }
+
+    None
+}
+
+pub(super) unsafe fn register_net_socket_handle_probe() {
+    extern "C" {
+        fn js_register_net_socket_handle_probe(f: unsafe extern "C" fn(i64) -> bool);
+    }
+
+    #[cfg(all(
+        feature = "bundled-net",
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
+    {
+        unsafe extern "C" fn net_socket_probe(handle: i64) -> bool {
+            crate::net::is_net_socket_handle(handle)
+        }
+        js_register_net_socket_handle_probe(net_socket_probe);
+    }
+
+    #[cfg(all(
+        not(feature = "bundled-net"),
+        feature = "external-net-pump",
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
+    {
+        unsafe extern "C" fn external_net_socket_probe(handle: i64) -> bool {
+            extern "C" {
+                fn js_ext_net_is_socket_handle(handle: i64) -> i32;
+            }
+            js_ext_net_is_socket_handle(handle) != 0
+        }
+        js_register_net_socket_handle_probe(external_net_socket_probe);
+    }
+}

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -6,11 +6,11 @@ This document is a structured gap analysis comparing the public Node.js + Bun ru
 
 | Category | Modules | Gap APIs | Verified-covered |
 |----------|---------|----------|------------------|
-| Whole-module gaps (zero coverage) | 18 | 472 | n/a |
-| Partial-module gaps | 29 | 1646 | 371 |
+| Whole-module gaps (zero coverage) | 17 | 467 | n/a |
+| Partial-module gaps | 29 | 1642 | 376 |
 | Web-global gaps | — | 282 | 107 |
 | Bun-only gaps (out of scope) | — | 394 | n/a |
-| **Total true gaps** |  | **2400** |  |
+| **Total true gaps** |  | **2391** |  |
 
 **Top modules by remaining true gaps (Node + Web):**
 
@@ -23,7 +23,7 @@ This document is a structured gap analysis comparing the public Node.js + Bun ru
 - `node:http2` — 97
 - `node:test (and node:test/reporters, node:test/mock)` — 93
 - `node:http` — 89
-- `node:zlib` — 79
+- `node:zlib` — 78
 - `node:stream` — 76
 - `node:worker_threads` — 60
 
@@ -320,18 +320,6 @@ Selected highlights (full list in `runtime-parity.md`):
 - `wasi.initialize(instance)`
 - `wasi.finalizeBindings(instance[, options])`
 - `wasi.wasiImport`
-
-### node:timers/promises
-
-**Total APIs: 5** · Perry covers: 0 · Gap: 5
-
-Selected highlights (full list in `runtime-parity.md`):
-
-- `setTimeout([delay[, value[, options]]])`
-- `setImmediate([value[, options]])`
-- `setInterval([delay[, value[, options]]])`
-- `scheduler.wait(delay[, options])`
-- `scheduler.yield()`
 
 ## Partial-module gaps
 
@@ -857,7 +845,7 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 
 ### node:zlib
 
-**Gap APIs: 79** · Already covered: 12
+**Gap APIs: 78** · Already covered: 13
 
 #### Missing from Perry
 
@@ -911,7 +899,7 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 - `Z_OK`
 - `Z_STREAM_END`
 - `Z_NEED_DICT`
-- … and 29 more (see `runtime-parity.md` for the full list)
+- … and 28 more (see `runtime-parity.md` for the full list)
 
 #### Covered (sampled)
 
@@ -921,6 +909,7 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 | `zlib.Gzip` | `ffi:js_zlib_gzip` |
 | `zlib.Gunzip` | `ffi:js_zlib_gunzip` |
 | `zlib.Inflate` | `ffi:js_zlib_inflate` |
+| `zlib.codes` | `manifest:zlib.codes` |
 | `zlib.deflate(buffer[, options], callback)` | `ffi:js_zlib_deflate` |
 | `zlib.deflateSync(buffer[, options])` | `ffi:js_zlib_deflate_sync` |
 | `zlib.gzip(buffer[, options], callback)` | `manifest:zlib.gzip` |
@@ -1067,7 +1056,7 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 
 ### node:net
 
-**Gap APIs: 56** · Already covered: 22
+**Gap APIs: 55** · Already covered: 23
 
 #### Missing from Perry
 
@@ -1121,7 +1110,7 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 - `socket.connecting`
 - `socket.destroyed`
 - `socket.localAddress`
-- … and 6 more (see `runtime-parity.md` for the full list)
+- … and 5 more (see `runtime-parity.md` for the full list)
 
 #### Covered (sampled)
 
@@ -1141,6 +1130,7 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 | `server.listen(path[, backlog][, callback])` | `ffi:js_net_server_listen` |
 | `server.listen([port[, host[, backlog]]][, callback])` | `ffi:js_net_server_listen` |
 | `new net.Socket([options])` | `manifest:net.Socket` |
+| `new net.Stream([options])` | `manifest:net.Stream` |
 | `socket.connect(options[, connectListener])` | `manifest:net.connect` |
 | … | 7 more covered APIs |
 
@@ -1905,12 +1895,10 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 
 ### node:timers
 
-**Gap APIs: 13** · Already covered: 4
+**Gap APIs: 11** · Already covered: 7
 
 #### Missing from Perry
 
-- `setImmediate(callback[, ...args])`
-- `clearImmediate(immediate)`
 - `immediate.ref()`
 - `immediate.unref()`
 - `immediate.hasRef()`
@@ -1927,8 +1915,11 @@ Modules where Perry has at least one coverage source. Listed in descending gap-s
 
 | API | Coverage source |
 |-----|-----------------|
+| `setImmediate(callback[, ...args])` | `manifest:timers.setImmediate` |
 | `setInterval(callback[, delay[, ...args]])` | `ffi:js_interval_timer_*` |
 | `setTimeout(callback[, delay[, ...args]])` | `ffi:js_set_timeout` |
+| `clearImmediate(immediate)` | `manifest:timers.clearImmediate` |
+| `timers.promises` | `manifest:timers.promises` |
 | `clearInterval(timeout)` | `rt:js_interval_timer_*` |
 | `clearTimeout(timeout)` | `rt:js_timer_*` |
 

--- a/test-parity/node-suite/net/exports/stream-alias.ts
+++ b/test-parity/node-suite/net/exports/stream-alias.ts
@@ -1,0 +1,19 @@
+import * as net from "node:net";
+
+const keys = Object.keys(net);
+
+console.log("keys includes Stream:", keys.includes("Stream"));
+console.log("class keys:", JSON.stringify(keys.filter((k) => ["Server", "Socket", "Stream"].includes(k))));
+console.log("Stream === Socket:", (net as any).Stream === net.Socket);
+console.log("Stream name:", (net as any).Stream?.name);
+console.log("Stream length:", (net as any).Stream?.length);
+
+const socket = new (net as any).Stream();
+
+console.log("stream instanceof Socket:", socket instanceof net.Socket);
+console.log(
+  "stream methods:",
+  [typeof socket.connect, typeof socket.write, typeof socket.destroy].join(","),
+);
+socket.destroy();
+console.log("destroy called");

--- a/test-parity/node-suite/timers/promises/parent-alias.ts
+++ b/test-parity/node-suite/timers/promises/parent-alias.ts
@@ -1,0 +1,26 @@
+import * as timers from "node:timers";
+import * as timersPromises from "node:timers/promises";
+
+console.log("timers keys includes promises:", Object.keys(timers).includes("promises"));
+console.log("timers.promises type:", typeof (timers as any).promises);
+console.log(
+  "parent === submodule:",
+  (timers as any).promises === timersPromises ? "true" : "false",
+);
+console.log("promise keys:", JSON.stringify(Object.keys((timers as any).promises).sort()));
+console.log(
+  "export identities:",
+  [
+    (timers as any).promises.setTimeout === timersPromises.setTimeout,
+    (timers as any).promises.setImmediate === timersPromises.setImmediate,
+    (timers as any).promises.setInterval === timersPromises.setInterval,
+    (timers as any).promises.scheduler === timersPromises.scheduler,
+  ].join(","),
+);
+console.log(
+  "scheduler methods:",
+  [
+    typeof (timers as any).promises.scheduler.wait,
+    typeof (timers as any).promises.scheduler.yield,
+  ].join(","),
+);

--- a/test-parity/node-suite/zlib/constants/codes.ts
+++ b/test-parity/node-suite/zlib/constants/codes.ts
@@ -1,0 +1,34 @@
+import * as zlib from "node:zlib";
+
+console.log("zlib keys includes codes:", Object.keys(zlib).includes("codes"));
+console.log("codes type:", typeof (zlib as any).codes);
+console.log("codes stable identity:", (zlib as any).codes === (zlib as any).codes);
+console.log("codes keys:", JSON.stringify(Object.keys((zlib as any).codes)));
+console.log(
+  "code values:",
+  [
+    (zlib as any).codes.Z_OK,
+    (zlib as any).codes.Z_STREAM_END,
+    (zlib as any).codes.Z_NEED_DICT,
+    (zlib as any).codes.Z_ERRNO,
+    (zlib as any).codes.Z_STREAM_ERROR,
+    (zlib as any).codes.Z_DATA_ERROR,
+    (zlib as any).codes.Z_MEM_ERROR,
+    (zlib as any).codes.Z_BUF_ERROR,
+    (zlib as any).codes.Z_VERSION_ERROR,
+  ].join(","),
+);
+console.log(
+  "reverse values:",
+  [
+    (zlib as any).codes[0],
+    (zlib as any).codes[1],
+    (zlib as any).codes[2],
+    (zlib as any).codes[-1],
+    (zlib as any).codes[-2],
+    (zlib as any).codes[-3],
+    (zlib as any).codes[-4],
+    (zlib as any).codes[-5],
+    (zlib as any).codes[-6],
+  ].join(","),
+);


### PR DESCRIPTION
## Summary
- Expose `net.Stream` as the `net.Socket` alias, including constructor lowering and dynamic `instanceof` for socket handles.
- Expose `timers.promises` and the `node:timers/promises` namespace shape through native namespace access.
- Add `zlib.codes` with Node-compatible forward and reverse return-code entries.
- Update the parity-gap docs and add focused node-suite fixtures for the three alias gaps.

## Issues
Closes #2689
Closes #2682
Closes #2688

## Why These Are Batched
These are small Node namespace/export-shape gaps with shared runtime/manifest/test coverage: native module namespace keys, aliased export values, and parity fixtures that compare Node export surfaces.

## Verification
- `TMPDIR="$PWD/target/tmp" PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module net` - 6 pass, 0 fail
- `TMPDIR="$PWD/target/tmp" PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module timers` - 87 pass, 0 fail
- `TMPDIR="$PWD/target/tmp" PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module zlib --filter codes` - 2 pass, 0 fail
- `TMPDIR="$PWD/target/tmp" CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo check -p perry-runtime -p perry-codegen -p perry-api-manifest -p perry-hir -p perry-stdlib`
- `cargo fmt --all -- --check`
- `git diff --check HEAD`
- `./scripts/check_file_size.sh`

## Known Limitations / Non-goals
- This does not expand the zlib Transform stream implementation; the zlib change is limited to the `codes` export table.
- This does not implement the remaining `net`, `timers`, or `zlib` APIs listed in the parity-gap document.
