### PR TITLE
fix(net): validate IP and auto-family helpers

### DIFF
--- a/crates/perry-ext-net/src/ip.rs
+++ b/crates/perry-ext-net/src/ip.rs
@@ -1,10 +1,15 @@
 //! `net.isIP` / `isIPv4` / `isIPv6` (issue #811) + the Happy-Eyeballs
 //! auto-select-family default accessors. Pure string/global-flag helpers
 //! with no socket state. Split out of `lib.rs` (#1852) to keep that file
-//! under the 2000-line gate; the logic is unchanged.
+//! under the 2000-line gate.
 
 use crate::string_from_header_i64;
 use perry_ffi::JsValue;
+
+extern "C" {
+    fn js_net_validate_default_auto_select_family(value: f64) -> i32;
+    fn js_net_validate_default_auto_select_family_attempt_timeout(value: f64) -> i32;
+}
 
 /// Issue #811 — `net.isIP(s)` returns 0/4/6 (number).
 fn classify_ip(s: &str) -> i32 {
@@ -22,12 +27,24 @@ fn is_ipv4_str(s: &str) -> bool {
 }
 
 fn is_ipv6_str(s: &str) -> bool {
-    // Node's `net.isIPv6` rejects brackets and zone-id (`%`) suffixes —
-    // those forms aren't bare addresses.
-    if s.contains('[') || s.contains(']') || s.contains('%') {
+    if s.contains('[') || s.contains(']') {
         return false;
     }
-    s.parse::<std::net::Ipv6Addr>().is_ok()
+    let address = match s.split_once('%') {
+        Some((address, zone)) => {
+            if zone.is_empty()
+                || zone.contains('%')
+                || !zone
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b':'))
+            {
+                return false;
+            }
+            address
+        }
+        None => s,
+    };
+    address.parse::<std::net::Ipv6Addr>().is_ok()
 }
 
 #[no_mangle]
@@ -73,7 +90,7 @@ pub unsafe extern "C" fn js_net_get_default_auto_select_family() -> f64 {
 
 #[no_mangle]
 pub unsafe extern "C" fn js_net_set_default_auto_select_family(val_f64: f64) -> f64 {
-    let val = JsValue(val_f64.to_bits()).to_bool();
+    let val = unsafe { js_net_validate_default_auto_select_family(val_f64) } != 0;
     AUTO_SELECT_FAMILY.store(val, std::sync::atomic::Ordering::Relaxed);
     f64::from_bits(JsValue::UNDEFINED.0)
 }
@@ -86,12 +103,7 @@ pub unsafe extern "C" fn js_net_get_default_auto_select_family_attempt_timeout()
 
 #[no_mangle]
 pub unsafe extern "C" fn js_net_set_default_auto_select_family_attempt_timeout(ms_f64: f64) -> f64 {
-    let n = JsValue(ms_f64.to_bits()).to_number();
-    let ms = if n.is_finite() && n >= 0.0 {
-        n as i32
-    } else {
-        0
-    };
+    let ms = unsafe { js_net_validate_default_auto_select_family_attempt_timeout(ms_f64) };
     AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS.store(ms, std::sync::atomic::Ordering::Relaxed);
     f64::from_bits(JsValue::UNDEFINED.0)
 }

--- a/crates/perry-runtime/src/net_validate.rs
+++ b/crates/perry-runtime/src/net_validate.rs
@@ -117,6 +117,58 @@ pub extern "C" fn js_net_validate_socket_timeout(value: f64) {
     }
 }
 
+/// `net.setDefaultAutoSelectFamily(value)` accepts only booleans.
+#[no_mangle]
+pub extern "C" fn js_net_validate_default_auto_select_family(value: f64) -> i32 {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_bool() {
+        let message = format!(
+            "The \"value\" argument must be of type boolean. Received {}",
+            describe_received(value)
+        );
+        throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    if jv.as_bool() {
+        1
+    } else {
+        0
+    }
+}
+
+/// `net.setDefaultAutoSelectFamilyAttemptTimeout(value)` accepts an integer
+/// in `[1, 2147483647]`, then applies Node's effective 10ms minimum.
+#[no_mangle]
+pub extern "C" fn js_net_validate_default_auto_select_family_attempt_timeout(value: f64) -> i32 {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !is_numeric(jv) {
+        let message = format!(
+            "The \"value\" argument must be of type number. Received {}",
+            describe_received(value)
+        );
+        throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    let n = if jv.is_int32() {
+        jv.as_int32() as f64
+    } else {
+        jv.as_number()
+    };
+    if !(n.is_finite() && n.fract() == 0.0) {
+        let message = format!(
+            "The value of \"value\" is out of range. It must be an integer. Received {}",
+            format_received_number(n)
+        );
+        throw_range_error_named(&message, "ERR_OUT_OF_RANGE");
+    }
+    if !(1.0..=2147483647.0).contains(&n) {
+        let message = format!(
+            "The value of \"value\" is out of range. It must be >= 1 && <= 2147483647. Received {}",
+            format_received_number(n)
+        );
+        throw_range_error_named(&message, "ERR_OUT_OF_RANGE");
+    }
+    (n as i32).max(10)
+}
+
 /// `net.createServer(options?, connectionListener?)` — the first positional
 /// argument must be either a function (the connection listener) or an object
 /// (the options bag); `null`/`undefined` are accepted as "no options". A

--- a/test-parity/node-suite/net/ip/zone-identifiers.ts
+++ b/test-parity/node-suite/net/ip/zone-identifiers.ts
@@ -1,0 +1,24 @@
+import * as net from "node:net";
+
+const samples = [
+  "::1",
+  "::ffff:127.0.0.1",
+  "fe80::1%lo0",
+  "fe80::1%eth0",
+  "fe80::1%18",
+  "::1%lo0",
+  "fe80::1%",
+  "fe80::1%bad_zone",
+  "[::1]",
+  "127.0.0.1%lo0",
+];
+
+for (const value of samples) {
+  console.log(
+    "ip",
+    JSON.stringify(value),
+    net.isIP(value),
+    net.isIPv4(value),
+    net.isIPv6(value),
+  );
+}

--- a/test-parity/node-suite/net/validation/auto-select-family-defaults.ts
+++ b/test-parity/node-suite/net/validation/auto-select-family-defaults.ts
@@ -1,0 +1,56 @@
+import * as net from "node:net";
+
+function label(value: any): string {
+  if (typeof value === "number" && Number.isNaN(value)) {
+    return "NaN";
+  }
+  return String(value);
+}
+
+function firstLine(err: any): string {
+  return String(err.message).split("\n")[0];
+}
+
+const familyValues: any[] = [true, false, 1, 0, "true", null, undefined];
+for (const value of familyValues) {
+  try {
+    const before = net.getDefaultAutoSelectFamily();
+    const result = net.setDefaultAutoSelectFamily(value);
+    console.log("family", label(value), "OK", net.getDefaultAutoSelectFamily(), result);
+    net.setDefaultAutoSelectFamily(before);
+  } catch (err: any) {
+    console.log("family", label(value), "THROW", err.name, err.code, "|", firstLine(err));
+  }
+}
+
+const timeoutValues: any[] = [
+  1,
+  9,
+  10,
+  0,
+  -1,
+  NaN,
+  Infinity,
+  "5",
+  null,
+  undefined,
+  1.5,
+  2147483647,
+  2147483648,
+];
+for (const value of timeoutValues) {
+  try {
+    const before = net.getDefaultAutoSelectFamilyAttemptTimeout();
+    const result = net.setDefaultAutoSelectFamilyAttemptTimeout(value);
+    console.log(
+      "timeout",
+      label(value),
+      "OK",
+      net.getDefaultAutoSelectFamilyAttemptTimeout(),
+      result,
+    );
+    net.setDefaultAutoSelectFamilyAttemptTimeout(before);
+  } catch (err: any) {
+    console.log("timeout", label(value), "THROW", err.name, err.code, "|", firstLine(err));
+  }
+}


### PR DESCRIPTION
Closes #3037
Closes #3038

## Summary
- Accept scoped IPv6 zone identifiers in `net.isIP()` / `net.isIPv6()` while continuing to reject bracketed host literals and invalid zone suffixes.
- Validate `net.setDefaultAutoSelectFamily(value)` as a boolean-only setter with Node-style `ERR_INVALID_ARG_TYPE` errors.
- Validate `net.setDefaultAutoSelectFamilyAttemptTimeout(value)` as an integer in `[1, 2147483647]`, including the effective 10ms minimum readback behavior.

## Why Batched
Both issues cover pure `node:net` helper/default-accessor behavior in the same implementation area and share the same focused node-suite harness. This avoids mixing in socket/server object-surface work or live network lifecycle changes.

## Tests Added
- `test-parity/node-suite/net/ip/zone-identifiers.ts`
- `test-parity/node-suite/net/validation/auto-select-family-defaults.ts`

## Verification
- Pre-fix `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module net`: 5 passed, 2 failed as expected (`zone-identifiers`, `auto-select-family-defaults`), report `test-parity/reports/parity_report_20260531_033214.json`.
- Post-fix/rebased `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module net`: 7 passed, 0 failed, report `test-parity/reports/parity_report_20260531_034353.json`.
- `RUSTC_WRAPPER= cargo check -p perry-runtime -p perry-codegen -p perry-hir -p perry-api-manifest -p perry`: passed with existing warnings.
- `cargo fmt --all -- --check`: passed.
- `./scripts/check_file_size.sh`: passed.
- `jq empty test-parity/known_failures.json`: passed.
- `git diff --check HEAD~1..HEAD`: passed.

## Known Limitations / Non-Goals
- Does not address `net.Socket` / `net.Server` method-value reads or broader object-surface parity.
- Does not change live socket connection behavior beyond the stored default helper values.