### PR TITLE
fix(process): emit warning events and deprecations

### DIFF
--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -863,7 +863,7 @@ fn collect_emit_args(args: *const ArrayHeader) -> Vec<f64> {
     values
 }
 
-fn emit_process_event(event: &str, args: &[f64]) -> bool {
+pub(crate) fn emit_process_event(event: &str, args: &[f64]) -> bool {
     let listeners = PROCESS_EMITTER.with(|emitter| {
         let mut emitter = emitter.borrow_mut();
         let Some(listeners) = emitter.events.get_mut(event) else {

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -1,5 +1,8 @@
 //! Process module - provides access to environment and process information
 
+use crate::closure::{
+    js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64, ClosureHeader,
+};
 use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
 
@@ -1096,49 +1099,196 @@ fn extract_cpu_pair(value: f64) -> (f64, f64) {
     (user, system)
 }
 
+fn string_value(s: &str) -> f64 {
+    let ptr = js_string_from_bytes(s.as_ptr(), s.len() as u32);
+    f64::from_bits(JSValue::string_ptr(ptr).bits())
+}
+
+fn warning_value_to_string(v: f64) -> String {
+    if JSValue::from_bits(v.to_bits()).is_undefined() {
+        return String::new();
+    }
+    let ptr = crate::value::js_jsvalue_to_string(v);
+    if ptr.is_null() {
+        return String::new();
+    }
+    unsafe {
+        let header = &*ptr;
+        let len = header.byte_len as usize;
+        let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned()
+    }
+}
+
+fn object_from_value(value: f64) -> Option<*mut crate::object::ObjectHeader> {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return None;
+    }
+    let ptr = jv.as_pointer::<u8>() as *mut u8;
+    if ptr.is_null() || !crate::object::is_valid_obj_ptr(ptr as *const u8) {
+        return None;
+    }
+    Some(ptr as *mut crate::object::ObjectHeader)
+}
+
+fn object_string_field(obj_handle: &crate::gc::RuntimeHandle<'_>, name: &str) -> Option<String> {
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let value = crate::object::js_object_get_field_by_name_f64(
+        obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
+        key,
+    );
+    if JSValue::from_bits(value.to_bits()).is_undefined() {
+        None
+    } else {
+        Some(warning_value_to_string(value))
+    }
+}
+
+fn set_error_string_prop(error: *mut crate::error::ErrorHeader, name: &str, value: &str) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let error_handle = scope.root_raw_mut_ptr(error);
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let key_handle = scope.root_string_ptr(key);
+    let value_handle = scope.root_nanbox_f64(string_value(value));
+    crate::object::js_object_set_field_by_name(
+        error_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
+        key_handle.get_raw_const_ptr::<StringHeader>() as *mut StringHeader,
+        value_handle.get_nanbox_f64(),
+    );
+}
+
+extern "C" fn process_warning_callback(closure: *const ClosureHeader) -> f64 {
+    use std::io::Write;
+
+    if closure.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let warning_handle = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 0));
+    let line = warning_value_to_string(js_closure_get_capture_f64(closure, 1));
+    let detail = warning_value_to_string(js_closure_get_capture_f64(closure, 2));
+    let hint = warning_value_to_string(js_closure_get_capture_f64(closure, 3));
+
+    let mut stderr = std::io::stderr().lock();
+    let _ = writeln!(stderr, "{line}");
+    if !detail.is_empty() {
+        let _ = writeln!(stderr, "{detail}");
+    }
+    if !hint.is_empty() {
+        let _ = writeln!(stderr, "{hint}");
+    }
+
+    crate::os::emit_process_event("warning", &[warning_handle.get_nanbox_f64()]);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+fn schedule_warning(warning: f64, label: &str, code: &str, msg: &str, detail: &str) {
+    let pid = std::process::id();
+    let line = if code.is_empty() {
+        format!("(node:{pid}) {label}: {msg}")
+    } else {
+        format!("(node:{pid}) [{code}] {label}: {msg}")
+    };
+    let hint_flag = if label == "DeprecationWarning" {
+        "--trace-deprecation"
+    } else {
+        "--trace-warnings"
+    };
+    let hint = format!("(Use `node {hint_flag} ...` to show where the warning was created)");
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let warning_handle = scope.root_nanbox_f64(warning);
+    let line_handle = scope.root_nanbox_f64(string_value(&line));
+    let detail_handle = scope.root_nanbox_f64(string_value(detail));
+    let hint_handle = scope.root_nanbox_f64(string_value(&hint));
+
+    let callback = js_closure_alloc(process_warning_callback as *const u8, 4);
+    if callback.is_null() {
+        return;
+    }
+    let callback_handle = scope.root_raw_mut_ptr(callback);
+    js_closure_set_capture_f64(
+        callback_handle.get_raw_mut_ptr(),
+        0,
+        warning_handle.get_nanbox_f64(),
+    );
+    js_closure_set_capture_f64(
+        callback_handle.get_raw_mut_ptr(),
+        1,
+        line_handle.get_nanbox_f64(),
+    );
+    js_closure_set_capture_f64(
+        callback_handle.get_raw_mut_ptr(),
+        2,
+        detail_handle.get_nanbox_f64(),
+    );
+    js_closure_set_capture_f64(
+        callback_handle.get_raw_mut_ptr(),
+        3,
+        hint_handle.get_nanbox_f64(),
+    );
+    crate::builtins::js_queue_next_tick(callback_handle.get_raw_const_ptr::<ClosureHeader>() as i64);
+}
+
 /// process.emitWarning(warning[, type, code, ctor]) -> undefined.
-/// Writes a formatted warning to stderr matching Node's shape:
-/// `(node:<pid>) <Type> [CODE]: <message>`. Anything that can't be
-/// coerced to a string is rendered via `js_jsvalue_to_string`. The 4th
-/// `ctor` arg (Node's trace anchor) is accepted but ignored — Perry
-/// doesn't capture stack traces here.
+///
+/// The direct-call lowering still passes the first three JS values here. The
+/// runtime parses the modern options-object overload, creates an Error-like
+/// warning object, and queues the warning job so stderr/event delivery happens
+/// after the current synchronous frame.
 #[no_mangle]
 pub extern "C" fn js_process_emit_warning(warning: f64, type_name: f64, code: f64) {
-    use std::io::Write;
-    let undef_bits = crate::value::TAG_UNDEFINED;
-    let value_to_string = |v: f64| -> String {
-        if v.to_bits() == undef_bits {
-            return String::new();
-        }
-        let ptr = crate::value::js_jsvalue_to_string(v);
-        if ptr.is_null() {
-            return String::new();
-        }
-        unsafe {
-            let header = &*ptr;
-            let len = header.byte_len as usize;
-            let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-            String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned()
-        }
-    };
+    let msg = warning_value_to_string(warning);
 
-    let msg = value_to_string(warning);
-    let raw_type = value_to_string(type_name);
-    let raw_code = value_to_string(code);
+    let (raw_type, raw_code, detail) = if let Some(options) = object_from_value(type_name) {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let options_handle = scope.root_raw_mut_ptr(options);
+        (
+            object_string_field(&options_handle, "type").unwrap_or_default(),
+            object_string_field(&options_handle, "code").unwrap_or_default(),
+            object_string_field(&options_handle, "detail").unwrap_or_default(),
+        )
+    } else {
+        (
+            warning_value_to_string(type_name),
+            warning_value_to_string(code),
+            String::new(),
+        )
+    };
     let label = if raw_type.is_empty() {
         "Warning".to_string()
     } else {
         raw_type
     };
-    let code_part = if raw_code.is_empty() {
-        String::new()
-    } else {
-        format!(" [{}]", raw_code)
-    };
-    let pid = std::process::id();
-    let line = format!("(node:{}) {}{}: {}\n", pid, label, code_part, msg);
-    let mut stderr = std::io::stderr().lock();
-    let _ = stderr.write_all(line.as_bytes());
+
+    let message_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let warning_error = crate::error::js_error_new_with_message(message_ptr);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let warning_handle = scope.root_raw_mut_ptr(warning_error);
+    set_error_string_prop(
+        warning_handle.get_raw_mut_ptr::<crate::error::ErrorHeader>(),
+        "name",
+        &label,
+    );
+    if !raw_code.is_empty() {
+        set_error_string_prop(
+            warning_handle.get_raw_mut_ptr::<crate::error::ErrorHeader>(),
+            "code",
+            &raw_code,
+        );
+    }
+    if !detail.is_empty() {
+        set_error_string_prop(
+            warning_handle.get_raw_mut_ptr::<crate::error::ErrorHeader>(),
+            "detail",
+            &detail,
+        );
+    }
+    let warning_value = crate::value::js_nanbox_pointer(
+        warning_handle.get_raw_const_ptr::<crate::error::ErrorHeader>() as i64,
+    );
+    schedule_warning(warning_value, &label, &raw_code, &msg, &detail);
 }
 
 /// process.availableMemory() -> number. Free system memory available to

--- a/crates/perry-runtime/src/util_promisify.rs
+++ b/crates/perry-runtime/src/util_promisify.rs
@@ -40,7 +40,9 @@ use crate::promise::{
     js_value_is_promise, ClosurePtr, Promise,
 };
 use crate::string::js_string_from_bytes;
-use crate::value::{JSValue, POINTER_MASK, POINTER_TAG, TAG_MASK, TAG_NULL, TAG_UNDEFINED};
+use crate::value::{
+    JSValue, POINTER_MASK, POINTER_TAG, TAG_MASK, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,
+};
 
 const TAG_UNDEFINED_F64: f64 = f64::from_bits(TAG_UNDEFINED);
 const TAG_NULL_F64: f64 = f64::from_bits(TAG_NULL);
@@ -160,6 +162,11 @@ fn register_thunks_once() {
         js_register_closure_rest(callbackify_outer_thunk as *const u8, 0);
         js_register_closure_arity(callbackify_fulfilled_thunk as *const u8, 1);
         js_register_closure_arity(callbackify_rejected_thunk as *const u8, 1);
+        js_register_closure_rest(deprecate_outer_thunk as *const u8, 0);
+        crate::builtins::register_function_name_if_absent(
+            deprecate_outer_thunk as *const () as usize,
+            "deprecated",
+        );
         flag.set(true);
     });
 }
@@ -202,15 +209,62 @@ pub extern "C" fn js_util_promisify(fn_value: f64) -> f64 {
     nanbox_pointer(closure_handle.get_raw_const_ptr::<ClosureHeader>() as *const u8)
 }
 
-/// Minimal `util.deprecate(fn, msg, code)` shape.
-///
-/// Full warning emission is separate; callers must at least receive a callable
-/// that forwards to the original function, and Node accepts string codes that
-/// contain spaces.
+fn function_length(value: f64) -> u32 {
+    if let Some(arity) = unsafe { crate::object::bound_native_callable_value_arity(value) } {
+        return arity;
+    }
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return 0;
+    }
+    let closure = jv.as_pointer::<ClosureHeader>();
+    if closure.is_null() {
+        return 0;
+    }
+    if let Some(len) = crate::object::builtin_closure_length(closure as usize) {
+        return len;
+    }
+    crate::closure::closure_arity(closure).unwrap_or(0)
+}
+
+/// `util.deprecate(fn, msg, code)` — returns a wrapper named `deprecated` that
+/// emits one `DeprecationWarning` on first invocation, then forwards all calls.
 #[no_mangle]
-pub extern "C" fn js_util_deprecate(fn_value: f64, _msg: f64, _code: f64) -> f64 {
+pub extern "C" fn js_util_deprecate(fn_value: f64, msg: f64, code: f64) -> f64 {
     validate_deprecate_target(fn_value);
-    fn_value
+
+    register_thunks_once();
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let fn_handle = scope.root_nanbox_f64(fn_value);
+    let msg_handle = scope.root_nanbox_f64(msg);
+    let code_handle = scope.root_nanbox_f64(code);
+    let closure = js_closure_alloc(deprecate_outer_thunk as *const u8, 4);
+    if closure.is_null() {
+        return TAG_UNDEFINED_F64;
+    }
+    let closure_handle = scope.root_raw_mut_ptr(closure);
+    js_closure_set_capture_f64(
+        closure_handle.get_raw_mut_ptr(),
+        0,
+        fn_handle.get_nanbox_f64(),
+    );
+    js_closure_set_capture_f64(
+        closure_handle.get_raw_mut_ptr(),
+        1,
+        msg_handle.get_nanbox_f64(),
+    );
+    js_closure_set_capture_f64(
+        closure_handle.get_raw_mut_ptr(),
+        2,
+        code_handle.get_nanbox_f64(),
+    );
+    js_closure_set_capture_f64(closure_handle.get_raw_mut_ptr(), 3, TAG_UNDEFINED_F64);
+    crate::object::set_builtin_closure_length(
+        closure_handle.get_raw_const_ptr::<ClosureHeader>() as usize,
+        function_length(fn_handle.get_nanbox_f64()),
+    );
+    nanbox_pointer(closure_handle.get_raw_const_ptr::<ClosureHeader>() as *const u8)
 }
 
 /// `util.callbackify(fn)` — returns a wrapper closure as a NaN-boxed f64.
@@ -340,6 +394,54 @@ extern "C" fn inner_callback_thunk(closure: *const ClosureHeader, err: f64, valu
         js_promise_reject(promise_ptr, err);
     }
     TAG_UNDEFINED_F64
+}
+
+/// `util.deprecate()` wrapper body. Receives all user arguments bundled in
+/// `rest_value`, emits one warning per wrapper, then forwards the call.
+extern "C" fn deprecate_outer_thunk(closure: *const ClosureHeader, rest_value: f64) -> f64 {
+    if closure.is_null() {
+        return TAG_UNDEFINED_F64;
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let fn_value = js_closure_get_capture_f64(closure, 0);
+    let msg = js_closure_get_capture_f64(closure, 1);
+    let code = js_closure_get_capture_f64(closure, 2);
+    let fn_handle = scope.root_nanbox_f64(fn_value);
+    let msg_handle = scope.root_nanbox_f64(msg);
+    let code_handle = scope.root_nanbox_f64(code);
+    let rest_handle = scope.root_nanbox_f64(rest_value);
+
+    if js_closure_get_capture_f64(closure, 3).to_bits() != TAG_TRUE {
+        js_closure_set_capture_f64(closure as *mut ClosureHeader, 3, f64::from_bits(TAG_TRUE));
+        let warning_type = js_string_from_bytes(b"DeprecationWarning".as_ptr(), 18);
+        let warning_type_value = f64::from_bits(JSValue::string_ptr(warning_type).bits());
+        let warning_type_handle = scope.root_nanbox_f64(warning_type_value);
+        crate::process::js_process_emit_warning(
+            msg_handle.get_nanbox_f64(),
+            warning_type_handle.get_nanbox_f64(),
+            code_handle.get_nanbox_f64(),
+        );
+    }
+
+    let rest_bits = rest_handle.get_nanbox_f64().to_bits();
+    let rest_arr_ptr = if (rest_bits & TAG_MASK) == POINTER_TAG {
+        (rest_bits & POINTER_MASK) as *const ArrayHeader
+    } else {
+        std::ptr::null()
+    };
+    let rest_len = if rest_arr_ptr.is_null() {
+        0
+    } else {
+        js_array_length(rest_arr_ptr) as usize
+    };
+    let rest_data = if rest_arr_ptr.is_null() {
+        std::ptr::null()
+    } else {
+        unsafe { (rest_arr_ptr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64 }
+    };
+
+    unsafe { crate::closure::js_native_call_value(fn_handle.get_nanbox_f64(), rest_data, rest_len) }
 }
 
 /// Outer callbackify body: `(closure, rest_array_value) -> undefined`.

--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -272,6 +272,9 @@ for raw in sys.stdin:
         # stderr after the script body, while Perry writes the equivalent
         # warning eagerly at the call site.
         sed -E '/^(\(node:[0-9]+\) )?Warning: (Count for .* does not exist|No such label .* for console\.(timeLog|timeEnd)\(\)|Label .* already exists for console\.time\(\))/d' | \
+        # Normalize Node-style process warning prefixes. The warning text is
+        # semantically relevant, but the pid is not stable across runs.
+        sed -E 's/^\(node:[0-9]+\) /\(node:<pid>\) /g' | \
         # Normalize console.trace output: strip stack frame lines so only
         # the "Trace: <message>" header survives for comparison.
         # Node.js emits "    at <symbol> (<location>)" JS stack frames;

--- a/test-parity/node-suite/process/methods/emit-warning-options-event.ts
+++ b/test-parity/node-suite/process/methods/emit-warning-options-event.ts
@@ -1,0 +1,17 @@
+const events: string[] = [];
+
+process.on("warning", (warning: any) => {
+  events.push(`${warning.name}:${warning.code ?? ""}:${warning.message}:${warning.detail ?? ""}`);
+  console.log("event:", events.join("|"));
+});
+
+console.log("before");
+const ret = process.emitWarning("hello", {
+  type: "CustomWarning",
+  code: "PERRY_TEST",
+  detail: "extra detail",
+});
+console.log("after:", String(ret), events.join("|"));
+
+process.nextTick(() => events.push("nextTick"));
+setImmediate(() => console.log("final:", events.join("|")));

--- a/test-parity/node-suite/process/methods/emit-warning-positional-event.ts
+++ b/test-parity/node-suite/process/methods/emit-warning-positional-event.ts
@@ -1,0 +1,12 @@
+const events: string[] = [];
+
+process.on("warning", (warning: any) => {
+  events.push(`${warning.name}:${warning.code ?? ""}:${warning.message}`);
+  console.log("event:", events.join("|"));
+});
+
+const ret = process.emitWarning("plain", "CustomWarning", "PERRY_POS");
+console.log("return:", String(ret), events.join("|"));
+
+process.nextTick(() => events.push("nextTick"));
+setImmediate(() => console.log("final:", events.join("|")));

--- a/test-parity/node-suite/util/deprecate/basic-warning.ts
+++ b/test-parity/node-suite/util/deprecate/basic-warning.ts
@@ -1,6 +1,14 @@
 import { deprecate } from "node:util";
 
+const events: string[] = [];
+process.on("warning", (warning: any) => {
+  events.push(`${warning.name}:${warning.code ?? ""}:${warning.message}`);
+  console.log("event:", events.join("|"));
+});
+
 const fn = deprecate((x: number) => x + 1, "deprecated fn", "DEP_PERRY_TEST");
+console.log("shape:", typeof fn, fn.name, fn.length);
 console.log("call1:", fn(1));
 console.log("call2:", fn(2));
+setImmediate(() => console.log("warnings:", JSON.stringify(events)));
 try { deprecate(() => 1, "msg", "bad code with spaces"); console.log("bad code no throw"); } catch (err: any) { console.log("bad code:", err?.name, err?.code || "no-code"); }


### PR DESCRIPTION
## Summary
- Parses `process.emitWarning(warning, options)` for `type`, `code`, and `detail`, while preserving the positional overload.
- Builds warning `Error` objects and queues Node-shaped stderr output plus `process.on("warning")` event delivery in next-tick order.
- Changes `util.deprecate()` to return a `deprecated` wrapper that preserves function length, forwards calls, and emits one `DeprecationWarning` on first invocation.
- Normalizes process-warning pids in parity output so warning text remains comparable.

## Linked Issues
Closes #2928
Closes #2956
Closes #2950

## Why Batched
These issues share the same warning pipeline: `util.deprecate()` needs first-call `DeprecationWarning` emission, and `process.emitWarning()` needs both overload parsing and warning-event delivery. Routing them through one runtime helper keeps stderr formatting, warning object construction, listener notification, and next-tick ordering consistent.

## Tests Added
- `test-parity/node-suite/process/methods/emit-warning-options-event.ts`
- `test-parity/node-suite/process/methods/emit-warning-positional-event.ts`
- Expanded `test-parity/node-suite/util/deprecate/basic-warning.ts` to cover wrapper shape, warning-once behavior, event payload, and permissive deprecate codes.

## Verification
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/process/methods/emit-warning-options-event.ts`
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/process/methods/emit-warning-positional-event.ts`
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/util/deprecate/basic-warning.ts`
- `PATH="/tmp/perry-node25-wrapper:$PATH" ./run_parity_tests.sh --suite node-suite --module process/methods` (13 pass, 0 fail, 0 compile fail)
- `PATH="/tmp/perry-node25-wrapper:$PATH" ./run_parity_tests.sh --suite node-suite --module util/deprecate` (2 pass, 0 fail, 0 compile fail)
- `cargo check -p perry-runtime`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`

## Known Limitations
- Does not implement process warning/deprecation flags such as `--no-warnings`, `--trace-deprecation`, `process.noDeprecation`, `process.throwDeprecation`, or `process.traceDeprecation`.
- Does not change bound/captured `process.emitWarning` dispatch behavior outside the existing direct/native module paths.

## Non-goals
- No broader `node:util` deprecation-wrapper prototype/constructor preservation work.
- No unrelated process EventEmitter behavior changes.
