### PR TITLE
fix(net): expose socket and server method values

### DIFF
--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -1726,6 +1726,11 @@ pub fn is_net_socket_handle(handle: i64) -> bool {
     statics::sockets().lock().unwrap().contains_key(&handle)
 }
 
+/// True iff `handle` is a currently-registered net server id.
+pub fn is_net_server_handle(handle: i64) -> bool {
+    statics::servers().lock().unwrap().contains_key(&handle)
+}
+
 /// `extern "C"` form of `is_net_socket_handle` — used by
 /// perry-stdlib's `common::dispatch::dispatch_handle_method`
 /// (HANDLE_METHOD_DISPATCH) when bundled-net is stripped and
@@ -1743,6 +1748,17 @@ pub fn is_net_socket_handle(handle: i64) -> bool {
 #[no_mangle]
 pub extern "C" fn js_ext_net_is_socket_handle(handle: i64) -> i32 {
     if is_net_socket_handle(handle) {
+        1
+    } else {
+        0
+    }
+}
+
+/// `extern "C"` form of `is_net_server_handle` for method-value/property
+/// dispatch on `net.Server` handles.
+#[no_mangle]
+pub extern "C" fn js_ext_net_is_server_handle(handle: i64) -> i32 {
+    if is_net_server_handle(handle) {
         1
     } else {
         0

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -957,6 +957,18 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         object: Box::new(object_expr),
                         property: property_name,
                     });
+                } else if module_name == "net"
+                    && ((class_name == "Socket" && is_net_socket_method_name(&property_name))
+                        || (class_name == "Server" && is_net_server_method_name(&property_name)))
+                {
+                    // `net.Socket` / `net.Server` method reads are callable
+                    // values. The call form still lowers through the native
+                    // method table; only bare reads use property dispatch.
+                    let object_expr = lower_expr(ctx, &member.obj)?;
+                    return Ok(Expr::PropertyGet {
+                        object: Box::new(object_expr),
+                        property: property_name,
+                    });
                 } else if module_name == "Headers" && is_headers_method_name(&property_name) {
                     // A bare Fetch Headers method read (`headers.entries`) is a
                     // function value, not a zero-arg native call. The call form
@@ -1905,6 +1917,63 @@ fn is_dgram_socket_method_name(prop: &str) -> bool {
             | "getSendBufferSize"
             | "ref"
             | "unref"
+    )
+}
+
+fn is_net_socket_method_name(prop: &str) -> bool {
+    matches!(
+        prop,
+        "address"
+            | "connect"
+            | "destroy"
+            | "destroySoon"
+            | "end"
+            | "pause"
+            | "ref"
+            | "resetAndDestroy"
+            | "resume"
+            | "setEncoding"
+            | "setKeepAlive"
+            | "setNoDelay"
+            | "setTimeout"
+            | "unref"
+            | "write"
+            | "on"
+            | "addListener"
+            | "once"
+            | "off"
+            | "removeListener"
+            | "removeAllListeners"
+            | "listenerCount"
+            | "eventNames"
+            | "listeners"
+            | "rawListeners"
+            | "upgradeToTLS"
+            | "setDefaultEncoding"
+            | "cork"
+            | "uncork"
+    )
+}
+
+fn is_net_server_method_name(prop: &str) -> bool {
+    matches!(
+        prop,
+        "address"
+            | "close"
+            | "getConnections"
+            | "listen"
+            | "ref"
+            | "unref"
+            | "on"
+            | "addListener"
+            | "once"
+            | "off"
+            | "removeListener"
+            | "removeAllListeners"
+            | "listenerCount"
+            | "eventNames"
+            | "listeners"
+            | "rawListeners"
     )
 }
 

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -53,21 +53,8 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
         return v;
     }
 
-    // Each dispatcher below is gated on TWO conditions: (a) its registry
-    // currently holds this handle id, AND (b) the method name is one this
-    // dispatcher actually handles. Both are required because handle id
-    // namespaces are not unified — `net.createConnection` uses its own
-    // `NEXT_NET_ID` counter, separate from the common HANDLES registry that
-    // backs Fastify/ioredis/HashHandle. A net.Socket at id=1 always
-    // collides with the first object created in the common registry. If we
-    // claimed a handle on registry match alone, calling `socket.write(b)` on
-    // a socket whose id collided with a HashHandle would route to
-    // `dispatch_hash` (registry says yes), find no `write` arm, and silently
-    // return undefined — the bytes never reach the wire (#91). Gating on
-    // method-name vocabulary lets the call fall through to the next
-    // dispatcher when a handle id is reused across registries with disjoint
-    // method sets. The proper long-term fix is a single unified id space;
-    // this is the surgical version.
+    // Dispatchers below gate on registry membership plus method vocabulary
+    // because native handle id spaces are not unified (#91).
 
     // Fastify app: routes for HTTP verbs + lifecycle methods.
     // #1113 adds `"on"` here — `app.server.on(event, cb)` dispatches
@@ -505,6 +492,13 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
         if unsafe { js_ext_net_is_socket_handle(handle) } != 0 {
             return dispatch_external_net_socket(handle, method_name, &args);
         }
+        if let Some(v) = crate::common::net_method_values::dispatch_external_server_method(
+            handle,
+            method_name,
+            &args,
+        ) {
+            return v;
+        }
     }
 
     // Web Fetch method dispatch (refs #421 — Phase 1 of the handle-NaN-boxing
@@ -847,7 +841,7 @@ unsafe fn dispatch_net_socket(handle: i64, method: &str, args: &[f64]) -> f64 {
             crate::net::js_net_socket_end(handle, chunk.to_bits() as i64);
             f64::from_bits(0x7FFC_0000_0000_0001)
         }
-        "destroy" => {
+        "destroy" | "destroySoon" => {
             crate::net::js_net_socket_destroy(handle);
             f64::from_bits(0x7FFC_0000_0000_0001)
         }
@@ -1038,7 +1032,7 @@ unsafe fn dispatch_external_net_socket(handle: i64, method: &str, args: &[f64]) 
             js_net_socket_end(handle, chunk.to_bits() as i64);
             f64::from_bits(0x7FFC_0000_0000_0001)
         }
-        "destroy" => {
+        "destroy" | "destroySoon" => {
             js_net_socket_destroy(handle);
             f64::from_bits(0x7FFC_0000_0000_0001)
         }
@@ -1189,6 +1183,10 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
             }
             return js_class_method_bind(handle as f64, name_bytes.as_ptr(), name_bytes.len());
         }
+    }
+
+    if let Some(v) = crate::common::net_method_values::dispatch_property(handle, property_name) {
+        return v;
     }
 
     // Server-side node:http request/response handles whose static

--- a/crates/perry-stdlib/src/common/mod.rs
+++ b/crates/perry-stdlib/src/common/mod.rs
@@ -8,6 +8,7 @@ pub mod handle;
 #[cfg(feature = "async-runtime")]
 pub mod async_bridge;
 pub mod dispatch;
+pub mod net_method_values;
 
 #[cfg(feature = "async-runtime")]
 pub use async_bridge::*;

--- a/crates/perry-stdlib/src/common/net_method_values.rs
+++ b/crates/perry-stdlib/src/common/net_method_values.rs
@@ -1,0 +1,261 @@
+//! net.Socket/net.Server method-value helpers for handle dispatch.
+
+fn nanbox_handle(handle: i64) -> f64 {
+    f64::from_bits(0x7FFD_0000_0000_0000u64 | (handle as u64 & 0x0000_FFFF_FFFF_FFFF))
+}
+
+#[cfg(all(
+    not(feature = "bundled-net"),
+    feature = "external-net-pump",
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+fn undefined() -> f64 {
+    f64::from_bits(0x7FFC_0000_0000_0001)
+}
+
+#[cfg(all(
+    not(feature = "bundled-net"),
+    feature = "external-net-pump",
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+fn null() -> f64 {
+    f64::from_bits(0x7FFC_0000_0000_0002)
+}
+
+fn bind_handle_method(handle: i64, name: &'static [u8]) -> f64 {
+    extern "C" {
+        fn js_class_method_bind(
+            instance: f64,
+            method_name_ptr: *const u8,
+            method_name_len: usize,
+        ) -> f64;
+    }
+    unsafe { js_class_method_bind(nanbox_handle(handle), name.as_ptr(), name.len()) }
+}
+
+#[cfg(all(
+    not(feature = "bundled-net"),
+    feature = "external-net-pump",
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+fn unbox_to_i64(v: f64) -> i64 {
+    (v.to_bits() & 0x0000_FFFF_FFFF_FFFF) as i64
+}
+
+#[cfg(all(
+    not(feature = "bundled-net"),
+    feature = "external-net-pump",
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+fn json_str_to_value(s: *mut perry_runtime::StringHeader) -> f64 {
+    if s.is_null() {
+        return null();
+    }
+    f64::from_bits(unsafe { perry_runtime::json::js_json_parse_or_null(s).bits() })
+}
+
+fn net_socket_method_name(prop: &str) -> Option<&'static [u8]> {
+    match prop {
+        "address" => Some(b"address"),
+        "connect" => Some(b"connect"),
+        "destroy" => Some(b"destroy"),
+        "destroySoon" => Some(b"destroySoon"),
+        "end" => Some(b"end"),
+        "pause" => Some(b"pause"),
+        "ref" => Some(b"ref"),
+        "resetAndDestroy" => Some(b"resetAndDestroy"),
+        "resume" => Some(b"resume"),
+        "setEncoding" => Some(b"setEncoding"),
+        "setKeepAlive" => Some(b"setKeepAlive"),
+        "setNoDelay" => Some(b"setNoDelay"),
+        "setTimeout" => Some(b"setTimeout"),
+        "unref" => Some(b"unref"),
+        "write" => Some(b"write"),
+        "on" => Some(b"on"),
+        "addListener" => Some(b"addListener"),
+        "once" => Some(b"once"),
+        "off" => Some(b"off"),
+        "removeListener" => Some(b"removeListener"),
+        "removeAllListeners" => Some(b"removeAllListeners"),
+        "listenerCount" => Some(b"listenerCount"),
+        "eventNames" => Some(b"eventNames"),
+        "listeners" => Some(b"listeners"),
+        "rawListeners" => Some(b"rawListeners"),
+        "upgradeToTLS" => Some(b"upgradeToTLS"),
+        "setDefaultEncoding" => Some(b"setDefaultEncoding"),
+        "cork" => Some(b"cork"),
+        "uncork" => Some(b"uncork"),
+        _ => None,
+    }
+}
+
+#[cfg(all(
+    not(feature = "bundled-net"),
+    feature = "external-net-pump",
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+fn net_server_method_name(prop: &str) -> Option<&'static [u8]> {
+    match prop {
+        "address" => Some(b"address"),
+        "close" => Some(b"close"),
+        "getConnections" => Some(b"getConnections"),
+        "listen" => Some(b"listen"),
+        "ref" => Some(b"ref"),
+        "unref" => Some(b"unref"),
+        "on" => Some(b"on"),
+        "addListener" => Some(b"addListener"),
+        "once" => Some(b"once"),
+        "off" => Some(b"off"),
+        "removeListener" => Some(b"removeListener"),
+        "removeAllListeners" => Some(b"removeAllListeners"),
+        "listenerCount" => Some(b"listenerCount"),
+        "eventNames" => Some(b"eventNames"),
+        "listeners" => Some(b"listeners"),
+        "rawListeners" => Some(b"rawListeners"),
+        _ => None,
+    }
+}
+
+pub(crate) fn dispatch_property(handle: i64, property_name: &str) -> Option<f64> {
+    if let Some(name) = net_socket_method_name(property_name) {
+        #[cfg(all(
+            feature = "bundled-net",
+            not(target_os = "ios"),
+            not(target_os = "android")
+        ))]
+        if crate::net::is_net_socket_handle(handle) {
+            return Some(bind_handle_method(handle, name));
+        }
+
+        #[cfg(all(
+            not(feature = "bundled-net"),
+            feature = "external-net-pump",
+            not(target_os = "ios"),
+            not(target_os = "android")
+        ))]
+        {
+            extern "C" {
+                fn js_ext_net_is_socket_handle(handle: i64) -> i32;
+            }
+            if unsafe { js_ext_net_is_socket_handle(handle) } != 0 {
+                return Some(bind_handle_method(handle, name));
+            }
+        }
+    }
+
+    #[cfg(all(
+        not(feature = "bundled-net"),
+        feature = "external-net-pump",
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
+    if let Some(name) = net_server_method_name(property_name) {
+        extern "C" {
+            fn js_ext_net_is_server_handle(handle: i64) -> i32;
+        }
+        if unsafe { js_ext_net_is_server_handle(handle) } != 0 {
+            return Some(bind_handle_method(handle, name));
+        }
+    }
+
+    None
+}
+
+#[cfg(all(
+    not(feature = "bundled-net"),
+    feature = "external-net-pump",
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+pub(crate) unsafe fn dispatch_external_server_method(
+    handle: i64,
+    method: &str,
+    args: &[f64],
+) -> Option<f64> {
+    if net_server_method_name(method).is_none() {
+        return None;
+    }
+
+    extern "C" {
+        fn js_ext_net_is_server_handle(handle: i64) -> i32;
+        fn js_net_server_listen(handle: i64, port: f64, callback_i64: i64);
+        fn js_net_server_close(handle: i64, callback_i64: i64);
+        fn js_net_server_address(handle: i64) -> *mut perry_runtime::StringHeader;
+        fn js_net_server_on(handle: i64, event_ptr: i64, cb: i64);
+        fn js_net_server_once(handle: i64, event_ptr: i64, cb: i64) -> i64;
+        fn js_net_server_remove_listener(handle: i64, event_ptr: i64, cb: i64) -> i64;
+        fn js_net_server_remove_all_listeners(handle: i64, event_ptr: i64) -> i64;
+        fn js_net_server_listener_count(handle: i64, event_ptr: i64) -> f64;
+        fn js_net_server_event_names(handle: i64) -> *mut perry_runtime::StringHeader;
+        fn js_net_server_listeners(handle: i64, event_ptr: i64) -> i64;
+        fn js_net_server_raw_listeners(handle: i64, event_ptr: i64) -> i64;
+    }
+
+    if js_ext_net_is_server_handle(handle) == 0 {
+        return None;
+    }
+
+    let result = match method {
+        "listen" => {
+            let port = args.first().copied().unwrap_or(0.0);
+            let callback = args.get(1).copied().map(unbox_to_i64).unwrap_or(0);
+            js_net_server_listen(handle, port, callback);
+            nanbox_handle(handle)
+        }
+        "close" => {
+            let callback = args.first().copied().map(unbox_to_i64).unwrap_or(0);
+            js_net_server_close(handle, callback);
+            nanbox_handle(handle)
+        }
+        "address" => json_str_to_value(js_net_server_address(handle)),
+        "on" | "addListener" if args.len() >= 2 => {
+            js_net_server_on(handle, unbox_to_i64(args[0]), unbox_to_i64(args[1]));
+            nanbox_handle(handle)
+        }
+        "once" if args.len() >= 2 => {
+            js_net_server_once(handle, unbox_to_i64(args[0]), unbox_to_i64(args[1]));
+            nanbox_handle(handle)
+        }
+        "off" | "removeListener" if args.len() >= 2 => {
+            js_net_server_remove_listener(handle, unbox_to_i64(args[0]), unbox_to_i64(args[1]));
+            nanbox_handle(handle)
+        }
+        "removeAllListeners" => {
+            let event = args.first().copied().map(unbox_to_i64).unwrap_or(0);
+            js_net_server_remove_all_listeners(handle, event);
+            nanbox_handle(handle)
+        }
+        "listenerCount" if !args.is_empty() => {
+            js_net_server_listener_count(handle, unbox_to_i64(args[0]))
+        }
+        "eventNames" => json_str_to_value(js_net_server_event_names(handle)),
+        "listeners" if !args.is_empty() => {
+            let arr = js_net_server_listeners(handle, unbox_to_i64(args[0]));
+            nanbox_handle(arr)
+        }
+        "rawListeners" if !args.is_empty() => {
+            let arr = js_net_server_raw_listeners(handle, unbox_to_i64(args[0]));
+            nanbox_handle(arr)
+        }
+        "ref" | "unref" => nanbox_handle(handle),
+        "getConnections" => {
+            if let Some(callback) = args.first().copied().map(unbox_to_i64) {
+                if callback >= 0x1000 {
+                    perry_runtime::closure::js_closure_call2(
+                        callback as *const perry_runtime::ClosureHeader,
+                        null(),
+                        0.0,
+                    );
+                }
+            }
+            undefined()
+        }
+        _ => undefined(),
+    };
+    Some(result)
+}

--- a/test-parity/node-suite/net/method-values/socket-server.ts
+++ b/test-parity/node-suite/net/method-values/socket-server.ts
@@ -1,0 +1,36 @@
+import * as net from "node:net";
+
+const server = net.createServer();
+
+console.log("server.address() before listen:", server.address());
+console.log("server.address typeof:", typeof server.address);
+console.log("server.close typeof:", typeof server.close);
+console.log("server.getConnections typeof:", typeof server.getConnections);
+console.log("server.listen typeof:", typeof server.listen);
+console.log("server.ref typeof:", typeof server.ref);
+console.log("server.unref typeof:", typeof server.unref);
+
+const serverListen = server.listen;
+console.log("server.listen alias typeof:", typeof serverListen);
+
+const socket = new net.Socket();
+
+console.log("socket.destroyed property:", socket.destroyed);
+console.log("socket.address typeof:", typeof socket.address);
+console.log("socket.connect typeof:", typeof socket.connect);
+console.log("socket.destroy typeof:", typeof socket.destroy);
+console.log("socket.destroySoon typeof:", typeof socket.destroySoon);
+console.log("socket.end typeof:", typeof socket.end);
+console.log("socket.pause typeof:", typeof socket.pause);
+console.log("socket.ref typeof:", typeof socket.ref);
+console.log("socket.resetAndDestroy typeof:", typeof socket.resetAndDestroy);
+console.log("socket.resume typeof:", typeof socket.resume);
+console.log("socket.setEncoding typeof:", typeof socket.setEncoding);
+console.log("socket.setKeepAlive typeof:", typeof socket.setKeepAlive);
+console.log("socket.setNoDelay typeof:", typeof socket.setNoDelay);
+console.log("socket.setTimeout typeof:", typeof socket.setTimeout);
+console.log("socket.unref typeof:", typeof socket.unref);
+console.log("socket.write typeof:", typeof socket.write);
+
+const socketWrite = socket.write;
+console.log("socket.write alias typeof:", typeof socketWrite);


### PR DESCRIPTION
Closes #3397

## Summary
- Bare `net.Socket` and `net.Server` method reads now return callable method values instead of falling through to zero-argument native method/getter paths.
- Native handle property dispatch now binds net socket/server method values for registered handles, including bundled and external net handles.
- External net server handles now expose the server-handle probe needed for method binding, and `destroySoon` aliases socket destroy dispatch for callable method-value paths.

## Why This Cut
This is a focused PR for the shared `node:net` method-value surface behind #3397. Related server connection-limit/drop behavior and Socket TOS APIs are separate compatibility gaps and are intentionally left out of this change.

## Tests Added
- `test-parity/node-suite/net/method-values/socket-server.ts`

## Verification
- Pre-fix: `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module net` failed 1/6 at the new fixture (`test-parity/reports/parity_report_20260531_035717.json`).
- Post-rebase: `PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module net` passed 6/6 (`test-parity/reports/parity_report_20260531_041114.json`).
- `RUSTC_WRAPPER= cargo check -p perry-runtime -p perry-codegen -p perry-hir -p perry-api-manifest -p perry -p perry-stdlib -p perry-ext-net` passed with existing warnings.
- `cargo fmt --all -- --check` passed.
- `./scripts/check_file_size.sh` passed.
- `jq empty test-parity/known_failures.json` passed.
- `git diff --check HEAD~1..HEAD` passed.

## Known Limitations / Non-goals
- Does not implement broader `net.Server` connection-limit/drop behavior (#2546).
- Does not implement Socket TOS APIs (#2548).
- Does not add `net.Server.setTimeout`; Node 24 reports that property as `undefined` for this surface.
