### PR TITLE
fix(node:async_hooks): createHook/AsyncResource validation + ALS arg forwarding

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/async_decimal.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/async_decimal.rs
@@ -3,19 +3,20 @@ use super::*;
 pub(super) const ASYNC_DECIMAL_ROWS: &[NativeModSig] = &[
     // ========== async_hooks.AsyncLocalStorage ==========
     // `new AsyncLocalStorage()` is dispatched by `lower_builtin_new`; the rows
-    // below cover the instance methods. `run(store, cb)` and `exit(cb)` pass
-    // the callback as a full NaN-boxed value (NA_F64) so the runtime can
-    // reject a non-callable callback with a `TypeError` (#3092) before
-    // mutating the async context; it extracts the closure pointer and invokes
-    // `js_closure_call0` internally. Pre-fix every method silently no-op'd
-    // through the unknown-method sentinel.
+    // below cover the instance methods. `run(store, cb, ...args)` and
+    // `exit(cb, ...args)` pass the callback as a full NaN-boxed value (NA_F64)
+    // so the runtime can reject a non-callable callback with a `TypeError`
+    // (#3092) before mutating the async context, plus a trailing `NA_VARARGS`
+    // slot that packs the `...args` into a JS array forwarded to the callback
+    // via `js_closure_call_array` (#3093). Pre-fix every method silently
+    // no-op'd through the unknown-method sentinel.
     NativeModSig {
         module: "async_hooks",
         has_receiver: true,
         method: "run",
         class_filter: None,
         runtime: "js_async_local_storage_run",
-        args: &[NA_F64, NA_F64],
+        args: &[NA_F64, NA_F64, NA_VARARGS],
         ret: NR_F64,
     },
     NativeModSig {
@@ -42,7 +43,7 @@ pub(super) const ASYNC_DECIMAL_ROWS: &[NativeModSig] = &[
         method: "exit",
         class_filter: None,
         runtime: "js_async_local_storage_exit",
-        args: &[NA_F64],
+        args: &[NA_F64, NA_VARARGS],
         ret: NR_F64,
     },
     NativeModSig {

--- a/crates/perry-runtime/src/async_hooks.rs
+++ b/crates/perry-runtime/src/async_hooks.rs
@@ -169,6 +169,42 @@ fn object_field(obj_value: f64, name: &[u8]) -> f64 {
     f64::from_bits(js_object_get_field_by_name(obj, key_handle.get_raw_const_ptr()).bits())
 }
 
+/// #3089 — `createHook(options)` destructures `options` immediately, so a
+/// nullish top-level value throws a plain `TypeError` (no error code) with
+/// Node's "Cannot destructure property 'init' of …" message *before* any
+/// callback is read. Non-nullish primitives (e.g. `0`) are accepted because
+/// destructuring them simply yields no callback fields.
+fn validate_create_hook_options(options: f64) {
+    let jv = JSValue::from_bits(options.to_bits());
+    let received = if jv.is_undefined() {
+        "'undefined' as it is undefined"
+    } else if jv.is_null() {
+        "'object null' as it is null"
+    } else {
+        return;
+    };
+    let message = format!("Cannot destructure property 'init' of {}.", received);
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+}
+
+/// #3089 — a *present* (non-`undefined`) hook member must be callable, matching
+/// Node's `validateFunction(value, 'hook.<name>')` which throws
+/// `TypeError [ERR_ASYNC_CALLBACK]` "hook.<name> must be a function". A missing
+/// or `undefined` member is allowed (left as a null callback).
+fn validate_hook_member(value: f64, member: &str) -> *const ClosureHeader {
+    let jv = JSValue::from_bits(value.to_bits());
+    if jv.is_undefined() {
+        return ptr::null();
+    }
+    if is_callable_value(value) {
+        return closure_from_value(value);
+    }
+    let message = format!("hook.{} must be a function", member);
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_ASYNC_CALLBACK")
+}
+
 fn callbacks_from_options(options: f64) -> HookCallbacks {
     let scope = crate::gc::RuntimeHandleScope::new();
     let options_handle = scope.root_nanbox_f64(options);
@@ -181,16 +217,18 @@ fn callbacks_from_options(options: f64) -> HookCallbacks {
         options_handle.get_nanbox_f64(),
         b"promiseResolve",
     ));
-    callbacks.init = closure_from_value(init.get_nanbox_f64());
-    callbacks.before = closure_from_value(before.get_nanbox_f64());
-    callbacks.after = closure_from_value(after.get_nanbox_f64());
-    callbacks.destroy = closure_from_value(destroy.get_nanbox_f64());
-    callbacks.promise_resolve = closure_from_value(promise_resolve.get_nanbox_f64());
+    callbacks.init = validate_hook_member(init.get_nanbox_f64(), "init");
+    callbacks.before = validate_hook_member(before.get_nanbox_f64(), "before");
+    callbacks.after = validate_hook_member(after.get_nanbox_f64(), "after");
+    callbacks.destroy = validate_hook_member(destroy.get_nanbox_f64(), "destroy");
+    callbacks.promise_resolve =
+        validate_hook_member(promise_resolve.get_nanbox_f64(), "promiseResolve");
     callbacks
 }
 
 #[no_mangle]
 pub extern "C" fn js_async_hooks_create_hook(options: f64) -> i64 {
+    validate_create_hook_options(options);
     let callbacks = callbacks_from_options(options);
     let mut hooks = HOOKS.lock().unwrap();
     let index = hooks.len();

--- a/crates/perry-stdlib/src/async_local_storage.rs
+++ b/crates/perry-stdlib/src/async_local_storage.rs
@@ -3,8 +3,9 @@
 //! Native implementation of Node.js AsyncLocalStorage from `async_hooks`.
 //! Provides run(), getStore(), enterWith(), exit(), and disable().
 
-use perry_runtime::closure::{is_closure_ptr, ClosureHeader};
-use perry_runtime::{async_context, js_closure_call0};
+use perry_runtime::array::{js_array_length, ArrayHeader};
+use perry_runtime::async_context;
+use perry_runtime::closure::{is_closure_ptr, js_closure_call_array, ClosureHeader};
 
 use crate::common::{get_handle_mut, register_handle, Handle};
 
@@ -33,6 +34,26 @@ unsafe fn validate_callback(callback: f64) -> *const ClosureHeader {
     perry_runtime::exception::js_throw(perry_runtime::value::js_nanbox_pointer(err as i64))
 }
 
+/// #3093 — invoke a validated callback with the forwarded rest arguments.
+/// `args_array` is a raw `*const ArrayHeader` (i64) holding the trailing
+/// `...args` packed by the codegen `NA_VARARGS` lowering; `0` / empty array
+/// means no forwarded args. Mirrors the data/len extraction used by
+/// `AsyncResource#runInAsyncScope` in perry-runtime.
+unsafe fn call_with_forwarded_args(cb: *const ClosureHeader, args_array: i64) -> f64 {
+    let closure_env = cb as i64;
+    if args_array == 0 {
+        return js_closure_call_array(closure_env, std::ptr::null(), 0);
+    }
+    let arr = args_array as *const ArrayHeader;
+    let len = js_array_length(arr) as i64;
+    let data = if arr.is_null() || len == 0 {
+        std::ptr::null()
+    } else {
+        (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64
+    };
+    js_closure_call_array(closure_env, data, len)
+}
+
 /// AsyncLocalStorage handle. Store stacks live in perry-runtime's active
 /// async context so schedulers can snapshot and restore them across async
 /// boundaries.
@@ -57,20 +78,23 @@ pub extern "C" fn js_async_local_storage_new() -> Handle {
     register_handle(AsyncLocalStorageHandle::new())
 }
 
-/// AsyncLocalStorage.run(store, callback)
-/// Push store onto stack, call callback, pop store, return result
+/// AsyncLocalStorage.run(store, callback, ...args)
+/// Push store onto stack, call callback with the forwarded rest args, pop
+/// store, return result. `args_array` carries the `...args` packed by the
+/// codegen `NA_VARARGS` lowering (#3093).
 #[no_mangle]
 pub unsafe extern "C" fn js_async_local_storage_run(
     handle: Handle,
     store: f64,
     callback: f64,
+    args_array: i64,
 ) -> f64 {
     // Validate before mutating the async context so an invalid callback throws
     // without leaving a pushed store behind (#3092).
     let cb = validate_callback(callback);
 
     async_context::push_store(handle, store);
-    let result = js_closure_call0(cb);
+    let result = call_with_forwarded_args(cb, args_array);
     async_context::pop_store(handle);
 
     result
@@ -97,10 +121,16 @@ pub extern "C" fn js_async_local_storage_enter_with(handle: Handle, store: f64) 
     }
 }
 
-/// AsyncLocalStorage.exit(callback)
-/// Save current stack, clear it, call callback, restore stack
+/// AsyncLocalStorage.exit(callback, ...args)
+/// Save current stack, clear it, call callback with the forwarded rest args,
+/// restore stack. `args_array` carries the `...args` packed by the codegen
+/// `NA_VARARGS` lowering (#3093).
 #[no_mangle]
-pub unsafe extern "C" fn js_async_local_storage_exit(handle: Handle, callback: f64) -> f64 {
+pub unsafe extern "C" fn js_async_local_storage_exit(
+    handle: Handle,
+    callback: f64,
+    args_array: i64,
+) -> f64 {
     // Validate before clearing the context so an invalid callback throws
     // without disturbing the saved store (#3092).
     let cb = validate_callback(callback);
@@ -111,7 +141,7 @@ pub unsafe extern "C" fn js_async_local_storage_exit(handle: Handle, callback: f
         None
     };
 
-    let result = js_closure_call0(cb);
+    let result = call_with_forwarded_args(cb, args_array);
 
     if let Some(saved) = saved {
         async_context::restore_store(handle, saved);

--- a/test-files/test_gap_asynchooks_3089_3090_3091_3093.ts
+++ b/test-files/test_gap_asynchooks_3089_3090_3091_3093.ts
@@ -1,0 +1,108 @@
+import async_hooks, { AsyncResource, AsyncLocalStorage } from "node:async_hooks";
+
+// #3089 — createHook option/member validation
+for (const value of [undefined, null]) {
+  try {
+    async_hooks.createHook(value as any);
+  } catch (err: any) {
+    console.log("options", String(value), err.name, err.code || "no-code", err.message);
+  }
+}
+for (const value of [null, 0, true, "x", {}, [], Symbol("s")]) {
+  try {
+    async_hooks.createHook({ init: value } as any);
+  } catch (err: any) {
+    console.log("init", String(value), err.name, err.code || "no-code", err.message);
+  }
+}
+for (const member of ["before", "after", "destroy", "promiseResolve"]) {
+  try {
+    async_hooks.createHook({ [member]: 5 } as any);
+  } catch (err: any) {
+    console.log(member, err.name, err.code || "no-code", err.message);
+  }
+}
+const undefMemberHook = async_hooks.createHook({ init: undefined });
+console.log("undef-member-ok", typeof undefMemberHook.enable);
+const primitiveOptionsHook = async_hooks.createHook(0 as any);
+console.log("primitive-options-ok", typeof primitiveOptionsHook.enable);
+const missingMemberHook = async_hooks.createHook({});
+console.log("missing-member-ok", typeof missingMemberHook.enable);
+
+// #3090 — AsyncResource constructor input validation
+for (const value of [undefined, null, 0, true, {}, [], Symbol("s")]) {
+  try {
+    new AsyncResource(value as any);
+  } catch (err: any) {
+    console.log("type", String(value), err.name, err.code || "no-code", err.message);
+  }
+}
+for (const value of [null, true, "x", {}, [], Symbol("s"), 1.5, NaN, Infinity]) {
+  try {
+    new AsyncResource("T", { triggerAsyncId: value } as any);
+  } catch (err: any) {
+    console.log("trigger", String(value), err.name, err.code || "no-code", err.message);
+  }
+}
+const triggerUndefRes = new AsyncResource("T", { triggerAsyncId: undefined });
+console.log("trigger-undefined-ok", typeof triggerUndefRes.asyncId());
+const triggerNeg1Res = new AsyncResource("T", { triggerAsyncId: -1 });
+console.log("trigger-neg1-ok", typeof triggerNeg1Res.asyncId());
+
+// #3091 — AsyncResource callback argument validation
+const ar = new AsyncResource("T");
+for (const value of [undefined, null, 0, true, "x", {}, [], Symbol("s")]) {
+  try {
+    ar.runInAsyncScope(value as any);
+  } catch (err: any) {
+    console.log("run", String(value), err.name, err.code || "no-code");
+  }
+}
+for (const value of [undefined, null, 0, true, "x", {}, [], Symbol("s")]) {
+  try {
+    ar.bind(value as any);
+  } catch (err: any) {
+    console.log("bind", String(value), err.name, err.code || "no-code", err.message);
+  }
+}
+console.log(
+  "run-args",
+  ar.runInAsyncScope(
+    function (this: any, ...args: any[]) {
+      return JSON.stringify(args) + "|this=" + String(this);
+    },
+    "ctx",
+    1,
+    2,
+    3,
+  ),
+);
+
+// #3093 — AsyncLocalStorage run/exit argument forwarding
+const als = new AsyncLocalStorage<string>();
+console.log(
+  "run ret:",
+  als.run(
+    "store",
+    function (...args: any[]) {
+      console.log("run args:", JSON.stringify(args), "store:", als.getStore());
+      return "r";
+    },
+    "a",
+    "b",
+    "c",
+  ),
+);
+console.log(
+  "exit ret:",
+  als.run("outer", () =>
+    als.exit(
+      function (...args: any[]) {
+        console.log("exit args:", JSON.stringify(args), "store:", als.getStore());
+        return "e";
+      },
+      "x",
+      "y",
+    ),
+  ),
+);


### PR DESCRIPTION
Closes #3089
Closes #3093

## Summary
Brings `node:async_hooks` `createHook` validation and `AsyncLocalStorage` argument forwarding to Node parity.

- **#3089 — createHook options/member validation.** `async_hooks.createHook(options)` now rejects a nullish top-level value with Node's plain `TypeError` (no error code) — `Cannot destructure property 'init' of 'undefined' as it is undefined.` / `... of 'object null' as it is null.` — before any callback is read. A *present* (non-`undefined`) `init`/`before`/`after`/`destroy`/`promiseResolve` member that is not callable now throws `TypeError [ERR_ASYNC_CALLBACK]` with `hook.<name> must be a function`. Missing/`undefined` members and non-nullish primitive top-level options (e.g. `0`) stay allowed, matching Node's destructuring semantics.
- **#3093 — ALS run/exit rest-argument forwarding.** `AsyncLocalStorage#run(store, callback, ...args)` and `#exit(callback, ...args)` now forward the trailing rest arguments to the callback. The native-table rows gained a trailing `NA_VARARGS` slot (already-existing codegen lowering packs `...args` into a JS array); the runtime helpers invoke the validated closure via `js_closure_call_array` with the forwarded args while preserving store push/pop (`run`) and store save/clear/restore (`exit`) semantics.

## Implementation
- `crates/perry-runtime/src/async_hooks.rs`: `validate_create_hook_options` (nullish guard) + `validate_hook_member` (present-non-callable guard), wired into `js_async_hooks_create_hook` / `callbacks_from_options`.
- `crates/perry-stdlib/src/async_local_storage.rs`: `js_async_local_storage_run`/`_exit` take a trailing `args_array: i64` and call the callback through `call_with_forwarded_args` (`js_closure_call_array`).
- `crates/perry-codegen/src/lower_call/native_table/async_decimal.rs`: `run` → `&[NA_F64, NA_F64, NA_VARARGS]`, `exit` → `&[NA_F64, NA_VARARGS]`.

No new HIR variant; no new codegen-emitted `#[no_mangle]` (only signatures of existing emitted helpers changed). `#3090`/`#3091` were already closed on `main` (AsyncResource constructor + callback validation present in `async_hooks.rs`); this PR's gap test re-covers them as a regression net but does not re-close them.

## Validation
`test-files/test_gap_asynchooks_3089_3090_3091_3093.ts` (imports `node:async_hooks`, prints `err.name`/`code`/`message` for throws and the forwarded args + return values for ALS `run`/`exit`) is **byte-identical** to `node --experimental-strip-types` under the DEFAULT auto-optimize compile.

Guards: `./scripts/check_file_size.sh` (exit 0), `cargo fmt --all -- --check` (clean), `cargo test --release -p perry-hir` (green), `cargo test --release -p perry-runtime async_hooks` (green single-threaded; the `test_async_hooks_promise_alloc_remains_malloc_tracked` failure under parallel `--test-threads` is pre-existing global-`HOOKS_ACTIVE` cross-test contamination, passes isolated and is unrelated to this change).
