### PR TITLE
fix(node:diagnostics_channel): runStores arg forwarding + name/bindStore/traceCallback validation

### DIFF
--- a/crates/perry-runtime/src/closure/dispatch.rs
+++ b/crates/perry-runtime/src/closure/dispatch.rs
@@ -593,6 +593,29 @@ pub extern "C" fn js_closure_call7(
             dispatch_bound_function(closure, &[arg0, arg1, arg2, arg3, arg4, arg5, arg6])
         };
     }
+    if let Some((fixed_arity, synth)) = lookup_closure_rest_full(func_ptr) {
+        return unsafe {
+            dispatch_rest_bundled(
+                closure,
+                func_ptr,
+                &[arg0, arg1, arg2, arg3, arg4, arg5, arg6],
+                fixed_arity,
+                synth,
+            )
+        };
+    }
+    if let Some(declared) = lookup_closure_arity(func_ptr) {
+        if declared > 7 {
+            return unsafe {
+                dispatch_with_arity(
+                    closure,
+                    func_ptr,
+                    &[arg0, arg1, arg2, arg3, arg4, arg5, arg6],
+                    declared,
+                )
+            };
+        }
+    }
     let func: extern "C" fn(*const ClosureHeader, f64, f64, f64, f64, f64, f64, f64) -> f64 =
         unsafe { std::mem::transmute(func_ptr) };
     func(closure, arg0, arg1, arg2, arg3, arg4, arg5, arg6)
@@ -624,6 +647,29 @@ pub extern "C" fn js_closure_call8(
         return unsafe {
             dispatch_bound_function(closure, &[arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7])
         };
+    }
+    if let Some((fixed_arity, synth)) = lookup_closure_rest_full(func_ptr) {
+        return unsafe {
+            dispatch_rest_bundled(
+                closure,
+                func_ptr,
+                &[arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7],
+                fixed_arity,
+                synth,
+            )
+        };
+    }
+    if let Some(declared) = lookup_closure_arity(func_ptr) {
+        if declared > 8 {
+            return unsafe {
+                dispatch_with_arity(
+                    closure,
+                    func_ptr,
+                    &[arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7],
+                    declared,
+                )
+            };
+        }
     }
     let func: extern "C" fn(*const ClosureHeader, f64, f64, f64, f64, f64, f64, f64, f64) -> f64 =
         unsafe { std::mem::transmute(func_ptr) };

--- a/crates/perry-runtime/src/node_submodules/diagnostics.rs
+++ b/crates/perry-runtime/src/node_submodules/diagnostics.rs
@@ -61,11 +61,30 @@ pub(crate) enum DiagChannelKey {
     Symbol(u64),
 }
 
+/// The `transform` argument remembered by `bindStore(store, transform)`.
+///
+/// Node distinguishes three cases (#3085): an omitted/`undefined` transform
+/// (the store context is just the published `data`), a callable transform
+/// (its return value becomes the context), and a *non-callable, non-undefined*
+/// transform value (`null`, a number, a string, …). The last case is retained
+/// — during `runStores` Node attempts to call it, fails, runs the callback
+/// with no store context, and reports an uncaught `TypeError: transform is not
+/// a function`. Discarding it (treating it like `undefined`) was the bug.
+#[derive(Clone, Copy)]
+pub(crate) enum StoreTransform {
+    /// No transform: context is the published `data` value.
+    None,
+    /// A callable transform closure.
+    Callable(f64),
+    /// A bound but non-callable transform value (triggers the Node TypeError).
+    NonCallable,
+}
+
 pub(crate) struct DiagChannelState {
     pub(crate) name: f64,
     pub(crate) obj: *mut ObjectHeader,
     pub(crate) subscribers: Vec<f64>,
-    pub(crate) stores: Vec<(f64, Option<f64>)>,
+    pub(crate) stores: Vec<(f64, StoreTransform)>,
 }
 
 pub(crate) struct DiagTracingState {
@@ -313,6 +332,31 @@ pub(crate) fn channel_key(name: f64) -> Option<DiagChannelKey> {
     None
 }
 
+/// True when `value` is a JS Symbol. `channel(symbol)` accepts symbols, but
+/// `tracingChannel(nameOrChannels)` rejects them (#3084) — Node's validator
+/// only allows a string name or a channel-object map there.
+fn is_symbol_value(value: f64) -> bool {
+    let bits = value.to_bits();
+    let tag = bits & 0xFFFF_0000_0000_0000;
+    tag == crate::value::POINTER_TAG && unsafe { crate::symbol::js_is_symbol(value) } != 0
+}
+
+/// Throw the Node `ERR_INVALID_ARG_TYPE` that `tracingChannel(symbol)` raises:
+/// `The "nameOrChannels" argument must be of type string or an instance of
+/// TracingChannel or Object. Received type symbol (Symbol(<desc>))`.
+fn throw_tracing_channel_symbol(value: f64) -> ! {
+    let desc = unsafe { crate::symbol::js_symbol_description(value) };
+    let inner = decode_string_value(desc).unwrap_or_default();
+    let msg = format!(
+        "The \"nameOrChannels\" argument must be of type string or an instance \
+         of TracingChannel or Object. Received type symbol (Symbol({inner}))"
+    );
+    let s = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    register_error_code(s, "ERR_INVALID_ARG_TYPE");
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(boxed_ptr(err))
+}
+
 pub(crate) fn diagnostics_channel_is_channel_instance_value(value: f64) -> bool {
     let js_value = JSValue::from_bits(value.to_bits());
     if !js_value.is_pointer() {
@@ -538,6 +582,17 @@ pub(crate) fn throw_type_error_no_code(message: &[u8]) -> ! {
     crate::exception::js_throw(boxed_ptr(err))
 }
 
+/// Build (but do not throw) the `TypeError: transform is not a function`
+/// error that a non-callable `bindStore` transform produces during
+/// `runStores`. Returned as a NaN-boxed value so it can be scheduled as an
+/// uncaught exception rather than thrown synchronously (#3085).
+pub(crate) fn make_transform_not_a_function_error() -> f64 {
+    let msg = b"transform is not a function";
+    let s = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    boxed_ptr(err)
+}
+
 pub(crate) fn next_diag_id() -> i64 {
     NEXT_DIAG_ID.with(|n| {
         let mut n = n.borrow_mut();
@@ -592,19 +647,6 @@ pub(crate) fn cast4(
 ) -> *const u8 {
     f as *const u8
 }
-#[allow(clippy::missing_transmute_annotations)]
-pub(crate) fn cast5(
-    f: extern "C" fn(*const ClosureHeader, f64, f64, f64, f64, f64) -> f64,
-) -> *const u8 {
-    f as *const u8
-}
-#[allow(clippy::missing_transmute_annotations)]
-pub(crate) fn cast7(
-    f: extern "C" fn(*const ClosureHeader, f64, f64, f64, f64, f64, f64, f64) -> f64,
-) -> *const u8 {
-    f as *const u8
-}
-
 pub(crate) fn method_closure(func: *const u8, arity: u32, id: i64) -> f64 {
     let c = js_closure_alloc(func, 1);
     js_closure_set_capture_ptr(c, 0, id);
@@ -1018,10 +1060,16 @@ pub(crate) extern "C" fn diag_channel_bind_store(
 ) -> f64 {
     ensure_subscriber_owner_thread();
     let id = method_id(closure);
-    let transform = if valid_closure_value(transform) {
-        Some(transform)
+    // An omitted or explicit `undefined` transform is the no-transform case;
+    // a callable is stored as-is; any other value is remembered as a
+    // non-callable transform so `runStores` can reproduce Node's uncaught
+    // `TypeError: transform is not a function` (#3085).
+    let transform = if transform.to_bits() == TAG_UNDEFINED {
+        StoreTransform::None
+    } else if valid_closure_value(transform) {
+        StoreTransform::Callable(transform)
     } else {
-        None
+        StoreTransform::NonCallable
     };
     let mut inserted = false;
     DIAG_CHANNELS.with(|m| {
@@ -1130,6 +1178,20 @@ pub(crate) fn run_stores_method_closure(id: i64) -> f64 {
     boxed_ptr(c)
 }
 
+/// Build the `traceCallback` method closure. Like `runStores`, registered as a
+/// synthetic-arguments closure so the FULL argument list — `fn`, `position`,
+/// `context`, `thisArg`, and every trailing `...args` — is bundled into one JS
+/// array, letting `traceCallback` honor `position` and forward all surrounding
+/// arguments (#3086). The fixed seven-argument `cast7` entrypoint used
+/// previously ignored `position` and dropped extra arguments.
+pub(crate) fn trace_callback_method_closure(id: i64) -> f64 {
+    let func = cast1(diag_trace_callback);
+    let c = js_closure_alloc(func, 1);
+    js_closure_set_capture_ptr(c, 0, id);
+    js_register_closure_synthetic_arguments(func, 0);
+    boxed_ptr(c)
+}
+
 /// Build a NaN-boxed JS array value from a slice of callback arguments.
 ///
 /// # Safety
@@ -1199,16 +1261,24 @@ pub(crate) extern "C" fn diag_channel_run_stores(
     js_closure_set_capture_ptr(next, 4, cb_args_arr.to_bits() as i64);
     let mut next_value = boxed_ptr(next);
     for (store, transform) in stores.into_iter().rev() {
-        let context = if let Some(t) = transform {
-            match catch_js(|| js_closure_call1(closure_ptr(t), data)) {
-                Ok(context) => context,
-                Err(err) => {
-                    schedule_uncaught(err);
-                    continue;
+        let context = match transform {
+            StoreTransform::Callable(t) => {
+                match catch_js(|| js_closure_call1(closure_ptr(t), data)) {
+                    Ok(context) => context,
+                    Err(err) => {
+                        schedule_uncaught(err);
+                        continue;
+                    }
                 }
             }
-        } else {
-            data
+            StoreTransform::NonCallable => {
+                // Node calls the stored transform; a non-callable value
+                // throws `TypeError: transform is not a function`, reported
+                // uncaught, and the store is not entered (#3085).
+                schedule_uncaught(make_transform_not_a_function_error());
+                continue;
+            }
+            StoreTransform::None => data,
         };
         let chain = js_closure_alloc(cast0(store_chain_thunk), 3);
         js_register_closure_arity(cast0(store_chain_thunk), 0);
@@ -1480,10 +1550,14 @@ pub(crate) extern "C" fn diag_trace_promise(
     }
 }
 
+/// The callback installed in place of the user's callback by
+/// `traceCallback`. Registered as a synthetic-arguments closure so it forwards
+/// every argument the traced function passes (`cb(null, "a", "b")`) to the
+/// user callback, matching Node's `ReflectApply(callback, this, arguments)`
+/// (#3086). `arguments[0]` is `err`, `arguments[1]` is `res`.
 pub(crate) extern "C" fn diag_trace_wrapped_callback(
     closure: *const ClosureHeader,
-    err: f64,
-    res: f64,
+    all_args: f64,
 ) -> f64 {
     let callback = js_closure_get_capture_f64(closure, 0);
     let context = js_closure_get_capture_f64(closure, 1);
@@ -1491,6 +1565,10 @@ pub(crate) extern "C" fn diag_trace_wrapped_callback(
     let async_end = js_closure_get_capture_ptr(closure, 3);
     let error = js_closure_get_capture_ptr(closure, 4);
     let context_obj = crate::value::js_nanbox_get_pointer(context) as *mut ObjectHeader;
+
+    let cb_args = unbox_arg_array(all_args);
+    let err = cb_args.first().copied().unwrap_or_else(undefined);
+    let res = cb_args.get(1).copied().unwrap_or_else(undefined);
 
     if crate::value::js_is_truthy(err) != 0 {
         set_field_value(context_obj, "error", err);
@@ -1500,7 +1578,7 @@ pub(crate) extern "C" fn diag_trace_wrapped_callback(
     }
 
     publish_channel(async_start, context);
-    let result = match catch_js(|| call_fn_value(callback, undefined(), &[err, res])) {
+    let result = match catch_js(|| call_fn_value(callback, undefined(), &cb_args)) {
         Ok(result) => result,
         Err(callback_err) => {
             publish_channel(async_end, context);
@@ -1511,19 +1589,53 @@ pub(crate) extern "C" fn diag_trace_wrapped_callback(
     result
 }
 
-pub(crate) extern "C" fn diag_trace_callback(
-    closure: *const ClosureHeader,
-    fn_value: f64,
-    _position: f64,
-    context: f64,
-    this_arg: f64,
-    callback: f64,
-    err: f64,
-    res: f64,
-) -> f64 {
-    if !valid_closure_value(callback) {
-        throw_invalid_arg();
-    }
+/// Throw the Node `ERR_INVALID_ARG_TYPE` for a non-function callback at the
+/// requested `traceCallback` position (#3086).
+fn throw_trace_callback_not_function() -> ! {
+    let msg = b"The \"callback\" argument must be of type function.";
+    let s = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    register_error_code(s, "ERR_INVALID_ARG_TYPE");
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(boxed_ptr(err))
+}
+
+pub(crate) extern "C" fn diag_trace_callback(closure: *const ClosureHeader, all_args: f64) -> f64 {
+    // Synthetic-arguments rest array: [fn, position, context, thisArg, ...args]
+    // (#3086). `position` defaults to -1 (the last trailing arg), the callback
+    // lives at `args[position]`, and the wrapped callback is spliced in at that
+    // position while all surrounding args are preserved.
+    let all = unbox_arg_array(all_args);
+    let undef = undefined();
+    let fn_value = all.first().copied().unwrap_or(undef);
+    let position_value = all.get(1).copied().unwrap_or(undef);
+    let context = all.get(2).copied().unwrap_or(undef);
+    let this_arg = all.get(3).copied().unwrap_or(undef);
+    let mut args: Vec<f64> = if all.len() > 4 {
+        all[4..].to_vec()
+    } else {
+        Vec::new()
+    };
+
+    // `position` defaults to -1. Resolve to a forward index using
+    // Array.prototype.at semantics (negative counts from the end). `position`
+    // arrives NaN-boxed (int32 or f64), so decode it as a JS number.
+    let position = if position_value.to_bits() == TAG_UNDEFINED {
+        -1i64
+    } else {
+        JSValue::from_bits(position_value.to_bits()).to_number() as i64
+    };
+    let idx = if position < 0 {
+        args.len() as i64 + position
+    } else {
+        position
+    };
+    let cb_index = if idx >= 0 && (idx as usize) < args.len() {
+        Some(idx as usize)
+    } else {
+        None
+    };
+    let callback = cb_index.map(|i| args[i]).unwrap_or(undef);
+
     let events = DIAG_TRACES.with(|m| {
         m.borrow()
             .get(&method_id(closure))
@@ -1537,7 +1649,16 @@ pub(crate) extern "C" fn diag_trace_callback(
             .unwrap_or(false)
     });
     if !active {
-        return call_fn_value(fn_value, this_arg, &[callback, err, res]);
+        // Inactive fast path: forward every argument verbatim, no callback
+        // validation and no wrapping (matches Node's `ReflectApply(fn,
+        // thisArg, args)`).
+        return call_fn_value(fn_value, this_arg, &args);
+    }
+
+    // Active path validates the resolved callback (Node's
+    // `validateFunction(callback, 'callback')`).
+    if !valid_closure_value(callback) {
+        throw_trace_callback_not_function();
     }
 
     let wrapped = js_closure_alloc(diag_trace_wrapped_callback as *const u8, 5);
@@ -1546,11 +1667,17 @@ pub(crate) extern "C" fn diag_trace_callback(
     js_closure_set_capture_ptr(wrapped, 2, events[2]);
     js_closure_set_capture_ptr(wrapped, 3, events[3]);
     js_closure_set_capture_ptr(wrapped, 4, events[4]);
-    js_register_closure_arity(diag_trace_wrapped_callback as *const u8, 2);
+    js_register_closure_synthetic_arguments(diag_trace_wrapped_callback as *const u8, 0);
     let wrapped_value = boxed_ptr(wrapped);
 
+    // Splice the wrapped callback in at the resolved position, preserving all
+    // surrounding arguments (#3086).
+    if let Some(i) = cb_index {
+        args[i] = wrapped_value;
+    }
+
     publish_channel(events[0], context);
-    match catch_js(|| call_fn_value(fn_value, this_arg, &[wrapped_value, err, res])) {
+    match catch_js(|| call_fn_value(fn_value, this_arg, &args)) {
         Ok(ret) => {
             publish_channel(events[1], context);
             ret
@@ -1573,7 +1700,13 @@ pub(crate) extern "C" fn thunk_diag_tracing_channel(
     name_or_channels: f64,
 ) -> f64 {
     let id = next_diag_id();
-    let events = if channel_key(name_or_channels).is_some() {
+    // `tracingChannel` accepts a string name or a channel-object map, but NOT a
+    // symbol (unlike plain `channel(symbol)`). Reject symbols with Node's
+    // ERR_INVALID_ARG_TYPE before the string-name branch (#3084).
+    if is_symbol_value(name_or_channels) {
+        throw_tracing_channel_symbol(name_or_channels);
+    }
+    let events = if decode_string_value(name_or_channels).is_some() {
         [
             ensure_channel(tracing_event_name(name_or_channels, "start")),
             ensure_channel(tracing_event_name(name_or_channels, "end")),
@@ -1620,11 +1753,7 @@ pub(crate) extern "C" fn thunk_diag_tracing_channel(
         "tracePromise",
         method_closure(cast3(diag_trace_promise), 3, id),
     );
-    set_field_value(
-        obj,
-        "traceCallback",
-        method_closure(cast7(diag_trace_callback), 7, id),
-    );
+    set_field_value(obj, "traceCallback", trace_callback_method_closure(id));
     DIAG_TRACES.with(|m| {
         m.borrow_mut().insert(id, DiagTracingState { obj, events });
     });

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -968,7 +968,7 @@ pub fn scan_node_submodule_singleton_roots_mut(visitor: &mut crate::gc::RuntimeR
             }
             for (store, transform) in &mut state.stores {
                 visitor.visit_nanbox_f64_slot(store);
-                if let Some(t) = transform.as_mut() {
+                if let StoreTransform::Callable(t) = transform {
                     visitor.visit_nanbox_f64_slot(t);
                 }
             }

--- a/test-files/test_gap_diagchannel_3082_3084_3085_3086.ts
+++ b/test-files/test_gap_diagchannel_3082_3084_3085_3086.ts
@@ -1,0 +1,112 @@
+import { channel, tracingChannel } from "node:diagnostics_channel";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+// Collect uncaught exceptions deterministically (they drain after sync code).
+const uncaught: string[] = [];
+process.on("uncaughtException", (err: any) => {
+  uncaught.push("uncaught:" + err.name + ":" + (err.code || "no-code") + ":" + err.message);
+});
+
+// ---- #3082: runStores forwards ALL callback arguments (bound + unbound) ----
+{
+  const ch = channel("runstores-bound");
+  const als = new AsyncLocalStorage();
+  ch.bindStore(als);
+  const ret = ch.runStores(
+    { value: 1 },
+    function (this: any, ...args: any[]) {
+      console.log("3082 bound args:", JSON.stringify(args));
+      console.log("3082 bound this.tag:", this && this.tag);
+      console.log("3082 bound store:", JSON.stringify(als.getStore()));
+      return "ret";
+    },
+    { tag: "ctx" },
+    "a",
+    "b",
+    "c",
+  );
+  console.log("3082 bound ret:", ret);
+}
+{
+  const ch = channel("runstores-unbound");
+  const ret = ch.runStores(
+    { value: 2 },
+    function (this: any, ...args: any[]) {
+      console.log("3082 unbound args:", JSON.stringify(args));
+      console.log("3082 unbound this.tag:", this && this.tag);
+      return "ret2";
+    },
+    { tag: "ctx2" },
+    "x",
+    "y",
+    "z",
+  );
+  console.log("3082 unbound ret:", ret);
+}
+
+// ---- #3084: tracingChannel rejects symbols; channel(symbol) is still ok ----
+for (const value of [Symbol("s"), Symbol.for("shared")]) {
+  try {
+    tracingChannel(value as any);
+    console.log("3084 no throw");
+  } catch (err: any) {
+    console.log("3084:", err.name, err.code, err.message);
+  }
+}
+console.log("3084 channel(symbol) ok:", typeof channel(Symbol("ok")));
+
+// ---- #3085: non-callable bindStore transform reports TypeError, no context --
+for (const transform of [null, 1]) {
+  const ch = channel("bind-transform-" + String(transform));
+  const als = new AsyncLocalStorage();
+  ch.bindStore(als, transform as any);
+  const ret = ch.runStores({ value: 9 }, () => {
+    console.log("3085 store:", JSON.stringify(als.getStore()), "transform:", String(transform));
+    return "ret";
+  });
+  console.log("3085 returned:", ret);
+}
+// explicit undefined transform = no-transform (store IS set)
+{
+  const ch = channel("bind-transform-undef");
+  const als = new AsyncLocalStorage();
+  ch.bindStore(als, undefined as any);
+  ch.runStores({ value: 7 }, () => {
+    console.log("3085 undef store:", JSON.stringify(als.getStore()));
+    return "ret";
+  });
+}
+
+// ---- #3086: traceCallback honors position + forwards surrounding args -------
+{
+  const ch = tracingChannel("tracecb-position");
+  const events: string[] = [];
+  ch.subscribe({
+    start: (ctx: any) => events.push("start:" + JSON.stringify(ctx)),
+    end: (ctx: any) => events.push("end:" + JSON.stringify(ctx)),
+    asyncStart: (ctx: any) => events.push("asyncStart:" + JSON.stringify(ctx.result)),
+    asyncEnd: (ctx: any) => events.push("asyncEnd:" + JSON.stringify(ctx.result)),
+  });
+  function target(a: any, cb: any, b: any, c: any) {
+    events.push("fn args:" + [a, typeof cb, b, c].join(","));
+    cb(null, "cb-value");
+    return "target-ret";
+  }
+  const ret = ch.traceCallback(
+    target as any,
+    1,
+    { ctx: true } as any,
+    { tag: "this" } as any,
+    "A",
+    (err: any, value: any) => events.push("callback:" + err + ":" + value),
+    "B",
+    "C",
+  );
+  console.log("3086 ret:", ret);
+  console.log(events.join("\n"));
+}
+
+// ---- flush uncaught exceptions deterministically ----
+setTimeout(() => {
+  for (const u of uncaught) console.log(u);
+}, 0);


### PR DESCRIPTION
Closes #3082
Closes #3084
Closes #3085
Closes #3086

## Implementation

All fixes are pure-runtime in `crates/perry-runtime/src/node_submodules/diagnostics.rs` (plus a latent dispatch-table fix in `closure/dispatch.rs`). No new HIR variants.

- **#3082 — runStores forwards all callback arguments.** `runStores(context, fn, thisArg, ...args)` is dispatched as a synthetic-arguments closure (`run_stores_method_closure`) that bundles the full argument list into one array, then splits it back into `[context, callback, thisArg, ...args]` and forwards every trailing arg to `fn` — both on the bound-store and no-store paths. Verified with 3 forwarded args under each path.

- **#3084 — tracingChannel rejects symbols.** `thunk_diag_tracing_channel` now rejects symbol `nameOrChannels` up front with Node's `TypeError [ERR_INVALID_ARG_TYPE]` (`... must be of type string or an instance of TracingChannel or Object. Received type symbol (Symbol(<desc>))`), reading the symbol description via `js_symbol_description`. The named-channel branch now matches on `decode_string_value(...)` (strings only); object maps still take the property branch. Plain `channel(symbol)` is unchanged and still valid.

- **#3085 — non-callable bindStore transform.** Introduced `StoreTransform { None, Callable(f64), NonCallable }` so a bound transform that is neither `undefined` nor callable (`null`, a number, a string) is remembered distinctly from an omitted transform. During `runStores`, a `NonCallable` transform schedules an uncaught `TypeError: transform is not a function`, runs the callback with no store context, and preserves the return value — matching Node. Explicit/omitted `undefined` remains the no-transform case (store context set to the published data). The GC root scanner in `mod.rs` was updated to scan only the `Callable` variant.

- **#3086 — traceCallback honors position + forwards args.** `traceCallback(fn, position, context, thisArg, ...args)` is now a synthetic-arguments closure. `position` defaults to `-1` and is resolved with `Array.prototype.at` semantics; the resolved callback is validated (`ERR_INVALID_ARG_TYPE` when active) and the wrapped callback is spliced in at that position while all surrounding args are preserved. The inactive (no-subscriber) fast path forwards every argument verbatim with no validation or wrapping. The wrapped callback is itself a synthetic-arguments closure so it forwards all args the traced function passes through to the user callback.

- **Dispatch-table fix (root cause for #3086).** `js_closure_call7`/`js_closure_call8` did not consult the rest/synthetic-arguments registry (unlike `call0`–`call6`), so a high-arity synthetic-arguments closure (traceCallback called with 8 args) bypassed argument bundling. Added the `lookup_closure_rest_full` + `lookup_closure_arity` checks to both, mirroring `call5`/`call6`. This is a general correctness fix for any rest/synthetic closure invoked with 7–8 positional args.

## Validation

New gap test `test-files/test_gap_diagchannel_3082_3084_3085_3086.ts` is **byte-identical** to `node --experimental-strip-types` under the DEFAULT auto-optimize compile (covers all four issues: runStores arg forwarding bound + unbound, symbol rejection + `channel(symbol)` still valid, non-callable transform TypeError + undefined-transform no-op, traceCallback position/arg forwarding + event ordering).

- `cargo build --release` cold: clean.
- `./scripts/check_file_size.sh`: OK (no file exceeds 2000 lines).
- `cargo fmt --all -- --check`: clean.
- `cargo test --release -p perry-runtime`: 925 passed, 0 failed.
- `cargo test --release -p perry-hir`: 6 passed, 0 failed.

No new codegen-emitted `#[no_mangle]` functions (no `#[used]` anchors needed). No HIR variant added.
