### PR TITLE
fix(node:process): EventEmitter name/listener validation + nextTick arg forwarding

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -102,9 +102,6 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 "ReferenceError" => 0xFFFF0012u32,
                 "SyntaxError" => 0xFFFF0013u32,
                 "AggregateError" => 0xFFFF0014u32,
-                // #2875: SuppressedError instances are ObjectHeaders stamped
-                // with this class id and registered as extending Error.
-                "SuppressedError" => 0xFFFF003Bu32,
                 "EvalError" | "globalThis.EvalError" => 0xFFFF0015u32,
                 "URIError" | "globalThis.URIError" => 0xFFFF0016u32,
                 // Uint8Array / Buffer — runtime detects these via a
@@ -330,15 +327,6 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let blk = ctx.block();
             let result = blk.call(I64, "js_array_from_value", &[(DOUBLE, &iter_box)]);
             Ok(nanbox_pointer_inline(blk, &result))
-        }
-
-        // #2874: `Iterator.from(x)` — wrap any iterable in a lazy
-        // iterator-helper object. `js_iterator_from` returns an already
-        // NaN-boxed pointer (f64), so return it directly.
-        Expr::IteratorFrom(iter) => {
-            let iter_box = lower_expr(ctx, iter)?;
-            let blk = ctx.block();
-            Ok(blk.call(DOUBLE, "js_iterator_from", &[(DOUBLE, &iter_box)]))
         }
 
         // Tagged-template strings literal — build cooked array, build raw
@@ -589,7 +577,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let cb_box = lower_expr(ctx, callback)?;
             if args.is_empty() {
                 let blk = ctx.block();
-                let cb_handle = unbox_to_i64(blk, &cb_box);
+                // #3046: validate the callback (non-callable → Node's
+                // `ERR_INVALID_ARG_TYPE` "callback" message) before queueing.
+                // `js_timer_validate_callback` always reports the "callback"
+                // argument name and returns the closure handle; idx 3 selects
+                // its generic-callback wording branch.
+                let cb_handle = blk.call(
+                    I64,
+                    "js_timer_validate_callback",
+                    &[(DOUBLE, &cb_box), (I32, "3")],
+                );
                 blk.call_void("js_queue_next_tick", &[(I64, &cb_handle)]);
                 return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
             }
@@ -607,7 +604,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 ptr_reg, n, buf
             ));
             let blk = ctx.block();
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #3046: same callback validation on the trailing-args path.
+            let cb_handle = blk.call(
+                I64,
+                "js_timer_validate_callback",
+                &[(DOUBLE, &cb_box), (I32, "3")],
+            );
             blk.call_void(
                 "js_queue_next_tick_args",
                 &[(I64, &cb_handle), (PTR, &ptr_reg), (I32, &n.to_string())],

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -283,7 +283,7 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         method: "on",
         class_filter: None,
         runtime: "js_process_on",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_JSV, NA_JSV],
         ret: NR_F64,
     },
     NativeModSig {
@@ -292,7 +292,7 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         method: "addListener",
         class_filter: None,
         runtime: "js_process_add_listener",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_JSV, NA_JSV],
         ret: NR_F64,
     },
     NativeModSig {
@@ -301,7 +301,7 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         method: "once",
         class_filter: None,
         runtime: "js_process_once",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_JSV, NA_JSV],
         ret: NR_F64,
     },
     NativeModSig {
@@ -310,7 +310,7 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         method: "prependListener",
         class_filter: None,
         runtime: "js_process_prepend_listener",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_JSV, NA_JSV],
         ret: NR_F64,
     },
     NativeModSig {
@@ -319,7 +319,7 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         method: "prependOnceListener",
         class_filter: None,
         runtime: "js_process_prepend_once_listener",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_JSV, NA_JSV],
         ret: NR_F64,
     },
     NativeModSig {
@@ -328,7 +328,7 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         method: "emit",
         class_filter: None,
         runtime: "js_process_emit",
-        args: &[NA_STR, NA_VARARGS],
+        args: &[NA_JSV, NA_VARARGS],
         ret: NR_F64,
     },
     NativeModSig {
@@ -337,7 +337,7 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         method: "removeListener",
         class_filter: None,
         runtime: "js_process_remove_listener",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_JSV, NA_JSV],
         ret: NR_F64,
     },
     NativeModSig {
@@ -346,7 +346,7 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         method: "off",
         class_filter: None,
         runtime: "js_process_off",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_JSV, NA_JSV],
         ret: NR_F64,
     },
     NativeModSig {
@@ -355,7 +355,7 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         method: "removeAllListeners",
         class_filter: None,
         runtime: "js_process_remove_all_listeners",
-        args: &[NA_STR],
+        args: &[NA_JSV],
         ret: NR_F64,
     },
     NativeModSig {
@@ -364,7 +364,7 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         method: "listenerCount",
         class_filter: None,
         runtime: "js_process_listener_count",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_JSV, NA_JSV],
         ret: NR_F64,
     },
     NativeModSig {
@@ -373,7 +373,7 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         method: "listeners",
         class_filter: None,
         runtime: "js_process_listeners",
-        args: &[NA_STR],
+        args: &[NA_JSV],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -382,7 +382,7 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         method: "rawListeners",
         class_filter: None,
         runtime: "js_process_raw_listeners",
-        args: &[NA_STR],
+        args: &[NA_JSV],
         ret: NR_PTR,
     },
     NativeModSig {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -632,7 +632,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_get_max_listeners", DOUBLE, &[]);
     module.declare_function("js_process_get_builtin_module", DOUBLE, &[DOUBLE]);
     module.declare_function("js_module_is_builtin", DOUBLE, &[DOUBLE]);
-    module.declare_function("js_process_next_tick", VOID, &[I64]);
+    module.declare_function("js_process_next_tick", VOID, &[I64, I64]);
     module.declare_function("js_process_stdin", DOUBLE, &[]);
     module.declare_function("js_process_stdout", DOUBLE, &[]);
     module.declare_function("js_process_stderr", DOUBLE, &[]);

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -89,9 +89,10 @@ pub(crate) use formatting::{
 
 pub use globals::{
     js_decode_uri, js_decode_uri_component, js_drain_queued_microtasks, js_encode_uri,
-    js_encode_uri_component, js_queue_microtask, js_queue_next_tick, js_structured_clone,
-    js_text_decoder_decode, js_text_encoder_encode, restore_queued_microtask_contexts,
-    scan_queued_microtask_roots, scan_queued_microtask_roots_mut,
+    js_encode_uri_component, js_queue_microtask, js_queue_next_tick, js_queue_next_tick_args,
+    js_structured_clone, js_text_decoder_decode, js_text_encoder_encode,
+    restore_queued_microtask_contexts, scan_queued_microtask_roots,
+    scan_queued_microtask_roots_mut,
 };
 
 pub use numbers::{

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -301,10 +301,14 @@ pub(crate) unsafe fn dispatch_native_module_method(
             ptr_addr(v)
         }
     };
-    let arg_event_ptr = |n: usize| -> *const crate::StringHeader {
+    let _arg_event_ptr = |n: usize| -> *const crate::StringHeader {
         crate::value::js_get_string_pointer_unified(arg(n)) as *const crate::StringHeader
     };
-    let arg_closure_ptr = |n: usize| -> *const crate::closure::ClosureHeader {
+    // Raw NaN-box bits of arg `n` (undefined when missing). Used by the
+    // process EventEmitter arms so the runtime can coerce event names and
+    // validate listeners against the full JS value (#3047/#3046).
+    let arg_bits = |n: usize| -> i64 { arg(n).to_bits() as i64 };
+    let _arg_closure_ptr = |n: usize| -> *const crate::closure::ClosureHeader {
         if n >= args_len {
             return std::ptr::null();
         }
@@ -413,33 +417,31 @@ pub(crate) unsafe fn dispatch_native_module_method(
         }
 
         // ── process EventEmitter API ──
-        ("process", "on") => crate::os::js_process_on(arg_event_ptr(0), arg_closure_ptr(1)),
-        ("process", "addListener") => {
-            crate::os::js_process_add_listener(arg_event_ptr(0), arg_closure_ptr(1))
-        }
-        ("process", "once") => crate::os::js_process_once(arg_event_ptr(0), arg_closure_ptr(1)),
+        ("process", "on") => crate::os::js_process_on(arg_bits(0), arg_bits(1)),
+        ("process", "addListener") => crate::os::js_process_add_listener(arg_bits(0), arg_bits(1)),
+        ("process", "once") => crate::os::js_process_once(arg_bits(0), arg_bits(1)),
         ("process", "prependListener") => {
-            crate::os::js_process_prepend_listener(arg_event_ptr(0), arg_closure_ptr(1))
+            crate::os::js_process_prepend_listener(arg_bits(0), arg_bits(1))
         }
         ("process", "prependOnceListener") => {
-            crate::os::js_process_prepend_once_listener(arg_event_ptr(0), arg_closure_ptr(1))
+            crate::os::js_process_prepend_once_listener(arg_bits(0), arg_bits(1))
         }
-        ("process", "emit") => crate::os::js_process_emit(arg_event_ptr(0), pack_args_from(1)),
+        ("process", "emit") => crate::os::js_process_emit(arg_bits(0), pack_args_from(1)),
         ("process", "removeListener") => {
-            crate::os::js_process_remove_listener(arg_event_ptr(0), arg_closure_ptr(1))
+            crate::os::js_process_remove_listener(arg_bits(0), arg_bits(1))
         }
-        ("process", "off") => crate::os::js_process_off(arg_event_ptr(0), arg_closure_ptr(1)),
+        ("process", "off") => crate::os::js_process_off(arg_bits(0), arg_bits(1)),
         ("process", "removeAllListeners") => {
-            crate::os::js_process_remove_all_listeners(arg_event_ptr(0))
+            crate::os::js_process_remove_all_listeners(arg_bits(0))
         }
         ("process", "listenerCount") => {
-            crate::os::js_process_listener_count(arg_event_ptr(0), arg_closure_ptr(1))
+            crate::os::js_process_listener_count(arg_bits(0), arg_bits(1))
         }
         ("process", "listeners") => {
-            ptr_to_f64(crate::os::js_process_listeners(arg_event_ptr(0)) as *const u8)
+            ptr_to_f64(crate::os::js_process_listeners(arg_bits(0)) as *const u8)
         }
         ("process", "rawListeners") => {
-            ptr_to_f64(crate::os::js_process_raw_listeners(arg_event_ptr(0)) as *const u8)
+            ptr_to_f64(crate::os::js_process_raw_listeners(arg_bits(0)) as *const u8)
         }
         ("process", "eventNames") => ptr_to_f64(crate::os::js_process_event_names() as *const u8),
         ("process", "setMaxListeners") => crate::os::js_process_set_max_listeners(arg(0)),
@@ -450,7 +452,8 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("process", "uptime") => crate::os::js_process_uptime(),
         ("process", "memoryUsage") => crate::process::js_process_memory_usage(),
         ("process", "nextTick") => {
-            crate::os::js_process_next_tick(arg_closure_ptr(0));
+            // Validate the callback and forward trailing args (#3046).
+            unsafe { crate::os::js_process_next_tick(arg_bits(0), pack_args_from(1)) };
             f64::from_bits(crate::value::TAG_UNDEFINED)
         }
         ("process", "chdir") => {

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -791,18 +791,74 @@ fn process_namespace_value() -> f64 {
     crate::object::js_create_native_module_namespace(b"process".as_ptr(), "process".len())
 }
 
+/// Coerce a raw NaN-boxed JS value into Node's EventEmitter event-name key
+/// (#3047). The `process` global is an EventEmitter, so non-symbol event
+/// names follow `ToString` semantics: `123` → `"123"`, `null` → `"null"`,
+/// `undefined` → `"undefined"`, `{}` → `"[object Object]"`. Strings pass
+/// through unchanged.
+///
+/// Returns `None` only when the value carries no string representation we
+/// can read back (it should not happen for the supported primitive/object
+/// inputs). Symbol event names are not yet keyed by identity — they coerce
+/// to their `String(sym)` form here, which is sufficient for the
+/// string-keyed emitter but does not preserve per-symbol identity.
+fn coerce_event_name(event_bits: i64) -> Option<String> {
+    let value = f64::from_bits(event_bits as u64);
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    // Fast path: already a heap/SSO string — read it directly so we never
+    // round-trip a perfectly good string through ToString.
+    if jv.is_string() || jv.is_short_string() {
+        let ptr = crate::value::js_get_string_pointer_unified(value) as *const StringHeader;
+        return read_event_name(ptr);
+    }
+    let coerced = crate::value::js_jsvalue_to_string(value);
+    read_event_name(coerced)
+}
+
+/// Validate an EventEmitter listener argument supplied as raw NaN-box bits
+/// and return its closure pointer (#3047). Non-callable values throw Node's
+/// `TypeError [ERR_INVALID_ARG_TYPE]` with the shared `"listener"` message
+/// via `js_validate_event_listener`, matching `perry-stdlib::events`.
+fn validate_listener(listener_bits: i64) -> *const crate::closure::ClosureHeader {
+    let name = "listener";
+    let ptr = unsafe {
+        crate::fs::validate::js_validate_event_listener(
+            listener_bits,
+            name.as_ptr(),
+            name.len() as u32,
+        )
+    };
+    ptr as *const crate::closure::ClosureHeader
+}
+
+/// Extract a closure pointer from raw NaN-box bits *without* throwing, for
+/// the lookup-style methods (`removeListener`/`off`/`listenerCount`) where
+/// Node simply finds no match for a non-callable rather than raising. A
+/// non-closure value yields a null pointer that matches no stored listener.
+fn listener_lookup_ptr(listener_bits: i64) -> *const crate::closure::ClosureHeader {
+    let value = f64::from_bits(listener_bits as u64);
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if jv.is_pointer() {
+        let ptr = jv.as_pointer::<u8>() as usize;
+        if crate::closure::is_closure_ptr(ptr) {
+            return ptr as *const crate::closure::ClosureHeader;
+        }
+    }
+    std::ptr::null()
+}
+
 fn register_process_listener(
-    event_ptr: *const StringHeader,
-    callback: *const crate::closure::ClosureHeader,
+    event_bits: i64,
+    listener_bits: i64,
     once: bool,
     prepend: bool,
 ) -> f64 {
-    let Some(event) = read_event_name(event_ptr) else {
+    // Node validates the listener *before* coercing the event name, so an
+    // invalid listener throws even for an odd event value.
+    let callback = validate_listener(listener_bits);
+    let Some(event) = coerce_event_name(event_bits) else {
         return process_namespace_value();
     };
-    if callback.is_null() {
-        return process_namespace_value();
-    }
 
     PROCESS_EMITTER.with(|emitter| {
         let mut emitter = emitter.borrow_mut();
@@ -826,8 +882,8 @@ fn boxed_bool(value: bool) -> f64 {
     })
 }
 
-fn listener_array(event_ptr: *const StringHeader, _raw: bool) -> *mut ArrayHeader {
-    let Some(event) = read_event_name(event_ptr) else {
+fn listener_array(event_bits: i64, _raw: bool) -> *mut ArrayHeader {
+    let Some(event) = coerce_event_name(event_bits) else {
         return crate::array::js_array_alloc(0);
     };
     let callbacks = PROCESS_EMITTER.with(|emitter| {
@@ -900,47 +956,37 @@ fn emit_process_event(event: &str, args: &[f64]) -> bool {
     true
 }
 
-/// process.on(event, handler) — register an event listener.
+/// process.on(event, listener) — register an event listener.
+///
+/// `event_bits`/`listener_bits` are the raw NaN-boxed JS values (codegen
+/// routes both through `NA_JSV`) so the event name is coerced with
+/// `ToString` and a non-callable listener throws `ERR_INVALID_ARG_TYPE`
+/// (#3047), matching Node's EventEmitter argument handling.
 #[no_mangle]
-pub extern "C" fn js_process_on(
-    event_ptr: *const StringHeader,
-    handler: *const crate::closure::ClosureHeader,
-) -> f64 {
-    register_process_listener(event_ptr, handler, false, false)
+pub extern "C" fn js_process_on(event_bits: i64, listener_bits: i64) -> f64 {
+    register_process_listener(event_bits, listener_bits, false, false)
 }
 
-/// process.addListener(event, handler) — alias for on().
+/// process.addListener(event, listener) — alias for on().
 #[no_mangle]
-pub extern "C" fn js_process_add_listener(
-    event_ptr: *const StringHeader,
-    handler: *const crate::closure::ClosureHeader,
-) -> f64 {
-    register_process_listener(event_ptr, handler, false, false)
+pub extern "C" fn js_process_add_listener(event_bits: i64, listener_bits: i64) -> f64 {
+    register_process_listener(event_bits, listener_bits, false, false)
 }
 
-/// process.once(event, handler) — one-shot listener (Node parity).
+/// process.once(event, listener) — one-shot listener (Node parity).
 #[no_mangle]
-pub extern "C" fn js_process_once(
-    event_ptr: *const StringHeader,
-    handler: *const crate::closure::ClosureHeader,
-) -> f64 {
-    register_process_listener(event_ptr, handler, true, false)
+pub extern "C" fn js_process_once(event_bits: i64, listener_bits: i64) -> f64 {
+    register_process_listener(event_bits, listener_bits, true, false)
 }
 
 #[no_mangle]
-pub extern "C" fn js_process_prepend_listener(
-    event_ptr: *const StringHeader,
-    handler: *const crate::closure::ClosureHeader,
-) -> f64 {
-    register_process_listener(event_ptr, handler, false, true)
+pub extern "C" fn js_process_prepend_listener(event_bits: i64, listener_bits: i64) -> f64 {
+    register_process_listener(event_bits, listener_bits, false, true)
 }
 
 #[no_mangle]
-pub extern "C" fn js_process_prepend_once_listener(
-    event_ptr: *const StringHeader,
-    handler: *const crate::closure::ClosureHeader,
-) -> f64 {
-    register_process_listener(event_ptr, handler, true, true)
+pub extern "C" fn js_process_prepend_once_listener(event_bits: i64, listener_bits: i64) -> f64 {
+    register_process_listener(event_bits, listener_bits, true, true)
 }
 
 /// Emit the synthetic `beforeExit` event with the would-be exit code as a
@@ -955,8 +1001,8 @@ pub extern "C" fn js_process_emit_before_exit(code: f64) {
 }
 
 #[no_mangle]
-pub extern "C" fn js_process_emit(event_ptr: *const StringHeader, args: *const ArrayHeader) -> f64 {
-    let Some(event) = read_event_name(event_ptr) else {
+pub extern "C" fn js_process_emit(event_bits: i64, args: *const ArrayHeader) -> f64 {
+    let Some(event) = coerce_event_name(event_bits) else {
         return boxed_bool(false);
     };
     let values = collect_emit_args(args);
@@ -964,11 +1010,9 @@ pub extern "C" fn js_process_emit(event_ptr: *const StringHeader, args: *const A
 }
 
 #[no_mangle]
-pub extern "C" fn js_process_remove_listener(
-    event_ptr: *const StringHeader,
-    handler: *const crate::closure::ClosureHeader,
-) -> f64 {
-    if let Some(event) = read_event_name(event_ptr) {
+pub extern "C" fn js_process_remove_listener(event_bits: i64, listener_bits: i64) -> f64 {
+    let handler = listener_lookup_ptr(listener_bits);
+    if let Some(event) = coerce_event_name(event_bits) {
         PROCESS_EMITTER.with(|emitter| {
             let mut emitter = emitter.borrow_mut();
             if let Some(listeners) = emitter.events.get_mut(&event) {
@@ -986,18 +1030,26 @@ pub extern "C" fn js_process_remove_listener(
 }
 
 #[no_mangle]
-pub extern "C" fn js_process_off(
-    event_ptr: *const StringHeader,
-    handler: *const crate::closure::ClosureHeader,
-) -> f64 {
-    js_process_remove_listener(event_ptr, handler)
+pub extern "C" fn js_process_off(event_bits: i64, listener_bits: i64) -> f64 {
+    js_process_remove_listener(event_bits, listener_bits)
 }
 
 #[no_mangle]
-pub extern "C" fn js_process_remove_all_listeners(event_ptr: *const StringHeader) -> f64 {
+pub extern "C" fn js_process_remove_all_listeners(event_bits: i64) -> f64 {
+    // `removeAllListeners()` / `removeAllListeners(undefined)` clears every
+    // event. Node treats a missing or `undefined`/`null` argument as
+    // "no specific event" rather than coercing it to the literal string
+    // `"undefined"`/`"null"`, so guard those tags before coercing.
+    let value = f64::from_bits(event_bits as u64);
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    let target = if jv.is_undefined() || jv.is_null() {
+        None
+    } else {
+        coerce_event_name(event_bits)
+    };
     PROCESS_EMITTER.with(|emitter| {
         let mut emitter = emitter.borrow_mut();
-        if let Some(event) = read_event_name(event_ptr) {
+        if let Some(event) = target {
             emitter.events.remove(&event);
             emitter.event_order.retain(|name| name != &event);
         } else {
@@ -1009,11 +1061,9 @@ pub extern "C" fn js_process_remove_all_listeners(event_ptr: *const StringHeader
 }
 
 #[no_mangle]
-pub extern "C" fn js_process_listener_count(
-    event_ptr: *const StringHeader,
-    handler: *const crate::closure::ClosureHeader,
-) -> f64 {
-    let Some(event) = read_event_name(event_ptr) else {
+pub extern "C" fn js_process_listener_count(event_bits: i64, listener_bits: i64) -> f64 {
+    let handler = listener_lookup_ptr(listener_bits);
+    let Some(event) = coerce_event_name(event_bits) else {
         return 0.0;
     };
     PROCESS_EMITTER.with(|emitter| {
@@ -1033,13 +1083,13 @@ pub extern "C" fn js_process_listener_count(
 }
 
 #[no_mangle]
-pub extern "C" fn js_process_listeners(event_ptr: *const StringHeader) -> *mut ArrayHeader {
-    listener_array(event_ptr, false)
+pub extern "C" fn js_process_listeners(event_bits: i64) -> *mut ArrayHeader {
+    listener_array(event_bits, false)
 }
 
 #[no_mangle]
-pub extern "C" fn js_process_raw_listeners(event_ptr: *const StringHeader) -> *mut ArrayHeader {
-    listener_array(event_ptr, true)
+pub extern "C" fn js_process_raw_listeners(event_bits: i64) -> *mut ArrayHeader {
+    listener_array(event_bits, true)
 }
 
 #[no_mangle]
@@ -1124,10 +1174,29 @@ pub fn emit_process_uncaught_exception(error: f64) {
     emit_process_event("uncaughtException", &[error]);
 }
 
-/// process.nextTick(callback) — schedule callback as a microtask.
+/// process.nextTick(callback, ...args) — schedule callback as a tick,
+/// forwarding trailing args (#3046). `callback_bits`/`args` are raw
+/// NaN-boxed values. A non-callable callback throws Node's
+/// `TypeError [ERR_INVALID_ARG_TYPE]` (`"callback"` message) synchronously.
+/// Used by the method-value dispatch path (`const nt = process.nextTick`)
+/// and the zero-arg `process.nextTick()` call form; the direct lowered form
+/// with trailing args goes through codegen's `js_queue_next_tick_args`.
+///
+/// # Safety
+/// `args` must be a valid NaN-boxed args array pointer, or null.
 #[no_mangle]
-pub extern "C" fn js_process_next_tick(callback: *const crate::closure::ClosureHeader) {
-    crate::builtins::js_queue_next_tick(callback as i64);
+pub unsafe extern "C" fn js_process_next_tick(callback_bits: i64, args: *const ArrayHeader) {
+    // Mirror codegen's setTimeout/queueMicrotask validation: the timer
+    // validator always reports the `"callback"` argument name, which is the
+    // wording Node uses for `process.nextTick`.
+    let callback =
+        crate::timer::js_timer_validate_callback(f64::from_bits(callback_bits as u64), 3);
+    let values = collect_emit_args(args);
+    if values.is_empty() {
+        crate::builtins::js_queue_next_tick(callback);
+    } else {
+        crate::builtins::js_queue_next_tick_args(callback, values.as_ptr(), values.len() as i32);
+    }
 }
 
 // `process.chdir()` + its Node-shaped error live in the `chdir` submodule

--- a/test-files/test_gap_process_emitter_3047_3046_3050.ts
+++ b/test-files/test_gap_process_emitter_3047_3046_3050.ts
@@ -1,0 +1,48 @@
+// Gap test: node:process EventEmitter argument handling.
+//   #3046 — process.nextTick callback validation + trailing-arg forwarding
+//   #3047 — process.on/once listener validation + event-name coercion
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+function show(label: string, fn: () => void): void {
+  try {
+    fn();
+    console.log(label, "OK");
+  } catch (err) {
+    const e = err as { name: string; code?: string; message: string };
+    console.log(label, "THROW", e.name, e.code, e.message.split("\n")[0]);
+  }
+}
+
+// ---- #3046: nextTick callback validation ----
+show("nt missing", () => process.nextTick());
+show("nt number", () => process.nextTick(123));
+show("nt object", () => process.nextTick({}));
+
+// ---- #3047: listener validation ----
+show("on missing listener", () => process.on("x"));
+show("on number listener", () => process.on("x", 1));
+show("once object listener", () => process.once("x", {}));
+
+// ---- #3047: event-name coercion (number/null/object) fires the listener ----
+let numFired = false;
+process.on(123, () => {
+  numFired = true;
+});
+const numEmitted = process.emit(123, "payload");
+console.log("coerce number", numFired, numEmitted);
+process.removeListener(123, () => {});
+
+// ---- #3046: nextTick trailing-arg forwarding (direct + method value) ----
+process.nextTick((...args: unknown[]) => console.log("tick direct", JSON.stringify(args)), "a", "b", "c");
+const nt = process.nextTick;
+nt((...args: unknown[]) => console.log("tick method", JSON.stringify(args)), "a", "b", "c");
+
+// ---- listeners()/listenerCount() basic shape ----
+function onFn(): void {}
+process.removeAllListeners("__probe__");
+process.on("__probe__", onFn);
+const ls = process.listeners("__probe__");
+console.log("listeners length", ls.length, ls[0] === onFn);
+console.log("listenerCount", process.listenerCount("__probe__"));
+process.removeAllListeners("__probe__");


### PR DESCRIPTION
Closes #3047
Closes #3046

`process` is an EventEmitter, so its listener methods and `nextTick` must
use Node's EventEmitter argument handling. This PR brings the
process-specific emitter in line with Node for event-name coercion,
listener validation, and `nextTick` callback validation + arg forwarding.

## Implementation

### #3047 — coerce event names and validate listeners
- The `js_process_on/once/addListener/prependListener/prependOnceListener/
  emit/removeListener/off/removeAllListeners/listenerCount/listeners/
  rawListeners` runtime FFIs now take the **raw NaN-box bits** of their
  event/listener arguments (codegen routes them through `NA_JSV`) instead
  of pre-stripped string/closure pointers, so the full JS value reaches
  the coercion/validation path.
- `coerce_event_name` applies `ToString` to non-symbol event names
  (`123` → `"123"`, `null` → `"null"`, `undefined` → `"undefined"`,
  `{}` → `"[object Object]"`), with a fast path for strings/SSO.
- `register_process_listener` validates the listener via the shared
  `js_validate_event_listener` helper (added in `fs/validate.rs`), so a
  non-callable listener throws `TypeError [ERR_INVALID_ARG_TYPE]` with the
  exact `"listener"` message — byte-identical to `perry-stdlib::events`.
- `removeListener`/`off`/`listenerCount` use a non-throwing lookup
  (Node finds no match for a non-callable rather than raising);
  `removeAllListeners()` / `removeAllListeners(undefined)` still clears all
  events (the `undefined`/`null` tag is not coerced to a literal key).

### #3046 — validate nextTick callbacks and forward args
- `Expr::ProcessNextTick` codegen now validates the callback on **both**
  the no-arg and trailing-arg branches via `js_timer_validate_callback`
  (which reports the `"callback"` argument name Node uses), matching the
  nearby `queueMicrotask` lowering.
- The method-value dispatch arm (`const nt = process.nextTick; nt(...)`)
  routes through `js_process_next_tick(callback_bits, args)`, which now
  validates the callback and forwards trailing args through
  `js_queue_next_tick_args`.

No new HIR variants. The native-table arg-kind changes (`NA_STR`/`NA_PTR`
→ `NA_JSV`) do not alter the public API surface, so `api-docs-drift` stays
green (verified via `regen_api_docs.sh` — no diff).

### Not in this PR
`#3050` (rawListeners exposing `once`-wrappers with a `.listener`
property) is **dropped**: even the main `perry-stdlib::events`
EventEmitter returns the unwrapped callback for `rawListeners` (no
once-wrapper closure with a readable `.listener` exists anywhere in the
runtime). Implementing it requires new infrastructure — synthesizing a
wrapper closure object that carries a `.listener` property — which is
beyond the scope of this process-emitter fix and would be better landed
once the shared events emitter grows that capability.

## Validation

Gap test `test-files/test_gap_process_emitter_3047_3046_3050.ts` is
**byte-identical** to `node --experimental-strip-types` under the default
auto-optimize compile (`diff` reports no differences, exit 0):

```
nt missing THROW TypeError ERR_INVALID_ARG_TYPE The "callback" argument must be of type function. Received undefined
nt number THROW TypeError ERR_INVALID_ARG_TYPE The "callback" argument must be of type function. Received type number (123)
nt object THROW TypeError ERR_INVALID_ARG_TYPE The "callback" argument must be of type function. Received an instance of Object
on missing listener THROW TypeError ERR_INVALID_ARG_TYPE The "listener" argument must be of type function. Received undefined
on number listener THROW TypeError ERR_INVALID_ARG_TYPE The "listener" argument must be of type function. Received type number (1)
once object listener THROW TypeError ERR_INVALID_ARG_TYPE The "listener" argument must be of type function. Received an instance of Object
coerce number true true
listeners length 1 true
listenerCount 1
tick direct ["a","b","c"]
tick method ["a","b","c"]
```

Guards: `./scripts/check_file_size.sh` (exit 0), `cargo fmt --all --
--check` (clean), `cargo test -p perry-hir` (6 passed — no new HIR
stable-hash tag), `cargo test -p perry-api-manifest` (18 passed). Full
`cargo build --release` cold green.
