### PR TITLE
fix(globals): AbortSignal static helpers/lifecycle + navigator object

### DIFF
--- a/crates/perry-codegen/src/expr/helpers.rs
+++ b/crates/perry-codegen/src/expr/helpers.rs
@@ -341,6 +341,7 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
             | "Reflect"
             | "performance"
             | "process"
+            | "navigator"
     )
 }
 
@@ -353,7 +354,14 @@ pub(crate) fn is_global_this_builtin_function_name(name: &str) -> bool {
     is_global_this_builtin_name(name)
         && !matches!(
             name,
-            "globalThis" | "console" | "Math" | "JSON" | "Reflect" | "performance" | "process"
+            "globalThis"
+                | "console"
+                | "Math"
+                | "JSON"
+                | "Reflect"
+                | "performance"
+                | "process"
+                | "navigator"
         )
 }
 

--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -260,7 +260,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         // JSON / Reflect stay "object" — they're namespaces,
                         // not constructors.
                         match property.as_str() {
-                            "process" | "console" | "globalThis" | "performance" => Some("object"),
+                            "process" | "console" | "globalThis" | "performance" | "navigator" => {
+                                Some("object")
+                            }
                             "Math" | "JSON" | "Reflect" => Some("object"),
                             n if is_global_this_builtin_function_name(n) => Some("function"),
                             _ => None,

--- a/crates/perry-codegen/src/expr/static_method.rs
+++ b/crates/perry-codegen/src/expr/static_method.rs
@@ -64,6 +64,29 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 let signal_handle = blk.call(I64, "js_abort_signal_timeout", &[(DOUBLE, &ms)]);
                 return Ok(nanbox_pointer_inline(blk, &signal_handle));
             }
+            // #2582: `AbortSignal.abort(reason?)` — returns a pre-aborted signal.
+            if class_name == "AbortSignal" && method_name == "abort" {
+                let reason = if !args.is_empty() {
+                    lower_expr(ctx, &args[0])?
+                } else {
+                    double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                };
+                let blk = ctx.block();
+                let signal_handle = blk.call(I64, "js_abort_signal_abort", &[(DOUBLE, &reason)]);
+                return Ok(nanbox_pointer_inline(blk, &signal_handle));
+            }
+            // #2582: `AbortSignal.any([signals])` — combined signal.
+            if class_name == "AbortSignal" && method_name == "any" {
+                let arr_box = if !args.is_empty() {
+                    lower_expr(ctx, &args[0])?
+                } else {
+                    double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                };
+                let blk = ctx.block();
+                let arr_handle = unbox_to_i64(blk, &arr_box);
+                let signal_handle = blk.call(I64, "js_abort_signal_any", &[(I64, &arr_handle)]);
+                return Ok(nanbox_pointer_inline(blk, &signal_handle));
+            }
             let key = (class_name.clone(), method_name.clone());
             if let Some(fn_name) = ctx.methods.get(&key).cloned() {
                 let mut lowered: Vec<String> = Vec::with_capacity(args.len());

--- a/crates/perry-codegen/src/lower_call/options/abort.rs
+++ b/crates/perry-codegen/src/lower_call/options/abort.rs
@@ -28,9 +28,20 @@ pub(in crate::lower_call) fn is_abort_controller_expr(ctx: &FnCtx<'_>, e: &Expr)
     }
 }
 
+/// Returns `true` if the expression statically resolves to an
+/// `AbortSignal`-typed value: a local declared `Named("AbortSignal")`.
+pub(in crate::lower_call) fn is_abort_signal_typed_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
+    matches!(
+        e,
+        Expr::LocalGet(id)
+            if matches!(ctx.local_types.get(id), Some(HirType::Named(n)) if n == "AbortSignal")
+    )
+}
+
 /// Lower AbortController / AbortSignal method calls:
 /// - `controller.abort(reason?)`
 /// - `controller.signal.addEventListener("abort", cb)`
+/// - `controller.signal.throwIfAborted()` / `signal.throwIfAborted()`
 /// - `AbortSignal.timeout(ms)` (static)
 ///
 /// Returns `None` if the call shape doesn't match one of the handled
@@ -41,6 +52,39 @@ pub(in crate::lower_call) fn lower_abort_controller_call(
     property: &str,
     args: &[Expr],
 ) -> Result<Option<String>> {
+    // ── controller.signal.throwIfAborted() / signal.throwIfAborted() ──
+    if property == "throwIfAborted" {
+        // Case 1: `<controller>.signal.throwIfAborted()` — derive the signal
+        // pointer from the controller.
+        if let Expr::PropertyGet {
+            object: inner_obj,
+            property: inner_prop,
+        } = object
+        {
+            if inner_prop == "signal" && is_abort_controller_expr(ctx, inner_obj) {
+                let ctrl_box = lower_expr(ctx, inner_obj)?;
+                let blk = ctx.block();
+                let ctrl_handle = unbox_to_i64(blk, &ctrl_box);
+                let signal_handle =
+                    blk.call(I64, "js_abort_controller_signal", &[(I64, &ctrl_handle)]);
+                blk.call_void("js_abort_signal_throw_if_aborted", &[(I64, &signal_handle)]);
+                return Ok(Some(double_literal(f64::from_bits(
+                    crate::nanbox::TAG_UNDEFINED,
+                ))));
+            }
+        }
+        // Case 2: receiver is itself an AbortSignal value (a local typed
+        // `AbortSignal`, or the result of `AbortSignal.abort/timeout/any`).
+        if is_abort_signal_typed_expr(ctx, object) {
+            let sig_box = lower_expr(ctx, object)?;
+            let blk = ctx.block();
+            let sig_handle = unbox_to_i64(blk, &sig_box);
+            blk.call_void("js_abort_signal_throw_if_aborted", &[(I64, &sig_handle)]);
+            return Ok(Some(double_literal(f64::from_bits(
+                crate::nanbox::TAG_UNDEFINED,
+            ))));
+        }
+    }
     // ── AbortSignal.timeout(ms) static ──
     if property == "timeout" {
         if let Expr::GlobalGet(_) = object {

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -995,6 +995,10 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_abort_controller_abort_reason", VOID, &[I64, DOUBLE]);
     module.declare_function("js_abort_signal_add_listener", VOID, &[I64, DOUBLE, DOUBLE]);
     module.declare_function("js_abort_signal_timeout", I64, &[DOUBLE]);
+    // #2582: AbortSignal static helpers + lifecycle.
+    module.declare_function("js_abort_signal_abort", I64, &[DOUBLE]);
+    module.declare_function("js_abort_signal_any", I64, &[I64]);
+    module.declare_function("js_abort_signal_throw_if_aborted", DOUBLE, &[I64]);
     module.declare_function("js_event_target_new", I64, &[]);
     module.declare_function("js_event_target_add_event_listener", VOID, &[I64, I64, I64]);
     module.declare_function(

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -1353,14 +1353,14 @@ pub(super) fn try_module_static_methods(
                 }
             }
 
-            // Check for AbortSignal.timeout(ms) static method call
+            // Check for AbortSignal static helpers: timeout / abort / any (#2582).
             if obj_ident.sym.as_ref() == "AbortSignal" {
                 if let ast::MemberProp::Ident(method_ident) = &member.prop {
                     let method_name = method_ident.sym.as_ref();
-                    if method_name == "timeout" {
+                    if matches!(method_name, "timeout" | "abort" | "any") {
                         return Ok(Ok(Expr::StaticMethodCall {
                             class_name: "AbortSignal".to_string(),
-                            method_name: "timeout".to_string(),
+                            method_name: method_name.to_string(),
                             args,
                         }));
                     }

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -56,6 +56,7 @@ pub mod math;
 pub mod native_abi;
 pub mod native_arena;
 pub mod native_handle;
+pub mod navigator;
 pub mod net_validate;
 pub mod node_stream;
 pub mod node_submodules;

--- a/crates/perry-runtime/src/navigator.rs
+++ b/crates/perry-runtime/src/navigator.rs
@@ -1,0 +1,108 @@
+//! Node `globalThis.navigator` object (#2923).
+//!
+//! Node exposes a browser-compatible `navigator` singleton carrying runtime
+//! metadata: `userAgent` (`"Node.js/<major>"`), `language` / `languages`,
+//! `hardwareConcurrency`, `platform`, and a `locks` stub. Perry installs this
+//! object on the `globalThis` singleton (see `object/global_this.rs`) and via
+//! the bare-`navigator` global name path so feature-detecting libraries read a
+//! Node-shaped object instead of `undefined`.
+//!
+//! Host-dependent values (`hardwareConcurrency`, `platform`) reflect the real
+//! machine; the rest match Node's defaults. The major version mirrors the Node
+//! target Perry reports through `process.version` (currently 22).
+
+use crate::array::{js_array_alloc, js_array_push_f64};
+use crate::object::{js_object_alloc_with_shape, js_object_set_field};
+use crate::string::js_string_from_bytes;
+use crate::value::{js_nanbox_pointer, js_nanbox_string, JSValue};
+
+const NAVIGATOR_CLASS_ID: u32 = 0x7FFF_FF22;
+
+/// Major Node version Perry advertises (mirrors `process.version` = v22.x).
+const NODE_MAJOR: &str = "22";
+
+fn nb_str(s: &str) -> JSValue {
+    let bytes = s.as_bytes();
+    let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+    JSValue::from_bits(js_nanbox_string(ptr as i64).to_bits())
+}
+
+/// Node `navigator.platform` value — the browser-style platform token, which
+/// differs from `os.platform()` (`"darwin"` etc).
+fn navigator_platform() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "MacIntel"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "Win32"
+    }
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        "Linux x86_64"
+    }
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        "Linux aarch64"
+    }
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "windows",
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
+    )))]
+    {
+        "Linux"
+    }
+}
+
+/// Build the `navigator` object. Fields (positional, matching the packed
+/// key order): `userAgent`, `language`, `languages`, `hardwareConcurrency`,
+/// `platform`, `locks`.
+#[no_mangle]
+pub extern "C" fn js_navigator_object() -> f64 {
+    // Packed null-separated keys; slot order must match the set_field calls.
+    let packed = b"userAgent\0language\0languages\0hardwareConcurrency\0platform\0locks\0";
+    let field_count: u32 = 6;
+    let obj = js_object_alloc_with_shape(
+        NAVIGATOR_CLASS_ID,
+        field_count,
+        packed.as_ptr(),
+        packed.len() as u32,
+    );
+
+    // userAgent: "Node.js/<major>"
+    let ua = format!("Node.js/{NODE_MAJOR}");
+    js_object_set_field(obj, 0, nb_str(&ua));
+
+    // language / languages
+    js_object_set_field(obj, 1, nb_str("en-US"));
+    let mut langs = js_array_alloc(1);
+    langs = js_array_push_f64(langs, f64::from_bits(nb_str("en-US").bits()));
+    js_object_set_field(
+        obj,
+        2,
+        JSValue::from_bits(js_nanbox_pointer(langs as i64).to_bits()),
+    );
+
+    // hardwareConcurrency: recommended parallelism (>= 1).
+    let cores = std::thread::available_parallelism()
+        .map(|n| n.get() as f64)
+        .unwrap_or(1.0);
+    js_object_set_field(obj, 3, JSValue::number(cores));
+
+    // platform: browser-style token.
+    js_object_set_field(obj, 4, nb_str(navigator_platform()));
+
+    // locks: a plain object stub (typeof === "object"). Web Locks API is not
+    // implemented; the property exists so feature-detection sees the shape.
+    let locks = crate::object::js_object_alloc(0, 0);
+    js_object_set_field(
+        obj,
+        5,
+        JSValue::from_bits(js_nanbox_pointer(locks as i64).to_bits()),
+    );
+
+    js_nanbox_pointer(obj as i64)
+}

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -170,6 +170,10 @@ pub(crate) const GLOBAL_THIS_BUILTIN_CONSTRUCTORS: &[&str] = &[
 pub(crate) const GLOBAL_THIS_BUILTIN_NAMESPACES: &[&str] =
     &["console", "process", "Math", "JSON", "Reflect"];
 
+// Note: `navigator` (#2923) is installed on the singleton directly (see
+// `populate_global_this_builtins`) rather than via this generic namespace
+// loop because it needs its own field-populated object, not an empty stub.
+
 /// JS global built-in functions exposed as function-valued properties on
 /// `globalThis`. Unlike constructor sentinels, these call through to Perry's
 /// real direct-call runtime helpers so rebinding works:
@@ -1014,6 +1018,14 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         let pkey = crate::string::js_string_from_bytes(pname.as_ptr(), pname.len() as u32);
         let pval = crate::perf_hooks::performance_namespace();
         js_object_set_field_by_name(singleton, pkey, pval);
+    }
+    // #2923: `globalThis.navigator` — Node's browser-compatible runtime
+    // metadata object. typeof is "object". Built once per process.
+    {
+        let nname = b"navigator";
+        let nkey = crate::string::js_string_from_bytes(nname.as_ptr(), nname.len() as u32);
+        let nval = crate::navigator::js_navigator_object();
+        js_object_set_field_by_name(singleton, nkey, nval);
     }
 }
 

--- a/crates/perry-runtime/src/url/abort.rs
+++ b/crates/perry-runtime/src/url/abort.rs
@@ -311,3 +311,119 @@ pub extern "C" fn js_abort_signal_remove_listener(
 pub extern "C" fn js_abort_signal_timeout(_ms: f64) -> *mut ObjectHeader {
     alloc_abort_signal()
 }
+
+/// Mark a signal as aborted with `reason` and fire its listeners. Idempotent:
+/// re-aborting an already-aborted signal is a no-op (Node behavior). Shared by
+/// `AbortSignal.abort()` and the `AbortSignal.any()` propagation listener.
+fn abort_signal_set_aborted(signal: *mut ObjectHeader, reason: f64) {
+    if signal.is_null() || abort_signal_is_aborted(signal) {
+        return;
+    }
+    js_object_set_field_f64(signal, 0, f64::from_bits(TAG_TRUE_AC));
+    js_object_set_field_f64(signal, 1, reason);
+    fire_abort_listeners(signal);
+}
+
+/// `AbortSignal.abort(reason?)` — returns an already-aborted signal whose
+/// `.reason` is `reason` (or an `AbortError` when omitted, matching Node).
+#[no_mangle]
+pub extern "C" fn js_abort_signal_abort(reason: f64) -> *mut ObjectHeader {
+    let signal = alloc_abort_signal();
+    let reason_bits = reason.to_bits();
+    // Node defaults the reason to an AbortError when none is supplied.
+    let effective = if reason_bits == TAG_UNDEFINED_AC {
+        js_abort_error_value()
+    } else {
+        reason
+    };
+    js_object_set_field_f64(signal, 0, f64::from_bits(TAG_TRUE_AC));
+    js_object_set_field_f64(signal, 1, effective);
+    signal
+}
+
+/// `abortSignal.throwIfAborted()` — throws `abortSignal.reason` when the
+/// signal is aborted, otherwise returns undefined (no-op).
+#[no_mangle]
+pub extern "C" fn js_abort_signal_throw_if_aborted(signal: *mut ObjectHeader) -> f64 {
+    if abort_signal_is_aborted(signal) {
+        let reason = crate::object::js_object_get_field_f64(signal, 1);
+        // Node throws the stored reason verbatim (which is the AbortError
+        // default when none was provided).
+        crate::exception::js_throw(reason);
+    }
+    f64::from_bits(TAG_UNDEFINED_AC)
+}
+
+extern "C" fn abort_any_propagate_thunk(
+    closure: *const crate::closure::ClosureHeader,
+    _arg: f64,
+) -> f64 {
+    // capture 0 = combined signal pointer (NaN-boxed), capture 1 = source signal.
+    let combined_bits = crate::closure::js_closure_get_capture_ptr(closure, 0) as u64;
+    let source_bits = crate::closure::js_closure_get_capture_ptr(closure, 1) as u64;
+    let combined =
+        crate::value::js_nanbox_get_pointer(f64::from_bits(combined_bits)) as *mut ObjectHeader;
+    let source =
+        crate::value::js_nanbox_get_pointer(f64::from_bits(source_bits)) as *mut ObjectHeader;
+    let reason = if source.is_null() {
+        f64::from_bits(TAG_UNDEFINED_AC)
+    } else {
+        crate::object::js_object_get_field_f64(source, 1)
+    };
+    abort_signal_set_aborted(combined, reason);
+    f64::from_bits(TAG_UNDEFINED_AC)
+}
+
+/// `AbortSignal.any(signals)` — returns a signal that aborts as soon as any of
+/// the input `signals` aborts, adopting that signal's `reason`. If any input is
+/// already aborted, the combined signal is returned pre-aborted.
+///
+/// `signals_arr` is the raw `*mut ArrayHeader` (i64 handle) for the input
+/// iterable already materialized as an array.
+#[no_mangle]
+pub extern "C" fn js_abort_signal_any(
+    signals_arr: *mut crate::array::ArrayHeader,
+) -> *mut ObjectHeader {
+    let combined = alloc_abort_signal();
+    if signals_arr.is_null() {
+        return combined;
+    }
+    let len = crate::array::js_array_length(signals_arr);
+    let combined_box = crate::value::js_nanbox_pointer(combined as i64);
+    for i in 0..len {
+        let elem = crate::array::js_array_get_f64(signals_arr, i);
+        let Some(source) = abort_signal_ptr_from_value(elem) else {
+            continue;
+        };
+        if abort_signal_is_aborted(source) {
+            // Adopt the first already-aborted source's reason immediately.
+            let reason = crate::object::js_object_get_field_f64(source, 1);
+            abort_signal_set_aborted(combined, reason);
+            return combined;
+        }
+        // Register a propagation listener that adopts this source's reason
+        // when it later aborts.
+        let func = abort_any_propagate_thunk as *const u8;
+        crate::closure::js_register_closure_arity(func, 1);
+        let closure = crate::closure::js_closure_alloc(func, 2);
+        crate::closure::js_closure_set_capture_ptr(closure, 0, combined_box.to_bits() as i64);
+        crate::closure::js_closure_set_capture_ptr(closure, 1, elem.to_bits() as i64);
+        let listener = crate::value::js_nanbox_pointer(closure as i64);
+        let abort_evt = create_string_f64("abort");
+        js_abort_signal_add_listener(source, abort_evt, listener);
+    }
+    combined
+}
+
+// #2582: keepalive anchors so the auto-optimize whole-program LLVM bitcode
+// rebuild doesn't internalize + dead-strip these codegen-only `#[no_mangle]`
+// entry points (see project_auto_optimize_keepalive_3320). These are only
+// referenced from generated `.o`, so without `#[used]` they vanish.
+#[used]
+static KEEP_ABORT_SIGNAL_ABORT: extern "C" fn(f64) -> *mut ObjectHeader = js_abort_signal_abort;
+#[used]
+static KEEP_ABORT_SIGNAL_ANY: extern "C" fn(*mut crate::array::ArrayHeader) -> *mut ObjectHeader =
+    js_abort_signal_any;
+#[used]
+static KEEP_ABORT_SIGNAL_THROW_IF_ABORTED: extern "C" fn(*mut ObjectHeader) -> f64 =
+    js_abort_signal_throw_if_aborted;

--- a/crates/perry-runtime/src/url/mod.rs
+++ b/crates/perry-runtime/src/url/mod.rs
@@ -19,8 +19,9 @@ pub mod url_class;
 
 pub use self::abort::{
     js_abort_controller_abort, js_abort_controller_abort_reason, js_abort_controller_new,
-    js_abort_controller_signal, js_abort_error_value, js_abort_signal_add_listener,
-    js_abort_signal_is_aborted, js_abort_signal_remove_listener, js_abort_signal_timeout,
+    js_abort_controller_signal, js_abort_error_value, js_abort_signal_abort,
+    js_abort_signal_add_listener, js_abort_signal_any, js_abort_signal_is_aborted,
+    js_abort_signal_remove_listener, js_abort_signal_throw_if_aborted, js_abort_signal_timeout,
 };
 pub use self::node_compat::{
     js_url_domain_to_ascii, js_url_domain_to_unicode, js_url_file_url_to_path,

--- a/test-files/test_gap_globals_abortsignal_navigator_2582_2923.ts
+++ b/test-files/test_gap_globals_abortsignal_navigator_2582_2923.ts
@@ -1,0 +1,52 @@
+// AbortSignal static helpers + lifecycle (#2582) and navigator object (#2923)
+
+// ── AbortController + signal lifecycle ──
+const ac = new AbortController();
+console.log("initial", ac.signal.aborted, ac.signal.reason);
+let seen = 0;
+ac.signal.addEventListener("abort", () => {
+  seen++;
+});
+ac.abort("boom");
+console.log("after", ac.signal.aborted, ac.signal.reason, seen);
+
+try {
+  ac.signal.throwIfAborted();
+  console.log("throwIfAborted did not throw");
+} catch (err) {
+  console.log("throwIfAborted threw", err === ac.signal.reason);
+}
+
+// ── AbortSignal.abort(reason) ──
+const s1 = AbortSignal.abort("x");
+console.log("abort static", s1.aborted, s1.reason);
+
+// not-aborted signal: throwIfAborted is a no-op
+const ac2 = new AbortController();
+ac2.signal.throwIfAborted();
+console.log("throwIfAborted noop ok", ac2.signal.aborted);
+
+// ── AbortSignal.timeout(ms) ──
+const t = AbortSignal.timeout(5);
+console.log("timeout initial", t.aborted, typeof t.reason);
+
+// ── AbortSignal.any([signals]) ──
+const a = new AbortController();
+const any = AbortSignal.any([a.signal]);
+console.log("any initial", any.aborted);
+a.abort("y");
+console.log("any after", any.aborted, any.reason);
+
+// pre-aborted input propagates immediately
+const pre = AbortSignal.abort("z");
+const any2 = AbortSignal.any([pre]);
+console.log("any pre-aborted", any2.aborted, any2.reason);
+
+// ── navigator (#2923) ──
+const n = globalThis.navigator;
+console.log("navigator type:", typeof n);
+console.log("userAgent prefix:", typeof n.userAgent, n.userAgent.startsWith("Node.js/"));
+console.log("language type:", typeof n.language);
+console.log("languages array:", Array.isArray(n.languages));
+console.log("hardwareConcurrency type:", typeof n.hardwareConcurrency, n.hardwareConcurrency > 0);
+console.log("platform type:", typeof n.platform);


### PR DESCRIPTION
Closes #2582
Closes #2923

## Implementation

### AbortSignal static helpers + lifecycle (#2582)
- **`AbortSignal.abort(reason?)`** — `js_abort_signal_abort` returns an already-aborted signal; `.reason` defaults to a Node-compatible `AbortError` (code `ABORT_ERR`) when no reason is supplied, else the supplied value.
- **`AbortSignal.any([signals])`** — `js_abort_signal_any` returns a combined signal that aborts (adopting the source's `reason`) when the first input signal aborts. A pre-aborted input propagates immediately; otherwise each input gets an `abort` listener that forwards its reason via a captured-closure propagation thunk.
- **`signal.throwIfAborted()`** — `js_abort_signal_throw_if_aborted` throws the stored `reason` when the signal is aborted, no-op otherwise. Wired in codegen for `<controller>.signal.throwIfAborted()` and `AbortSignal`-typed receivers.
- HIR maps `AbortSignal.{timeout,abort,any}` to the existing `Expr::StaticMethodCall` variant (extended the existing `timeout`-only arm) — **no new HIR variant added**.
- Codegen `static_method.rs` lowers `abort`/`any` to the new FFIs; `lower_call/options/abort.rs` adds the `throwIfAborted` arm. New runtime FFIs declared in `runtime_decls`, with `#[used]` keepalive anchors so the auto-optimize whole-program bitcode rebuild doesn't dead-strip them.

`AbortSignal.timeout(ms)` keeps its existing initial-state stub (no real timer); the issue's remaining timer-driven abort is a separate infra item and the gap test only asserts its initial `.aborted`/`typeof .reason` shape.

### navigator object (#2923)
- New `crates/perry-runtime/src/navigator.rs` builds the `navigator` object: `userAgent` (`"Node.js/<major>"`, mirroring `process.version` = v22), `language` (`en-US`), `languages` (array), `hardwareConcurrency` (real `available_parallelism`), `platform` (browser-style token: `MacIntel` / `Win32` / `Linux x86_64` …), and a `locks` object stub.
- Installed on the `globalThis` singleton next to `performance` (`object/global_this.rs`).
- Added `navigator` to codegen's global-object name lists (`is_global_this_builtin_name`, the namespace-typeof set, and the `typeof` short-circuit in `literals_vars.rs`) so `globalThis.navigator` routes through the singleton and `typeof navigator === "object"`.

## Validation
Gap test `test-files/test_gap_globals_abortsignal_navigator_2582_2923.ts` compiled under the **default auto-optimize** flow is **byte-identical** to `node --experimental-strip-types`:

```
initial false undefined
after true boom 1
throwIfAborted threw true
abort static true x
throwIfAborted noop ok false
timeout initial false undefined
any initial false
any after true y
any pre-aborted true z
navigator type: object
userAgent prefix: string true
language type: string
languages array: true
hardwareConcurrency type: number true
platform type: string
```

Guards green: `./scripts/check_file_size.sh` (OK), `cargo fmt --all -- --check` (clean), `cargo test -p perry-hir` (132 passed incl. `expr_variant_stable_hash_tags_are_unique`), `cargo test -p perry-runtime` (url/abort/stream-promises modules pass).
