### PR TITLE
fix(util): implement util.debug as debuglog alias (#3430)

### DIFF
--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -406,6 +406,7 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
             b"callbackify",
             b"convertProcessSignalToExitCode",
             b"debuglog",
+            b"debug",
             b"deprecate",
             b"format",
             b"formatWithOptions",
@@ -1400,6 +1401,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("util", "inspect")
             | ("util", "aborted")
             | ("util", "debuglog")
+            | ("util", "debug")
             | ("util", "getCallSites")
             | ("util", "getSystemErrorName")
             | ("util", "getSystemErrorMessage")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1000,6 +1000,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         // #2514: util.parseEnv(content) → object.
         ("util", "parseEnv") => crate::util_parse_env::js_util_parse_env(arg(0)),
         ("util", "debuglog") => super::native_module::util_debuglog_logger_value(),
+        ("util", "debug") => super::native_module::util_debuglog_logger_value(),
         ("util", "isArray") => crate::array::js_array_is_array(arg(0)),
         ("util", "isDeepStrictEqual") => {
             crate::builtins::js_util_is_deep_strict_equal(arg(0), arg(1))

--- a/test-files/test_gap_3430_util_debug.ts
+++ b/test-files/test_gap_3430_util_debug.ts
@@ -1,0 +1,8 @@
+// #3430 — util.debug is an alias of util.debuglog: returns a logger function.
+// With NODE_DEBUG unset, the returned logger is a no-op returning undefined.
+import * as util from "node:util";
+
+console.log(typeof util.debug);
+const log = util.debug("mysection");
+console.log(typeof log);
+console.log(String(log("hello")));


### PR DESCRIPTION
Implements `util.debug` (#3430).

`util.debug` is an exact alias of `util.debuglog` (in Node, `util.debug === util.debuglog`). Perry already implements `debuglog`, so this wires `util.debug` (and the `node:sys` mirror) to the same `util_debuglog_logger_value()` runtime helper — no new runtime code.

Edits: `native_module.rs` whitelist + value-gate, dispatch arm reusing the debuglog logger, manifest `method("util","debug")` and `method("sys","debug")`, docs regenerated.

## Validation

`test-files/test_gap_3430_util_debug.ts` is byte-for-byte identical to `node --experimental-strip-types`: `typeof util.debug === "function"`, `util.debug("mysection")` returns a function, and calling it (with NODE_DEBUG unset) returns `undefined`.

`cargo build --release -p perry-runtime -p perry-stdlib -p perry` clean; `cargo test -p perry-api-manifest --lib sys_alias_mirrors_util_manifest` passes; `cargo fmt --all -- --check` clean; api docs regenerate idempotently.
