### PR TITLE
fix(util): implement util.debug as debuglog alias (#3430)

### DIFF
--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -406,6 +406,7 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
             b"callbackify",
             b"convertProcessSignalToExitCode",
             b"debuglog",
+            b"debug",
             b"deprecate",
             b"format",
             b"formatWithOptions",
@@ -1400,6 +1401,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("util", "inspect")
             | ("util", "aborted")
             | ("util", "debuglog")
+            | ("util", "debug")
             | ("util", "getCallSites")
             | ("util", "getSystemErrorName")
             | ("util", "getSystemErrorMessage")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1003,6 +1003,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         // #2514: util.parseEnv(content) → object.
         ("util", "parseEnv") => crate::util_parse_env::js_util_parse_env(arg(0)),
         ("util", "debuglog") => super::native_module::util_debuglog_logger_value(),
+        ("util", "debug") => super::native_module::util_debuglog_logger_value(),
         ("util", "isArray") => crate::array::js_array_is_array(arg(0)),
         ("util", "isDeepStrictEqual") => {
             crate::builtins::js_util_is_deep_strict_equal(arg(0), arg(1))

--- a/test-files/test_gap_3430_util_debug.ts
+++ b/test-files/test_gap_3430_util_debug.ts
@@ -1,0 +1,5 @@
+import * as util from "node:util";
+console.log(typeof util.debug);
+const log = util.debug("mysection");
+console.log(typeof log);
+console.log(String(log("hello")));


### PR DESCRIPTION
Implements `util.debug` (#3430) as an alias of `util.debuglog`.

In Node, `util.debug === util.debuglog` — both return a section logger function. Perry already implements `debuglog` (via the `util_debuglog_logger_value()` runtime helper registered in `native_module.rs`'s callable-export whitelist + value-gate + dispatch). This mirrors those exact three registration points for `debug`, reusing the same helper — no new runtime code, no separate manifest entry (debuglog itself has none; both are exposed through the runtime callable-export path, which the regenerated api docs now reflect).

## Validation

`test-files/test_gap_3430_util_debug.ts` is byte-for-byte identical to `node --experimental-strip-types`:

```
function          // typeof util.debug
function          // typeof util.debug("mysection")
undefined         // calling the logger (NODE_DEBUG unset) returns undefined
```

`cargo build --release -p perry-runtime -p perry-stdlib -p perry` clean; `cargo test -p perry-api-manifest --lib sys_alias_mirrors_util_manifest` passes; `cargo fmt --all -- --check` clean; api docs regenerated (idempotent — second run shows zero drift).
