### PR TITLE
fix(util): implement debuglog logger factory (#3430)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -3011,6 +3011,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("util", "formatWithOptions", false, None),
     method("util", "promisify", false, None),
     method("util", "callbackify", false, None),
+    method("util", "debuglog", false, None),
     method("util", "deprecate", false, None),
     method("util", "inherits", false, None),
     method_sig(
@@ -3086,6 +3087,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("sys", "formatWithOptions", false, None),
     method("sys", "promisify", false, None),
     method("sys", "callbackify", false, None),
+    method("sys", "debuglog", false, None),
     method("sys", "deprecate", false, None),
     method("sys", "inherits", false, None),
     method_sig(

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1992 entries across 94 modules
+// Coverage: 1996 entries across 94 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -2787,6 +2787,10 @@ declare module "sys" {
   /** stdlib */
   export function convertProcessSignalToExitCode(...args: any[]): any;
   /** stdlib */
+  export function debug(...args: any[]): any;
+  /** stdlib */
+  export function debuglog(...args: any[]): any;
+  /** stdlib */
   export function deprecate(...args: any[]): any;
   /** stdlib */
   export function format(...args: any[]): any;
@@ -2922,6 +2926,10 @@ declare module "util" {
   export function callbackify(...args: any[]): any;
   /** stdlib */
   export function convertProcessSignalToExitCode(...args: any[]): any;
+  /** stdlib */
+  export function debug(...args: any[]): any;
+  /** stdlib */
+  export function debuglog(...args: any[]): any;
   /** stdlib */
   export function deprecate(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1992 entries across 94 modules.
+Total: 1996 entries across 94 modules.
 
 ## Modules
 
@@ -2416,6 +2416,8 @@ Total: 1992 entries across 94 modules.
 - `aborted` — module
 - `callbackify` — module
 - `convertProcessSignalToExitCode` — module
+- `debug` — module
+- `debuglog` — module
 - `deprecate` — module
 - `format` — module
 - `formatWithOptions` — module
@@ -2544,6 +2546,8 @@ Total: 1992 entries across 94 modules.
 - `aborted` — module
 - `callbackify` — module
 - `convertProcessSignalToExitCode` — module
+- `debug` — module
+- `debuglog` — module
 - `deprecate` — module
 - `format` — module
 - `formatWithOptions` — module

--- a/test-files/test_gap_3430_util_debuglog.ts
+++ b/test-files/test_gap_3430_util_debuglog.ts
@@ -1,0 +1,5 @@
+import * as util from "node:util";
+console.log(typeof util.debuglog);
+const log = util.debuglog("mysection");
+console.log(typeof log);
+console.log(String(log("hello")));


### PR DESCRIPTION
Implements `util.debuglog(section)` — the runtime logger (`util_debuglog_logger_value`), whitelist, value-gate, and dispatch arm already existed, but the symbol had no API-manifest entry so imports failed the #463 R005 unimplemented gate. Adds the manifest entries for `debuglog` (mirrored into the deprecated `sys` alias to keep `sys_alias_mirrors_util_manifest` balanced).

Byte-for-byte identical to `node --experimental-strip-types`:
```
typeof util.debuglog        → function
util.debuglog("x")          → function; calling it (NODE_DEBUG unset) → undefined
```

The `util.debug` alias requested in #3430 is deferred: its value-read+call path resolves differently from the method-call dispatch and returns undefined; tracking that separately so this lands the working logger factory first.