### PR TITLE
fix(node:url): WHATWG IPv4 host canonicalization (hostname setter + domainToASCII) (#3056, #3059)

### DIFF
--- a/crates/perry-codegen/src/expr/url_main.rs
+++ b/crates/perry-codegen/src/expr/url_main.rs
@@ -134,9 +134,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let url_v = lower_expr(ctx, url)?;
             let url_handle = unbox_to_i64(ctx.block(), &url_v);
             let val_v = lower_expr(ctx, value)?;
-            let val_str_ptr =
+            // #3056: the hostname setter Web-IDL-stringifies its RHS
+            // (`String(value)`, Symbols throw) so `u.hostname = 123` becomes
+            // the host string `"123"` (then canonicalized to `"0.0.0.123"` in
+            // the runtime). Other setters keep the existing string-pointer
+            // extraction to avoid behavioural drift.
+            let val_str_ptr = if matches!(expr, Expr::UrlSetHostname { .. }) {
                 ctx.block()
-                    .call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &val_v)]);
+                    .call(I64, "js_url_coerce_string", &[(DOUBLE, &val_v)])
+            } else {
+                ctx.block()
+                    .call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &val_v)])
+            };
             ctx.block()
                 .call_void(runtime_fn, &[(I64, &url_handle), (I64, &val_str_ptr)]);
             // Assignment expression evaluates to the value on the RHS.

--- a/crates/perry-runtime/src/url/mod.rs
+++ b/crates/perry-runtime/src/url/mod.rs
@@ -152,6 +152,41 @@ pub(crate) fn string_header_to_string(value: *mut crate::StringHeader) -> String
     }
 }
 
+/// WHATWG host canonicalization via the `url` crate (#3056, #3059).
+///
+/// Perry's URL uses a custom hostname parser that runs only IDNA
+/// (`idna::domain_to_ascii`) — it never applies the WHATWG IPv4 / numeric
+/// host parser, so `123` stayed `"123"` instead of canonicalizing to the
+/// IPv4 address `"0.0.0.123"`, and `0x7f.1` stayed `"0x7f.1"` instead of
+/// `"127.0.0.1"`. We borrow the `url` crate's full WHATWG host parser by
+/// reparsing `http://<host>/` and reading back `host_str()`:
+///
+/// * numeric / IPv4-shorthand hosts → canonical dotted-quad IPv4
+///   (`"123"` → `"0.0.0.123"`, `"0x7f.1"` → `"127.0.0.1"`),
+/// * ordinary registrable hostnames → returned unchanged
+///   (`"example.com"` → `"example.com"`),
+/// * already-punycode IDN labels → returned unchanged
+///   (`"xn--mnchen-3ya.de"` → `"xn--mnchen-3ya.de"`),
+/// * hosts the WHATWG parser rejects (out-of-range numeric like
+///   `"999999999999"`, `"256.256.256.256"`) → `None`.
+///
+/// `host` is expected to already be a candidate host string (post-IDNA for
+/// the domain helpers, or the raw setter value). Callers decide what `None`
+/// means for them (the hostname setter leaves the host unchanged; the
+/// `domainTo*` helpers return `""`), matching Node.
+pub(crate) fn whatwg_canonicalize_host(host: &str) -> Option<String> {
+    url::Url::parse(&format!("http://{host}/"))
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_string))
+}
+
+/// True when `host` is a canonical dotted-quad IPv4 literal. Used by
+/// `domainToUnicode` to decide whether to return the canonicalized IPv4
+/// (Node yields the IP for numeric hosts) versus the Unicode IDN form.
+pub(crate) fn is_ipv4_host(host: &str) -> bool {
+    host.parse::<std::net::Ipv4Addr>().is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::parse::{parse_url, resolve_url};

--- a/crates/perry-runtime/src/url/node_compat.rs
+++ b/crates/perry-runtime/src/url/node_compat.rs
@@ -230,23 +230,43 @@ pub extern "C" fn js_url_path_to_file_url(path_f64: f64) -> f64 {
     crate::value::js_nanbox_pointer(obj as i64)
 }
 
+/// `url.domainToASCII(domain)` (#3059). Node Web-IDL-stringifies the argument
+/// (`String(domain)`; a Symbol throws TypeError) and runs the full WHATWG host
+/// parser, so a numeric / IPv4-shorthand domain canonicalizes to a dotted-quad
+/// IPv4 address (`123` → `"0.0.0.123"`, `0x7f.1` → `"127.0.0.1"`) rather than
+/// being treated as a literal label. Unparsable hosts yield `""`.
 #[no_mangle]
 pub extern "C" fn js_url_domain_to_ascii(input_f64: f64) -> f64 {
-    let input = get_string_content(input_f64);
+    let input = string_from_header(js_url_coerce_string(input_f64));
     if input.chars().any(|c| c.is_ascii_whitespace()) {
         return create_string_f64("");
     }
-    let out = idna::domain_to_ascii(&input).unwrap_or_else(|_| String::new());
+    // `whatwg_canonicalize_host` runs IDNA *and* the WHATWG numeric/IPv4 host
+    // parser, matching Node's `domainToASCII` exactly (IDN → punycode, numeric
+    // → IPv4, invalid → None → ""). It supersedes the bare `idna::domain_to_ascii`.
+    let out = whatwg_canonicalize_host(&input).unwrap_or_default();
     create_string_f64(&out)
 }
 
+/// `url.domainToUnicode(domain)` (#3059). Mirrors `domainToASCII`'s coercion
+/// and WHATWG host parsing, but returns the Unicode IDN form. For numeric /
+/// IPv4-shorthand hosts Node returns the canonical IPv4 address (`123` →
+/// `"0.0.0.123"`); for registrable hostnames it returns the decoded Unicode
+/// (`xn--mnchen-3ya.de` → `münchen.de`); invalid hosts yield `""`.
 #[no_mangle]
 pub extern "C" fn js_url_domain_to_unicode(input_f64: f64) -> f64 {
-    let input = get_string_content(input_f64);
+    let input = string_from_header(js_url_coerce_string(input_f64));
     if input.chars().any(|c| c.is_ascii_whitespace()) {
         return create_string_f64("");
     }
-    let (out, _) = idna::domain_to_unicode(&input);
+    let out = match whatwg_canonicalize_host(&input) {
+        // Out-of-range / unparsable host → "" (matches Node).
+        None => String::new(),
+        // Numeric / IPv4-shorthand → canonical IPv4 address (Node yields the IP).
+        Some(canon) if is_ipv4_host(&canon) => canon,
+        // Registrable hostname → Unicode IDN form.
+        Some(_) => idna::domain_to_unicode(&input).0,
+    };
     create_string_f64(&out)
 }
 

--- a/crates/perry-runtime/src/url/url_class.rs
+++ b/crates/perry-runtime/src/url/url_class.rs
@@ -141,7 +141,18 @@ fn normalize_hostname_value(raw: &str) -> Option<String> {
         return None;
     }
     match idna::domain_to_ascii(raw) {
-        Ok(ascii) if !ascii.is_empty() => Some(ascii),
+        Ok(ascii) if !ascii.is_empty() => {
+            // #3056: apply the WHATWG numeric/IPv4-shorthand host parser as a
+            // post-step. `idna::domain_to_ascii` only runs IDNA, so a numeric
+            // host like `123` survives as `"123"` instead of canonicalizing to
+            // the IPv4 address `"0.0.0.123"`. The `url` crate's WHATWG host
+            // parser does this correctly; for ordinary hostnames it returns
+            // the same string (no change). When it rejects the host (e.g.
+            // out-of-range numeric `999999999999`) Node leaves the hostname
+            // unchanged — `None` propagates that, since `js_url_set_hostname`
+            // is a no-op on `None`.
+            super::whatwg_canonicalize_host(&ascii)
+        }
         _ => None,
     }
 }

--- a/test-files/test_gap_url_host_canon_3056_3059.ts
+++ b/test-files/test_gap_url_host_canon_3056_3059.ts
@@ -1,0 +1,44 @@
+// Gap test: WHATWG IPv4 / numeric host canonicalization for node:url
+// (#3056, #3059).
+//
+// #3056: `url.hostname = value` Web-IDL-stringifies the RHS and runs the
+//   WHATWG host parser, so a numeric / IPv4-shorthand host canonicalizes to a
+//   dotted-quad IPv4 address (`123` -> "0.0.0.123", "0x7f.1" -> "127.0.0.1").
+//   Ordinary + IDN hostnames are unchanged; an out-of-range numeric host
+//   (`999999999999`) leaves the existing hostname untouched.
+// #3059: `url.domainToASCII` / `url.domainToUnicode` apply the same WHATWG
+//   host parsing to their (stringified) argument: numeric -> IPv4, IDN ->
+//   punycode / Unicode, invalid -> "".
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+import url from "node:url";
+
+const u1 = new URL("http://x/");
+u1.hostname = 123 as any;
+console.log("hostname number:", u1.hostname);
+console.log("host number:", u1.host);
+console.log("href number:", u1.href);
+
+const u2 = new URL("http://x/");
+u2.hostname = "0x7f.1";
+console.log("hostname hex:", u2.hostname);
+
+const u3 = new URL("http://x/");
+u3.hostname = "example.com";
+console.log("hostname normal:", u3.hostname);
+
+const u4 = new URL("http://x/");
+u4.hostname = "münchen.de";
+console.log("hostname idn:", u4.hostname);
+
+const u5 = new URL("http://x/");
+u5.hostname = "999999999999";
+console.log("hostname oob (unchanged):", u5.hostname);
+
+console.log("domainToASCII number:", url.domainToASCII(123 as any));
+console.log("domainToUnicode number:", url.domainToUnicode(123 as any));
+console.log("domainToASCII idn:", url.domainToASCII("münchen.de"));
+console.log("domainToUnicode puny:", url.domainToUnicode("xn--mnchen-3ya.de"));
+console.log("domainToASCII normal:", url.domainToASCII("example.com"));
+console.log("domainToASCII oob:", JSON.stringify(url.domainToASCII("999999999999")));


### PR DESCRIPTION
Closes #3056
Closes #3059

Adds `whatwg_canonicalize_host` (reparses `http://<host>/` via the `url` crate) so numeric/IPv4-shorthand hosts canonicalize per WHATWG (`u.hostname=123`→`0.0.0.123`; `url.domainToASCII(123)`→`0.0.0.123`) while ordinary hostnames and punycode IDN labels are unchanged. Gap test + existing URL parity tests byte-identical to Node. Verified under default auto-optimize compile.