### PR TITLE
fix(stream/promises): align promise semantics

### DIFF
--- a/crates/perry-runtime/src/node_stream_pipeline.rs
+++ b/crates/perry-runtime/src/node_stream_pipeline.rs
@@ -488,9 +488,13 @@ pub(super) fn fail_collected_pipeline(stages: &[f64], callback: f64, err: f64) {
     }
 }
 
-pub(super) fn complete_collected_pipeline(callback: f64) {
+pub(super) fn complete_collected_pipeline(callback: f64, value: f64) {
     if is_callable_value(callback) {
-        call_listener_args(f64::from_bits(TAG_UNDEFINED), callback, &[]);
+        call_listener_args(
+            f64::from_bits(TAG_UNDEFINED),
+            callback,
+            &[f64::from_bits(TAG_UNDEFINED), value],
+        );
     }
 }
 
@@ -532,8 +536,10 @@ pub(super) fn run_collected_pipeline(
                             fail_collected_pipeline(stages, callback, err);
                             return last;
                         }
+                        complete_collected_pipeline(callback, f64::from_bits(TAG_UNDEFINED));
+                    } else {
+                        complete_collected_pipeline(callback, result);
                     }
-                    complete_collected_pipeline(callback);
                     return last;
                 }
                 Ok(result) => match collect_pipeline_chunks(result) {
@@ -558,7 +564,7 @@ pub(super) fn run_collected_pipeline(
                 return last;
             }
             if is_last {
-                complete_collected_pipeline(callback);
+                complete_collected_pipeline(callback, f64::from_bits(TAG_UNDEFINED));
                 return last;
             }
             match collect_pipeline_chunks(stage) {
@@ -577,13 +583,13 @@ pub(super) fn run_collected_pipeline(
                 }
             }
             if is_last {
-                complete_collected_pipeline(callback);
+                complete_collected_pipeline(callback, f64::from_bits(TAG_UNDEFINED));
                 return last;
             }
         }
     }
 
-    complete_collected_pipeline(callback);
+    complete_collected_pipeline(callback, f64::from_bits(TAG_UNDEFINED));
     last
 }
 

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -1811,6 +1811,30 @@ pub(crate) fn js_node_stream_hidden_error(stream: f64) -> Option<f64> {
     readable_hidden_error(stream)
 }
 
+pub(crate) fn js_node_stream_is_classic_stream(stream: f64) -> bool {
+    get_hidden_value(stream, hidden_readable_flag_key()).is_some()
+        || get_hidden_value(stream, hidden_writable_flag_key()).is_some()
+}
+
+pub(crate) fn js_node_stream_has_readable_side(stream: f64) -> bool {
+    get_hidden_value(stream, hidden_readable_flag_key()).is_some()
+}
+
+pub(crate) fn js_node_stream_has_writable_side(stream: f64) -> bool {
+    get_hidden_value(stream, hidden_writable_flag_key()).is_some()
+}
+
+pub(crate) fn js_node_stream_readable_side_done(stream: f64) -> bool {
+    !js_node_stream_has_readable_side(stream)
+        || stream_hidden_ended(stream)
+        || has_truthy_hidden(stream, hidden_end_emitted_key())
+}
+
+pub(crate) fn js_node_stream_writable_side_done(stream: f64) -> bool {
+    !js_node_stream_has_writable_side(stream)
+        || has_truthy_hidden(stream, hidden_finish_emitted_key())
+}
+
 #[cfg(test)]
 pub(crate) fn js_node_stream_is_stub_ended_after_read(stream: f64) -> bool {
     probe_read_once(stream);

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -1433,7 +1433,7 @@ mod tests {
     }
 
     #[test]
-    fn stream_promises_finished_resolves_for_clean_stub_stream() {
+    fn stream_promises_finished_resolves_for_finished_writable_side_stub_stream() {
         let stream = crate::node_stream::js_node_stream_passthrough_new(undefined_value());
         let end = get_object_property(stream, b"end").expect("stream.end should exist");
         let prev_this = crate::object::js_implicit_this_set(stream);
@@ -1441,8 +1441,17 @@ mod tests {
             let _ = crate::closure::js_native_call_value(end, std::ptr::null(), 0);
         }
         crate::object::js_implicit_this_set(prev_this);
+        let _ = crate::promise::js_promise_run_microtasks();
 
-        let promise_value = thunk_streamP_finished(std::ptr::null(), stream, undefined_value());
+        let opts = js_object_alloc(0, 1);
+        js_object_set_field_by_name(
+            opts,
+            js_string_from_bytes(b"readable".as_ptr(), 8),
+            f64::from_bits(crate::value::TAG_FALSE),
+        );
+
+        let promise_value =
+            thunk_streamP_finished(std::ptr::null(), stream, boxed_ptr(opts as *const u8));
         let promise = promise_ptr(promise_value);
 
         assert_eq!(crate::promise::js_promise_state(promise), 1);
@@ -1572,14 +1581,19 @@ mod tests {
     }
 
     #[test]
-    fn stream_promises_finished_with_signal_resolves_for_ended_stub_stream() {
+    fn stream_promises_finished_with_signal_resolves_for_finished_writable_side_stub_stream() {
         let controller = crate::url::js_abort_controller_new();
         let signal = crate::url::js_abort_controller_signal(controller);
-        let opts = js_object_alloc(0, 1);
+        let opts = js_object_alloc(0, 2);
         js_object_set_field_by_name(
             opts,
             js_string_from_bytes(b"signal".as_ptr(), 6),
             boxed_ptr(signal as *const u8),
+        );
+        js_object_set_field_by_name(
+            opts,
+            js_string_from_bytes(b"readable".as_ptr(), 8),
+            f64::from_bits(crate::value::TAG_FALSE),
         );
         let stream = crate::node_stream::js_node_stream_passthrough_new(undefined_value());
         let end = get_object_property(stream, b"end").expect("stream.end should exist");
@@ -1588,6 +1602,7 @@ mod tests {
             let _ = crate::closure::js_native_call_value(end, std::ptr::null(), 0);
         }
         crate::object::js_implicit_this_set(prev_this);
+        let _ = crate::promise::js_promise_run_microtasks();
 
         let promise_value =
             thunk_streamP_finished(std::ptr::null(), stream, boxed_ptr(opts as *const u8));

--- a/crates/perry-runtime/src/node_submodules/stream_promises.rs
+++ b/crates/perry-runtime/src/node_submodules/stream_promises.rs
@@ -15,7 +15,9 @@ use crate::closure::{
     js_closure_alloc, js_closure_get_capture_f64, js_closure_get_capture_ptr,
     js_closure_set_capture_f64, js_closure_set_capture_ptr, ClosureHeader,
 };
-use crate::object::{js_object_get_field_by_name_f64, ObjectHeader};
+use crate::object::{
+    js_object_alloc, js_object_get_field_by_name_f64, js_object_set_field_by_name, ObjectHeader,
+};
 use crate::string::js_string_from_bytes;
 use crate::value::JSValue;
 use std::os::raw::c_int;
@@ -132,6 +134,35 @@ fn premature_close_error_value() -> f64 {
     value_from_ptr(err as *const u8)
 }
 
+fn type_error_value_with_code(message: &str, code: &'static str) -> f64 {
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    crate::node_submodules::register_error_code_pub(msg, code);
+    value_from_ptr(crate::error::js_typeerror_new(msg) as *const u8)
+}
+
+fn missing_streams_error_value() -> f64 {
+    type_error_value_with_code(
+        "The \"streams\" argument must be specified",
+        "ERR_MISSING_ARGS",
+    )
+}
+
+fn invalid_finished_stream_error_value(stream: f64) -> f64 {
+    let message = format!(
+        "The \"stream\" argument must be an instance of ReadableStream, WritableStream, or Stream. Received {}",
+        crate::fs::validate::describe_received(stream)
+    );
+    type_error_value_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn invalid_pipeline_body_error_value(body: f64) -> f64 {
+    let message = format!(
+        "The \"body\" argument must be of type function or an instance of Blob, ReadableStream, WritableStream, Stream, Iterable, AsyncIterable, or Promise or {{ readable, writable }} pair. Received {}",
+        crate::fs::validate::describe_received(body)
+    );
+    type_error_value_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
 pub(crate) fn signal_reason(signal: f64) -> f64 {
     match get_object_property(signal, b"reason") {
         Some(reason) if !JSValue::from_bits(reason.to_bits()).is_undefined() => reason,
@@ -181,26 +212,36 @@ extern "C" fn stream_promises_finished_error_listener(
     closure: *const ClosureHeader,
     err: f64,
 ) -> f64 {
-    let promise = js_closure_get_capture_ptr(closure, 0) as *mut crate::promise::Promise;
-    crate::promise::js_promise_reject(promise, err);
+    let state = js_closure_get_capture_ptr(closure, 0) as *mut ObjectHeader;
+    finished_state_reject(state, err);
     undefined_value()
 }
 
-extern "C" fn stream_promises_finished_done_listener(closure: *const ClosureHeader) -> f64 {
-    let promise = js_closure_get_capture_ptr(closure, 0) as *mut crate::promise::Promise;
-    crate::promise::js_promise_resolve(promise, undefined_value());
+extern "C" fn stream_promises_finished_side_listener(closure: *const ClosureHeader) -> f64 {
+    let state = js_closure_get_capture_ptr(closure, 0) as *mut ObjectHeader;
+    let readable_side = js_closure_get_capture_f64(closure, 1).to_bits() == crate::value::TAG_TRUE;
+    if readable_side {
+        finished_state_set_bool(state, b"readableDone", true);
+    } else {
+        finished_state_set_bool(state, b"writableDone", true);
+    }
+    finished_state_try_resolve(state);
     undefined_value()
 }
 
 extern "C" fn stream_promises_finished_close_listener(closure: *const ClosureHeader) -> f64 {
-    let promise = js_closure_get_capture_ptr(closure, 0) as *mut crate::promise::Promise;
-    let stream = f64::from_bits(js_closure_get_capture_ptr(closure, 1) as u64);
+    let state = js_closure_get_capture_ptr(closure, 0) as *mut ObjectHeader;
+    if finished_state_bool(state, b"settled") {
+        return undefined_value();
+    }
+    let stream = finished_state_value(state, b"stream");
     if let Some(err) = crate::node_stream::js_node_stream_hidden_error(stream) {
-        crate::promise::js_promise_reject(promise, err);
-    } else if crate::node_stream::js_node_stream_is_stub_ended(stream) {
-        crate::promise::js_promise_resolve(promise, undefined_value());
-    } else {
-        crate::promise::js_promise_reject(promise, premature_close_error_value());
+        finished_state_reject(state, err);
+        return undefined_value();
+    }
+    finished_state_refresh_done(state, stream);
+    if !finished_state_try_resolve(state) {
+        finished_state_reject(state, premature_close_error_value());
     }
     undefined_value()
 }
@@ -220,7 +261,7 @@ fn register_finished_listener_arities() {
         1,
     );
     crate::closure::js_register_closure_arity(
-        stream_promises_finished_done_listener as *const u8,
+        stream_promises_finished_side_listener as *const u8,
         0,
     );
     crate::closure::js_register_closure_arity(
@@ -229,7 +270,111 @@ fn register_finished_listener_arities() {
     );
 }
 
-fn pending_finished_promise(stream: f64, signal: Option<f64>) -> f64 {
+fn finished_state_key(name: &[u8]) -> *mut crate::string::StringHeader {
+    js_string_from_bytes(name.as_ptr(), name.len() as u32)
+}
+
+fn finished_state_value(state: *mut ObjectHeader, name: &[u8]) -> f64 {
+    if state.is_null() {
+        return undefined_value();
+    }
+    js_object_get_field_by_name_f64(state as *const ObjectHeader, finished_state_key(name))
+}
+
+fn finished_state_set(state: *mut ObjectHeader, name: &[u8], value: f64) {
+    if state.is_null() {
+        return;
+    }
+    js_object_set_field_by_name(state, finished_state_key(name), value);
+}
+
+fn finished_state_bool(state: *mut ObjectHeader, name: &[u8]) -> bool {
+    finished_state_value(state, name).to_bits() == crate::value::TAG_TRUE
+}
+
+fn finished_state_set_bool(state: *mut ObjectHeader, name: &[u8], value: bool) {
+    finished_state_set(
+        state,
+        name,
+        f64::from_bits(if value {
+            crate::value::TAG_TRUE
+        } else {
+            crate::value::TAG_FALSE
+        }),
+    );
+}
+
+fn finished_state_promise(state: *mut ObjectHeader) -> *mut crate::promise::Promise {
+    crate::value::js_nanbox_get_pointer(finished_state_value(state, b"promise"))
+        as *mut crate::promise::Promise
+}
+
+fn finished_state_resolve(state: *mut ObjectHeader) {
+    if finished_state_bool(state, b"settled") {
+        return;
+    }
+    finished_state_set_bool(state, b"settled", true);
+    crate::promise::js_promise_resolve(finished_state_promise(state), undefined_value());
+}
+
+fn finished_state_reject(state: *mut ObjectHeader, err: f64) {
+    if finished_state_bool(state, b"settled") {
+        return;
+    }
+    finished_state_set_bool(state, b"settled", true);
+    crate::promise::js_promise_reject(finished_state_promise(state), err);
+}
+
+fn finished_state_try_resolve(state: *mut ObjectHeader) -> bool {
+    if finished_state_bool(state, b"settled") {
+        return true;
+    }
+    let readable_done =
+        !finished_state_bool(state, b"needReadable") || finished_state_bool(state, b"readableDone");
+    let writable_done =
+        !finished_state_bool(state, b"needWritable") || finished_state_bool(state, b"writableDone");
+    if readable_done && writable_done {
+        finished_state_resolve(state);
+        true
+    } else {
+        false
+    }
+}
+
+fn finished_state_refresh_done(state: *mut ObjectHeader, stream: f64) {
+    if crate::node_stream::js_node_stream_readable_side_done(stream) {
+        finished_state_set_bool(state, b"readableDone", true);
+    }
+    if crate::node_stream::js_node_stream_writable_side_done(stream) {
+        finished_state_set_bool(state, b"writableDone", true);
+    }
+}
+
+fn finished_option_enabled(options: f64, name: &[u8]) -> bool {
+    get_object_property(options, name)
+        .map(|value| value.to_bits() != crate::value::TAG_FALSE)
+        .unwrap_or(true)
+}
+
+fn finished_required_sides(stream: f64, options: f64) -> (bool, bool) {
+    let need_readable = finished_option_enabled(options, b"readable")
+        && crate::node_stream::js_node_stream_has_readable_side(stream);
+    let need_writable = finished_option_enabled(options, b"writable")
+        && crate::node_stream::js_node_stream_has_writable_side(stream);
+    (need_readable, need_writable)
+}
+
+fn finished_sides_done(stream: f64, need_readable: bool, need_writable: bool) -> bool {
+    (!need_readable || crate::node_stream::js_node_stream_readable_side_done(stream))
+        && (!need_writable || crate::node_stream::js_node_stream_writable_side_done(stream))
+}
+
+fn pending_finished_promise(
+    stream: f64,
+    signal: Option<f64>,
+    need_readable: bool,
+    need_writable: bool,
+) -> f64 {
     register_finished_listener_arities();
     let promise = crate::promise::js_promise_new();
     let handle = raw_ptr_from_value(stream) as i64;
@@ -238,19 +383,46 @@ fn pending_finished_promise(stream: f64, signal: Option<f64>) -> f64 {
         return promise_value_from_ptr(promise);
     }
 
+    let state = js_object_alloc(0, 7);
+    finished_state_set(state, b"promise", promise_value_from_ptr(promise));
+    finished_state_set(state, b"stream", stream);
+    finished_state_set_bool(state, b"settled", false);
+    finished_state_set_bool(state, b"needReadable", need_readable);
+    finished_state_set_bool(state, b"needWritable", need_writable);
+    finished_state_set_bool(
+        state,
+        b"readableDone",
+        crate::node_stream::js_node_stream_readable_side_done(stream),
+    );
+    finished_state_set_bool(
+        state,
+        b"writableDone",
+        crate::node_stream::js_node_stream_writable_side_done(stream),
+    );
+    if finished_state_try_resolve(state) {
+        return promise_value_from_ptr(promise);
+    }
+
     let error_listener = js_closure_alloc(stream_promises_finished_error_listener as *const u8, 1);
-    js_closure_set_capture_ptr(error_listener, 0, promise as i64);
+    js_closure_set_capture_ptr(error_listener, 0, state as i64);
     add_once_listener(handle, b"error", listener_value(error_listener));
 
-    let done_listener = js_closure_alloc(stream_promises_finished_done_listener as *const u8, 1);
-    js_closure_set_capture_ptr(done_listener, 0, promise as i64);
-    let done_listener = listener_value(done_listener);
-    add_once_listener(handle, b"end", done_listener);
-    add_once_listener(handle, b"finish", done_listener);
+    if need_readable {
+        let end_listener = js_closure_alloc(stream_promises_finished_side_listener as *const u8, 2);
+        js_closure_set_capture_ptr(end_listener, 0, state as i64);
+        js_closure_set_capture_f64(end_listener, 1, f64::from_bits(crate::value::TAG_TRUE));
+        add_once_listener(handle, b"end", listener_value(end_listener));
+    }
+    if need_writable {
+        let finish_listener =
+            js_closure_alloc(stream_promises_finished_side_listener as *const u8, 2);
+        js_closure_set_capture_ptr(finish_listener, 0, state as i64);
+        js_closure_set_capture_f64(finish_listener, 1, f64::from_bits(crate::value::TAG_FALSE));
+        add_once_listener(handle, b"finish", listener_value(finish_listener));
+    }
 
-    let close_listener = js_closure_alloc(stream_promises_finished_close_listener as *const u8, 2);
-    js_closure_set_capture_ptr(close_listener, 0, promise as i64);
-    js_closure_set_capture_ptr(close_listener, 1, stream.to_bits() as i64);
+    let close_listener = js_closure_alloc(stream_promises_finished_close_listener as *const u8, 1);
+    js_closure_set_capture_ptr(close_listener, 0, state as i64);
     add_once_listener(handle, b"close", listener_value(close_listener));
 
     if let Some(signal) = signal {
@@ -280,7 +452,44 @@ fn write_chunks_to_destination(destination: f64, chunks: &[f64]) {
     let _ = invoke_destination_method(destination, b"end", &end_args);
 }
 
+fn is_missing_pipeline_arg(value: f64) -> bool {
+    JSValue::from_bits(value.to_bits()).is_undefined()
+}
+
+fn is_invalid_pipeline_body(value: f64) -> bool {
+    let jsval = JSValue::from_bits(value.to_bits());
+    jsval.is_undefined()
+        || jsval.is_null()
+        || jsval.is_bool()
+        || jsval.is_number()
+        || jsval.is_int32()
+        || jsval.is_bigint()
+        || unsafe { crate::symbol::js_is_symbol(value) != 0 }
+}
+
+fn validate_stream_promises_pipeline_args(
+    source: f64,
+    destination: f64,
+    rest: &[f64],
+) -> Result<(), f64> {
+    if is_missing_pipeline_arg(source) || is_missing_pipeline_arg(destination) {
+        return Err(missing_streams_error_value());
+    }
+    for body in std::iter::once(source)
+        .chain(std::iter::once(destination))
+        .chain(rest.iter().copied())
+    {
+        if is_invalid_pipeline_body(body) {
+            return Err(invalid_pipeline_body_error_value(body));
+        }
+    }
+    Ok(())
+}
+
 fn direct_stream_promises_pipeline(source: f64, destination: f64, options: f64) -> f64 {
+    if let Err(err) = validate_stream_promises_pipeline_args(source, destination, &[]) {
+        return promise_rejected(err);
+    }
     let signal = options_signal(options);
     if let Some(signal) = signal {
         if signal_aborted(signal) {
@@ -313,7 +522,11 @@ fn direct_stream_promises_pipeline(source: f64, destination: f64, options: f64) 
     }
 }
 
-extern "C" fn stream_promises_pipeline_callback(closure: *const ClosureHeader, err: f64) -> f64 {
+extern "C" fn stream_promises_pipeline_callback(
+    closure: *const ClosureHeader,
+    err: f64,
+    value: f64,
+) -> f64 {
     if closure.is_null() {
         return undefined_value();
     }
@@ -322,7 +535,7 @@ extern "C" fn stream_promises_pipeline_callback(closure: *const ClosureHeader, e
         crate::value::js_nanbox_get_pointer(promise_value) as *mut crate::promise::Promise;
     let err_value = JSValue::from_bits(err.to_bits());
     if err_value.is_undefined() || err_value.is_null() {
-        crate::promise::js_promise_resolve(promise, undefined_value());
+        crate::promise::js_promise_resolve(promise, value);
     } else {
         crate::promise::js_promise_reject(promise, err);
     }
@@ -355,10 +568,14 @@ pub(crate) extern "C" fn thunk_streamP_pipeline(
         None => return direct_stream_promises_pipeline(source, destination, options_or_rest),
     };
 
+    if let Err(err) = validate_stream_promises_pipeline_args(source, destination, &rest_values) {
+        return promise_rejected(err);
+    }
+
     let promise = crate::promise::js_promise_new();
     let promise_value = promise_value_from_ptr(promise);
 
-    crate::closure::js_register_closure_arity(stream_promises_pipeline_callback as *const u8, 1);
+    crate::closure::js_register_closure_arity(stream_promises_pipeline_callback as *const u8, 2);
     let callback = js_closure_alloc(stream_promises_pipeline_callback as *const u8, 1);
     js_closure_set_capture_f64(callback, 0, promise_value);
 
@@ -385,24 +602,24 @@ pub(crate) extern "C" fn thunk_streamP_finished(
     stream: f64,
     options: f64,
 ) -> f64 {
-    if let Some(signal) = options_signal(options) {
+    if !crate::node_stream::js_node_stream_is_classic_stream(stream) {
+        return promise_rejected(invalid_finished_stream_error_value(stream));
+    }
+
+    let signal = options_signal(options);
+    if let Some(signal) = signal {
         if signal_aborted(signal) {
             return promise_rejected(signal_reason(signal));
         }
-        if let Some(err) = crate::node_stream::js_node_stream_hidden_error(stream) {
-            return promise_rejected(err);
-        }
-        if crate::node_stream::js_node_stream_is_stub_ended(stream) {
-            return promise_undefined();
-        }
-        return pending_finished_promise(stream, Some(signal));
     }
 
     if let Some(err) = crate::node_stream::js_node_stream_hidden_error(stream) {
         promise_rejected(err)
-    } else if crate::node_stream::js_node_stream_is_stub_ended(stream) {
-        promise_undefined()
     } else {
-        pending_finished_promise(stream, None)
+        let (need_readable, need_writable) = finished_required_sides(stream, options);
+        if finished_sides_done(stream, need_readable, need_writable) {
+            return promise_undefined();
+        }
+        pending_finished_promise(stream, signal, need_readable, need_writable)
     }
 }

--- a/test-parity/node-suite/stream/promises/finished-duplex-side-options.ts
+++ b/test-parity/node-suite/stream/promises/finished-duplex-side-options.ts
@@ -1,0 +1,32 @@
+import { Duplex } from "node:stream";
+import { finished } from "node:stream/promises";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(() => resolve("pending"), ms));
+const state = (p: Promise<unknown>) => Promise.race([
+  p.then(() => "resolved", (err: any) => `rejected:${err?.code || err?.name || "error"}`),
+  delay(30),
+]);
+
+const writeOnlySettled = new Duplex({
+  read() {},
+  write(_chunk, _enc, cb) { cb(); },
+});
+const defaultAfterFinish = finished(writeOnlySettled);
+const readableFalseAfterFinish = finished(writeOnlySettled, { readable: false });
+writeOnlySettled.end("x");
+console.log("default after finish only:", await state(defaultAfterFinish));
+console.log("readable false after finish only:", await state(readableFalseAfterFinish));
+defaultAfterFinish.catch(() => {});
+writeOnlySettled.destroy();
+
+const readOnlySettled = new Duplex({
+  read() { this.push(null); },
+  write(_chunk, _enc, cb) { cb(); },
+});
+const defaultAfterEnd = finished(readOnlySettled);
+const writableFalseAfterEnd = finished(readOnlySettled, { writable: false });
+readOnlySettled.resume();
+console.log("default after end only:", await state(defaultAfterEnd));
+console.log("writable false after end only:", await state(writableFalseAfterEnd));
+defaultAfterEnd.catch(() => {});
+readOnlySettled.destroy();

--- a/test-parity/node-suite/stream/promises/pipeline-terminal-return.ts
+++ b/test-parity/node-suite/stream/promises/pipeline-terminal-return.ts
@@ -1,0 +1,13 @@
+import { Readable, PassThrough } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+const terminal = await pipeline(Readable.from(["a", "b"]), async (source: AsyncIterable<any>) => {
+  let out = "";
+  for await (const chunk of source) out += String(chunk);
+  return out.toUpperCase();
+});
+
+const streamToStream = await pipeline(Readable.from(["x"]), new PassThrough());
+
+console.log("terminal return:", terminal);
+console.log("stream return undefined:", streamToStream === undefined);

--- a/test-parity/node-suite/stream/promises/validation-errors.ts
+++ b/test-parity/node-suite/stream/promises/validation-errors.ts
@@ -1,0 +1,19 @@
+import { pipeline, finished } from "node:stream/promises";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(() => resolve("pending"), ms));
+
+async function probe(label: string, fn: () => unknown) {
+  const result = await Promise.race([
+    Promise.resolve()
+      .then(fn)
+      .then((value) => `resolved:${String(value)}`, (err: any) => `rejected:${err?.name}:${err?.code}`),
+    delay(30),
+  ]);
+  console.log(`${label}:`, result);
+}
+
+await probe("finished number", () => finished(123 as any));
+await probe("finished string", () => finished("x" as any));
+await probe("pipeline no args", () => (pipeline as any)());
+await probe("pipeline one number", () => (pipeline as any)(123));
+await probe("pipeline number number", () => (pipeline as any)(123, 456));


### PR DESCRIPTION
## Summary

Fixes a focused `node:stream/promises` semantics cluster:

- validate invalid `finished()` and `pipeline()` inputs with Node-style rejected promises and error codes
- make `finished()` wait for both required Duplex sides, while honoring `{ readable: false }` and `{ writable: false }`
- resolve `pipeline()` with the terminal async function return value when the last stage is callable

## Linked Issues

Closes #3070
Closes #3229
Closes #3230

## Why Batched

These behaviors share the same `node:stream/promises` entry points and depend on the same classic stream side-state helpers. Keeping them together avoids overlapping validation/lifecycle changes in separate PRs.

## Tests Added

- `test-parity/node-suite/stream/promises/validation-errors.ts`
- `test-parity/node-suite/stream/promises/finished-duplex-side-options.ts`
- `test-parity/node-suite/stream/promises/pipeline-terminal-return.ts`

## Verification

- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/stream/promises/validation-errors.ts`
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/stream/promises/finished-duplex-side-options.ts`
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/stream/promises/pipeline-terminal-return.ts`
- `PATH="/tmp/perry-node25-wrapper:$PATH" ./run_parity_tests.sh --suite node-suite --module stream/promises`  
  Result: 21 pass, 0 fail, 0 compile fail
- `PATH="/tmp/perry-node25-wrapper:$PATH" ./run_parity_tests.sh --suite node-suite --module stream/pipeline`  
  Result: 14 pass, 1 fail, 0 compile fail; the remaining `stream/pipeline/basic` mismatch also reproduces on `origin/main`
- `cargo test -p perry-runtime stream_promises --quiet`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- `cargo fmt --all -- --check`
- `git diff --check && git diff --check origin/main...HEAD`
- `jq empty test-parity/known_failures.json`
- `./scripts/check_file_size.sh`

## Non-Goals

- No `node:stream/web` changes
- No `node:stream/consumers` changes
- No broad classic stream pipeline rewrite beyond the semantics required for these issues
