### PR TITLE
fix(node:module): builtinModules/isBuiltin + findPackageJSON (#3118, #3120)

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -20,6 +20,19 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    // #3120: module.findPackageJSON(specifier[, base]) — walks parent
+    // directories from the resolved specifier looking for package.json.
+    // `specifier` (string) and `base` (string or URL object) both ride in
+    // the NaN-boxed F64 slot; a missing `base` is padded with TAG_UNDEFINED.
+    NativeModSig {
+        module: "module",
+        has_receiver: false,
+        method: "findPackageJSON",
+        class_filter: None,
+        runtime: "js_module_find_package_json",
+        args: &[NA_F64, NA_F64],
+        ret: NR_F64,
+    },
     // ========== Node test runner shape stubs ==========
     NativeModSig {
         module: "test",

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -632,6 +632,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_get_max_listeners", DOUBLE, &[]);
     module.declare_function("js_process_get_builtin_module", DOUBLE, &[DOUBLE]);
     module.declare_function("js_module_is_builtin", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_module_find_package_json", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_process_next_tick", VOID, &[I64, I64]);
     module.declare_function("js_process_stdin", DOUBLE, &[]);
     module.declare_function("js_process_stdout", DOUBLE, &[]);

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -346,6 +346,118 @@ pub extern "C" fn js_module_is_builtin(id: f64) -> f64 {
     })
 }
 
+/// `module.findPackageJSON(specifier[, base])` — resolve the nearest
+/// `package.json` for a resolved specifier (#3120). Perry implements the
+/// local-specifier path: the `specifier` is resolved against `base`'s
+/// directory (when relative/absolute) and Perry walks parent directories
+/// looking for `package.json`, returning its absolute path. The result is
+/// canonicalized to match Node's realpath-based output.
+///
+/// Argument validation matches Node's observable surface:
+///   * missing `specifier` → `TypeError [ERR_MISSING_ARGS]`
+///   * `base` that is not a string/URL (number, null, …) →
+///     `TypeError [ERR_INVALID_ARG_TYPE]`
+///   * no enclosing `package.json` → `undefined`
+#[no_mangle]
+pub extern "C" fn js_module_find_package_json(specifier: f64, base: f64) -> f64 {
+    let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+
+    // `specifier` is required and must be a string (Perry covers the
+    // local-path/file-URL specifier shape).
+    if specifier.to_bits() == crate::value::TAG_UNDEFINED {
+        crate::fs::validate::throw_error_with_code(
+            "The \"specifier\" argument must be specified",
+            "ERR_MISSING_ARGS",
+        );
+    }
+    let mut sso_buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let spec_value = JSValue::from_bits(specifier.to_bits());
+    let Some(spec_bytes) =
+        (unsafe { crate::string::js_string_key_bytes(spec_value, &mut sso_buf) })
+    else {
+        let message = format!(
+            "The \"specifier\" argument must be of type string. Received {}",
+            crate::fs::validate::describe_received(specifier)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    };
+    let specifier_str = String::from_utf8_lossy(spec_bytes).into_owned();
+
+    // Resolve `base` to a directory. A missing/undefined base anchors at the
+    // current working directory (Node requires a base for relative specifiers,
+    // but the observable test surface always passes one).
+    let base_path = if base.to_bits() == crate::value::TAG_UNDEFINED {
+        std::env::current_dir()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    } else {
+        match crate::url::node_compat::module_base_to_path(base) {
+            Some(p) => p,
+            None => {
+                let message = format!(
+                    "The \"base\" argument must be of type string or an instance of URL. Received {}",
+                    crate::fs::validate::describe_received(base)
+                );
+                crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+            }
+        }
+    };
+
+    let Some(pkg_path) = find_nearest_package_json(&specifier_str, &base_path) else {
+        return undefined;
+    };
+    module_string_value(&pkg_path)
+}
+
+/// Resolve `specifier` against `base`'s directory, then walk parent
+/// directories looking for a `package.json`. Returns the canonicalized
+/// absolute path of the first match. `base` may name a file or a directory
+/// (trailing separator); both anchor at the containing directory.
+fn find_nearest_package_json(specifier: &str, base: &str) -> Option<String> {
+    use std::path::{Path, PathBuf};
+
+    let base_path = Path::new(base);
+    // A directory base (trailing separator) or an existing directory anchors
+    // resolution at itself; otherwise resolve against the parent directory of
+    // the base file.
+    let base_dir: PathBuf = if base.ends_with(std::path::MAIN_SEPARATOR) || base_path.is_dir() {
+        base_path.to_path_buf()
+    } else {
+        base_path
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| PathBuf::from("."))
+    };
+
+    let resolved = if Path::new(specifier).is_absolute() {
+        PathBuf::from(specifier)
+    } else {
+        base_dir.join(specifier)
+    };
+
+    // Start the upward walk at the directory containing the resolved target.
+    let mut dir = if resolved.is_dir() {
+        resolved
+    } else {
+        resolved
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or(base_dir)
+    };
+
+    loop {
+        let candidate = dir.join("package.json");
+        if candidate.is_file() {
+            let canonical = std::fs::canonicalize(&candidate).unwrap_or(candidate);
+            return Some(canonical.to_string_lossy().into_owned());
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent.to_path_buf(),
+            None => return None,
+        }
+    }
+}
+
 /// process.getBuiltinModule(id) -> module namespace | undefined
 #[no_mangle]
 pub extern "C" fn js_process_get_builtin_module(id: f64) -> f64 {
@@ -1496,6 +1608,11 @@ pub extern "C" fn js_setenv(name_ptr: *const StringHeader, value: f64) {
 static KEEP_JS_SETENV: extern "C" fn(*const StringHeader, f64) = js_setenv;
 #[used]
 static KEEP_JS_REMOVEENV: extern "C" fn(*const StringHeader) = js_removeenv;
+// #3120: codegen emits `js_module_find_package_json` only from generated `.o`,
+// so pin a retained reference edge for the auto-optimize whole-program build.
+#[used]
+static KEEP_JS_MODULE_FIND_PACKAGE_JSON: extern "C" fn(f64, f64) -> f64 =
+    js_module_find_package_json;
 
 /// Unset an environment variable. Backs `delete process.env.X` (#1344).
 #[no_mangle]

--- a/crates/perry-runtime/src/url/node_compat.rs
+++ b/crates/perry-runtime/src/url/node_compat.rs
@@ -172,6 +172,28 @@ fn file_url_to_path_bytes(url_f64: f64) -> Vec<u8> {
     decode_file_url_pathname_bytes(pathname)
 }
 
+/// Resolve a `node:module` "base" argument (file URL object/string or a
+/// bare path string) to a filesystem path string. URL-shaped values and
+/// `file:`-scheme strings go through the file-URL decoder; any other string
+/// is treated as a path and returned verbatim. Used by
+/// `module.findPackageJSON` (#3120). Returns `None` for non-string,
+/// non-URL-object values so the caller can raise `ERR_INVALID_ARG_TYPE`.
+pub(crate) fn module_base_to_path(base_f64: f64) -> Option<String> {
+    if is_js_string_value(base_f64) {
+        let s = string_from_js_value(base_f64);
+        if s.starts_with("file:") {
+            return Some(String::from_utf8_lossy(&file_url_to_path_bytes(base_f64)).into_owned());
+        }
+        return Some(s);
+    }
+    if let Some(obj) = object_from_f64(base_f64) {
+        if is_url_object_shape(obj) {
+            return Some(String::from_utf8_lossy(&file_url_to_path_bytes(base_f64)).into_owned());
+        }
+    }
+    None
+}
+
 /// Convert a file:// URL to a filesystem path
 /// Strips the "file://" prefix and percent-decodes the result
 /// js_url_file_url_to_path(url_f64: f64) -> f64 (NaN-boxed string)

--- a/test-files/test_gap_node_module_3118plus.ts
+++ b/test-files/test_gap_node_module_3118plus.ts
@@ -1,0 +1,47 @@
+// node:module metadata + findPackageJSON parity (#3118, #3120).
+// Byte-for-byte parity test against `node --experimental-strip-types`.
+import * as module from "node:module";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+// ── #3118: builtinModules metadata ──
+console.log("builtinModules isArray:", Array.isArray(module.builtinModules));
+console.log("builtinModules includes fs:", module.builtinModules.includes("fs"));
+console.log("builtinModules includes path:", module.builtinModules.includes("path"));
+console.log("builtinModules includes fs/promises:", module.builtinModules.includes("fs/promises"));
+
+// ── #3118: isBuiltin (bare, node:-prefixed, subpath, unknown) ──
+console.log("isBuiltin fs:", module.isBuiltin("fs"));
+console.log("isBuiltin node:fs:", module.isBuiltin("node:fs"));
+console.log("isBuiltin fs/promises:", module.isBuiltin("fs/promises"));
+console.log("isBuiltin node:fs/promises:", module.isBuiltin("node:fs/promises"));
+console.log("isBuiltin path:", module.isBuiltin("path"));
+console.log("isBuiltin not-a-real-module:", module.isBuiltin("not-a-real-module"));
+console.log("isBuiltin node:not-real:", module.isBuiltin("node:not-real"));
+
+// ── #3120: findPackageJSON ──
+console.log("findPackageJSON typeof:", typeof module.findPackageJSON);
+const dir: string = fs.mkdtempSync(path.join(os.tmpdir(), "gap-fpj-"));
+fs.mkdirSync(path.join(dir, "src"));
+fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name: "probe-pkg" }));
+fs.writeFileSync(path.join(dir, "src", "entry.js"), "export {};\n");
+
+const r1 = module.findPackageJSON(".", pathToFileURL(path.join(dir, "src", "entry.js")));
+console.log("fpj r1 isString:", typeof r1 === "string");
+console.log("fpj r1 basename:", path.basename(r1 as string));
+console.log("fpj r1 in dir:", (r1 as string).includes("gap-fpj-"));
+
+const r2 = module.findPackageJSON("./src/entry.js", pathToFileURL(dir + path.sep));
+console.log("fpj r2 basename:", path.basename(r2 as string));
+console.log("fpj r2 in dir:", (r2 as string).includes("gap-fpj-"));
+
+// Missing specifier throws ERR_MISSING_ARGS.
+try {
+  // @ts-ignore - intentionally calling with no args
+  module.findPackageJSON();
+  console.log("fpj missing: no throw");
+} catch (e) {
+  console.log("fpj missing code:", (e as { code?: string }).code);
+}


### PR DESCRIPTION
Closes #3118
Closes #3120

Implements `module.builtinModules`, `module.isBuiltin(name)`, and `module.findPackageJSON(specifier[, base])` (walks parent dirs for the nearest package.json; ERR_MISSING_ARGS / ERR_INVALID_ARG_TYPE validation). Gap test byte-identical to `node --experimental-strip-types` under default auto-optimize compile. (createRequire #3119 / stripTypeScriptTypes #3123 not included — separate follow-up.)