### PR TITLE
fix(node:v8): serialize/deserialize + getHeapStatistics + GCProfiler (#3137, #3138, #3142)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -103,6 +103,7 @@ pub const NATIVE_MODULES: &[&str] = &[
     "cluster",
     "tty",
     "perf_hooks",
+    "v8",
     "process",
     "perry/tui",
     "perry/ui",
@@ -181,6 +182,7 @@ pub const RUNTIME_ONLY_MODULES: &[&str] = &[
     "perry/background",
     "tty",
     "perf_hooks",
+    "v8",
 ];
 
 const fn method(
@@ -3373,6 +3375,16 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         true,
         Some("PerformanceObserver"),
     ),
+    // --- node:v8 (#3137/#3138/#3142) ---
+    method("v8", "serialize", false, None),
+    method("v8", "deserialize", false, None),
+    method("v8", "getHeapStatistics", false, None),
+    method("v8", "getHeapCodeStatistics", false, None),
+    method("v8", "getHeapSpaceStatistics", false, None),
+    method("v8", "cachedDataVersionTag", false, None),
+    class("v8", "GCProfiler"),
+    method("v8", "start", true, Some("GCProfiler")),
+    method("v8", "stop", true, Some("GCProfiler")),
     // --- buffer (module-level helpers in addition to the Buffer class
     //     already registered above) ---
     method("buffer", "alloc", false, None),

--- a/crates/perry-codegen/src/expr/new_dynamic.rs
+++ b/crates/perry-codegen/src/expr/new_dynamic.rs
@@ -180,6 +180,32 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 }
             }
 
+            // `new v8.GCProfiler()` (#3142) — represent the profiler instance
+            // as the `"v8.GCProfiler"` native-module namespace so its
+            // `start()` / `stop()` methods dispatch through the runtime
+            // native-module method table (same shape as `new crypto.Certificate`).
+            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+                if property == "GCProfiler" {
+                    if let Expr::NativeModuleRef(mod_name) = object.as_ref() {
+                        if mod_name == "v8" {
+                            for a in args {
+                                let _ = lower_expr(ctx, a)?;
+                            }
+                            let module_name = "v8.GCProfiler";
+                            let mod_idx = ctx.strings.intern(module_name);
+                            let mod_bytes_global =
+                                format!("@{}", ctx.strings.entry(mod_idx).bytes_global);
+                            let mod_len_str = module_name.len().to_string();
+                            return Ok(ctx.block().call(
+                                DOUBLE,
+                                "js_create_native_module_namespace",
+                                &[(PTR, &mod_bytes_global), (I64, &mod_len_str)],
+                            ));
+                        }
+                    }
+                }
+            }
+
             // `new (PerformanceObserver as any)(cb?)` — the `as any` cast
             // (used because no-arg construction is a TS type error) strips the
             // bare identifier, so the constructor arrives as

--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -178,6 +178,38 @@ pub(crate) fn lower_native_method_call(
         return Ok(v);
     }
 
+    // node:v8 (#3137/#3138). serialize/deserialize + heap-stat helpers route to
+    // the `js_v8_*` runtime entry points. All are receiver-less statics.
+    if module == "v8" && object.is_none() {
+        let runtime = match method {
+            "serialize" => Some(("js_v8_serialize", true)),
+            "deserialize" => Some(("js_v8_deserialize", true)),
+            "getHeapStatistics" => Some(("js_v8_get_heap_statistics", false)),
+            "getHeapCodeStatistics" => Some(("js_v8_get_heap_code_statistics", false)),
+            "getHeapSpaceStatistics" => Some(("js_v8_get_heap_space_statistics", false)),
+            "cachedDataVersionTag" => Some(("js_v8_cached_data_version_tag", false)),
+            _ => None,
+        };
+        if let Some((fname, takes_arg)) = runtime {
+            if takes_arg {
+                let arg = if let Some(first) = args.first() {
+                    lower_expr(ctx, first)?
+                } else {
+                    double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                };
+                // Lower remaining args for side effects (Node ignores them).
+                for extra in args.iter().skip(1) {
+                    let _ = lower_expr(ctx, extra)?;
+                }
+                return Ok(ctx.block().call(DOUBLE, fname, &[(DOUBLE, &arg)]));
+            }
+            for extra in args {
+                let _ = lower_expr(ctx, extra)?;
+            }
+            return Ok(ctx.block().call(DOUBLE, fname, &[]));
+        }
+    }
+
     if module == "crypto"
         && class_name == Some("ECDH")
         && method == "convertKey"

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -590,6 +590,14 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_version", I64, &[]);
     module.declare_function("js_process_versions", DOUBLE, &[]);
     module.declare_function("js_process_memory_usage", DOUBLE, &[]);
+    // node:v8 (#3137/#3138/#3142).
+    module.declare_function("js_v8_serialize", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_v8_deserialize", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_v8_get_heap_statistics", DOUBLE, &[]);
+    module.declare_function("js_v8_get_heap_code_statistics", DOUBLE, &[]);
+    module.declare_function("js_v8_get_heap_space_statistics", DOUBLE, &[]);
+    module.declare_function("js_v8_cached_data_version_tag", DOUBLE, &[]);
+    module.declare_function("js_v8_gc_profiler_report", DOUBLE, &[]);
     module.declare_function("js_process_thread_cpu_usage", DOUBLE, &[]);
     module.declare_function("js_process_available_memory", DOUBLE, &[]);
     module.declare_function("js_process_constrained_memory", DOUBLE, &[]);

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -420,6 +420,34 @@ pub(super) fn try_native_module_methods(
                 }
             }
 
+            // node:v8 module methods (#3137/#3138). serialize/deserialize and
+            // the heap-stat helpers lower to a receiver-less NativeMethodCall
+            // dispatched in codegen to the `js_v8_*` runtime entry points.
+            let is_v8_module =
+                obj_name == "v8" || ctx.lookup_builtin_module_alias(&obj_name) == Some("v8");
+            if is_v8_module {
+                if let ast::MemberProp::Ident(method_ident) = &member.prop {
+                    let method_name = method_ident.sym.as_ref();
+                    match method_name {
+                        "serialize"
+                        | "deserialize"
+                        | "getHeapStatistics"
+                        | "getHeapCodeStatistics"
+                        | "getHeapSpaceStatistics"
+                        | "cachedDataVersionTag" => {
+                            return Ok(Ok(Expr::NativeMethodCall {
+                                module: "v8".to_string(),
+                                class_name: None,
+                                object: None,
+                                method: method_name.to_string(),
+                                args,
+                            }));
+                        }
+                        _ => {} // Fall through to generic handling
+                    }
+                }
+            }
+
             // Check for Buffer static methods. Issue #831: aliased
             // imports of Buffer (`import { Buffer as RuntimeBuffer } from
             // "node:buffer"`) must route through the same dedicated

--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -9,6 +9,9 @@ pub mod fork;
 // #2130: V8 structured-clone codec for `serialization: 'advanced'` IPC.
 mod v8_serde;
 
+// #3137: reuse the codec for the public `node:v8` serialize/deserialize API.
+pub(crate) use v8_serde::{v8_deserialize, v8_serialize};
+
 use std::collections::HashMap;
 use std::fs::File;
 use std::process::{Command, Stdio};

--- a/crates/perry-runtime/src/child_process/v8_serde.rs
+++ b/crates/perry-runtime/src/child_process/v8_serde.rs
@@ -400,7 +400,7 @@ impl Serializer {
 }
 
 /// Serialize a JS value to a V8 structured-clone payload (with header).
-pub(super) fn v8_serialize(value: f64) -> Vec<u8> {
+pub(crate) fn v8_serialize(value: f64) -> Vec<u8> {
     let _gc = GcSuppressGuard::new();
     let mut ser = Serializer::new();
     ser.write_header();
@@ -658,7 +658,7 @@ impl<'a> Deserializer<'a> {
 }
 
 /// Deserialize a V8 structured-clone payload (header optional) to a JS value.
-pub(super) fn v8_deserialize(buf: &[u8]) -> f64 {
+pub(crate) fn v8_deserialize(buf: &[u8]) -> f64 {
     let _gc = GcSuppressGuard::new();
     let mut de = Deserializer::new(buf);
     de.read_header();

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -61,6 +61,8 @@ pub mod net_validate;
 pub mod node_stream;
 pub mod node_submodules;
 pub mod node_test;
+// #3137/#3138/#3142: public `node:v8` serialize/deserialize + heap stats + GCProfiler.
+pub mod node_v8;
 // #2935: surface the zlib option-level resolver at the crate root so
 // perry-stdlib's bundled codecs (and the `perry-ext-zlib` extern) can reach it.
 pub use node_submodules::js_zlib_resolve_level;

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -63,6 +63,7 @@ pub mod node_submodules;
 pub mod node_test;
 // #3137/#3138/#3142: public `node:v8` serialize/deserialize + heap stats + GCProfiler.
 pub mod node_v8;
+mod process_env_file;
 // #2935: surface the zlib option-level resolver at the crate root so
 // perry-stdlib's bundled codecs (and the `perry-ext-zlib` extern) can reach it.
 pub use node_submodules::js_zlib_resolve_level;

--- a/crates/perry-runtime/src/node_v8.rs
+++ b/crates/perry-runtime/src/node_v8.rs
@@ -1,0 +1,244 @@
+//! `node:v8` public API surface.
+//!
+//! Implements the subset of the Node `v8` module that Perry can back with
+//! native internals:
+//!
+//! * `v8.serialize(value)` / `v8.deserialize(buf)` (#3137) — reuse the V8
+//!   structured-clone codec that already backs `child_process` advanced IPC
+//!   (`child_process::v8_serialize` / `v8_deserialize`). `serialize` wraps the
+//!   bytes in a Node `Buffer`; `deserialize` reads the bytes back out of a
+//!   Buffer / TypedArray. The wire framing is Perry's own (host-object
+//!   discriminator etc.), so it is NOT byte-compatible with V8's exact output,
+//!   but `deserialize(serialize(x))` round-trips faithfully which is all the
+//!   public contract guarantees.
+//! * `v8.getHeapStatistics()` / `getHeapCodeStatistics()` /
+//!   `getHeapSpaceStatistics()` / `cachedDataVersionTag()` (#3138) — return the
+//!   Node-compatible object/array *shapes* with numeric values sourced from
+//!   Perry's arena / RSS counters. The field *names and types* match Node so
+//!   package feature-detection works; the values reflect Perry internals.
+//! * `v8.GCProfiler` (#3142) — `new v8.GCProfiler()` is represented as the
+//!   `"v8.GCProfiler"` native-module namespace; `start()` returns `undefined`
+//!   and `stop()` returns a `{ version, startTime, statistics, endTime }`
+//!   report object, matching Node's shape.
+
+use crate::object::ObjectHeader;
+use crate::string::js_string_from_bytes;
+use crate::value::JSValue;
+
+// Symbol retention: these `#[no_mangle]` entry points are emitted only by
+// codegen's `node:v8` dispatch — no Rust caller references them, so the
+// auto-optimize whole-program-LLVM build would dead-strip them without an
+// anchor (see node_stream_keepalive.rs). Pin each via a `#[used]` static.
+#[used]
+static KEEP_V8_SERIALIZE: extern "C" fn(f64) -> f64 = js_v8_serialize;
+#[used]
+static KEEP_V8_DESERIALIZE: extern "C" fn(f64) -> f64 = js_v8_deserialize;
+#[used]
+static KEEP_V8_HEAP_STATS: extern "C" fn() -> f64 = js_v8_get_heap_statistics;
+#[used]
+static KEEP_V8_CODE_STATS: extern "C" fn() -> f64 = js_v8_get_heap_code_statistics;
+#[used]
+static KEEP_V8_SPACE_STATS: extern "C" fn() -> f64 = js_v8_get_heap_space_statistics;
+#[used]
+static KEEP_V8_VERSION_TAG: extern "C" fn() -> f64 = js_v8_cached_data_version_tag;
+#[used]
+static KEEP_V8_GC_PROFILER_REPORT: extern "C" fn() -> f64 = js_v8_gc_profiler_report;
+
+const TAG_UNDEFINED_BITS: u64 = 0x7FFC_0000_0000_0001;
+
+fn undefined() -> f64 {
+    f64::from_bits(TAG_UNDEFINED_BITS)
+}
+
+/// Build a plain object from `(name, value)` numeric/any pairs.
+unsafe fn build_object(pairs: &[(&str, f64)]) -> f64 {
+    let obj = crate::object::js_object_alloc(0, pairs.len() as u32);
+    for (name, value) in pairs {
+        let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        crate::object::js_object_set_field_by_name(obj, key, *value);
+    }
+    f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+}
+
+/// Read the raw bytes backing a deserialize input. Accepts Node `Buffer`,
+/// `Uint8Array` / other TypedArrays, and `ArrayBuffer`. Returns `None` for
+/// anything else (caller throws `ERR_INVALID_ARG_TYPE` like Node).
+unsafe fn input_bytes(value: f64) -> Option<Vec<u8>> {
+    let jsv = JSValue::from_bits(value.to_bits());
+    if !jsv.is_pointer() {
+        return None;
+    }
+    let addr = (value.to_bits() & crate::value::POINTER_MASK) as usize;
+    if addr < 0x10000 {
+        return None;
+    }
+    if crate::buffer::is_registered_buffer(addr) {
+        let data = crate::buffer::js_native_buffer_data_ptr(value);
+        let len = crate::buffer::js_native_buffer_byte_len(value);
+        if data.is_null() || len == 0 {
+            return Some(Vec::new());
+        }
+        return Some(std::slice::from_raw_parts(data, len).to_vec());
+    }
+    if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
+        let ta = addr as *const crate::typedarray::TypedArrayHeader;
+        return Some(
+            crate::typedarray::typed_array_bytes(ta)
+                .map(|b| b.to_vec())
+                .unwrap_or_default(),
+        );
+    }
+    None
+}
+
+/// `v8.serialize(value)` → Node `Buffer` holding the structured-clone payload.
+#[no_mangle]
+pub extern "C" fn js_v8_serialize(value: f64) -> f64 {
+    let bytes = crate::child_process::v8_serialize(value);
+    let buf = crate::buffer::js_buffer_alloc(bytes.len() as i32, 0);
+    if buf.is_null() {
+        return undefined();
+    }
+    unsafe {
+        let data = (buf as *mut u8).add(std::mem::size_of::<crate::buffer::BufferHeader>());
+        if !bytes.is_empty() {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), data, bytes.len());
+        }
+        (*buf).length = bytes.len() as u32;
+    }
+    f64::from_bits(JSValue::pointer(buf as *const u8).bits())
+}
+
+/// `v8.deserialize(buffer)` → reconstructed JS value.
+#[no_mangle]
+pub extern "C" fn js_v8_deserialize(value: f64) -> f64 {
+    let bytes = unsafe { input_bytes(value) };
+    match bytes {
+        Some(bytes) => crate::child_process::v8_deserialize(&bytes),
+        None => crate::fs::validate::throw_type_error_with_code(
+            "The \"buffer\" argument must be an instance of Buffer, TypedArray, or DataView.",
+            "ERR_INVALID_ARG_TYPE",
+        ),
+    }
+}
+
+/// `v8.getHeapStatistics()` — Node-shaped heap stats with numeric values.
+#[no_mangle]
+pub extern "C" fn js_v8_get_heap_statistics() -> f64 {
+    let mut heap_used: u64 = 0;
+    let mut heap_total: u64 = 0;
+    crate::arena::js_arena_stats(&mut heap_used, &mut heap_total);
+    let rss = crate::process::get_rss_bytes();
+    // A plausible default V8 old-space limit; not enforced by Perry.
+    let heap_size_limit: u64 = 2_197_815_296;
+    unsafe {
+        build_object(&[
+            ("total_heap_size", heap_total as f64),
+            ("total_heap_size_executable", 0.0),
+            ("total_physical_size", rss as f64),
+            (
+                "total_available_size",
+                heap_size_limit.saturating_sub(heap_used) as f64,
+            ),
+            ("used_heap_size", heap_used as f64),
+            ("heap_size_limit", heap_size_limit as f64),
+            ("malloced_memory", heap_total as f64),
+            ("peak_malloced_memory", heap_total as f64),
+            ("does_zap_garbage", 0.0),
+            ("number_of_native_contexts", 1.0),
+            ("number_of_detached_contexts", 0.0),
+            ("total_global_handles_size", 0.0),
+            ("used_global_handles_size", 0.0),
+            ("external_memory", 0.0),
+            ("total_allocated_bytes", heap_total as f64),
+        ])
+    }
+}
+
+/// `v8.getHeapCodeStatistics()` — Node-shaped code stats (numeric values).
+#[no_mangle]
+pub extern "C" fn js_v8_get_heap_code_statistics() -> f64 {
+    unsafe {
+        build_object(&[
+            ("code_and_metadata_size", 0.0),
+            ("bytecode_and_metadata_size", 0.0),
+            ("external_script_source_size", 0.0),
+            ("cpu_profiler_metadata_size", 0.0),
+        ])
+    }
+}
+
+/// `v8.getHeapSpaceStatistics()` — array of space-stat objects.
+#[no_mangle]
+pub extern "C" fn js_v8_get_heap_space_statistics() -> f64 {
+    let mut heap_used: u64 = 0;
+    let mut heap_total: u64 = 0;
+    crate::arena::js_arena_stats(&mut heap_used, &mut heap_total);
+    let rss = crate::process::get_rss_bytes();
+    let spaces: &[&str] = &[
+        "read_only_space",
+        "new_space",
+        "old_space",
+        "code_space",
+        "shared_space",
+        "new_large_object_space",
+        "large_object_space",
+        "code_large_object_space",
+        "shared_large_object_space",
+    ];
+    let arr = crate::array::js_array_alloc(spaces.len() as u32);
+    unsafe {
+        for (i, name) in spaces.iter().enumerate() {
+            // Attribute all live usage to old_space, the rest report empty —
+            // a Node-compatible shape with non-negative numeric fields.
+            let (size, used, avail) = if i == 2 {
+                (
+                    heap_total as f64,
+                    heap_used as f64,
+                    (heap_total.saturating_sub(heap_used)) as f64,
+                )
+            } else {
+                (0.0, 0.0, 0.0)
+            };
+            let name_str = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            let name_val = f64::from_bits(JSValue::string_ptr(name_str).bits());
+            let entry = build_object(&[
+                ("space_size", size),
+                ("space_used_size", used),
+                ("space_available_size", avail),
+                ("physical_space_size", if i == 2 { rss as f64 } else { 0.0 }),
+            ]);
+            // Set space_name (a string) separately to keep build_object numeric.
+            let entry_obj = (entry.to_bits() & crate::value::POINTER_MASK) as *mut ObjectHeader;
+            let key = js_string_from_bytes(b"space_name".as_ptr(), 10);
+            crate::object::js_object_set_field_by_name(entry_obj, key, name_val);
+            crate::array::js_array_push_f64(arr, entry);
+        }
+    }
+    f64::from_bits(JSValue::pointer(arr as *const u8).bits())
+}
+
+/// `v8.cachedDataVersionTag()` — a stable numeric tag for this build.
+#[no_mangle]
+pub extern "C" fn js_v8_cached_data_version_tag() -> f64 {
+    // Node returns a uint32 derived from V8/flags; we return a stable
+    // build-specific tag. The contract only requires a number. A plain
+    // (non-integer-tagged) f64 is a valid JS number value.
+    0x5045_5252u32 as f64
+}
+
+/// `(new v8.GCProfiler()).stop()` report object.
+#[no_mangle]
+pub extern "C" fn js_v8_gc_profiler_report() -> f64 {
+    let now = crate::date::js_date_now();
+    let statistics = crate::array::js_array_alloc(0);
+    let stats_val = f64::from_bits(JSValue::pointer(statistics as *const u8).bits());
+    unsafe {
+        build_object(&[
+            ("version", 1.0),
+            ("startTime", now),
+            ("statistics", stats_val),
+            ("endTime", now),
+        ])
+    }
+}

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1600,6 +1600,10 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("crypto.Certificate", "verifySpkac")
             | ("crypto.Certificate", "exportPublicKey")
             | ("crypto.Certificate", "exportChallenge")
+            // #3142: `(new v8.GCProfiler()).start` / `.stop` read as functions
+            // so `typeof profiler.start === "function"` holds.
+            | ("v8.GCProfiler", "start")
+            | ("v8.GCProfiler", "stop")
             // node:zlib — sync codecs, callback codecs, stream factories and
             // class names read as callables. Needed for `util.promisify(zlib.gzip)`
             // (#1857-style hook), `const compress = zlib.gzipSync`, and

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1462,6 +1462,11 @@ pub(crate) unsafe fn dispatch_native_module_method(
             }
         }
 
+        // #3142: `new v8.GCProfiler()` is the "v8.GCProfiler" namespace.
+        // `start()` returns undefined; `stop()` returns the report object.
+        ("v8.GCProfiler", "start") => f64::from_bits(JSValue::undefined().bits()),
+        ("v8.GCProfiler", "stop") => crate::node_v8::js_v8_gc_profiler_report(),
+
         // #2533: captured / aliased server factories
         // (`const createServer = options.createServer || createServerHTTP;
         // createServer(opts, handler)` — `@hono/node-server`'s `serve()`). The

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -1,5 +1,8 @@
 //! Process module - provides access to environment and process information
 
+#[allow(unused_imports)]
+pub(crate) use crate::process_env_file::js_process_load_env_file;
+
 use crate::closure::{
     js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64, ClosureHeader,
 };
@@ -1918,91 +1921,6 @@ pub extern "C" fn js_process_memory_usage() -> f64 {
 
     // Return as NaN-boxed pointer (convert bits to f64)
     f64::from_bits(JSValue::pointer(obj as *const u8).bits())
-}
-
-/// process.loadEnvFile(path?) — read a `.env`-formatted file from disk and
-/// merge its `KEY=value` entries into `process.env`. Node 20.12+. With no
-/// path, the default is `.env` in the current working directory. Throws a
-/// Node-shaped `Error` (`code: "ENOENT"`, `syscall: "open"`) when the file
-/// can't be opened. #2135 (#1399 follow-through): previously a no-op that
-/// returned undefined so probe-and-call sites didn't crash; with
-/// `process.env.X = v` now persisting via std::env (#1344), eager loading
-/// is meaningful.
-#[no_mangle]
-pub extern "C" fn js_process_load_env_file(path_ptr: *const StringHeader) {
-    let target = unsafe {
-        if path_ptr.is_null() {
-            ".env".to_string()
-        } else {
-            let len = (*path_ptr).byte_len as usize;
-            let data = (path_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-            let bytes = std::slice::from_raw_parts(data, len);
-            match std::str::from_utf8(bytes) {
-                Ok(s) => s.to_string(),
-                Err(_) => return,
-            }
-        }
-    };
-    let contents = match std::fs::read_to_string(&target) {
-        Ok(s) => s,
-        Err(err) => unsafe {
-            throw_load_env_file_open_error(&err, &target);
-        },
-    };
-    for line in contents.lines() {
-        let trimmed = line.trim_start();
-        // Comments and blank lines.
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-        let Some((raw_key, raw_value)) = trimmed.split_once('=') else {
-            continue;
-        };
-        let key = raw_key.trim();
-        if key.is_empty() {
-            continue;
-        }
-        // Strip a matched surrounding quote pair on the trimmed value;
-        // otherwise keep the trimmed text verbatim (so unquoted spaces
-        // around `=` are dropped but inner `=` survives — see Node's
-        // built-in `.env` parser).
-        let value_trimmed = raw_value.trim();
-        let value = strip_matched_quotes(value_trimmed);
-        std::env::set_var(key, value);
-    }
-}
-
-fn strip_matched_quotes(s: &str) -> &str {
-    let bytes = s.as_bytes();
-    if bytes.len() >= 2 {
-        let first = bytes[0];
-        let last = bytes[bytes.len() - 1];
-        if (first == b'"' || first == b'\'') && first == last {
-            return &s[1..s.len() - 1];
-        }
-    }
-    s
-}
-
-unsafe fn throw_load_env_file_open_error(err: &std::io::Error, target: &str) -> ! {
-    use std::io::ErrorKind;
-    let code: &'static str = match err.kind() {
-        ErrorKind::NotFound => "ENOENT",
-        ErrorKind::PermissionDenied => "EACCES",
-        _ => "EIO",
-    };
-    let desc = match code {
-        "ENOENT" => "no such file or directory",
-        "EACCES" => "permission denied",
-        _ => "i/o error",
-    };
-    let message = format!("{code}: {desc}, open '{target}'");
-    let msg_ptr = js_string_from_bytes(message.as_ptr(), message.len() as u32);
-    crate::node_submodules::register_error_code_pub(msg_ptr, code);
-    crate::node_submodules::register_error_syscall(msg_ptr, "open");
-    crate::node_submodules::register_error_path(msg_ptr, target.to_string());
-    let err_ptr = crate::error::js_error_new_with_message(msg_ptr);
-    crate::exception::js_throw(crate::value::js_nanbox_pointer(err_ptr as i64));
 }
 
 // Issue #2013 — process-arg-validation helpers shared by `js_process_chdir`

--- a/crates/perry-runtime/src/process_env_file.rs
+++ b/crates/perry-runtime/src/process_env_file.rs
@@ -1,0 +1,88 @@
+//! `process.loadEnvFile` dotenv parsing (extracted from process.rs to keep it
+//! under the 2000-line cap). `use super::*` preserves the parent visibility.
+use super::*;
+
+/// process.loadEnvFile(path?) — read a `.env`-formatted file from disk and
+/// merge its `KEY=value` entries into `process.env`. Node 20.12+. With no
+/// path, the default is `.env` in the current working directory. Throws a
+/// Node-shaped `Error` (`code: "ENOENT"`, `syscall: "open"`) when the file
+/// can't be opened. #2135 (#1399 follow-through): previously a no-op that
+/// returned undefined so probe-and-call sites didn't crash; with
+/// `process.env.X = v` now persisting via std::env (#1344), eager loading
+/// is meaningful.
+#[no_mangle]
+pub extern "C" fn js_process_load_env_file(path_ptr: *const StringHeader) {
+    let target = unsafe {
+        if path_ptr.is_null() {
+            ".env".to_string()
+        } else {
+            let len = (*path_ptr).byte_len as usize;
+            let data = (path_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+            let bytes = std::slice::from_raw_parts(data, len);
+            match std::str::from_utf8(bytes) {
+                Ok(s) => s.to_string(),
+                Err(_) => return,
+            }
+        }
+    };
+    let contents = match std::fs::read_to_string(&target) {
+        Ok(s) => s,
+        Err(err) => unsafe {
+            throw_load_env_file_open_error(&err, &target);
+        },
+    };
+    for line in contents.lines() {
+        let trimmed = line.trim_start();
+        // Comments and blank lines.
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let Some((raw_key, raw_value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        let key = raw_key.trim();
+        if key.is_empty() {
+            continue;
+        }
+        // Strip a matched surrounding quote pair on the trimmed value;
+        // otherwise keep the trimmed text verbatim (so unquoted spaces
+        // around `=` are dropped but inner `=` survives — see Node's
+        // built-in `.env` parser).
+        let value_trimmed = raw_value.trim();
+        let value = strip_matched_quotes(value_trimmed);
+        std::env::set_var(key, value);
+    }
+}
+
+fn strip_matched_quotes(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' || first == b'\'') && first == last {
+            return &s[1..s.len() - 1];
+        }
+    }
+    s
+}
+
+unsafe fn throw_load_env_file_open_error(err: &std::io::Error, target: &str) -> ! {
+    use std::io::ErrorKind;
+    let code: &'static str = match err.kind() {
+        ErrorKind::NotFound => "ENOENT",
+        ErrorKind::PermissionDenied => "EACCES",
+        _ => "EIO",
+    };
+    let desc = match code {
+        "ENOENT" => "no such file or directory",
+        "EACCES" => "permission denied",
+        _ => "i/o error",
+    };
+    let message = format!("{code}: {desc}, open '{target}'");
+    let msg_ptr = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    crate::node_submodules::register_error_code_pub(msg_ptr, code);
+    crate::node_submodules::register_error_syscall(msg_ptr, "open");
+    crate::node_submodules::register_error_path(msg_ptr, target.to_string());
+    let err_ptr = crate::error::js_error_new_with_message(msg_ptr);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err_ptr as i64));
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1996 entries across 94 modules
+// Coverage: 2003 entries across 95 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -2787,8 +2787,6 @@ declare module "sys" {
   /** stdlib */
   export function convertProcessSignalToExitCode(...args: any[]): any;
   /** stdlib */
-  export function debug(...args: any[]): any;
-  /** stdlib */
   export function debuglog(...args: any[]): any;
   /** stdlib */
   export function deprecate(...args: any[]): any;
@@ -2927,8 +2925,6 @@ declare module "util" {
   /** stdlib */
   export function convertProcessSignalToExitCode(...args: any[]): any;
   /** stdlib */
-  export function debug(...args: any[]): any;
-  /** stdlib */
   export function debuglog(...args: any[]): any;
   /** stdlib */
   export function deprecate(...args: any[]): any;
@@ -3048,6 +3044,23 @@ declare module "uuid" {
   export function v7(): string;
   /** stdlib */
   export function validate(id: string): boolean;
+}
+
+declare module "v8" {
+  /** stdlib */
+  export class GCProfiler { [key: string]: any; }
+  /** stdlib */
+  export function cachedDataVersionTag(...args: any[]): any;
+  /** stdlib */
+  export function deserialize(...args: any[]): any;
+  /** stdlib */
+  export function getHeapCodeStatistics(...args: any[]): any;
+  /** stdlib */
+  export function getHeapSpaceStatistics(...args: any[]): any;
+  /** stdlib */
+  export function getHeapStatistics(...args: any[]): any;
+  /** stdlib */
+  export function serialize(...args: any[]): any;
 }
 
 declare module "validator" {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1992 entries across 94 modules
+// Coverage: 2001 entries across 95 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -3040,6 +3040,23 @@ declare module "uuid" {
   export function v7(): string;
   /** stdlib */
   export function validate(id: string): boolean;
+}
+
+declare module "v8" {
+  /** stdlib */
+  export class GCProfiler { [key: string]: any; }
+  /** stdlib */
+  export function cachedDataVersionTag(...args: any[]): any;
+  /** stdlib */
+  export function deserialize(...args: any[]): any;
+  /** stdlib */
+  export function getHeapCodeStatistics(...args: any[]): any;
+  /** stdlib */
+  export function getHeapSpaceStatistics(...args: any[]): any;
+  /** stdlib */
+  export function getHeapStatistics(...args: any[]): any;
+  /** stdlib */
+  export function serialize(...args: any[]): any;
 }
 
 declare module "validator" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1996 entries across 94 modules.
+Total: 2003 entries across 95 modules.
 
 ## Modules
 
@@ -96,6 +96,7 @@ Total: 1996 entries across 94 modules.
 - [`util`](#util)
 - [`util/types`](#util-types)
 - [`uuid`](#uuid)
+- [`v8`](#v8)
 - [`validator`](#validator)
 - [`worker_threads`](#worker-threads)
 - [`ws`](#ws)
@@ -2416,7 +2417,6 @@ Total: 1996 entries across 94 modules.
 - `aborted` — module
 - `callbackify` — module
 - `convertProcessSignalToExitCode` — module
-- `debug` — module
 - `debuglog` — module
 - `deprecate` — module
 - `format` — module
@@ -2546,7 +2546,6 @@ Total: 1996 entries across 94 modules.
 - `aborted` — module
 - `callbackify` — module
 - `convertProcessSignalToExitCode` — module
-- `debug` — module
 - `debuglog` — module
 - `deprecate` — module
 - `format` — module
@@ -2618,6 +2617,23 @@ Total: 1996 entries across 94 modules.
 - `v4` — module
 - `v7` — module
 - `validate` — module
+
+## `v8`
+
+### Classes
+
+- `GCProfiler`
+
+### Methods
+
+- `cachedDataVersionTag` — module
+- `deserialize` — module
+- `getHeapCodeStatistics` — module
+- `getHeapSpaceStatistics` — module
+- `getHeapStatistics` — module
+- `serialize` — module
+- `start` — instance *(class: `GCProfiler`)*
+- `stop` — instance *(class: `GCProfiler`)*
 
 ## `validator`
 

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1992 entries across 94 modules.
+Total: 2001 entries across 95 modules.
 
 ## Modules
 
@@ -96,6 +96,7 @@ Total: 1992 entries across 94 modules.
 - [`util`](#util)
 - [`util/types`](#util-types)
 - [`uuid`](#uuid)
+- [`v8`](#v8)
 - [`validator`](#validator)
 - [`worker_threads`](#worker-threads)
 - [`ws`](#ws)
@@ -2614,6 +2615,23 @@ Total: 1992 entries across 94 modules.
 - `v4` — module
 - `v7` — module
 - `validate` — module
+
+## `v8`
+
+### Classes
+
+- `GCProfiler`
+
+### Methods
+
+- `cachedDataVersionTag` — module
+- `deserialize` — module
+- `getHeapCodeStatistics` — module
+- `getHeapSpaceStatistics` — module
+- `getHeapStatistics` — module
+- `serialize` — module
+- `start` — instance *(class: `GCProfiler`)*
+- `stop` — instance *(class: `GCProfiler`)*
 
 ## `validator`
 

--- a/test-files/test_gap_node_v8_3137plus.ts
+++ b/test-files/test_gap_node_v8_3137plus.ts
@@ -1,0 +1,101 @@
+import v8 from "node:v8";
+
+// deep-equality helper (handles primitives, arrays, plain objects, Buffer-like)
+function deepEqual(a: any, b: any): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (typeof a === "bigint") return a === b;
+  if (a === null || b === null) return a === b;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (typeof a === "object") {
+    const ak = Object.keys(a).sort();
+    const bk = Object.keys(b).sort();
+    if (ak.length !== bk.length) return false;
+    for (let i = 0; i < ak.length; i++) {
+      if (ak[i] !== bk[i]) return false;
+      if (!deepEqual(a[ak[i]], b[bk[i]])) return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+// ---- #3137: v8.serialize / v8.deserialize round trips ----
+const primitives: any[] = [42, -7, 3.5, "hello", "", true, false, null];
+for (const value of primitives) {
+  const buf = v8.serialize(value);
+  const out = v8.deserialize(buf);
+  console.log("prim", out === value, typeof out);
+}
+
+const obj = { a: 1, b: "x", c: [true, false, null], d: { nested: 9 } };
+const objOut = v8.deserialize(v8.serialize(obj));
+console.log("object", deepEqual(obj, objOut));
+
+const arr = [1, "two", 3.5, [4, 5], { k: "v" }];
+const arrOut = v8.deserialize(v8.serialize(arr));
+console.log("array", deepEqual(arr, arrOut));
+
+const big = 9007199254740993n;
+const bigOut = v8.deserialize(v8.serialize(big));
+console.log("bigint", bigOut === big);
+
+const dt = new Date("2020-01-02T03:04:05.000Z");
+const dtOut = v8.deserialize(v8.serialize(dt));
+console.log("date", dtOut instanceof Date && dtOut.getTime() === dt.getTime());
+
+console.log("isBuffer", Buffer.isBuffer(v8.serialize(obj)));
+
+// ---- #3138: heap statistics shape ----
+const hs = v8.getHeapStatistics();
+const heapKeys = [
+  "total_heap_size",
+  "used_heap_size",
+  "heap_size_limit",
+  "external_memory",
+  "total_available_size",
+  "total_physical_size",
+  "number_of_native_contexts",
+  "number_of_detached_contexts",
+  "total_allocated_bytes",
+];
+console.log(
+  "heap",
+  heapKeys.every((k) => typeof (hs as any)[k] === "number"),
+);
+console.log("cachedDataVersionTag", typeof v8.cachedDataVersionTag());
+
+const cs = v8.getHeapCodeStatistics();
+console.log("codeStats", typeof cs === "object" && cs !== null);
+
+const ss = v8.getHeapSpaceStatistics();
+console.log(
+  "spaceStats",
+  Array.isArray(ss) &&
+    ss.length > 0 &&
+    typeof ss[0].space_name === "string" &&
+    typeof ss[0].space_size === "number",
+);
+
+// ---- #3142: GCProfiler report shape ----
+console.log("GCProfiler typeof", typeof v8.GCProfiler);
+const profiler = new v8.GCProfiler();
+console.log("start typeof", typeof profiler.start);
+console.log("stop typeof", typeof profiler.stop);
+console.log("start ret", profiler.start());
+const report = profiler.stop();
+console.log("report keys", JSON.stringify(Object.keys(report).sort()));
+console.log(
+  "report types",
+  typeof report.version === "number" &&
+    typeof report.startTime === "number" &&
+    typeof report.endTime === "number" &&
+    Array.isArray(report.statistics),
+);


### PR DESCRIPTION
Closes #3137
Closes #3138
Closes #3142

New `node_v8.rs`: `v8.serialize`/`v8.deserialize` round-trips (reuses the structured-clone codec), `getHeapStatistics`/`getHeapCodeStatistics`/`getHeapSpaceStatistics` Node-shaped numeric output, `cachedDataVersionTag`, and `GCProfiler` start/stop report shape. Gap test byte-identical to `node --experimental-strip-types` under default auto-optimize compile. (Extracted process.loadEnvFile to a sibling module to stay under the 2000-line cap after merging main.)