### PR TITLE
fix(codegen): guard closure display-name registration on materialized closures (#3527)

### DIFF
--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -1300,7 +1300,21 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
     // that hir.functions already produced a wrapper entry for.
     let registered_fn_ids: std::collections::HashSet<perry_types::FuncId> =
         hir.functions.iter().map(|f| f.id).collect();
+    // #3527: only register a display name for a `perry_closure_*` symbol when
+    // that closure was actually materialized as an LLVM global (i.e. it is in
+    // the `closures` set compiled above via `compile_closure`). `hir.closure_display_names`
+    // can hold stale entries for closures that were never emitted — e.g.
+    // `module.exports = function named(){}` records a display name for a fid that
+    // CJS export lowering replaces with a different, materialized fid. Registering
+    // a name for the stale fid emits a `js_register_function_name` call referencing
+    // an undefined `@perry_closure_*` global, which makes `clang -c` fail with
+    // "use of undefined value" (regression class of #318/#343).
+    let materialized_closure_ids: std::collections::HashSet<perry_types::FuncId> =
+        closures.iter().map(|(id, _)| *id).collect();
     for (func_id, display) in &hir.closure_display_names {
+        if !materialized_closure_ids.contains(func_id) {
+            continue;
+        }
         if display.is_empty() || named_inline_closure_ids.contains(func_id) {
             continue;
         }


### PR DESCRIPTION
## What

Fixes the central codegen bug in #3527: codegen emitted `js_register_function_name(@perry_closure_<mod>__<fid>, …)` for closures that were never materialized as LLVM globals, so `clang -c` failed with `error: use of undefined value '@perry_closure_*'`.

## Root cause

Display-name registration in `emit_module_artifacts` (`crates/perry-codegen/src/codegen/artifacts.rs`) has three branches:

- **(a)** top-level `hir.functions` → `__perry_wrap_*` symbols (always exist). Safe.
- **(b)** closures bound to a top-level `Stmt::Let { init: Closure }` (always materialized). Safe.
- **(c)** every remaining entry in `hir.closure_display_names` → emitted a `js_register_function_name` call **without checking the closure was actually materialized** as a `@perry_closure_*` global.

`crates/perry-hir/src/lower/expr_function.rs` records a display name for *every* named function expression. For an unbound assignment like `module.exports = function sign(){}`, CJS export lowering materializes a **different** func_id for the function — leaving the original named-fn-expr fid stale (never compiled via `compile_closure`). Branch (c) then registered a name for that stale fid, producing a call to an undefined `@perry_closure_*` global.

Confirmed in the emitted IR for a 1-file repro: `@perry_closure_m_js__4/__5/__6` are `define`d, but `__3` appears only in a dangling `js_register_function_name(@perry_closure_m_js__3, …)` call.

This is the regression class of #318/#343, but **not** a missing collector arm — the collector walk (`walk_expr_children`) is exhaustive. It's a registration/materialization mismatch.

## Fix

Guard branch (c) on the materialized closure set — the `closures` slice that `compile_closure` already iterates at `artifacts.rs:153`:

```rust
let materialized_closure_ids: HashSet<FuncId> = closures.iter().map(|(id, _)| *id).collect();
for (func_id, display) in &hir.closure_display_names {
    if !materialized_closure_ids.contains(func_id) { continue; }  // #3527
    // ...existing display.is_empty() / named_inline_closure_ids / registered_fn_ids skips
}
```

+14 lines, codegen-only. Branches (a)/(b) unchanged (already safe).

## Repro (no node_modules)

```js
// m.js
module.exports = function sign(n){ return n < 0 ? -1 : 1; };
```
```ts
// main.ts
const s = require('./m'); console.log(s(-3));
```

Before: `error: use of undefined value '@perry_closure_m_js__3'`. After: compiles, runs, prints `-1`.

Discriminator: `const sign = function sign(){…}` (let-bound, branch b) always compiled fine; only the `module.exports =` / unbound-assignment form triggered the bug.

## Verification

- **1-file repro:** was failing → now compiles & runs (`-1`). ✅
- **Full Express tree** (`express@5.2.1`, 129 modules): `use of undefined value '@perry_closure_*'` **49 → 0**; total clang codegen failures **49 → 1**. ✅
- **Regression:** named-fn-expr bound to const, plain arrow, top-level fn, class method, and `arr.map((p,i)=>…)` (the #343 case) all still compile + run correctly. ✅

## Out of scope (follow-ups, see #3527)

- The one remaining Express codegen failure is unrelated: `qs/lib/stringify.js` → `Call callee shape not supported (LocalGet) with 18 args` (high-arity indirect-call limit; qs's recursive 18-arg `stringify` self-call).
- A per-module codegen/lowering failure does not currently fail the overall build (binary is still written), which masks errors like the above — should be addressed separately.
