### PR TITLE
fix(typedarray): wire remaining %TypedArray%.prototype methods + instanceof (#3148)

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -110,6 +110,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // in that same registry so `encoded instanceof Uint8Array`
                 // returns true.
                 "Uint8Array" | "Buffer" => 0xFFFF0004u32,
+                // Other %TypedArray% kinds (#3148). The runtime resolves the
+                // actual kind via TYPED_ARRAY_REGISTRY + class_id_for_kind in
+                // instanceof.rs; these reserved ids must match the
+                // CLASS_ID_* constants in perry-runtime/src/typedarray.rs.
+                "Int8Array" => 0xFFFF0030u32,
+                "Int16Array" => 0xFFFF0032u32,
+                "Uint16Array" => 0xFFFF0033u32,
+                "Int32Array" => 0xFFFF0034u32,
+                "Uint32Array" => 0xFFFF0035u32,
+                "Float32Array" => 0xFFFF0036u32,
+                "Float64Array" => 0xFFFF0037u32,
+                "Uint8ClampedArray" => 0xFFFF0038u32,
+                "BigInt64Array" => 0xFFFF0039u32,
+                "BigUint64Array" => 0xFFFF003Au32,
                 // Built-in JS types: Date, RegExp, Map, Set. The runtime
                 // detects these via per-type registries (or, for Date,
                 // by checking that the value is a finite f64 timestamp).

--- a/crates/perry-codegen/src/lower_array_method.rs
+++ b/crates/perry-codegen/src/lower_array_method.rs
@@ -861,6 +861,57 @@ pub(crate) fn lower_array_method(
             );
             Ok(result)
         }
+        // #3148: TypedArray.prototype.set(source, offset?). Copies elements
+        // from an Array/TypedArray source into this typed array. The runtime
+        // helper no-ops for non-typed-array receivers, so it is safe under the
+        // broadened `is_array_expr` (which also routes plain arrays here).
+        "set" => {
+            let src_box = if let Some(a) = args.first() {
+                lower_expr(ctx, a)?
+            } else {
+                double_literal(f64::from_bits(TAG_UNDEFINED))
+            };
+            let off_box = if args.len() >= 2 {
+                lower_expr(ctx, &args[1])?
+            } else {
+                double_literal(0.0)
+            };
+            let blk = ctx.block();
+            let recv_handle = unbox_to_i64(blk, &recv_box);
+            Ok(blk.call(
+                DOUBLE,
+                "js_typed_array_set_from",
+                &[(I64, &recv_handle), (DOUBLE, &src_box), (DOUBLE, &off_box)],
+            ))
+        }
+        // #3148: TypedArray.prototype.subarray(begin?, end?) — returns a new
+        // same-kind TypedArray over the selected range.
+        "subarray" => {
+            let (has_begin, begin_box) = if let Some(a) = args.first() {
+                ("1".to_string(), lower_expr(ctx, a)?)
+            } else {
+                ("0".to_string(), double_literal(0.0))
+            };
+            let (has_end, end_box) = if args.len() >= 2 {
+                ("1".to_string(), lower_expr(ctx, &args[1])?)
+            } else {
+                ("0".to_string(), double_literal(0.0))
+            };
+            let blk = ctx.block();
+            let recv_handle = unbox_to_i64(blk, &recv_box);
+            let result = blk.call(
+                I64,
+                "js_typed_array_subarray",
+                &[
+                    (I64, &recv_handle),
+                    (I32, &has_begin),
+                    (DOUBLE, &begin_box),
+                    (I32, &has_end),
+                    (DOUBLE, &end_box),
+                ],
+            );
+            Ok(nanbox_pointer_inline(blk, &result))
+        }
         // Best-effort fallback: lower args for side effects, return
         // the receiver.
         _ => {

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -122,6 +122,13 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_typed_array_with", I64, &[I64, DOUBLE, DOUBLE]);
     module.declare_function("js_typed_array_find_last", DOUBLE, &[I64, I64]);
     module.declare_function("js_typed_array_find_last_index", DOUBLE, &[I64, I64]);
+    // #3148: TypedArray.prototype.set(source, offset?) / subarray(begin?, end?).
+    module.declare_function("js_typed_array_set_from", DOUBLE, &[I64, DOUBLE, DOUBLE]);
+    module.declare_function(
+        "js_typed_array_subarray",
+        I64,
+        &[I64, I32, DOUBLE, I32, DOUBLE],
+    );
     // Object introspection / mutation (Agent A's accessor-descriptor work).
     module.declare_function("js_object_has_own", DOUBLE, &[DOUBLE, DOUBLE]);
     // #2891: Object.prototype.propertyIsEnumerable.call(obj, key).

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -1695,6 +1695,28 @@ pub(crate) fn receiver_class_name(ctx: &FnCtx<'_>, e: &Expr) -> Option<String> {
 pub(crate) fn is_array_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     match static_type_of(ctx, e) {
         Some(HirType::Array(_)) | Some(HirType::Tuple(_)) => true,
+        // #3148: %TypedArray% receivers route their not-already-folded methods
+        // (fill / reverse / keys / values / entries / set / subarray) through
+        // `lower_array_method`; the generic `js_array_*` helpers delegate to the
+        // element-typed `js_typed_array_*` impls via `lookup_typed_array_kind`.
+        // Uint8Array / Uint8ClampedArray are intentionally excluded — they are
+        // buffer-backed and dispatched by `dispatch_buffer_method`.
+        Some(HirType::Named(ref n))
+            if matches!(
+                n.as_str(),
+                "Int8Array"
+                    | "Int16Array"
+                    | "Int32Array"
+                    | "Uint16Array"
+                    | "Uint32Array"
+                    | "Float32Array"
+                    | "Float64Array"
+                    | "BigInt64Array"
+                    | "BigUint64Array"
+            ) =>
+        {
+            true
+        }
         // `T | null`, `T | undefined`, `T[] | null` — when an `if (x)`
         // guard narrows away the null/undefined, the truthy branch
         // still has the same union type in the HIR, so recognize

--- a/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
@@ -248,10 +248,22 @@ pub(super) fn try_local_array_methods(
                             "slice" => {
                                 // arr.slice(start, end?) - returns new array
                                 // Only convert to ArraySlice if we KNOW it's an Array type
-                                // (Type::Any could be a string, which has its own .slice() method)
+                                // (Type::Any could be a string, which has its own .slice() method).
+                                // TypedArray receivers (#3148) also route here so
+                                // `int32arr.slice(1,3)` returns a same-kind TypedArray
+                                // (js_array_slice delegates via lookup_typed_array_kind).
                                 let is_definitely_array = ctx
                                     .lookup_local_type(&arr_name)
-                                    .map(|ty| matches!(ty, Type::Array(_)))
+                                    .map(|ty| {
+                                        matches!(ty, Type::Array(_))
+                                            || matches!(ty, Type::Named(n) if matches!(
+                                                n.as_str(),
+                                                "Int8Array" | "Int16Array" | "Int32Array"
+                                                | "Uint16Array" | "Uint32Array"
+                                                | "Float32Array" | "Float64Array"
+                                                | "BigInt64Array" | "BigUint64Array"
+                                            ))
+                                    })
                                     .unwrap_or(false);
                                 if is_definitely_array && !args.is_empty() {
                                     let mut args_iter = args.into_iter();

--- a/crates/perry-runtime/src/array/concat_reverse.rs
+++ b/crates/perry-runtime/src/array/concat_reverse.rs
@@ -133,6 +133,12 @@ pub extern "C" fn js_array_reverse(arr: *mut ArrayHeader) -> *mut ArrayHeader {
     if arr.is_null() {
         return arr;
     }
+    // #3148: TypedArray receiver — reverse over element-typed storage.
+    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+        return crate::typedarray::js_typed_array_reverse(
+            arr as *mut crate::typedarray::TypedArrayHeader,
+        ) as *mut ArrayHeader;
+    }
     unsafe {
         let len = (*arr).length as usize;
         if len <= 1 {
@@ -161,6 +167,17 @@ pub extern "C" fn js_array_fill(arr: *mut ArrayHeader, value: f64) -> *mut Array
     let arr = clean_arr_ptr_mut(arr);
     if arr.is_null() {
         return arr;
+    }
+    // #3148: TypedArray receiver — fill the whole array, element-typed.
+    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+        return crate::typedarray::js_typed_array_fill(
+            arr as *mut crate::typedarray::TypedArrayHeader,
+            value,
+            0,
+            0.0,
+            0,
+            0.0,
+        ) as *mut ArrayHeader;
     }
     unsafe {
         let len = (*arr).length as usize;
@@ -191,6 +208,17 @@ pub extern "C" fn js_array_fill_range(
     let arr = clean_arr_ptr_mut(arr);
     if arr.is_null() {
         return arr;
+    }
+    // #3148: TypedArray receiver — fill [start, end) over element-typed storage.
+    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+        return crate::typedarray::js_typed_array_fill(
+            arr as *mut crate::typedarray::TypedArrayHeader,
+            value,
+            1,
+            start,
+            1,
+            end,
+        ) as *mut ArrayHeader;
     }
     unsafe {
         let len = (*arr).length as i64;

--- a/crates/perry-runtime/src/array/immutable.rs
+++ b/crates/perry-runtime/src/array/immutable.rs
@@ -267,6 +267,22 @@ pub extern "C" fn js_array_copy_within(
     if arr.is_null() {
         return arr;
     }
+    // #3148: TypedArray receiver — copy over element-typed storage. The typed
+    // impl treats an undefined `end` as "to length", so pass TAG_UNDEFINED
+    // when no end argument was provided.
+    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+        let end_value = if has_end != 0 {
+            end
+        } else {
+            f64::from_bits(crate::value::TAG_UNDEFINED)
+        };
+        return crate::typedarray::js_typed_array_copy_within(
+            arr as *mut crate::typedarray::TypedArrayHeader,
+            target,
+            start,
+            end_value,
+        ) as *mut ArrayHeader;
+    }
     unsafe {
         let len = (*arr).length as isize;
         let elements = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -537,6 +537,13 @@ pub extern "C" fn js_array_join(
     if arr.is_null() {
         return crate::string::js_string_from_bytes(b"".as_ptr(), 0);
     }
+    // #3148: TypedArray receiver — join element-typed values (Node formatting).
+    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+        return crate::typedarray::js_typed_array_join(
+            arr as *const crate::typedarray::TypedArrayHeader,
+            separator,
+        );
+    }
     unsafe {
         let length = (*arr).length;
 

--- a/crates/perry-runtime/src/array/iter_object.rs
+++ b/crates/perry-runtime/src/array/iter_object.rs
@@ -133,19 +133,33 @@ unsafe fn array_iter_obj_raw(arr: *const ArrayHeader, kind: i32) -> i64 {
     js_nanbox_get_pointer(nanboxed)
 }
 
+/// #3148: materialize a TypedArray receiver to a plain Array (element-typed
+/// reads) before building the iterator object, so `int32arr.values()` /
+/// `.keys()` / `.entries()` yield the numeric elements rather than the raw
+/// byte buffer reinterpreted as f64.
+#[inline]
+fn typed_array_iter_arr(arr: *const ArrayHeader) -> *const ArrayHeader {
+    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+        crate::typedarray::typed_array_to_array(arr as *const crate::typedarray::TypedArrayHeader)
+            as *const ArrayHeader
+    } else {
+        arr
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn js_array_values_iter_obj(arr: *const ArrayHeader) -> i64 {
-    unsafe { array_iter_obj_raw(arr, KIND_VALUES) }
+    unsafe { array_iter_obj_raw(typed_array_iter_arr(arr), KIND_VALUES) }
 }
 
 #[no_mangle]
 pub extern "C" fn js_array_keys_iter_obj(arr: *const ArrayHeader) -> i64 {
-    unsafe { array_iter_obj_raw(arr, KIND_KEYS) }
+    unsafe { array_iter_obj_raw(typed_array_iter_arr(arr), KIND_KEYS) }
 }
 
 #[no_mangle]
 pub extern "C" fn js_array_entries_iter_obj(arr: *const ArrayHeader) -> i64 {
-    unsafe { array_iter_obj_raw(arr, KIND_ENTRIES) }
+    unsafe { array_iter_obj_raw(typed_array_iter_arr(arr), KIND_ENTRIES) }
 }
 
 /// Build the `{ value, done }` iterator-result object. `value` arrives as

--- a/crates/perry-runtime/src/array/splice_slice.rs
+++ b/crates/perry-runtime/src/array/splice_slice.rs
@@ -156,6 +156,14 @@ pub extern "C" fn js_array_slice(
     if arr.is_null() {
         return js_array_alloc(0);
     }
+    // #3148: TypedArray slice — return a same-kind TypedArray.
+    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+        return crate::typedarray::js_typed_array_slice(
+            arr as *const crate::typedarray::TypedArrayHeader,
+            start,
+            end,
+        ) as *mut ArrayHeader;
+    }
     unsafe {
         let len = (*arr).length as i32;
 

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -457,10 +457,10 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
         return false_val;
     }
 
-    // Typed arrays — Int8Array..Float64Array reserved IDs (0xFFFF0030..37).
+    // Typed arrays — Int8Array..BigUint64Array reserved IDs (0xFFFF0030..3A).
     // The pointer can arrive as either a NaN-boxed POINTER_TAG value or a
     // raw bitcast f64, so handle both forms.
-    if (0xFFFF0030..=0xFFFF0037).contains(&class_id) {
+    if (0xFFFF0030..=0xFFFF003A).contains(&class_id) {
         let addr = if jsval.is_pointer() {
             (bits & 0x0000_FFFF_FFFF_FFFF) as usize
         } else {

--- a/crates/perry-runtime/src/typedarray.rs
+++ b/crates/perry-runtime/src/typedarray.rs
@@ -1672,6 +1672,195 @@ pub fn format_typed_array(ta: *const TypedArrayHeader) -> String {
     }
 }
 
+// #3148: %TypedArray%.prototype join / slice / reverse / fill / subarray.
+// (reduce/reduceRight/copyWithin/set_from/findIndex live above — added separately.)
+/// `ta.join(sep?)` — Number→String each element (Node formatting), joined by
+/// `sep` (default ","). Returns a heap StringHeader.
+#[no_mangle]
+pub extern "C" fn js_typed_array_join(
+    ta: *const TypedArrayHeader,
+    separator: *const crate::string::StringHeader,
+) -> *mut crate::string::StringHeader {
+    use crate::string::{js_string_from_bytes, StringHeader};
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return js_string_from_bytes(b"".as_ptr(), 0);
+    }
+    unsafe {
+        let len = (*ta).length as usize;
+        if len == 0 {
+            return js_string_from_bytes(ptr::null(), 0);
+        }
+        let kind = (*ta).kind;
+        let sep_str = if separator.is_null() {
+            ","
+        } else {
+            let sep_len = (*separator).byte_len as usize;
+            let sep_data = (separator as *const u8).add(std::mem::size_of::<StringHeader>());
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(sep_data, sep_len))
+        };
+        let mut result = String::new();
+        for i in 0..len {
+            if i > 0 {
+                result.push_str(sep_str);
+            }
+            result.push_str(&format_typed_value(kind, load_at(ta, i)));
+        }
+        let ret = js_string_from_bytes(result.as_ptr(), result.len() as u32);
+        std::hint::black_box(&result);
+        drop(result);
+        ret
+    }
+}
+
+/// `ta.join(sepValue)` — NaN-boxed-separator entry point mirroring
+/// `js_array_join_value`.
+#[no_mangle]
+pub extern "C" fn js_typed_array_join_value(
+    ta: *const TypedArrayHeader,
+    separator_value: f64,
+) -> *mut crate::string::StringHeader {
+    let separator = if separator_value.to_bits() == crate::value::TAG_UNDEFINED {
+        ptr::null()
+    } else {
+        crate::value::js_jsvalue_to_string(separator_value) as *const crate::string::StringHeader
+    };
+    js_typed_array_join(ta, separator)
+}
+
+/// `ta.slice(start, end?)` — returns a NEW same-kind TypedArray with the
+/// selected elements. Mirrors `js_array_slice` index normalization.
+#[no_mangle]
+pub extern "C" fn js_typed_array_slice(
+    ta: *const TypedArrayHeader,
+    start: i32,
+    end: i32,
+) -> *mut TypedArrayHeader {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return typed_array_alloc(KIND_FLOAT64, 0);
+    }
+    unsafe {
+        let kind = (*ta).kind;
+        let len = (*ta).length as i32;
+        let start_idx = if start < 0 {
+            (len + start).max(0) as u32
+        } else {
+            (start as u32).min(len as u32)
+        };
+        let end_idx = if end == i32::MAX {
+            len as u32
+        } else if end < 0 {
+            (len + end).max(0) as u32
+        } else {
+            (end as u32).min(len as u32)
+        };
+        let slice_len = end_idx.saturating_sub(start_idx);
+        let out = typed_array_alloc(kind, slice_len);
+        for i in 0..slice_len as usize {
+            store_at(out, i, load_at(ta, start_idx as usize + i));
+        }
+        out
+    }
+}
+
+/// `ta.reverse()` — in-place reversal; returns the same typed array.
+#[no_mangle]
+pub extern "C" fn js_typed_array_reverse(ta: *mut TypedArrayHeader) -> *mut TypedArrayHeader {
+    let ta = clean_ta_ptr(ta as *const TypedArrayHeader) as *mut TypedArrayHeader;
+    if ta.is_null() {
+        return ta;
+    }
+    unsafe {
+        let len = (*ta).length as usize;
+        if len <= 1 {
+            return ta;
+        }
+        let mut i = 0usize;
+        let mut j = len - 1;
+        while i < j {
+            let a = load_at(ta, i);
+            let b = load_at(ta, j);
+            store_at(ta, i, b);
+            store_at(ta, j, a);
+            i += 1;
+            j -= 1;
+        }
+        ta
+    }
+}
+
+/// `ta.fill(value, start?, end?)` — in-place fill; returns the same typed
+/// array. `start`/`end` follow Array.prototype.fill index normalization; pass
+/// `has_start == 0` to fill the whole array.
+#[no_mangle]
+pub extern "C" fn js_typed_array_fill(
+    ta: *mut TypedArrayHeader,
+    value: f64,
+    has_start: i32,
+    start: f64,
+    has_end: i32,
+    end: f64,
+) -> *mut TypedArrayHeader {
+    let ta = clean_ta_ptr(ta as *const TypedArrayHeader) as *mut TypedArrayHeader;
+    if ta.is_null() {
+        return ta;
+    }
+    unsafe {
+        let len = (*ta).length as isize;
+        let v = jsvalue_to_f64(value);
+        let norm = |x: f64, default: isize| -> isize {
+            let mut n = if x.is_nan() { default } else { x as isize };
+            if n < 0 {
+                n += len;
+            }
+            n.clamp(0, len)
+        };
+        let s = if has_start != 0 { norm(start, 0) } else { 0 };
+        let e = if has_end != 0 { norm(end, len) } else { len };
+        let mut i = s;
+        while i < e {
+            store_at(ta, i as usize, v);
+            i += 1;
+        }
+        ta
+    }
+}
+
+/// `ta.subarray(begin?, end?)` — returns a NEW same-kind TypedArray that
+/// COPIES the selected range. (Perry materializes rather than aliasing the
+/// backing store; observationally identical for reads and independent writes
+/// of the common cases #3148 targets.)
+#[no_mangle]
+pub extern "C" fn js_typed_array_subarray(
+    ta: *const TypedArrayHeader,
+    has_begin: i32,
+    begin: f64,
+    has_end: i32,
+    end: f64,
+) -> *mut TypedArrayHeader {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() || lookup_typed_array_kind(ta as usize).is_none() {
+        return typed_array_alloc(KIND_FLOAT64, 0);
+    }
+    unsafe {
+        let len = (*ta).length as i32;
+        let norm = |has: i32, v: f64, default: i32| -> i32 {
+            if has == 0 || v.is_nan() {
+                return default;
+            }
+            let mut x = v as i32;
+            if x < 0 {
+                x += len;
+            }
+            x.clamp(0, len)
+        };
+        let b = norm(has_begin, begin, 0);
+        let e = norm(has_end, end, len);
+        js_typed_array_slice(ta, b, e)
+    }
+}
+
 fn format_typed_value(kind: u8, v: f64) -> String {
     match kind {
         KIND_FLOAT32 | KIND_FLOAT64 => {

--- a/test-files/test_gap_typed_array_proto_methods.ts
+++ b/test-files/test_gap_typed_array_proto_methods.ts
@@ -1,0 +1,83 @@
+// #3148: %TypedArray%.prototype remaining methods + instanceof.
+// Byte-matched against `node --experimental-strip-types`.
+// Receivers are local variables (the acceptance form); inline
+// `new Int32Array(...).fill()` is a separate pre-existing limitation
+// shared by ALL typed-array methods (including PR #2499's map/filter).
+
+function show(label: string, v: unknown): void {
+  console.log(label, JSON.stringify(v));
+}
+
+// ---- Int32Array (integer element kind) ----
+const fillTA = new Int32Array([1, 2, 3, 4, 5]);
+fillTA.fill(7);
+show("fill", Array.from(fillTA));
+
+const fillRangeTA = new Int32Array([1, 2, 3, 4, 5]);
+fillRangeTA.fill(9, 1, 3);
+show("fill-range", Array.from(fillRangeTA));
+
+const cwTA = new Int32Array([1, 2, 3, 4, 5]);
+cwTA.copyWithin(0, 3);
+show("copyWithin", Array.from(cwTA));
+
+const revTA = new Int32Array([1, 2, 3, 4, 5]);
+revTA.reverse();
+show("reverse", Array.from(revTA));
+
+const a = new Int32Array([1, 2, 3, 4, 5]);
+show("reduce", a.reduce((s, x) => s + x, 0));
+show("reduce-noinit", a.reduce((s, x) => s + x));
+show("reduceRight", a.reduceRight((acc, x) => acc + "-" + x, "z"));
+show("join", a.join("-"));
+show("join-default", a.join());
+show("indexOf", a.indexOf(3));
+show("indexOf-miss", a.indexOf(99));
+
+const liTA = new Int32Array([1, 3, 3, 4]);
+show("lastIndexOf", liTA.lastIndexOf(3));
+show("includes", a.includes(3));
+show("includes-miss", a.includes(99));
+
+const sl = a.slice(1, 3);
+show("slice", Array.from(sl));
+show("slice-same-kind", sl instanceof Int32Array);
+
+const sub = a.subarray(1, 3);
+show("subarray", Array.from(sub));
+show("subarray-same-kind", sub instanceof Int32Array);
+
+const setTarget = new Int32Array([0, 0, 0, 0]);
+setTarget.set([9, 9], 1);
+show("set", Array.from(setTarget));
+
+const keys: number[] = [];
+for (const k of a.keys()) keys.push(k);
+show("keys", keys);
+
+const vals: number[] = [];
+for (const v of a.values()) vals.push(v);
+show("values", vals);
+
+const ents: Array<[number, number]> = [];
+for (const [i, v] of a.entries()) ents.push([i, v]);
+show("entries", ents);
+
+// ---- instanceof ----
+show("instanceof-self", a instanceof Int32Array);
+show("instanceof-wrong", a instanceof Float64Array);
+show("instanceof-nonTA", [1, 2, 3] instanceof Int32Array);
+
+// ---- Float64Array (float element kind) ----
+const f = new Float64Array([1.5, 2.5, 3.5]);
+const f64fill = new Float64Array([1, 2, 3]);
+f64fill.fill(0.25);
+show("f64-fill", Array.from(f64fill));
+show("f64-reduce", f.reduce((s, x) => s + x, 0));
+show("f64-join", f.join(","));
+show("f64-indexOf", f.indexOf(2.5));
+
+const nanTA = new Float64Array([NaN]);
+show("f64-includes-NaN", nanTA.includes(NaN));
+show("f64-slice-kind", f.slice(0, 1) instanceof Float64Array);
+show("f64-instanceof", f instanceof Float64Array);


### PR DESCRIPTION
Closes #3148. Follow-up to PR #2499.

Wires the remaining `%TypedArray%.prototype` methods and `instanceof` for all typed-array kinds. `reduce`/`reduceRight`/`copyWithin`/`findIndex`/`set` already landed on main independently; this fills in the rest by routing typed-array receivers through the generic `js_array_*` helpers, which delegate to element-typed `js_typed_array_*` impls via `lookup_typed_array_kind`.

## What's added

**Runtime (`typedarray.rs`)** — `js_typed_array_join` / `join_value` / `slice` / `reverse` / `fill` / `subarray`. `slice`/`subarray` return a same-kind TypedArray.

**Delegation guards**
- `js_array_reverse` / `js_array_fill` / `js_array_fill_range` (concat_reverse.rs)
- `js_array_slice` (splice_slice.rs)
- `js_array_join` (iter_methods.rs)
- `js_array_copy_within` (immutable.rs) — this path was previously unguarded; broadening `is_array_expr` routes TA receivers through it, so the guard is required to avoid reading the element-typed buffer as boxed f64
- keys/values/entries iterator objects materialize the TA to a plain array first (iter_object.rs) so iteration yields numbers, not raw f64 bytes

**`instanceof`** — reserved per-kind class ids `0xFFFF0030..3A` (through `BigUint64Array`) in codegen, resolved at runtime via `class_id_for_kind`. `x instanceof Int32Array` is now true (and false for the wrong kind / non-TA).

**Codegen routing** — `is_array_expr` recognizes Named TA receivers so their not-already-folded methods reach `lower_array_method` (+ new `set`/`subarray` arms + extern decls); the `local_array_methods` slice arm folds TA receivers to `ArraySlice`.

`indexOf` / `lastIndexOf` / `includes` already delegate (pre-existing, #2457).

## Validation

- Byte-matches `node --experimental-strip-types` for `Int32Array` **and** `Float64Array` across all the above methods + `instanceof` (`test-files/test_gap_typed_array_proto_methods.ts`).
- Plain arrays and already-landed TA methods (`map`/`filter`/`at`/`with`/`sort`/`findLast`) verified unaffected — guards only fire for genuine TA pointers.
- `cargo fmt` clean. `perry-runtime` suite green (the only failures are pre-existing `gc::tests::barrier` flakes that pass in isolation; my changes touch no GC code).
