### PR TITLE
fix(perf_hooks): record resource and function timing entries

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -3395,10 +3395,9 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("perf_hooks", "toJSON", false, None),
     method("perf_hooks", "clearResourceTimings", false, None),
     method("perf_hooks", "setResourceTimingBufferSize", false, None),
-    // #1478: stub — records the entry (no-op today, see codegen).
+    // Resource timing entries are recorded through the perf_hooks timeline.
     method("perf_hooks", "markResourceTiming", false, None),
-    // #1335: returns `fn` unchanged today; the spec'd "wraps fn to
-    // record a 'function' timeline entry" piece isn't recorded yet.
+    // timerify returns a wrapper that emits observer-visible function entries.
     method("perf_hooks", "timerify", false, None),
     // #1336: monitorEventLoopDelay() / createHistogram() return a
     // Histogram-shaped object whose method/property reads route

--- a/crates/perry-codegen/src/lower_call/native/perf_hooks.rs
+++ b/crates/perry-codegen/src/lower_call/native/perf_hooks.rs
@@ -132,26 +132,36 @@ pub(super) fn lower_perf_hooks_method(
                     &[(DOUBLE, &a0)],
                 )
             }
-            // #1478: performance.markResourceTiming(info) appends a
-            // PerformanceResourceTiming entry built from a
-            // PerformanceTimingInfo-shaped object. Perry doesn't track
-            // the resource-timing buffer yet — return undefined as a
-            // no-op so feature-detect-and-call (`typeof X === "function"`
-            // + invocation) doesn't crash. The accompanying read of
-            // performance.getEntriesByType("resource") still returns
-            // an empty array.
-            "markResourceTiming" => undef.clone(),
-            // #1335: performance.timerify(fn) wraps `fn` so each call
-            // records a 'function' timeline entry; the wrapper still
-            // returns fn's result. Perry doesn't track function
-            // timings, so the simplest spec-compatible behavior is to
-            // return `fn` itself — `typeof timerified === "function"`
-            // still holds, calling it produces the original result,
-            // and the only missing side effect is pushing an entry
-            // into the PerformanceObserver "function" type (which
-            // isn't in our supported entryTypes set today, so no
-            // observer would see it anyway).
-            "timerify" => lower_or_undef(ctx, 0)?,
+            "markResourceTiming" => {
+                let a0 = lower_or_undef(ctx, 0)?;
+                let a1 = lower_or_undef(ctx, 1)?;
+                let a2 = lower_or_undef(ctx, 2)?;
+                let a3 = lower_or_undef(ctx, 3)?;
+                let a4 = lower_or_undef(ctx, 4)?;
+                let a5 = lower_or_undef(ctx, 5)?;
+                let a6 = lower_or_undef(ctx, 6)?;
+                let a7 = lower_or_undef(ctx, 7)?;
+                ctx.block().call(
+                    DOUBLE,
+                    "js_perf_mark_resource_timing",
+                    &[
+                        (DOUBLE, &a0),
+                        (DOUBLE, &a1),
+                        (DOUBLE, &a2),
+                        (DOUBLE, &a3),
+                        (DOUBLE, &a4),
+                        (DOUBLE, &a5),
+                        (DOUBLE, &a6),
+                        (DOUBLE, &a7),
+                    ],
+                )
+            }
+            "timerify" => {
+                let a0 = lower_or_undef(ctx, 0)?;
+                let a1 = lower_or_undef(ctx, 1)?;
+                ctx.block()
+                    .call(DOUBLE, "js_perf_timerify", &[(DOUBLE, &a0), (DOUBLE, &a1)])
+            }
             // #1336: perf_hooks.monitorEventLoopDelay(options?) returns
             // an IntervalHistogram; createHistogram(options?) returns a
             // RecordableHistogram. Both are stubs (every stat reads 0

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1308,6 +1308,14 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_perf_to_json", DOUBLE, &[]);
     module.declare_function("js_perf_clear_resource_timings", DOUBLE, &[]);
     module.declare_function("js_perf_set_resource_timing_buffer_size", DOUBLE, &[DOUBLE]);
+    module.declare_function(
+        "js_perf_mark_resource_timing",
+        DOUBLE,
+        &[
+            DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE,
+        ],
+    );
+    module.declare_function("js_perf_timerify", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_perf_observer_new", DOUBLE, &[DOUBLE]);
     module.declare_function("js_perf_observer_observe", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_perf_observer_disconnect", DOUBLE, &[DOUBLE]);

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1334,16 +1334,12 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("perf_hooks", "toJSON")
             | ("perf_hooks", "clearResourceTimings")
             | ("perf_hooks", "setResourceTimingBufferSize")
-            // #1478: performance.markResourceTiming(info) records a
-            // PerformanceResourceTiming. Perry's runtime no-ops it but
-            // the property must still read as a function for
-            // feature-detection (`typeof X === "function"`) wrappers.
+            // performance.markResourceTiming(info) records a resource entry;
+            // the property also reads as a function for feature-detection
+            // wrappers.
             | ("perf_hooks", "markResourceTiming")
-            // #1335: performance.timerify(fn) wraps `fn` to record a
-            // 'function' timeline entry per call. Perry currently
-            // returns `fn` unchanged (no entry recorded), but the
-            // property must still read as a function for
-            // feature-detection.
+            // performance.timerify(fn) returns a wrapper that preserves the
+            // result and emits observer-visible function entries.
             | ("perf_hooks", "timerify")
             // #1366: `crypto.getRandomValues` is the WebCrypto sync
             // randomness API. Perry lowers the call form via a

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -548,6 +548,17 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("perf_hooks", "setResourceTimingBufferSize") => {
             crate::perf_hooks::js_perf_set_resource_timing_buffer_size(arg(0))
         }
+        ("perf_hooks", "markResourceTiming") => crate::perf_hooks::js_perf_mark_resource_timing(
+            arg(0),
+            arg(1),
+            arg(2),
+            arg(3),
+            arg(4),
+            arg(5),
+            arg(6),
+            arg(7),
+        ),
+        ("perf_hooks", "timerify") => crate::perf_hooks::js_perf_timerify(arg(0), arg(1)),
 
         // ── PerformanceObserver instance (perf_observer) ──
         // The registry index lives in field[1] of the namespace object; the

--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -19,16 +19,18 @@
 
 use crate::object::{
     js_object_alloc_with_shape, js_object_get_field, js_object_get_field_by_name,
-    js_object_set_field,
+    js_object_set_field, js_object_set_field_by_name,
 };
 use crate::string::StringHeader;
 use crate::value::JSValue;
 use std::cell::{Cell, RefCell};
-use std::sync::OnceLock;
+use std::sync::{Once, OnceLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 const ENTRY_TYPE_MARK: u8 = 0;
 const ENTRY_TYPE_MEASURE: u8 = 1;
+const ENTRY_TYPE_RESOURCE: u8 = 2;
+const ENTRY_TYPE_FUNCTION: u8 = 3;
 
 pub(crate) const CLASS_ID_PERFORMANCE_ENTRY: u32 = 0xFFFF_0080;
 pub(crate) const CLASS_ID_PERFORMANCE_MARK: u32 = 0xFFFF_0081;
@@ -66,7 +68,13 @@ struct PerfEntry {
     duration: f64,
     /// NaN-boxed JSValue bits of the entry's `detail` (defaults to `null`).
     detail_bits: u64,
+    /// Stable materialized entry object returned by both the creation API and
+    /// later timeline queries for that entry.
+    object_bits: u64,
+    initiator_type: Option<String>,
 }
+
+static TIMERIFY_WRAPPER_REGISTERED: Once = Once::new();
 
 thread_local! {
     static PERF_ENTRIES: RefCell<Vec<PerfEntry>> = const { RefCell::new(Vec::new()) };
@@ -293,9 +301,26 @@ fn str_value(s: &str) -> JSValue {
     JSValue::string_ptr(ptr)
 }
 
+unsafe fn set_named_field(obj: *mut crate::object::ObjectHeader, name: &str, value: JSValue) {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_set_field_by_name(obj, key, f64::from_bits(value.bits()));
+}
+
+fn entry_type_name(entry_type: u8) -> &'static str {
+    match entry_type {
+        ENTRY_TYPE_MEASURE => "measure",
+        ENTRY_TYPE_RESOURCE => "resource",
+        ENTRY_TYPE_FUNCTION => "function",
+        _ => "mark",
+    }
+}
+
 /// Materialize a `PerfEntry` into a `{ name, entryType, startTime, duration,
 /// detail }` JS object and return its NaN-boxed pointer bits.
 unsafe fn entry_to_object(e: &PerfEntry) -> f64 {
+    if e.object_bits != 0 {
+        return f64::from_bits(e.object_bits);
+    }
     let obj = js_object_alloc_with_shape(
         PERF_ENTRY_SHAPE,
         5,
@@ -311,16 +336,14 @@ unsafe fn entry_to_object(e: &PerfEntry) -> f64 {
             c.set(keys_ptr);
         }
     });
-    let type_str = if e.entry_type == ENTRY_TYPE_MEASURE {
-        "measure"
-    } else {
-        "mark"
-    };
     js_object_set_field(obj, 0, str_value(&e.name));
-    js_object_set_field(obj, 1, str_value(type_str));
+    js_object_set_field(obj, 1, str_value(entry_type_name(e.entry_type)));
     js_object_set_field(obj, 2, JSValue::number(e.start_time));
     js_object_set_field(obj, 3, JSValue::number(e.duration));
     js_object_set_field(obj, 4, JSValue::from_bits(e.detail_bits));
+    if let Some(initiator_type) = &e.initiator_type {
+        set_named_field(obj, "initiatorType", str_value(initiator_type));
+    }
     crate::value::js_nanbox_pointer(obj as i64)
 }
 
@@ -499,8 +522,12 @@ pub extern "C" fn js_perf_mark(name_val: f64, options_val: f64) -> f64 {
             start_time,
             duration: 0.0,
             detail_bits,
+            object_bits: 0,
+            initiator_type: None,
         };
+        let mut entry = entry;
         let obj = entry_to_object(&entry);
+        entry.object_bits = obj.to_bits();
         notify_observers(&entry);
         PERF_ENTRIES.with(|store| store.borrow_mut().push(entry));
         obj
@@ -603,8 +630,12 @@ unsafe fn finish_measure(name: String, start_time: f64, duration: f64, detail_bi
         start_time,
         duration,
         detail_bits,
+        object_bits: 0,
+        initiator_type: None,
     };
+    let mut entry = entry;
     let obj = entry_to_object(&entry);
+    entry.object_bits = obj.to_bits();
     notify_observers(&entry);
     PERF_ENTRIES.with(|store| store.borrow_mut().push(entry));
     obj
@@ -649,16 +680,10 @@ pub extern "C" fn js_perf_get_entries() -> f64 {
 pub extern "C" fn js_perf_get_entries_by_type(type_val: f64) -> f64 {
     unsafe {
         let want = coerce_to_string(type_val);
-        let want_type = if want == "measure" {
-            ENTRY_TYPE_MEASURE
-        } else {
-            ENTRY_TYPE_MARK
-        };
-        // Only "mark"/"measure" are tracked; an unknown type yields [].
-        if want != "mark" && want != "measure" {
-            return entries_to_array(|_| false);
+        match entry_type_code(&want) {
+            Some(want_type) => entries_to_array(move |e| e.entry_type == want_type),
+            None => entries_to_array(|_| false),
         }
-        entries_to_array(move |e| e.entry_type == want_type)
     }
 }
 
@@ -671,6 +696,8 @@ pub extern "C" fn js_perf_get_entries_by_name(name_val: f64, type_val: f64) -> f
             match t.as_str() {
                 "mark" => Some(ENTRY_TYPE_MARK),
                 "measure" => Some(ENTRY_TYPE_MEASURE),
+                "resource" => Some(ENTRY_TYPE_RESOURCE),
+                "function" => Some(ENTRY_TYPE_FUNCTION),
                 _ => Some(255),
             }
         } else {
@@ -819,18 +846,166 @@ pub extern "C" fn js_perf_node_timing() -> f64 {
 }
 
 // ── clearResourceTimings() / setResourceTimingBufferSize(n) ──────────────────
-// Perry has no Resource Timing buffer (no PerformanceResourceTiming entries are
-// ever recorded), so these are no-ops matching Node's signatures — both return
-// `undefined`. They exist so user code that manages the resource-timing buffer
-// runs unchanged.
 #[no_mangle]
 pub extern "C" fn js_perf_clear_resource_timings() -> f64 {
+    PERF_ENTRIES.with(|store| {
+        store
+            .borrow_mut()
+            .retain(|entry| entry.entry_type != ENTRY_TYPE_RESOURCE);
+    });
     f64::from_bits(JSValue::undefined().bits())
 }
 
 #[no_mangle]
 pub extern "C" fn js_perf_set_resource_timing_buffer_size(_n: f64) -> f64 {
     f64::from_bits(JSValue::undefined().bits())
+}
+
+#[no_mangle]
+pub extern "C" fn js_perf_mark_resource_timing(
+    timing_info: f64,
+    requested_url: f64,
+    initiator_type: f64,
+    _global: f64,
+    _cache_mode: f64,
+    _body_info: f64,
+    _response_status: f64,
+    _delivery_type: f64,
+) -> f64 {
+    unsafe {
+        let Some(timing_obj) = as_object_ptr(timing_info) else {
+            throw_type_error_with_code(
+                "The \"timingInfo\" argument must be of type object",
+                "ERR_INVALID_ARG_TYPE",
+            );
+        };
+        let name = coerce_to_string(requested_url);
+        let initiator = coerce_to_string(initiator_type);
+        let start_time = option_number(timing_obj, "startTime")
+            .or_else(|| option_number(timing_obj, "fetchStart"))
+            .unwrap_or(0.0);
+        let entry = PerfEntry {
+            name,
+            entry_type: ENTRY_TYPE_RESOURCE,
+            start_time,
+            duration: f64::NAN,
+            detail_bits: JSValue::null().bits(),
+            object_bits: 0,
+            initiator_type: Some(initiator),
+        };
+        let mut entry = entry;
+        let obj = entry_to_object(&entry);
+        entry.object_bits = obj.to_bits();
+        notify_observers(&entry);
+        PERF_ENTRIES.with(|store| store.borrow_mut().push(entry));
+        obj
+    }
+}
+
+unsafe fn collect_rest_args(rest: f64) -> Vec<f64> {
+    let ptr = crate::value::js_nanbox_get_pointer(rest) as *const crate::array::ArrayHeader;
+    if ptr.is_null() {
+        return Vec::new();
+    }
+    let len = crate::array::js_array_length(ptr) as usize;
+    let mut args = Vec::with_capacity(len);
+    for i in 0..len {
+        args.push(crate::array::js_array_get_f64(ptr, i as u32));
+    }
+    args
+}
+
+unsafe fn closure_ptr_from_value(value: f64) -> Option<*const crate::closure::ClosureHeader> {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return None;
+    }
+    let ptr = jv.as_pointer::<crate::closure::ClosureHeader>();
+    if ptr.is_null() || (*ptr).type_tag != crate::closure::CLOSURE_MAGIC {
+        return None;
+    }
+    Some(ptr)
+}
+
+unsafe fn function_value_name(value: f64) -> String {
+    let Some(closure) = closure_ptr_from_value(value) else {
+        return String::new();
+    };
+    crate::builtins::function_name_for_ptr((*closure).func_ptr as usize)
+        .or_else(|| {
+            let name_value = crate::closure::closure_get_dynamic_prop(closure as usize, "name");
+            string_of(JSValue::from_bits(name_value.to_bits()))
+        })
+        .unwrap_or_default()
+}
+
+extern "C" fn perf_timerify_wrapper(
+    closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    unsafe {
+        let target = crate::closure::js_closure_get_capture_f64(closure, 0);
+        let name_value = crate::closure::js_closure_get_capture_f64(closure, 1);
+        let name = string_of(JSValue::from_bits(name_value.to_bits())).unwrap_or_default();
+        let args = collect_rest_args(rest);
+        let start_time = perf_now();
+        let result = crate::closure::js_native_call_value(target, args.as_ptr(), args.len());
+        let duration = (perf_now() - start_time).max(0.0);
+        let entry = PerfEntry {
+            name,
+            entry_type: ENTRY_TYPE_FUNCTION,
+            start_time,
+            duration,
+            detail_bits: JSValue::null().bits(),
+            object_bits: 0,
+            initiator_type: None,
+        };
+        let mut entry = entry;
+        let obj = entry_to_object(&entry);
+        entry.object_bits = obj.to_bits();
+        notify_observers(&entry);
+        result
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_perf_timerify(fn_value: f64, _options: f64) -> f64 {
+    unsafe {
+        if !is_function_value(fn_value) {
+            throw_type_error_with_code(
+                "The \"fn\" argument must be of type function",
+                "ERR_INVALID_ARG_TYPE",
+            );
+        }
+        TIMERIFY_WRAPPER_REGISTERED.call_once(|| {
+            crate::closure::js_register_closure_rest(perf_timerify_wrapper as *const u8, 0);
+        });
+        let name = function_value_name(fn_value);
+        let closure = crate::closure::js_closure_alloc(perf_timerify_wrapper as *const u8, 2);
+        crate::closure::js_closure_set_capture_f64(closure, 0, fn_value);
+        let name_value = str_value(&name);
+        crate::closure::js_closure_set_capture_f64(closure, 1, f64::from_bits(name_value.bits()));
+
+        if let Some(target) = closure_ptr_from_value(fn_value) {
+            if let Some(arity) = crate::closure::closure_arity(target) {
+                crate::object::set_builtin_closure_length(closure as usize, arity);
+            }
+        }
+
+        let wrapper_name = if name.is_empty() {
+            "timerified".to_string()
+        } else {
+            format!("timerified {name}")
+        };
+        let wrapper_name_value = str_value(&wrapper_name);
+        crate::closure::closure_set_dynamic_prop(
+            closure as usize,
+            "name",
+            f64::from_bits(wrapper_name_value.bits()),
+        );
+        crate::gc::runtime_write_barrier_root_heap_word(closure as u64);
+        f64::from_bits(JSValue::pointer(closure as *mut u8).bits())
+    }
 }
 
 // ── PerformanceObserver ──────────────────────────────────────────────────────
@@ -920,6 +1095,8 @@ fn entry_type_code(name: &str) -> Option<u8> {
     match name {
         "mark" => Some(ENTRY_TYPE_MARK),
         "measure" => Some(ENTRY_TYPE_MEASURE),
+        "resource" => Some(ENTRY_TYPE_RESOURCE),
+        "function" => Some(ENTRY_TYPE_FUNCTION),
         _ => None,
     }
 }
@@ -1178,8 +1355,8 @@ pub unsafe fn current_list_get_by_name(name_val: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_perf_supported_entry_types() -> f64 {
     unsafe {
-        let mut arr = crate::array::js_array_alloc(2);
-        for t in ["mark", "measure"] {
+        let mut arr = crate::array::js_array_alloc(4);
+        for t in ["function", "mark", "measure", "resource"] {
             arr = crate::array::js_array_push(arr, str_value(t));
         }
         crate::value::js_nanbox_pointer(arr as i64)
@@ -1193,6 +1370,9 @@ pub fn scan_perf_entries_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
     PERF_ENTRIES.with(|store| {
         for e in store.borrow_mut().iter_mut() {
             visitor.visit_nanbox_u64_slot(&mut e.detail_bits);
+            if e.object_bits != 0 {
+                visitor.visit_nanbox_u64_slot(&mut e.object_bits);
+            }
         }
     });
     OBSERVERS.with(|o| {
@@ -1201,12 +1381,18 @@ pub fn scan_perf_entries_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
             visitor.visit_nanbox_u64_slot(&mut obs.obj_bits);
             for e in obs.pending.iter_mut() {
                 visitor.visit_nanbox_u64_slot(&mut e.detail_bits);
+                if e.object_bits != 0 {
+                    visitor.visit_nanbox_u64_slot(&mut e.object_bits);
+                }
             }
         }
     });
     CURRENT_LIST.with(|c| {
         for e in c.borrow_mut().iter_mut() {
             visitor.visit_nanbox_u64_slot(&mut e.detail_bits);
+            if e.object_bits != 0 {
+                visitor.visit_nanbox_u64_slot(&mut e.object_bits);
+            }
         }
     });
     // Keep the cached `performance` namespace alive + forwarded so the

--- a/test-parity/node-suite/perf_hooks/resource-timing/mark-resource-entry.ts
+++ b/test-parity/node-suite/perf_hooks/resource-timing/mark-resource-entry.ts
@@ -1,0 +1,36 @@
+import { performance } from "node:perf_hooks";
+
+performance.clearResourceTimings();
+
+const before = performance.getEntriesByType("resource").length;
+const timingInfo: any = {
+  startTime: 10,
+  redirectStart: 0,
+  redirectEnd: 0,
+  fetchStart: 10,
+  domainLookupStart: 11,
+  domainLookupEnd: 12,
+  connectStart: 13,
+  connectEnd: 14,
+  requestStart: 15,
+  responseStart: 16,
+  responseEnd: 20,
+};
+
+const returned: any = performance.markResourceTiming(
+  timingInfo,
+  "https://example.test/a",
+  "fetch",
+  globalThis,
+  "",
+);
+const entries: any[] = performance.getEntriesByType("resource") as any[];
+const last: any = entries[entries.length - 1];
+
+console.log("returned object:", typeof returned);
+console.log("same returned:", returned === last);
+console.log("delta:", entries.length - before);
+console.log("fields:", last.name, last.entryType, last.initiatorType, last.startTime);
+console.log("duration nan:", Number.isNaN(last.duration));
+performance.clearResourceTimings();
+console.log("after clear:", performance.getEntriesByType("resource").length);

--- a/test-parity/node-suite/perf_hooks/timerify/function-entry.ts
+++ b/test-parity/node-suite/perf_hooks/timerify/function-entry.ts
@@ -1,0 +1,26 @@
+import { performance, PerformanceObserver } from "node:perf_hooks";
+
+const seen: string[] = [];
+const obs = new PerformanceObserver((list: any) => {
+  for (const entry of list.getEntries()) {
+    seen.push(`${entry.name}:${entry.entryType}:${typeof entry.duration}:${entry.duration >= 0}`);
+  }
+});
+
+obs.observe({ entryTypes: ["function"] });
+
+function add(a: number, b: number): number {
+  return a + b;
+}
+
+const wrapped = performance.timerify(add);
+console.log("same fn:", wrapped === add);
+console.log("name:", wrapped.name);
+console.log("length:", wrapped.length);
+console.log("result:", wrapped(2, 3));
+
+setTimeout(() => {
+  console.log("seen count:", seen.length);
+  console.log("first:", seen[0] || "none");
+  obs.disconnect();
+}, 20);


### PR DESCRIPTION
Closes #3466
Closes #3468

## Summary
- Records resource entries from performance.markResourceTiming(...) and returns the materialized entry object used by timeline queries.
- Makes performance.timerify(fn) return a wrapper that preserves call results/arity metadata and emits observer-visible function entries.
- Adds focused parity fixtures for resource timing entry identity/clearing and timerify observer delivery.

## Verification
- PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module perf_hooks -> pass, 80 parity pass / 0 fail / 0 compile fail (test-parity/reports/parity_report_20260531_070109.json)
- RUSTC_WRAPPER= cargo test -p perry-codegen --test manifest_consistency -> pass, 4 tests
- RUSTC_WRAPPER= cargo check -p perry-runtime -p perry-codegen -p perry-hir -p perry-api-manifest -p perry -> pass with existing warnings
- cargo fmt --all -- --check -> pass
- ./scripts/check_file_size.sh -> pass
- jq empty test-parity/known_failures.json -> pass
- git diff --check origin/main..HEAD -> pass