### PR TITLE
fix(codegen): support indirect/closure calls with more than 16 args (#3527)

### DIFF
--- a/crates/perry-codegen/src/lower_call/console_promise.rs
+++ b/crates/perry-codegen/src/lower_call/console_promise.rs
@@ -777,63 +777,91 @@ pub fn try_lower_closure_call_fallthrough(
     //
     // The runtime checks the closure header on its own — if the value
     // isn't actually a closure, js_closure_call<N> handles the error.
-    if args.len() <= 16 {
-        // Issue #519: when the callee shape is `recv.method(args)` (a
-        // PropertyGet) — i.e. a method-style invocation — bind the
-        // receiver as the implicit `this` for the duration of the call.
-        // Non-arrow function bodies (including FuncRef wrappers) read
-        // `this` via `js_implicit_this_get` when their lexical
-        // this_stack is empty (codegen Expr::This fallback). Without
-        // this save/set/restore, hono's `RegExpRouter.match = match`
-        // (where `match` is an imported function declaration whose
-        // body does `this.buildAllMatchers()`) sees `this = undefined`
-        // and TypeErrors out at the first chained method call.
-        //
-        // We evaluate `object` once into a fresh slot so that
-        // (a) it's only side-effect-evaluated once, and
-        // (b) the lowered `callee` (which re-reads `object` to get the
-        //     property) and the IMPLICIT_THIS save/set both see the
-        //     same receiver value.
-        let method_recv: Option<String> = if let Expr::PropertyGet { object, .. } = callee {
-            // Skip the method-binding when the receiver is a global,
-            // namespace import, or NativeModuleRef — those aren't
-            // user objects and shouldn't influence `this`.
-            if matches!(
-                object.as_ref(),
-                Expr::GlobalGet(_) | Expr::NativeModuleRef(_) | Expr::ExternFuncRef { .. }
-            ) {
-                None
-            } else {
-                Some(lower_expr(ctx, object)?)
-            }
-        } else {
+    // Issue #519: when the callee shape is `recv.method(args)` (a
+    // PropertyGet) — i.e. a method-style invocation — bind the
+    // receiver as the implicit `this` for the duration of the call.
+    // Non-arrow function bodies (including FuncRef wrappers) read
+    // `this` via `js_implicit_this_get` when their lexical
+    // this_stack is empty (codegen Expr::This fallback). Without
+    // this save/set/restore, hono's `RegExpRouter.match = match`
+    // (where `match` is an imported function declaration whose
+    // body does `this.buildAllMatchers()`) sees `this = undefined`
+    // and TypeErrors out at the first chained method call.
+    //
+    // We evaluate `object` once into a fresh slot so that
+    // (a) it's only side-effect-evaluated once, and
+    // (b) the lowered `callee` (which re-reads `object` to get the
+    //     property) and the IMPLICIT_THIS save/set both see the
+    //     same receiver value.
+    //
+    // The `this`-binding / closure-unbox setup below is arity-independent;
+    // only the final dispatch differs. Arities 0..=16 use the per-arity
+    // `js_closure_call{N}` register helpers (fast path); arities > 16 (no
+    // `js_closure_call17`+ exists) marshal the args through a stack buffer
+    // and dispatch via `js_closure_call_array`. Refs #3527 (qs's recursive
+    // `stringify` self-calls with 18 args).
+    let method_recv: Option<String> = if let Expr::PropertyGet { object, .. } = callee {
+        // Skip the method-binding when the receiver is a global,
+        // namespace import, or NativeModuleRef — those aren't
+        // user objects and shouldn't influence `this`.
+        if matches!(
+            object.as_ref(),
+            Expr::GlobalGet(_) | Expr::NativeModuleRef(_) | Expr::ExternFuncRef { .. }
+        ) {
             None
-        };
-
-        let recv_box = lower_expr(ctx, callee)?;
-        let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());
-        for a in args {
-            lowered_args.push(lower_expr(ctx, a)?);
+        } else {
+            Some(lower_expr(ctx, object)?)
         }
-        let prev_this: Option<String> = if let Some(ref this_val) = method_recv {
-            let blk = ctx.block();
-            Some(blk.call(DOUBLE, "js_implicit_this_set", &[(DOUBLE, this_val)]))
-        } else {
-            None
-        };
+    } else {
+        None
+    };
+
+    let recv_box = lower_expr(ctx, callee)?;
+    let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());
+    for a in args {
+        lowered_args.push(lower_expr(ctx, a)?);
+    }
+    let prev_this: Option<String> = if let Some(ref this_val) = method_recv {
+        let blk = ctx.block();
+        Some(blk.call(DOUBLE, "js_implicit_this_set", &[(DOUBLE, this_val)]))
+    } else {
+        None
+    };
+
+    let result = if lowered_args.len() <= 16 {
         let blk = ctx.block();
         let closure_handle = unbox_to_i64(blk, &recv_box);
-        let runtime_fn = format!("js_closure_call{}", args.len());
+        let runtime_fn = format!("js_closure_call{}", lowered_args.len());
         let mut call_args: Vec<(crate::types::LlvmType, &str)> = vec![(I64, &closure_handle)];
         for v in &lowered_args {
             call_args.push((DOUBLE, v.as_str()));
         }
-        let result = blk.call(DOUBLE, &runtime_fn, &call_args);
-        if let Some(prev) = prev_this {
-            ctx.block()
-                .call(DOUBLE, "js_implicit_this_set", &[(DOUBLE, &prev)]);
+        blk.call(DOUBLE, &runtime_fn, &call_args)
+    } else {
+        // #3527: > 16 args — stack-allocate a `[N x double]` array (entry-block
+        // alloca, see #167), store each lowered arg, and dispatch through the
+        // variadic `js_closure_call_array(closure_i64, args_ptr, argc)`. This
+        // mirrors the `js_native_call_value` marshaling used elsewhere in
+        // lower_call. `args_ptr` is non-null here since argc > 16 > 0.
+        let n = lowered_args.len();
+        let buf = ctx.func.alloca_entry_array(DOUBLE, n);
+        let blk = ctx.block();
+        for (i, v) in lowered_args.iter().enumerate() {
+            let slot = blk.gep(DOUBLE, &buf, &[(I64, &format!("{}", i))]);
+            blk.store(DOUBLE, v, &slot);
         }
-        return Ok(Some(result));
+        let closure_handle = unbox_to_i64(blk, &recv_box);
+        let argc = n.to_string();
+        blk.call(
+            DOUBLE,
+            "js_closure_call_array",
+            &[(I64, &closure_handle), (PTR, &buf), (I64, &argc)],
+        )
+    };
+
+    if let Some(prev) = prev_this {
+        ctx.block()
+            .call(DOUBLE, "js_implicit_this_set", &[(DOUBLE, &prev)]);
     }
-    Ok(None)
+    Ok(Some(result))
 }

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1207,7 +1207,11 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_call_function", DOUBLE, &[I64, I64, I64, I64, I64]);
     module.declare_function("js_call_method", DOUBLE, &[DOUBLE, I64, I64, I64, I64]);
     module.declare_function("js_call_value", DOUBLE, &[DOUBLE, I64, I64]);
-    module.declare_function("js_closure_call_array", DOUBLE, &[I64, I64, I64]);
+    // (closure_env i64, args_ptr, args_len i64). The args pointer is a real
+    // pointer to a `[N x double]` stack buffer; declare it PTR (ABI-identical
+    // to I64 in the integer register class) so call sites can pass an alloca
+    // directly. See `try_lower_closure_call_fallthrough` (#3527).
+    module.declare_function("js_closure_call_array", DOUBLE, &[I64, PTR, I64]);
     module.declare_function(
         "js_closure_call_apply_with_spread",
         DOUBLE,

--- a/crates/perry-runtime/src/closure/dispatch.rs
+++ b/crates/perry-runtime/src/closure/dispatch.rs
@@ -1412,7 +1412,7 @@ pub unsafe extern "C" fn js_closure_call_array(
             a(13),
             a(14),
         ),
-        _ => js_closure_call16(
+        16 => js_closure_call16(
             closure,
             a(0),
             a(1),
@@ -1431,6 +1431,37 @@ pub unsafe extern "C" fn js_closure_call_array(
             a(14),
             a(15),
         ),
+        // #3527: arities above 16 can't go through a fixed per-arity
+        // `js_closure_callN` (none exist past 16). Build the full unboxed
+        // arg slice and dispatch through the strategy resolver so the
+        // closure body is called with ALL its args (the old `_ =>
+        // js_closure_call16(...)` silently dropped args 16.. — breaking
+        // qs's recursive `stringify`, which self-calls with 18 args). For
+        // a plain (Direct) closure with no registered rest/arity, dispatch
+        // through `dispatch_with_arity` with the provided count so the body
+        // is transmuted to its real N-arg signature.
+        _ => {
+            let mut full: Vec<f64> = Vec::with_capacity(n);
+            for i in 0..n {
+                full.push(a(i));
+            }
+            let func_ptr = get_valid_func_ptr(closure);
+            if func_ptr.is_null() {
+                throw_not_callable();
+            }
+            if let Some(result) = dispatch_registered_call(closure, func_ptr, &full) {
+                return result;
+            }
+            if let Some(result) =
+                dispatch_rest_or_declared_arity(closure, func_ptr, &full, n as u32)
+            {
+                return result;
+            }
+            // Direct closure: declared arity == provided count. Reuse the
+            // arity dispatcher (it transmutes to the concrete N-arg fn and
+            // forwards the slice unchanged when provided == declared).
+            dispatch_with_arity(closure, func_ptr, &full, n as u32)
+        }
     }
 }
 

--- a/crates/perry-runtime/src/closure/registry.rs
+++ b/crates/perry-runtime/src/closure/registry.rs
@@ -482,70 +482,92 @@ pub unsafe fn dispatch_with_arity(
             }
         };
     }
+    // One match arm per declared arity. Each arm transmutes `func_ptr` to
+    // the concrete `(closure, f64 x N)` signature and forwards the (padded)
+    // args. Arities up to 32 are supported so high-arity closures dispatched
+    // dynamically — e.g. qs's recursive `stringify`, which declares 18
+    // params and self-calls with 18 args (#3527) — call their body
+    // correctly instead of mis-calling and corrupting registers. The
+    // `arm!` macro builds the fn type and the (padded) call args from the
+    // arg-index token list; `arm!(@ty $i)` maps any index token to `f64`.
+    macro_rules! arm {
+        (@ty $i:tt) => { f64 };
+        ($($i:tt),* $(,)?) => {{
+            let f: extern "C" fn(*const ClosureHeader $(, arm!(@ty $i))*) -> f64 =
+                std::mem::transmute(func_ptr);
+            f(closure $(, a!($i))*)
+        }};
+    }
     match k {
         0 => {
             let f: extern "C" fn(*const ClosureHeader) -> f64 = std::mem::transmute(func_ptr);
             f(closure)
         }
-        1 => {
-            let f: extern "C" fn(*const ClosureHeader, f64) -> f64 = std::mem::transmute(func_ptr);
-            f(closure, a!(0))
+        1 => arm!(0),
+        2 => arm!(0, 1),
+        3 => arm!(0, 1, 2),
+        4 => arm!(0, 1, 2, 3),
+        5 => arm!(0, 1, 2, 3, 4),
+        6 => arm!(0, 1, 2, 3, 4, 5),
+        7 => arm!(0, 1, 2, 3, 4, 5, 6),
+        8 => arm!(0, 1, 2, 3, 4, 5, 6, 7),
+        9 => arm!(0, 1, 2, 3, 4, 5, 6, 7, 8),
+        10 => arm!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+        11 => arm!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+        12 => arm!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+        13 => arm!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
+        14 => arm!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13),
+        15 => arm!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14),
+        16 => arm!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+        17 => arm!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16),
+        18 => arm!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17),
+        19 => arm!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18),
+        20 => arm!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19),
+        21 => arm!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20),
+        22 => arm!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21),
+        23 => {
+            arm!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22)
         }
-        2 => {
-            let f: extern "C" fn(*const ClosureHeader, f64, f64) -> f64 =
-                std::mem::transmute(func_ptr);
-            f(closure, a!(0), a!(1))
+        24 => arm!(
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23
+        ),
+        25 => arm!(
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24
+        ),
+        26 => arm!(
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25
+        ),
+        27 => arm!(
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26
+        ),
+        28 => arm!(
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27
+        ),
+        29 => arm!(
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28
+        ),
+        30 => arm!(
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29
+        ),
+        31 => arm!(
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30
+        ),
+        32 => arm!(
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31
+        ),
+        _ => {
+            // Unsupported arity (>32 declared params). Fall back to
+            // undefined rather than mis-calling and triggering UB.
+            f64::from_bits(crate::value::TAG_UNDEFINED)
         }
-        3 => {
-            let f: extern "C" fn(*const ClosureHeader, f64, f64, f64) -> f64 =
-                std::mem::transmute(func_ptr);
-            f(closure, a!(0), a!(1), a!(2))
-        }
-        4 => {
-            let f: extern "C" fn(*const ClosureHeader, f64, f64, f64, f64) -> f64 =
-                std::mem::transmute(func_ptr);
-            f(closure, a!(0), a!(1), a!(2), a!(3))
-        }
-        5 => {
-            let f: extern "C" fn(*const ClosureHeader, f64, f64, f64, f64, f64) -> f64 =
-                std::mem::transmute(func_ptr);
-            f(closure, a!(0), a!(1), a!(2), a!(3), a!(4))
-        }
-        6 => {
-            let f: extern "C" fn(*const ClosureHeader, f64, f64, f64, f64, f64, f64) -> f64 =
-                std::mem::transmute(func_ptr);
-            f(closure, a!(0), a!(1), a!(2), a!(3), a!(4), a!(5))
-        }
-        7 => {
-            let f: extern "C" fn(*const ClosureHeader, f64, f64, f64, f64, f64, f64, f64) -> f64 =
-                std::mem::transmute(func_ptr);
-            f(closure, a!(0), a!(1), a!(2), a!(3), a!(4), a!(5), a!(6))
-        }
-        8 => {
-            let f: extern "C" fn(
-                *const ClosureHeader,
-                f64,
-                f64,
-                f64,
-                f64,
-                f64,
-                f64,
-                f64,
-                f64,
-            ) -> f64 = std::mem::transmute(func_ptr);
-            f(
-                closure,
-                a!(0),
-                a!(1),
-                a!(2),
-                a!(3),
-                a!(4),
-                a!(5),
-                a!(6),
-                a!(7),
-            )
-        }
-        _ => f64::from_bits(crate::value::TAG_UNDEFINED),
     }
 }
 


### PR DESCRIPTION
## What

Fixes the next codegen blocker in #3527: indirect/closure calls were capped at **16 args**, so the `qs` package failed to compile (its recursive `stringify` declares 18 params and self-calls with 18 args).

```
Error compiling module 'node_modules/qs/lib/stringify.js' ... with --backend llvm:
  perry-codegen: Call callee shape not supported (LocalGet) with 18 args
```

## Root cause

When a call's callee resolves through a local holding a closure (e.g. a recursive named function expression referencing itself — an indirect `LocalGet` callee), `try_lower_closure_call_fallthrough` (`crates/perry-codegen/src/lower_call/console_promise.rs`) only handled `args.len() <= 16`, dispatching via the per-arity `js_closure_call0..16` runtime helpers. Above 16 it returned `Ok(None)`, so `lower_call` bailed with "Call callee shape not supported".

Two latent runtime issues compounded it:
- `js_closure_call_array` (the existing variadic helper) had a catch-all arm that delegated to `js_closure_call16`, **silently dropping args past index 15**.
- `dispatch_with_arity` only had concrete transmute arms up to **8** (returning `undefined` above that), so a dynamically-dispatched 18-arg body would have been mis-called.

## Fix (4 files)

**Codegen** — `lower_call/console_promise.rs` + `runtime_decls/stdlib_ffi.rs`:
- Route calls with `>16` args through the existing `js_closure_call_array(closure, args_ptr, argc)`, marshaling args into an entry-block `[N x double]` stack alloca (mirrors the native-call marshaling pattern already in this file; entry-block alloca per #167 to avoid per-iteration stack growth).
- Declare `js_closure_call_array`'s pointer param as `PTR` (ABI-identical to `I64`) so the alloca passes directly.
- The `<=16` per-arity fast path is unchanged.

**Runtime** — `closure/dispatch.rs` + `closure/registry.rs`:
- `js_closure_call_array` catch-all arm now builds the full unboxed arg slice and dispatches through the strategy resolver (registered call → rest → declared arity) instead of dropping args past 15.
- `dispatch_with_arity` extended from 8 to **32** concrete arms via an `arm!` macro, so high-arity closures dispatched dynamically call their real N-arg signature.

## Verification

Rebuilt `perry-runtime` + `perry-stdlib` + `perry`, then with the new binary:

| case | path | result |
|------|------|--------|
| 3-arg indirect call | fast path | PASS → `123` |
| 16-arg indirect call | fast path (boundary) | PASS → `136` |
| 18-arg recursive self-call | array path | PASS → `153` ✓ |
| 20-arg recursive self-call | array path | PASS → `190` ✓ |

The 18/20-arg cases return the **correct numeric sums**, proving no args are dropped past index 15. Confirmed the 18-arg repro fails on `origin/main` (`Call callee shape not supported (LocalGet) with 18 args`) and passes here.

On the Express dependency tree, this clears the **last** remaining codegen failure (`qs/lib/stringify.js`) after the closure-display-name fix in #3537.

## Notes

- Stacked conceptually on #3537 (both #3527 follow-ups) but independent — this branch is off `main`.
- Version bump + changelog left for the maintainer per repo workflow.
