### PR TITLE
fix(compile): fail build on per-module codegen failure (#3527)

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -3854,6 +3854,24 @@ pub fn run_with_parse_cache(
             .map(|name| failed_modules.iter().any(|m| m == name))
             .unwrap_or(false);
 
+        // #3527: a per-module codegen failure produces a broken (or empty
+        // stub) object. The driver historically linked empty `<prefix>__init`
+        // stubs for *non-entry* failed modules and still reported success
+        // (`COMPILE_EXIT=0`). For a real program that's a false positive: the
+        // textbook Express app surfaced 49 modules failing codegen, linked
+        // anyway, and `Bus error: 10`d at launch with zero output. The exit
+        // code lied. Default to aborting the build on ANY module codegen
+        // failure so the failure is visible in the exit status. The old
+        // stub-link path — genuinely useful for the iterative "peel back one
+        // blocker at a time" debugging the issue author did — stays available
+        // behind `PERRY_ALLOW_PARTIAL_CODEGEN=1`.
+        let allow_partial = std::env::var_os("PERRY_ALLOW_PARTIAL_CODEGEN").is_some();
+        // A failed entry module always aborts: its `main` symbol is required
+        // by the linker and an empty `<prefix>__init` stub doesn't satisfy
+        // it. A non-entry failure aborts unless the partial-codegen hatch is
+        // set.
+        let will_abort = entry_failed || !allow_partial;
+
         let bar = "═".repeat(72);
         let (red_on, red_off, bold_on, bold_off) = if use_color {
             ("\x1b[1;31m", "\x1b[0m", "\x1b[1m", "\x1b[0m")
@@ -3861,23 +3879,28 @@ pub fn run_with_parse_cache(
             ("", "", "", "")
         };
         eprintln!();
+        eprintln!("{}{}{}", red_on, bar, red_off);
         if entry_failed {
-            eprintln!("{}{}{}", red_on, bar, red_off);
             eprintln!(
                 "{}✗ ENTRY MODULE FAILED TO COMPILE — REFUSING TO LINK{}",
                 red_on, red_off
             );
-            eprintln!("{}{}{}", red_on, bar, red_off);
+        } else if will_abort {
+            eprintln!(
+                "{}✗ {} module(s) failed to compile — REFUSING TO LINK{}",
+                red_on,
+                failed_modules.len(),
+                red_off
+            );
         } else {
-            eprintln!("{}{}{}", red_on, bar, red_off);
             eprintln!(
                 "{}⚠ {} module(s) failed to compile — linking with empty stubs{}",
                 red_on,
                 failed_modules.len(),
                 red_off
             );
-            eprintln!("{}{}{}", red_on, bar, red_off);
         }
+        eprintln!("{}{}{}", red_on, bar, red_off);
         eprintln!();
         for m in &failed_modules {
             let is_entry = Some(m.as_str()) == entry_module_name.as_deref();
@@ -3896,10 +3919,31 @@ pub fn run_with_parse_cache(
                 "entry module '{}' failed to compile (see errors above)",
                 entry_module_name.as_deref().unwrap_or("?")
             ));
+        } else if will_abort {
+            eprintln!(
+                "Aborting: {} module(s) above failed codegen. Linking the surviving",
+                failed_modules.len()
+            );
+            eprintln!("objects with empty stubs would produce a binary that crashes (Bus");
+            eprintln!("error / SIGSEGV) the moment any code in a failed module runs — so the");
+            eprintln!("build fails here rather than emitting a misleading COMPILE_EXIT=0.");
+            eprintln!();
+            eprintln!("Fix the codegen errors above (search for `Error compiling module`),");
+            eprintln!("or set `PERRY_ALLOW_PARTIAL_CODEGEN=1` to link empty `<prefix>__init`");
+            eprintln!("stubs for the failed modules and surface deeper errors during");
+            eprintln!("iterative debugging (the resulting binary is inert/unsafe in those");
+            eprintln!("modules and may crash at runtime).");
+            eprintln!();
+            return Err(anyhow!(
+                "{} module(s) failed to compile (see errors above); set \
+                 PERRY_ALLOW_PARTIAL_CODEGEN=1 to link empty stubs anyway",
+                failed_modules.len()
+            ));
         } else {
-            eprintln!("Continuing with linking. Empty `<prefix>__init` stubs will be");
-            eprintln!("emitted for the failed modules so the binary still links, but");
-            eprintln!("any code in those modules will be inert at runtime.");
+            eprintln!("PERRY_ALLOW_PARTIAL_CODEGEN=1 set: continuing with linking. Empty");
+            eprintln!("`<prefix>__init` stubs will be emitted for the failed modules so the");
+            eprintln!("binary still links, but any code in those modules will be inert at");
+            eprintln!("runtime (and may crash if actually invoked).");
             eprintln!();
         }
     }
@@ -4363,11 +4407,14 @@ pub fn run_with_parse_cache(
     });
 
     if !failed_modules.is_empty() {
-        // The loud failure summary + entry-module abort already ran
-        // earlier (right after the parallel compile loop), so by the
-        // time we get here we know the entry module compiled OK and
-        // every entry in `failed_modules` is a non-entry module that
-        // we're consciously stubbing out so the binary can still link.
+        // The loud failure summary + abort already ran earlier (right
+        // after the parallel compile loop). #3527: reaching this block
+        // with a non-empty `failed_modules` now implies the caller set
+        // `PERRY_ALLOW_PARTIAL_CODEGEN=1` — without it, any module failure
+        // returns `Err` up there. So by the time we get here we know the
+        // entry module compiled OK and every entry in `failed_modules` is
+        // a non-entry module the caller has explicitly opted to stub out
+        // so the binary can still link.
         // Generate one empty `<prefix>__init` per failed module — the
         // entry main and any consumer module call each non-entry init
         // in order, so the symbols need to exist or the linker fails.


### PR DESCRIPTION
## What

Fixes item **#7(b)** of #3527 — the silent-build-failure masking bug.

The compile driver linked empty `<prefix>__init` stubs for any **non-entry** module that failed codegen and still reported success (`COMPILE_EXIT=0`). For a real program that's a false positive: the textbook Express app in #3527 surfaced **49 modules failing codegen**, linked the surviving objects anyway, and `Bus error: 10`d at launch with zero output. The exit code lied, which masked the underlying `@perry_closure_*` codegen bug (#7a) as a "successful" build.

## Change

`crates/perry/src/commands/compile.rs` — the post-codegen failure-summary block now **aborts the build on ANY module codegen failure** by default:

- Non-zero exit + loud `✗ N module(s) failed to compile — REFUSING TO LINK` summary.
- The entry-module hard-fail behavior is unchanged.
- The old "link with empty stubs" path — genuinely useful for the iterative "peel back one blocker at a time" debugging the issue author did — stays available behind a new `PERRY_ALLOW_PARTIAL_CODEGEN=1` escape hatch.

The error message itself documents the hatch, so the surface is self-explaining.

## Verification

Built `perry` and ran three cases (multi-module program; `helper.ts` triggers a real codegen failure via a >16-arg indirect call through a local):

| Case | Result |
|------|--------|
| Happy-path program (no failures) | `COMPILE_EXIT=0`, runs correctly — **no regression** |
| Codegen failure, default | `COMPILE_EXIT=1`, **no binary**, loud REFUSING-TO-LINK |
| Codegen failure + `PERRY_ALLOW_PARTIAL_CODEGEN=1` | `COMPILE_EXIT=0`, binary linked with stubs (old behavior preserved) |

`cargo fmt --all -- --check` is clean.

## Scope / follow-ups

Deliberately scoped to #7(b) only. Not touched here (separate concerns, some in flight by another agent): #7(a) the `@perry_closure_*` undefined-symbol codegen bug, the high-arity indirect-call work, the `"*"` wildcard compile-routing no-op (#4), and the eval-family / stdlib-surface gaps.
