### PR TITLE
fix(compile): honor "*"/"@scope/*" wildcard in perry.compilePackages routing (#3527)

### DIFF
--- a/crates/perry/src/commands/compile/host_config.rs
+++ b/crates/perry/src/commands/compile/host_config.rs
@@ -477,6 +477,53 @@ pub(super) fn apply_pkg_and_toml_config(
         ctx.lockdown = true;
     }
 
+    // #3527 (blocker #4): materialize `"*"` / `"@scope/*"` wildcard entries
+    // in `perry.compilePackages` into concrete installed package names.
+    //
+    // The *trust* gate (`allowlist_matches`, used for the #497 check below and
+    // for `perry.allow.compilePackages`) honors `"*"`, but the *routing*
+    // predicates — `is_in_compile_package`, the HIR `COMPILE_PACKAGES_OVERRIDE`
+    // lookup, and the many `ctx.compile_packages.contains(name)` sites — all do
+    // exact package-name matching. So a literal `"*"` passed the trust gate yet
+    // was a silent no-op for compile routing: every dependency still routed to
+    // the (removed) JS runtime. Expanding it here makes "compile everything"
+    // actually compile everything, and removes the need to hand-enumerate every
+    // transitive dependency (the Express tree is 65 packages). This runs after
+    // the env-var overrides so `PERRY_ALLOW_PERRY_FEATURES=1` builds expand too.
+    let has_universal = ctx.compile_packages.iter().any(|p| p == "*");
+    let scope_wildcards: Vec<String> = ctx
+        .compile_packages
+        .iter()
+        .filter_map(|p| p.strip_suffix("/*").map(|s| s.to_string()))
+        .collect();
+    if has_universal || !scope_wildcards.is_empty() {
+        let installed = super::resolve::enumerate_installed_packages(project_root);
+        let mut added = 0usize;
+        for name in installed {
+            let matches = has_universal
+                || scope_wildcards.iter().any(|scope| {
+                    name.strip_prefix(scope.as_str())
+                        .map(|rest| rest.starts_with('/'))
+                        .unwrap_or(false)
+                });
+            if matches && ctx.compile_packages.insert(name) {
+                added += 1;
+            }
+        }
+        // Drop the literal wildcard tokens: they never match a real
+        // node_modules path in the routing predicates, so leaving them in would
+        // just be dead entries (and `is_in_compile_package` would search for a
+        // nonsensical `node_modules/*/` substring).
+        ctx.compile_packages
+            .retain(|p| p != "*" && !p.ends_with("/*"));
+        if let OutputFormat::Text = format {
+            println!(
+                "  Compile package wildcard: expanded to {} installed package(s)",
+                added
+            );
+        }
+    }
+
     // #497: deferred allowlist check for `perry.compilePackages` (the
     // parse loop populated `ctx.compile_packages` above; we validate
     // after env-var overrides). Every entry that flowed in needs a

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -171,6 +171,72 @@ pub(super) fn is_in_compile_package(path: &Path, compile_packages: &HashSet<Stri
     false
 }
 
+/// Enumerate every installed package name reachable from `project_root`'s
+/// `node_modules` tree (the nearest one walking up, plus any nested
+/// `node_modules` directories for transitive deps npm chose not to hoist).
+///
+/// Used by #3527 to materialize the `"*"` / `"@scope/*"` wildcard entries in
+/// `perry.compilePackages` into concrete package names. The routing
+/// predicates (`is_in_compile_package`, the HIR `COMPILE_PACKAGES_OVERRIDE`,
+/// and the many `compile_packages.contains(name)` sites) all match exact
+/// package names, so the wildcard has to be expanded before routing or it is a
+/// silent no-op. Returns scoped names as `@scope/name`.
+pub(super) fn enumerate_installed_packages(project_root: &Path) -> HashSet<String> {
+    let mut out = HashSet::new();
+    if let Some(nm) = find_node_modules(project_root) {
+        collect_packages_in_node_modules(&nm, &mut out);
+    }
+    out
+}
+
+/// Walk a single `node_modules` directory, recording each package name and
+/// recursing into any nested `node_modules` it contains.
+fn collect_packages_in_node_modules(node_modules: &Path, out: &mut HashSet<String>) {
+    let entries = match fs::read_dir(node_modules) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        // Skip npm bookkeeping dirs (`.bin`, `.cache`, `.package-lock.json`).
+        if name.starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        if name.starts_with('@') {
+            // Scope directory: each child is a `@scope/pkg`.
+            if let Ok(scoped) = fs::read_dir(&path) {
+                for sub in scoped.flatten() {
+                    let sub_name = sub.file_name();
+                    let sub_name = sub_name.to_string_lossy();
+                    if sub_name.starts_with('.') {
+                        continue;
+                    }
+                    let sub_path = sub.path();
+                    if !sub_path.is_dir() {
+                        continue;
+                    }
+                    out.insert(format!("{}/{}", name, sub_name));
+                    let nested = sub_path.join("node_modules");
+                    if nested.is_dir() {
+                        collect_packages_in_node_modules(&nested, out);
+                    }
+                }
+            }
+            continue;
+        }
+        out.insert(name.to_string());
+        let nested = path.join("node_modules");
+        if nested.is_dir() {
+            collect_packages_in_node_modules(&nested, out);
+        }
+    }
+}
+
 /// Find node_modules directory starting from a given path
 pub(super) fn find_node_modules(start: &Path) -> Option<PathBuf> {
     let mut current = start.to_path_buf();

--- a/crates/perry/src/commands/compile/resolve/tests.rs
+++ b/crates/perry/src/commands/compile/resolve/tests.rs
@@ -1480,4 +1480,49 @@ mod declaration_sidecar_tests {
         assert!(is_declaration_file(Path::new("index.d.cts")));
         assert!(!is_declaration_file(Path::new("index.ts")));
     }
+
+    /// #3527 (blocker #4): `enumerate_installed_packages` must surface every
+    /// package name in the `node_modules` tree — flat deps, `@scope/pkg`
+    /// entries, and transitive deps nested under a package's own
+    /// `node_modules` — so the `"*"` / `"@scope/*"` wildcard in
+    /// `perry.compilePackages` can be expanded into concrete names. npm
+    /// bookkeeping dirs (`.bin`, `.cache`) must be skipped.
+    #[test]
+    fn enumerate_installed_packages_covers_flat_scoped_and_nested() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let nm = root.join("node_modules");
+
+        // Flat deps + npm bookkeeping that must be ignored.
+        std::fs::create_dir_all(nm.join("express")).expect("mkdir express");
+        std::fs::create_dir_all(nm.join("qs")).expect("mkdir qs");
+        std::fs::create_dir_all(nm.join(".bin")).expect("mkdir .bin");
+        std::fs::create_dir_all(nm.join(".cache")).expect("mkdir .cache");
+        std::fs::write(nm.join(".package-lock.json"), b"{}").expect("write lockfile");
+
+        // Scoped package.
+        std::fs::create_dir_all(nm.join("@scope/pkg")).expect("mkdir @scope/pkg");
+
+        // Transitive dep npm chose not to hoist (nested node_modules), plus a
+        // nested scoped dep two levels down.
+        std::fs::create_dir_all(nm.join("express/node_modules/nested-dep"))
+            .expect("mkdir nested-dep");
+        std::fs::create_dir_all(nm.join("express/node_modules/@deep/leaf"))
+            .expect("mkdir @deep/leaf");
+
+        let found = enumerate_installed_packages(root);
+
+        assert!(found.contains("express"), "flat dep");
+        assert!(found.contains("qs"), "flat dep");
+        assert!(found.contains("@scope/pkg"), "scoped dep");
+        assert!(found.contains("nested-dep"), "nested transitive dep");
+        assert!(found.contains("@deep/leaf"), "nested scoped dep");
+        assert!(!found.contains(".bin"), "npm bin dir skipped");
+        assert!(!found.contains(".cache"), "npm cache dir skipped");
+        assert!(
+            !found.contains(".package-lock.json"),
+            "lockfile (a file, not a dir) skipped"
+        );
+        assert_eq!(found.len(), 5, "exactly the five real packages");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes **blocker #4** of the Express-compile inventory (#3527): the `"*"` (and `"@scope/*"`) wildcard in `perry.compilePackages` was honored by the *trust* gate but silently ignored by *compile routing*, so `compilePackages: ["*"]` left every dependency routed to the (removed) JS runtime — strictly worse than naming each package.

## Root cause

`allowlist_matches` (the #497 trust gate, and `perry.allow.compilePackages`) honors `"*"`/`"@scope/*"`. But the routing predicates all do **exact package-name matching**:
- `is_in_compile_package` (substring `node_modules/<pkg>/`)
- the HIR `COMPILE_PACKAGES_OVERRIDE` lookup in `is_native_module`
- every `ctx.compile_packages.contains(name)` site

So a literal `"*"` passed the trust gate, then matched no real package path → the natural "compile everything" ergonomic was a no-op.

## Fix

Expand the wildcard into concrete installed package names at config-load time:
- **`enumerate_installed_packages`** (resolve.rs) walks the project `node_modules` tree — flat deps, `@scope/pkg`, and non-hoisted transitive deps under nested `node_modules` — skipping npm bookkeeping dirs (`.bin`, `.cache`).
- **`apply_pkg_and_toml_config`** (host_config.rs) materializes `"*"`/`"@scope/*"` into those names *before* the #497 check and routing, then drops the literal wildcard tokens. Runs after env-var overrides so `PERRY_ALLOW_PERRY_FEATURES=1` builds expand too.

Every downstream routing check then works unchanged. This also removes the need to hand-enumerate every transitive dependency — the Express tree is 65 packages.

## Verification

- **Express 5.2.1**, `compilePackages: ["*"]` + `allow.compilePackages: ["*"]`: now prints `Compile package wildcard: expanded to 65 installed package(s)` and routes **129 modules: 129 native, 0 JavaScript** — identical to the hand-enumerated 65-package config — and compiles to a native binary (with the documented eval/unimplemented escape hatches). Previously `express` routed to V8 immediately.
- **Unit test** `enumerate_installed_packages_covers_flat_scoped_and_nested` covers flat/scoped/nested enumeration and skipping of npm bookkeeping dirs.
- `cargo fmt --all -- --check` clean; `cargo check -p perry` clean (only pre-existing warnings).

## Scope / remaining #3527 chain

This closes the last self-contained **compile-routing** bug in the chain. Already merged: #3537 (7a closure display-name), #3543 (qs high-arity indirect call), #3546 (7b fail-build-on-codegen-error). Remaining blockers are large, separately-tracked features: #5 eval/`new Function` (#1677, depd/function-bind), #6 `buffer.hasOwnProperty` (#463), and runtime-layer #1021 (async self-fetch) / #3272 (IncomingMessage.headers).

No version bump / changelog entry — folded in at merge per the worktree-PR convention.
