### PR TITLE
chore(parity): parallel gap radar + current gap report

### DIFF
--- a/scripts/parity_gap_report.py
+++ b/scripts/parity_gap_report.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Fast, PARALLEL parity-gap radar over test262 + Node core, emitting ONE
+severity-sorted JSON report of every failing case.
+
+Why this exists
+---------------
+`scripts/test262_subset.py` and `scripts/node_core_subset.py` are strictly
+serial (one `for` loop) and only keep `--sample-cap` example failures per
+bucket. A full test262 sweep that way is ~16h and never lists every failure.
+
+A single Perry compile is ~1.0s wall but only ~0.2s CPU (it's link/spawn
+bound), so the machine's other cores sit idle. This driver fans the per-case
+work out across a process pool and records EVERY non-pass case, then writes a
+report sorted worst-first:
+
+    compile-fail (3)  > runtime-fail (2)  > diff / wrong-output (1)
+
+It REUSES the discovery / assembly / normalization helpers from the two
+existing radars so the verdicts stay identical to the canonical runners — this
+is purely a parallel, full-capture wrapper.
+
+Usage
+-----
+    # representative fast pass (~15-20 min): sample each category + all node-core
+    scripts/parity_gap_report.py --sample-per-cat 150
+
+    # full exhaustive sweep (~1.5-2h): every applicable case
+    scripts/parity_gap_report.py
+
+    # just one corpus / scope
+    scripts/parity_gap_report.py --corpus test262 --dir built-ins/RegExp
+    scripts/parity_gap_report.py --corpus node-core --api buffer fs
+
+Notes
+-----
+* node-core's auto-optimize APIs (http/net/https/zlib/crypto/events) need a
+  workspace-cwd ext-crate relink that is NOT parallel-safe, so this quick radar
+  runs every API under PERRY_NO_AUTO_OPTIMIZE. Those APIs may show inflated
+  compile/runtime-fail counts (link artifacts, not real gaps) — each such
+  failure is tagged `auto_optimize_api: true` in the report. For a *final*
+  measurement of those, use scripts/node_core_subset.py --auto-optimize.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import test262_subset as T262  # noqa: E402
+import node_core_subset as NC  # noqa: E402
+
+SEVERITY_RANK = {"compile-fail": 3, "runtime-fail": 2, "diff": 1}
+
+# Process-global state set once per worker via the pool initializer.
+_W: dict = {}
+
+
+# --------------------------------------------------------------------------
+# worker setup
+# --------------------------------------------------------------------------
+def _init_worker(perry_bin: str, timeout: int, use_lld: bool,
+                 t262_root: str, t262_harness: str, t262_preamble: str,
+                 nc_root: str, nc_fixtures: str) -> None:
+    env = dict(os.environ)
+    env.update(FORCE_COLOR="0", NO_COLOR="1", NODE_DISABLE_COLORS="1",
+               PERRY_ALLOW_UNIMPLEMENTED="1", PERRY_NO_AUTO_OPTIMIZE="1",
+               PERRY_NO_CACHE="1")
+    if use_lld:
+        env["PERRY_LLD_LINK"] = "1"
+    _W["perry"] = perry_bin
+    _W["timeout"] = timeout
+    _W["base_env"] = env
+    _W["t262_root"] = Path(t262_root)
+    _W["t262_harness"] = Path(t262_harness)
+    _W["t262_preamble"] = t262_preamble
+    _W["nc_root"] = Path(nc_root)
+    _W["nc_fixtures"] = nc_fixtures
+
+
+def _judge_test262(rel: str) -> dict | None:
+    """Compile+run one assembled test262 case. Returns a failure record or
+    None on pass / skip. Mirrors test262_subset.main()'s classification."""
+    test_root = _W["t262_root"] / "test"
+    path = test_root / rel
+    try:
+        src = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        return None  # vanished between discovery and run
+    meta = T262.parse_frontmatter(src)
+    if meta is None:
+        return None
+    try:
+        program = T262.assemble(src, meta, _W["t262_harness"], _W["t262_preamble"])
+    except OSError:
+        return None  # missing include -> skip (matches canonical runner)
+
+    env = _W["base_env"]
+    to = _W["timeout"]
+    with tempfile.TemporaryDirectory(prefix="t262w-") as d:
+        dp = Path(d)
+        staged = dp / "case.js"
+        staged.write_text(program)
+        out_bin = dp / "case.out"
+
+        n_exit, n_out = NC.run(["node", str(staged)], env, to)
+        node_clean = n_exit == 0
+
+        c_exit, c_out = NC.run(
+            [_W["perry"], "compile", str(staged), "-o", str(out_bin)],
+            env, to, cwd=str(dp))
+
+        if c_exit != 0:
+            if node_clean:
+                return _rec("test262", T262.top_dir(rel), rel, "compile-fail",
+                            T262.error_line(c_out))
+            return None  # negative case, both reject -> pass
+
+        p_exit, p_out = NC.run([str(out_bin)], env, to)
+        perry_clean = p_exit == 0
+        if node_clean and perry_clean:
+            if T262.normalize(p_out) == T262.normalize(n_out):
+                return None
+            return _rec("test262", T262.top_dir(rel), rel, "diff",
+                        T262.first_line(p_out))
+        if node_clean and not perry_clean:
+            return _rec("test262", T262.top_dir(rel), rel, "runtime-fail",
+                        T262.first_line(p_out))
+        if not node_clean and not perry_clean:
+            return None  # negative case, both reject -> pass
+        return _rec("test262", T262.top_dir(rel), rel, "runtime-fail",
+                    "Perry ran clean; Node rejected (missed negative)")
+
+
+def _judge_nodecore(api: str, test_file: str) -> dict | None:
+    """Compile+run one Node core test under the common/ shim. Mirrors
+    node_core_subset.main()'s classification (no auto-optimize)."""
+    env = _W["base_env"]
+    to = _W["timeout"]
+    ao = api in NC._AUTO_OPTIMIZE_APIS
+    with tempfile.TemporaryDirectory(prefix="ncw-") as d:
+        dp = Path(d)
+        common = dp / "common"
+        common.mkdir()
+        for name, src in (("index.js", "index.js"),
+                          ("tmpdir.js", "tmpdir.js"),
+                          ("fixtures.js", "fixtures.js")):
+            shutil.copy(NC.SHIM_DIR / src, common / name)
+        if _W["nc_fixtures"]:
+            try:
+                (dp / "fixtures").symlink_to(_W["nc_fixtures"],
+                                             target_is_directory=True)
+            except OSError:
+                pass
+        par = dp / "parallel"
+        par.mkdir()
+        staged = par / Path(test_file).name
+        shutil.copy(test_file, staged)
+        out_bin = dp / "case.out"
+
+        run_env = dict(env)
+        if _W["nc_fixtures"]:
+            run_env["PERRY_NODE_CORE_FIXTURES"] = _W["nc_fixtures"]
+
+        n_exit, n_out = NC.run(["node", str(staged)], run_env, to)
+        if n_exit != 0:
+            return None  # node-skip — never charged against Perry
+
+        c_exit, c_out = NC.run(
+            [_W["perry"], "compile", str(staged), "-o", str(out_bin)],
+            run_env, to, cwd=str(par))
+        if c_exit != 0:
+            return _rec("node-core", api, Path(test_file).name, "compile-fail",
+                        NC.error_line(c_out), auto_optimize_api=ao)
+
+        p_exit, p_out = NC.run([str(out_bin)], run_env, to)
+        if p_exit != 0:
+            return _rec("node-core", api, Path(test_file).name, "runtime-fail",
+                        NC.first_meaningful_line(p_out), auto_optimize_api=ao)
+        if NC.normalize(p_out) == NC.normalize(n_out):
+            return None
+        return _rec("node-core", api, Path(test_file).name, "diff",
+                    NC.first_meaningful_line(p_out), auto_optimize_api=ao)
+
+
+def _rec(corpus: str, category: str, test: str, severity: str, reason: str,
+         **extra) -> dict:
+    r = {"corpus": corpus, "category": category, "test": test,
+         "severity": severity, "severity_rank": SEVERITY_RANK[severity],
+         "reason": (reason or "")[:300]}
+    r.update(extra)
+    return r
+
+
+# dispatch one work item (picklable top-level fn for the pool)
+def _run_item(item: tuple) -> dict | None:
+    kind = item[0]
+    if kind == "t262":
+        return _judge_test262(item[1])
+    return _judge_nodecore(item[1], item[2])
+
+
+# --------------------------------------------------------------------------
+# work-list construction (parent process)
+# --------------------------------------------------------------------------
+def build_test262_items(root: Path, dirs, all_features: bool,
+                        sample_per_cat: int) -> list[tuple]:
+    applicable = set(T262.read_list(T262.TEST262_DIR / "features-applicable.txt"))
+    per_cat: dict[str, int] = {}
+    items: list[tuple] = []
+    for rel, _src, _meta in T262.discover(root, dirs, applicable, all_features):
+        cat = T262.top_dir(rel)
+        if sample_per_cat and per_cat.get(cat, 0) >= sample_per_cat:
+            continue
+        per_cat[cat] = per_cat.get(cat, 0) + 1
+        items.append(("t262", rel))
+    return items
+
+
+def build_nodecore_items(root: Path, apis, max_per_api: int) -> list[tuple]:
+    items: list[tuple] = []
+    for api in apis:
+        tests = NC.resolve_tests(root, api)
+        if max_per_api:
+            tests = tests[:max_per_api]
+        for tf in tests:
+            items.append(("nc", api, str(tf)))
+    return items
+
+
+def build_report(failures: list[dict], cases_judged: int, elapsed: float,
+                 perry_bin: str, config: dict) -> dict:
+    """Sort failures worst-first and roll up the severity/corpus/category
+    breakdowns. Shared by the live run and `--rebuild-from`."""
+    failures = sorted(failures, key=lambda r: (-r.get("severity_rank", 0),
+                                               r.get("corpus", ""),
+                                               r.get("category", ""),
+                                               r.get("test", "")))
+    by_sev: dict[str, int] = {}
+    by_corpus: dict[str, int] = {}
+    by_cat: dict[str, dict[str, int]] = {}
+    for r in failures:
+        by_sev[r["severity"]] = by_sev.get(r["severity"], 0) + 1
+        by_corpus[r["corpus"]] = by_corpus.get(r["corpus"], 0) + 1
+        c = by_cat.setdefault(f'{r["corpus"]}:{r["category"]}',
+                              {"compile-fail": 0, "runtime-fail": 0, "diff": 0})
+        c[r["severity"]] += 1
+    return {
+        "generated_unix": int(time.time()),
+        "elapsed_seconds": round(elapsed, 1),
+        "perry_bin": perry_bin,
+        "config": config,
+        "summary": {
+            "cases_judged": cases_judged,
+            "total_failures": len(failures),
+            "by_severity": dict(sorted(by_sev.items(),
+                                       key=lambda kv: -SEVERITY_RANK.get(kv[0], 0))),
+            "by_corpus": by_corpus,
+            "by_category": dict(sorted(by_cat.items(),
+                                       key=lambda kv: -sum(kv[1].values()))),
+        },
+        "failures": failures,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Parallel parity-gap radar (#799/#800)")
+    ap.add_argument("--corpus", default="test262,node-core",
+                    help="comma list: test262, node-core (default both)")
+    ap.add_argument("--workers", type=int, default=max(2, (os.cpu_count() or 4) + 2),
+                    help="parallel workers (default cpu+2; compiles are link-bound)")
+    ap.add_argument("--timeout", type=int, default=5, help="per-step timeout (s)")
+    ap.add_argument("--no-lld", action="store_true", help="don't force PERRY_LLD_LINK")
+    # test262 scope
+    ap.add_argument("--dir", nargs="*", default=list(T262.DEFAULT_DIRS))
+    ap.add_argument("--all-features", action="store_true")
+    ap.add_argument("--sample-per-cat", type=int, default=0,
+                    help="cap test262 cases per top-dir category (0 = all)")
+    # node-core scope
+    ap.add_argument("--api", nargs="*", default=None)
+    ap.add_argument("--max-per-api", type=int, default=0)
+    # io
+    ap.add_argument("--perry-bin", type=Path,
+                    default=REPO_ROOT / "target" / "release" / "perry")
+    ap.add_argument("--out", type=Path,
+                    default=REPO_ROOT / "test-compat" / "parity_gaps_report.json")
+    ap.add_argument("--rebuild-from", type=Path, default=None,
+                    help="reconstruct the sorted report from a partial "
+                         ".partial.jsonl (e.g. after a crash) and exit")
+    args = ap.parse_args()
+
+    if args.rebuild_from is not None:
+        failures = []
+        for line in args.rebuild_from.read_text().splitlines():
+            line = line.strip()
+            if line:
+                failures.append(json.loads(line))
+        report = build_report(failures, cases_judged=len(failures), elapsed=0.0,
+                              perry_bin=str(args.perry_bin),
+                              config={"rebuilt_from": str(args.rebuild_from)})
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(report, indent=2) + "\n")
+        print(f"rebuilt {len(failures)} failures -> {args.out}", file=sys.stderr)
+        print(f"  by severity: {report['summary']['by_severity']}", file=sys.stderr)
+        return 0
+
+    corpora = {c.strip() for c in args.corpus.split(",") if c.strip()}
+    if not args.perry_bin.exists():
+        print(f"error: perry binary not found at {args.perry_bin} "
+              f"(cargo build --release -p perry)", file=sys.stderr)
+        return 2
+
+    t262_root = (REPO_ROOT / "vendor" / "test262").resolve()
+    nc_root = (REPO_ROOT / "vendor" / "nodejs").resolve()
+    nc_fixtures = nc_root / "test" / "fixtures"
+    nc_fixtures_s = str(nc_fixtures) if nc_fixtures.is_dir() else ""
+
+    items: list[tuple] = []
+    if "test262" in corpora:
+        if not (t262_root / "test").is_dir():
+            print(f"warn: test262 not vendored at {t262_root}, skipping",
+                  file=sys.stderr)
+        else:
+            items += build_test262_items(t262_root, args.dir, args.all_features,
+                                         args.sample_per_cat)
+    if "node-core" in corpora:
+        apis = args.api or NC.read_api_list(NC.NODE_CORE_DIR / "supported-apis.txt")
+        if not (nc_root / "test" / "parallel").is_dir():
+            print(f"warn: node corpus not vendored at {nc_root}, skipping",
+                  file=sys.stderr)
+        else:
+            items += build_nodecore_items(nc_root, apis, args.max_per_api)
+
+    total = len(items)
+    print(f"radar: {total} cases | {args.workers} workers | timeout {args.timeout}s "
+          f"| lld {'off' if args.no_lld else 'on'}", file=sys.stderr)
+    if total == 0:
+        print("nothing to run", file=sys.stderr)
+        return 1
+
+    t0 = time.time()
+    failures: list[dict] = []
+    judged = 0
+    init_args = (str(args.perry_bin), args.timeout, not args.no_lld,
+                 str(t262_root), str(t262_root / "harness"),
+                 (T262.PREAMBLE.read_text() if T262.PREAMBLE.exists() else ""),
+                 str(nc_root), nc_fixtures_s)
+
+    # Crash-safe streaming: every failure is flushed to a JSONL sidecar the
+    # instant it's judged, so an OOM/kill mid-run loses nothing already found
+    # (the previous all-in-memory design lost ~3.9k results to an OOM at 95%).
+    # The final sorted report is rebuilt from this file at the end; if the run
+    # dies, `--rebuild-from <jsonl>` reconstructs the report from the partial.
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    jsonl_path = args.out.with_suffix(".partial.jsonl")
+    jf = jsonl_path.open("w")
+    try:
+        with ProcessPoolExecutor(max_workers=args.workers,
+                                 initializer=_init_worker,
+                                 initargs=init_args) as ex:
+            futs = [ex.submit(_run_item, it) for it in items]
+            for fut in as_completed(futs):
+                judged += 1
+                if judged % 250 == 0 or judged == total:
+                    el = time.time() - t0
+                    rate = judged / el if el else 0
+                    eta = (total - judged) / rate if rate else 0
+                    print(f"  {judged}/{total}  fails={len(failures)}  "
+                          f"{rate:.1f}/s  eta {eta/60:.1f}m", file=sys.stderr)
+                try:
+                    rec = fut.result()
+                except Exception:  # noqa: BLE001 — never let one case kill the run
+                    rec = None
+                if rec is not None:
+                    failures.append(rec)
+                    jf.write(json.dumps(rec) + "\n")
+                    jf.flush()  # durable per-case so a crash loses nothing
+    finally:
+        jf.close()
+
+    elapsed = time.time() - t0
+    report = build_report(failures, cases_judged=total, elapsed=elapsed,
+                          perry_bin=str(args.perry_bin),
+                          config={
+                              "corpus": sorted(corpora), "workers": args.workers,
+                              "timeout": args.timeout, "lld": not args.no_lld,
+                              "sample_per_cat": args.sample_per_cat,
+                              "max_per_api": args.max_per_api,
+                              "all_features": args.all_features,
+                          })
+    args.out.write_text(json.dumps(report, indent=2) + "\n")
+    try:
+        jsonl_path.unlink()  # full report written; partial no longer needed
+    except OSError:
+        pass
+
+    print(f"\ndone in {elapsed/60:.1f}m | {len(failures)} failures "
+          f"of {total} judged", file=sys.stderr)
+    print(f"  by severity: {report['summary']['by_severity']}", file=sys.stderr)
+    print(f"  report: {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test-compat/parity_gaps_report.json
+++ b/test-compat/parity_gaps_report.json
@@ -1,0 +1,22938 @@
+{
+  "generated_unix": 1780216897,
+  "elapsed_seconds": 2127.7,
+  "perry_bin": "/Users/amlug/projects/perry/perry/target/release/perry",
+  "config": {
+    "corpus": [
+      "node-core",
+      "test262"
+    ],
+    "workers": 6,
+    "timeout": 8,
+    "lld": true,
+    "sample_per_cat": 60,
+    "max_per_api": 0,
+    "all_features": false
+  },
+  "summary": {
+    "cases_judged": 4759,
+    "total_failures": 2687,
+    "by_severity": {
+      "compile-fail": 407,
+      "runtime-fail": 2146,
+      "diff": 134
+    },
+    "by_corpus": {
+      "node-core": 958,
+      "test262": 1729
+    },
+    "by_category": {
+      "node-core:http": {
+        "compile-fail": 212,
+        "runtime-fail": 59,
+        "diff": 0
+      },
+      "node-core:stream": {
+        "compile-fail": 9,
+        "runtime-fail": 125,
+        "diff": 1
+      },
+      "node-core:net": {
+        "compile-fail": 87,
+        "runtime-fail": 11,
+        "diff": 0
+      },
+      "node-core:fs": {
+        "compile-fail": 1,
+        "runtime-fail": 84,
+        "diff": 7
+      },
+      "node-core:child_process": {
+        "compile-fail": 13,
+        "runtime-fail": 48,
+        "diff": 1
+      },
+      "test262:built-ins/DataView": {
+        "compile-fail": 0,
+        "runtime-fail": 54,
+        "diff": 0
+      },
+      "test262:built-ins/TypedArray": {
+        "compile-fail": 0,
+        "runtime-fail": 54,
+        "diff": 0
+      },
+      "test262:built-ins/Promise": {
+        "compile-fail": 0,
+        "runtime-fail": 24,
+        "diff": 29
+      },
+      "test262:language/eval-code": {
+        "compile-fail": 0,
+        "runtime-fail": 52,
+        "diff": 0
+      },
+      "test262:built-ins/Proxy": {
+        "compile-fail": 0,
+        "runtime-fail": 51,
+        "diff": 0
+      },
+      "test262:built-ins/Reflect": {
+        "compile-fail": 0,
+        "runtime-fail": 51,
+        "diff": 0
+      },
+      "test262:built-ins/WeakSet": {
+        "compile-fail": 0,
+        "runtime-fail": 50,
+        "diff": 0
+      },
+      "test262:built-ins/Function": {
+        "compile-fail": 0,
+        "runtime-fail": 49,
+        "diff": 0
+      },
+      "test262:built-ins/WeakMap": {
+        "compile-fail": 0,
+        "runtime-fail": 48,
+        "diff": 0
+      },
+      "node-core:process": {
+        "compile-fail": 3,
+        "runtime-fail": 39,
+        "diff": 3
+      },
+      "node-core:zlib": {
+        "compile-fail": 2,
+        "runtime-fail": 42,
+        "diff": 1
+      },
+      "test262:built-ins/Date": {
+        "compile-fail": 0,
+        "runtime-fail": 45,
+        "diff": 0
+      },
+      "node-core:https": {
+        "compile-fail": 37,
+        "runtime-fail": 7,
+        "diff": 0
+      },
+      "test262:built-ins/AsyncGeneratorPrototype": {
+        "compile-fail": 0,
+        "runtime-fail": 21,
+        "diff": 23
+      },
+      "test262:built-ins/BigInt": {
+        "compile-fail": 0,
+        "runtime-fail": 44,
+        "diff": 0
+      },
+      "test262:built-ins/Array": {
+        "compile-fail": 0,
+        "runtime-fail": 43,
+        "diff": 0
+      },
+      "test262:built-ins/Map": {
+        "compile-fail": 0,
+        "runtime-fail": 43,
+        "diff": 0
+      },
+      "test262:built-ins/GeneratorPrototype": {
+        "compile-fail": 0,
+        "runtime-fail": 42,
+        "diff": 0
+      },
+      "test262:built-ins/Set": {
+        "compile-fail": 0,
+        "runtime-fail": 42,
+        "diff": 0
+      },
+      "test262:language/arguments-object": {
+        "compile-fail": 0,
+        "runtime-fail": 24,
+        "diff": 18
+      },
+      "test262:language/expressions": {
+        "compile-fail": 0,
+        "runtime-fail": 42,
+        "diff": 0
+      },
+      "test262:built-ins/NativeErrors": {
+        "compile-fail": 0,
+        "runtime-fail": 41,
+        "diff": 0
+      },
+      "test262:built-ins/TypedArrayConstructors": {
+        "compile-fail": 0,
+        "runtime-fail": 41,
+        "diff": 0
+      },
+      "test262:built-ins/Object": {
+        "compile-fail": 0,
+        "runtime-fail": 40,
+        "diff": 0
+      },
+      "test262:built-ins/Number": {
+        "compile-fail": 0,
+        "runtime-fail": 39,
+        "diff": 0
+      },
+      "test262:built-ins/RegExp": {
+        "compile-fail": 0,
+        "runtime-fail": 39,
+        "diff": 0
+      },
+      "node-core:buffer": {
+        "compile-fail": 1,
+        "runtime-fail": 36,
+        "diff": 1
+      },
+      "test262:language/directive-prologue": {
+        "compile-fail": 12,
+        "runtime-fail": 24,
+        "diff": 0
+      },
+      "test262:built-ins/JSON": {
+        "compile-fail": 0,
+        "runtime-fail": 36,
+        "diff": 0
+      },
+      "test262:built-ins/String": {
+        "compile-fail": 0,
+        "runtime-fail": 34,
+        "diff": 0
+      },
+      "node-core:crypto": {
+        "compile-fail": 0,
+        "runtime-fail": 30,
+        "diff": 3
+      },
+      "test262:built-ins/ArrayBuffer": {
+        "compile-fail": 0,
+        "runtime-fail": 33,
+        "diff": 0
+      },
+      "test262:built-ins/Error": {
+        "compile-fail": 0,
+        "runtime-fail": 33,
+        "diff": 0
+      },
+      "test262:built-ins/Symbol": {
+        "compile-fail": 0,
+        "runtime-fail": 33,
+        "diff": 0
+      },
+      "test262:language/computed-property-names": {
+        "compile-fail": 0,
+        "runtime-fail": 32,
+        "diff": 0
+      },
+      "test262:language/statements": {
+        "compile-fail": 0,
+        "runtime-fail": 7,
+        "diff": 24
+      },
+      "test262:built-ins/Boolean": {
+        "compile-fail": 0,
+        "runtime-fail": 30,
+        "diff": 0
+      },
+      "test262:language/statementList": {
+        "compile-fail": 0,
+        "runtime-fail": 30,
+        "diff": 0
+      },
+      "test262:built-ins/Math": {
+        "compile-fail": 0,
+        "runtime-fail": 28,
+        "diff": 0
+      },
+      "test262:built-ins/AsyncFromSyncIteratorPrototype": {
+        "compile-fail": 0,
+        "runtime-fail": 3,
+        "diff": 17
+      },
+      "test262:language/function-code": {
+        "compile-fail": 0,
+        "runtime-fail": 20,
+        "diff": 0
+      },
+      "test262:built-ins/ArrayIteratorPrototype": {
+        "compile-fail": 0,
+        "runtime-fail": 19,
+        "diff": 0
+      },
+      "test262:built-ins/AsyncGeneratorFunction": {
+        "compile-fail": 0,
+        "runtime-fail": 19,
+        "diff": 0
+      },
+      "test262:built-ins/GeneratorFunction": {
+        "compile-fail": 0,
+        "runtime-fail": 19,
+        "diff": 0
+      },
+      "node-core:async_hooks": {
+        "compile-fail": 1,
+        "runtime-fail": 16,
+        "diff": 0
+      },
+      "test262:built-ins/global": {
+        "compile-fail": 8,
+        "runtime-fail": 9,
+        "diff": 0
+      },
+      "test262:language/types": {
+        "compile-fail": 0,
+        "runtime-fail": 16,
+        "diff": 0
+      },
+      "test262:built-ins/encodeURI": {
+        "compile-fail": 0,
+        "runtime-fail": 15,
+        "diff": 0
+      },
+      "test262:built-ins/encodeURIComponent": {
+        "compile-fail": 0,
+        "runtime-fail": 15,
+        "diff": 0
+      },
+      "test262:built-ins/AsyncFunction": {
+        "compile-fail": 0,
+        "runtime-fail": 14,
+        "diff": 0
+      },
+      "node-core:timers": {
+        "compile-fail": 1,
+        "runtime-fail": 12,
+        "diff": 0
+      },
+      "node-core:console": {
+        "compile-fail": 0,
+        "runtime-fail": 11,
+        "diff": 2
+      },
+      "test262:built-ins/ThrowTypeError": {
+        "compile-fail": 0,
+        "runtime-fail": 12,
+        "diff": 0
+      },
+      "node-core:url": {
+        "compile-fail": 0,
+        "runtime-fail": 10,
+        "diff": 0
+      },
+      "test262:built-ins/decodeURIComponent": {
+        "compile-fail": 0,
+        "runtime-fail": 10,
+        "diff": 0
+      },
+      "test262:built-ins/parseFloat": {
+        "compile-fail": 0,
+        "runtime-fail": 10,
+        "diff": 0
+      },
+      "test262:language/white-space": {
+        "compile-fail": 0,
+        "runtime-fail": 10,
+        "diff": 0
+      },
+      "node-core:assert": {
+        "compile-fail": 1,
+        "runtime-fail": 5,
+        "diff": 3
+      },
+      "test262:language/identifier-resolution": {
+        "compile-fail": 5,
+        "runtime-fail": 4,
+        "diff": 0
+      },
+      "node-core:path": {
+        "compile-fail": 0,
+        "runtime-fail": 9,
+        "diff": 0
+      },
+      "test262:built-ins/MapIteratorPrototype": {
+        "compile-fail": 0,
+        "runtime-fail": 9,
+        "diff": 0
+      },
+      "test262:built-ins/SetIteratorPrototype": {
+        "compile-fail": 0,
+        "runtime-fail": 9,
+        "diff": 0
+      },
+      "test262:built-ins/decodeURI": {
+        "compile-fail": 0,
+        "runtime-fail": 9,
+        "diff": 0
+      },
+      "test262:built-ins/parseInt": {
+        "compile-fail": 0,
+        "runtime-fail": 9,
+        "diff": 0
+      },
+      "test262:language/line-terminators": {
+        "compile-fail": 0,
+        "runtime-fail": 9,
+        "diff": 0
+      },
+      "node-core:util": {
+        "compile-fail": 0,
+        "runtime-fail": 7,
+        "diff": 1
+      },
+      "test262:language/future-reserved-words": {
+        "compile-fail": 7,
+        "runtime-fail": 0,
+        "diff": 0
+      },
+      "test262:language/global-code": {
+        "compile-fail": 2,
+        "runtime-fail": 5,
+        "diff": 0
+      },
+      "node-core:os": {
+        "compile-fail": 0,
+        "runtime-fail": 6,
+        "diff": 0
+      },
+      "test262:built-ins/StringIteratorPrototype": {
+        "compile-fail": 0,
+        "runtime-fail": 6,
+        "diff": 0
+      },
+      "test262:built-ins/Iterator": {
+        "compile-fail": 0,
+        "runtime-fail": 5,
+        "diff": 0
+      },
+      "test262:built-ins/isFinite": {
+        "compile-fail": 1,
+        "runtime-fail": 3,
+        "diff": 0
+      },
+      "test262:built-ins/isNaN": {
+        "compile-fail": 1,
+        "runtime-fail": 3,
+        "diff": 0
+      },
+      "node-core:querystring": {
+        "compile-fail": 0,
+        "runtime-fail": 4,
+        "diff": 0
+      },
+      "test262:built-ins/AsyncIteratorPrototype": {
+        "compile-fail": 0,
+        "runtime-fail": 4,
+        "diff": 0
+      },
+      "test262:built-ins/undefined": {
+        "compile-fail": 0,
+        "runtime-fail": 4,
+        "diff": 0
+      },
+      "node-core:events": {
+        "compile-fail": 0,
+        "runtime-fail": 3,
+        "diff": 0
+      },
+      "node-core:string_decoder": {
+        "compile-fail": 0,
+        "runtime-fail": 3,
+        "diff": 0
+      },
+      "test262:language/block-scope": {
+        "compile-fail": 0,
+        "runtime-fail": 3,
+        "diff": 0
+      },
+      "test262:language/comments": {
+        "compile-fail": 2,
+        "runtime-fail": 0,
+        "diff": 0
+      },
+      "test262:language/reserved-words": {
+        "compile-fail": 1,
+        "runtime-fail": 1,
+        "diff": 0
+      },
+      "test262:built-ins/Infinity": {
+        "compile-fail": 0,
+        "runtime-fail": 2,
+        "diff": 0
+      },
+      "test262:built-ins/NaN": {
+        "compile-fail": 0,
+        "runtime-fail": 2,
+        "diff": 0
+      },
+      "test262:language/punctuators": {
+        "compile-fail": 0,
+        "runtime-fail": 1,
+        "diff": 0
+      },
+      "test262:language/rest-parameters": {
+        "compile-fail": 0,
+        "runtime-fail": 1,
+        "diff": 0
+      }
+    }
+  },
+  "failures": [
+    {
+      "corpus": "node-core",
+      "category": "assert",
+      "test": "test-assert-checktag.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: dynamic dispatch on stdlib namespace `process` is refused at compile time \u2014 this catches the obfuscation pattern `process[runtimeVar]()` used by malicious npm packages. (#503)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-http-parser-destroy.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-arraybuffer.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error compiling module 'parallel/test-buffer-arraybuffer.js' (/private/tmp/claude-501/ncw-ly0cvfpf/parallel/test-buffer-arraybuffer.js) with --backend llvm: lowering closure func_id=13: lowering closure body func_id=13: perry-codegen: unknown Buffer encoding \"fhqwhgads\": expected one of utf8, utf-8,",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-disconnect.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-flush-stdio.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Generating code...",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-fork-abort-signal.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_child_process_fork_abort_signal_js.o",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-fork-closed-channel-segfault.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-fork-getconnections.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-fork-net-socket.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-fork-net.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-fork-stdio.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-recv-handle.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-send-keep-open.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-send-returns-boolean.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-spawn-event.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_child_process_spawn_event_js.o",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-spawn-shell.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Generating code...",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-stat.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: dynamic dispatch on stdlib namespace `fs` is refused at compile time \u2014 this catches the obfuscation pattern `fs[runtimeVar]()` used by malicious npm packages. (#503)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-1.0-keep-alive.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-1.0.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-abort-before-end.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-abort-client.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-abort-queued.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-abort-stream-end.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-agent-abort-controller.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-agent-error-on-idle.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_http_agent_error_on_idle_js.o",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-agent-keep-alive-timeout-buffer.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-agent-keepalive-delay.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-agent-keepalive.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-agent-no-protocol.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-agent-null.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-agent-remove.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-agent-reuse-drained-socket-only.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-agent-scheduling.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-agent-timeout.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-agent-uninitialized-with-handle.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-agent-uninitialized.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-allow-content-length-304.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-automatic-headers.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-blank-header.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-buffer-sanity.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-byteswritten.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-catch-uncaughtexception.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-chunk-extensions-limit.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-chunk-problem.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-chunked-304.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-chunked-smuggling.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-abort-destroy.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-abort-keep-alive-destroy-res.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Generating code...",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-abort-keep-alive-queued-tcp-socket.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Undefined variable in update expression: socketsCreated",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-abort-no-agent.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-abort-unix-socket.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Generating code...",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-abort2.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-agent-abort-close-event.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-agent-end-close-event.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-close-event.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-close-with-default-agent.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-default-headers-exist.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-encoding.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-error-rawbytes.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_http_client_error_rawbytes_js.o",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-get-url.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-headers-array.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-input-function.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-keep-alive-hint.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-keep-alive-release-before-finish.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-override-global-agent.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-race-2.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-race.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-read-in-error.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Generating code...",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-reject-chunked-with-content-length.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-reject-cr-no-lf.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-request-options.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-res-destroyed.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-response-timeout.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-timeout-agent.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-timeout-connect-listener.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-timeout-event.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-timeout-option-listeners.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-timeout-option.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-timeout-with-data.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-timeout.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-connect.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-content-length-mismatch.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-contentLength0.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-createConnection.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-date-header.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-decoded-auth.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-default-encoding.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-destroyed-socket-write2.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-dont-set-default-headers-with-set-header.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-dont-set-default-headers-with-setHost.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-dont-set-default-headers.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-double-content-length.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-dummy-characters-smuggling.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-dump-req-when-res-ends.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-early-hints-invalid-argument.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-early-hints.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-eof-on-connect.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-expect-continue-reuse-race.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-expect-continue.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-expect-handling.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-flush-headers.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-flush-response-headers.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-full-response.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-generic-streams.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-header-obstext.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-header-read.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-highwatermark.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-host-headers.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-incoming-message-options.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-information-processing.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-insecure-parser-per-stream.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-invalid-te.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-invalidheaderfield.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-keep-alive-close-on-header.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-keep-alive-drop-requests.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-keep-alive-max-requests.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-keep-alive-pipeline-max-requests.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-keep-alive-timeout-buffer.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-keepalive-client.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-keepalive-free.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-keepalive-override.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-keepalive-request.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-listening.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-malformed-request.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-many-ended-pipelines.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-max-header-size-per-stream.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-max-headers-count.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-max-sockets.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-missing-header-separator-cr.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-missing-header-separator-lf.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-no-read-no-dump.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-destroyed.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-end-cork.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-end-multiple.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-finish-writable.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-finish.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-finished.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-first-chunk-singlebyte-encoding.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-properties.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-writableFinished.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-parser-finish-error.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_http_parser_finish_error_js.o",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-parser-freed-before-upgrade.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-parser-memory-retention.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-pause.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-perf_hooks.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-pipeline-assertionerror-finish.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_http_pipeline_assertionerror_finish_js.o",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-pipeline-flood.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-pipeline-socket-parser-typeerror.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_http_pipeline_socket_parser_typeerror_js.o",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-proxy.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-raw-headers.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-rawheaders-limit.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-readable-data-event.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-remove-connection-header-persists-connection.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-remove-header-stays-removed.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-req-res-close.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-request-arguments.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-request-dont-override-options.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-request-end-twice.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-request-end.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-request-host-header.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-request-join-authorization-headers.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-request-large-payload.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-request-method-delete-payload.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-request-smuggling-content-length.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-res-write-after-end.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-res-write-end-dont-take-array.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-response-add-header-after-sent.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-response-close.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-response-cork.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-response-multi-content-length.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-response-remove-header-after-sent.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-response-setheaders.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-response-writehead-returns-this.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-clear-timer.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-client-error.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_http_server_client_error_js.o",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-connection-list-when-close.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-consumed-timeout.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-de-chunked-trailer.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-delete-parser.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-drop-connections-in-cluster.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-keep-alive-defaults.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-keep-alive-max-requests-null.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-keep-alive-timeout.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-multiheaders.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-multiheaders2.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-multiple-client-error.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_http_server_multiple_client_error_js.o",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-non-utf8-header.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-options-incoming-message.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-options-server-response.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-reject-chunked-with-content-length.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-reject-cr-no-lf.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-stale-close.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-unconsume-consume.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-unconsume.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-write-after-end.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-write-end-after-end.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-set-header-chain.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-set-timeout-server.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-set-timeout.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-set-trailers.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-socket-encoding-error.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_http_socket_encoding_error_js.o",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-socket-error-listeners.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_http_socket_error_listeners_js.o",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-status-message.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-timeout-client-warning.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-timeout-overflow.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-transfer-encoding-repeated-chunked.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-transfer-encoding-smuggling.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-uncaught-from-request-callback.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-upgrade-advertise.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-upgrade-client2.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-upgrade-reconsume-stream.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-upgrade-server-callback.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-upgrade-server.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-upgrade-server2.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-url.parse-auth-with-header-in-request.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-url.parse-auth.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-url.parse-basic.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-url.parse-https.request.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-url.parse-path.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-url.parse-post.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-url.parse-search.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-wget.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-write-callbacks.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-write-empty-string.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-write-head-2.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-zero-length-write.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-zerolengthbuffer.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-abortcontroller.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-agent-abort-controller.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-agent-additional-options.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-agent-disable-session-reuse.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-agent-keylog.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-agent-servername.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-agent-session-reuse.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-agent-sni.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-agent-sockets-leak.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-agent-unref-socket.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-agent.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-argument-of-creating.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-byteswritten.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-client-checkServerIdentity.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-client-get-url.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-client-override-global-agent.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-client-reject.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-client-renegotiation-limit.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-close.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-drain.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-expect-continue-reuse-race.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-insecure-parse-per-stream.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-keep-alive-drop-requests.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-max-header-size-per-stream.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-max-headers-count.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-request-arguments.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-resume-after-renew.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-selfsigned-no-keycertsign-no-crash.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-server-options-incoming-message.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-server-options-server-response.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-set-timeout-server.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-simple.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-socket-options.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-strict.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-timeout-server-2.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-timeout-server.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-truncate.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-after-close.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-allow-half-open.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-better-error-messages-listen-path.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_net_better_error_messages_listen_path_js.o",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-better-error-messages-listen.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_net_better_error_messages_listen_js.o",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-binary.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: `eval(...)` is refused at compile time: /private/tmp/claude-501/ncw-yixuo_u9/parallel/test-net-binary.js:45 (user source). Perry is an ahead-of-time compiler \u2014 it cannot evaluate a code string built from runtime data. (#1677)",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-bytes-read.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-bytes-stats.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-bytes-written-large.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-child-process-connect-reset.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-client-bind-twice.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-connect-abort-controller.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-connect-immediate-destroy.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-connect-keepalive.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-connect-nodelay.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-connect-options-ipv6.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-connect-options-port.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-connect-reset-after-destroy.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-connect-reset-before-connected.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-connect-reset-until-connected.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-connect-reset.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-dns-lookup-skip.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-end-destroyed.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-error-twice.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_net_error_twice_js.o",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-isip.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-isipv4.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-isipv6.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-keepalive.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-large-string.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-listen-after-destroying-stdin.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-listen-close-server-callback-is-not-function.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-listen-close-server.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-listen-error.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_net_listen_error_js.o",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-listen-exclusive-random-ports.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-listen-fd0.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-listen-handle-in-cluster-1.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-listen-invalid-port.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-listen-ipv6only.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-listen-twice.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-listening.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-pause-resume-connecting.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-persistent-keepalive.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-reconnect.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-remote-address.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-blocklist.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-call-listen-multiple-times.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-close-before-calling-lookup-callback.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-close-before-ipc-response.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-close.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-drop-connections.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-keepalive.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-listen-options-signal.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-listen-remove-callback.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-max-connections-close-makes-more-available.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-max-connections.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-nodelay.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-options.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-pause-on-connect.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-reset.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-unref-persistent.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-unref.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-settimeout.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-byteswritten.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-close-after-end.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-connect-invalid-autoselectfamilyattempttimeout.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-connect-without-cb.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-connecting.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-constructor.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-destroy-send.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-destroy-twice.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-end-before-connect.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-end-callback.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-local-address.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-ready-without-cb.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-reset-send.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-reset-twice.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-setnodelay.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-timeout-unref.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-timeout.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-write-after-close.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-write-error.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Wrote object file: parallel_test_net_socket_write_error_js.o",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-stream.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-sync-cork.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-throttle.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-timeout-no-handle.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-write-after-close.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-write-after-end-nt.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-write-cb-on-destroy-before-connect.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-default.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: CommonJS `require(\"../common\")` is not supported under `perry compile` \u2014 use a static `import` instead (e.g. `import * as m from \"../common\"` or `import { x } from \"../common\"`). Closes #668.",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-getactivehandles.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-getactiveresources-track-active-handles.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-base-typechecking.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-destroy.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-events-prepend.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Generating code...",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-finished.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipeline.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error compiling module 'parallel/test-stream-pipeline.js' (/private/tmp/claude-501/ncw-2zrb11mu/parallel/test-stream-pipeline.js) with --backend llvm: clang -c failed (status=exit status: 1).",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-async-iterators.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-next-no-null.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error compiling module 'parallel/test-stream-readable-next-no-null.js' (/private/tmp/claude-501/ncw-1830_0b1/parallel/test-stream-readable-next-no-null.js) with --backend llvm: clang -c failed (status=exit status: 1).",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-toArray.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error compiling module 'parallel/test-stream-toArray.js' (/private/tmp/claude-501/ncw-tl_mfr9x/parallel/test-stream-toArray.js) with --backend llvm: lowering closure func_id=71: lowering closure body func_id=71: perry-codegen: Array.fill expects 1-3 args, got 0",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-toWeb-allows-server-response.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "timers",
+      "test": "test-timers-unrefed-in-callback.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Undefined symbols for architecture arm64:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-convenience-methods.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: dynamic dispatch on stdlib namespace `zlib` is refused at compile time \u2014 this catches the obfuscation pattern `zlib[runtimeVar]()` used by malicious npm packages. (#503)",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-truncated.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: dynamic dispatch on stdlib namespace `zlib` is refused at compile time \u2014 this catches the obfuscation pattern `zlib[runtimeVar]()` used by malicious npm packages. (#503)",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S10.2.3_A1.3_T1.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: `eval(...)` is refused at compile time: /private/tmp/claude-501/t262w-xwehgiyx/case.js:271 (user source). Perry is an ahead-of-time compiler \u2014 it cannot evaluate a code string built from runtime data. (#1677)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S10.2.3_A1.3_T2.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: `eval(...)` is refused at compile time: /private/tmp/claude-501/t262w-u075_uyh/case.js:301 (user source). Perry is an ahead-of-time compiler \u2014 it cannot evaluate a code string built from runtime data. (#1677)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S10.2.3_A1.3_T3.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: `eval(...)` is refused at compile time: /private/tmp/claude-501/t262w-xskgt1sy/case.js:331 (user source). Perry is an ahead-of-time compiler \u2014 it cannot evaluate a code string built from runtime data. (#1677)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S10.2.3_A1.3_T4.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: `eval(...)` is refused at compile time: /private/tmp/claude-501/t262w-qqozpu80/case.js:261 (user source). Perry is an ahead-of-time compiler \u2014 it cannot evaluate a code string built from runtime data. (#1677)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S10.2.3_A2.3_T1.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: `eval(...)` is refused at compile time: /private/tmp/claude-501/t262w-irsx_022/case.js:264 (user source). Perry is an ahead-of-time compiler \u2014 it cannot evaluate a code string built from runtime data. (#1677)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S10.2.3_A2.3_T2.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: `eval(...)` is refused at compile time: /private/tmp/claude-501/t262w-zayy_537/case.js:276 (user source). Perry is an ahead-of-time compiler \u2014 it cannot evaluate a code string built from runtime data. (#1677)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S10.2.3_A2.3_T3.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: `eval(...)` is refused at compile time: /private/tmp/claude-501/t262w-6trx5lw2/case.js:288 (user source). Perry is an ahead-of-time compiler \u2014 it cannot evaluate a code string built from runtime data. (#1677)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S10.2.3_A2.3_T4.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: `eval(...)` is refused at compile time: /private/tmp/claude-501/t262w-icfvod7p/case.js:260 (user source). Perry is an ahead-of-time compiler \u2014 it cannot evaluate a code string built from runtime data. (#1677)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/isFinite",
+      "test": "built-ins/isFinite/tonumber-operations.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: isFinite requires one argument"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/isNaN",
+      "test": "built-ins/isNaN/tonumber-operations.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: isNaN requires one argument"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/comments",
+      "test": "language/comments/S7.4_A5.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: `eval(...)` is refused at compile time: /private/tmp/claude-501/t262w-zp440lvw/case.js:266 (user source). Perry is an ahead-of-time compiler \u2014 it cannot evaluate a code string built from runtime data. (#1677)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/comments",
+      "test": "language/comments/S7.4_A6.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: `eval(...)` is refused at compile time: /private/tmp/claude-501/t262w-ubru2b1j/case.js:285 (user source). Perry is an ahead-of-time compiler \u2014 it cannot evaluate a code string built from runtime data. (#1677)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-1-s.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-95ny0365/case.js: Parse error: Error { error: (7265..7271, TS1109) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-10-s.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-tyo5d3z2/case.js: Parse error: Error { error: (7252..7258, TS1109) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-11-s.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-4biexm2w/case.js: Parse error: Error { error: (7419..7425, Expected(\",\", \"public\")) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-12-s.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-izqf4m6o/case.js: Parse error: Error { error: (7260..7266, TS1109) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-13-s.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-grr939k5/case.js: Parse error: Error { error: (7257..7263, TS1109) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-3-s.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-p7oubidj/case.js: Parse error: Error { error: (7250..7256, TS1109) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-31-s.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-3c8856_s/case.js: Parse error: Error { error: (7329..7335, TS1109) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-32-s.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-rqaanuou/case.js: Parse error: Error { error: (7322..7328, TS1109) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-4-s.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-39vr_p3l/case.js: Parse error: Error { error: (7249..7255, TS1109) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-6-s.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-wddjznfh/case.js: Parse error: Error { error: (7281..7287, TS1109) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-7-s.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-rbhp1ots/case.js: Parse error: Error { error: (7228..7234, TS1109) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-9-s.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-693_vw_s/case.js: Parse error: Error { error: (7254..7260, TS1109) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/future-reserved-words",
+      "test": "language/future-reserved-words/implements.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-k7_ze6bx/case.js: Parse error: Error { error: (7266..7281, EscapeInReservedWord { word: \"implements\" }) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/future-reserved-words",
+      "test": "language/future-reserved-words/interface.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-fbnywl8i/case.js: Parse error: Error { error: (7286..7300, EscapeInReservedWord { word: \"interface\" }) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/future-reserved-words",
+      "test": "language/future-reserved-words/package.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-ob2dccj2/case.js: Parse error: Error { error: (7257..7269, EscapeInReservedWord { word: \"package\" }) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/future-reserved-words",
+      "test": "language/future-reserved-words/private.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-74b9e4k7/case.js: Parse error: Error { error: (7257..7269, EscapeInReservedWord { word: \"private\" }) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/future-reserved-words",
+      "test": "language/future-reserved-words/protected.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-dkjmk0zb/case.js: Parse error: Error { error: (7263..7277, EscapeInReservedWord { word: \"protected\" }) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/future-reserved-words",
+      "test": "language/future-reserved-words/public.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-x9nvqu9e/case.js: Parse error: Error { error: (7254..7265, EscapeInReservedWord { word: \"public\" }) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/future-reserved-words",
+      "test": "language/future-reserved-words/static.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-yc_j2aqm/case.js: Parse error: Error { error: (7254..7265, EscapeInReservedWord { word: \"static\" }) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/global-code",
+      "test": "language/global-code/decl-func-dup.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error compiling module 'case.js' (/private/tmp/claude-501/t262w-yeoy2te_/case.js) with --backend llvm: clang -c failed (status=exit status: 1)."
+    },
+    {
+      "corpus": "test262",
+      "category": "language/global-code",
+      "test": "language/global-code/yield-non-strict.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-0_s97ik0/case.js: Parse error: Error { error: (7374..7379, TS1109) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/identifier-resolution",
+      "test": "language/identifier-resolution/S10.2.2_A1_T5.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Parse warning: Error { error: (7362..7366, TS2410) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/identifier-resolution",
+      "test": "language/identifier-resolution/S10.2.2_A1_T6.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Parse warning: Error { error: (7349..7353, TS2410) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/identifier-resolution",
+      "test": "language/identifier-resolution/S10.2.2_A1_T7.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Parse warning: Error { error: (7349..7353, TS2410) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/identifier-resolution",
+      "test": "language/identifier-resolution/S10.2.2_A1_T8.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Parse warning: Error { error: (7349..7353, TS2410) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/identifier-resolution",
+      "test": "language/identifier-resolution/S10.2.2_A1_T9.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Parse warning: Error { error: (7330..7334, TS2410) }"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/reserved-words",
+      "test": "language/reserved-words/await-script.js",
+      "severity": "compile-fail",
+      "severity_rank": 3,
+      "reason": "Error: Failed to parse /private/tmp/claude-501/t262w-hdmhjk1i/case.js: Parse error: Error { error: (7118..7123, InvalidIdentInAsync) }"
+    },
+    {
+      "corpus": "node-core",
+      "category": "assert",
+      "test": "test-assert-class-destructuring.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "assert",
+      "test": "test-assert-class.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "assert",
+      "test": "test-assert-deep-with-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "assert",
+      "test": "test-assert-fail.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "assert",
+      "test": "test-assert-if-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-asyncresource-constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-correctly-switch-promise-hook.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-enable-disable-enable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-enable-recursive.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-execution-async-resource-await.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: The \"original\" argument must be of type function. Received type boolean (true)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-execution-async-resource.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-fatal-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-promise.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'triggerId')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-stack-overflow-nested-async.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-stack-overflow-try-catch.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-stack-overflow.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-top-level-clearimmediate.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-worker-asyncfn-terminate-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-worker-asyncfn-terminate-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: postMessage is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-worker-asyncfn-terminate-3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "async_hooks",
+      "test": "test-async-hooks-worker-asyncfn-terminate-4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-bigint64.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-compare-offset.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-compare.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-constants.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-constructor-node-modules-paths.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-constructor-outside-node-modules.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: (boolean).runInNewContext is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-copy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-equals.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-failed-alloc-typed-arrays.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: (number).fill is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-fakes.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-inheritance.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Object.setPrototypeOf called on null or undefined",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-isascii.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-isutf8.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-iterator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-new.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-parent-property.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-pool-untransferable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-prototype-inspect.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-read.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-readdouble.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-readfloat.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-readint.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-readuint.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-safe-unsafe.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-set-inspect-max-bytes.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-sharedarraybuffer.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object.",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-slice.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-swap.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be deeply strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-tojson.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be deeply strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-tostring-range.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-tostring.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "RangeError: toString() radix must be between 2 and 36",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-write.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-writedouble.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-writefloat.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-writeint.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-writeuint.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-advanced-serialization-largebuffer.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-advanced-serialization-splitted-length-field.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-advanced-serialization.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-can-write-to-stdout.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-destroy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-env.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-exec-abortcontroller-promisified.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-exec-encoding.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-exec-env.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'stdout')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-exec-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'pid')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-exec-maxbuf.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-exec-std-encoding.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'setEncoding')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-exec-stdout-stderr-data-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-execFile-promisified-abortController.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-execfile-maxbuf.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-execfile.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-execfilesync-maxbuf.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-execsync-maxbuf.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-exit-code.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-fork-args.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-fork-dgram.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: once is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-fork-exec-argv.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-kill.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-no-deprecation.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-pipe-dataflow.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-promisified.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-reject-null-bytes.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-send-after-close.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-send-cb.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-send-type-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-silent.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-spawn-argv0.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-spawn-controller.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-spawn-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-spawn-windows-batch-file.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-spawnsync-env.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-spawnsync-input.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be deeply strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-spawnsync-maxbuf.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-spawnsync-timeout.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-stdin-ipc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-stdin.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-stdio-big-write-end.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-stdio-inherit.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-stdio-merge-stdouts-into-cat.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-stdio-reuse-readable-stdio.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-stdout-flush-exit.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-stdout-ipc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-uid-gid.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "console",
+      "test": "test-console-assign-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "foo",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "console",
+      "test": "test-console-async-write-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Console expects a writable stream instance for stdout",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "console",
+      "test": "test-console-clear.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "console",
+      "test": "test-console-count.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "default: 1",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "console",
+      "test": "test-console-log-stdio-broken-dest.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Console expects a writable stream instance for stdout",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "console",
+      "test": "test-console-log-throw-primitive.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Console expects a writable stream instance for stdout",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "console",
+      "test": "test-console-methods.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Console expects a writable stream instance for stdout",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "console",
+      "test": "test-console-no-swallow-stack-overflow.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "console",
+      "test": "test-console-sync-write-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Console expects a writable stream instance for stdout",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "console",
+      "test": "test-console-table.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "console",
+      "test": "test-console-with-frozen-intrinsics.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: (number).log is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-aes-wrap.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: aes128-wrap test case failed",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-certificate.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-dh-curves.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected actual to be strictly unequal to expected",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-dh-group-setters.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-dh-padding.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-domain.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: (boolean).create is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-domains.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: (boolean).create is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-ecdh-convert-key.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-encoding-validation-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'update')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-gcm-explicit-short-tag.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'setAuthTag')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-gcm-implicit-short-tag.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'setAuthTag')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-getcipherinfo.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-hash-stream-pipe.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: pipe is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-hash.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: md5 with latin1 digest failed to evaluate to expected hash",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-hmac.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Hmac is expected to return a new instance when called without `new`",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-key-objects-messageport.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'publicKey')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-keygen-invalid-parameter-encoding-dsa.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-keygen-invalid-parameter-encoding-ec.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-keygen-key-objects.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'publicKey')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-keygen-non-standard-public-exponent.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'publicKey')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-lazy-transform-writable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "RangeError: toString() radix must be between 2 and 36",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-prime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-psychic-signatures.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'importKey')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-secret-keygen.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-subtle-cross-realm.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'digest')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-subtle-zero-length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'importKey')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-update-encoding.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-verify-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-webcrypto-aes-decrypt-tag-too-small.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'importKey')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-worker-thread.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'publicKey')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "events",
+      "test": "test-events-getmaxlisteners.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "events",
+      "test": "test-events-list.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be deeply strictly equal",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "events",
+      "test": "test-events-once.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-assert-encoding-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-buffer.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: expected .empty-hidden-repl-history-file, got  by hex decoding .empty-hidden-repl-history-file",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-buffertype-writesync.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-chmod-mask.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-chown-type-check.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-constants.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-copyfile-respect-permissions.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-cp-sync-dereference.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-empty-readStream.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: data event should not emit with arguments:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-internal-assertencoding.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-lchmod.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-lchown.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: The \"path\" argument must be of type string or an instance of Buffer or URL. Received type boolean (false)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-link.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-make-callback.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-makeStatsCallback.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-mkdir-recursive-eaccess.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-mkdir-rmdir.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-mkdtemp-prefix-check.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-non-number-arguments-throw.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-null-bytes.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-open-numeric-flags.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-open.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'close')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-options-immutable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-promises-exists.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-promises-file-handle-dispose.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-promises-file-handle-read.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-promises-file-handle-stream.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-promises-file-handle-sync.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: The \"mode\" argument must be of type number. Received type string ('r')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-promises-file-handle-writeFile.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected rejection",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-promises-watch-iterator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-promises-watch.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-promises-write-optional-params.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected rejection",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-promises-writefile-typedarray.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be deeply strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-read-empty-buffer.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-read-file-assert-encoding.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-read-optional-params.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-read-stream-autoClose.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-read-stream-concurrent-reads.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-read-stream-encoding.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: setDefaultEncoding is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-read-stream-err.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: no more 'data' events should follow with arguments: // Copyright Joyent, Inc. and other Node contributors.",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-read-stream-inherit.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-read-stream-pos.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-read-stream-resume.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: setEncoding is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-read-stream-throw-type-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-read-stream.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-read-type.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-read.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-readSync-optional-params.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-readdir-stack-overflow.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-readfile-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-readfile-flags.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'code')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-readfile-pipe-large.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: ifError got unwanted exception: Command failed: \"/tmp/claude-501/ncw-cah85d5y/case.out\" \"/private/tmp/claude-501/ncw-cah85d5y/parallel/test-fs-readfile-pipe-large.js\" child < \"/tmp/claude-501/perry-node-core-tmp/readfile_pipe_large_test.txt\"",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-readfilesync-pipe-large.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: ifError got unwanted exception: Command failed: \"/tmp/claude-501/ncw-nk3_0rwe/case.out\" \"/private/tmp/claude-501/ncw-nk3_0rwe/parallel/test-fs-readfilesync-pipe-large.js\" child < \"/tmp/claude-501/perry-node-core-tmp/readfilesync_pipe_large_test.txt\"",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-readv-sync.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-readv.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-ready-event-stream.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-realpath-buffer-encoding.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-realpath-pipe.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-stat-bigint.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: isFile is not a safe integer, difference should < 1.",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-stream-fs-options.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: createWriteStream options.fs.open should throw if isn't a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-stream-options.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-symlink-longpath.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: The \"path\" argument must be of type string.",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-syncwritestream.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-timestamp-parsing-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-utimes.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-watch-encoding.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-watch-stop-async.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: stop is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-watch-stop-sync.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: stop is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-watchfile.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-write-buffer.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-write-file-sync.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-write-negativeoffset.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-write-sigxfsz.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-write-stream-autoclose-option.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-write-stream-change-open.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-write-stream-end.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-write-stream-throw-type-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-write-stream.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-write-sync-optional-params.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-write-sync.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-writefile-with-fd.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The input did not match the regular expression",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-writev-promises.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-writev-sync.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-writev.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-addrequest-localaddress.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'addRequest')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-agent-timeout-option.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-abort3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-defaults.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-headers-host-array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: http request should throw when passing array as header host",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-incomingmessage-destroy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-insecure-http-parser-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: http request should throw when passing invalid insecureHTTPParser",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-invalid-path.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-set-timeout-after-end.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-set-timeout.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-timeout-option-with-agent.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-client-unescaped-path.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-common.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-default-port.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-dns-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-header-badrequest.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-header-validators.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'constructor')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-import-websocket.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-incoming-matchKnownFields.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: _addHeaderLine is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-incoming-message-connection-setter.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-incoming-message-destroy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: destroy is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-invalid-path-chars.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-invalid-urls.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-invalidheaderfield2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-max-header-size.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-buffer.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: write is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-destroy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-message-capture-rejection.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-message-write-callback.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: assignSocket is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'prototype')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-outgoing-settimeout.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: setTimeout is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-parser-multiple-execute.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-parser.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'REQUEST')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-req-close-robust-from-tampering.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'unref')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-request-invalid-method-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-response-readable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: listen is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-async-dispose.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-capture-rejections.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-close-all.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-close-destroy-timeout.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-close-idle-wait-response.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-close-idle.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-headers-timeout-delayed-headers.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-headers-timeout-interrupted-headers.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-headers-timeout-pipelining.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'headersTimeout')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-incomingmessage-destroy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-keepalive-end.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'unref')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-method.query.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-request-timeout-delayed-body.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'requestTimeout')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-request-timeout-delayed-headers.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-request-timeout-interrupted-body.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'requestTimeout')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-request-timeout-interrupted-headers.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-request-timeout-pipelining.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'requestTimeout')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-request-timeout-upgrade.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-response-standalone.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: assignSocket is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-server-timeouts-validation.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'headersTimeout')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-set-max-idle-http-parser.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-url.parse-only-support-http-https-protocol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "http",
+      "test": "test-http-writable-true-after-close.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-agent-constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-server-async-dispose.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-server-close-all.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-server-close-destroy-timeout.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-server-close-idle.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-server-headers-timeout.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'headersTimeout')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "https",
+      "test": "test-https-server-request-timeout.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'requestTimeout')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-access-byteswritten.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'bytesWritten')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-better-error-messages-path.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-blocklist.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: addAddress is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-connect-no-arg.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-connect-options-invalid.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-dns-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: [object Object]",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-localerror.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-options-lookup.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-server-capture-rejection.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-connect-invalid-autoselectfamily.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "net",
+      "test": "test-net-socket-no-halfopen-enforcer.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: listenerCount is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "os",
+      "test": "test-os-constants-signals.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "os",
+      "test": "test-os-eol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "os",
+      "test": "test-os-homedir-no-envvar.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "os",
+      "test": "test-os-process-priority.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "os",
+      "test": "test-os-userinfo-handles-getter-errors.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "os",
+      "test": "test-os.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "path",
+      "test": "test-path-extname.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception:",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "path",
+      "test": "test-path-glob.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected foo\\bar\\baz to match foo/** on win32",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "path",
+      "test": "test-path-join.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "path",
+      "test": "test-path-makelong.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'toNamespacedPath')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "path",
+      "test": "test-path-normalize.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "path",
+      "test": "test-path-relative.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "path",
+      "test": "test-path-resolve.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'resolve')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "path",
+      "test": "test-path-zero-length-strings.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "path",
+      "test": "test-path.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-abort.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-argv-0.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-beforeexit-throw-exit.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Error",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-binding-util.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-config.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-dlopen-undefined-exports.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-env-ignore-getter-setter.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-env-symbols.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-env.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-euid-egid.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-exception-capture-errors.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-exception-capture-should-abort-on-uncaught-setflagsfromstring.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Error: foo",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-exception-capture-should-abort-on-uncaught.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Error: foo",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-exception-capture.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Error: foo",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-exec-argv.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'setEncoding')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-execpath.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-execve-abort.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-execve-no-args.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-execve-on-exit.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-execve-permission-granted.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-execve-socket.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-execve-validation.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-execve.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-exit-recursive.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-external-stdio-close-spawn.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: send is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-getactiverequests.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-getactiveresources-track-interval-lifetime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-getactiveresources-track-multiple-timers.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-getactiveresources-track-timer-lifetime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-ppid.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-really-exit.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-redirect-warnings-env.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-redirect-warnings.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-remove-all-signal-listeners.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'mustCall')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-setsourcemapsenabled.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-threadCpuUsage-worker-threads.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-uid-gid.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-uncaught-exception-monitor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "querystring",
+      "test": "test-querystring-escape.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "querystring",
+      "test": "test-querystring-maxKeys-non-finite.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "querystring",
+      "test": "test-querystring-multichar-separator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "querystring",
+      "test": "test-querystring.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: (boolean).runInNewContext is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-aliases-legacy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-auto-destroy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: resume is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-await-drain-writers-in-synchronously-recursion-write.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: pipe is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-big-packet.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: pipe is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-big-push.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-catch-rejections.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: write is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-compose-operator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-compose.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-construct.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-consumers.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-decoder-objectmode.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-destroy-event-order.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-drop-take.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-duplex-end.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-duplex-from.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-duplex-props.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-duplex-readable-end.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: pipe is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-duplex-readable-writable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-duplex-writable-finished.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-duplex.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'objectMode')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-end-of-streams.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-end-paused.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-error-once.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-event-names.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: eventNames is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-filter.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-flatMap.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be deeply strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-forEach.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-inheritance.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-ispaused.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: isPaused is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-map.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be deeply strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-objectmode-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-once-readable-pipe.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: once is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-passthrough-drain.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-await-drain-manual-resume.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: pipe is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-await-drain-push-while-write.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: pipe is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-cleanup.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Object.setPrototypeOf called on null or undefined",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-deadlock.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: write is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-error-handling.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: pipe is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-error-unhandled.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: pipe is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-event.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Object.setPrototypeOf called on null or undefined",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-flow-after-unpipe.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-flow.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-manual-resume.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'pipe')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-multiple-pipes.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-needDrain.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: write is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-same-destination-twice.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: pipe is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-unpipe-streams.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'pipes')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipe-without-listenerCount.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipeline-async-iterator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: The \"streams\" argument must be specified",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipeline-http2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'listen')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipeline-listeners.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: end is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipeline-queued-end-in-destroy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipeline-uncaught.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: end is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-pipeline-with-empty-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: The \"streams\" argument must be specified",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-promises.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-push-order.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: read is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-aborted.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-add-chunk-during-data.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: once is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-data.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: setEncoding is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-default-encoding.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-didRead.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-dispose.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: resume is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-emittedReadable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'emittedReadable')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-end-destroyed.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-ended.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-error-end.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-event.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-flow-recursion.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: read is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-hwm-0-async.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-hwm-0-no-flow-data.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-hwm-0.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-invalid-chunk.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-needReadable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'needReadable')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-no-unneeded-readable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: resume is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-pause-and-resume.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-readable-then-resume.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-readable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-reading-readingMore.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'reading')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-resumeScheduled.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'resumeScheduled')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-setEncoding-null.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'encoding')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-unpipe-resume.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: resume is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-unshift.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readable-with-unimplemented-_read.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: read is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-readableListening-state.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'readableListening')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-reduce.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be deeply strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-set-default-hwm.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-transform-callback-twice.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-transform-constructor-set-methods.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-transform-flush-data.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: end is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-transform-hwm0.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: write is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-transform-objectmode-falsey-value.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-transform-split-highwatermark.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-transform-split-objectmode.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'objectMode')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-typedarray.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: write is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-uint8array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: write is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-unshift-empty-chunk.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-unshift-read-race.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-aborted.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-change-default-encoding.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-constructor-set-methods.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-decoded-encoding.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-end-cb-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-end-cb-uncaught.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: write is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-end-multiple.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: end is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-ended-state.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'ended')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-final-async.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-final-destroy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: end is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-finish-destroyed.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-finished-state.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-finished.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-invalid-chunk.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-needdrain-state.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'needDrain')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-null.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-properties.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-samecb-singletick.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Console expects a writable stream instance for stdout",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-writable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-write-cb-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-write-cb-twice.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: write is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-write-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: end is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writable-write-writev-finish.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writableState-ending.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writableState-uncorked-bufferedRequestCount.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: cork is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-write-destroy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-write-drain.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-writev.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "# decode=true uncork=true multi=true",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "string_decoder",
+      "test": "test-string-decoder-end.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: write is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "string_decoder",
+      "test": "test-string-decoder-fuzz.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: write is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "string_decoder",
+      "test": "test-string-decoder.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "timers",
+      "test": "test-timers-api-refs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "timers",
+      "test": "test-timers-args.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: (boolean).apply is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "timers",
+      "test": "test-timers-clearImmediate-als.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'set')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "timers",
+      "test": "test-timers-destroyed.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "timers",
+      "test": "test-timers-immediate-queue-throw.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: (boolean).create is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "timers",
+      "test": "test-timers-promises-scheduler.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'yield')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "timers",
+      "test": "test-timers-promises.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "timers",
+      "test": "test-timers-reset-process-domain-on-throw.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "process.domain should be null in this timer callback, but is: 0",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "timers",
+      "test": "test-timers-to-primitive.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "timers",
+      "test": "test-timers-unref.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "timers",
+      "test": "test-timers-user-call.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "timers",
+      "test": "test-timers-zero-timeout.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "url",
+      "test": "test-url-domain-ascii-unicode.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "url",
+      "test": "test-url-fileurltopath.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "url",
+      "test": "test-url-format-invalid-input.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "url",
+      "test": "test-url-format-whatwg.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "url",
+      "test": "test-url-format.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "url",
+      "test": "test-url-invalid-file-url-path-input.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The thrown error did not match the expected matcher",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "url",
+      "test": "test-url-parse-query.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'forEach')",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "url",
+      "test": "test-url-relative.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "url",
+      "test": "test-url-revokeobjecturl.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "url",
+      "test": "test-url-urltooptions.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "util",
+      "test": "test-util-format.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "util",
+      "test": "test-util-getcallsites-preparestacktrace.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "util",
+      "test": "test-util-inherits.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be deeply strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "util",
+      "test": "test-util-inspect-getters-accessing-this.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "util",
+      "test": "test-util-isDeepStrictEqual.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "util",
+      "test": "test-util-stripvtcontrolcharacters.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "util",
+      "test": "test-util-types-exists.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-brotli-16GB.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'end')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-brotli-flush.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: write is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-brotli-from-brotli.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: pipe is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-brotli-kmaxlength-rangeerror.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-brotli.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: 4840,4840,4840,4840,4840,4840,4840,4840,4840,4840,4840,4840",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-close-after-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-const.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: zlib.constants.Z_OK should be immutable",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-crc32.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-create-raw.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-deflate-constructors.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The expression evaluated to a falsy value",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-deflate-raw-inherits.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Object.setPrototypeOf called on null or undefined",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-destroy-pipe.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: write is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-destroy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected values to be strictly equal",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-dictionary-fail.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The input did not match the regular expression",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-empty-buffer.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: The \"original\" argument must be of type function. Received undefined",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-failed-init.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-flush-drain.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-flush-flags.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-flush-write-sync-interleaved.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'setEncoding')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-flush.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-from-concatenated-gzip.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: ifError got unwanted exception: failed to write whole buffer",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-from-gzip-with-trailing-garbage.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Error: incorrect header check: invalid gzip header",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-invalid-arg-value-brotli-compress.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-invalid-input.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-kmaxlength-rangeerror.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-maxOutputLength.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: The \"callback\" argument must be of type function. Received an instance of Object",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-object-write.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-premature-end.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'setEncoding')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-random-byte-pipes.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-sync-no-event.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: on is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-unzip-one-byte-chunks.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-write-after-close.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-write-after-end.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-write-after-flush.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-zero-byte.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-zero-windowBits.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-zstd-flush.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: write is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-zstd-from-zstd.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: pipe is not a function",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-zstd-kmaxlength-rangeerror.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-zstd-pledged-src-size.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'on')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-zstd.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'length')",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Missing expected exception",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/15.4.5.1-5-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of a[4294967295] is expected to be \"not an array element\" Expected SameValue(\u00abundefined\u00bb, \u00ab\"not an array element\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/15.4.5.1-5-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of a.length is expected to be 3 Expected SameValue(\u00ab193\u00bb, \u00ab3\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.1_A1.1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of x.myproperty is expected to be 42 Expected SameValue(\u00abundefined\u00bb, \u00ab42\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.1_A1.1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: x.toString() must return \"[object Array]\" Expected SameValue(\u00ab\"\"\u00bb, \u00ab\"[object Array]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.1_A1.1_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Array.prototype.isPrototypeOf(Array()) must return true Expected SameValue(\u00abundefined\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.1_A1.2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: x.getClass() must return \"[object Array]\" Expected SameValue(\u00ab\u00bb, \u00ab\"[object Array]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.1_A2.1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of Array(0, 1, 0, 1).length is expected to be 4 Expected SameValue(\u00ab0\u00bb, \u00ab4\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.1_A2.2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of result is expected to be true Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.2.1_A1.1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of x.myproperty is expected to be 1 Expected SameValue(\u00abundefined\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.2.1_A1.1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: x.toString() must return \"[object Array]\" Expected SameValue(\u00ab\"\"\u00bb, \u00ab\"[object Array]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.2.1_A1.1_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Array.prototype.isPrototypeOf(new Array()) must return true Expected SameValue(\u00abundefined\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.2.1_A1.2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: x.getClass() must return \"[object Array]\" Expected SameValue(\u00ab[object Object]\u00bb, \u00ab\"[object Array]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.2.1_A2.1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of new Array(0, 1, 0, 1).length is expected to be 4 Expected SameValue(\u00ab0\u00bb, \u00ab4\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.2.1_A2.2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of result is expected to be true Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.3_A1.1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of Array.myproperty is expected to be 1 Expected SameValue(\u00ab0\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.3_A1.1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Array.toString() must return \"[object Function]\" Expected SameValue(\u00ab\"0\"\u00bb, \u00ab\"[object Function]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.3_A1.1_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Function.prototype.isPrototypeOf(Array) must return true Expected SameValue(\u00abundefined\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.5.1_A1.2_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of x[2] is expected to be -1 Expected SameValue(\u00abundefined\u00bb, \u00ab-1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.5.1_A2.1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of x.length is expected to be 0 Expected SameValue(\u00ab193\u00bb, \u00ab0\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.5.2_A1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of x.length is expected to be 2147483649 Expected SameValue(\u00ab193\u00bb, \u00ab2147483649\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.5.2_A1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of x.length is expected to be 0 Expected SameValue(\u00ab193\u00bb, \u00ab0\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.5.2_A3_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "RangeError: Invalid array length"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4.5.2_A3_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4_A1.1_T10.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4_A1.1_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of x[0] is expected to equal undefined Expected SameValue(\u00ab0\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4_A1.1_T6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of x[\"true\"] is expected to be 1 Expected SameValue(\u00abundefined\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4_A1.1_T7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of y[1] is expected to be 1 Expected SameValue(\u00abundefined\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4_A1.1_T8.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of y[1] is expected to be 1 Expected SameValue(\u00abundefined\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/S15.4_A1.1_T9.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of x[\"[object Object]\"] is expected to be 0 Expected SameValue(\u00abundefined\u00bb, \u00ab0\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/from/Array.from-descriptor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: from should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/from/Array.from-name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/from/Array.from_arity.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/from/Array.from_forwards-length-for-array-likes.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'length')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/from/calling-from-valid-1-noStrict.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Perry ran clean; Node rejected (missed negative)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/from/elements-updated-after.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of value is expected to be 127 Expected SameValue(\u00ab4\u00bb, \u00ab127\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/from/get-iter-method-err.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Array.from(items) throws a Test262Error exception Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/from/items-is-arraybuffer.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of result.length is expected to be 0 Expected SameValue(\u00ab7\u00bb, \u00ab0\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/from/items-is-null-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/from/iter-adv-err.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Array.from(items) throws a Test262Error exception Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/from/iter-cstm-ctor-err.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Array.from.call(C, items) throws a Test262Error exception Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/from/iter-cstm-ctor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The result of evaluating (result instanceof C) is expected to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/from/iter-get-iter-err.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Array.from(itemsPoisonedSymbolIterator) throws a Test262Error exception Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Array",
+      "test": "built-ins/Array/from/iter-get-iter-val-err.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Array.from(itemsPoisonedIteratorValue) throws a Test262Error exception Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/allocation-limit.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `length` parameter is 7 PiB Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/isView/arg-is-dataview-subclass-instance.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected true but got false"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/isView/arg-is-typedarray-subclass-instance.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected true but got false (Testing with  and makePassthrough.)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/isView/arg-is-typedarray.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true (Testing with undefined and makePassthrough.)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/isView/invoked-as-a-fn.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/isView/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/isView/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/isView/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: isView should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/length-is-too-large-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `length` parameter is too large Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/negative-length-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/byteLength/invoked-as-accessor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/byteLength/invoked-as-func.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/byteLength/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/byteLength/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/byteLength/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'set')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/byteLength/this-is-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/slice/context-is-not-arraybuffer-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/slice/context-is-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/slice/descriptor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: slice should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/slice/end-default-if-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab0\u00bb, \u00ab2\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/slice/extensible.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected true but got false"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/slice/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/slice/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/slice/number-conversion.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"\"\u00bb, \u00ab\"start-end\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/slice/species-constructor-is-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `constructor` value is null Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/prototype/slice/species-constructor-is-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/return-abrupt-from-length-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `length` parameter is a Symbol Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/return-abrupt-from-length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/toindex-length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: object's valueOf Expected SameValue(\u00ab0\u00bb, \u00ab42\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayBuffer",
+      "test": "built-ins/ArrayBuffer/undefined-newtarget-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/Symbol.toStringTag/value-from-to-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"[object Array Iterator]\"\u00bb, \u00ab\"[object Object]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/Float32Array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'next')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/Float64Array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'next')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/Int16Array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'next')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/Int32Array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'next')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/Int8Array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'next')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/Uint16Array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'next')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/Uint32Array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'next')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/Uint8Array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/Uint8ClampedArray.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'next')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/args-mapped-expansion-after-exhaustion.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Exhausted result `value` Expected SameValue(\u00ab4\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/args-mapped-truncation-before-exhaustion.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Exhausted result `value` Expected SameValue(\u00ab3\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/args-unmapped-expansion-after-exhaustion.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Exhausted result `value` Expected SameValue(\u00ab4\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/args-unmapped-truncation-before-exhaustion.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Exhausted result `value` Expected SameValue(\u00ab3\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/iteration-mutable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Exhausted result `done` flag (after push) Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/non-own-slots.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ArrayIteratorPrototype",
+      "test": "built-ins/ArrayIteratorPrototype/next/property-descriptor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: next should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/next/iterator-result-poisoned-done.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Error: Catch me."
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/next/iterator-result-poisoned-value.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Error: Catch me."
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/next/iterator-result-rejected.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Error: Catch me."
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFunction",
+      "test": "built-ins/AsyncFunction/AsyncFunction-construct.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFunction",
+      "test": "built-ins/AsyncFunction/AsyncFunction-is-extensible.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'x')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFunction",
+      "test": "built-ins/AsyncFunction/AsyncFunction-is-subclass.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFunction",
+      "test": "built-ins/AsyncFunction/AsyncFunction-length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFunction",
+      "test": "built-ins/AsyncFunction/AsyncFunction-name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFunction",
+      "test": "built-ins/AsyncFunction/AsyncFunction-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFunction",
+      "test": "built-ins/AsyncFunction/AsyncFunction.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"function\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFunction",
+      "test": "built-ins/AsyncFunction/AsyncFunctionPrototype-is-extensible.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFunction",
+      "test": "built-ins/AsyncFunction/AsyncFunctionPrototype-is-not-callable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFunction",
+      "test": "built-ins/AsyncFunction/AsyncFunctionPrototype-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFunction",
+      "test": "built-ins/AsyncFunction/instance-construct-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFunction",
+      "test": "built-ins/AsyncFunction/instance-has-name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFunction",
+      "test": "built-ins/AsyncFunction/instance-length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFunction",
+      "test": "built-ins/AsyncFunction/is-not-a-global.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: AsyncFunction should not be present as a global Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/extensibility.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/has-instance.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/instance-await-expr-in-param.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/instance-construct-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/instance-length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/instance-name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/instance-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/instance-yield-expr-in-param.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/invoked-as-constructor-no-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/invoked-as-function-multiple-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/invoked-as-function-no-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/invoked-as-function-single-argument.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/prototype/extensibility.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/prototype/not-callable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/prototype/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorFunction",
+      "test": "built-ins/AsyncGeneratorFunction/prototype/prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/next/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/next/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/next/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/next/this-val-not-async-generator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/next/this-val-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/return-state-completed-broken-promise.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/this-val-not-async-generator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/this-val-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/request-queue-order-state-executing.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Error: Catch me."
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/return-rejected-promise.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Promise rejected."
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/this-val-not-async-generator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/this-val-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/throw-suspendedStart-promise.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: [object Object]"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/throw-suspendedStart.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Error: boop"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncIteratorPrototype",
+      "test": "built-ins/AsyncIteratorPrototype/Symbol.asyncIterator/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncIteratorPrototype",
+      "test": "built-ins/AsyncIteratorPrototype/Symbol.asyncIterator/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncIteratorPrototype",
+      "test": "built-ins/AsyncIteratorPrototype/Symbol.asyncIterator/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncIteratorPrototype",
+      "test": "built-ins/AsyncIteratorPrototype/Symbol.asyncIterator/return-val.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/asIntN/arithmetic.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/asIntN/asIntN.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"number\"\u00bb, \u00ab\"function\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/asIntN/bigint-tobigint.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/asIntN/bits-toindex.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/asIntN/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/asIntN/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/asIntN/order-of-steps.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/asUintN/arithmetic.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/asUintN/asUintN.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"number\"\u00bb, \u00ab\"function\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/asUintN/bigint-tobigint.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/asUintN/bits-toindex.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/asUintN/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/asUintN/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/asUintN/order-of-steps.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/call-value-of-when-to-string-present.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "RangeError: The number NaN cannot be converted to a BigInt because it is not an integer"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/constructor-coercion.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "RangeError: The number NaN cannot be converted to a BigInt because it is not an integer"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/constructor-from-string-syntax-errors.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/infinity-throws-rangeerror.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/nan-throws-rangeerror.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/negative-infinity-throws.rangeerror.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/non-integer-rangeerror.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/parseInt/nonexistent.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abnull\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: constructor should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: prototype should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/toString/a-z.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/toString/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/toString/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/toString/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: toString should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/toString/prototype-call.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/toString/radix-err.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/toString/radix-tointegerorinfinity-throws-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/toString/radix-tointegerorinfinity-throws-toprimitive-or-bigint.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/valueOf/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/valueOf/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/valueOf/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: valueOf should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/valueOf/return.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'call')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/valueOf/this-value-invalid-object-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"function\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/prototype/valueOf/this-value-invalid-primitive-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"function\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/tostring-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/valueof-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/BigInt",
+      "test": "built-ins/BigInt/wrapper-object-ordinary-toprimitive.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: hint: default Expected SameValue(\u00ab\"[object Object]\"\u00bb, \u00ab\"1\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/S15.6.2.1_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/S15.6.2.1_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: x1.valueOf() must return true Expected SameValue(\u00ab[object Object]\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/S15.6.2.1_A4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: obj.toString() must return \"[object Boolean]\" Expected SameValue(\u00ab\"[object Object]\"\u00bb, \u00ab\"[object Boolean]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/S15.6.3_A1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/S15.6.3_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Function.prototype.isPrototypeOf(Boolean) must return true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/S15.6.3_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/S9.2_A1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/S15.6.3.1_A1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of Boolean.prototype is expected to be false"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/S15.6.3.1_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected obj[prototype] to have writable:false."
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/S15.6.3.1_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected obj[prototype] to have configurable:false."
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/S15.6.3.1_A4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/constructor/S15.6.4.1_A1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of Boolean.prototype.constructor is expected to equal the value of Boolean Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/toString/S15.6.4.2_A1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Boolean.prototype.toString() must return \"false\" Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"false\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/toString/S15.6.4.2_A1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "RangeError: toString() radix must be between 2 and 36"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/toString/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/toString/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/valueOf/S15.6.4.3_A1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Boolean.prototype.valueOf() must return false Expected SameValue(\u00abundefined\u00bb, \u00abfalse\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/valueOf/S15.6.4.3_A1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Boolean.prototype.valueOf(true) must return false Expected SameValue(\u00abundefined\u00bb, \u00abfalse\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/valueOf/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Boolean",
+      "test": "built-ins/Boolean/prototype/valueOf/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/buffer-not-object-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: 0 Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/byteoffset-is-negative-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: -1 Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/defined-bytelength-and-byteoffset.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/defined-byteoffset-undefined-bytelength.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/defined-byteoffset.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/excessive-bytelength-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: offset: 0, length 4 Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/excessive-byteoffset-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: 2 Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/instance-extensibility.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: confirms extensibility adding a new property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/negative-bytelength-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: new DataView(buffer, 0, -1); Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/negative-byteoffset-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: new DataView(buffer, -1); Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/newtarget-undefined-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abnull\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/buffer/invoked-as-accessor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/buffer/invoked-as-func.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/buffer/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/buffer/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/buffer/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'set')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/buffer/this-is-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/byteLength/invoked-as-accessor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/byteLength/invoked-as-func.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/byteLength/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/byteLength/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/byteLength/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'set')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/byteLength/this-is-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/byteOffset/invoked-as-accessor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/byteOffset/invoked-as-func.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/byteOffset/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/byteOffset/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/byteOffset/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'set')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/byteOffset/return-byteoffset.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab0\u00bb, \u00ab12\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/byteOffset/this-is-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigInt64/index-is-out-of-range.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: DataView access at index Infinity should throw Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigInt64/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigInt64/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigInt64/negative-byteoffset-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: DataView access at index -1 should throw Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigInt64/return-abrupt-from-tonumber-byteoffset-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigInt64/return-abrupt-from-tonumber-byteoffset.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: valueOf Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigInt64/return-value-clean-arraybuffer.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: sample.getBigInt64(0, true) Expected SameValue(\u00abundefined\u00bb, \u00ab0n\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigInt64/this-is-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigUint64/index-is-out-of-range.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: DataView access at index Infinity should throw Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigUint64/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigUint64/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigUint64/negative-byteoffset-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: DataView access at index -1 should throw Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigUint64/return-abrupt-from-tonumber-byteoffset-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigUint64/return-abrupt-from-tonumber-byteoffset.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: valueOf Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigUint64/return-value-clean-arraybuffer.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: sample.getBigUint64(0, true) Expected SameValue(\u00abundefined\u00bb, \u00ab0n\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getBigUint64/this-is-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getFloat32/index-is-out-of-range.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: getIndex == Infinity Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getFloat32/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getFloat32/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getFloat32/negative-byteoffset-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/DataView",
+      "test": "built-ins/DataView/prototype/getFloat32/return-abrupt-from-tonumber-byteoffset-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.2.1_A1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `typeof Date()` is expected to be \"string\" Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"string\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.2.1_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: isEqual(Date(), (new Date()).toString()) must return true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Date.prototype.isPrototypeOf(x12) must return true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A2_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Date.prototype.isPrototypeOf(x12) must return true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A2_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Date.prototype.isPrototypeOf(x12) must return true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A2_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Date.prototype.isPrototypeOf(x12) must return true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A2_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Date.prototype.isPrototypeOf(x12) must return true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A2_T6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Date.prototype.isPrototypeOf(x12) must return true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A3_T1.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Object.prototype.toString.call(new Date(1899, 11)) must return \"[object Date]\" Expected SameValue(\u00ab\"[object Object]\"\u00bb, \u00ab\"[object Date]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A3_T1.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: x1.toString() must return \"[object Date]\" Expected SameValue(\u00ab\"Fri Dec 01 1899 00:00:00 GMT+0100 (local)\"\u00bb, \u00ab\"[object Date]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A3_T2.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Object.prototype.toString.call(new Date(1899, 11, 31)) must return \"[object Date]\" Expected SameValue(\u00ab\"[object Object]\"\u00bb, \u00ab\"[object Date]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A3_T2.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: x1.toString() must return \"[object Date]\" Expected SameValue(\u00ab\"Sun Dec 31 1899 00:00:00 GMT+0100 (local)\"\u00bb, \u00ab\"[object Date]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A3_T3.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Object.prototype.toString.call(new Date(1899, 11, 31, 23)) must return \"[object Date]\" Expected SameValue(\u00ab\"[object Object]\"\u00bb, \u00ab\"[object Date]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A3_T3.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: x1.toString() must return \"[object Date]\" Expected SameValue(\u00ab\"Sun Dec 31 1899 23:00:00 GMT+0100 (local)\"\u00bb, \u00ab\"[object Date]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A3_T4.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Object.prototype.toString.call(new Date(1899, 11, 31, 23, 59)) must return \"[object Date]\" Expected SameValue(\u00ab\"[object Object]\"\u00bb, \u00ab\"[object Date]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A3_T4.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: x1.toString() must return \"[object Date]\" Expected SameValue(\u00ab\"Sun Dec 31 1899 23:59:00 GMT+0100 (local)\"\u00bb, \u00ab\"[object Date]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A3_T5.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Object.prototype.toString.call(new Date(1899, 11, 31, 23, 59, 59)) must return \"[object Date]\" Expected SameValue(\u00ab\"[object Object]\"\u00bb, \u00ab\"[object Date]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A3_T5.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: x1.toString() must return \"[object Date]\" Expected SameValue(\u00ab\"Sun Dec 31 1899 23:59:59 GMT+0100 (local)\"\u00bb, \u00ab\"[object Date]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A3_T6.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Object.prototype.toString.call(new Date(1899, 11, 31, 23, 59, 59, 999)) must return \"[object Date]\" Expected SameValue(\u00ab\"[object Object]\"\u00bb, \u00ab\"[object Date]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A3_T6.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: x1.toString() must return \"[object Date]\" Expected SameValue(\u00ab\"Sun Dec 31 1899 23:59:59 GMT+0100 (local)\"\u00bb, \u00ab\"[object Date]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A4_T0.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `new Date(new PoisonedValueOf(1))` throws a Test262Error exception Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A4_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `new Date(new PoisonedValueOf(1), new PoisonedValueOf(2))` throws a Test262Error exception Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A4_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `new Date(new PoisonedValueOf(1), new PoisonedValueOf(2), new PoisonedValueOf(3))` throws a Test262Error exception Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A4_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `new Date(new PoisonedValueOf(1), new PoisonedValueOf(2), new PoisonedValueOf(3), new PoisonedValueOf(4))` throws a Test262Error exception Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A4_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `new Date(new PoisonedValueOf(1), new PoisonedValueOf(2), new PoisonedValueOf(3), new PoisonedValueOf(4), new PoisonedValueOf(5))` throws a Test262Error exception Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A4_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `new Date(new PoisonedValueOf(1), new PoisonedValueOf(2), new PoisonedValueOf(3), new PoisonedValueOf(4), new PoisonedValueOf(5), new PoisonedValueOf(6))` throws a Test262Error exception Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A4_T6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `new Date(new PoisonedValueOf(1), new PoisonedValueOf(2), new PoisonedValueOf(3), new PoisonedValueOf(4), new PoisonedValueOf(5), new PoisonedValueOf(6), new PoisonedValueOf(7))` throws a Test262Error exception Expected a Test262Error to be thrown but no exception was thrown at a"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A6_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of x is expected to equal NaN Expected SameValue(\u00ab-2211670800000\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A6_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of x is expected to equal NaN Expected SameValue(\u00ab-2209078800000\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A6_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of x is expected to equal NaN Expected SameValue(\u00ab-2208996000000\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A6_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of x is expected to equal NaN Expected SameValue(\u00ab-2208992460000\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.1_A6_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of x is expected to equal NaN Expected SameValue(\u00ab-2208992401000\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.2_A2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Date.prototype.isPrototypeOf(x12) must return true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.2_A3_T1.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Object.prototype.toString.call(new Date(date_1899_end)) must return \"[object Date]\" Expected SameValue(\u00ab\"[object Object]\"\u00bb, \u00ab\"[object Date]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.3.2_A3_T1.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: x1.toString() must return \"[object Date]\" Expected SameValue(\u00ab\"Mon Jan 01 1900 00:59:59 GMT+0100 (local)\"\u00bb, \u00ab\"[object Date]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.4_A1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.4_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.4_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.4_A4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Function.prototype.isPrototypeOf(Date) must return true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/S15.9.4_A5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/TimeClip_negative_zero.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: TimeClip does not return negative zero Expected SameValue(\u00ab-0\u00bb, \u00ab0\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/UTC/coercion-errors.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: year Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/UTC/coercion-order.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"\"\u00bb, \u00ab\"yearmonthdatehoursminutessecondsms\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/UTC/infinity-make-day.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: year: Infinity - single arg Expected SameValue(\u00ab-62198755200000\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Date",
+      "test": "built-ins/Date/UTC/infinity-make-time.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: hour: Infinity Expected SameValue(\u00ab-2208992400000\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/error-message-tostring-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: If _message_ is a Symbol, Error must throw TypeError Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/error-message-tostring-toprimitive.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Error should throw a TypeError in its ToPrimitive step Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/instance-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Error.prototype.isPrototypeOf(new Error()) returns true Expected SameValue(\u00abundefined\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/internal-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/message_property.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: message should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab\"Error\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/S15.11.3.1_A1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected obj[prototype] to have configurable:false."
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/S15.11.3.1_A2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/S15.11.3.1_A3_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/S15.11.3.1_A4_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/S15.11.4_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/S15.11.4_A4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/constructor/S15.11.4.1_A1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of err.constructor is expected to equal the value of Error Expected SameValue(\u00ab-2147483647\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/constructor/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: constructor should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/message/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: message should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/name/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/toString/15.11.4.4-10-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: errObj.toString() Expected SameValue(\u00ab\"Error: ErrorMessage\"\u00bb, \u00ab\"ErrorName: ErrorMessage\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/toString/15.11.4.4-8-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: errObj.toString() Expected SameValue(\u00ab\"Error: ErrorMessage\"\u00bb, \u00ab\"ErrorMessage\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/toString/15.11.4.4-8-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected errObj.toString() to be '', actually Error"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/toString/15.11.4.4-9-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: errObj.toString() Expected SameValue(\u00ab\"Error\"\u00bb, \u00ab\"ErrorName\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/toString/called-as-function.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Object.defineProperty called on non-object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/toString/invalid-receiver.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Error.prototype.toString.call(undefined) Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/toString/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/toString/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/toString/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: toString should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/toString/tostring-get-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name field getter should throw to cover abrupt completion return case in step 3 Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/toString/tostring-message-throws-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: If message field is a symbol, Error.prototype.toString must throw a TypeError Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/toString/tostring-message-throws-toprimitive.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: ToPrimitive(msg) called by ToString(msg) throws TypeError Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/prototype/toString/undefined-props.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab\"Error\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/the-initial-value-of-errorprototypemessage-is-the-empty-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'message')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/tostring-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: new Error.toString() returns \"[object Error]\" (Object.prototype.toString) Expected SameValue(\u00ab\"Error\"\u00bb, \u00ab\"[object Error]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Error",
+      "test": "built-ins/Error/tostring-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Error().toString() returns \"Error\" Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"Error\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.2.1-10-6gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.2.1-11-1-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.2.1-11-3-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.2.1-11-5-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5-1gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5-2gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-11gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-15gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-16gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-17gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-18gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-19gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-1gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-20gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-21gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-22gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-23gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-24gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-25gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-26gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-27gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-28gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-29gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-2gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-30gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-31gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-32gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-33gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-34gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-35gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-36gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-37gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-38gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-39gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-3gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-40gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-41gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-42gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-43gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-44gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-45gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-46gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-47gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-48gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-49gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-4gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-50gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-51gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Function",
+      "test": "built-ins/Function/15.3.5.4_2-52gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/extensibility.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/has-instance.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/instance-construct-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/instance-length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/instance-name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/instance-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/instance-restricted-properties.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/instance-yield-expr-in-param.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/invoked-as-constructor-no-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/invoked-as-function-multiple-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/invoked-as-function-no-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/invoked-as-function-single-argument.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/prototype/extensibility.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/prototype/not-callable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/prototype/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'constructor')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorFunction",
+      "test": "built-ins/GeneratorFunction/prototype/prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/next/context-method-invocation.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/next/from-state-executing.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Error when invoked without value Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/next/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/next/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/next/property-descriptor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/next/this-val-not-generator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/next/this-val-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/return/from-state-executing.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/return/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/return/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/return/property-descriptor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/return/this-val-not-generator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/return/this-val-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/return/try-catch-within-catch.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: statement following `yield` not executed (following `return`) Expected SameValue(\u00ab2\u00bb, \u00ab0\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/return/try-finally-nested-try-catch-within-catch.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `finally` code path not executed Expected SameValue(\u00ab1\u00bb, \u00ab0\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/return/try-finally-nested-try-catch-within-finally.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Error"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/return/try-finally-nested-try-catch-within-inner-try.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `finally` code path executed Expected SameValue(\u00ab0\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/return/try-finally-nested-try-catch-within-outer-try-before-nested.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `finally` code path executed Expected SameValue(\u00ab0\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/return/try-finally-set-property-within-try.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: finally block must supersede return value Expected SameValue(\u00ab45\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/return/try-finally-within-try.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `finally` code path executed Expected SameValue(\u00ab0\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/from-state-completed.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a E but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/from-state-executing.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Thrown value was not an object!"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/from-state-suspended-start.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a E but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/property-descriptor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/this-val-not-generator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/this-val-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of null (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/try-catch-before-try.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/try-catch-following-catch.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: [object] (bits=0x7FFD05D8B468A008)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/try-catch-within-catch.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Test262Error:"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/try-catch-within-try.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Third result `value` Expected SameValue(\u00abundefined\u00bb, \u00abTest262Error: \u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/try-finally-before-try.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/try-finally-following-finally.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/try-finally-nested-try-catch-within-catch.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Error"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/try-finally-nested-try-catch-within-finally.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Error"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/try-finally-nested-try-catch-within-inner-try.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Third result `value` Expected SameValue(\u00abundefined\u00bb, \u00abError\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/try-finally-nested-try-catch-within-outer-try-after-nested.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Error"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/try-finally-nested-try-catch-within-outer-try-before-nested.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Second result `value` Expected SameValue(\u00abundefined\u00bb, \u00ab4\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/try-finally-within-finally.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/GeneratorPrototype",
+      "test": "built-ins/GeneratorPrototype/throw/try-finally-within-try.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Test262Error:"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Infinity",
+      "test": "built-ins/Infinity/S15.1.1.2_A3_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `delete Infinity` is expected to be false Expected SameValue(\u00ab1\u00bb, \u00abfalse\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Infinity",
+      "test": "built-ins/Infinity/S15.1.1.2_A4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Iterator",
+      "test": "built-ins/Iterator/prototype/Symbol.iterator/is-function.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"function\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Iterator",
+      "test": "built-ins/Iterator/prototype/Symbol.iterator/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Iterator",
+      "test": "built-ins/Iterator/prototype/Symbol.iterator/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Iterator",
+      "test": "built-ins/Iterator/prototype/Symbol.iterator/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Symbol(Symbol.iterator) should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Iterator",
+      "test": "built-ins/Iterator/prototype/Symbol.iterator/return-val.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'call')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/15.12-0-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: typeof(o) Expected SameValue(\u00ab\"number\"\u00bb, \u00ab\"object\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/15.12-0-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/15.12-0-3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-0-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-0-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Thrown value was not an object!"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-0-3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Thrown value was not an object!"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-0-4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Thrown value was not an object!"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-0-5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Thrown value was not an object!"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-0-6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Thrown value was not an object!"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-0-8.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Thrown value was not an object!"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-g1-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: <TAB> should produce a syntax error as whitespace results in two tokens Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-g1-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: <CR> should produce a syntax error as whitespace results in two tokens Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-g1-3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: <LF> should produce a syntax error as whitespace results in two tokens Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-g1-4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: <SP> should produce a syntax error as whitespace results in two tokens Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-g2-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Thrown value was not an object!"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-g2-3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Thrown value was not an object!"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-g2-4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-g4-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-g4-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-g4-3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-g4-4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-g5-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Thrown value was not an object!"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/15.12.1.1-g5-3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Thrown value was not an object!"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/invalid-whitespace.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: \\u1680 Thrown value was not an object!"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: parse should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/revived-proxy-revoked.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/revived-proxy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: proxy for ordinary object Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/reviver-array-define-prop-err.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/reviver-array-delete-err.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/reviver-array-get-prop-from-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected true but got false"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/reviver-array-length-coerce-err.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/reviver-array-length-get-err.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/reviver-array-non-configurable-prop-create.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Object.defineProperty called on non-object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/JSON",
+      "test": "built-ins/JSON/parse/reviver-array-non-configurable-prop-delete.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Object.defineProperty called on non-object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/get-set-method-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/iterable-calls-set.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `Map.prototype.set` called twice. Expected SameValue(\u00ab0\u00bb, \u00ab2\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/iterator-close-after-set-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/iterator-close-failure-after-set-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/iterator-is-undefined-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/iterator-item-first-entry-returns-abrupt.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/iterator-item-second-entry-returns-abrupt.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/iterator-items-are-not-object-close-iterator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/iterator-items-are-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/iterator-next-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/iterator-value-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/map-iterable-throws-when-set-is-not-callable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/newtarget.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `Object.getPrototypeOf(m1)` returns `Map.prototype` Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/properties-of-map-instances.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `Object.getPrototypeOf(new Map())` returns `Map.prototype` Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/Symbol.iterator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/clear/clear.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: clear should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/clear/context-is-not-map-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/clear/context-is-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/clear/context-is-set-object-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/clear/context-is-weakmap-object-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/clear/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/clear/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/clear/returns-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: clears a map and returns undefined Expected SameValue(\u00ab0\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/delete/context-is-not-map-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/delete/context-is-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/delete/context-is-set-object-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/delete/context-is-weakmap-object-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/delete/delete.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: delete should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/delete/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/delete/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/descriptor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: prototype should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/entries/does-not-have-mapdata-internal-slot-set.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/entries/does-not-have-mapdata-internal-slot-weakmap.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/entries/does-not-have-mapdata-internal-slot.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/entries/entries.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: entries should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/entries/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/entries/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/entries/this-not-object-throw.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/forEach/callback-result-is-abrupt.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Map",
+      "test": "built-ins/Map/prototype/forEach/callback-this-non-strict.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Perry ran clean; Node rejected (missed negative)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/MapIteratorPrototype",
+      "test": "built-ins/MapIteratorPrototype/next/does-not-have-mapiterator-internal-slots-map.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/MapIteratorPrototype",
+      "test": "built-ins/MapIteratorPrototype/next/does-not-have-mapiterator-internal-slots.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/MapIteratorPrototype",
+      "test": "built-ins/MapIteratorPrototype/next/iteration-mutable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Exhausted result `value` (repeated request) Expected SameValue(\u00ab4,44\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/MapIteratorPrototype",
+      "test": "built-ins/MapIteratorPrototype/next/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/MapIteratorPrototype",
+      "test": "built-ins/MapIteratorPrototype/next/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/MapIteratorPrototype",
+      "test": "built-ins/MapIteratorPrototype/next/this-not-object-throw-entries.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/MapIteratorPrototype",
+      "test": "built-ins/MapIteratorPrototype/next/this-not-object-throw-keys.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/MapIteratorPrototype",
+      "test": "built-ins/MapIteratorPrototype/next/this-not-object-throw-prototype-iterator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/MapIteratorPrototype",
+      "test": "built-ins/MapIteratorPrototype/next/this-not-object-throw-values.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/E/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: E should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/LN10/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: LN10 should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/LN2/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: LN2 should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/LOG10E/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: LOG10E should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/LOG2E/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: LOG2E should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/PI/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: PI should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/SQRT1_2/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'enumerable')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/SQRT2/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: SQRT2 should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/abs/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/abs/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/abs/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: abs should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/acos/S15.8.2.2_A1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abNaN\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/acos/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/acos/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/acos/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: acos should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/acosh/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/acosh/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/acosh/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: acosh should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/asin/S15.8.2.3_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: -1.000000000000001 Expected SameValue(\u00abNaN\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/asin/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/asin/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/asin/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: asin should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/asinh/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/asinh/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/asinh/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: asinh should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/atan/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/atan/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Math",
+      "test": "built-ins/Math/atan/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: atan should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NaN",
+      "test": "built-ins/NaN/S15.1.1.1_A3_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `delete NaN` is expected to be false Expected SameValue(\u00ab1\u00bb, \u00abfalse\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NaN",
+      "test": "built-ins/NaN/S15.1.1.1_A4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/EvalError/instance-proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abEvalError\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/EvalError/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/EvalError/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/EvalError/proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abnull\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/EvalError/prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00abEvalError\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/EvalError/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/EvalError/prototype/message.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab\"\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/EvalError/prototype/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/EvalError/prototype/proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/RangeError/instance-proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abRangeError\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/RangeError/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/RangeError/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/RangeError/proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abnull\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/RangeError/prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00abRangeError\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/RangeError/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/RangeError/prototype/message.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab\"\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/RangeError/prototype/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/RangeError/prototype/proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/ReferenceError/instance-proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abReferenceError\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/ReferenceError/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/ReferenceError/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/ReferenceError/proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abnull\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/ReferenceError/prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00abReferenceError\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/ReferenceError/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/ReferenceError/prototype/message.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab\"\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/ReferenceError/prototype/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/ReferenceError/prototype/proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/SyntaxError/instance-proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abSyntaxError\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/SyntaxError/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/SyntaxError/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/SyntaxError/proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abnull\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/SyntaxError/prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00abSyntaxError\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/SyntaxError/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/SyntaxError/prototype/message.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab\"\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/SyntaxError/prototype/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/SyntaxError/prototype/proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/TypeError/instance-proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abTypeError\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/TypeError/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/TypeError/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/TypeError/proto.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abnull\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/NativeErrors",
+      "test": "built-ins/NativeErrors/TypeError/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/15.7.3-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Function.prototype.isPrototypeOf(Number) Expected SameValue(\u00abundefined\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/15.7.3-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: p Expected SameValue(\u00abnull\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/15.7.4-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: s Expected SameValue(\u00ab\"[object Object]\"\u00bb, \u00ab\"[object Number]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/EPSILON.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: EPSILON should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/MAX_SAFE_INTEGER.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'set')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/MAX_VALUE/S15.7.3.2_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'writable')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/MAX_VALUE/S15.7.3.2_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'configurable')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/MAX_VALUE/S15.7.3.2_A4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/MIN_SAFE_INTEGER.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'set')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/MIN_VALUE/S15.7.3.3_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'writable')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/MIN_VALUE/S15.7.3.3_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'configurable')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/MIN_VALUE/S15.7.3.3_A4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/MIN_VALUE/value.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Number.MIN_VALUE divided by 2 should underflow to 0 Expected SameValue(\u00ab0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/NEGATIVE_INFINITY/S15.7.3.5_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'writable')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/NEGATIVE_INFINITY/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'enumerable')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/NaN.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: NaN should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/POSITIVE_INFINITY/S15.7.3.6_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'writable')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/POSITIVE_INFINITY/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'enumerable')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.1.1_A1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Number(\"INFINITY\") returns NaN Expected SameValue(\u00abInfinity\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.2.1_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'prototype')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.2.1_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: x1.valueOf() must return 1 Expected SameValue(\u00ab[object Object]\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.2.1_A4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: obj.toString() must return \"[object Number]\" Expected SameValue(\u00ab\"[object Object]\"\u00bb, \u00ab\"[object Number]\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.3_A1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.3_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.3_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.3_A4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.3_A5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.3_A6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.3_A7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Function.prototype.isPrototypeOf(Number) must return true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.3_A8.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.5_A1_T01.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of (new Number()).constructor is expected to equal the value of Number.prototype.constructor Expected SameValue(\u00abundefined\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.5_A1_T02.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of (new Number()).toString is expected to equal the value of Number.prototype.toString Expected SameValue(\u00abundefined\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.5_A1_T03.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of (new Number()).toLocaleString is expected to equal the value of Number.prototype.toLocaleString Expected SameValue(\u00abundefined\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.5_A1_T04.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of (new Number()).valueOf is expected to equal the value of Number.prototype.valueOf Expected SameValue(\u00abundefined\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.5_A1_T05.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of (new Number()).toFixed is expected to equal the value of Number.prototype.toFixed Expected SameValue(\u00abundefined\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.5_A1_T06.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of (new Number()).toExponential is expected to equal the value of Number.prototype.toExponential Expected SameValue(\u00abundefined\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S15.7.5_A1_T07.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of (new Number()).toPrecision is expected to equal the value of Number.prototype.toPrecision Expected SameValue(\u00abundefined\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S8.12.8_A4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The result of evaluating (e instanceof TypeError) is expected to be true Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Number",
+      "test": "built-ins/Number/S9.1_A1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Number({valueOf: function() {return \"1\"}, toString: function() {return 0}}) must return 1 Expected SameValue(\u00ab0\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.1.1_A2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of obj.constructor is expected to equal the value of Boolean Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.1.1_A2_T10.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj is expected to equal the value of arr Expected SameValue(\u00ab1,2,3,4\u00bb, \u00ab1,2,3,4\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.1.1_A2_T11.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `typeof func` is expected to be \"undefined\" Expected SameValue(\u00ab\"object\"\u00bb, \u00ab\"undefined\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.1.1_A2_T12.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of obj.constructor is expected to equal the value of Number Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.1.1_A2_T13.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of obj.constructor is expected to equal the value of Boolean Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.1.1_A2_T14.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of obj.constructor is expected to equal the value of String Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.1.1_A2_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of obj.constructor is expected to equal the value of Number Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.1.1_A2_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of obj.constructor is expected to equal the value of String Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.1.1_A2_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of obj.constructor is expected to equal the value of Number Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.1.1_A2_T6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of obj.constructor is expected to equal the value of Number Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.1.1_A2_T7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of obj.constructor is expected to equal the value of String Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.1.1_A3_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of obj.constructor is expected to equal the value of Number Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.1.1_A3_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of obj.constructor is expected to equal the value of Number Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj is expected to equal the value of obj Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A2_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj is expected to equal the value of func Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A2_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj is expected to equal the value of arr Expected SameValue(\u00ab[object Object]\u00bb, \u00ab1,2,3,4\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A2_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj is expected to equal the value of obj Expected SameValue(\u00ab[object Object]\u00bb, \u00abSat Apr 01 1978 00:00:00 GMT+0100 (local)\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A2_T6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj is expected to equal the value of func Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A2_T7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `typeof func` is expected to be \"undefined\" Expected SameValue(\u00ab\"object\"\u00bb, \u00ab\"undefined\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A3_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj.constructor is expected to equal the value of String Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A3_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj.constructor is expected to equal the value of String Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A3_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj.constructor is expected to equal the value of String Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A4_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj.constructor is expected to equal the value of Boolean Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A4_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj.constructor is expected to equal the value of Boolean Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A4_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj.constructor is expected to equal the value of Boolean Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A5_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj.constructor is expected to equal the value of Number Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A5_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj.constructor is expected to equal the value of Number Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A5_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj.constructor is expected to equal the value of Number Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A5_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of n_obj.constructor is expected to equal the value of Number Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A6_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of obj.constructor is expected to equal the value of Number Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.2.1_A6_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of obj.constructor is expected to equal the value of Number Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.3_A1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.3_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of !!Function.prototype.isPrototypeOf(Object) is expected to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S15.2.3_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S9.9_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Object(true).valueOf() must return true Expected SameValue(\u00ab[object Object]\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S9.9_A4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Object(0).valueOf() must return 0 Expected SameValue(\u00ab[object Object]\u00bb, \u00ab0\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/S9.9_A5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Object(\"some string\").valueOf() must return \"some string\" Expected SameValue(\u00ab[object Object]\u00bb, \u00ab\"some string\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/assign/OnlyOneArgument.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"string\"\u00bb, \u00ab\"object\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/assign/Override-notstringtarget.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The length should be 4 in the final object. Expected SameValue(\u00ab0\u00bb, \u00ab4\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Object",
+      "test": "built-ins/Object/assign/Override.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value should be {\"0\":\"1\"}. Expected SameValue(\u00ab0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/S25.4.4.1_A4.1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/S25.4.4.1_A5.1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Test262Error:"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/call-resolve-element-after-return.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: callCount after call to all() Expected SameValue(\u00ab0\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/call-resolve-element-items.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: callCount after call to all() Expected SameValue(\u00ab0\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/call-resolve-element.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: callCount after call to all() Expected SameValue(\u00ab0\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/capability-executor-called-twice.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: executor initially called with no arguments Expected SameValue(\u00ab\"\"\u00bb, \u00ab\"abc\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/capability-executor-not-callable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: executor not called at all Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/capability-resolve-throws-no-close.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Perry ran clean; Node rejected (missed negative)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/ctx-ctor-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/ctx-ctor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/ctx-non-ctor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/ctx-non-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/does-not-invoke-array-setters.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Perry ran clean; Node rejected (missed negative)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/invoke-resolve-get-once-no-calls.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Got `resolve` only once for each iterated value Expected SameValue(\u00ab0\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/invoke-resolve-return.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: new `then` method invoked exactly once Expected SameValue(\u00ab0\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/invoke-resolve.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `resolve` invoked once for each iterated value Expected SameValue(\u00ab0\u00bb, \u00ab3\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/invoke-then.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `then` invoked once for every iterated value Expected SameValue(\u00ab0\u00bb, \u00ab3\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-assigned-false-reject.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-assigned-null-reject.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-assigned-number-reject.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-assigned-string-reject.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-assigned-symbol-reject.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-assigned-true-reject.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-next-val-err-reject.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Test262Error:"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/apply/call-parameters.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/apply/call-result.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/apply/null-handler.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/apply/return-abrupt.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/apply/trap-is-missing-target-is-proxy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/apply/trap-is-not-callable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/apply/trap-is-null-target-is-proxy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/apply/trap-is-null.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/apply/trap-is-undefined-no-property.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/apply/trap-is-undefined-target-is-proxy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/apply/trap-is-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/construct/call-parameters.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: trap context is the handler object Expected SameValue(\u00abundefined\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/construct/null-handler.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/construct/return-is-abrupt.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/construct/return-not-object-throws-boolean.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/construct/return-not-object-throws-null.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/construct/return-not-object-throws-number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/construct/return-not-object-throws-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/construct/return-not-object-throws-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/construct/return-not-object-throws-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/construct/trap-is-not-callable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/create-handler-not-object-throw-boolean.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/create-handler-not-object-throw-null.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/create-handler-not-object-throw-number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/create-handler-not-object-throw-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/create-handler-not-object-throw-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/create-handler-not-object-throw-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/create-target-is-not-callable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/create-target-is-revoked-function-proxy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"object\"\u00bb, \u00ab\"function\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/create-target-not-object-throw-boolean.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/create-target-not-object-throw-null.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/create-target-not-object-throw-number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/create-target-not-object-throw-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/create-target-not-object-throw-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/create-target-not-object-throw-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/defineProperty/call-parameters.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/defineProperty/null-handler.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/defineProperty/return-boolean-and-define-target.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: attr should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/defineProperty/return-is-abrupt.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/defineProperty/targetdesc-configurable-desc-not-configurable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor-not-configurable-target.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/defineProperty/targetdesc-undefined-not-configurable-descriptor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/defineProperty/targetdesc-undefined-target-is-not-extensible.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/defineProperty/trap-is-missing-target-is-proxy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/defineProperty/trap-is-not-callable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/defineProperty/trap-is-null-target-is-proxy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/defineProperty/trap-is-undefined-target-is-proxy.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/defineProperty/trap-is-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/deleteProperty/call-parameters.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: handler object as the trap context Expected SameValue(\u00abundefined\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Proxy",
+      "test": "built-ins/Proxy/deleteProperty/null-handler.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/apply/apply.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: apply should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/apply/arguments-list-is-not-array-like-but-still-valid.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Actual [] and expected [undefined] should have the same contents."
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/apply/arguments-list-is-not-array-like.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `Reflect.apply(fn, null, {get length() {throw new Test262Error();}})` throws a Test262Error exception Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/apply/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/apply/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/apply/target-is-not-callable-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/construct/construct.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: construct should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/defineProperty/define-properties.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/defineProperty/define-symbol-properties.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'writable')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/defineProperty/defineProperty.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: defineProperty should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/defineProperty/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/defineProperty/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/defineProperty/return-abrupt-from-attributes.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/defineProperty/return-abrupt-from-property-key.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/defineProperty/return-abrupt-from-result.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/defineProperty/target-is-not-object-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/defineProperty/target-is-symbol-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/deleteProperty/delete-symbol-properties.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab42\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/deleteProperty/deleteProperty.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: deleteProperty should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/deleteProperty/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/deleteProperty/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/deleteProperty/return-abrupt-from-property-key.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/deleteProperty/return-abrupt-from-result.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/deleteProperty/target-is-not-object-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/deleteProperty/target-is-symbol-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/enumerate/undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/get/get.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: get should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/get/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/get/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/get/return-abrupt-from-property-key.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/get/return-abrupt-from-result.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/get/return-value-from-symbol-key.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab42\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/get/target-is-not-object-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/get/target-is-symbol-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getOwnPropertyDescriptor/getOwnPropertyDescriptor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: getOwnPropertyDescriptor should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getOwnPropertyDescriptor/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getOwnPropertyDescriptor/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getOwnPropertyDescriptor/return-abrupt-from-property-key.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getOwnPropertyDescriptor/return-abrupt-from-result.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getOwnPropertyDescriptor/return-from-accessor-descriptor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getOwnPropertyDescriptor/return-from-data-descriptor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getOwnPropertyDescriptor/symbol-property.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getOwnPropertyDescriptor/target-is-not-object-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getOwnPropertyDescriptor/target-is-symbol-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getOwnPropertyDescriptor/undefined-own-property.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getOwnPropertyDescriptor/undefined-property.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getPrototypeOf/getPrototypeOf.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: getPrototypeOf should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getPrototypeOf/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getPrototypeOf/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getPrototypeOf/return-abrupt-from-result.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Reflect",
+      "test": "built-ins/Reflect/getPrototypeOf/skip-own-properties.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: skip own properties Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/15.10.2.15-6-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/15.10.2.5-3-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/15.10.4.1-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/15.10.4.1-3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.1_A1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The result of evaluating (e instanceof SyntaxError) is expected to be true Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.1_A1_T13.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The result of evaluating (e instanceof SyntaxError) is expected to be true Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.1_A1_T14.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The result of evaluating (e instanceof SyntaxError) is expected to be true Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.1_A1_T15.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The result of evaluating (e instanceof SyntaxError) is expected to be true Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.1_A1_T16.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The result of evaluating (e instanceof SyntaxError) is expected to be true Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.1_A1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The result of evaluating (e instanceof SyntaxError) is expected to be true Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.1_A1_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The result of evaluating (e instanceof SyntaxError) is expected to be true Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.1_A1_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The result of evaluating (e instanceof SyntaxError) is expected to be true Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.1_A1_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The result of evaluating (e instanceof SyntaxError) is expected to be true Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.1_A1_T6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The result of evaluating (e instanceof SyntaxError) is expected to be true Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.10_A2.1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "SyntaxError: Invalid regular expression: /\\cA/: invalid pattern"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.10_A2.1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "SyntaxError: Invalid regular expression: /\\ca/: invalid pattern"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.10_A5.1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: No match for character: < Expected SameValue(\u00abnull\u00bb, \u00abnull\u00bb) to be false"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.11_A1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "SyntaxError: Invalid regular expression: /\\0/: invalid pattern"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.11_A1_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #2: var arr = (/(A)\\1/.exec(\"AA\")); arr[1] === \"A\". Actual. undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.11_A1_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: var arr = (/\\1(A)/.exec(\"AA\")); arr[0] === \"A\". Actual. null"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.11_A1_T6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #2: var arr = /(A)\\1(B)\\2/.exec(\"AABB\"); arr[1] === \"A\". Actual. undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.11_A1_T7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: var arr = /\\1(A)(B)\\2/.exec(\"ABB\"); arr[0] === \"ABB\". Actual. null"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.11_A1_T8.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #2: var arr = /((((((((((A))))))))))\\1\\2\\3\\4\\5\\6\\7\\8\\9\\10/.exec(\"AAAAAAAAAAA\"); arr[1] === \"A\". Actual. undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.11_A1_T9.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #2: var arr = /((((((((((A))))))))))\\10\\9\\8\\7\\6\\5\\4\\3\\2\\1/.exec(\"AAAAAAAAAAA\"); arr[1] === \"A\". Actual. undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "SyntaxError: Invalid regular expression: /[]a/: invalid pattern"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T10.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of __executed.index is expected to equal the value of __expected.index Expected SameValue(\u00ab2\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T11.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of __executed.index is expected to equal the value of __expected.index Expected SameValue(\u00ab0\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T12.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of __executed.index is expected to equal the value of __expected.index Expected SameValue(\u00ab0\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T13.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of __executed.index is expected to equal the value of __expected.index Expected SameValue(\u00ab15\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T14.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of __executed.index is expected to equal the value of __expected.index Expected SameValue(\u00ab3\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T15.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of __executed.index is expected to equal the value of __expected.index Expected SameValue(\u00ab4\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T17.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "SyntaxError: Invalid regular expression: /[]/: invalid pattern"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "SyntaxError: Invalid regular expression: /a[]/: invalid pattern"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of __executed.index is expected to equal the value of __expected.index Expected SameValue(\u00ab2\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of __executed.index is expected to equal the value of __expected.index Expected SameValue(\u00ab3\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of __executed.index is expected to equal the value of __expected.index Expected SameValue(\u00ab1\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of __executed.index is expected to equal the value of __expected.index Expected SameValue(\u00ab0\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T8.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of __executed.index is expected to equal the value of __expected.index Expected SameValue(\u00ab3\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/RegExp",
+      "test": "built-ins/RegExp/S15.10.2.13_A1_T9.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of __executed.index is expected to equal the value of __expected.index Expected SameValue(\u00ab3\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/Symbol.iterator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/add/add.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: add should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/add/does-not-have-setdata-internal-slot-array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/add/does-not-have-setdata-internal-slot-map.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/add/does-not-have-setdata-internal-slot-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/add/does-not-have-setdata-internal-slot-set-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/add/does-not-have-setdata-internal-slot-weakset.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/add/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/add/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/add/this-not-object-throw-boolean.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/add/this-not-object-throw-null.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/add/this-not-object-throw-number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/add/this-not-object-throw-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/add/this-not-object-throw-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/add/this-not-object-throw-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/clear/clear.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: clear should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/clear/does-not-have-setdata-internal-slot-array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/clear/does-not-have-setdata-internal-slot-map.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/clear/does-not-have-setdata-internal-slot-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/clear/does-not-have-setdata-internal-slot-set.prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/clear/does-not-have-setdata-internal-slot-weakset.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/clear/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/clear/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/clear/this-not-object-throw-boolean.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/clear/this-not-object-throw-null.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/clear/this-not-object-throw-number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/clear/this-not-object-throw-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/clear/this-not-object-throw-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/clear/this-not-object-throw-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/constructor/set-prototype-constructor-intrinsic.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `Set.prototype.constructor` is `Set` Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/constructor/set-prototype-constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: constructor should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/delete/delete.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: delete should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/delete/does-not-have-setdata-internal-slot-array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/delete/does-not-have-setdata-internal-slot-map.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/delete/does-not-have-setdata-internal-slot-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/delete/does-not-have-setdata-internal-slot-set-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/delete/does-not-have-setdata-internal-slot-weakset.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/delete/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/delete/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Set",
+      "test": "built-ins/Set/prototype/delete/this-not-object-throw-boolean.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/SetIteratorPrototype",
+      "test": "built-ins/SetIteratorPrototype/next/does-not-have-mapiterator-internal-slots-set.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/SetIteratorPrototype",
+      "test": "built-ins/SetIteratorPrototype/next/does-not-have-mapiterator-internal-slots.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/SetIteratorPrototype",
+      "test": "built-ins/SetIteratorPrototype/next/iteration-mutable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Exhausted result `value` (repeated request) Expected SameValue(\u00ab4\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/SetIteratorPrototype",
+      "test": "built-ins/SetIteratorPrototype/next/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/SetIteratorPrototype",
+      "test": "built-ins/SetIteratorPrototype/next/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/SetIteratorPrototype",
+      "test": "built-ins/SetIteratorPrototype/next/this-not-object-throw-entries.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/SetIteratorPrototype",
+      "test": "built-ins/SetIteratorPrototype/next/this-not-object-throw-keys.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/SetIteratorPrototype",
+      "test": "built-ins/SetIteratorPrototype/next/this-not-object-throw-prototype-iterator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/SetIteratorPrototype",
+      "test": "built-ins/SetIteratorPrototype/next/this-not-object-throw-values.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/15.5.5.5.2-3-6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: s[NaN] Expected SameValue(\u00ab\"l\"\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/15.5.5.5.2-3-7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: s[Infinity] Expected SameValue(\u00ab\"l\"\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/15.5.5.5.2-3-8.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: s[Math.pow(2, 32)-1] Expected SameValue(\u00ab\"\"\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/15.5.5.5.2-7-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: s[-1] Expected SameValue(\u00ab\"\"\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/15.5.5.5.2-7-4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: s[11] Expected SameValue(\u00ab\"\"\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.1.1_A1_T16.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #8: __str = String(.00000012345); __str === \"1.2345e-7\". Actual: __str ===0.00000012345"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.1.1_A1_T18.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #2: __str = String(1000000000000000000000); __str === \"1e+21\". Actual: __str ===1000000000000000000000"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.1.1_A1_T19.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #2: __str = String(new Array(1,2,3)); __str === \"1,2,3\". Actual: __str ===[object Object]"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.1.1_A1_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #2: var x; __str = String(x); __str === \"undefined\". Actual: __str ===0"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.1.1_A1_T6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.1.1_A1_T8.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #2: Array.prototype.toString=function(){return \"__ARRAY__\";}; __str = String(new Array); __str === \"__ARRAY__\". Actual: __str ==="
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str = new String; __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T10.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str = new String(__obj); __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T11.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str = new String(__obj); __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T16.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str =new String(.12345); __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T17.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str = new String(1.2345); __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T18.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str = new String(1000000000000000000000); __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T19.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str = new String(new Array(1,2,3)); __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str = new String(); __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str = new String(\"\"); __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str = new String(1.0); __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str = new String(NaN); __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str = new String(false); __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str = new String({}); __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T8.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str = new String(function(){}); __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A1_T9.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.5: __str = new String(function(){return [1,2,3]}()); __str.constructor === String. Actual: __str.constructor ===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: var __str__obj = new String(\"abba\"); String.prototype.isPrototypeOf(__str__obj)===true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A2_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #2: var __str__obj = new String(\"shocking blue\"); String.prototype.__custom__prop = \"bor\"; __str__obj[\"__custom__prop\"]===\"bor\". Actual: __str__obj[\"__custom__prop\"]===undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.2.1_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: var __str__obj = new String(\"seamaid\"); __str__obj.toString = Object.prototype.toString; __str__obj.toString() === \"[object String]\". Actual: __str__obj.toString() ===[object Object]"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.3_A2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: Function.prototype.isPrototypeOf(String) return true. Actual: undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.3_A2_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: Function.prototype.indicator = 1; String.indicator === 1. Actual: String.indicator ===0"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.5.1_A1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: var __str__instance = new String(\"ABC\\u0041\\u0042\\u0043\"); __str__instance.length === 6, where __str__instance is new String(\"ABC\\u0041\\u0042\\u0043\"). Actual: __str__instance.length ===0"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.5.1_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: var __str__instance = new String(\"globglob\"); __str__instance.hasOwnProperty(\"length\") return true. Actual: false"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/String",
+      "test": "built-ins/String/S15.5.5.1_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: var __str__instance = new String(\"globglob\"); __str__instance.hasOwnProperty(\"length\") return true. Actual: false"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/StringIteratorPrototype",
+      "test": "built-ins/StringIteratorPrototype/ancestry.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/StringIteratorPrototype",
+      "test": "built-ins/StringIteratorPrototype/next/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/StringIteratorPrototype",
+      "test": "built-ins/StringIteratorPrototype/next/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/StringIteratorPrototype",
+      "test": "built-ins/StringIteratorPrototype/next/next-iteration-surrogate-pairs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'next')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/StringIteratorPrototype",
+      "test": "built-ins/StringIteratorPrototype/next/next-iteration.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'next')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/StringIteratorPrototype",
+      "test": "built-ins/StringIteratorPrototype/next/next-missing-internal-slots.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Object prototype may only be an Object or null"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/asyncIterator/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: asyncIterator should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/auto-boxing-non-strict.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `sym[62]` is `undefined`, after executing `sym[62] = 0;` Expected SameValue(\u00ab0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/auto-boxing-strict.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `Object.getPrototypeOf(Symbol('66')).constructor` is `Symbol` Expected SameValue(\u00abundefined\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/desc-to-string-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/desc-to-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"\"\u00bb, \u00ab\"toStringvalueOf\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/for/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/for/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/for/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"number\"\u00bb, \u00ab\"function\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/for/to-string-err.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/invoked-with-new.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/iterator/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: iterator should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/keyFor/arg-non-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"number\"\u00bb, \u00ab\"function\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/keyFor/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/keyFor/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/keyFor/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"number\"\u00bb, \u00ab\"function\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/not-callable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/prototype/intrinsic.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `Object.getPrototypeOf(Symbol('66'))` returns `Symbol.prototype` Expected SameValue(\u00abSymbol(66)\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/prototype/toString/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/prototype/toString/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/prototype/toString/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"function\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/prototype/toString/toString-default-attributes-strict.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/prototype/toString/toString.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'call')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/prototype/valueOf/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/prototype/valueOf/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/prototype/valueOf/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"function\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/prototype/valueOf/this-val-non-obj.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/prototype/valueOf/this-val-obj-non-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/prototype/valueOf/this-val-obj-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'call')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Symbol",
+      "test": "built-ins/Symbol/prototype/valueOf/this-val-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'call')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ThrowTypeError",
+      "test": "built-ins/ThrowTypeError/extensible.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ThrowTypeError",
+      "test": "built-ins/ThrowTypeError/forbidden-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ThrowTypeError",
+      "test": "built-ins/ThrowTypeError/forbidden-caller.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ThrowTypeError",
+      "test": "built-ins/ThrowTypeError/frozen.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ThrowTypeError",
+      "test": "built-ins/ThrowTypeError/is-function.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ThrowTypeError",
+      "test": "built-ins/ThrowTypeError/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ThrowTypeError",
+      "test": "built-ins/ThrowTypeError/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ThrowTypeError",
+      "test": "built-ins/ThrowTypeError/property-order.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ThrowTypeError",
+      "test": "built-ins/ThrowTypeError/prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ThrowTypeError",
+      "test": "built-ins/ThrowTypeError/throws-type-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ThrowTypeError",
+      "test": "built-ins/ThrowTypeError/unique-per-realm-non-simple.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/ThrowTypeError",
+      "test": "built-ins/ThrowTypeError/unique-per-realm-unmapped-args.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'get')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/from/arylk-get-length-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/from/arylk-to-length-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/from/invoked-as-func.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/from/invoked-as-method.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/from/iter-access-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/from/iter-invoke-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/from/iter-next-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/from/iter-next-value-error.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/from/iterated-array-changed-by-tonumber.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/from/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/from/mapfn-is-not-callable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: mapfn is null Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/from/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/from/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: from should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/from/this-is-not-constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/invoked.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/of/invoked-as-func.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/of/invoked-as-method.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/of/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/of/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/of/prop-desc.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: of should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/of/this-is-not-constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/Symbol.iterator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Symbol(Symbol.iterator) should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/buffer/invoked-as-accessor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/buffer/invoked-as-func.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/buffer/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/buffer/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/buffer/this-has-no-typedarrayname-internal.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/buffer/this-inherits-typedarray.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Internal slot should not be inherited Expected a  to be thrown but no exception was thrown at all (Testing with  and makePassthrough.)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/buffer/this-is-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: this is undefined Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteLength/BigInt/return-bytelength.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab336\u00bb, \u00abNaN\u00bb) to be true (Testing with  and makePassthrough.)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteLength/invoked-as-accessor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteLength/invoked-as-func.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteLength/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteLength/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteLength/return-bytelength.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab336\u00bb, \u00abNaN\u00bb) to be true (Testing with  and makePassthrough.)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteLength/this-has-no-typedarrayname-internal.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteLength/this-is-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: this is undefined Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteOffset/BigInt/return-byteoffset.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: TA(buffer, offset) Expected SameValue(\u00ab0\u00bb, \u00abNaN\u00bb) to be true (Testing with  and makeArrayBuffer.)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteOffset/invoked-as-accessor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteOffset/invoked-as-func.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteOffset/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteOffset/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteOffset/return-byteoffset.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: TA(buffer, offset) Expected SameValue(\u00ab0\u00bb, \u00abNaN\u00bb) to be true (Testing with  and makeArrayBuffer.)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteOffset/this-has-no-typedarrayname-internal.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/byteOffset/this-is-not-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: this is undefined Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/copyWithin/BigInt/coerced-values-end.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: null value coerced to 0 (Testing with  and makePassthrough.)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/copyWithin/BigInt/coerced-values-start.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: undefined value coerced to 0 (Testing with  and makePassthrough.)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/copyWithin/BigInt/coerced-values-target.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: undefined value coerced to 0 (Testing with  and makePassthrough.)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/copyWithin/BigInt/negative-end.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: [0, 1, 2, 3].copyWithin(0, 1, -1) -> [1, 2, 2, 3] (Testing with  and makePassthrough.)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/copyWithin/BigInt/negative-out-of-bounds-end.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: [0, 1, 2, 3].copyWithin(0, 1, -10) -> [0, 1, 2, 3] (Testing with  and makePassthrough.)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArray",
+      "test": "built-ins/TypedArray/prototype/copyWithin/BigInt/negative-out-of-bounds-start.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: [0, 1, 2, 3]).copyWithin(0, -10) -> [0, 1, 2, 3] (Testing with  and makePassthrough.)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/BigInt64Array/BYTES_PER_ELEMENT.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: BYTES_PER_ELEMENT should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/BigInt64Array/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/BigInt64Array/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/BigInt64Array/prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: prototype should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/BigInt64Array/prototype/BYTES_PER_ELEMENT.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: BYTES_PER_ELEMENT should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/BigInt64Array/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: constructor should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/BigInt64Array/prototype/not-typedarray-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/BigUint64Array/BYTES_PER_ELEMENT.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: BYTES_PER_ELEMENT should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/BigUint64Array/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/BigUint64Array/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/BigUint64Array/prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: prototype should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/BigUint64Array/prototype/BYTES_PER_ELEMENT.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: BYTES_PER_ELEMENT should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/BigUint64Array/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: constructor should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/BigUint64Array/prototype/not-typedarray-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Float32Array/BYTES_PER_ELEMENT.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab0\u00bb, \u00ab4\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Float32Array/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Float32Array/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Float32Array/prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00abnull\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Float32Array/prototype/BYTES_PER_ELEMENT.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab4\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Float32Array/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Float32Array/prototype/not-typedarray-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Float64Array/BYTES_PER_ELEMENT.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab0\u00bb, \u00ab8\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Float64Array/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Float64Array/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Float64Array/prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00abnull\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Float64Array/prototype/BYTES_PER_ELEMENT.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab8\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Float64Array/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Float64Array/prototype/not-typedarray-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Int16Array/BYTES_PER_ELEMENT.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab0\u00bb, \u00ab2\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Int16Array/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Int16Array/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Int16Array/prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00abnull\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Int16Array/prototype/BYTES_PER_ELEMENT.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab2\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Int16Array/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Int16Array/prototype/not-typedarray-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Int32Array/BYTES_PER_ELEMENT.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab0\u00bb, \u00ab4\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Int32Array/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Int32Array/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Int32Array/prototype/BYTES_PER_ELEMENT.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab4\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Int32Array/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/TypedArrayConstructors",
+      "test": "built-ins/TypedArrayConstructors/Int32Array/prototype/not-typedarray-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/empty-iterable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/get-set-method-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/iterable-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/iterable-with-object-keys.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Called WeakMap#set for each object Expected SameValue(\u00ab0\u00bb, \u00ab2\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/iterator-close-after-set-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/iterator-item-first-entry-returns-abrupt.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/iterator-item-second-entry-returns-abrupt.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/iterator-items-are-not-object-close-iterator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/iterator-items-keys-cannot-be-held-weakly.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/iterator-next-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/iterator-value-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/no-iterable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/properties-of-map-instances.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `Object.getPrototypeOf(new WeakMap())` returns `WeakMap.prototype` Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/delete/delete.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: delete should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-map.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-set.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-weakmap-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/delete/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/delete/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/delete/this-not-object-throw-boolean.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/delete/this-not-object-throw-null.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/delete/this-not-object-throw-number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/delete/this-not-object-throw-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/delete/this-not-object-throw-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/delete/this-not-object-throw-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/get/does-not-have-weakmapdata-internal-slot-map.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/get/does-not-have-weakmapdata-internal-slot-set.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/get/does-not-have-weakmapdata-internal-slot.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/get/get.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: get should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/get/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/get/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/get/this-not-object-throw.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-map.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-set.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-weakmap-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/has/has.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: has should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/has/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/has/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/has/this-not-object-throw-boolean.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/has/this-not-object-throw-null.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakMap",
+      "test": "built-ins/WeakMap/prototype/has/this-not-object-throw-number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/add-not-callable-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/empty-iterable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/get-add-method-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/iterable-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/iterable-with-object-values.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Called WeakSet#add for each object Expected SameValue(\u00ab0\u00bb, \u00ab2\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/iterator-close-after-add-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/iterator-next-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/iterator-value-failure.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/no-iterable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/add.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: add should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-map.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-set.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-weakset-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/this-not-object-throw-boolean.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/this-not-object-throw-null.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/this-not-object-throw-number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/this-not-object-throw-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/this-not-object-throw-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/this-not-object-throw-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/add/throw-when-value-cannot-be-held-weakly.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/constructor/weakset-prototype-constructor-intrinsic.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of WeakSet.prototype.constructor is \"WeakSet\" Expected SameValue(\u00ab[object Object]\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/constructor/weakset-prototype-constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: constructor should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/delete/delete.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: delete should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-map.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-set.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-weakset-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/delete/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/delete/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/delete/this-not-object-throw-boolean.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/delete/this-not-object-throw-null.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/delete/this-not-object-throw-number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/delete/this-not-object-throw-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/delete/this-not-object-throw-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/delete/this-not-object-throw-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-array.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-map.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-set.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-weakset-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/has/has.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: has should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/has/length.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/WeakSet",
+      "test": "built-ins/WeakSet/prototype/has/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURI",
+      "test": "built-ins/decodeURI/S15.1.3.1_A2.5_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #20000-10FFFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURI",
+      "test": "built-ins/decodeURI/S15.1.3.1_A5.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURI",
+      "test": "built-ins/decodeURI/S15.1.3.1_A5.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURI",
+      "test": "built-ins/decodeURI/S15.1.3.1_A5.3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURI",
+      "test": "built-ins/decodeURI/S15.1.3.1_A5.4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: decodeURI.length === 1. Actual: 0"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURI",
+      "test": "built-ins/decodeURI/S15.1.3.1_A5.5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURI",
+      "test": "built-ins/decodeURI/S15.1.3.1_A5.7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.2: new decodeURI() throw TypeError. Actual: Test262Error: #1.1: new decodeURI() throw TypeError. Actual: [object Object]"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURI",
+      "test": "built-ins/decodeURI/S15.1.3.1_A6_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: var object = {valueOf: function() {return \"%5E\"}}; decodeURI(object) === [object Object]. Actual:"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURI",
+      "test": "built-ins/decodeURI/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURIComponent",
+      "test": "built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #20000-10FFFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURIComponent",
+      "test": "built-ins/decodeURIComponent/S15.1.3.2_A5.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURIComponent",
+      "test": "built-ins/decodeURIComponent/S15.1.3.2_A5.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURIComponent",
+      "test": "built-ins/decodeURIComponent/S15.1.3.2_A5.3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURIComponent",
+      "test": "built-ins/decodeURIComponent/S15.1.3.2_A5.4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: decodeURIComponent.length === 1. Actual: 0"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURIComponent",
+      "test": "built-ins/decodeURIComponent/S15.1.3.2_A5.5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURIComponent",
+      "test": "built-ins/decodeURIComponent/S15.1.3.2_A5.7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.2: new decodeURIComponent() throw TypeError. Actual: Test262Error: #1.1: new decodeURIComponent() throw TypeError. Actual: [object Object]"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURIComponent",
+      "test": "built-ins/decodeURIComponent/S15.1.3.2_A6_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: var object = {valueOf: function() {return \"%5E\"}}; decodeURIComponent(object) === [object Object]. Actual: r"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURIComponent",
+      "test": "built-ins/decodeURIComponent/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/decodeURIComponent",
+      "test": "built-ins/decodeURIComponent/throw-URIError.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/S15.1.3.3_A1.1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #DC00-DFFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/S15.1.3.3_A1.1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #DC00-DFFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/S15.1.3.3_A1.2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #D800-DBFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/S15.1.3.3_A1.2_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #D800-DBFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/S15.1.3.3_A1.3_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #D800-DBFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/S15.1.3.3_A2.4_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #D800-DBFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/S15.1.3.3_A2.4_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #DC00-DFFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/S15.1.3.3_A5.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/S15.1.3.3_A5.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/S15.1.3.3_A5.3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/S15.1.3.3_A5.4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: encodeURI.length === 1. Actual: 0"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/S15.1.3.3_A5.5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/S15.1.3.3_A5.7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.2: new encodeURI() throw TypeError. Actual: Test262Error: #1.1: new encodeURI() throw TypeError. Actual: [object Object]"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/S15.1.3.3_A6_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: var object = {valueOf: function() {return \"^\"}}; encodeURI(object) === %5Bobject%20Object%5D. Actual: %0F"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURI",
+      "test": "built-ins/encodeURI/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/S15.1.3.4_A1.1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #DC00-DFFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/S15.1.3.4_A1.1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #DC00-DFFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/S15.1.3.4_A1.2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #D800-DBFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/S15.1.3.4_A1.2_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #D800-DBFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/S15.1.3.4_A1.3_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #D800-DBFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/S15.1.3.4_A2.4_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #D800-DBFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/S15.1.3.4_A2.4_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #DC00-DFFF"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/S15.1.3.4_A5.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/S15.1.3.4_A5.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/S15.1.3.4_A5.3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/S15.1.3.4_A5.4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: encodeURIComponent.length === 1. Actual: 0"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/S15.1.3.4_A5.5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/S15.1.3.4_A5.7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.2: new encodeURIComponent() throw TypeError. Actual: Test262Error: #1.1: new encodeURIComponent() throw TypeError. Actual: [object Object]"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/S15.1.3.4_A6_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: var object = {valueOf: function() {return \"^\"}}; encodeURIComponent(object) === %5Bobject%20Object%5D. Actual:"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/encodeURIComponent",
+      "test": "built-ins/encodeURIComponent/name.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: name should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/10.2.1.1.3-4-16-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/10.2.1.1.3-4-18-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S10.2.3_A2.1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S10.2.3_A2.1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S10.2.3_A2.1_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S10.2.3_A2.1_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S15.1_A1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S15.1_A1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/global",
+      "test": "built-ins/global/S15.1_A2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/isFinite",
+      "test": "built-ins/isFinite/S15.1.2.5_A2.7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/isFinite",
+      "test": "built-ins/isFinite/return-abrupt-from-tonumber-number-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/isFinite",
+      "test": "built-ins/isFinite/return-abrupt-from-tonumber-number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: valueOf Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/isNaN",
+      "test": "built-ins/isNaN/S15.1.2.4_A2.7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/isNaN",
+      "test": "built-ins/isNaN/return-abrupt-from-tonumber-number-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/isNaN",
+      "test": "built-ins/isNaN/return-abrupt-from-tonumber-number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: valueOf Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseFloat",
+      "test": "built-ins/parseFloat/S15.1.2.3_A1_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: parseFloat(new Number(-1.1)) === parseFloat(\"-1.1\"). Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseFloat",
+      "test": "built-ins/parseFloat/S15.1.2.3_A1_T6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: parseFloat(new String(\"-1.1\")) === parseFloat(\"-1.1\"). Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseFloat",
+      "test": "built-ins/parseFloat/S15.1.2.3_A1_T7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #8.2: var object = {valueOf: function() {return {}}, toString: function() {return {}}}; parseFloat(object) throw TypeError. Actual: Test262Error: #8.1: var object = {valueOf: function() {return {}}, toString: function() {return {}}}; parseFloat(object) throw TypeError. Actual: Na"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseFloat",
+      "test": "built-ins/parseFloat/S15.1.2.3_A2_T10.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.1680"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseFloat",
+      "test": "built-ins/parseFloat/S15.1.2.3_A2_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: parseFloat(\"\\u00A01.1\") === parseFloat(\"1.1\"). Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseFloat",
+      "test": "built-ins/parseFloat/S15.1.2.3_A2_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: parseFloat(\"\\u000B1.1\") === parseFloat(\"1.1\"). Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseFloat",
+      "test": "built-ins/parseFloat/S15.1.2.3_A2_T8.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: parseFloat(\"\\u20281.1\") === parseFloat(\"1.1\"). Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseFloat",
+      "test": "built-ins/parseFloat/S15.1.2.3_A2_T9.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: parseFloat(\"\\u20291.1\") === parseFloat(\"1.1\"). Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseFloat",
+      "test": "built-ins/parseFloat/S15.1.2.3_A7.5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseFloat",
+      "test": "built-ins/parseFloat/S15.1.2.3_A7.7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.2: new parseFloat() throw TypeError. Actual: Test262Error: #1.1: new parseFloat() throw TypeError. Actual: [object Object]"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseInt",
+      "test": "built-ins/parseInt/S15.1.2.2_A1_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: parseInt(new Number(-1)) must return the same value returned by parseInt(\"-1\") Expected SameValue(\u00abNaN\u00bb, \u00ab-1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseInt",
+      "test": "built-ins/parseInt/S15.1.2.2_A1_T6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: parseInt(new String(\"-1\")) must return the same value returned by parseInt(\"-1\") Expected SameValue(\u00abNaN\u00bb, \u00ab-1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseInt",
+      "test": "built-ins/parseInt/S15.1.2.2_A1_T7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The result of `(e instanceof TypeError)` is true Expected SameValue(\u00abfalse\u00bb, \u00abtrue\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseInt",
+      "test": "built-ins/parseInt/S15.1.2.2_A3.1_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: parseInt(\"11\", new Boolean(true)) must return NaN Expected SameValue(\u00ab11\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseInt",
+      "test": "built-ins/parseInt/S15.1.2.2_A3.1_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: parseInt(\"11\", new Number(2)) must return the same value returned by parseInt(\"11\", 2) Expected SameValue(\u00ab11\u00bb, \u00ab3\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseInt",
+      "test": "built-ins/parseInt/S15.1.2.2_A3.1_T6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: parseInt(\"11\", new String(\"2\")) must return the same value returned by parseInt(\"11\", 2) Expected SameValue(\u00ab11\u00bb, \u00ab3\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseInt",
+      "test": "built-ins/parseInt/S15.1.2.2_A3.1_T7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: parseInt(\"11\", {valueOf: function() {return 2}}) must return the same value returned by parseInt(\"11\", 2) Expected SameValue(\u00ab11\u00bb, \u00ab3\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseInt",
+      "test": "built-ins/parseInt/S15.1.2.2_A9.5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/parseInt",
+      "test": "built-ins/parseInt/S15.1.2.2_A9.6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/undefined",
+      "test": "built-ins/undefined/15.1.1.3-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: typeof undefined Expected SameValue(\u00ab\"number\"\u00bb, \u00ab\"undefined\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/undefined",
+      "test": "built-ins/undefined/S15.1.1.3_A1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/undefined",
+      "test": "built-ins/undefined/S15.1.1.3_A3_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: delete undefined === false. Actual: 1"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/undefined",
+      "test": "built-ins/undefined/S15.1.1.3_A4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot convert undefined or null to object"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.5-1-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.5-7-b-1-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-10-c-ii-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: foo(10,\"sss\",1) !== true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-10-c-ii-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: foo(10,\"sss\",1) !== true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-11-b-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: 0 should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-12-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'configurable')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-13-a-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"function\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-13-c-1-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-13-c-2-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00abundefined\u00bb) to be false"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-13-c-3-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'configurable')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-14-c-1-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: callee should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-14-c-4-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-2gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-5-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00ab[object Object]\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-6-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00abundefined\u00bb) to be false"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-6-2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/10.6-7-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length should be an own property"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/S10.1.6_A1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: (new f1(1,2,3,4,5)).length===5, where f1 returns \"arguments\" that is set to \"value of the argument property\""
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/S10.6_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: arguments doesn't exists"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/S10.6_A3_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: arguments object doesn't exists"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/S10.6_A3_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: arguments object don't exists"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/S10.6_A4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: arguments object doesn't exists"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/S10.6_A5_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: arguments object doesn't exists"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/S10.6_A5_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: arguments object don't exists"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/block-scope",
+      "test": "language/block-scope/leave/outermost-binding-updated-in-catch-block-nested-block-let-declaration-unseen-outside-of-block.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected true but got false"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/block-scope",
+      "test": "language/block-scope/shadowing/const-declaration-shadowing-catch-parameter.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab3\u00bb, \u00ab\"stuff3\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/block-scope",
+      "test": "language/block-scope/shadowing/const-declarations-shadowing-parameter-name-let-const-and-var-variables.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab2\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/basics/number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `object[1]` is `'B'`. Defined in `object` as `[1]: 'B'` Expected SameValue(\u00ab0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/accessor/getter-duplicates.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `new C().a` is `'A'` Expected SameValue(\u00abundefined\u00bb, \u00ab\"A\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/accessor/getter.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `new C().a` is `'A'` Expected SameValue(\u00abundefined\u00bb, \u00ab\"A\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/accessor/setter-duplicates.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `calls` is `1`, after executing `new C().a = 'A';` Expected SameValue(\u00ab0\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/accessor/setter.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `calls` is `1`, after executing `new C().a = 'A';` Expected SameValue(\u00ab0\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/method/constructor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The result of `C !== C.prototype.constructor` is `true`"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/method/generator.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Actual [constructor] and expected [constructor, a] should have the same contents."
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/method/number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/method/string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Actual [constructor, a, c] and expected [constructor, a, b, c, d] should have the same contents."
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/method/symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Actual [] and expected [Symbol(), Symbol()] should have the same contents."
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/static/generator-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/static/getter-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/static/method-number-order.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Actual [constructor] and expected [1, 2, length, name, prototype, a, c] should have the same contents."
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/static/method-number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/static/method-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/static/method-string-order.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Actual [constructor] and expected [length, name, prototype, a, b, c, d] should have the same contents."
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/static/method-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `C.b()` returns `'B'`. Defined as `static ['b']() { return 'B'; }` Expected SameValue(\u00ab1\u00bb, \u00ab\"B\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/static/method-symbol-order.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Actual [constructor] and expected [length, name, prototype, a, c] should have the same contents."
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/static/method-symbol.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `C[sym1]()` returns `'B'`. Defined as `static [sym1]() { return 'B'; }` Expected SameValue(\u00abundefined\u00bb, \u00ab\"B\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/class/static/setter-prototype.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/object/accessor/getter-super.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `object.a` is `'a proto m'`. Defined as `get ['a']() { return 'a' + super.m(); }` Expected SameValue(\u00ab\"a0\"\u00bb, \u00ab\"a proto m\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/object/accessor/getter.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `A[1]` is `1` Expected SameValue(\u00ab0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/object/accessor/setter-super.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `value` is `'a 2'`, after executing `object.a = 2;` Expected SameValue(\u00ab0\u00bb, \u00ab\"a 2\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/object/accessor/setter.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `calls` is `1`, after executing `A.a = 'A'; A[1] = 1; A[s] = s;` Expected SameValue(\u00ab2\u00bb, \u00ab3\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/object/method/number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/object/method/string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Actual [a, c, b, d] and expected [a, b, c, d] should have the same contents."
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/object/method/super.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `object.a()` returns `'a proto m'`, after executing `Object.setPrototypeOf(object, proto);` Expected SameValue(\u00ab\"a0\"\u00bb, \u00ab\"a proto m\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/object/property/number-duplicates.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `object['1e+55']` is `'B'`. Defined as `[1e55]: 'B'` Expected SameValue(\u00abundefined\u00bb, \u00ab\"B\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/to-name-side-effects/class.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Actual [] and expected [0] should have the same contents. order set for key1"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/to-name-side-effects/numbers-class.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Actual [] and expected [0] should have the same contents. order set for key1"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/to-name-side-effects/numbers-object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `counter` is `2` Expected SameValue(\u00ab0\u00bb, \u00ab2\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/computed-property-names",
+      "test": "language/computed-property-names/to-name-side-effects/object.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `counter` is `2` Expected SameValue(\u00ab0\u00bb, \u00ab2\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-14-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-29-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-30-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-5-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/10.1.1-8-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/14.1-16-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected true but got false"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/14.1-17-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected true but got false"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/14.1-3-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected true but got false"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/14.1-4-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected true but got false"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/14.1-5-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected true but got false"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/14.1-6-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected true but got false"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/14.1-7-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected true but got false"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/func-decl-final-runtime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab0\u00bb, \u00abnull\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/func-decl-inside-func-decl-runtime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/func-decl-no-semi-runtime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/func-decl-not-first-runtime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab0\u00bb, \u00abnull\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/func-decl-runtime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/func-expr-inside-func-decl-runtime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/func-expr-no-semi-runtime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/func-expr-runtime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/get-accsr-inside-func-expr-runtime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/get-accsr-not-first-runtime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab0\u00bb, \u00abnull\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/get-accsr-runtime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/directive-prologue",
+      "test": "language/directive-prologue/set-accsr-inside-func-expr-runtime.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/eval-code",
+      "test": "language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A2.1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.2: x + 1 throw ReferenceError. Actual: Test262Error: #1.1: x + 1 throw ReferenceError. Actual: 1"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A2.1_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.2: 1 + y throw ReferenceError. Actual: Test262Error: #1.1: 1 + y throw ReferenceError. Actual: 1"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A2.2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: {valueOf: function() {return 1}} + 1 === 2. Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A2.2_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: var date = new Date(0); date + date === date.toString() + date.toString(). Actual: 0"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A2.2_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: function f1() {return 0;}; f1 + 1 === f1.toString() + 1"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A2.3_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.3: var x = { valueOf: function () { throw \"x\"; } }; var y = { valueOf: function () { throw \"y\"; } }; x + y throw \"x\". Actual: Test262Error: #1.1: var x = { valueOf: function () { throw \"x\"; } }; var y = { valueOf: function () { throw \"y\"; } }; x + y throw \"x\". Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A2.4_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.2: x + (x = 1) throw ReferenceError. Actual: Test262Error: #1.1: x + (x = 1) throw ReferenceError. Actual: 1"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A2.4_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: (y = 1) + y === 2. Actual: 1"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A3.1_T1.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #2: new Boolean(true) + true === 2. Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A3.1_T1.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #2: new Number(1) + 1 === 2. Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A3.1_T2.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: new Boolean(true) + 1 === 2. Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A3.1_T2.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: new Number(1) + null === 1. Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A3.1_T2.5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: new Boolean(true) + null === 1. Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A3.2_T1.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #2: new String(\"1\") + \"1\" === \"11\". Actual: [object Object]1"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A3.2_T1.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: ({} + function(){return 1}) === ({}.toString() + function(){return 1}.toString()). Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A3.2_T2.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: new String(\"1\") + 1 === \"11\". Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A3.2_T2.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: new Boolean(true) + \"1\" === \"true1\". Actual: [object Object]1"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A3.2_T2.3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: new String(\"1\") + undefined === \"1undefined\". Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/S11.6.1_A3.2_T2.4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: new String(\"1\") + null === \"1null\". Actual: NaN"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/bigint-and-number.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/order-of-evaluation.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: ?GetValue(lhs) throws. Expected a MyError but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/addition/symbol-to-string.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/11.1.4_4-5-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: arr.hasOwnProperty(\"0\") !== true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/11.1.4_5-6-1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: arr.hasOwnProperty(\"1\") !== true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/S11.1.4_A1.1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: var array = []; array.toString === Array.prototype.toString. Actual: undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/S11.1.4_A1.2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: var array = [,,,,,]; array.toString === Array.prototype.toString. Actual: undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/S11.1.4_A1.3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: var array = [1,2,3,4,5]; array.toString === Array.prototype.toString. Actual: undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/S11.1.4_A1.4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: var array = [,,,1,2]; array.toString === Array.prototype.toString. Actual: undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/S11.1.4_A1.5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: var array = [4,5,,,,]; array.toString === Array.prototype.toString. Actual: undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/S11.1.4_A1.6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: var array = [,,3,,,]; array.toString === Array.prototype.toString. Actual: undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/S11.1.4_A1.7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: var array = [1,2,,4,5]; array.toString === Array.prototype.toString. Actual: undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/S11.1.4_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #3: var array = [[1,2], [3], []]; array.toString === Array.prototype.toString. Actual: undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/spread-err-mult-err-expr-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/spread-err-mult-err-iter-get-value.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/spread-err-mult-err-itr-get-call.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/spread-err-mult-err-itr-get-get.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/spread-err-mult-err-itr-step.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/spread-err-mult-err-itr-value.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/spread-err-mult-err-unresolvable.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/spread-err-sngl-err-expr-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/expressions",
+      "test": "language/expressions/array/spread-err-sngl-err-itr-get-call.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-1-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: bar.call(1) Expected SameValue(\u00ab\"number\"\u00bb, \u00ab\"object\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-100-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: \"ab\".replace(\"b\", f) Expected SameValue(\u00ab\"a\\u0000\"\u00bb, \u00ab\"aa\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-100gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: 'this' had incorrect value!"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-102-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"a\\u0000\"\u00bb, \u00ab\"aa\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-102gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: 'this' had incorrect value!"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-103.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: (5).x == 5"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-104.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: (5).x === 5"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-105.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: typeof (5).x Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"object\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-106.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: typeof (5).x Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"number\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-13-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: f() Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"undefined\"\u00bb) to be false"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-13gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: 'this' had incorrect value!"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-15-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: f() Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"undefined\"\u00bb) to be false"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-15gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: 'this' had incorrect value!"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-17-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-17gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-18gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-2-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: bar.call(\"1\") Expected SameValue(\u00ab\"string\"\u00bb, \u00ab\"object\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-20-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-27gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/function-code",
+      "test": "language/function-code/10.4.3-1-3-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: bar.call() Expected SameValue(\u00ab\"undefined\"\u00bb, \u00ab\"object\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/global-code",
+      "test": "language/global-code/S10.1.7_A1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: The this value associated with an executioncontext is immutable. Actual: this was deleted"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/global-code",
+      "test": "language/global-code/block-decl-strict.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/global-code",
+      "test": "language/global-code/decl-lex.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: `const` binding is strictly immutable Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/global-code",
+      "test": "language/global-code/switch-case-decl-strict.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/global-code",
+      "test": "language/global-code/switch-dflt-decl-strict.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/identifier-resolution",
+      "test": "language/identifier-resolution/S10.2.2_A1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/identifier-resolution",
+      "test": "language/identifier-resolution/S10.2.2_A1_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: Scope chain disturbed"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/identifier-resolution",
+      "test": "language/identifier-resolution/S11.1.2_A1_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1.2: this.z; z === undefined throw ReferenceError. Actual: TypeError: Cannot read properties of undefined (reading 'z')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/identifier-resolution",
+      "test": "language/identifier-resolution/assign-to-global-undefined.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Perry ran clean; Node rejected (missed negative)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/line-terminators",
+      "test": "language/line-terminators/S7.3_A5.4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/line-terminators",
+      "test": "language/line-terminators/S7.3_A7_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/line-terminators",
+      "test": "language/line-terminators/S7.3_A7_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/line-terminators",
+      "test": "language/line-terminators/S7.3_A7_T3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/line-terminators",
+      "test": "language/line-terminators/S7.3_A7_T4.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/line-terminators",
+      "test": "language/line-terminators/S7.3_A7_T5.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/line-terminators",
+      "test": "language/line-terminators/S7.3_A7_T6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/line-terminators",
+      "test": "language/line-terminators/S7.3_A7_T7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/line-terminators",
+      "test": "language/line-terminators/S7.3_A7_T8.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/punctuators",
+      "test": "language/punctuators/S7.7_A1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'nan')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/reserved-words",
+      "test": "language/reserved-words/ident-name-keyword-accessor.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Property \"await\" sets correct value Expected SameValue(\u00ab0\u00bb, \u00ab\"await\"\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/rest-parameters",
+      "test": "language/rest-parameters/with-new-target.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: The value of `arguments.length` is `a.length` Expected SameValue(\u00ab0\u00bb, \u00abundefined\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-array-literal-with-item.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-array-literal.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-arrow-function-assignment-expr.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-arrow-function-functionbody.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-block-with-labels.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-block.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-expr-arrow-function-boolean-literal.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-let-declaration.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-regexp-literal-flags.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-regexp-literal.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-with-statment-array-literal-with-item.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-with-statment-array-literal.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-with-statment-arrow-function-assignment-expr.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-with-statment-arrow-function-functionbody.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-with-statment-block-with-labels.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-with-statment-block.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-with-statment-expr-arrow-function-boolean-literal.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-with-statment-let-declaration.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-with-statment-regexp-literal-flags.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-block-with-statment-regexp-literal.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-class-array-literal-with-item.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-class-array-literal.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-class-arrow-function-assignment-expr.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-class-arrow-function-functionbody.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-class-block-with-labels.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-class-block.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-class-expr-arrow-function-boolean-literal.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-class-let-declaration.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-class-regexp-literal-flags.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statementList",
+      "test": "language/statementList/eval-class-regexp-literal.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/cptn-decl.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/dflt-params-abrupt.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Test262Error:"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/dflt-params-trailing-comma.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: length is properly set Expected SameValue(\u00ab2\u00bb, \u00ab1\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/eval-var-scope-syntax-err.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/evaluation-body.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Perry ran clean; Node rejected (missed negative)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/evaluation-default-that-throws.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/evaluation-mapped-arguments.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab1\u00bb, \u00ab2\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/boolean/S8.3_A1_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #0 x !== undefined, but actual is 0"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/object/S8.6.1_A2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/object/S8.6.1_A3.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #1: delete Number.NaN === false. Actual: 1"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/object/S8.6.2_A1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #2.1: protoObj={}; function FooObj(){}; var obj__= new FooObj; Object.prototype.isPrototypeOf(obj__) === true. Actual: false"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/object/S8.6.2_A6.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: #2: var numInstance=new Number; numInstance.constructor === Number. Actual: undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/object/S8.6.2_A7.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/object/S8.6_A2_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"bar\"\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/object/S8.6_A2_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00abundefined\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/object/S8.6_A3_T1.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected SameValue(\u00ab\"bar\"\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/object/S8.6_A3_T2.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: ++__map.foo Expected SameValue(\u00abundefined\u00bb, \u00abNaN\u00bb) to be true"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/reference/8.7.2-1-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/reference/8.7.2-3-a-1gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/reference/8.7.2-3-a-2gs.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a Test262Error but got a undefined"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/reference/8.7.2-3-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/reference/8.7.2-4-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "Uncaught exception: Expected a  to be thrown but no exception was thrown at all"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/types",
+      "test": "language/types/reference/8.7.2-5-s.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: Cannot read properties of undefined (reading 'name')"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/white-space",
+      "test": "language/white-space/comment-multi-form-feed.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/white-space",
+      "test": "language/white-space/comment-multi-horizontal-tab.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/white-space",
+      "test": "language/white-space/comment-multi-nbsp.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/white-space",
+      "test": "language/white-space/comment-multi-space.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/white-space",
+      "test": "language/white-space/comment-multi-vertical-tab.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/white-space",
+      "test": "language/white-space/comment-single-form-feed.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/white-space",
+      "test": "language/white-space/comment-single-horizontal-tab.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/white-space",
+      "test": "language/white-space/comment-single-nbsp.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/white-space",
+      "test": "language/white-space/comment-single-space.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/white-space",
+      "test": "language/white-space/comment-single-vertical-tab.js",
+      "severity": "runtime-fail",
+      "severity_rank": 2,
+      "reason": "TypeError: value is not a function"
+    },
+    {
+      "corpus": "node-core",
+      "category": "assert",
+      "test": "test-assert-calltracker-getCalls.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "assert",
+      "test": "test-assert-partial-deep-equal.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "assert",
+      "test": "test-assert-typedarray-deepequal.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "buffer",
+      "test": "test-buffer-resizable.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "child_process",
+      "test": "test-child-process-set-blocking.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "console",
+      "test": "test-console-issue-43095.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "{ proxy: [object Object], revoke: [Function (anonymous)] }",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "console",
+      "test": "test-console-stdio-setters.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "fhqwhgads",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-authenticated-stream.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "1..0 # Skipped: unsupported cipher: aes-128-ccm",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-des3-wrap.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "1..0 # Skipped: des3-wrap cipher is not available",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "crypto",
+      "test": "test-crypto-padding-aes256.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "1..0 # Skipped: aes256 cipher is not available",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-append-file-flush.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-open-no-close.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "5/31/2026, 10:28:35 AM fs open() callback",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-operations-with-surrogate-pairs.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-readfile-pipe.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-write-file-flush.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-write-stream-err.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "fs",
+      "test": "test-fs-write-stream-flush.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-no-deprecation.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(node:27133) DeprecationWarning: Something is deprecated.",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-ref-unref.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "process",
+      "test": "test-process-uptime.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "4.2e-8",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "stream",
+      "test": "test-stream-push-strings.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "util",
+      "test": "test-util-text-decoder.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": false
+    },
+    {
+      "corpus": "node-core",
+      "category": "zlib",
+      "test": "test-zlib-type-error.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)",
+      "auto_optimize_api": true
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/next/iterator-result-prototype.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/next/iterator-result-unwrap-promise.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/return/iterator-result-poisoned-done.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/return/iterator-result-poisoned-value.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/return/iterator-result-unwrap-promise.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/return/iterator-result.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/return/poisoned-get-return.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/return/poisoned-return.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/return/result-object-error.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/return/return-undefined.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/throw/iterator-result-poisoned-done.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/throw/iterator-result-poisoned-value.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/throw/iterator-result-unwrap-promise.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/throw/iterator-result.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/throw/poisoned-get-throw.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/throw/poisoned-throw.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncFromSyncIteratorPrototype",
+      "test": "built-ins/AsyncFromSyncIteratorPrototype/throw/result-object-error.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/next/iterator-result-prototype.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/next/request-queue-order-state-executing.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/next/request-queue-order.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/next/request-queue-promise-resolve-order.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/iterator-result-prototype.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/request-queue-order-state-executing.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/return-state-completed.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/return-suspendedStart-broken-promise.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/return-suspendedStart-promise.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/return-suspendedStart.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/return-suspendedYield-broken-promise-try-catch.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/return-suspendedYield-promise.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/return-suspendedYield-try-finally-return.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/return-suspendedYield-try-finally-throw.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/return-suspendedYield-try-finally.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/return/return-suspendedYield.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/throw-state-completed.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/throw-suspendedYield-promise.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/throw-suspendedYield-try-catch.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/throw-suspendedYield-try-finally-return.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/throw-suspendedYield-try-finally-throw.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/throw-suspendedYield-try-finally.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/AsyncGeneratorPrototype",
+      "test": "built-ins/AsyncGeneratorPrototype/throw/throw-suspendedYield.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/S25.4.4.1_A2.2_T1.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/S25.4.4.1_A2.3_T1.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/S25.4.4.1_A2.3_T2.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/S25.4.4.1_A2.3_T3.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/S25.4.4.1_A3.1_T1.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/S25.4.4.1_A3.1_T2.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/S25.4.4.1_A3.1_T3.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/S25.4.4.1_A7.1_T1.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/S25.4.4.1_A7.2_T1.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/S25.4.4.1_A8.1_T1.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/S25.4.4.1_A8.2_T1.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/S25.4.4.1_A8.2_T2.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/capability-resolve-throws-reject.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/invoke-resolve-error-reject.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/invoke-resolve-get-error-reject.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/invoke-resolve-get-error.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/invoke-resolve-on-promises-every-iteration-of-custom.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/invoke-resolve-on-promises-every-iteration-of-promise.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/invoke-resolve-on-values-every-iteration-of-promise.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/invoke-then-error-reject.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/invoke-then-get-error-reject.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-arg-is-false-reject.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-arg-is-null-reject.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-arg-is-number-reject.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-arg-is-string-resolve.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-arg-is-symbol-reject.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-arg-is-true-reject.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-arg-is-undefined-reject.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "built-ins/Promise",
+      "test": "built-ins/Promise/all/iter-assigned-undefined-reject.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/async-gen-meth-args-trailing-comma-multiple.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/async-gen-meth-args-trailing-comma-null.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/async-gen-meth-args-trailing-comma-single-args.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/async-gen-meth-args-trailing-comma-spread-operator.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/async-gen-meth-args-trailing-comma-undefined.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/async-gen-named-func-expr-args-trailing-comma-multiple.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/async-gen-named-func-expr-args-trailing-comma-null.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/async-gen-named-func-expr-args-trailing-comma-single-args.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/async-gen-named-func-expr-args-trailing-comma-spread-operator.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/async-gen-named-func-expr-args-trailing-comma-undefined.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/cls-decl-async-gen-func-args-trailing-comma-multiple.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/cls-decl-async-gen-func-args-trailing-comma-null.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/cls-decl-async-gen-func-args-trailing-comma-single-args.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/cls-decl-async-gen-func-args-trailing-comma-spread-operator.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/cls-decl-async-gen-func-args-trailing-comma-undefined.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/cls-decl-async-gen-meth-args-trailing-comma-multiple.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/cls-decl-async-gen-meth-args-trailing-comma-null.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/arguments-object",
+      "test": "language/arguments-object/cls-decl-async-gen-meth-args-trailing-comma-single-args.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/dflt-params-arg-val-not-undefined.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/dflt-params-arg-val-undefined.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/dflt-params-ref-later.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/dflt-params-ref-prior.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/dflt-params-ref-self.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/evaluation-body-that-returns-after-await.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/evaluation-body-that-returns.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/evaluation-body-that-throws-after-await.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/evaluation-body-that-throws.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/evaluation-this-value-passed.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/evaluation-unmapped-arguments.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/forbidden-ext/b1/async-func-decl-forbidden-ext-direct-access-prop-arguments.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/forbidden-ext/b1/async-func-decl-forbidden-ext-direct-access-prop-caller.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/forbidden-ext/b2/async-func-decl-forbidden-ext-indirect-access-own-prop-caller-get.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/forbidden-ext/b2/async-func-decl-forbidden-ext-indirect-access-own-prop-caller-value.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/forbidden-ext/b2/async-func-decl-forbidden-ext-indirect-access-prop-caller.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/params-trailing-comma-multiple.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/params-trailing-comma-single.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/returns-async-arrow-returns-arguments-from-parent-function.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/returns-async-arrow-returns-newtarget.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/returns-async-arrow.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/returns-async-function-returns-arguments-from-own-function.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/returns-async-function-returns-newtarget.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    },
+    {
+      "corpus": "test262",
+      "category": "language/statements",
+      "test": "language/statements/async-function/returns-async-function.js",
+      "severity": "diff",
+      "severity_rank": 1,
+      "reason": "(no output)"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds a parallel parity-gap radar and the current sweep snapshot.

- **`scripts/parity_gap_report.py`** — parallel (process-pool), crash-safe parity
  radar over test262 + Node core. Streams every failure to a `.partial.jsonl`
  sidecar per-case (survives OOM/kill), then builds one severity-sorted JSON:
  `compile-fail` > `runtime-fail` > `diff`. Reuses the discovery/assemble/normalize
  helpers from `test262_subset.py` and `node_core_subset.py` so verdicts stay
  identical to the canonical serial runners. Supports `--sample-per-cat`,
  `--max-per-api`, `--corpus`, `--rebuild-from <jsonl>`.
- **`test-compat/parity_gaps_report.json`** — current snapshot (force-added past
  the broad `*report*.json` gitignore so the backlog is shareable).

## Snapshot summary

Sweep: test262 60/category + all node-core, 6 workers, 8s timeout.
4759 cases judged, **2687 failures**:

| Severity | Count |
|---|---|
| compile-fail | 407 |
| runtime-fail | 2146 |
| diff | 134 |

**Caveat:** ~335 of the compile-fails are `Undefined symbols ... arm64` link
artifacts in `http`/`net`/`https` — the radar runs without auto-optimize (not
parallel-safe), so those ext-crate-backed APIs mis-bucket. They are NOT compiler
gaps. For a real measurement of those APIs use
`node_core_subset.py --auto-optimize`. Runtime-fail clusters that compile fine
(TypedArray, DataView, Proxy, Reflect, Weak*, Map/Set) are the highest-signal
real gaps.

## Notes

- No version bump / CHANGELOG entry: this is a tooling + data artifact, no
  compiler behavior change.
- The radar is a coverage radar, not a CI gate.
