### PR TITLE
[codex] node:v8 lifecycle helper surfaces

### DIFF
--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -238,16 +238,14 @@ pub(crate) fn lower_native_method_call(
     // `class_name` (`v8.startupSnapshot.isBuildingSnapshot()`,
     // `v8.promiseHooks.onInit(fn)`). Dispatch them statically.
     if module == "v8" {
+        // startupSnapshot helpers ignore their arguments (Perry never builds a
+        // snapshot); evaluate args for side effects then call the no-arg helper.
         let v8_sub = match (class_name, method) {
             (Some("startupSnapshot"), "isBuildingSnapshot") => Some("js_v8_is_building_snapshot"),
             (
                 Some("startupSnapshot"),
                 "addSerializeCallback" | "addDeserializeCallback" | "setDeserializeMainFunction",
             ) => Some("js_v8_throw_not_building_snapshot"),
-            (
-                Some("promiseHooks"),
-                "onInit" | "onBefore" | "onAfter" | "onSettled" | "createHook",
-            ) => Some("js_v8_promise_hook_register"),
             _ => None,
         };
         if let Some(fname) = v8_sub {
@@ -255,6 +253,28 @@ pub(crate) fn lower_native_method_call(
                 let _ = lower_expr(ctx, a)?;
             }
             return Ok(ctx.block().call(DOUBLE, fname, &[]));
+        }
+
+        // #3139: promiseHooks registrars install real lifecycle hooks. Pass the
+        // callback (onInit/&c.) or options object (createHook) as the first arg.
+        let v8_hook = match (class_name, method) {
+            (Some("promiseHooks"), "onInit") => Some("js_v8_promise_hooks_on_init"),
+            (Some("promiseHooks"), "onBefore") => Some("js_v8_promise_hooks_on_before"),
+            (Some("promiseHooks"), "onAfter") => Some("js_v8_promise_hooks_on_after"),
+            (Some("promiseHooks"), "onSettled") => Some("js_v8_promise_hooks_on_settled"),
+            (Some("promiseHooks"), "createHook") => Some("js_v8_promise_hooks_create_hook"),
+            _ => None,
+        };
+        if let Some(fname) = v8_hook {
+            let arg = if let Some(first) = args.first() {
+                lower_expr(ctx, first)?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            for extra in args.iter().skip(1) {
+                let _ = lower_expr(ctx, extra)?;
+            }
+            return Ok(ctx.block().call(DOUBLE, fname, &[(DOUBLE, &arg)]));
         }
     }
 

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -684,6 +684,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_v8_namespace", DOUBLE, &[PTR, I64]);
     module.declare_function("js_v8_throw_not_building_snapshot", DOUBLE, &[]);
     module.declare_function("js_v8_promise_hook_register", DOUBLE, &[]);
+    module.declare_function("js_v8_promise_hooks_on_init", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_v8_promise_hooks_on_before", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_v8_promise_hooks_on_after", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_v8_promise_hooks_on_settled", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_v8_promise_hooks_create_hook", DOUBLE, &[DOUBLE]);
     module.declare_function("js_process_thread_cpu_usage", DOUBLE, &[DOUBLE]);
     module.declare_function("js_process_available_memory", DOUBLE, &[]);
     module.declare_function("js_process_constrained_memory", DOUBLE, &[]);

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -271,6 +271,7 @@ pub fn gc_init() {
     gc_register_mutable_root_scanner(crate::regex::scan_last_exec_groups_root_mut);
     gc_register_mutable_root_scanner(crate::array::scan_template_raw_roots_mut);
     gc_register_mutable_root_scanner(crate::perf_hooks::scan_perf_entries_roots_mut);
+    gc_register_mutable_root_scanner(crate::v8::scan_v8_promise_hook_roots_mut);
     gc_register_mutable_root_scanner(crate::typed_feedback::scan_typed_feedback_roots_mut);
     gc_register_mutable_root_scanner(transition_cache_mutable_root_scanner);
     gc_register_mutable_root_scanner(crate::object::scan_object_cache_roots_mut);

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -91,6 +91,7 @@ pub mod typed_feedback;
 pub mod typedarray;
 pub mod typedarray_half;
 pub mod url;
+pub mod v8;
 pub mod value;
 pub mod wasi;
 pub mod web_storage;

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1900,16 +1900,15 @@ pub(crate) unsafe fn dispatch_native_module_method(
             _ => f64::from_bits(JSValue::undefined().bits()),
         },
 
-        // #3679: `v8.promiseHooks` namespace. Hook registrars return a stop
-        // function (Node returns a callable that removes the hook); we hand
-        // back a no-op callable so `const stop = onInit(fn); stop()` works.
+        // #3139: `v8.promiseHooks` namespace. Hook registrars install real
+        // Promise-lifecycle callbacks (fired from `promise/{then,microtasks,
+        // async_step}.rs`) and return a stop function that removes the hook.
         ("v8.promiseHooks", m) => match m {
-            "onInit" | "onBefore" | "onAfter" | "onSettled" | "createHook" => {
-                let c = crate::closure::js_closure_alloc_singleton(
-                    crate::node_v8::js_v8_noop_undefined as *const u8,
-                );
-                crate::value::js_nanbox_pointer(c as i64)
-            }
+            "onInit" => crate::v8::js_v8_promise_hooks_on_init(arg(0)),
+            "onBefore" => crate::v8::js_v8_promise_hooks_on_before(arg(0)),
+            "onAfter" => crate::v8::js_v8_promise_hooks_on_after(arg(0)),
+            "onSettled" => crate::v8::js_v8_promise_hooks_on_settled(arg(0)),
+            "createHook" => crate::v8::js_v8_promise_hooks_create_hook(arg(0)),
             _ => f64::from_bits(JSValue::undefined().bits()),
         },
 

--- a/crates/perry-runtime/src/promise/async_step.rs
+++ b/crates/perry-runtime/src/promise/async_step.rs
@@ -17,6 +17,12 @@ pub extern "C" fn js_promise_resolved(value: f64) -> *mut Promise {
     // await). The probes still run on real pointers below.
     if is_definitely_primitive(value) {
         let promise = js_promise_new();
+        // When lifecycle hooks are active, go through the real resolve path so
+        // `settled`/`before`/`after` fire (instead of poking the state field).
+        if crate::v8::promise_hooks_active() || crate::async_hooks::hooks_active() {
+            js_promise_resolve(promise, value);
+            return promise;
+        }
         unsafe {
             (*promise).state = PromiseState::Fulfilled;
             (*promise).value = value;
@@ -90,6 +96,15 @@ pub extern "C" fn js_promise_resolved_then(
     on_fulfilled: ClosurePtr,
     on_rejected: ClosurePtr,
 ) -> *mut Promise {
+    // The primitive fast path below bypasses `js_promise_new`/`then`, so it
+    // would never fire `v8.promiseHooks` (#3139). When hooks are active, route
+    // through the real resolve+then path instead.
+    if crate::v8::promise_hooks_active() {
+        bump(&MT_FAST_PATH_MISS);
+        let p1 = js_promise_resolved(value);
+        return js_promise_then(p1, on_fulfilled, on_rejected);
+    }
+
     if is_definitely_primitive(value) {
         bump(&MT_FAST_PATH_HIT);
         // FAST PATH (primitive) — skip Promise.resolve()'s allocation

--- a/crates/perry-runtime/src/promise/microtasks.rs
+++ b/crates/perry-runtime/src/promise/microtasks.rs
@@ -255,6 +255,7 @@ fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
                         let async_id = (*promise).async_id;
                         let trigger_async_id = (*promise).trigger_async_id;
                         crate::async_hooks::before(async_id, trigger_async_id);
+                        crate::v8::promise_hook_before(promise);
                         let result = crate::closure::js_closure_call1(callback, value);
                         // Keep the callback result rooted across `after()` (which
                         // can run JS when async_hooks are active) via the value
@@ -266,6 +267,7 @@ fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
                         CURRENT_MICROTASK_VALUE.with(|c| c.set(result));
                         let promise = promise_handle.get_raw_mut_ptr::<Promise>();
                         let next = next_handle.get_raw_mut_ptr::<Promise>();
+                        crate::v8::promise_hook_after(promise);
                         crate::async_hooks::after(async_id);
                         if let Some(t) = t1 {
                             MT_TIME_NS_CALLBACK
@@ -363,8 +365,11 @@ fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
                     } else {
                         None
                     };
+                    crate::v8::promise_hook_before(next);
                     let result = crate::closure::js_closure_call1(callback, value);
                     CURRENT_MICROTASK_VALUE.with(|c| c.set(result));
+                    let next_for_after = CURRENT_MICROTASK_NEXT.with(|c| c.get());
+                    crate::v8::promise_hook_after(next_for_after);
                     if let Some(t) = t1 {
                         MT_TIME_NS_CALLBACK
                             .fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
@@ -599,6 +604,7 @@ fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
                         unsafe { (*next).trigger_async_id }
                     };
                     crate::async_hooks::before(step_async_id, step_trigger_id);
+                    crate::v8::promise_hook_before(next);
                     let result = call_async_step_direct(step_closure, value, is_error_bits);
                     CURRENT_MICROTASK_VALUE.with(|c| c.set(result));
                     if let Some(t) = t1 {
@@ -616,6 +622,8 @@ fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
                     });
                     // #789: pair the `before()` above — fires the after hook and
                     // pops the execution-id stack using the captured id.
+                    let next_for_after = CURRENT_MICROTASK_NEXT.with(|c| c.get());
+                    crate::v8::promise_hook_after(next_for_after);
                     crate::async_hooks::after(step_async_id);
                     CURRENT_MICROTASK_CALLBACK.with(|c| c.set(std::ptr::null()));
 

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -32,9 +32,16 @@ unsafe fn store_promise_next_slot(
 /// Allocate a new Promise
 #[no_mangle]
 pub extern "C" fn js_promise_new() -> *mut Promise {
+    js_promise_new_with_parent(ptr::null_mut())
+}
+
+/// Allocate a new Promise, recording `parent` so `v8.promiseHooks` `init`
+/// callbacks (#3139) receive the parent promise.
+pub(crate) fn js_promise_new_with_parent(parent: *mut Promise) -> *mut Promise {
     bump(&MT_PROMISE_NEW_COUNT);
-    let hooks_active = crate::async_hooks::hooks_active();
-    let raw = if hooks_active {
+    let async_hooks_active = crate::async_hooks::hooks_active();
+    let lifecycle_hooks_active = async_hooks_active || crate::v8::promise_hooks_active();
+    let raw = if lifecycle_hooks_active {
         crate::gc::gc_malloc(std::mem::size_of::<Promise>(), crate::gc::GC_TYPE_PROMISE)
     } else {
         crate::arena::arena_alloc_gc(
@@ -46,10 +53,11 @@ pub extern "C" fn js_promise_new() -> *mut Promise {
     let promise = raw as *mut Promise;
     let scope = crate::gc::RuntimeHandleScope::new();
     let promise_handle = scope.root_raw_mut_ptr(promise);
+    let parent_handle = scope.root_raw_mut_ptr(parent);
     unsafe {
         // GC_STORE_AUDIT(INIT): initializes freshly allocated Promise storage before the promise is published.
         ptr::write(promise, Promise::new());
-        if hooks_active {
+        if async_hooks_active {
             let promise = promise_handle.get_raw_mut_ptr::<Promise>();
             let resource =
                 f64::from_bits(0x7FFD_0000_0000_0000 | (promise as u64 & 0x0000_FFFF_FFFF_FFFF));
@@ -59,6 +67,10 @@ pub extern "C" fn js_promise_new() -> *mut Promise {
             (*promise).trigger_async_id = ids.trigger_async_id;
         }
     }
+    crate::v8::promise_hook_init(
+        promise_handle.get_raw_mut_ptr::<Promise>(),
+        parent_handle.get_raw_mut_ptr::<Promise>(),
+    );
     promise_handle.get_raw_mut_ptr::<Promise>()
 }
 
@@ -128,6 +140,7 @@ pub extern "C" fn js_promise_resolve(promise: *mut Promise, value: f64) {
         (*promise).state = PromiseState::Fulfilled;
         store_promise_jsvalue_slot(promise, std::ptr::addr_of_mut!((*promise).value), value);
         crate::async_hooks::promise_resolve((*promise).async_id);
+        crate::v8::promise_hook_settled(promise);
 
         // Schedule callbacks. Push to TASK_QUEUE whenever there's anything
         // for the microtask runner to do — either invoke the user callback,
@@ -291,6 +304,7 @@ pub extern "C" fn js_promise_reject(promise: *mut Promise, reason: f64) {
         (*promise).state = PromiseState::Rejected;
         store_promise_jsvalue_slot(promise, std::ptr::addr_of_mut!((*promise).reason), reason);
         crate::async_hooks::promise_resolve((*promise).async_id);
+        crate::v8::promise_hook_settled(promise);
 
         // Schedule callbacks. Same propagation rule as `js_promise_resolve`
         // (#236): push to the queue whenever there's a callback to invoke
@@ -336,7 +350,17 @@ pub extern "C" fn js_promise_then(
         return ptr::null_mut();
     }
 
-    let next = js_promise_new();
+    // `js_promise_new_with_parent` can allocate via the GC and fire
+    // `v8.promiseHooks` `init` callbacks (running JS), so root the inputs across
+    // it before threading them into the chained promise.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let promise_handle = scope.root_raw_mut_ptr(promise);
+    let on_fulfilled_handle = scope.root_raw_const_ptr(on_fulfilled);
+    let on_rejected_handle = scope.root_raw_const_ptr(on_rejected);
+    let next = js_promise_new_with_parent(promise);
+    let promise = promise_handle.get_raw_mut_ptr::<Promise>();
+    let on_fulfilled = on_fulfilled_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>();
+    let on_rejected = on_rejected_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>();
 
     unsafe {
         store_promise_closure_slot(
@@ -479,8 +503,14 @@ pub extern "C" fn js_promise_finally(
 ) -> *mut Promise {
     use crate::closure::{js_closure_alloc, js_closure_set_capture_ptr};
 
-    // Create the `next` promise that callers chain off.
-    let next = js_promise_new();
+    // Create the `next` promise that callers chain off. Root inputs across the
+    // allocation since `v8.promiseHooks` `init` may run JS (#3139).
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let promise_handle = scope.root_raw_mut_ptr(promise);
+    let on_finally_handle = scope.root_raw_const_ptr(on_finally);
+    let next = js_promise_new_with_parent(promise);
+    let promise = promise_handle.get_raw_mut_ptr::<Promise>();
+    let on_finally = on_finally_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>();
     let next_i64 = next as i64;
 
     // Build the fulfilled wrapper: captures [on_finally, next].

--- a/crates/perry-runtime/src/v8.rs
+++ b/crates/perry-runtime/src/v8.rs
@@ -1,0 +1,377 @@
+//! Real `node:v8` Promise lifecycle hooks (`v8.promiseHooks`) for #3139.
+//!
+//! Perry does not embed V8 for heap snapshots, cached data, or serializers (the
+//! diagnostic/serializer surface lives in `node_v8.rs`), but Node's Promise
+//! lifecycle hooks can be represented directly by the native runtime. Hook
+//! registrars install callbacks here, and the Promise machinery in
+//! `promise/{then,microtasks,async_step}.rs` fires them on allocation, callback
+//! entry/exit, and settlement.
+
+use std::cell::Cell;
+use std::ptr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{LazyLock, Mutex};
+
+use crate::closure::{
+    js_closure_alloc, js_closure_call1, js_closure_call2, js_closure_get_capture_ptr,
+    js_closure_set_capture_ptr, js_register_closure_arity, ClosureHeader,
+};
+use crate::object::{js_object_get_field_by_name, ObjectHeader};
+use crate::promise::Promise;
+use crate::string::{js_string_from_bytes, StringHeader};
+use crate::value::{JSValue, POINTER_MASK, POINTER_TAG, TAG_MASK, TAG_UNDEFINED};
+
+const TAG_UNDEFINED_F64: f64 = f64::from_bits(TAG_UNDEFINED);
+
+static PROMISE_HOOKS_ACTIVE: AtomicUsize = AtomicUsize::new(0);
+static PROMISE_HOOKS: LazyLock<Mutex<Vec<PromiseHookRecord>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
+
+#[derive(Clone, Copy)]
+struct PromiseHookCallbacks {
+    init: *const ClosureHeader,
+    before: *const ClosureHeader,
+    after: *const ClosureHeader,
+    settled: *const ClosureHeader,
+}
+
+unsafe impl Send for PromiseHookCallbacks {}
+unsafe impl Sync for PromiseHookCallbacks {}
+
+impl PromiseHookCallbacks {
+    fn empty() -> Self {
+        Self {
+            init: ptr::null(),
+            before: ptr::null(),
+            after: ptr::null(),
+            settled: ptr::null(),
+        }
+    }
+
+    fn has_any(&self) -> bool {
+        !self.init.is_null()
+            || !self.before.is_null()
+            || !self.after.is_null()
+            || !self.settled.is_null()
+    }
+}
+
+struct PromiseHookRecord {
+    callbacks: PromiseHookCallbacks,
+    enabled: bool,
+}
+
+thread_local! {
+    static IN_PROMISE_HOOK_CALLBACK: Cell<bool> = const { Cell::new(false) };
+}
+
+#[inline]
+pub fn promise_hooks_active() -> bool {
+    PROMISE_HOOKS_ACTIVE.load(Ordering::Relaxed) != 0
+}
+
+fn promise_value(promise: *mut Promise) -> f64 {
+    f64::from_bits(JSValue::pointer(promise as *const u8).bits())
+}
+
+fn string_header_eq(ptr: *const StringHeader, expected: &str) -> bool {
+    if ptr.is_null() {
+        return false;
+    }
+    unsafe {
+        let len = (*ptr).byte_len as usize;
+        let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        std::slice::from_raw_parts(data, len) == expected.as_bytes()
+    }
+}
+
+fn is_function_value(value: f64) -> bool {
+    string_header_eq(crate::builtins::js_value_typeof(value), "function")
+}
+
+fn closure_from_function_value(value: f64) -> *const ClosureHeader {
+    if !is_function_value(value) {
+        return ptr::null();
+    }
+    let bits = value.to_bits();
+    if (bits & TAG_MASK) != POINTER_TAG {
+        return ptr::null();
+    }
+    let ptr = (bits & POINTER_MASK) as usize;
+    if crate::closure::is_closure_ptr(ptr) {
+        ptr as *const ClosureHeader
+    } else {
+        ptr::null()
+    }
+}
+
+fn object_field(obj_value: f64, name: &[u8]) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_handle = scope.root_nanbox_f64(obj_value);
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32) as *const StringHeader;
+    let key_handle = scope.root_string_ptr(key);
+    let value = JSValue::from_bits(obj_handle.get_nanbox_f64().to_bits());
+    if !value.is_pointer() {
+        return TAG_UNDEFINED_F64;
+    }
+    let obj = value.as_pointer::<ObjectHeader>();
+    if obj.is_null() {
+        return TAG_UNDEFINED_F64;
+    }
+    f64::from_bits(js_object_get_field_by_name(obj, key_handle.get_raw_const_ptr()).bits())
+}
+
+fn throw_invalid_hook(label: &'static str, value: f64) -> ! {
+    let message = format!(
+        "The \"{}\" argument must be of type function. Received {}",
+        label,
+        crate::fs::validate::describe_received(value),
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn required_hook(value: f64, label: &'static str) -> *const ClosureHeader {
+    let callback = closure_from_function_value(value);
+    if callback.is_null() {
+        throw_invalid_hook(label, value);
+    }
+    callback
+}
+
+fn optional_hook(options: f64, property: &[u8], label: &'static str) -> *const ClosureHeader {
+    let value = object_field(options, property);
+    if JSValue::from_bits(value.to_bits()).is_undefined() {
+        return ptr::null();
+    }
+    required_hook(value, label)
+}
+
+fn callbacks_from_options(options: f64) -> PromiseHookCallbacks {
+    PromiseHookCallbacks {
+        init: optional_hook(options, b"init", "initHook"),
+        before: optional_hook(options, b"before", "beforeHook"),
+        after: optional_hook(options, b"after", "afterHook"),
+        settled: optional_hook(options, b"settled", "settledHook"),
+    }
+}
+
+fn register_stop_trampoline_once() {
+    thread_local! {
+        static REGISTERED: Cell<bool> = const { Cell::new(false) };
+    }
+    REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
+        js_register_closure_arity(promise_hook_stop_trampoline as *const u8, 0);
+        registered.set(true);
+    });
+}
+
+extern "C" fn promise_hook_stop_trampoline(closure: *const ClosureHeader) -> f64 {
+    if closure.is_null() {
+        return TAG_UNDEFINED_F64;
+    }
+    let index = js_closure_get_capture_ptr(closure, 0) as usize;
+    disable_promise_hook(index);
+    TAG_UNDEFINED_F64
+}
+
+fn make_stop_function(index: usize) -> f64 {
+    register_stop_trampoline_once();
+    let closure = js_closure_alloc(promise_hook_stop_trampoline as *const u8, 1);
+    js_closure_set_capture_ptr(closure, 0, index as i64);
+    f64::from_bits(JSValue::pointer(closure as *const u8).bits())
+}
+
+fn install_promise_hook(callbacks: PromiseHookCallbacks) -> f64 {
+    let mut hooks = PROMISE_HOOKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let index = hooks.len();
+    let enabled = callbacks.has_any();
+    hooks.push(PromiseHookRecord { callbacks, enabled });
+    if enabled {
+        PROMISE_HOOKS_ACTIVE.fetch_add(1, Ordering::Relaxed);
+    }
+    make_stop_function(index)
+}
+
+fn disable_promise_hook(index: usize) {
+    let mut hooks = PROMISE_HOOKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(record) = hooks.get_mut(index) else {
+        return;
+    };
+    if record.enabled && record.callbacks.has_any() {
+        PROMISE_HOOKS_ACTIVE.fetch_sub(1, Ordering::Relaxed);
+    }
+    record.enabled = false;
+    record.callbacks = PromiseHookCallbacks::empty();
+}
+
+fn enabled_callbacks() -> Vec<PromiseHookCallbacks> {
+    if !promise_hooks_active() {
+        return Vec::new();
+    }
+    PROMISE_HOOKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .iter()
+        .filter(|hook| hook.enabled)
+        .map(|hook| hook.callbacks)
+        .collect()
+}
+
+fn with_promise_hook_callbacks(mut f: impl FnMut(PromiseHookCallbacks)) {
+    if !promise_hooks_active() {
+        return;
+    }
+    IN_PROMISE_HOOK_CALLBACK.with(|guard| {
+        if guard.get() {
+            return;
+        }
+        guard.set(true);
+        for callbacks in enabled_callbacks() {
+            f(callbacks);
+        }
+        guard.set(false);
+    });
+}
+
+#[no_mangle]
+pub extern "C" fn js_v8_promise_hooks_on_init(callback: f64) -> f64 {
+    install_promise_hook(PromiseHookCallbacks {
+        init: required_hook(callback, "initHook"),
+        ..PromiseHookCallbacks::empty()
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn js_v8_promise_hooks_on_before(callback: f64) -> f64 {
+    install_promise_hook(PromiseHookCallbacks {
+        before: required_hook(callback, "beforeHook"),
+        ..PromiseHookCallbacks::empty()
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn js_v8_promise_hooks_on_after(callback: f64) -> f64 {
+    install_promise_hook(PromiseHookCallbacks {
+        after: required_hook(callback, "afterHook"),
+        ..PromiseHookCallbacks::empty()
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn js_v8_promise_hooks_on_settled(callback: f64) -> f64 {
+    install_promise_hook(PromiseHookCallbacks {
+        settled: required_hook(callback, "settledHook"),
+        ..PromiseHookCallbacks::empty()
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn js_v8_promise_hooks_create_hook(options: f64) -> f64 {
+    install_promise_hook(callbacks_from_options(options))
+}
+
+pub(crate) fn promise_hook_init(promise: *mut Promise, parent: *mut Promise) {
+    if promise.is_null() || !promise_hooks_active() {
+        return;
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let promise_handle = scope.root_raw_mut_ptr(promise);
+    let parent_handle = scope.root_raw_mut_ptr(parent);
+    with_promise_hook_callbacks(|callbacks| {
+        if callbacks.init.is_null() {
+            return;
+        }
+        let callback_handle = scope.root_raw_const_ptr(callbacks.init);
+        let promise_arg = promise_value(promise_handle.get_raw_mut_ptr::<Promise>());
+        let parent_ptr = parent_handle.get_raw_mut_ptr::<Promise>();
+        let parent_arg = if parent_ptr.is_null() {
+            TAG_UNDEFINED_F64
+        } else {
+            promise_value(parent_ptr)
+        };
+        js_closure_call2(callback_handle.get_raw_const_ptr(), promise_arg, parent_arg);
+    });
+}
+
+pub(crate) fn promise_hook_before(promise: *mut Promise) {
+    if promise.is_null() || !promise_hooks_active() {
+        return;
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let promise_handle = scope.root_raw_mut_ptr(promise);
+    with_promise_hook_callbacks(|callbacks| {
+        if callbacks.before.is_null() {
+            return;
+        }
+        let callback_handle = scope.root_raw_const_ptr(callbacks.before);
+        js_closure_call1(
+            callback_handle.get_raw_const_ptr(),
+            promise_value(promise_handle.get_raw_mut_ptr::<Promise>()),
+        );
+    });
+}
+
+pub(crate) fn promise_hook_after(promise: *mut Promise) {
+    if promise.is_null() || !promise_hooks_active() {
+        return;
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let promise_handle = scope.root_raw_mut_ptr(promise);
+    with_promise_hook_callbacks(|callbacks| {
+        if callbacks.after.is_null() {
+            return;
+        }
+        let callback_handle = scope.root_raw_const_ptr(callbacks.after);
+        js_closure_call1(
+            callback_handle.get_raw_const_ptr(),
+            promise_value(promise_handle.get_raw_mut_ptr::<Promise>()),
+        );
+    });
+}
+
+pub(crate) fn promise_hook_settled(promise: *mut Promise) {
+    if promise.is_null() || !promise_hooks_active() {
+        return;
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let promise_handle = scope.root_raw_mut_ptr(promise);
+    with_promise_hook_callbacks(|callbacks| {
+        if callbacks.settled.is_null() {
+            return;
+        }
+        let callback_handle = scope.root_raw_const_ptr(callbacks.settled);
+        js_closure_call1(
+            callback_handle.get_raw_const_ptr(),
+            promise_value(promise_handle.get_raw_mut_ptr::<Promise>()),
+        );
+    });
+}
+
+pub fn scan_v8_promise_hook_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    let mut hooks = PROMISE_HOOKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for hook in hooks.iter_mut() {
+        visitor.visit_raw_const_ptr_slot(&mut hook.callbacks.init);
+        visitor.visit_raw_const_ptr_slot(&mut hook.callbacks.before);
+        visitor.visit_raw_const_ptr_slot(&mut hook.callbacks.after);
+        visitor.visit_raw_const_ptr_slot(&mut hook.callbacks.settled);
+    }
+}
+
+#[cfg(test)]
+pub fn reset_for_tests() {
+    PROMISE_HOOKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clear();
+    PROMISE_HOOKS_ACTIVE.store(0, Ordering::Relaxed);
+    IN_PROMISE_HOOK_CALLBACK.with(|c| c.set(false));
+}

--- a/test-files/test_parity_v8_lifecycle.ts
+++ b/test-files/test_parity_v8_lifecycle.ts
@@ -1,0 +1,119 @@
+// Focused parity fixture for the Perry-backed node:v8 lifecycle helpers.
+
+import * as v8 from "node:v8";
+
+console.log("v8.promiseHooks typeof:", typeof v8.promiseHooks);
+// NOTE: native-module namespace objects currently leak the internal
+// `__module__` marker through `Object.keys` (a generic pre-existing gap, not
+// specific to node:v8), so assert the exported surface by presence instead of
+// raw key enumeration.
+console.log(
+  "v8.promiseHooks has all:",
+  ["createHook", "onInit", "onBefore", "onAfter", "onSettled"].every(
+    (k) => typeof (v8.promiseHooks as any)[k] === "function",
+  ),
+);
+console.log("v8.promiseHooks.onInit typeof:", typeof v8.promiseHooks.onInit);
+console.log("v8.promiseHooks.onBefore typeof:", typeof v8.promiseHooks.onBefore);
+console.log("v8.promiseHooks.onAfter typeof:", typeof v8.promiseHooks.onAfter);
+console.log("v8.promiseHooks.onSettled typeof:", typeof v8.promiseHooks.onSettled);
+console.log("v8.promiseHooks.createHook typeof:", typeof v8.promiseHooks.createHook);
+
+console.log("v8.startupSnapshot typeof:", typeof v8.startupSnapshot);
+console.log(
+  "v8.startupSnapshot has all:",
+  [
+    "addDeserializeCallback",
+    "addSerializeCallback",
+    "setDeserializeMainFunction",
+    "isBuildingSnapshot",
+  ].every((k) => typeof (v8.startupSnapshot as any)[k] === "function"),
+);
+console.log("v8.startupSnapshot.isBuildingSnapshot:", v8.startupSnapshot.isBuildingSnapshot());
+
+try {
+  v8.promiseHooks.onInit();
+} catch (e: any) {
+  console.log("onInit missing:", e && e.name, e && e.code);
+}
+
+try {
+  v8.promiseHooks.onBefore(1 as any);
+} catch (e: any) {
+  console.log("onBefore invalid:", e && e.name, e && e.code);
+}
+
+try {
+  v8.promiseHooks.createHook({ init: 1 as any });
+} catch (e: any) {
+  console.log("createHook invalid:", e && e.name, e && e.code);
+}
+
+let stoppedInitCount = 0;
+const stopImmediately = v8.promiseHooks.onInit(() => {
+  stoppedInitCount++;
+});
+stopImmediately();
+stopImmediately();
+Promise.resolve("stopped");
+console.log("stopped init count:", stoppedInitCount);
+
+let createHookInitCount = 0;
+const stopCreatedHook = v8.promiseHooks.createHook({
+  init() {
+    createHookInitCount++;
+  },
+});
+Promise.resolve("created");
+stopCreatedHook();
+stopCreatedHook();
+console.log("createHook init fired:", createHookInitCount > 0);
+
+let rootInits = 0;
+let childInits = 0;
+let beforeCount = 0;
+let afterCount = 0;
+let settledCount = 0;
+
+const stops = [
+  v8.promiseHooks.onInit((_promise: any, parent: any) => {
+    if (parent === undefined) rootInits++;
+    else childInits++;
+  }),
+  v8.promiseHooks.onBefore((_promise: any) => {
+    beforeCount++;
+  }),
+  v8.promiseHooks.onAfter((_promise: any) => {
+    afterCount++;
+  }),
+  v8.promiseHooks.onSettled((_promise: any) => {
+    settledCount++;
+  }),
+];
+
+Promise.resolve("x")
+  .then((value: string) => value + "y")
+  .then((value: string) => {
+    for (const stop of stops) stop();
+    console.log(
+      "promiseHooks lifecycle:",
+      rootInits > 0,
+      childInits > 0,
+      beforeCount > 0,
+      afterCount > 0,
+      settledCount > 0,
+      value,
+    );
+
+    for (const [name, fn] of [
+      ["addSerializeCallback", v8.startupSnapshot.addSerializeCallback],
+      ["addDeserializeCallback", v8.startupSnapshot.addDeserializeCallback],
+      ["setDeserializeMainFunction", v8.startupSnapshot.setDeserializeMainFunction],
+    ] as any[]) {
+      try {
+        fn(() => {});
+      } catch (e: any) {
+        console.log(name + " error:", e && e.name, e && e.code);
+      }
+    }
+  });


### PR DESCRIPTION
## Summary

Closes #3139
Closes #3141

- adds the `node:v8` native module namespace for Perry-backed lifecycle helpers only
- implements `v8.promiseHooks.onInit/onBefore/onAfter/onSettled/createHook` on Perry Promise allocation, callback execution, and settlement paths
- implements `v8.startupSnapshot` normal-runtime helper state: `isBuildingSnapshot()` returns `0`, registration helpers throw `ERR_NOT_BUILDING_SNAPSHOT`
- updates manifest/codegen/runtime dispatch, generated API docs, parity gap metadata, and a focused lifecycle fixture

## Validation

- `command -v curl && command -v python3 && bash ~/.codex/skills/deepwiki/scripts/run.sh --repo PerryTS/perry --question ... --output /tmp/perry-node-v8-lifecycle-deepwiki.md --timeout 1800` - passed
- `cargo fmt --check` - passed
- `cargo check -p perry-runtime` - passed
- `scripts/regen_api_docs.sh` - passed
- `target/release/perry test-files/test_parity_v8_lifecycle.ts -o /tmp/perry_v8_lifecycle && /tmp/perry_v8_lifecycle` - passed; output matches the equivalent Node plain-JS probe
- `./run_parity_tests.sh --filter test_parity_v8_lifecycle` - local environment skipped the fixture because `/usr/bin/node` v22.22.1 is built without TypeScript stripping (`ERR_NO_TYPESCRIPT` for any `.ts` file)
- `cargo test -p perry-codegen --test manifest_consistency` - passed (4 tests)
- `cargo test -p perry-api-manifest` - passed (12 tests + doctests)
- `cargo test -p perry-runtime` - attempted; the parallel full suite reported `gc::tests::barrier::test_minor_gc_promotes_after_two_survivals` once and then hung in long GC tests. Reran `cargo test -p perry-runtime gc::tests::barrier::test_minor_gc_promotes_after_two_survivals -- --nocapture` and it passed.
