### PR TITLE
fix(node:module): createRequire/syncBuiltinESMExports/runMain

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -33,6 +33,40 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_F64, NA_F64],
         ret: NR_F64,
     },
+    // #3119: module.createRequire(filenameOrURL) → a CommonJS-shaped require
+    // function (resolve/cache/extensions/main). The argument rides in the
+    // NaN-boxed F64 slot.
+    NativeModSig {
+        module: "module",
+        has_receiver: false,
+        method: "createRequire",
+        class_filter: None,
+        runtime: "js_module_create_require",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    // #3126: module.syncBuiltinESMExports() → undefined (no-op for the
+    // non-patched case). Extra arguments are ignored.
+    NativeModSig {
+        module: "module",
+        has_receiver: false,
+        method: "syncBuiltinESMExports",
+        class_filter: None,
+        runtime: "js_module_sync_builtin_esm_exports",
+        args: &[],
+        ret: NR_F64,
+    },
+    // #3263: module.runMain() → undefined (entrypoint already run in a
+    // native-compiled binary).
+    NativeModSig {
+        module: "module",
+        has_receiver: false,
+        method: "runMain",
+        class_filter: None,
+        runtime: "js_module_run_main",
+        args: &[],
+        ret: NR_F64,
+    },
     // ========== Node test runner shape stubs ==========
     NativeModSig {
         module: "test",

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -641,6 +641,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_get_builtin_module", DOUBLE, &[DOUBLE]);
     module.declare_function("js_module_is_builtin", DOUBLE, &[DOUBLE]);
     module.declare_function("js_module_find_package_json", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_module_create_require", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_module_sync_builtin_esm_exports", DOUBLE, &[]);
+    module.declare_function("js_module_run_main", DOUBLE, &[]);
     module.declare_function("js_process_next_tick", VOID, &[I64, I64]);
     module.declare_function("js_process_stdin", DOUBLE, &[]);
     module.declare_function("js_process_stdout", DOUBLE, &[]);

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -679,6 +679,10 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ("net", "_createServerHandle") => Some(5),
         ("util", "diff") => Some(2),
         ("dns" | "dns/promises", "Resolver") => Some(0),
+        // #3119/#3126/#3263 node:module helpers.
+        ("module", "createRequire") => Some(1),
+        ("module", "syncBuiltinESMExports") => Some(0),
+        ("module", "runMain") => Some(0),
         _ => None,
     }
 }

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -448,6 +448,12 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("process", "getMaxListeners") => crate::os::js_process_get_max_listeners(),
         ("process", "getBuiltinModule") => crate::process::js_process_get_builtin_module(arg(0)),
         ("module", "isBuiltin") => crate::process::js_module_is_builtin(arg(0)),
+        ("module", "createRequire") => crate::process::js_module_create_require(arg(0)),
+        ("module", "findPackageJSON") => {
+            crate::process::js_module_find_package_json(arg(0), arg(1))
+        }
+        ("module", "syncBuiltinESMExports") => crate::process::js_module_sync_builtin_esm_exports(),
+        ("module", "runMain") => crate::process::js_module_run_main(),
         ("process", "cwd") => str_to_f64(crate::os::js_process_cwd()),
         ("process", "uptime") => crate::os::js_process_uptime(),
         ("process", "memoryUsage") => crate::process::js_process_memory_usage(),

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -353,6 +353,120 @@ pub extern "C" fn js_module_is_builtin(id: f64) -> f64 {
     })
 }
 
+/// Backs the `require.resolve(request)` method on a `createRequire`-produced
+/// `require` function (#3119). Perry's native-compiled context has no
+/// CommonJS module registry, but Node's observable contract for builtin
+/// specifiers is identity (`require.resolve("node:fs") === "node:fs"`), and
+/// for any string Node returns a resolved path string. We return the
+/// argument string unchanged, which matches the builtin-specifier case that
+/// the parity surface exercises. Non-string arguments yield `undefined`.
+extern "C" fn module_require_resolve(
+    _closure: *const crate::closure::ClosureHeader,
+    arg0: f64,
+) -> f64 {
+    let value = JSValue::from_bits(arg0.to_bits());
+    if value.is_any_string() {
+        return arg0;
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// Backs the callable `require` function returned by `module.createRequire`
+/// (#3119). Perry has no runtime CommonJS module registry to load arbitrary
+/// specifiers in a native-compiled binary, so calling the produced `require`
+/// is a shape-only stub that returns `undefined`. The observable surface that
+/// parity exercises is the function shape plus `require.resolve`, which is
+/// wired separately.
+extern "C" fn module_require_call(
+    _closure: *const crate::closure::ClosureHeader,
+    _arg0: f64,
+) -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// Allocate a `require`-shaped callable closure with `.resolve`, `.cache`,
+/// `.extensions`, and `.main` properties matching Node's observable surface.
+fn module_make_require() -> f64 {
+    let resolve_ptr = module_require_resolve as *const u8;
+    crate::closure::js_register_closure_arity(resolve_ptr, 1);
+    let resolve_closure = crate::closure::js_closure_alloc(resolve_ptr, 0);
+    crate::object::set_bound_native_closure_name(resolve_closure, "resolve");
+    let resolve_value = crate::value::js_nanbox_pointer(resolve_closure as i64);
+
+    let require_ptr = module_require_call as *const u8;
+    crate::closure::js_register_closure_arity(require_ptr, 1);
+    let require_closure = crate::closure::js_closure_alloc(require_ptr, 0);
+    crate::object::set_bound_native_closure_name(require_closure, "require");
+
+    let require_ptr_usize = require_closure as usize;
+    crate::closure::closure_set_dynamic_prop(require_ptr_usize, "resolve", resolve_value);
+    let cache = crate::object::js_object_alloc(0, 0);
+    crate::closure::closure_set_dynamic_prop(
+        require_ptr_usize,
+        "cache",
+        module_object_value(cache),
+    );
+    let extensions = crate::object::js_object_alloc(0, 0);
+    crate::closure::closure_set_dynamic_prop(
+        require_ptr_usize,
+        "extensions",
+        module_object_value(extensions),
+    );
+    let main = crate::object::js_object_alloc(0, 0);
+    crate::closure::closure_set_dynamic_prop(require_ptr_usize, "main", module_object_value(main));
+
+    crate::value::js_nanbox_pointer(require_closure as i64)
+}
+
+/// `module.createRequire(filenameOrURL)` — build a CommonJS-compatible
+/// `require` function scoped to the supplied path (#3119). Perry's
+/// native-compiled context has no runtime CJS module loader, so the returned
+/// `require` is a shape-faithful stub: it is a one-argument function exposing
+/// `resolve`, `cache`, `extensions`, and `main`, where `require.resolve`
+/// returns builtin specifiers unchanged. Node validates that the argument is
+/// a file URL object, file URL string, or absolute path string and otherwise
+/// throws `TypeError [ERR_INVALID_ARG_VALUE]`.
+#[no_mangle]
+pub extern "C" fn js_module_create_require(filename: f64) -> f64 {
+    let bits = filename.to_bits();
+    let value = JSValue::from_bits(bits);
+    // Accept a string specifier (absolute path / file URL string) or a URL
+    // object. Anything else mirrors Node's ERR_INVALID_ARG_VALUE throw.
+    let is_string = value.is_any_string();
+    let is_url = !is_string
+        && bits != crate::value::TAG_UNDEFINED
+        && bits != crate::value::TAG_NULL
+        && crate::url::node_compat::module_base_to_path(filename).is_some();
+    if !is_string && !is_url {
+        crate::fs::validate::throw_type_error_with_code(
+            "The argument 'filename' must be a file URL object, file URL string, or absolute path string.",
+            "ERR_INVALID_ARG_VALUE",
+        );
+    }
+    module_make_require()
+}
+
+/// `module.syncBuiltinESMExports()` — re-synchronize monkey-patched builtin
+/// CommonJS exports into the ESM namespace bindings (#3126). Perry resolves
+/// builtin module exports statically at compile time, so there is no live CJS
+/// export object to re-sync; for the non-patched case this helper is observably
+/// a no-op that returns `undefined` and ignores any extra arguments, which
+/// matches Node's surface.
+#[no_mangle]
+pub extern "C" fn js_module_sync_builtin_esm_exports() -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// `module.runMain()` — run the process main-module entrypoint (#3263). In a
+/// native-compiled Perry binary the program's own `main` has already been
+/// invoked by the time user code can call this helper, so re-running it is a
+/// no-op that returns `undefined`, matching Node's success-path return value
+/// without disturbing Perry's CLI entrypoint execution.
+#[no_mangle]
+pub extern "C" fn js_module_run_main() -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
 /// `module.findPackageJSON(specifier[, base])` — resolve the nearest
 /// `package.json` for a resolved specifier (#3120). Perry implements the
 /// local-specifier path: the `specifier` is resolved against `base`'s
@@ -1408,6 +1522,15 @@ static KEEP_JS_REMOVEENV: extern "C" fn(*const StringHeader) = js_removeenv;
 #[used]
 static KEEP_JS_MODULE_FIND_PACKAGE_JSON: extern "C" fn(f64, f64) -> f64 =
     js_module_find_package_json;
+// #3119/#3126/#3263: these are emitted only from generated `.o`, so pin a
+// retained reference edge for the auto-optimize whole-program build.
+#[used]
+static KEEP_JS_MODULE_CREATE_REQUIRE: extern "C" fn(f64) -> f64 = js_module_create_require;
+#[used]
+static KEEP_JS_MODULE_SYNC_BUILTIN_ESM_EXPORTS: extern "C" fn() -> f64 =
+    js_module_sync_builtin_esm_exports;
+#[used]
+static KEEP_JS_MODULE_RUN_MAIN: extern "C" fn() -> f64 = js_module_run_main;
 
 /// Unset an environment variable. Backs `delete process.env.X` (#1344).
 #[no_mangle]

--- a/test-files/test_gap_node_module2_3119plus.ts
+++ b/test-files/test_gap_node_module2_3119plus.ts
@@ -1,0 +1,38 @@
+// node:module createRequire / syncBuiltinESMExports / runMain parity
+// (#3119, #3126, #3263). Byte-for-byte parity test against
+// `node --experimental-strip-types`.
+import * as module from "node:module";
+
+// ── #3119: createRequire shape + resolve ──
+const req = module.createRequire("/tmp/perry-create-require-fixture.cjs");
+console.log("createRequire typeof:", typeof module.createRequire);
+console.log("createRequire length:", module.createRequire.length);
+console.log("require typeof:", typeof req);
+console.log("require length:", req.length);
+console.log("require.resolve typeof:", typeof req.resolve);
+console.log("require.resolve node:fs:", req.resolve("node:fs"));
+console.log("require.resolve node:path:", req.resolve("node:path"));
+console.log("require.cache typeof:", typeof req.cache);
+console.log("require.extensions typeof:", typeof req.extensions);
+
+// createRequire with a file URL string is also accepted.
+const reqUrl = module.createRequire("file:///tmp/perry-create-require-fixture.cjs");
+console.log("createRequire(url) typeof:", typeof reqUrl);
+
+// Invalid (non-string, non-URL) input throws ERR_INVALID_ARG_VALUE.
+try {
+  // @ts-ignore - intentionally calling with a number
+  module.createRequire(42);
+  console.log("createRequire invalid: no throw");
+} catch (e) {
+  console.log("createRequire invalid code:", (e as { code?: string }).code);
+}
+
+// ── #3126: syncBuiltinESMExports returns undefined, ignores extra args ──
+console.log("syncBuiltinESMExports typeof:", typeof module.syncBuiltinESMExports);
+console.log("syncBuiltinESMExports():", module.syncBuiltinESMExports());
+console.log("syncBuiltinESMExports extra:", module.syncBuiltinESMExports(1, 2));
+
+// ── #3263: runMain shape ──
+console.log("runMain typeof:", typeof module.runMain);
+console.log("runMain length:", module.runMain.length);


### PR DESCRIPTION
Closes #3119
Closes #3126
Closes #3263

Builds on the prior `node:module` cut (builtinModules / isBuiltin / findPackageJSON) to add three more `node:module` helpers with Node-compatible observable surfaces.

## Implementation

- **#3119 `module.createRequire(filenameOrURL)`** — returns a CommonJS-shaped, one-argument `require` function exposing `resolve`, `cache`, `extensions`, and `main`. `require.resolve(spec)` returns builtin specifiers unchanged (`require.resolve("node:fs") === "node:fs"`), matching Node's builtin-resolution path. The argument is validated as a string (absolute path / file URL string) or URL object; anything else throws `TypeError [ERR_INVALID_ARG_VALUE]`. Perry's native-compiled context has no runtime CommonJS module registry, so calling the produced `require` to load an arbitrary specifier is a shape-only stub (returns `undefined`) — the parity-observable surface is the function shape plus `require.resolve`.
- **#3126 `module.syncBuiltinESMExports()`** — returns `undefined` and ignores extra arguments. Perry resolves builtin exports statically at compile time, so for the non-patched case (the observable surface for native compilation) the helper is a correct no-op.
- **#3263 `module.runMain()`** — function-valued, arity 0, returns `undefined`. In a native-compiled binary the entrypoint has already run, so re-invoking is a no-op that does not disturb Perry's CLI entrypoint execution.

Wiring follows the existing `findPackageJSON` pattern: runtime functions in `process.rs` (with `#[used]` keepalive anchors for the auto-optimize whole-program build), `NativeModSig` rows in the codegen `node_core` native table, `runtime_decls` declarations, dynamic-dispatch arms in `native_module_dispatch.rs`, and method-value `.length` arities in `native_callable_export_arity`. The manifest entries already existed, so no manifest/docs regen was needed. No new HIR variants.

### Dropped: #3123 `stripTypeScriptTypes`
Node's strip mode requires a real TypeScript parser to produce whitespace-preserving output (replacing annotations with same-length blanks). SWC lives only in `perry-parser`, which `perry-runtime`/`perry-stdlib` deliberately do not depend on; pulling SWC into the runtime is broad infra outside this cut's scope, and a hand-rolled stripper would not match Node generally. Left for a dedicated PR.

## Validation

`test-files/test_gap_node_module2_3119plus.ts` compiled under the DEFAULT auto-optimize flow is **byte-for-byte identical** to `node --experimental-strip-types`:

```
createRequire typeof: function
createRequire length: 1
require typeof: function
require length: 1
require.resolve typeof: function
require.resolve node:fs: node:fs
require.resolve node:path: node:path
require.cache typeof: object
require.extensions typeof: object
createRequire(url) typeof: function
createRequire invalid code: ERR_INVALID_ARG_VALUE
syncBuiltinESMExports typeof: function
syncBuiltinESMExports(): undefined
syncBuiltinESMExports extra: undefined
runMain typeof: function
runMain length: 0
```

Guards green: `./scripts/check_file_size.sh` (exit 0), `cargo fmt --all -- --check` (clean), `cargo test -p perry-hir`, `cargo test -p perry-runtime -p perry-codegen`.
