### PR TITLE
#3598 MessagePort local delivery semantics

### DIFF
--- a/crates/perry-stdlib/src/worker_threads.rs
+++ b/crates/perry-stdlib/src/worker_threads.rs
@@ -60,18 +60,26 @@ thread_local! {
 struct MessagePortState {
     /// Id of the paired port. `postMessage` delivers to the peer's inbox.
     peer: u64,
+    /// NaN-boxed MessagePort object value, used as MessageEvent target.
+    object_bits: u64,
     /// Queue of delivered messages as JSON strings (oldest first).
     inbox: VecDeque<String>,
     /// `message` event listener (NaN-boxed closure value bits), if registered.
     message_cb: Option<u64>,
     /// `close` event listener (NaN-boxed closure value bits), if registered.
     close_cb: Option<u64>,
+    /// `message` listeners registered through addEventListener().
+    message_event_cbs: Vec<u64>,
+    /// `close` listeners registered through addEventListener().
+    close_event_cbs: Vec<u64>,
     /// Whether `.start()` (or a `message` listener) has been attached. Until a
     /// port is started, queued messages are not dispatched to the listener
     /// (Node semantics), though `receiveMessageOnPort` still drains them.
     started: bool,
     /// Whether `close()` has been called on this port.
     closed: bool,
+    /// Whether a close event still needs to be delivered.
+    close_pending: bool,
 }
 
 static ENVIRONMENT_DATA_GC_REGISTERED: Once = Once::new();
@@ -95,10 +103,18 @@ fn scan_environment_data_roots_mut(visitor: &mut perry_runtime::gc::RuntimeRootV
     // moves (#3157). Stored as NaN-boxed closure value bits.
     MESSAGE_PORTS.with(|ports| {
         for state in ports.borrow_mut().values_mut() {
+            visitor.visit_nanbox_u64_slot(&mut state.object_bits);
             if let Some(cb) = state.message_cb.as_mut() {
                 visitor.visit_nanbox_u64_slot(cb);
             }
             if let Some(cb) = state.close_cb.as_mut() {
+                visitor.visit_nanbox_u64_slot(cb);
+            }
+            for cb in state
+                .message_event_cbs
+                .iter_mut()
+                .chain(state.close_event_cbs.iter_mut())
+            {
                 visitor.visit_nanbox_u64_slot(cb);
             }
         }
@@ -189,10 +205,25 @@ fn set_object_field(obj: *mut perry_runtime::object::ObjectHeader, name: &str, v
     perry_runtime::object::js_object_set_field_by_name(obj, key, value);
 }
 
+fn get_object_field(obj: *const perry_runtime::object::ObjectHeader, name: &str) -> f64 {
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    perry_runtime::object::js_object_get_field_by_name_f64(obj, key)
+}
+
 fn closure_value(func_ptr: *const u8, arity: u32) -> f64 {
     perry_runtime::closure::js_register_closure_arity(func_ptr, arity);
     let closure = perry_runtime::closure::js_closure_alloc(func_ptr, 0);
     f64::from_bits(JSValue::pointer(closure as *const u8).bits())
+}
+
+fn callback_bits_from_value(value: f64) -> Option<u64> {
+    let bits = value.to_bits();
+    let js_value = JSValue::from_bits(bits);
+    if !js_value.is_pointer() {
+        return None;
+    }
+    let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
+    perry_runtime::closure::is_closure_ptr(ptr).then_some(bits)
 }
 
 extern "C" fn worker_threads_noop0(_closure: *const ClosureHeader) -> f64 {
@@ -236,11 +267,79 @@ fn deserialize_message(msg: &str) -> f64 {
     f64::from_bits(unsafe { js_json_parse(str_ptr) })
 }
 
+fn call_callback0(callback_bits: u64, this_bits: u64) {
+    let closure = closure_ptr_from_bits(callback_bits);
+    if closure.is_null() {
+        return;
+    }
+    let prev_this = perry_runtime::object::js_implicit_this_set(f64::from_bits(this_bits));
+    perry_runtime::closure::js_closure_call0(closure);
+    perry_runtime::object::js_implicit_this_set(prev_this);
+}
+
+fn call_callback1(callback_bits: u64, this_bits: u64, arg: f64) {
+    let closure = closure_ptr_from_bits(callback_bits);
+    if closure.is_null() {
+        return;
+    }
+    let prev_this = perry_runtime::object::js_implicit_this_set(f64::from_bits(this_bits));
+    perry_runtime::closure::js_closure_call1(closure, arg);
+    perry_runtime::object::js_implicit_this_set(prev_this);
+}
+
+fn object_event_handler(target_bits: u64, name: &str) -> Option<u64> {
+    if target_bits == 0 {
+        return None;
+    }
+    let target = f64::from_bits(target_bits);
+    let js = JSValue::from_bits(target.to_bits());
+    if !js.is_pointer() {
+        return None;
+    }
+    let obj = perry_runtime::value::js_nanbox_get_pointer(target)
+        as *const perry_runtime::object::ObjectHeader;
+    if obj.is_null() {
+        return None;
+    }
+    callback_bits_from_value(get_object_field(obj, name))
+}
+
+fn event_object(event_type: &str, target_bits: u64, data: Option<f64>) -> f64 {
+    let obj = perry_runtime::object::js_object_alloc(0, 6);
+    let type_ptr = js_string_from_bytes(event_type.as_ptr(), event_type.len() as u32);
+    let type_value = f64::from_bits(JSValue::string_ptr(type_ptr).bits());
+    let target = f64::from_bits(target_bits);
+    set_object_field(obj, "type", type_value);
+    set_object_field(obj, "target", target);
+    set_object_field(obj, "currentTarget", target);
+    set_object_field(obj, "defaultPrevented", js_bool(false));
+    let ctor = perry_runtime::object::js_object_alloc(0, 1);
+    if let Some(data) = data {
+        set_object_field(obj, "data", data);
+        let name = js_string_from_bytes(b"MessageEvent".as_ptr(), 12);
+        set_object_field(
+            ctor,
+            "name",
+            f64::from_bits(JSValue::string_ptr(name).bits()),
+        );
+    } else {
+        let name = js_string_from_bytes(b"Event".as_ptr(), 5);
+        set_object_field(
+            ctor,
+            "name",
+            f64::from_bits(JSValue::string_ptr(name).bits()),
+        );
+    }
+    set_object_field(obj, "constructor", object_value(ctor));
+    object_value(obj)
+}
+
 /// Build a MessagePort JS object for a same-process channel. The id is also
 /// stored on the object (hidden `__perryPortId` field) so `receiveMessageOnPort`
 /// can recover it from the object reference.
 fn message_port_object(port_id: u64) -> *mut perry_runtime::object::ObjectHeader {
     let obj = perry_runtime::object::js_object_alloc(0, 0);
+    let object_bits = object_value(obj).to_bits();
     set_object_field(
         obj,
         "postMessage",
@@ -273,6 +372,16 @@ fn message_port_object(port_id: u64) -> *mut perry_runtime::object::ObjectHeader
     );
     set_object_field(
         obj,
+        "addEventListener",
+        port_bound_closure(port_add_event_listener as *const u8, 2, port_id),
+    );
+    set_object_field(
+        obj,
+        "removeEventListener",
+        port_bound_closure(port_remove_event_listener as *const u8, 2, port_id),
+    );
+    set_object_field(
+        obj,
         "close",
         port_bound_closure(port_close as *const u8, 0, port_id),
     );
@@ -297,6 +406,13 @@ fn message_port_object(port_id: u64) -> *mut perry_runtime::object::ObjectHeader
         closure_value(worker_threads_has_ref as *const u8, 0),
     );
     set_object_field(obj, "__perryPortId", f64::from_bits(port_id));
+    set_object_field(obj, "onmessage", js_null());
+    set_object_field(obj, "onmessageerror", js_null());
+    MESSAGE_PORTS.with(|ports| {
+        if let Some(state) = ports.borrow_mut().get_mut(&port_id) {
+            state.object_bits = object_bits;
+        }
+    });
     obj
 }
 
@@ -305,7 +421,7 @@ extern "C" fn port_post_message(closure: *const ClosureHeader, value: f64, _tran
     let port_id = port_id_from_closure(closure);
     // Reject values flagged uncloneable (#3159). Match Node's DataCloneError.
     if UNCLONEABLE_OBJECTS.with(|set| set.borrow().contains(&value.to_bits())) {
-        return throw_data_clone_error("object could not be cloned.");
+        throw_data_clone_error("object could not be cloned.");
     }
     let serialized = serialize_message(value);
     MESSAGE_PORTS.with(|ports| {
@@ -317,9 +433,12 @@ extern "C" fn port_post_message(closure: *const ClosureHeader, value: f64, _tran
             }
         };
         if let Some(peer_state) = ports.borrow_mut().get_mut(&peer) {
-            peer_state.inbox.push_back(serialized);
+            if !peer_state.closed {
+                peer_state.inbox.push_back(serialized);
+            }
         }
     });
+    perry_runtime::event_pump::js_notify_main_thread();
     js_undefined()
 }
 
@@ -365,6 +484,62 @@ extern "C" fn port_off(closure: *const ClosureHeader, event: f64, _callback: f64
     js_undefined()
 }
 
+/// port.addEventListener(event, callback) (#3598).
+extern "C" fn port_add_event_listener(
+    closure: *const ClosureHeader,
+    event: f64,
+    callback: f64,
+) -> f64 {
+    let port_id = port_id_from_closure(closure);
+    let event_name = string_value_to_string(event).unwrap_or_default();
+    let Some(cb_bits) = callback_bits_from_value(callback) else {
+        return js_undefined();
+    };
+    crate::common::async_bridge::ensure_pump_registered();
+    MESSAGE_PORTS.with(|ports| {
+        if let Some(state) = ports.borrow_mut().get_mut(&port_id) {
+            match event_name.as_str() {
+                "message" => {
+                    state.started = true;
+                    if !state.message_event_cbs.contains(&cb_bits) {
+                        state.message_event_cbs.push(cb_bits);
+                    }
+                }
+                "close" => {
+                    if !state.close_event_cbs.contains(&cb_bits) {
+                        state.close_event_cbs.push(cb_bits);
+                    }
+                }
+                _ => {}
+            }
+        }
+    });
+    js_undefined()
+}
+
+/// port.removeEventListener(event, callback) (#3598).
+extern "C" fn port_remove_event_listener(
+    closure: *const ClosureHeader,
+    event: f64,
+    callback: f64,
+) -> f64 {
+    let port_id = port_id_from_closure(closure);
+    let event_name = string_value_to_string(event).unwrap_or_default();
+    let Some(cb_bits) = callback_bits_from_value(callback) else {
+        return js_undefined();
+    };
+    MESSAGE_PORTS.with(|ports| {
+        if let Some(state) = ports.borrow_mut().get_mut(&port_id) {
+            match event_name.as_str() {
+                "message" => state.message_event_cbs.retain(|cb| *cb != cb_bits),
+                "close" => state.close_event_cbs.retain(|cb| *cb != cb_bits),
+                _ => {}
+            }
+        }
+    });
+    js_undefined()
+}
+
 /// port.start() — enable delivery of queued messages to the listener (#3157).
 extern "C" fn port_start(closure: *const ClosureHeader) -> f64 {
     let port_id = port_id_from_closure(closure);
@@ -379,12 +554,27 @@ extern "C" fn port_start(closure: *const ClosureHeader) -> f64 {
 /// port.close() — mark closed and queue `close` events on both ends (#3157).
 extern "C" fn port_close(closure: *const ClosureHeader) -> f64 {
     let port_id = port_id_from_closure(closure);
+    let peer_id = MESSAGE_PORTS.with(|ports| ports.borrow().get(&port_id).map(|state| state.peer));
     MESSAGE_PORTS.with(|ports| {
         let mut ports = ports.borrow_mut();
         if let Some(state) = ports.get_mut(&port_id) {
+            if !state.closed {
+                state.close_pending = true;
+            }
             state.closed = true;
+            state.inbox.clear();
+        }
+        if let Some(peer_id) = peer_id {
+            if let Some(peer) = ports.get_mut(&peer_id) {
+                if !peer.closed {
+                    peer.close_pending = true;
+                }
+                peer.closed = true;
+                peer.inbox.clear();
+            }
         }
     });
+    perry_runtime::event_pump::js_notify_main_thread();
     js_undefined()
 }
 
@@ -494,6 +684,7 @@ pub extern "C" fn js_worker_threads_post_message_to_thread(
 #[no_mangle]
 pub extern "C" fn js_worker_threads_message_channel_new() -> f64 {
     ensure_environment_data_gc_scanner();
+    crate::common::async_bridge::ensure_pump_registered();
     let (id1, id2) = NEXT_PORT_ID.with(|n| {
         let mut n = n.borrow_mut();
         let a = *n;
@@ -534,24 +725,62 @@ pub extern "C" fn js_worker_threads_channels_process_pending() -> i32 {
     // Snapshot deliverable (port_id, callback, message) tuples, then invoke the
     // callbacks OUTSIDE the MESSAGE_PORTS borrow — a listener may re-enter
     // postMessage / close, which needs to borrow MESSAGE_PORTS again.
+    struct MessageDispatch {
+        target_bits: u64,
+        raw_cb: Option<u64>,
+        event_cbs: Vec<u64>,
+        handler_cb: Option<u64>,
+        msg: String,
+    }
+
     loop {
-        let next: Option<(u64, String)> = MESSAGE_PORTS.with(|ports| {
-            let mut ports = ports.borrow_mut();
-            for state in ports.values_mut() {
-                if state.started && !state.closed && state.message_cb.is_some() {
-                    if let Some(msg) = state.inbox.pop_front() {
-                        return Some((state.message_cb.unwrap(), msg));
-                    }
-                }
-            }
-            None
+        let candidates: Vec<(u64, u64)> = MESSAGE_PORTS.with(|ports| {
+            ports
+                .borrow()
+                .iter()
+                .filter_map(|(port_id, state)| {
+                    (!state.closed && !state.inbox.is_empty())
+                        .then_some((*port_id, state.object_bits))
+                })
+                .collect()
         });
+        let mut next: Option<MessageDispatch> = None;
+        for (port_id, target_bits) in candidates {
+            let handler_cb = object_event_handler(target_bits, "onmessage");
+            next = MESSAGE_PORTS.with(|ports| {
+                let mut ports = ports.borrow_mut();
+                let state = ports.get_mut(&port_id)?;
+                let has_event_target = state.started
+                    && (state.message_cb.is_some() || !state.message_event_cbs.is_empty());
+                if state.closed || (!has_event_target && handler_cb.is_none()) {
+                    return None;
+                }
+                state.inbox.pop_front().map(|msg| MessageDispatch {
+                    target_bits: state.object_bits,
+                    raw_cb: state.message_cb,
+                    event_cbs: state.message_event_cbs.clone(),
+                    handler_cb,
+                    msg,
+                })
+            });
+            if next.is_some() {
+                break;
+            }
+        }
         match next {
-            Some((cb_bits, msg)) => {
-                let value = deserialize_message(&msg);
-                let closure = closure_ptr_from_bits(cb_bits);
-                if !closure.is_null() {
-                    perry_runtime::closure::js_closure_call1(closure, value);
+            Some(dispatch) => {
+                let value = deserialize_message(&dispatch.msg);
+                if let Some(cb_bits) = dispatch.raw_cb {
+                    call_callback1(cb_bits, dispatch.target_bits, value);
+                }
+                if !dispatch.event_cbs.is_empty() || dispatch.handler_cb.is_some() {
+                    let event = event_object("message", dispatch.target_bits, Some(value));
+                    for cb_bits in dispatch.event_cbs {
+                        call_callback1(cb_bits, dispatch.target_bits, event);
+                    }
+                    if let Some(cb_bits) = dispatch.handler_cb {
+                        call_callback1(cb_bits, dispatch.target_bits, event);
+                    }
                 }
                 dispatched += 1;
             }
@@ -560,21 +789,35 @@ pub extern "C" fn js_worker_threads_channels_process_pending() -> i32 {
     }
 
     // Fire `close` callbacks once for newly-closed ports.
-    let close_cbs: Vec<u64> = MESSAGE_PORTS.with(|ports| {
-        let mut cbs = Vec::new();
+    struct CloseDispatch {
+        target_bits: u64,
+        raw_cb: Option<u64>,
+        event_cbs: Vec<u64>,
+    }
+
+    let close_events: Vec<CloseDispatch> = MESSAGE_PORTS.with(|ports| {
+        let mut events = Vec::new();
         for state in ports.borrow_mut().values_mut() {
-            if state.closed {
-                if let Some(cb) = state.close_cb.take() {
-                    cbs.push(cb);
-                }
+            if state.close_pending {
+                state.close_pending = false;
+                events.push(CloseDispatch {
+                    target_bits: state.object_bits,
+                    raw_cb: state.close_cb,
+                    event_cbs: state.close_event_cbs.clone(),
+                });
             }
         }
-        cbs
+        events
     });
-    for cb_bits in close_cbs {
-        let closure = closure_ptr_from_bits(cb_bits);
-        if !closure.is_null() {
-            perry_runtime::closure::js_closure_call0(closure);
+    for event in close_events {
+        if let Some(cb_bits) = event.raw_cb {
+            call_callback0(cb_bits, event.target_bits);
+        }
+        if !event.event_cbs.is_empty() {
+            let close_event = event_object("close", event.target_bits, None);
+            for cb_bits in event.event_cbs {
+                call_callback1(cb_bits, event.target_bits, close_event);
+            }
         }
         dispatched += 1;
     }
@@ -586,16 +829,30 @@ pub extern "C" fn js_worker_threads_channels_process_pending() -> i32 {
 /// `message` listener with queued or potentially-incoming messages (#3157).
 #[no_mangle]
 pub extern "C" fn js_worker_threads_channels_has_pending() -> i32 {
-    let pending = MESSAGE_PORTS.with(|ports| {
+    let pending_without_onmessage = MESSAGE_PORTS.with(|ports| {
         ports.borrow().values().any(|state| {
-            (state.started
-                && state.message_cb.is_some()
-                && !state.closed
-                && !state.inbox.is_empty())
-                || (state.closed && state.close_cb.is_some())
+            let has_event_target = state.started
+                && (state.message_cb.is_some() || !state.message_event_cbs.is_empty());
+            (!state.closed && !state.inbox.is_empty() && has_event_target) || state.close_pending
         })
     });
-    if pending {
+    if pending_without_onmessage {
+        return 1;
+    }
+
+    let onmessage_targets: Vec<u64> = MESSAGE_PORTS.with(|ports| {
+        ports
+            .borrow()
+            .values()
+            .filter_map(|state| {
+                (!state.closed && !state.inbox.is_empty()).then_some(state.object_bits)
+            })
+            .collect()
+    });
+    if onmessage_targets
+        .into_iter()
+        .any(|target_bits| object_event_handler(target_bits, "onmessage").is_some())
+    {
         1
     } else {
         0

--- a/reference/deepwiki/issue-3598-message-delivery-node.md
+++ b/reference/deepwiki/issue-3598-message-delivery-node.md
@@ -1,0 +1,310 @@
+# DeepWiki Response
+
+Repository: `nodejs/node`
+Question: For Node.js worker_threads MessageChannel, MessagePort, and BroadcastChannel, summarize observable local delivery semantics for postMessage, message events/event handler properties, close(), ordering, receiveMessageOnPort, and same-name BroadcastChannel delivery. Include source-file citations where possible.
+Search: https://deepwiki.com/search/for-nodejs-workerthreads-messa_69833a05-a653-4090-b373-359cf1dd8b85
+
+**Question**: For Node.js worker_threads MessageChannel, MessagePort, and BroadcastChannel, summarize observable local delivery semantics for postMessage, message events/event handler properties, close(), ordering, receiveMessageOnPort, and same-name BroadcastChannel delivery. Include source-file citations where possible.
+
+You're asking about the local delivery semantics for `postMessage`, `message` events, `close()`, message ordering, `receiveMessageOnPort`, and same-name `BroadcastChannel` delivery within Node.js `worker_threads` for `MessageChannel`, `MessagePort`, and `BroadcastChannel`.
+
+### `MessageChannel` and `MessagePort`
+
+`MessageChannel` creates a pair of `MessagePort` objects, `port1` and `port2`, which are linked for two-way communication [1](#ref-q1-1) .
+
+#### `postMessage` and `message` events
+
+When `port.postMessage(value[, transferList])` is called on one `MessagePort`, the `value` is sent to its linked `MessagePort` [2](#ref-q1-2) . The `value` is transferred using a structured clone algorithm, allowing for complex JavaScript values, including circular references, built-in types, and typed arrays [3](#ref-q1-3) . If `ArrayBuffer` instances are included in the `transferList`, their underlying memory is moved, making them unusable on the sending side [4](#ref-q1-4) . If not in `transferList`, the `ArrayBuffer` is copied [5](#ref-q1-5) . `SharedArrayBuffer` instances are accessible from both threads without being transferred [6](#ref-q1-6) .
+
+The receiving `MessagePort` emits a `'message'` event, and its `onmessage` listener is invoked with the cloned `value` [7](#ref-q1-7) . Messages are processed in the order they are received [8](#ref-q1-8) . If deserialization fails, a `'messageerror'` event is emitted [9](#ref-q1-9) .
+
+#### `close()`
+
+Calling `port.close()` disables further sending of messages on both sides of the connection [10](#ref-q1-10) . A `'close'` event is emitted on both `MessagePort` instances in the channel [11](#ref-q1-11) .
+
+#### `receiveMessageOnPort`
+
+The `receiveMessageOnPort(port)` function allows synchronously receiving a single message from a given `MessagePort` [12](#ref-q1-12) . If no message is available, `undefined` is returned [13](#ref-q1-13) . When this function is used, no `'message'` event is emitted, and the `onmessage` listener is not invoked [14](#ref-q1-14) .
+
+### `BroadcastChannel`
+
+`BroadcastChannel` instances enable asynchronous one-to-many communication among all `BroadcastChannel` instances bound to the same channel name [15](#ref-q1-15) .
+
+#### `postMessage` and `message` events
+
+`broadcastChannel.postMessage(message)` sends a message to all other `BroadcastChannel` instances with the same name [16](#ref-q1-16) . The `message` is a cloneable JavaScript value [17](#ref-q1-17) . Each receiving `BroadcastChannel` instance emits a `'message'` event, and its `onmessage` property is invoked with a `MessageEvent` argument containing the `data` [18](#ref-q1-18)  [19](#ref-q1-19) . If a received message cannot be deserialized, an `onmessageerror` event is invoked [20](#ref-q1-20) .
+
+#### `close()`
+
+`broadcastChannel.close()` closes the `BroadcastChannel` connection, detaching its internal handle and preventing further messages from being sent or received through this instance [21](#ref-q1-21)  [22](#ref-q1-22) .
+
+#### Same-name `BroadcastChannel` delivery
+
+All `BroadcastChannel` instances created with the same `name` are connected [23](#ref-q1-23) . Messages posted to one instance are delivered to all other active instances sharing that name [15](#ref-q1-15) .
+
+### Ordering
+
+For both `MessagePort` and `BroadcastChannel`, messages are delivered in the order they are sent. The `MessagePort::OnMessage` function processes messages from an `incoming_messages_` queue, ensuring order [8](#ref-q1-8) .
+
+## Notes
+
+The `receiveMessageOnPort` function was updated in Node.js v15.12.0 to also accept a `BroadcastChannel` as its `port` argument [24](#ref-q1-24) . This means you can use `receiveMessageOnPort` to synchronously read messages from a `BroadcastChannel` as well, with the same implications regarding `onmessage` listeners not being invoked.
+
+Wiki pages you might want to explore:
+- [Core Runtime Architecture (nodejs/node)](/wiki/nodejs/node#2)
+
+View this search on DeepWiki: https://deepwiki.com/search/for-nodejs-workerthreads-messa_69833a05-a653-4090-b373-359cf1dd8b85
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `doc/api/worker_threads.md:1049-1054`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1049-L1054)
+
+```markdown
+Instances of the `worker.MessageChannel` class represent an asynchronous,
+two-way communications channel.
+The `MessageChannel` has no methods of its own. `new MessageChannel()`
+yields an object with `port1` and `port2` properties, which refer to linked
+[`MessagePort`][] instances.
+```
+
+<a id="ref-q1-2"></a>
+### [2] `doc/api/worker_threads.md:1220-1221`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1220-L1221)
+
+```markdown
+Sends a JavaScript value to the receiving side of this channel.
+`value` is transferred in a way which is compatible with
+```
+
+<a id="ref-q1-3"></a>
+### [3] `doc/api/worker_threads.md:1222-1230`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1222-L1230)
+
+```markdown
+the [HTML structured clone algorithm][].
+
+In particular, the significant differences to `JSON` are:
+
+* `value` may contain circular references.
+* `value` may contain instances of builtin JS types such as `RegExp`s,
+  `BigInt`s, `Map`s, `Set`s, etc.
+* `value` may contain typed arrays, both using `ArrayBuffer`s
+  and `SharedArrayBuffer`s.
+```
+
+<a id="ref-q1-4"></a>
+### [4] `doc/api/worker_threads.md:1268-1273`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1268-L1273)
+
+```markdown
+`transferList` may be a list of {ArrayBuffer}, [`MessagePort`][], and
+[`FileHandle`][] objects.
+After transferring, they are not usable on the sending side of the channel
+anymore (even if they are not contained in `value`). Unlike with
+[child processes][], transferring handles such as network sockets is currently
+not supported.
+```
+
+<a id="ref-q1-5"></a>
+### [5] `doc/api/worker_threads.md:1278-1280`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1278-L1280)
+
+```markdown
+`value` may still contain `ArrayBuffer` instances that are not in
+`transferList`; in that case, the underlying memory is copied rather than moved.
+```
+
+<a id="ref-q1-6"></a>
+### [6] `doc/api/worker_threads.md:1275-1276`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1275-L1276)
+
+```markdown
+If `value` contains {SharedArrayBuffer} instances, those are accessible
+from either thread. They cannot be listed in `transferList`.
+```
+
+<a id="ref-q1-7"></a>
+### [7] `doc/api/worker_threads.md:1141-1144`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1141-L1144)
+
+```markdown
+* `value` {any} The transmitted value
+
+The `'message'` event is emitted for any incoming message, containing the cloned
+input of [`port.postMessage()`][].
+```
+
+<a id="ref-q1-8"></a>
+### [8] `src/node_messaging.cc:824-829`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/src/node_messaging.cc#L824-L829)
+
+```cpp
+    Mutex::ScopedLock lock(data_->mutex_);
+    processing_limit = std::max(data_->incoming_messages_.size(),
+                                static_cast<size_t>(1000));
+  } else {
+    processing_limit = std::numeric_limits<size_t>::max();
+  }
+```
+
+<a id="ref-q1-9"></a>
+### [9] `doc/api/worker_threads.md:1159-1160`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1159-L1160)
+
+```markdown
+The `'messageerror'` event is emitted when deserializing a message failed.
+```
+
+<a id="ref-q1-10"></a>
+### [10] `doc/api/worker_threads.md:1173-1175`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1173-L1175)
+
+```markdown
+Disables further sending of messages on either side of the connection.
+This method can be called when no further communication will happen over this
+`MessagePort`.
+```
+
+<a id="ref-q1-11"></a>
+### [11] `doc/api/worker_threads.md:1177-1178`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1177-L1178)
+
+```markdown
+The [`'close'` event][] is emitted on both `MessagePort` instances that
+are part of the channel.
+```
+
+<a id="ref-q1-12"></a>
+### [12] `doc/api/worker_threads.md:605-606`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L605-L606)
+
+```markdown
+Receive a single message from a given `MessagePort`. If no message is available,
+`undefined` is returned, otherwise an object with a single `message` property
+```
+
+<a id="ref-q1-13"></a>
+### [13] `doc/api/worker_threads.md:606-607`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L606-L607)
+
+```markdown
+`undefined` is returned, otherwise an object with a single `message` property
+that contains the message payload, corresponding to the oldest message in the
+```
+
+<a id="ref-q1-14"></a>
+### [14] `doc/api/worker_threads.md:634-636`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L634-L636)
+
+```markdown
+When this function is used, no `'message'` event is emitted and the
+`onmessage` listener is not invoked.
+```
+
+<a id="ref-q1-15"></a>
+### [15] `doc/api/worker_threads.md:928-930`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L928-L930)
+
+```markdown
+Instances of `BroadcastChannel` allow asynchronous one-to-many communication
+with all other `BroadcastChannel` instances bound to the same channel name.
+```
+
+<a id="ref-q1-16"></a>
+### [16] `doc/api/worker_threads.md:1015-1020`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1015-L1020)
+
+```markdown
+
+<!-- YAML
+added: v15.4.0
+-->
+
+* `message` {any} Any cloneable JavaScript value.
+```
+
+<a id="ref-q1-17"></a>
+### [17] `doc/api/worker_threads.md:1020`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1020)
+
+```markdown
+* `message` {any} Any cloneable JavaScript value.
+```
+
+<a id="ref-q1-18"></a>
+### [18] `doc/api/worker_threads.md:1002-1004`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1002-L1004)
+
+```markdown
+* Type: {Function} Invoked with a single `MessageEvent` argument
+  when a message is received.
+```
+
+<a id="ref-q1-19"></a>
+### [19] `lib/internal/worker/io.js:348-350`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/lib/internal/worker/io.js#L348-L350)
+
+```javascript
+function onMessageEvent(type, data) {
+  this.dispatchEvent(lazyMessageEvent(type, { data }));
+}
+```
+
+<a id="ref-q1-20"></a>
+### [20] `doc/api/worker_threads.md:1009-1012`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1009-L1012)
+
+```markdown
+-->
+
+* Type: {Function} Invoked with a received message cannot be
+  deserialized.
+```
+
+<a id="ref-q1-21"></a>
+### [21] `doc/api/worker_threads.md:993-994`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L993-L994)
+
+```markdown
+
+Closes the `BroadcastChannel` connection.
+```
+
+<a id="ref-q1-22"></a>
+### [22] `lib/internal/worker/io.js:403-414`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/lib/internal/worker/io.js#L403-L414)
+
+```javascript
+  close() {
+    if (!isBroadcastChannel(this))
+      throw new ERR_INVALID_THIS('BroadcastChannel');
+    if (this[kHandle] === undefined)
+      return;
+    this[kHandle].off('message', this[kOnMessage]);
+    this[kHandle].off('messageerror', this[kOnMessageError]);
+    this[kOnMessage] = undefined;
+    this[kOnMessageError] = undefined;
+    this[kHandle].close();
+    this[kHandle] = undefined;
+  }
+```
+
+<a id="ref-q1-23"></a>
+### [23] `doc/api/worker_threads.md:985-987`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L985-L987)
+
+```markdown
+* `name` {any} The name of the channel to connect to. Any JavaScript value
+  that can be converted to a string using `` `${name}` `` is permitted.
+```
+
+<a id="ref-q1-24"></a>
+### [24] `doc/api/worker_threads.md:597-598`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L597-L598)
+
+```markdown
+    pr-url: https://github.com/nodejs/node/pull/37535
+    description: The port argument can also refer to a `BroadcastChannel` now.
+```

--- a/test-parity/node-suite/worker_threads/message-channel/delivery.ts
+++ b/test-parity/node-suite/worker_threads/message-channel/delivery.ts
@@ -1,0 +1,30 @@
+import * as worker_threads from "node:worker_threads";
+
+const channel = new worker_threads.MessageChannel();
+const port1 = channel.port1;
+const port2 = channel.port2;
+
+port1.on("message", (value: any) => console.log("port on:", value));
+port1.addEventListener("message", (event: any) =>
+  console.log("port event:", event.type, event.data, event.target === port1),
+);
+port1.onmessage = (event: any) =>
+  console.log("port handler:", event.type, event.data);
+port1.on("close", () => console.log("port close"));
+
+port2.postMessage("async-1");
+port2.postMessage("sync-2");
+
+const received = worker_threads.receiveMessageOnPort(port1);
+console.log("receive:", received ? received.message : received);
+
+setTimeout(() => {
+  port1.close();
+  port2.postMessage("after-close");
+
+  setTimeout(() => {
+    const afterClose = worker_threads.receiveMessageOnPort(port1);
+    console.log("after close receive:", afterClose ? afterClose.message : afterClose);
+    port2.close();
+  }, 0);
+}, 20);


### PR DESCRIPTION
Refs #3598

## Summary
- rebase onto current `origin/main`, preserving main's JSON-backed same-process MessageChannel queue from #3157/#3159
- layer the missing local `MessagePort` delivery surface on top: `onmessage`, `addEventListener()` / `removeEventListener()`, EventEmitter-style delivery, event objects, peer `close()` suppression, and close events on both ends
- keep queued MessagePort work alive through the existing stdlib event pump behavior and add a deterministic Node baseline fixture for ordering, event shape, synchronous receive, and close behavior
- preserve the DeepWiki Node `worker_threads` delivery reference under `reference/deepwiki/`

## Verification
- `git fetch origin main --prune && git rebase origin/main` (conflicts resolved)
- `cargo fmt --check`
- `cargo check -p perry-stdlib` (passes; repository has existing warning noise in `perry-runtime`/`perry-stdlib`)
- `node test-parity/node-suite/worker_threads/message-channel/delivery.ts`

Not run: broad release parity; kept verification bounded per coordination.

## Remaining work
- `BroadcastChannel` delivery semantics remain out of this slice.
- Full structured clone and transfer-list semantics beyond the current JSON-backed local queue remain follow-up work.
- Cross-worker/isolate MessagePort transfer remains follow-up territory.
- Global constructor identity/prototype shape remains intentionally left to draft PR #3634.