### PR TITLE
Preserve queueMicrotask FIFO ordering for #3598

### DIFF
--- a/crates/perry-runtime/src/builtins/globals.rs
+++ b/crates/perry-runtime/src/builtins/globals.rs
@@ -402,7 +402,7 @@ pub extern "C" fn js_structured_clone(value: f64) -> f64 {
 /// should print "sync" then "micro", not "micro" then "sync".
 #[no_mangle]
 pub extern "C" fn js_queue_microtask(callback: i64) {
-    queue_microtask_with_type(callback, "Microtask", Vec::new());
+    crate::promise::enqueue_queue_microtask(callback);
 }
 
 #[no_mangle]
@@ -468,13 +468,20 @@ pub fn restore_queued_microtask_contexts() {
     });
 }
 
-/// Drain queued microtasks. Called by `js_promise_run_microtasks`.
+/// Drain queued nextTick jobs. Called by `js_promise_run_microtasks` before
+/// regular Promise/queueMicrotask jobs so Node's nextTick priority is
+/// preserved.
 #[no_mangle]
 pub extern "C" fn js_drain_queued_microtasks() {
+    let _ = drain_queued_microtasks_count();
+}
+
+pub(crate) fn drain_queued_microtasks_count() -> i32 {
     use crate::closure::{
         js_closure_call0, js_closure_call1, js_closure_call2, js_closure_call3, js_closure_call4,
         js_closure_call5, js_closure_call6, js_closure_call7, js_closure_call8, js_closure_call9,
     };
+    let mut ran = 0;
     loop {
         let task = QUEUED_MICROTASKS.with(|q| {
             let mut queue = q.borrow_mut();
@@ -547,10 +554,16 @@ pub extern "C" fn js_drain_queued_microtasks() {
                         crate::async_context::restore_context(previous);
                     }
                 });
+                ran += 1;
             }
             None => break,
         }
     }
+    ran
+}
+
+pub(crate) fn queued_microtasks_pending() -> bool {
+    QUEUED_MICROTASKS.with(|q| !q.borrow().is_empty())
 }
 
 pub fn scan_queued_microtask_roots(mark: &mut dyn FnMut(f64)) {

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -96,6 +96,8 @@ pub use globals::{
     scan_queued_microtask_roots_mut,
 };
 
+pub(crate) use globals::{drain_queued_microtasks_count, queued_microtasks_pending};
+
 pub use numbers::{
     js_is_finite, js_is_nan, js_number_coerce, js_number_is_finite, js_number_is_integer,
     js_number_is_nan, js_number_is_safe_integer, js_parse_float, js_parse_int, js_string_coerce,

--- a/crates/perry-runtime/src/gc/tests/runtime_roots.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots.rs
@@ -1690,7 +1690,7 @@ fn test_timer_tick_roots_callback_args_and_previous_context_across_hooks() {
 }
 
 #[test]
-fn test_queued_microtask_previous_context_survives_hook_gc() {
+fn test_next_tick_previous_context_survives_hook_gc() {
     const ALS_HANDLE: i64 = -8_502;
 
     let _async_hook_guard = AsyncHookRuntimeTestGuard::new();
@@ -1706,9 +1706,9 @@ fn test_queued_microtask_previous_context_survives_hook_gc() {
 
     crate::async_context::clear_store(ALS_HANDLE);
     let callback = crate::closure::js_closure_alloc(test_no_capture_singleton_func as *const u8, 0);
-    crate::builtins::js_queue_microtask(callback as i64);
+    crate::builtins::js_queue_next_tick(callback as i64);
 
-    let previous = test_string_value(b"microtask-previous-context");
+    let previous = test_string_value(b"nexttick-previous-context");
     let previous_original = (previous.to_bits() & POINTER_MASK) as usize;
     crate::async_context::enter_with(ALS_HANDLE, previous);
 
@@ -1716,12 +1716,12 @@ fn test_queued_microtask_previous_context_survives_hook_gc() {
     crate::builtins::js_drain_queued_microtasks();
     drain_scheduled_minor_gc(
         before,
-        "queued microtask before hook should trigger copied-minor GC",
+        "nextTick before hook should trigger copied-minor GC",
     );
 
     let restored = crate::async_context::get_store(ALS_HANDLE)
-        .expect("queued microtask should restore previous AsyncLocalStorage context");
-    assert_moved_string_value(restored, previous_original, b"microtask-previous-context");
+        .expect("nextTick should restore previous AsyncLocalStorage context");
+    assert_moved_string_value(restored, previous_original, b"nexttick-previous-context");
     crate::async_context::clear_store(ALS_HANDLE);
 }
 

--- a/crates/perry-runtime/src/promise/microtasks.rs
+++ b/crates/perry-runtime/src/promise/microtasks.rs
@@ -123,466 +123,511 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
         }
     }
 
-    // Drain queued microtasks (from queueMicrotask() calls) under the same
-    // trap used for Promise callbacks so context is restored if a callback
-    // throws through the runtime.
-    crate::builtins::js_drain_queued_microtasks();
-
     // Cached profile flag — set once by mt_profile_register() above.
     // Reading the env var directly here was ~30 ns per microtask drain;
     // the atomic load is ~1 ns.
     let prof = mt_profile_enabled();
     loop {
-        let t0 = if prof {
-            Some(std::time::Instant::now())
-        } else {
-            None
-        };
-        let task = TASK_QUEUE.with(|q| q.borrow_mut().pop_front());
-        if let Some(t) = t0 {
-            MT_TIME_NS_QUEUE.fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
-        }
+        let ran_before_checkpoint = ran;
 
-        match task {
-            None => break,
-            Some(Task::Promise(promise, value, is_fulfilled, task_context)) => {
-                bump(&MT_RUN_COUNT);
-                enter_microtask_context(&task_context);
-                unsafe {
-                    let callback = if is_fulfilled {
-                        (*promise).on_fulfilled
-                    } else {
-                        (*promise).on_rejected
-                    };
+        // Node runs process.nextTick jobs before regular microtasks, while
+        // queueMicrotask jobs share FIFO order with Promise reactions.
+        ran += crate::builtins::drain_queued_microtasks_count();
 
-                    // No callback registered → propagate the value/reason
-                    // to the next promise without invoking anything.
-                    if callback.is_null() {
+        loop {
+            let t0 = if prof {
+                Some(std::time::Instant::now())
+            } else {
+                None
+            };
+            let task = TASK_QUEUE.with(|q| q.borrow_mut().pop_front());
+            if let Some(t) = t0 {
+                MT_TIME_NS_QUEUE.fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
+            }
+
+            match task {
+                None => break,
+                Some(Task::Promise(promise, value, is_fulfilled, task_context)) => {
+                    bump(&MT_RUN_COUNT);
+                    enter_microtask_context(&task_context);
+                    unsafe {
+                        let callback = if is_fulfilled {
+                            (*promise).on_fulfilled
+                        } else {
+                            (*promise).on_rejected
+                        };
+
+                        // No callback registered → propagate the value/reason
+                        // to the next promise without invoking anything.
+                        if callback.is_null() {
+                            CURRENT_MICROTASK_PROMISE.with(|c| c.set(promise));
+                            CURRENT_MICROTASK_VALUE.with(|c| c.set(value));
+                            CURRENT_MICROTASK_NEXT.with(|c| c.set((*promise).next));
+                            if !(*promise).next.is_null() {
+                                if is_fulfilled {
+                                    js_promise_resolve((*promise).next, value);
+                                } else {
+                                    js_promise_reject((*promise).next, value);
+                                }
+                            }
+                            let promise =
+                                CURRENT_MICROTASK_PROMISE.with(|c| c.replace(std::ptr::null_mut()));
+                            CURRENT_MICROTASK_VALUE.with(|c| c.set(0.0));
+                            CURRENT_MICROTASK_NEXT.with(|c| c.set(std::ptr::null_mut()));
+                            clear_promise_context(promise);
+                            restore_microtask_context();
+                            ran += 1;
+                            continue;
+                        }
+
+                        // Record the running promise so the trap (above)
+                        // can reject its `next` if the callback throws.
+                        //
+                        // #1663: the callback can re-entrantly drain the
+                        // microtask queue — a non-transformed async closure's
+                        // `await` busy-waits on `js_promise_run_microtasks`, and
+                        // each nested `Task::Promise` dispatch overwrites these
+                        // same TLS cells (and clears them on exit). Reloading
+                        // `promise` / `next` from the cells after the callback
+                        // would then observe a stale or NULL pointer; the very
+                        // next line dereferences `(*promise).async_id` (offset
+                        // 0x30) and segfaults. Root our promise + next in a
+                        // handle scope so we reload the GC-updated pointers from
+                        // there, and save/restore the previous cell values so a
+                        // nested drain leaves the enclosing arm — and its
+                        // exception-trap routing — intact. This mirrors the
+                        // INLINE_TRAP save/restore in the Inline/AsyncStep arms.
+                        let scope = crate::gc::RuntimeHandleScope::new();
+                        let promise_handle = scope.root_raw_mut_ptr(promise);
+                        let next_handle = scope.root_raw_mut_ptr((*promise).next);
+                        let prev_promise = CURRENT_MICROTASK_PROMISE.with(|c| c.get());
+                        let prev_callback = CURRENT_MICROTASK_CALLBACK.with(|c| c.get());
+                        let prev_value = CURRENT_MICROTASK_VALUE.with(|c| c.get());
+                        let prev_next = CURRENT_MICROTASK_NEXT.with(|c| c.get());
+                        let prev_promise_handle = scope.root_raw_mut_ptr(prev_promise);
+                        let prev_next_handle = scope.root_raw_mut_ptr(prev_next);
+
                         CURRENT_MICROTASK_PROMISE.with(|c| c.set(promise));
+                        CURRENT_MICROTASK_CALLBACK.with(|c| c.set(callback));
                         CURRENT_MICROTASK_VALUE.with(|c| c.set(value));
                         CURRENT_MICROTASK_NEXT.with(|c| c.set((*promise).next));
-                        if !(*promise).next.is_null() {
+
+                        let t1 = if prof {
+                            Some(std::time::Instant::now())
+                        } else {
+                            None
+                        };
+                        // #1663: capture async_id + trigger as plain values BEFORE
+                        // the callback. They are immutable for the promise's life,
+                        // and the callback can re-entrantly drain microtasks (which
+                        // can move the promise via GC or realloc the GC-root handle
+                        // stack). Reading `(*promise).async_id` AFTER the callback
+                        // to feed `after()` was the exact deref that segfaulted; use
+                        // the captured value so `after()` needs no live promise.
+                        let async_id = (*promise).async_id;
+                        let trigger_async_id = (*promise).trigger_async_id;
+                        crate::async_hooks::before(async_id, trigger_async_id);
+                        let result = crate::closure::js_closure_call1(callback, value);
+                        // Keep the callback result rooted across `after()` (which
+                        // can run JS when async_hooks are active) via the value
+                        // cell, then reload promise/next from our handles — never
+                        // the TLS cells, which a re-entrant drain may have nulled.
+                        // The reload goes through the out-of-line `get_raw_mut_ptr`
+                        // (#1663) so it re-resolves the handle stack after the
+                        // callback instead of reading a stale cached slot address.
+                        CURRENT_MICROTASK_VALUE.with(|c| c.set(result));
+                        let promise = promise_handle.get_raw_mut_ptr::<Promise>();
+                        let next = next_handle.get_raw_mut_ptr::<Promise>();
+                        crate::async_hooks::after(async_id);
+                        if let Some(t) = t1 {
+                            MT_TIME_NS_CALLBACK
+                                .fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
+                        }
+
+                        let t2 = if prof {
+                            Some(std::time::Instant::now())
+                        } else {
+                            None
+                        };
+                        if !next.is_null() {
+                            let result = CURRENT_MICROTASK_VALUE.with(|c| c.get());
+                            propagate_callback_result(result, next);
+                        }
+                        clear_promise_context(promise);
+                        if let Some(t) = t2 {
+                            MT_TIME_NS_RESOLVE
+                                .fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
+                        }
+
+                        // Restore the previous CURRENT_MICROTASK_* cells so an
+                        // enclosing (re-entrant) dispatch resumes with its own
+                        // promise/next/value for settlement and trap routing,
+                        // instead of the NULLs this arm would otherwise leave.
+                        CURRENT_MICROTASK_PROMISE
+                            .with(|c| c.set(prev_promise_handle.get_raw_mut_ptr::<Promise>()));
+                        CURRENT_MICROTASK_CALLBACK.with(|c| c.set(prev_callback));
+                        CURRENT_MICROTASK_VALUE.with(|c| c.set(prev_value));
+                        CURRENT_MICROTASK_NEXT
+                            .with(|c| c.set(prev_next_handle.get_raw_mut_ptr::<Promise>()));
+                    }
+                    restore_microtask_context();
+                    ran += 1;
+                }
+                Some(Task::PromiseAll(state, value, is_fulfilled, task_context)) => {
+                    bump(&MT_RUN_COUNT);
+                    enter_microtask_context(&task_context);
+                    combinators::promise_all_settle(state, value, is_fulfilled);
+                    restore_microtask_context();
+                    ran += 1;
+                }
+                Some(Task::Inline(callback, value, next, is_fulfilled, task_context)) => {
+                    bump(&MT_RUN_COUNT);
+                    enter_microtask_context(&task_context);
+                    // Inline tasks are produced by `js_promise_resolved_then`
+                    // (the `Promise.resolve(<primitive>).then(cb_f, cb_e)`
+                    // fast path). We've already skipped allocating the
+                    // source promise — now dispatch directly: invoke the
+                    // stored callback, propagate the result to `next`.
+                    if callback.is_null() {
+                        if !next.is_null() {
                             if is_fulfilled {
-                                js_promise_resolve((*promise).next, value);
+                                js_promise_resolve(next, value);
                             } else {
-                                js_promise_reject((*promise).next, value);
+                                js_promise_reject(next, value);
                             }
                         }
-                        let promise =
-                            CURRENT_MICROTASK_PROMISE.with(|c| c.replace(std::ptr::null_mut()));
-                        CURRENT_MICROTASK_VALUE.with(|c| c.set(0.0));
-                        CURRENT_MICROTASK_NEXT.with(|c| c.set(std::ptr::null_mut()));
-                        clear_promise_context(promise);
                         restore_microtask_context();
                         ran += 1;
                         continue;
                     }
 
-                    // Record the running promise so the trap (above)
-                    // can reject its `next` if the callback throws.
+                    // For exception unwinding, mirror the Promise variant:
+                    // store a fake `cur` whose `.next` is what we want to
+                    // reject if the callback throws. Allocate a minimal
+                    // stub on the GC heap so the trap path still finds a
+                    // valid `*mut Promise`. This is rarely hit (only on
+                    // user-throw inside the inline callback) and we can
+                    // afford the alloc on the slow path.
                     //
-                    // #1663: the callback can re-entrantly drain the
-                    // microtask queue — a non-transformed async closure's
-                    // `await` busy-waits on `js_promise_run_microtasks`, and
-                    // each nested `Task::Promise` dispatch overwrites these
-                    // same TLS cells (and clears them on exit). Reloading
-                    // `promise` / `next` from the cells after the callback
-                    // would then observe a stale or NULL pointer; the very
-                    // next line dereferences `(*promise).async_id` (offset
-                    // 0x30) and segfaults. Root our promise + next in a
-                    // handle scope so we reload the GC-updated pointers from
-                    // there, and save/restore the previous cell values so a
-                    // nested drain leaves the enclosing arm — and its
-                    // exception-trap routing — intact. This mirrors the
-                    // INLINE_TRAP save/restore in the Inline/AsyncStep arms.
-                    let scope = crate::gc::RuntimeHandleScope::new();
-                    let promise_handle = scope.root_raw_mut_ptr(promise);
-                    let next_handle = scope.root_raw_mut_ptr((*promise).next);
-                    let prev_promise = CURRENT_MICROTASK_PROMISE.with(|c| c.get());
-                    let prev_callback = CURRENT_MICROTASK_CALLBACK.with(|c| c.get());
-                    let prev_value = CURRENT_MICROTASK_VALUE.with(|c| c.get());
-                    let prev_next = CURRENT_MICROTASK_NEXT.with(|c| c.get());
-                    let prev_promise_handle = scope.root_raw_mut_ptr(prev_promise);
-                    let prev_next_handle = scope.root_raw_mut_ptr(prev_next);
-
-                    CURRENT_MICROTASK_PROMISE.with(|c| c.set(promise));
+                    // Issue #748: same save/restore reasoning as the
+                    // Task::AsyncStep arm below — preserve any outer
+                    // INLINE_TRAP (set by an enclosing `js_async_first_call`)
+                    // when the runner is invoked re-entrantly from inside
+                    // a non-transformed async closure's busy-wait.
+                    let prev_trap = INLINE_TRAP.with(|c| c.get());
+                    let trap_scope = crate::gc::RuntimeHandleScope::new();
+                    let prev_trap_next_handle = trap_scope.root_raw_mut_ptr(prev_trap.trap_next);
+                    let prev_trap_step_handle = trap_scope.root_raw_const_ptr(
+                        prev_trap.current_step as *const crate::closure::ClosureHeader,
+                    );
                     CURRENT_MICROTASK_CALLBACK.with(|c| c.set(callback));
                     CURRENT_MICROTASK_VALUE.with(|c| c.set(value));
-                    CURRENT_MICROTASK_NEXT.with(|c| c.set((*promise).next));
+                    CURRENT_MICROTASK_NEXT.with(|c| c.set(next));
+                    INLINE_TRAP.with(|c| {
+                        c.set(InlineTrap {
+                            trap_next: next,
+                            current_step: 0,
+                        })
+                    });
 
                     let t1 = if prof {
                         Some(std::time::Instant::now())
                     } else {
                         None
                     };
-                    // #1663: capture async_id + trigger as plain values BEFORE
-                    // the callback. They are immutable for the promise's life,
-                    // and the callback can re-entrantly drain microtasks (which
-                    // can move the promise via GC or realloc the GC-root handle
-                    // stack). Reading `(*promise).async_id` AFTER the callback
-                    // to feed `after()` was the exact deref that segfaulted; use
-                    // the captured value so `after()` needs no live promise.
-                    let async_id = (*promise).async_id;
-                    let trigger_async_id = (*promise).trigger_async_id;
-                    crate::async_hooks::before(async_id, trigger_async_id);
                     let result = crate::closure::js_closure_call1(callback, value);
-                    // Keep the callback result rooted across `after()` (which
-                    // can run JS when async_hooks are active) via the value
-                    // cell, then reload promise/next from our handles — never
-                    // the TLS cells, which a re-entrant drain may have nulled.
-                    // The reload goes through the out-of-line `get_raw_mut_ptr`
-                    // (#1663) so it re-resolves the handle stack after the
-                    // callback instead of reading a stale cached slot address.
                     CURRENT_MICROTASK_VALUE.with(|c| c.set(result));
-                    let promise = promise_handle.get_raw_mut_ptr::<Promise>();
-                    let next = next_handle.get_raw_mut_ptr::<Promise>();
-                    crate::async_hooks::after(async_id);
                     if let Some(t) = t1 {
                         MT_TIME_NS_CALLBACK
                             .fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
                     }
+
+                    INLINE_TRAP.with(|c| {
+                        c.set(InlineTrap {
+                            trap_next: prev_trap_next_handle.get_raw_mut_ptr::<Promise>(),
+                            current_step: prev_trap_step_handle
+                                .get_raw_const_ptr::<crate::closure::ClosureHeader>()
+                                as usize,
+                        })
+                    });
+                    CURRENT_MICROTASK_CALLBACK.with(|c| c.set(std::ptr::null()));
 
                     let t2 = if prof {
                         Some(std::time::Instant::now())
                     } else {
                         None
                     };
+                    let next = CURRENT_MICROTASK_NEXT.with(|c| c.replace(std::ptr::null_mut()));
                     if !next.is_null() {
-                        let result = CURRENT_MICROTASK_VALUE.with(|c| c.get());
+                        let result = CURRENT_MICROTASK_VALUE.with(|c| c.replace(0.0));
                         propagate_callback_result(result, next);
+                    } else {
+                        CURRENT_MICROTASK_VALUE.with(|c| c.set(0.0));
                     }
-                    clear_promise_context(promise);
                     if let Some(t) = t2 {
                         MT_TIME_NS_RESOLVE
                             .fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
                     }
-
-                    // Restore the previous CURRENT_MICROTASK_* cells so an
-                    // enclosing (re-entrant) dispatch resumes with its own
-                    // promise/next/value for settlement and trap routing,
-                    // instead of the NULLs this arm would otherwise leave.
+                    restore_microtask_context();
+                    ran += 1;
+                }
+                Some(Task::Microtask {
+                    callback,
+                    context,
+                    async_id,
+                    trigger_async_id,
+                }) => {
+                    bump(&MT_RUN_COUNT);
+                    enter_microtask_context(&context);
+                    let scope = crate::gc::RuntimeHandleScope::new();
+                    let prev_promise = CURRENT_MICROTASK_PROMISE.with(|c| c.get());
+                    let prev_callback = CURRENT_MICROTASK_CALLBACK.with(|c| c.get());
+                    let prev_value = CURRENT_MICROTASK_VALUE.with(|c| c.get());
+                    let prev_next = CURRENT_MICROTASK_NEXT.with(|c| c.get());
+                    let prev_promise_handle = scope.root_raw_mut_ptr(prev_promise);
+                    let prev_next_handle = scope.root_raw_mut_ptr(prev_next);
+                    CURRENT_MICROTASK_PROMISE.with(|c| c.set(std::ptr::null_mut()));
+                    CURRENT_MICROTASK_CALLBACK.with(|c| c.set(callback));
+                    CURRENT_MICROTASK_VALUE.with(|c| c.set(0.0));
+                    CURRENT_MICROTASK_NEXT.with(|c| c.set(std::ptr::null_mut()));
+                    crate::async_hooks::before(async_id, trigger_async_id);
+                    crate::closure::js_closure_call0(callback);
+                    crate::async_hooks::after(async_id);
+                    crate::async_hooks::destroy(async_id);
                     CURRENT_MICROTASK_PROMISE
                         .with(|c| c.set(prev_promise_handle.get_raw_mut_ptr::<Promise>()));
                     CURRENT_MICROTASK_CALLBACK.with(|c| c.set(prev_callback));
                     CURRENT_MICROTASK_VALUE.with(|c| c.set(prev_value));
                     CURRENT_MICROTASK_NEXT
                         .with(|c| c.set(prev_next_handle.get_raw_mut_ptr::<Promise>()));
-                }
-                restore_microtask_context();
-                ran += 1;
-            }
-            Some(Task::PromiseAll(state, value, is_fulfilled, task_context)) => {
-                bump(&MT_RUN_COUNT);
-                enter_microtask_context(&task_context);
-                combinators::promise_all_settle(state, value, is_fulfilled);
-                restore_microtask_context();
-                ran += 1;
-            }
-            Some(Task::Inline(callback, value, next, is_fulfilled, task_context)) => {
-                bump(&MT_RUN_COUNT);
-                enter_microtask_context(&task_context);
-                // Inline tasks are produced by `js_promise_resolved_then`
-                // (the `Promise.resolve(<primitive>).then(cb_f, cb_e)`
-                // fast path). We've already skipped allocating the
-                // source promise — now dispatch directly: invoke the
-                // stored callback, propagate the result to `next`.
-                if callback.is_null() {
-                    if !next.is_null() {
-                        if is_fulfilled {
-                            js_promise_resolve(next, value);
-                        } else {
-                            js_promise_reject(next, value);
-                        }
-                    }
                     restore_microtask_context();
                     ran += 1;
-                    continue;
                 }
-
-                // For exception unwinding, mirror the Promise variant:
-                // store a fake `cur` whose `.next` is what we want to
-                // reject if the callback throws. Allocate a minimal
-                // stub on the GC heap so the trap path still finds a
-                // valid `*mut Promise`. This is rarely hit (only on
-                // user-throw inside the inline callback) and we can
-                // afford the alloc on the slow path.
-                //
-                // Issue #748: same save/restore reasoning as the
-                // Task::AsyncStep arm below — preserve any outer
-                // INLINE_TRAP (set by an enclosing `js_async_first_call`)
-                // when the runner is invoked re-entrantly from inside
-                // a non-transformed async closure's busy-wait.
-                let prev_trap = INLINE_TRAP.with(|c| c.get());
-                let trap_scope = crate::gc::RuntimeHandleScope::new();
-                let prev_trap_next_handle = trap_scope.root_raw_mut_ptr(prev_trap.trap_next);
-                let prev_trap_step_handle = trap_scope.root_raw_const_ptr(
-                    prev_trap.current_step as *const crate::closure::ClosureHeader,
-                );
-                CURRENT_MICROTASK_CALLBACK.with(|c| c.set(callback));
-                CURRENT_MICROTASK_VALUE.with(|c| c.set(value));
-                CURRENT_MICROTASK_NEXT.with(|c| c.set(next));
-                INLINE_TRAP.with(|c| {
-                    c.set(InlineTrap {
-                        trap_next: next,
-                        current_step: 0,
-                    })
-                });
-
-                let t1 = if prof {
-                    Some(std::time::Instant::now())
-                } else {
-                    None
-                };
-                let result = crate::closure::js_closure_call1(callback, value);
-                CURRENT_MICROTASK_VALUE.with(|c| c.set(result));
-                if let Some(t) = t1 {
-                    MT_TIME_NS_CALLBACK.fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
-                }
-
-                INLINE_TRAP.with(|c| {
-                    c.set(InlineTrap {
-                        trap_next: prev_trap_next_handle.get_raw_mut_ptr::<Promise>(),
-                        current_step: prev_trap_step_handle
-                            .get_raw_const_ptr::<crate::closure::ClosureHeader>()
-                            as usize,
-                    })
-                });
-                CURRENT_MICROTASK_CALLBACK.with(|c| c.set(std::ptr::null()));
-
-                let t2 = if prof {
-                    Some(std::time::Instant::now())
-                } else {
-                    None
-                };
-                let next = CURRENT_MICROTASK_NEXT.with(|c| c.replace(std::ptr::null_mut()));
-                if !next.is_null() {
-                    let result = CURRENT_MICROTASK_VALUE.with(|c| c.replace(0.0));
-                    propagate_callback_result(result, next);
-                } else {
-                    CURRENT_MICROTASK_VALUE.with(|c| c.set(0.0));
-                }
-                if let Some(t) = t2 {
-                    MT_TIME_NS_RESOLVE.fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
-                }
-                restore_microtask_context();
-                ran += 1;
-            }
-            Some(Task::AsyncStep(step_closure, value, next, is_error, task_context)) => {
-                bump(&MT_RUN_COUNT);
-                enter_microtask_context(&task_context);
-                // Direct dispatch of the async-step closure. Skips the
-                // then_v_arrow / then_e_arrow wrapper that would
-                // otherwise be invoked as the on_fulfilled / on_rejected
-                // callback — the wrapper just calls
-                // `__step(value, is_error)` which is exactly what we do
-                // here with two fewer indirections (closure alloc +
-                // closure call).
-                if step_closure.is_null() {
-                    if !next.is_null() {
-                        if is_error {
-                            js_promise_reject(next, value);
-                        } else {
-                            js_promise_resolve(next, value);
+                Some(Task::AsyncStep(step_closure, value, next, is_error, task_context)) => {
+                    bump(&MT_RUN_COUNT);
+                    enter_microtask_context(&task_context);
+                    // Direct dispatch of the async-step closure. Skips the
+                    // then_v_arrow / then_e_arrow wrapper that would
+                    // otherwise be invoked as the on_fulfilled / on_rejected
+                    // callback — the wrapper just calls
+                    // `__step(value, is_error)` which is exactly what we do
+                    // here with two fewer indirections (closure alloc +
+                    // closure call).
+                    if step_closure.is_null() {
+                        if !next.is_null() {
+                            if is_error {
+                                js_promise_reject(next, value);
+                            } else {
+                                js_promise_resolve(next, value);
+                            }
                         }
+                        restore_microtask_context();
+                        ran += 1;
+                        continue;
                     }
-                    restore_microtask_context();
-                    ran += 1;
-                    continue;
-                }
-                CURRENT_MICROTASK_CALLBACK.with(|c| c.set(step_closure));
-                CURRENT_MICROTASK_VALUE.with(|c| c.set(value));
-                CURRENT_MICROTASK_NEXT.with(|c| c.set(next));
-                // Issue #712 + #921 + #922 defensive guard. Track
-                // consecutive is_error=true dispatches; reject the
-                // chain if it crosses ASYNC_STEP_REENTRY_BOUND.
-                //
-                // Originally (#712) the guard required SAME `step_closure`
-                // to count up — but the #921/#922 production loops
-                // (gscmaster-api Fastify route handlers) alternate
-                // between two async-step closures (route handler ↔
-                // middleware ↔ inner await), each one rethrowing the
-                // same TypeError. With the same-closure check, the
-                // counter resets every other dispatch and the loop
-                // never trips the guard — the user observed 5.7M
-                // identical `value is not a function` lines before PM2
-                // restarted the process.
-                //
-                // Drop the same-closure check: count ANY consecutive
-                // run of `is_error=true` dispatches. A legitimate
-                // throw-in-a-loop pattern interleaves `is_error=false`
-                // steps (the loop's post-catch state) between throws,
-                // so its consecutive count never grows beyond 1.
-                if is_error {
-                    let prev = ASYNC_STEP_GUARD.with(|c| c.get());
-                    let new_count = prev.consecutive_error_count.saturating_add(1);
-                    if new_count > ASYNC_STEP_REENTRY_BOUND {
+                    CURRENT_MICROTASK_CALLBACK.with(|c| c.set(step_closure));
+                    CURRENT_MICROTASK_VALUE.with(|c| c.set(value));
+                    CURRENT_MICROTASK_NEXT.with(|c| c.set(next));
+                    // Issue #712 + #921 + #922 defensive guard. Track
+                    // consecutive is_error=true dispatches; reject the
+                    // chain if it crosses ASYNC_STEP_REENTRY_BOUND.
+                    //
+                    // Originally (#712) the guard required SAME `step_closure`
+                    // to count up — but the #921/#922 production loops
+                    // (gscmaster-api Fastify route handlers) alternate
+                    // between two async-step closures (route handler ↔
+                    // middleware ↔ inner await), each one rethrowing the
+                    // same TypeError. With the same-closure check, the
+                    // counter resets every other dispatch and the loop
+                    // never trips the guard — the user observed 5.7M
+                    // identical `value is not a function` lines before PM2
+                    // restarted the process.
+                    //
+                    // Drop the same-closure check: count ANY consecutive
+                    // run of `is_error=true` dispatches. A legitimate
+                    // throw-in-a-loop pattern interleaves `is_error=false`
+                    // steps (the loop's post-catch state) between throws,
+                    // so its consecutive count never grows beyond 1.
+                    if is_error {
+                        let prev = ASYNC_STEP_GUARD.with(|c| c.get());
+                        let new_count = prev.consecutive_error_count.saturating_add(1);
+                        if new_count > ASYNC_STEP_REENTRY_BOUND {
+                            ASYNC_STEP_GUARD.with(|c| {
+                                c.set(AsyncStepGuard {
+                                    last_closure: 0,
+                                    consecutive_error_count: 0,
+                                })
+                            });
+                            if !next.is_null() {
+                                let msg = b"async step driver detected runaway re-entry (issue #712/#921/#922 guard); rejecting Promise to prevent unbounded loop. Common cause: throw across an await boundary inside try/catch; convert to a result-tag pattern.";
+                                let msg_str = crate::string::js_string_from_bytes(
+                                    msg.as_ptr(),
+                                    msg.len() as u32,
+                                );
+                                let err = crate::error::js_typeerror_new(msg_str);
+                                let err_val = crate::value::js_nanbox_pointer(err as i64);
+                                let next = CURRENT_MICROTASK_NEXT
+                                    .with(|c| c.replace(std::ptr::null_mut()));
+                                js_promise_reject(next, err_val);
+                            }
+                            CURRENT_MICROTASK_CALLBACK.with(|c| c.set(std::ptr::null()));
+                            CURRENT_MICROTASK_VALUE.with(|c| c.set(0.0));
+                            CURRENT_MICROTASK_NEXT.with(|c| c.set(std::ptr::null_mut()));
+                            restore_microtask_context();
+                            ran += 1;
+                            continue;
+                        }
+                        ASYNC_STEP_GUARD.with(|c| {
+                            c.set(AsyncStepGuard {
+                                last_closure: step_closure as usize,
+                                consecutive_error_count: new_count,
+                            })
+                        });
+                    } else {
                         ASYNC_STEP_GUARD.with(|c| {
                             c.set(AsyncStepGuard {
                                 last_closure: 0,
                                 consecutive_error_count: 0,
                             })
                         });
-                        if !next.is_null() {
-                            let msg = b"async step driver detected runaway re-entry (issue #712/#921/#922 guard); rejecting Promise to prevent unbounded loop. Common cause: throw across an await boundary inside try/catch; convert to a result-tag pattern.";
-                            let msg_str =
-                                crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-                            let err = crate::error::js_typeerror_new(msg_str);
-                            let err_val = crate::value::js_nanbox_pointer(err as i64);
-                            let next =
-                                CURRENT_MICROTASK_NEXT.with(|c| c.replace(std::ptr::null_mut()));
-                            js_promise_reject(next, err_val);
-                        }
-                        CURRENT_MICROTASK_CALLBACK.with(|c| c.set(std::ptr::null()));
-                        CURRENT_MICROTASK_VALUE.with(|c| c.set(0.0));
-                        CURRENT_MICROTASK_NEXT.with(|c| c.set(std::ptr::null_mut()));
-                        restore_microtask_context();
-                        ran += 1;
-                        continue;
+                        // Issue #922: a non-error step dispatched, signalling
+                        // forward progress through the user's async state
+                        // machine. Reset the throw_not_callable counter so a
+                        // legitimate later throw-in-a-loop doesn't trip the
+                        // circuit breaker just because the program threw
+                        // 100_000 cumulative times across the whole run.
+                        crate::closure::reset_throw_not_callable_counter();
                     }
-                    ASYNC_STEP_GUARD.with(|c| {
-                        c.set(AsyncStepGuard {
-                            last_closure: step_closure as usize,
-                            consecutive_error_count: new_count,
+                    // Stash both trap_next + current_step in a single TLS
+                    // write so the hot path doesn't pay two `.with()` calls
+                    // per microtask. `current_step` gates the
+                    // `js_async_step_chain` / `js_async_step_done` reuse
+                    // path: nested async-fn calls pass a DIFFERENT step
+                    // closure → fail the gate → alloc their own next, so
+                    // their settlement can't collapse onto the parent's.
+                    //
+                    // Issue #748: save the previous INLINE_TRAP value and
+                    // restore it after step dispatch. The microtask runner
+                    // can be called RE-ENTRANTLY from inside an outer
+                    // async-step body — specifically when a non-transformed
+                    // async closure's `await` busy-waits on
+                    // `js_promise_run_microtasks()`. The outer body
+                    // (e.g. a top-level async function's state machine
+                    // closure) was entered via `js_async_first_call` which
+                    // set INLINE_TRAP to `{trap_next: null, current_step:
+                    // outer_step}`. Without save/restore, clearing to empty
+                    // after the inner Task::AsyncStep dispatch would leak
+                    // back to the outer body — `Expr::CurrentStepClosure`
+                    // (lowered to `js_get_current_step_closure`) returns
+                    // NULL after control returns from the busy-wait, and
+                    // the outer's `AsyncStepChain` queues a Task::AsyncStep
+                    // with step=NULL. That task hits the null-step short
+                    // circuit (line 1316) which only propagates the value
+                    // to `next` without ever calling the outer step body's
+                    // state-1 code — symptom: the outer body's post-await
+                    // statements never execute and the returned Promise
+                    // settles with the awaited value rather than the
+                    // explicit return expression.
+                    let prev_trap = INLINE_TRAP.with(|c| c.get());
+                    let trap_scope = crate::gc::RuntimeHandleScope::new();
+                    let prev_trap_next_handle = trap_scope.root_raw_mut_ptr(prev_trap.trap_next);
+                    let prev_trap_step_handle = trap_scope.root_raw_const_ptr(
+                        prev_trap.current_step as *const crate::closure::ClosureHeader,
+                    );
+                    INLINE_TRAP.with(|c| {
+                        c.set(InlineTrap {
+                            trap_next: next,
+                            current_step: step_closure as usize,
                         })
                     });
-                } else {
-                    ASYNC_STEP_GUARD.with(|c| {
-                        c.set(AsyncStepGuard {
-                            last_closure: 0,
-                            consecutive_error_count: 0,
-                        })
-                    });
-                    // Issue #922: a non-error step dispatched, signalling
-                    // forward progress through the user's async state
-                    // machine. Reset the throw_not_callable counter so a
-                    // legitimate later throw-in-a-loop doesn't trip the
-                    // circuit breaker just because the program threw
-                    // 100_000 cumulative times across the whole run.
-                    crate::closure::reset_throw_not_callable_counter();
-                }
-                // Stash both trap_next + current_step in a single TLS
-                // write so the hot path doesn't pay two `.with()` calls
-                // per microtask. `current_step` gates the
-                // `js_async_step_chain` / `js_async_step_done` reuse
-                // path: nested async-fn calls pass a DIFFERENT step
-                // closure → fail the gate → alloc their own next, so
-                // their settlement can't collapse onto the parent's.
-                //
-                // Issue #748: save the previous INLINE_TRAP value and
-                // restore it after step dispatch. The microtask runner
-                // can be called RE-ENTRANTLY from inside an outer
-                // async-step body — specifically when a non-transformed
-                // async closure's `await` busy-waits on
-                // `js_promise_run_microtasks()`. The outer body
-                // (e.g. a top-level async function's state machine
-                // closure) was entered via `js_async_first_call` which
-                // set INLINE_TRAP to `{trap_next: null, current_step:
-                // outer_step}`. Without save/restore, clearing to empty
-                // after the inner Task::AsyncStep dispatch would leak
-                // back to the outer body — `Expr::CurrentStepClosure`
-                // (lowered to `js_get_current_step_closure`) returns
-                // NULL after control returns from the busy-wait, and
-                // the outer's `AsyncStepChain` queues a Task::AsyncStep
-                // with step=NULL. That task hits the null-step short
-                // circuit (line 1316) which only propagates the value
-                // to `next` without ever calling the outer step body's
-                // state-1 code — symptom: the outer body's post-await
-                // statements never execute and the returned Promise
-                // settles with the awaited value rather than the
-                // explicit return expression.
-                let prev_trap = INLINE_TRAP.with(|c| c.get());
-                let trap_scope = crate::gc::RuntimeHandleScope::new();
-                let prev_trap_next_handle = trap_scope.root_raw_mut_ptr(prev_trap.trap_next);
-                let prev_trap_step_handle = trap_scope.root_raw_const_ptr(
-                    prev_trap.current_step as *const crate::closure::ClosureHeader,
-                );
-                INLINE_TRAP.with(|c| {
-                    c.set(InlineTrap {
-                        trap_next: next,
-                        current_step: step_closure as usize,
-                    })
-                });
 
-                let t1 = if prof {
-                    Some(std::time::Instant::now())
-                } else {
-                    None
-                };
-                let is_error_bits = if is_error {
-                    f64::from_bits(0x7FFC_0000_0000_0004) // TAG_TRUE
-                } else {
-                    f64::from_bits(0x7FFC_0000_0000_0003) // TAG_FALSE
-                };
-                // #789: bracket the await continuation with async_hooks
-                // before/after so `executionAsyncId()` reflects the async
-                // function's resource id during its resumed body and the
-                // before/after hooks fire — mirroring the `Task::Promise`
-                // arm above. Capture the result promise's ids as plain
-                // values BEFORE the callback (a re-entrant drain can move
-                // `next` via GC, #1663) and feed the same id to `after()`.
-                // `before`/`after` early-return on id 0, so this is a no-op
-                // when async_hooks are inactive.
-                let step_async_id = if next.is_null() {
-                    0
-                } else {
-                    unsafe { (*next).async_id }
-                };
-                let step_trigger_id = if next.is_null() {
-                    0
-                } else {
-                    unsafe { (*next).trigger_async_id }
-                };
-                crate::async_hooks::before(step_async_id, step_trigger_id);
-                let result = call_async_step_direct(step_closure, value, is_error_bits);
-                CURRENT_MICROTASK_VALUE.with(|c| c.set(result));
-                if let Some(t) = t1 {
-                    MT_TIME_NS_CALLBACK.fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
-                }
-
-                INLINE_TRAP.with(|c| {
-                    c.set(InlineTrap {
-                        trap_next: prev_trap_next_handle.get_raw_mut_ptr::<Promise>(),
-                        current_step: prev_trap_step_handle
-                            .get_raw_const_ptr::<crate::closure::ClosureHeader>()
-                            as usize,
-                    })
-                });
-                // #789: pair the `before()` above — fires the after hook and
-                // pops the execution-id stack using the captured id.
-                crate::async_hooks::after(step_async_id);
-                CURRENT_MICROTASK_CALLBACK.with(|c| c.set(std::ptr::null()));
-
-                let t2 = if prof {
-                    Some(std::time::Instant::now())
-                } else {
-                    None
-                };
-                // Self-chain marker: when `js_async_step_chain` reused
-                // our `next` Promise (the steady-state primitive-await
-                // path), the result is the same Promise pointer. The
-                // next iteration's `Task::AsyncStep` is already on the
-                // queue carrying the same `next`; nothing to propagate
-                // here.
-                let next = CURRENT_MICROTASK_NEXT.with(|c| c.replace(std::ptr::null_mut()));
-                if !next.is_null() {
-                    let result = CURRENT_MICROTASK_VALUE.with(|c| c.replace(0.0));
-                    let result_is_self_chain = if js_value_is_promise(result) != 0 {
-                        crate::value::js_nanbox_get_pointer(result) as *mut Promise == next
+                    let t1 = if prof {
+                        Some(std::time::Instant::now())
                     } else {
-                        false
+                        None
                     };
-                    if !result_is_self_chain {
-                        propagate_callback_result(result, next);
+                    let is_error_bits = if is_error {
+                        f64::from_bits(0x7FFC_0000_0000_0004) // TAG_TRUE
+                    } else {
+                        f64::from_bits(0x7FFC_0000_0000_0003) // TAG_FALSE
+                    };
+                    // #789: bracket the await continuation with async_hooks
+                    // before/after so `executionAsyncId()` reflects the async
+                    // function's resource id during its resumed body and the
+                    // before/after hooks fire — mirroring the `Task::Promise`
+                    // arm above. Capture the result promise's ids as plain
+                    // values BEFORE the callback (a re-entrant drain can move
+                    // `next` via GC, #1663) and feed the same id to `after()`.
+                    // `before`/`after` early-return on id 0, so this is a no-op
+                    // when async_hooks are inactive.
+                    let step_async_id = if next.is_null() {
+                        0
+                    } else {
+                        unsafe { (*next).async_id }
+                    };
+                    let step_trigger_id = if next.is_null() {
+                        0
+                    } else {
+                        unsafe { (*next).trigger_async_id }
+                    };
+                    crate::async_hooks::before(step_async_id, step_trigger_id);
+                    let result = call_async_step_direct(step_closure, value, is_error_bits);
+                    CURRENT_MICROTASK_VALUE.with(|c| c.set(result));
+                    if let Some(t) = t1 {
+                        MT_TIME_NS_CALLBACK
+                            .fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
                     }
-                } else {
-                    CURRENT_MICROTASK_VALUE.with(|c| c.set(0.0));
+
+                    INLINE_TRAP.with(|c| {
+                        c.set(InlineTrap {
+                            trap_next: prev_trap_next_handle.get_raw_mut_ptr::<Promise>(),
+                            current_step: prev_trap_step_handle
+                                .get_raw_const_ptr::<crate::closure::ClosureHeader>()
+                                as usize,
+                        })
+                    });
+                    // #789: pair the `before()` above — fires the after hook and
+                    // pops the execution-id stack using the captured id.
+                    crate::async_hooks::after(step_async_id);
+                    CURRENT_MICROTASK_CALLBACK.with(|c| c.set(std::ptr::null()));
+
+                    let t2 = if prof {
+                        Some(std::time::Instant::now())
+                    } else {
+                        None
+                    };
+                    // Self-chain marker: when `js_async_step_chain` reused
+                    // our `next` Promise (the steady-state primitive-await
+                    // path), the result is the same Promise pointer. The
+                    // next iteration's `Task::AsyncStep` is already on the
+                    // queue carrying the same `next`; nothing to propagate
+                    // here.
+                    let next = CURRENT_MICROTASK_NEXT.with(|c| c.replace(std::ptr::null_mut()));
+                    if !next.is_null() {
+                        let result = CURRENT_MICROTASK_VALUE.with(|c| c.replace(0.0));
+                        let result_is_self_chain = if js_value_is_promise(result) != 0 {
+                            crate::value::js_nanbox_get_pointer(result) as *mut Promise == next
+                        } else {
+                            false
+                        };
+                        if !result_is_self_chain {
+                            propagate_callback_result(result, next);
+                        }
+                    } else {
+                        CURRENT_MICROTASK_VALUE.with(|c| c.set(0.0));
+                    }
+                    if let Some(t) = t2 {
+                        MT_TIME_NS_RESOLVE
+                            .fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
+                    }
+                    restore_microtask_context();
+                    ran += 1;
                 }
-                if let Some(t) = t2 {
-                    MT_TIME_NS_RESOLVE.fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
-                }
-                restore_microtask_context();
-                ran += 1;
             }
+        }
+
+        if ran == ran_before_checkpoint {
+            break;
         }
     }
 
@@ -592,7 +637,7 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
     // those drain on the next pump iteration before newly due timers.
     ran += crate::timer::js_timer_tick();
     ran += crate::timer::js_callback_timer_tick();
-    crate::builtins::js_drain_queued_microtasks();
+    ran += crate::builtins::drain_queued_microtasks_count();
     ran += crate::timer::js_interval_timer_tick();
 
     crate::exception::js_try_end();

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -379,6 +379,15 @@ pub(crate) enum Task {
         AsyncContextSnapshot,
     ),
     Inline(ClosurePtr, f64, *mut Promise, bool, AsyncContextSnapshot),
+    /// `queueMicrotask(callback)` jobs share the same FIFO queue as Promise
+    /// reactions. `process.nextTick` stays in the separate higher-priority
+    /// queue owned by `builtins::globals`.
+    Microtask {
+        callback: ClosurePtr,
+        context: AsyncContextSnapshot,
+        async_id: u64,
+        trigger_async_id: u64,
+    },
     /// Direct dispatch to a 2-arg async-step closure. Equivalent to
     /// `Inline(then_v_arrow, value, next, true)` where `then_v_arrow`
     /// is a wrapper that calls `step(value, is_error)` — but skips the
@@ -471,6 +480,24 @@ pub(crate) struct AsyncStepGuard {
 /// and well below the 5.7M observed in #712 — high enough to avoid
 /// false positives, low enough to terminate quickly when the bug fires.
 pub(crate) const ASYNC_STEP_REENTRY_BOUND: u32 = 10_000;
+
+pub(crate) fn enqueue_queue_microtask(callback: i64) {
+    let context = capture_context();
+    let ids = crate::async_hooks::init_resource(
+        "Microtask",
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+        false,
+    );
+    TASK_QUEUE.with(|q| {
+        q.borrow_mut().push_back(Task::Microtask {
+            callback: callback as ClosurePtr,
+            context,
+            async_id: ids.async_id,
+            trigger_async_id: ids.trigger_async_id,
+        });
+    });
+    crate::event_pump::js_notify_main_thread();
+}
 
 #[derive(Default)]
 pub(crate) struct PromiseContextStore {
@@ -694,6 +721,9 @@ pub extern "C" fn js_microtasks_pending() -> i32 {
         return 1;
     }
     if crate::thread::js_thread_has_pending() != 0 {
+        return 1;
+    }
+    if crate::builtins::queued_microtasks_pending() {
         return 1;
     }
     TASK_QUEUE.with(|q| if q.borrow().is_empty() { 0 } else { 1 })

--- a/crates/perry-runtime/src/promise/scanners.rs
+++ b/crates/perry-runtime/src/promise/scanners.rs
@@ -35,6 +35,12 @@ pub fn scan_promise_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
                     visitor.visit_nanbox_f64_slot(value);
                     scan_snapshot_roots_mut(context, visitor);
                 }
+                Task::Microtask {
+                    callback, context, ..
+                } => {
+                    visitor.visit_raw_const_ptr_slot(callback);
+                    scan_snapshot_roots_mut(context, visitor);
+                }
                 Task::AsyncStep(cb, value, next, _, context) => {
                     visitor.visit_raw_const_ptr_slot(cb);
                     visitor.visit_raw_mut_ptr_slot(next);
@@ -256,6 +262,9 @@ fn scan_task_step(
         | Task::AsyncStep(cb, value, next, _, context) => {
             scan_task_slot_inline(cb, value, next, context, visitor, state, remaining)
         }
+        Task::Microtask {
+            callback, context, ..
+        } => scan_task_slot_microtask(callback, context, visitor, state, remaining),
     }
 }
 
@@ -340,6 +349,29 @@ fn scan_task_slot_inline(
             _ => false,
         };
         state.slot += 1;
+    }
+    crate::async_context::scan_snapshot_roots_mut_step(
+        context,
+        visitor,
+        &mut state.context_entry,
+        &mut state.context_store,
+        remaining,
+    )
+}
+
+fn scan_task_slot_microtask(
+    callback: &mut *const crate::closure::ClosureHeader,
+    context: &mut AsyncContextSnapshot,
+    visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
+    state: &mut PromiseRootScanState,
+    remaining: &mut usize,
+) -> bool {
+    if state.slot == 0 {
+        if !consume_root_work(remaining) {
+            return false;
+        }
+        visitor.visit_raw_const_ptr_slot(callback);
+        state.slot = 1;
     }
     crate::async_context::scan_snapshot_roots_mut_step(
         context,

--- a/reference/deepwiki/perry-queue-microtask-navigator-3598.md
+++ b/reference/deepwiki/perry-queue-microtask-navigator-3598.md
@@ -1,0 +1,496 @@
+# DeepWiki Response
+
+Repository: `PerryTS/perry`
+Question: For PerryTS/perry, identify the current source files and test locations relevant to queueMicrotask, Promise microtask FIFO ordering, process.nextTick priority, and navigator/Navigator global shape for issue 3598. Focus on implementation hooks and deterministic parity fixtures.
+Search: https://deepwiki.com/search/for-perrytsperry-identify-the_47f157a9-87c8-494c-ab32-6a63d9219f5f
+
+**Question**: For PerryTS/perry, identify the current source files and test locations relevant to queueMicrotask, Promise microtask FIFO ordering, process.nextTick priority, and navigator/Navigator global shape for issue 3598. Focus on implementation hooks and deterministic parity fixtures.
+
+The user is asking to identify source files and test locations related to `queueMicrotask`, Promise microtask FIFO ordering, `process.nextTick` priority, and `navigator/Navigator` global shape within the `PerryTS/perry` repository, specifically for issue 3598, focusing on implementation hooks and deterministic parity fixtures.
+
+## `queueMicrotask` and `process.nextTick` Implementation and FIFO Ordering [1](#ref-q1-1)
+The core implementation for `queueMicrotask` and `process.nextTick` is found in `crates/perry-runtime/src/builtins/globals.rs` [1](#ref-q1-1) . The `js_queue_microtask` function schedules a closure on the microtask queue [2](#ref-q1-2) . Similarly, `js_queue_next_tick` and `js_queue_next_tick_args` handle `process.nextTick` calls, with `js_queue_next_tick_args` supporting trailing arguments [3](#ref-q1-3) . Both ultimately call `queue_microtask_with_type` to add the task to the `QUEUED_MICROTASKS` thread-local queue [4](#ref-q1-4) .
+
+The `js_drain_queued_microtasks` function, called by `js_promise_run_microtasks`, processes these queued microtasks [5](#ref-q1-5) . It iterates through the `QUEUED_MICROTASKS` queue, removing tasks from the front (`queue.remove(0)`) to ensure FIFO ordering [6](#ref-q1-6) . This function also handles `AsyncContextSnapshot` for context preservation and `async_hooks` for instrumentation [7](#ref-q1-7) .
+
+The `js_promise_run_microtasks` function in `crates/perry-runtime/src/promise/microtasks.rs` is responsible for draining the microtask queue [8](#ref-q1-8) . It first drains other queues like `gc_destroy_queue`, `scheduled_resolves`, `diagnostics_channel_process_pending`, and `js_thread_process_pending`, and then calls `js_drain_queued_microtasks` to process `queueMicrotask` and `process.nextTick` tasks [9](#ref-q1-9)  [10](#ref-q1-10) . This establishes the priority of `process.nextTick` and `queueMicrotask` tasks over timers, matching Node's turn ordering [11](#ref-q1-11) .
+
+The lowering of `queueMicrotask` and `process.nextTick` calls in the compiler is handled in `crates/perry-codegen/src/expr/instance_misc1.rs` [12](#ref-q1-12) . `Expr::QueueMicrotask` lowers to a call to `js_queue_microtask` [13](#ref-q1-13) , and `Expr::ProcessNextTick` lowers to either `js_queue_next_tick` or `js_queue_next_tick_args` depending on the presence of additional arguments [14](#ref-q1-14) . These runtime functions are declared in `crates/perry-codegen/src/runtime_decls/strings.rs` [15](#ref-q1-15) .
+
+## Promise Microtask FIFO Ordering [16](#ref-q1-16)
+The `TASK_QUEUE` in `crates/perry-runtime/src/promise/mod.rs` is a `VecDeque`, which ensures FIFO ordering for Promise microtasks [17](#ref-q1-17) . This queue is drained by `js_promise_run_microtasks` [18](#ref-q1-18) . The `Task` enum defines different types of microtasks, including `Promise`, `PromiseAll`, `Inline`, and `AsyncStep` [19](#ref-q1-19) .
+
+## `navigator/Navigator` Global Shape for Issue 3598
+The provided context does not contain specific information regarding the `navigator/Navigator` global shape or issue 3598.
+
+## Implementation Hooks and Deterministic Parity Fixtures
+The microtask draining process includes several hooks:
+*   `drain_gc_destroy_queue()` [20](#ref-q1-20)
+*   `process_scheduled_resolves()` [21](#ref-q1-21)
+*   `diagnostics_channel_process_pending()` [22](#ref-q1-22)
+*   `js_thread_process_pending()` [23](#ref-q1-23)
+These are called before processing the main `TASK_QUEUE` [24](#ref-q1-24) .
+
+The `js_promise_run_microtasks` function also incorporates an exception trap using `setjmp` to handle errors within microtask callbacks, ensuring that a `throw` from a callback rejects the chained `next` promise without exiting the microtask loop [25](#ref-q1-25) .
+
+For `queueMicrotask` and `process.nextTick` callbacks, `async_hooks::init_resource`, `async_hooks::before`, and `async_hooks::after` are used to manage asynchronous context and provide instrumentation [26](#ref-q1-26)  [27](#ref-q1-27)  [28](#ref-q1-28) .
+
+The event loop in `crates/perry-codegen/src/codegen/entry.rs` demonstrates the overall orchestration, where `js_promise_run_microtasks` and timer ticks are repeatedly called to process events [29](#ref-q1-29) . This ensures deterministic execution order.
+
+## Notes
+The prompt mentions "issue 3598" and "navigator/Navigator global shape". While the provided context extensively covers microtask handling, `queueMicrotask`, `process.nextTick`, and Promise ordering, there is no direct mention of "issue 3598" or the "navigator/Navigator" global object. It's possible that these aspects are handled in other parts of the codebase not included in the provided snippets, or that "issue 3598" refers to a specific bug related to the microtask queue behavior that is implicitly addressed by the described implementation.
+
+Wiki pages you might want to explore:
+- [Parsing & HIR Lowering (PerryTS/perry)](/wiki/PerryTS/perry#2.1)
+- [Closures, Promises & Async Runtime (PerryTS/perry)](/wiki/PerryTS/perry#3.4)
+
+View this search on DeepWiki: https://deepwiki.com/search/for-perrytsperry-identify-the_47f157a9-87c8-494c-ab32-6a63d9219f5f
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `crates/perry-runtime/src/builtins/globals.rs:376-395`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/builtins/globals.rs#L376-L395)
+
+```rust
+// ============================================================
+// queueMicrotask
+// ============================================================
+
+/// queueMicrotask(callback) — schedule a closure on the microtask queue.
+/// The closure runs during the next `js_promise_run_microtasks()` drain,
+/// AFTER the current synchronous code completes. Previously this called
+/// the closure immediately, which broke the JS spec ordering:
+///   queueMicrotask(() => log("micro"));
+///   log("sync");
+/// should print "sync" then "micro", not "micro" then "sync".
+#[no_mangle]
+pub extern "C" fn js_queue_microtask(callback: i64) {
+    queue_microtask_with_type(callback, "Microtask", Vec::new());
+}
+
+#[no_mangle]
+pub extern "C" fn js_queue_next_tick(callback: i64) {
+    queue_microtask_with_type(callback, "TickObject", Vec::new());
+}
+```
+
+<a id="ref-q1-2"></a>
+### [2] `crates/perry-runtime/src/builtins/globals.rs:387-389`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/builtins/globals.rs#L387-L389)
+
+```rust
+#[no_mangle]
+pub extern "C" fn js_queue_microtask(callback: i64) {
+    queue_microtask_with_type(callback, "Microtask", Vec::new());
+```
+
+<a id="ref-q1-3"></a>
+### [3] `crates/perry-runtime/src/builtins/globals.rs:393-413`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/builtins/globals.rs#L393-L413)
+
+```rust
+pub extern "C" fn js_queue_next_tick(callback: i64) {
+    queue_microtask_with_type(callback, "TickObject", Vec::new());
+}
+
+/// process.nextTick(cb, ...args) — forwards trailing args to `cb` when the
+/// tick fires (#1351). `args_ptr`/`n_args` describe a NaN-boxed-f64 buffer
+/// allocated on the caller's stack; we copy the slice eagerly because the
+/// drain runs after the caller returns.
+///
+/// # Safety
+/// `args_ptr` must point to `n_args` valid `f64` values, or be null if
+/// `n_args == 0`.
+#[no_mangle]
+pub unsafe extern "C" fn js_queue_next_tick_args(callback: i64, args_ptr: *const f64, n_args: i32) {
+    let args: Vec<f64> = if args_ptr.is_null() || n_args <= 0 {
+        Vec::new()
+    } else {
+        std::slice::from_raw_parts(args_ptr, n_args as usize).to_vec()
+    };
+    queue_microtask_with_type(callback, "TickObject", args);
+}
+```
+
+<a id="ref-q1-4"></a>
+### [4] `crates/perry-runtime/src/builtins/globals.rs:415-431`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/builtins/globals.rs#L415-L431)
+
+```rust
+fn queue_microtask_with_type(callback: i64, type_name: &str, args: Vec<f64>) {
+    let context = crate::async_context::capture_context();
+    let ids = crate::async_hooks::init_resource(
+        type_name,
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+        false,
+    );
+    QUEUED_MICROTASKS.with(|q| {
+        q.borrow_mut().push(QueuedMicrotask {
+            callback,
+            context,
+            async_id: ids.async_id,
+            trigger_async_id: ids.trigger_async_id,
+            args,
+        });
+    });
+}
+```
+
+<a id="ref-q1-5"></a>
+### [5] `crates/perry-runtime/src/builtins/globals.rs:455-457`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/builtins/globals.rs#L455-L457)
+
+```rust
+/// Drain queued microtasks. Called by `js_promise_run_microtasks`.
+#[no_mangle]
+pub extern "C" fn js_drain_queued_microtasks() {
+```
+
+<a id="ref-q1-6"></a>
+### [6] `crates/perry-runtime/src/builtins/globals.rs:463-468`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/builtins/globals.rs#L463-L468)
+
+```rust
+        let task = QUEUED_MICROTASKS.with(|q| {
+            let mut queue = q.borrow_mut();
+            if queue.is_empty() {
+                None
+            } else {
+                Some(queue.remove(0))
+```
+
+<a id="ref-q1-7"></a>
+### [7] `crates/perry-runtime/src/builtins/globals.rs:473-487`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/builtins/globals.rs#L473-L487)
+
+```rust
+                callback: cb,
+                context,
+                async_id,
+                trigger_async_id,
+                args,
+            }) => {
+                let scope = crate::gc::RuntimeHandleScope::new();
+                let callback_handle =
+                    scope.root_raw_const_ptr(cb as *const crate::closure::ClosureHeader);
+                let arg_handles = scope.root_nanbox_f64_slice(&args);
+                let previous = crate::async_context::enter_context(&context);
+                QUEUED_MICROTASK_PREV_CONTEXTS.with(|stack| {
+                    stack.borrow_mut().push(previous);
+                });
+                crate::async_hooks::before(async_id, trigger_async_id);
+```
+
+<a id="ref-q1-8"></a>
+### [8] `crates/perry-runtime/src/promise/microtasks.rs:26-27`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/promise/microtasks.rs#L26-L27)
+
+```rust
+#[no_mangle]
+pub extern "C" fn js_promise_run_microtasks() -> i32 {
+```
+
+<a id="ref-q1-9"></a>
+### [9] `crates/perry-runtime/src/promise/microtasks.rs:31-41`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/promise/microtasks.rs#L31-L41)
+
+```rust
+    ran += crate::async_hooks::drain_gc_destroy_queue();
+
+    // Process any scheduled resolutions (simulates async completions)
+    ran += super::combinators::process_scheduled_resolves();
+
+    // Process diagnostics_channel publishes queued by perry/thread workers.
+    ran += crate::node_submodules::diagnostics_channel_process_pending();
+
+    // Process pending thread results (from perry/thread spawn)
+    ran += crate::thread::js_thread_process_pending();
+```
+
+<a id="ref-q1-10"></a>
+### [10] `crates/perry-runtime/src/promise/microtasks.rs:126`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/promise/microtasks.rs#L126)
+
+```rust
+    crate::builtins::js_drain_queued_microtasks();
+```
+
+<a id="ref-q1-11"></a>
+### [11] `crates/perry-runtime/src/promise/microtasks.rs:586-588`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/promise/microtasks.rs#L586-L588)
+
+```rust
+    // Timers run after already-queued promise/queueMicrotask jobs, matching
+    // Node's turn ordering (`Promise.resolve().then(...)` before
+    // `setTimeout(..., 0)`). Timer callbacks may enqueue more microtasks;
+```
+
+<a id="ref-q1-12"></a>
+### [12] `crates/perry-codegen/src/expr/instance_misc1.rs:454-496`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-codegen/src/expr/instance_misc1.rs#L454-L496)
+
+```rust
+        // -------- queueMicrotask(fn) stub --------
+        Expr::QueueMicrotask(cb) => {
+            let cb_box = lower_expr(ctx, cb)?;
+            let blk = ctx.block();
+            let cb_handle = unbox_to_i64(blk, &cb_box);
+            blk.call_void("js_queue_microtask", &[(I64, &cb_handle)]);
+            Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
+        }
+
+        // -------- process.nextTick(fn, ...args) --------
+        // Trailing args are forwarded to the callback when the tick fires
+        // (#1351). Pack them into a stack buffer of doubles and hand off to
+        // the varargs runtime entry; the no-args form goes through the
+        // simpler `js_queue_next_tick` to avoid the alloca cost.
+        Expr::ProcessNextTick { callback, args } => {
+            let cb_box = lower_expr(ctx, callback)?;
+            if args.is_empty() {
+                let blk = ctx.block();
+                let cb_handle = unbox_to_i64(blk, &cb_box);
+                blk.call_void("js_queue_next_tick", &[(I64, &cb_handle)]);
+                return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
+            }
+            let n = args.len();
+            let buf = ctx.func.alloca_entry_array(DOUBLE, n);
+            for (i, a) in args.iter().enumerate() {
+                let v = lower_expr(ctx, a)?;
+                let blk = ctx.block();
+                let slot = blk.gep(DOUBLE, &buf, &[(I64, &format!("{}", i))]);
+                blk.store(DOUBLE, &v, &slot);
+            }
+            let ptr_reg = ctx.block().next_reg();
+            ctx.block().emit_raw(format!(
+                "{} = getelementptr [{} x double], ptr {}, i64 0, i64 0",
+                ptr_reg, n, buf
+            ));
+            let blk = ctx.block();
+            let cb_handle = unbox_to_i64(blk, &cb_box);
+            blk.call_void(
+                "js_queue_next_tick_args",
+                &[(I64, &cb_handle), (PTR, &ptr_reg), (I32, &n.to_string())],
+            );
+            Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
+        }
+```
+
+<a id="ref-q1-13"></a>
+### [13] `crates/perry-codegen/src/expr/instance_misc1.rs:455-460`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-codegen/src/expr/instance_misc1.rs#L455-L460)
+
+```rust
+        Expr::QueueMicrotask(cb) => {
+            let cb_box = lower_expr(ctx, cb)?;
+            let blk = ctx.block();
+            let cb_handle = unbox_to_i64(blk, &cb_box);
+            blk.call_void("js_queue_microtask", &[(I64, &cb_handle)]);
+            Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
+```
+
+<a id="ref-q1-14"></a>
+### [14] `crates/perry-codegen/src/expr/instance_misc1.rs:468-494`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-codegen/src/expr/instance_misc1.rs#L468-L494)
+
+```rust
+        Expr::ProcessNextTick { callback, args } => {
+            let cb_box = lower_expr(ctx, callback)?;
+            if args.is_empty() {
+                let blk = ctx.block();
+                let cb_handle = unbox_to_i64(blk, &cb_box);
+                blk.call_void("js_queue_next_tick", &[(I64, &cb_handle)]);
+                return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
+            }
+            let n = args.len();
+            let buf = ctx.func.alloca_entry_array(DOUBLE, n);
+            for (i, a) in args.iter().enumerate() {
+                let v = lower_expr(ctx, a)?;
+                let blk = ctx.block();
+                let slot = blk.gep(DOUBLE, &buf, &[(I64, &format!("{}", i))]);
+                blk.store(DOUBLE, &v, &slot);
+            }
+            let ptr_reg = ctx.block().next_reg();
+            ctx.block().emit_raw(format!(
+                "{} = getelementptr [{} x double], ptr {}, i64 0, i64 0",
+                ptr_reg, n, buf
+            ));
+            let blk = ctx.block();
+            let cb_handle = unbox_to_i64(blk, &cb_box);
+            blk.call_void(
+                "js_queue_next_tick_args",
+                &[(I64, &cb_handle), (PTR, &ptr_reg), (I32, &n.to_string())],
+            );
+```
+
+<a id="ref-q1-15"></a>
+### [15] `crates/perry-codegen/src/runtime_decls/strings.rs:1002-1011`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-codegen/src/runtime_decls/strings.rs#L1002-L1011)
+
+```rust
+    // Microtask queue (queueMicrotask / process.nextTick).
+    module.declare_function("js_queue_microtask", VOID, &[I64]);
+    module.declare_function("js_queue_next_tick", VOID, &[I64]);
+    // #1351: process.nextTick(cb, ...args) — trailing args packed into a
+    // stack buffer of doubles, forwarded when the tick fires.
+    module.declare_function(
+        "js_queue_next_tick_args",
+        VOID,
+        &[I64, crate::types::PTR, I32],
+    );
+```
+
+<a id="ref-q1-16"></a>
+### [16] `crates/perry-runtime/src/promise/mod.rs:377-382`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/promise/mod.rs#L377-L382)
+
+```rust
+// Global task queue for pending promise callbacks. Must be FIFO per
+// ECMAScript microtask semantics: `Promise.resolve(1).then(...)` and
+// `Promise.resolve(2).then(...)` registered in source order must run
+// their continuations in source order (1 first, then 2). Using a
+// `Vec` with `.pop()` produces LIFO ordering, breaking every test
+// that prints inside multiple parallel promise chains.
+```
+
+<a id="ref-q1-17"></a>
+### [17] `crates/perry-runtime/src/promise/mod.rs:383-385`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/promise/mod.rs#L383-L385)
+
+```rust
+thread_local! {
+    pub(crate) static TASK_QUEUE: RefCell<std::collections::VecDeque<Task>>
+        = const { RefCell::new(std::collections::VecDeque::new()) };
+```
+
+<a id="ref-q1-18"></a>
+### [18] `crates/perry-runtime/src/promise/microtasks.rs:138-140`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/promise/microtasks.rs#L138-L140)
+
+```rust
+        let task = TASK_QUEUE.with(|q| q.borrow_mut().pop_front());
+        if let Some(t) = t0 {
+            MT_TIME_NS_QUEUE.fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
+```
+
+<a id="ref-q1-19"></a>
+### [19] `crates/perry-runtime/src/promise/mod.rs:359-374`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/promise/mod.rs#L359-L374)
+
+```rust
+pub(crate) enum Task {
+    Promise(*mut Promise, f64, bool, AsyncContextSnapshot),
+    PromiseAll(
+        combinators::PromiseAllState,
+        f64,
+        bool,
+        AsyncContextSnapshot,
+    ),
+    Inline(ClosurePtr, f64, *mut Promise, bool, AsyncContextSnapshot),
+    /// Direct dispatch to a 2-arg async-step closure. Equivalent to
+    /// `Inline(then_v_arrow, value, next, true)` where `then_v_arrow`
+    /// is a wrapper that calls `step(value, is_error)` — but skips the
+    /// then_v_arrow alloc + dispatch by carrying `step_closure` and
+    /// the `is_error` flag directly. Saves one closure allocation
+    /// per await on the steady-state primitive-await path.
+    AsyncStep(ClosurePtr, f64, *mut Promise, bool, AsyncContextSnapshot),
+```
+
+<a id="ref-q1-20"></a>
+### [20] `crates/perry-runtime/src/promise/microtasks.rs:31`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/promise/microtasks.rs#L31)
+
+```rust
+    ran += crate::async_hooks::drain_gc_destroy_queue();
+```
+
+<a id="ref-q1-21"></a>
+### [21] `crates/perry-runtime/src/promise/microtasks.rs:34`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/promise/microtasks.rs#L34)
+
+```rust
+    ran += super::combinators::process_scheduled_resolves();
+```
+
+<a id="ref-q1-22"></a>
+### [22] `crates/perry-runtime/src/promise/microtasks.rs:37`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/promise/microtasks.rs#L37)
+
+```rust
+    ran += crate::node_submodules::diagnostics_channel_process_pending();
+```
+
+<a id="ref-q1-23"></a>
+### [23] `crates/perry-runtime/src/promise/microtasks.rs:40`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/promise/microtasks.rs#L40)
+
+```rust
+    ran += crate::thread::js_thread_process_pending();
+```
+
+<a id="ref-q1-24"></a>
+### [24] `crates/perry-runtime/src/promise/microtasks.rs:42`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/promise/microtasks.rs#L42)
+
+```rust
+    // Then process the task queue.
+```
+
+<a id="ref-q1-25"></a>
+### [25] `crates/perry-runtime/src/promise/microtasks.rs:44-56`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/promise/microtasks.rs#L44-L56)
+
+```rust
+    // ── Exception trap (Issue #...): install ONE setjmp for the WHOLE
+    // loop body, instead of a fresh setjmp per microtask. The previous
+    // shape paid setjmp+js_try_push/end every microtask just so that a
+    // `throw` from a callback could be re-routed to reject the chained
+    // `next` promise. setjmp+longjmp on aarch64 saves ~16 callee-saved
+    // x-regs and ~8 d-regs per call — that's ~25 ns per microtask, and
+    // an async benchmark with 200k microtasks pays ~5 ms in setjmp cost
+    // alone. The single outer setjmp captures the same "throw out of a
+    // microtask body" case (since `js_throw` longjmps to the most recent
+    // try block; if no user try is in scope, this one is it). When the
+    // longjmp lands, we read the current promise context out of a
+    // thread-local set just before invoking the callback, reject its
+    // `next`, and continue the loop.
+```
+
+<a id="ref-q1-26"></a>
+### [26] `crates/perry-runtime/src/builtins/globals.rs:417-421`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/builtins/globals.rs#L417-L421)
+
+```rust
+    let ids = crate::async_hooks::init_resource(
+        type_name,
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+        false,
+    );
+```
+
+<a id="ref-q1-27"></a>
+### [27] `crates/perry-runtime/src/builtins/globals.rs:487`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/builtins/globals.rs#L487)
+
+```rust
+                crate::async_hooks::before(async_id, trigger_async_id);
+```
+
+<a id="ref-q1-28"></a>
+### [28] `crates/perry-runtime/src/builtins/globals.rs:527`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-runtime/src/builtins/globals.rs#L527)
+
+```rust
+                crate::async_hooks::after(async_id);
+```
+
+<a id="ref-q1-29"></a>
+### [29] `crates/perry-codegen/src/codegen/entry.rs:469-472`
+Source: [PerryTS/perry @ c720d2a4](https://github.com/PerryTS/perry/blob/c720d2a4/crates/perry-codegen/src/codegen/entry.rs#L469-L472)
+
+```rust
+                let _ = ctx.block().call(I32, "js_promise_run_microtasks", &[]);
+                let _ = ctx.block().call(I32, "js_timer_tick", &[]);
+                let _ = ctx.block().call(I32, "js_callback_timer_tick", &[]);
+                let _ = ctx.block().call(I32, "js_interval_timer_tick", &[]);
+```

--- a/test-parity/node-suite/globals/queue-microtask-promise-fifo.ts
+++ b/test-parity/node-suite/globals/queue-microtask-promise-fifo.ts
@@ -1,0 +1,38 @@
+const waitImmediate = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+const fifo: string[] = [];
+Promise.resolve().then(() => fifo.push("promise1"));
+queueMicrotask(() => fifo.push("queue"));
+Promise.resolve().then(() => fifo.push("promise2"));
+await waitImmediate();
+console.log("fifo:", fifo.join(","));
+
+const nested: string[] = [];
+Promise.resolve().then(() => {
+  nested.push("promise1");
+  queueMicrotask(() => nested.push("queue-in-promise"));
+  Promise.resolve().then(() => nested.push("promise-in-promise"));
+});
+queueMicrotask(() => {
+  nested.push("queue1");
+  Promise.resolve().then(() => nested.push("promise-in-queue"));
+  queueMicrotask(() => nested.push("queue-in-queue"));
+});
+Promise.resolve().then(() => nested.push("promise2"));
+await waitImmediate();
+console.log("nested:", nested.join(","));
+
+const nextTick: string[] = [];
+await new Promise<void>((resolve) => {
+  setImmediate(() => {
+    if (typeof process?.nextTick === "function") {
+      process.nextTick(() => nextTick.push("tick"));
+    }
+    Promise.resolve().then(() => nextTick.push("promise"));
+    queueMicrotask(() => nextTick.push("queue"));
+    setImmediate(() => {
+      resolve();
+    });
+  });
+});
+console.log("nextTick:", nextTick.join(","));


### PR DESCRIPTION
## Summary
- Move `queueMicrotask` callbacks into the Promise microtask FIFO via a new `Task::Microtask` path.
- Keep `process.nextTick` on the existing higher-priority queue and drain it before Promise/queueMicrotask checkpoints.
- Add a deterministic Node fixture for Promise, queueMicrotask, nested microtasks, and nextTick ordering.

Refs #3598

## Verification
- `git diff --check`
- `node test-parity/node-suite/globals/queue-microtask-promise-fifo.ts`
  - `fifo: promise1,queue,promise2`
  - `nested: promise1,queue1,promise2,queue-in-promise,promise-in-promise,promise-in-queue,queue-in-queue`
  - `nextTick: tick,promise,queue`
- `cargo fmt --check`
- `cargo check -p perry-hir -p perry-codegen -p perry-stdlib -p perry-runtime`
- Attempted `./run_parity_tests.sh --suite node-suite --module globals --filter queue-microtask-promise-fifo`; stopped it while it remained in `Building compiler (release)...` with no fixture output.

## Remaining / Out Of Scope
- Navigator/Navigator global shape, URLPattern, TextEncoderStream/TextDecoderStream, and broader URL/encoding parity are split to separate workers.
- This PR does not take fetch, WebCrypto, WebSocket, MessageChannel, WebAssembly, DOM abort/clone, or weakref work.
