### PR TITLE
Support structuredClone transfer options (#3598)

### DIFF
--- a/crates/perry-codegen-js/src/emit/exprs_more.rs
+++ b/crates/perry-codegen-js/src/emit/exprs_more.rs
@@ -1200,9 +1200,13 @@ impl JsEmitter {
                 self.emit_expr(inner);
                 self.output.push(')');
             }
-            Expr::StructuredClone(inner) => {
+            Expr::StructuredClone { value, options } => {
                 self.output.push_str("structuredClone(");
-                self.emit_expr(inner);
+                self.emit_expr(value);
+                if !matches!(options.as_ref(), Expr::Undefined) {
+                    self.output.push_str(", ");
+                    self.emit_expr(options);
+                }
                 self.output.push(')');
             }
             Expr::QueueMicrotask(inner) => {

--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -368,13 +368,16 @@ pub fn check_escapes_in_expr(
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
         | Expr::FinalizationRegistryNew(operand)
-        | Expr::StructuredClone(operand)
         | Expr::QueueMicrotask(operand)
         | Expr::ArrayIsArray(operand) => {
             check_escapes_in_expr(operand, candidates, classes, escaped);
         }
         Expr::JsonParseTyped { text, .. } => {
             check_escapes_in_expr(text, candidates, classes, escaped);
+        }
+        Expr::StructuredClone { value, options } => {
+            check_escapes_in_expr(value, candidates, classes, escaped);
+            check_escapes_in_expr(options, candidates, classes, escaped);
         }
         Expr::ProcessNextTick { callback, args } => {
             check_escapes_in_expr(callback, candidates, classes, escaped);

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -257,7 +257,6 @@ fn collect_used_new_fields_in_expr(
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
         | Expr::FinalizationRegistryNew(operand)
-        | Expr::StructuredClone(operand)
         | Expr::QueueMicrotask(operand)
         | Expr::ArrayIsArray(operand)
         | Expr::ObjectRest {
@@ -268,6 +267,10 @@ fn collect_used_new_fields_in_expr(
         | Expr::Btoa(operand) => collect_used_new_fields_in_expr(operand, non_escaping_news, used),
         Expr::JsonParseTyped { text, .. } => {
             collect_used_new_fields_in_expr(text, non_escaping_news, used)
+        }
+        Expr::StructuredClone { value, options } => {
+            collect_used_new_fields_in_expr(value, non_escaping_news, used);
+            collect_used_new_fields_in_expr(options, non_escaping_news, used);
         }
         Expr::ProcessNextTick { callback, args } => {
             collect_used_new_fields_in_expr(callback, non_escaping_news, used);

--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -1115,7 +1115,6 @@ pub fn collect_localset_ids_in_expr_filtered(
         | Expr::ForOfToArray(operand)
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
-        | Expr::StructuredClone(operand)
         | Expr::QueueMicrotask(operand)
         | Expr::FsExistsSync(operand)
         | Expr::FsReadFileSync(operand)
@@ -1154,6 +1153,10 @@ pub fn collect_localset_ids_in_expr_filtered(
         | Expr::MathMinSpread(operand)
         | Expr::MathMaxSpread(operand) => {
             walk(operand, out);
+        }
+        Expr::StructuredClone { value, options } => {
+            walk(value, out);
+            walk(options, out);
         }
         Expr::ObjectCreate(proto, props) => {
             walk(proto, out);

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -220,7 +220,6 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         | Expr::ForOfToArray(operand)
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
-        | Expr::StructuredClone(operand)
         | Expr::QueueMicrotask(operand)
         | Expr::FsExistsSync(operand)
         | Expr::FsReadFileSync(operand)
@@ -259,6 +258,10 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         | Expr::MathMinSpread(operand)
         | Expr::MathMaxSpread(operand) => {
             walk(operand, out);
+        }
+        Expr::StructuredClone { value, options } => {
+            walk(value, out);
+            walk(options, out);
         }
         Expr::ObjectCreate(proto, props) => {
             walk(proto, out);

--- a/crates/perry-codegen/src/expr/env_clones.rs
+++ b/crates/perry-codegen/src/expr/env_clones.rs
@@ -407,12 +407,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_pointer_inline(blk, &h))
         }
 
-        // -------- structuredClone(v) — real deep copy --------
-        Expr::StructuredClone(operand) => {
-            let v = lower_expr(ctx, operand)?;
-            Ok(ctx
-                .block()
-                .call(DOUBLE, "js_structured_clone", &[(DOUBLE, &v)]))
+        // -------- structuredClone(v[, options]) — real deep copy --------
+        Expr::StructuredClone { value, options } => {
+            let v = lower_expr(ctx, value)?;
+            let opts = lower_expr(ctx, options)?;
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_structured_clone_with_options",
+                &[(DOUBLE, &v), (DOUBLE, &opts)],
+            ))
         }
 
         // -------- `new WeakRef(target)` — allocate a wrapper object --------

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1816,7 +1816,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ProcessPid
         | Expr::ProcessPpid
         | Expr::ProcessArgv
-        | Expr::StructuredClone(..)
+        | Expr::StructuredClone { .. }
         | Expr::WeakRefNew(..) => env_clones::lower(ctx, expr),
         Expr::FsUnlinkSync(..) | Expr::Await(..) => fs_await::lower(ctx, expr),
         Expr::StaticFieldGet { .. }

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -283,8 +283,13 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_string_replace_all_string_fn", I64, &[I64, I64, DOUBLE]);
     module.declare_function("js_string_replace_regex_fn", I64, &[I64, I64, DOUBLE]);
     module.declare_function("js_string_replace_all_regex_fn", I64, &[I64, I64, DOUBLE]);
-    // structuredClone(v) — real deep copy, was stubbed as passthrough.
+    // structuredClone(v[, options]) — real deep copy, with ArrayBuffer transfer.
     module.declare_function("js_structured_clone", DOUBLE, &[DOUBLE]);
+    module.declare_function(
+        "js_structured_clone_with_options",
+        DOUBLE,
+        &[DOUBLE, DOUBLE],
+    );
     // WeakRef / FinalizationRegistry (weakref.rs). `js_weakref_new` /
     // `js_finreg_new` return raw `*mut ObjectHeader` (i64 pointer, must be
     // POINTER_TAG-boxed at the call site). The deref/register/unregister

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -778,8 +778,11 @@ pub enum Expr {
     /// decodeURIComponent(string) -> string
     DecodeURIComponent(Box<Expr>),
 
-    /// structuredClone(value) -> deep-cloned value
-    StructuredClone(Box<Expr>),
+    /// structuredClone(value[, options]) -> deep-cloned value
+    StructuredClone {
+        value: Box<Expr>,
+        options: Box<Expr>,
+    },
     /// queueMicrotask(callback) -> void
     QueueMicrotask(Box<Expr>),
 

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -190,7 +190,16 @@ pub(super) fn try_global_builtins(
             }
             "structuredClone" => {
                 if !args.is_empty() {
-                    return Ok(Ok(Expr::StructuredClone(Box::new(args.remove(0)))));
+                    let value = args.remove(0);
+                    let options = if !args.is_empty() {
+                        args.remove(0)
+                    } else {
+                        Expr::Undefined
+                    };
+                    return Ok(Ok(Expr::StructuredClone {
+                        value: Box::new(value),
+                        options: Box::new(options),
+                    }));
                 } else {
                     return Err(anyhow!("structuredClone requires one argument"));
                 }

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -236,7 +236,7 @@ impl SH for Expr {
             Expr::DecodeURI(e) => { tag(h, 184); e.as_ref().hash(h); }
             Expr::EncodeURIComponent(e) => { tag(h, 185); e.as_ref().hash(h); }
             Expr::DecodeURIComponent(e) => { tag(h, 186); e.as_ref().hash(h); }
-            Expr::StructuredClone(e) => { tag(h, 187); e.as_ref().hash(h); }
+            Expr::StructuredClone { value, options } => { tag(h, 187); value.as_ref().hash(h); options.as_ref().hash(h); }
             Expr::QueueMicrotask(e) => { tag(h, 188); e.as_ref().hash(h); }
             Expr::IterResultSet(e, b) => { tag(h, 189); e.as_ref().hash(h); b.hash(h); }
             Expr::IterResultGetValue => tag(h, 190),

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -201,7 +201,6 @@ where
         | Expr::DecodeURI(v)
         | Expr::EncodeURIComponent(v)
         | Expr::DecodeURIComponent(v)
-        | Expr::StructuredClone(v)
         | Expr::QueueMicrotask(v)
         | Expr::IterResultSet(v, _)
         | Expr::CryptoRandomBytes(v)
@@ -1058,6 +1057,10 @@ where
             if let Some(e) = encoding {
                 f(e);
             }
+        }
+        Expr::StructuredClone { value, options } => {
+            f(value);
+            f(options);
         }
         Expr::BufferFromArrayBuffer {
             data,

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -202,7 +202,6 @@ where
         | Expr::DecodeURI(v)
         | Expr::EncodeURIComponent(v)
         | Expr::DecodeURIComponent(v)
-        | Expr::StructuredClone(v)
         | Expr::QueueMicrotask(v)
         | Expr::IterResultSet(v, _)
         | Expr::CryptoRandomBytes(v)
@@ -1043,6 +1042,10 @@ where
             if let Some(e) = encoding {
                 f(e);
             }
+        }
+        Expr::StructuredClone { value, options } => {
+            f(value);
+            f(options);
         }
         Expr::BufferFromArrayBuffer {
             data,

--- a/crates/perry-runtime/src/builtins/globals.rs
+++ b/crates/perry-runtime/src/builtins/globals.rs
@@ -171,6 +171,14 @@ pub extern "C" fn js_decode_uri_component(value: f64) -> i64 {
 thread_local! {
     static STRUCTURED_CLONE_IN_PROGRESS: std::cell::RefCell<std::collections::HashSet<usize>>
         = std::cell::RefCell::new(std::collections::HashSet::new());
+    static STRUCTURED_CLONE_TRANSFER_STATE: std::cell::RefCell<Option<StructuredCloneTransferState>>
+        = std::cell::RefCell::new(None);
+}
+
+#[derive(Default)]
+struct StructuredCloneTransferState {
+    transferables: std::collections::HashSet<usize>,
+    clones: std::collections::HashMap<usize, usize>,
 }
 
 fn structured_clone_seen(ptr: usize) -> bool {
@@ -198,10 +206,225 @@ impl Drop for CloneCycleGuard {
     }
 }
 
+struct CloneTransferStateGuard(Option<StructuredCloneTransferState>);
+impl Drop for CloneTransferStateGuard {
+    fn drop(&mut self) {
+        STRUCTURED_CLONE_TRANSFER_STATE.with(|state| {
+            *state.borrow_mut() = self.0.take();
+        });
+    }
+}
+
+fn throw_structured_clone_type_error(message: &str) -> ! {
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+fn throw_data_clone_error(message: &str) -> ! {
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_error_new_with_name_message(b"DataCloneError", msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+fn pointer_addr(value: f64) -> Option<usize> {
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if jv.is_pointer() {
+        Some((jv.bits() & crate::value::POINTER_MASK) as usize)
+    } else {
+        None
+    }
+}
+
+fn gc_type_for_pointer(addr: usize) -> Option<u8> {
+    if addr < 0x10000
+        || crate::buffer::is_registered_buffer(addr)
+        || crate::symbol::is_registered_symbol(addr)
+        || crate::set::is_registered_set(addr)
+    {
+        return None;
+    }
+    unsafe { Some(*((addr as *const u8).sub(crate::gc::GC_HEADER_SIZE))) }
+}
+
+fn is_array_value(value: f64) -> bool {
+    pointer_addr(value)
+        .is_some_and(|addr| gc_type_for_pointer(addr) == Some(crate::gc::GC_TYPE_ARRAY))
+}
+
+fn get_object_property(value: f64, name: &[u8]) -> f64 {
+    let Some(addr) = pointer_addr(value) else {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    };
+    if gc_type_for_pointer(addr) != Some(crate::gc::GC_TYPE_OBJECT) {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let val =
+        crate::object::js_object_get_field_by_name(addr as *mut crate::object::ObjectHeader, key);
+    f64::from_bits(val.bits())
+}
+
+fn transfer_existing_clone(addr: usize) -> Option<usize> {
+    STRUCTURED_CLONE_TRANSFER_STATE.with(|state| {
+        state
+            .borrow()
+            .as_ref()
+            .and_then(|state| state.clones.get(&addr).copied())
+    })
+}
+
+fn transfer_requested(addr: usize) -> bool {
+    STRUCTURED_CLONE_TRANSFER_STATE.with(|state| {
+        state
+            .borrow()
+            .as_ref()
+            .is_some_and(|state| state.transferables.contains(&addr))
+    })
+}
+
+fn record_transfer_clone(src: usize, cloned: usize) {
+    STRUCTURED_CLONE_TRANSFER_STATE.with(|state| {
+        if let Some(state) = state.borrow_mut().as_mut() {
+            state.clones.insert(src, cloned);
+        }
+    });
+}
+
+fn detach_unseen_transferables() {
+    STRUCTURED_CLONE_TRANSFER_STATE.with(|state| {
+        if let Some(state) = state.borrow().as_ref() {
+            for addr in &state.transferables {
+                if state.clones.contains_key(addr) {
+                    continue;
+                }
+                unsafe {
+                    let src = *addr as *mut crate::buffer::BufferHeader;
+                    (*src).length = 0;
+                    (*src).capacity = 0;
+                }
+            }
+        }
+    });
+}
+
+fn clone_buffer_header(addr: usize, detach_source: bool) -> f64 {
+    if detach_source {
+        if let Some(existing) = transfer_existing_clone(addr) {
+            return crate::value::js_nanbox_pointer(existing as i64);
+        }
+    }
+
+    let src = addr as *mut crate::buffer::BufferHeader;
+    let src_len = unsafe { (*src).length };
+    let dst = crate::buffer::buffer_alloc(src_len);
+    unsafe {
+        (*dst).length = src_len;
+        if src_len > 0 {
+            std::ptr::copy_nonoverlapping(
+                crate::buffer::buffer_data(src),
+                crate::buffer::buffer_data_mut(dst),
+                src_len as usize,
+            );
+        }
+    }
+
+    let dst_addr = dst as usize;
+    if crate::buffer::is_array_buffer(addr) {
+        crate::buffer::mark_as_array_buffer(dst_addr);
+    } else if crate::buffer::is_shared_array_buffer(addr) {
+        crate::buffer::mark_as_shared_array_buffer(dst_addr);
+    } else if crate::buffer::is_data_view(addr) {
+        crate::buffer::mark_as_data_view(dst_addr);
+        crate::buffer::set_buffer_ab_alias(dst_addr, crate::buffer::resolve_buffer_ab_alias(addr));
+    } else if crate::buffer::is_uint8array_buffer(addr) {
+        crate::buffer::mark_as_uint8array(dst_addr);
+        crate::buffer::set_buffer_ab_alias(dst_addr, crate::buffer::resolve_buffer_ab_alias(addr));
+    } else {
+        crate::buffer::set_buffer_ab_alias(dst_addr, crate::buffer::resolve_buffer_ab_alias(addr));
+    }
+
+    if detach_source {
+        record_transfer_clone(addr, dst_addr);
+        unsafe {
+            (*src).length = 0;
+            (*src).capacity = 0;
+        }
+    }
+
+    crate::value::js_nanbox_pointer(dst_addr as i64)
+}
+
+fn collect_transfer_list(options: f64) -> std::collections::HashSet<usize> {
+    let options_value = crate::value::JSValue::from_bits(options.to_bits());
+    if options_value.is_undefined() || options_value.is_null() {
+        return std::collections::HashSet::new();
+    }
+    if !options_value.is_pointer() {
+        throw_structured_clone_type_error(
+            "Failed to execute 'structuredClone': Options cannot be converted to a dictionary",
+        );
+    }
+
+    let transfer = get_object_property(options, b"transfer");
+    if crate::value::JSValue::from_bits(transfer.to_bits()).is_undefined() {
+        return std::collections::HashSet::new();
+    }
+    if !is_array_value(transfer) {
+        throw_structured_clone_type_error(
+            "Failed to execute 'structuredClone': transfer in Options can not be converted to sequence",
+        );
+    }
+
+    let transfer_addr = pointer_addr(transfer).unwrap_or(0);
+    let transfer_arr = transfer_addr as *const crate::array::ArrayHeader;
+    let len = crate::array::js_array_length(transfer_arr);
+    let mut out = std::collections::HashSet::new();
+    for i in 0..len {
+        let item = crate::array::js_array_get_f64(transfer_arr, i);
+        let Some(item_addr) = pointer_addr(item) else {
+            throw_data_clone_error("Found invalid value in transferList");
+        };
+        if !crate::buffer::is_array_buffer(item_addr)
+            || crate::buffer::is_shared_array_buffer(item_addr)
+        {
+            throw_data_clone_error("Found invalid value in transferList");
+        }
+        if !out.insert(item_addr) {
+            throw_data_clone_error("Transfer list contains duplicate ArrayBuffer");
+        }
+    }
+    out
+}
+
 /// structuredClone(value) -> deep-cloned value
 /// Handles numbers (pass-through), strings (copy), arrays/objects (shallow for now)
 #[no_mangle]
 pub extern "C" fn js_structured_clone(value: f64) -> f64 {
+    js_structured_clone_inner(value)
+}
+
+/// structuredClone(value, options) -> deep-cloned value with supported transfers.
+#[no_mangle]
+pub extern "C" fn js_structured_clone_with_options(value: f64, options: f64) -> f64 {
+    let transferables = collect_transfer_list(options);
+    let previous = STRUCTURED_CLONE_TRANSFER_STATE.with(|state| {
+        state.borrow_mut().replace(StructuredCloneTransferState {
+            transferables,
+            clones: std::collections::HashMap::new(),
+        })
+    });
+    let _guard = CloneTransferStateGuard(previous);
+    let cloned = js_structured_clone_inner(value);
+    detach_unseen_transferables();
+    cloned
+}
+
+fn js_structured_clone_inner(value: f64) -> f64 {
+    if crate::value::is_js_handle(value) && crate::value::js_handle_is_function(value) {
+        throw_data_clone_error("Function could not be cloned");
+    }
+
     let bits = value.to_bits();
     // Pass through primitives (undefined, null, true, false)
     if bits == 0x7FFC_0000_0000_0001
@@ -242,19 +465,32 @@ pub extern "C" fn js_structured_clone(value: f64) -> f64 {
             if (ptr as usize) < 0x10000 {
                 return value;
             }
+            let addr = ptr as usize;
+            if crate::symbol::is_registered_symbol(addr) {
+                throw_data_clone_error("Symbol could not be cloned");
+            }
+            if crate::value::is_js_handle(value) && crate::value::js_handle_is_function(value) {
+                throw_data_clone_error("Function could not be cloned");
+            }
+            if crate::closure::is_closure_ptr(addr) {
+                throw_data_clone_error("Function could not be cloned");
+            }
+            if crate::buffer::is_registered_buffer(addr) {
+                return clone_buffer_header(addr, transfer_requested(addr));
+            }
             // #1512: short-circuit on cycle so `o.self = o` doesn't infinite-
             // recurse. The cycle edge resolves to the original value, not
             // the clone — that breaks full reference-identity preservation
             // but keeps cycles from stack-overflowing the runtime.
-            if structured_clone_seen(ptr as usize) {
+            if structured_clone_seen(addr) {
                 return value;
             }
-            structured_clone_mark(ptr as usize);
-            let _guard = CloneCycleGuard(ptr as usize);
+            structured_clone_mark(addr);
+            let _guard = CloneCycleGuard(addr);
             // Set is tracked in SET_REGISTRY (not GC_TYPE_SET since it has
             // no GC header). Check the registry BEFORE touching the GC
             // header bytes — they'd be garbage for raw-allocated sets.
-            if crate::set::is_registered_set(ptr as usize) {
+            if crate::set::is_registered_set(addr) {
                 let src = ptr as *const crate::set::SetHeader;
                 let size = crate::set::js_set_size(src);
                 let scope = crate::gc::RuntimeHandleScope::new();

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -2058,7 +2058,7 @@ The counts above are the last generated parity-gap counts on this branch. They w
 | `console` | `builtin` |
 | `performance` | `expr:PerformanceNow` |
 | `queueMicrotask(cb)` | `rt:promise microtask queue` |
-| `structuredClone(value, options?)` | `rt:js_structured_clone` |
+| `structuredClone(value, options?)` | `rt:js_structured_clone_with_options` |
 | `atob(b64)` | `expr:Atob` |
 | `btoa(str)` | `expr:Btoa` |
 | `fetch(input, init?)` | `expr:FetchWithOptions` |

--- a/docs/src/language/limitations.md
+++ b/docs/src/language/limitations.md
@@ -110,8 +110,11 @@ their APIs behave as expected — `set` / `get` / `has` / `delete`, `add`,
 never collide on the same slot.
 
 The one caveat is that Perry's garbage collector does not yet treat these
-references as *weak*, so targets are **retained rather than collected**. In
-practice:
+references as *weak*, so targets are **retained rather than collected**. The
+current runtime stores `WeakRef` targets and `FinalizationRegistry`
+registrations in ordinary object/array fields (`crates/perry-runtime/src/weakref.rs`),
+and the adjacent GC root scanners do not have a weak-slot clearing/finalizer
+queue hook yet. In practice:
 
 - `WeakRef.deref()` always returns the original target (it is never reported as
   collected).

--- a/test-parity/node-suite/globals/structured-clone-transfer.ts
+++ b/test-parity/node-suite/globals/structured-clone-transfer.ts
@@ -1,0 +1,59 @@
+function show(label: string, fn: () => unknown) {
+  try {
+    console.log(label + ":", fn());
+  } catch (err: any) {
+    console.log(label + ":", err?.name);
+  }
+}
+
+show("arraybuffer clone", () => {
+  const ab = new ArrayBuffer(4);
+  const bytes = new Uint8Array(ab);
+  bytes[0] = 11;
+  bytes[3] = 44;
+  const clone = structuredClone(ab);
+  const cloneBytes = new Uint8Array(clone);
+  return [
+    ab.byteLength,
+    clone.byteLength,
+    clone === ab,
+    cloneBytes[0],
+    cloneBytes[3],
+  ].join(",");
+});
+
+show("arraybuffer transfer", () => {
+  const ab = new ArrayBuffer(3);
+  new Uint8Array(ab)[1] = 77;
+  const moved = structuredClone(ab, { transfer: [ab] });
+  return [ab.byteLength, moved.byteLength, new Uint8Array(moved)[1]].join(",");
+});
+
+show("object transfer", () => {
+  const ab = new ArrayBuffer(2);
+  new Uint8Array(ab)[0] = 9;
+  const src = { ab };
+  const out = structuredClone(src, { transfer: [ab] });
+  return [
+    ab.byteLength,
+    out.ab.byteLength,
+    new Uint8Array(out.ab)[0],
+    out.ab === ab,
+  ].join(",");
+});
+
+show("unreachable transfer", () => {
+  const ab = new ArrayBuffer(5);
+  const out = structuredClone({ ok: true }, { transfer: [ab] });
+  return [ab.byteLength, out.ok].join(",");
+});
+
+show("invalid transfer value", () => structuredClone({}, { transfer: [{}] }));
+show("duplicate transfer", () => {
+  const ab = new ArrayBuffer(1);
+  return structuredClone({}, { transfer: [ab, ab] });
+});
+show("bad options", () => structuredClone({}, 1 as any));
+show("bad transfer shape", () => structuredClone({}, { transfer: null as any }));
+show("clone function", () => structuredClone(() => {}));
+show("clone symbol", () => structuredClone(Symbol("x")));


### PR DESCRIPTION
Refs #3598

## Summary
- Thread `structuredClone(value, options)` through HIR/codegen into a new runtime options-aware entry point.
- Add ArrayBuffer transfer-list validation, duplicate detection, deterministic clone identity, copied bytes, and source detachment for Perry BufferHeader-backed ArrayBuffers.
- Add DataCloneError-name throws for uncloneable function/symbol values and invalid transfer entries.
- Document the remaining true-weak WeakRef/FinalizationRegistry limitation with the current strong-field storage evidence.
- Add deterministic Node-suite fixture coverage for structuredClone clone/transfer/error shape.

## Verification
- `cargo check -p perry-runtime -p perry-hir -p perry-codegen`
- `node --experimental-strip-types test-parity/node-suite/globals/structured-clone-transfer.ts`
- Attempted `./run_parity_tests.sh --suite node-suite --module globals --filter structured-clone-transfer`; stopped after it remained in the release-build step with no fixture output, matching the expected release-build contention case.

## Remaining
- structuredClone transfer support is limited to locally supported ArrayBuffer storage; MessagePort/AbortSignal/other Web transferables remain unsupported.
- Full structured clone graph identity for cycles is still the existing limitation in `js_structured_clone` (cycle edges short-circuit to the original).
- WeakRef and FinalizationRegistry still do not provide true weak clearing or cleanup callbacks: `crates/perry-runtime/src/weakref.rs` stores targets/registrations in ordinary object/array fields, and the adjacent GC root scanners do not yet expose a low-risk weak-slot clearing/finalizer queue hook.
