### PR TITLE
fix(net): validate connect ports

### DIFF
--- a/crates/perry-stdlib/src/net/mod.rs
+++ b/crates/perry-stdlib/src/net/mod.rs
@@ -486,7 +486,10 @@ pub unsafe extern "C" fn js_net_socket_connect(arg1_f64: f64, arg2_f64: f64, arg
             _ => "localhost".to_string(),
         };
         let port = match get_object_number_field(arg1_f64, "port") {
-            Some(p) => p as u16,
+            Some(p) => {
+                perry_runtime::net_validate::js_net_validate_connect_port(p);
+                p as u16
+            }
             None => return 0,
         };
         let handle = spawn_socket_task(host, port, /* direct_tls: */ None);
@@ -494,6 +497,7 @@ pub unsafe extern "C" fn js_net_socket_connect(arg1_f64: f64, arg2_f64: f64, arg
         return handle;
     }
     // Positional form: arg2 is a NaN-boxed string, arg3 is the cb.
+    perry_runtime::net_validate::js_net_validate_connect_port(arg1_f64);
     let host_ptr = perry_runtime::js_get_string_pointer_unified(arg2_f64);
     let host = match string_from_header_i64(host_ptr) {
         Some(h) => h,
@@ -557,6 +561,7 @@ pub unsafe extern "C" fn js_net_socket_alloc() -> i64 {
 ///    args: &[NA_F64, NA_STR], ret: NR_VOID }`.
 #[no_mangle]
 pub unsafe extern "C" fn js_net_socket_method_connect(handle: i64, port: f64, host_ptr: i64) {
+    perry_runtime::net_validate::js_net_validate_connect_port(port);
     let host = match string_from_header_i64(host_ptr) {
         Some(h) => h,
         None => {


### PR DESCRIPTION
## Summary
- Validate bundled `node:net` `connect` port values before converting them to `u16` or spawning socket work.
- Route positional `net.connect(port, host)`, options-object `net.connect({ port, host })`, and deferred `new net.Socket().connect(port, host)` through the existing Node-shaped `ERR_SOCKET_BAD_PORT` validator.
- Keep the already-valid external-net path behavior aligned with the bundled stdlib net path.

## Linked Issues
Closes #3639

## Why This Cut
This is the focused `node:net` validation slice from the low-level networking umbrella. The failing fixture was isolated to connect-port validation, while the adjacent validation fixtures already cover separate server/listen/timeout/default-option paths.

## Tests
- Used the existing focused parity fixture `test-parity/node-suite/net/validation/connect-port.ts` that already captured the regression.
- Verified the broader `net/validation` fixture group after the fix.

## Verification
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/net/validation/connect-port.ts` confirmed the Node baseline.
- Pre-fix `PATH=/tmp/perry-node25-bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module net --filter validation/connect-port` failed with Perry printing `NO THROW` for invalid connect ports.
- `RUSTC_WRAPPER= cargo check -p perry-stdlib` passed with existing warning noise.
- `PATH=/tmp/perry-node25-bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module net --filter validation` passed 5/5, report `test-parity/reports/parity_report_20260531_104322.json`.
- After the final rebase, `PATH=/tmp/perry-node25-bin:$PATH RUSTC_WRAPPER= ./run_parity_tests.sh --suite node-suite --module net --filter validation/connect-port` passed 1/1, report `test-parity/reports/parity_report_20260531_104632.json`.
- `cargo fmt --all -- --check` passed.
- `git diff --check HEAD~1` passed.
- `./scripts/check_file_size.sh` passed.
- `jq empty test-parity/known_failures.json` passed.

## Known Limitations / Non-goals
- This does not implement broader TCP/TLS/DNS/dgram behavior from #3593.
- This does not change server listen validation, socket timeout validation, or auto-select-family defaults beyond confirming their validation fixtures still pass.
- This keeps scope to numeric connect-port validation covered by #3639 and the existing fixture; broader option-shape work remains for follow-up validation issues.