### PR TITLE
fix(node:process): loadEnvFile path handling, error-event semantics, sourceMaps toggle

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -456,6 +456,29 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_VOID,
     },
+    // #3108 (Node process parity): process.sourceMapsEnabled getter — reads
+    // the live flag toggled by setSourceMapsEnabled, returns a boolean.
+    NativeModSig {
+        module: "process",
+        has_receiver: false,
+        method: "sourceMapsEnabled",
+        class_filter: None,
+        runtime: "js_process_source_maps_enabled",
+        args: &[],
+        ret: NR_F64,
+    },
+    // #3108 (Node process parity): process.setSourceMapsEnabled(enabled)
+    // toggles the live source-map flag. Pass the full JS value so the
+    // runtime can reject non-boolean arguments with ERR_INVALID_ARG_TYPE.
+    NativeModSig {
+        module: "process",
+        has_receiver: false,
+        method: "setSourceMapsEnabled",
+        class_filter: None,
+        runtime: "js_process_set_source_maps_enabled",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     // #2135 (Node process parity): process.getgroups() — Array<number>
     // of supplementary GIDs from libc::getgroups (empty on non-unix).
     NativeModSig {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -639,6 +639,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_set_max_listeners", DOUBLE, &[DOUBLE]);
     module.declare_function("js_process_get_max_listeners", DOUBLE, &[]);
     module.declare_function("js_process_get_builtin_module", DOUBLE, &[DOUBLE]);
+    // #3108: process.sourceMapsEnabled getter + setSourceMapsEnabled(bool).
+    module.declare_function("js_process_source_maps_enabled", DOUBLE, &[]);
+    module.declare_function("js_process_set_source_maps_enabled", DOUBLE, &[DOUBLE]);
     module.declare_function("js_module_is_builtin", DOUBLE, &[DOUBLE]);
     module.declare_function("js_module_find_package_json", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_process_next_tick", VOID, &[I64, I64]);

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -140,14 +140,21 @@ pub(super) fn try_native_module_methods(
                             return Ok(Ok(Expr::Undefined));
                         }
                         "setSourceMapsEnabled" => {
-                            // #1400: process.setSourceMapsEnabled(bool) —
-                            // toggles runtime source-map resolution in Node.
-                            // Perry compiles AOT and has no resolver to
-                            // toggle, so the call is a no-op returning
-                            // undefined. Without this, framework startup
-                            // code that conditionally enables maps crashes
-                            // on "value is not a function".
-                            return Ok(Ok(Expr::Undefined));
+                            // #1400 / #3108: process.setSourceMapsEnabled(bool)
+                            // toggles the live source-map flag. Perry compiles
+                            // AOT and has no resolver, so the flag drives
+                            // nothing observable — but it round-trips through
+                            // process.sourceMapsEnabled and validates that the
+                            // argument is a boolean (else ERR_INVALID_ARG_TYPE),
+                            // matching Node. Lower to the runtime setter,
+                            // passing the original argument for validation.
+                            return Ok(Ok(Expr::NativeMethodCall {
+                                module: "process".to_string(),
+                                class_name: None,
+                                object: None,
+                                method: "setSourceMapsEnabled".to_string(),
+                                args,
+                            }));
                         }
                         "getBuiltinModule" => {
                             return Ok(Ok(Expr::NativeMethodCall {

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -187,15 +187,22 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // runtime's `node:dgram`/network stack handles it) —
                     // the literal mirrors what we actually link in.
                     "features" => return Ok(process_features_literal()),
-                    // #1400: process.sourceMapsEnabled — boolean indicating
-                    // whether the runtime's source-map support is on. Perry
-                    // compiles AOT and doesn't ship a source-map resolver,
-                    // so the value is always false. Without this arm the
-                    // bare read returned a 0 sentinel — falsy in a boolean
-                    // context but `typeof` was `"number"`, so libraries
-                    // doing `typeof process.sourceMapsEnabled === "boolean"`
-                    // bailed out (e.g. some Vitest stack-trace formatters).
-                    "sourceMapsEnabled" => return Ok(Expr::Bool(false)),
+                    // #1400 / #3108: process.sourceMapsEnabled — live boolean
+                    // reflecting setSourceMapsEnabled(). Perry compiles AOT
+                    // and ships no source-map resolver, so the flag drives
+                    // nothing observable, but it round-trips through the
+                    // setter (starting `false`) so `typeof ... === "boolean"`
+                    // holds and toggles are observable. Lower to a 0-arg
+                    // native getter that reads the runtime flag.
+                    "sourceMapsEnabled" => {
+                        return Ok(Expr::NativeMethodCall {
+                            module: "process".to_string(),
+                            class_name: None,
+                            object: None,
+                            method: "sourceMapsEnabled".to_string(),
+                            args: Vec::new(),
+                        })
+                    }
                     // #1412: `process.moduleLoadList` is Node's list of
                     // built-in modules already loaded into the
                     // interpreter. Perry AOT-compiles every reachable
@@ -384,7 +391,16 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         ]));
                     }
                     "features" => return Ok(process_features_literal()),
-                    "sourceMapsEnabled" => return Ok(Expr::Bool(false)),
+                    // #3108: live boolean toggle — see the matching arm above.
+                    "sourceMapsEnabled" => {
+                        return Ok(Expr::NativeMethodCall {
+                            module: "process".to_string(),
+                            class_name: None,
+                            object: None,
+                            method: "sourceMapsEnabled".to_string(),
+                            args: Vec::new(),
+                        })
+                    }
                     "moduleLoadList" => return Ok(Expr::Array(vec![])),
                     "finalization" => {
                         return Ok(Expr::Object(vec![

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -935,11 +935,7 @@ pub(crate) fn emit_process_event(event: &str, args: &[f64]) -> bool {
 
     if listeners.is_empty() {
         if event == "error" {
-            crate::exception::js_throw(
-                args.first()
-                    .copied()
-                    .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED)),
-            );
+            throw_unhandled_error_event(args);
         }
         return false;
     }
@@ -954,6 +950,44 @@ pub(crate) fn emit_process_event(event: &str, args: &[f64]) -> bool {
         }
     }
     true
+}
+
+/// Emit Node's special unhandled-`error`-event semantics (#3052).
+///
+/// `EventEmitter` (and therefore the `process` global) treats `emit("error", …)`
+/// with no registered `error` listener specially: if the first argument is an
+/// `Error` instance (or a subclass) it is re-thrown *as-is* — the same object,
+/// preserving its `code`, prototype, and identity. Otherwise Node constructs a
+/// fresh `Error` with `code: "ERR_UNHANDLED_ERROR"` and a message of
+/// `Unhandled error. (<util.inspect(arg)>)`, where a missing argument inspects
+/// to `undefined`. This replaces the previous behaviour of throwing the raw
+/// first argument (so `emit("error", "boom")` now throws an `ERR_UNHANDLED_ERROR`
+/// `Error` rather than the bare `"boom"` string).
+fn throw_unhandled_error_event(args: &[f64]) -> ! {
+    let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let first = args.first().copied().unwrap_or(undefined);
+
+    // `arg instanceof Error` → rethrow the original value untouched.
+    let is_error =
+        crate::value::js_is_truthy(crate::object::js_util_types_is_native_error(first)) != 0;
+    if is_error {
+        crate::exception::js_throw(first);
+    }
+
+    // Otherwise: `Unhandled error. (<inspected>)` with ERR_UNHANDLED_ERROR.
+    let inspected = unsafe { read_inspected(crate::builtins::js_util_inspect(first, undefined)) };
+    let message = format!("Unhandled error. ({inspected})");
+    let msg_ptr = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    crate::node_submodules::register_error_code_pub(msg_ptr, "ERR_UNHANDLED_ERROR");
+    let err_ptr = crate::error::js_error_new_with_message(msg_ptr);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err_ptr as i64));
+}
+
+/// Read the `util.inspect` result (a NaN-boxed string value) back into a Rust
+/// `String` for embedding in the unhandled-error message.
+unsafe fn read_inspected(value: f64) -> String {
+    let ptr = crate::value::js_get_string_pointer_unified(value) as *const StringHeader;
+    read_event_name(ptr).unwrap_or_default()
 }
 
 /// process.on(event, listener) — register an event listener.

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -1774,3 +1774,56 @@ pub(crate) fn is_array_value(jv: JSValue) -> bool {
     let gc_header = unsafe { &*(ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader) };
     gc_header.obj_type == crate::gc::GC_TYPE_ARRAY
 }
+
+// #3108 — `process.sourceMapsEnabled` / `process.setSourceMapsEnabled(bool)`.
+//
+// Node exposes a live boolean toggle: `setSourceMapsEnabled(true|false)`
+// flips the flag and returns `undefined`, the getter reflects it, and a
+// non-boolean setter argument throws `TypeError [ERR_INVALID_ARG_TYPE]`.
+// Perry compiles AOT and ships no source-map resolver, so the flag drives
+// nothing observable beyond its own state — but mirroring Node's round-trip
+// + validation lets feature-detecting libraries (and the parity suite)
+// behave identically. The flag starts `false`, matching a fresh Node process
+// launched without `--enable-source-maps`.
+use std::sync::atomic::{AtomicBool, Ordering};
+static SOURCE_MAPS_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// `process.sourceMapsEnabled` getter — returns the current toggle as a
+/// NaN-boxed boolean.
+#[no_mangle]
+pub extern "C" fn js_process_source_maps_enabled() -> f64 {
+    let on = SOURCE_MAPS_ENABLED.load(Ordering::Relaxed);
+    f64::from_bits(if on {
+        crate::value::TAG_TRUE
+    } else {
+        crate::value::TAG_FALSE
+    })
+}
+
+/// `process.setSourceMapsEnabled(enabled)` — validates that `enabled` is a
+/// boolean (else `TypeError [ERR_INVALID_ARG_TYPE]`), stores it, and returns
+/// `undefined`. Receives the full NaN-boxed value so missing/null/numeric/
+/// string/object arguments are rejected exactly as Node does.
+#[no_mangle]
+pub extern "C" fn js_process_set_source_maps_enabled(value: f64) -> f64 {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_bool() {
+        let message = format!(
+            "The \"enabled\" argument must be of type boolean. Received {}",
+            crate::fs::validate::describe_received(value)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    SOURCE_MAPS_ENABLED.store(jv.as_bool(), Ordering::Relaxed);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+// Codegen emits these two entry points only from generated `.o` (see the
+// process native table). Pin retained-reference edges so the auto-optimize
+// whole-program build doesn't internalize + dead-strip them. Same rationale
+// as KEEP_JS_SETENV above.
+#[used]
+static KEEP_JS_PROCESS_SOURCE_MAPS_ENABLED: extern "C" fn() -> f64 = js_process_source_maps_enabled;
+#[used]
+static KEEP_JS_PROCESS_SET_SOURCE_MAPS_ENABLED: extern "C" fn(f64) -> f64 =
+    js_process_set_source_maps_enabled;

--- a/test-files/test_gap_process_misc_3045plus.ts
+++ b/test-files/test_gap_process_misc_3045plus.ts
@@ -1,0 +1,96 @@
+// Gap test: node:process miscellaneous parity.
+//   #3045 — process.loadEnvFile(path?) argument handling (string/Buffer/URL,
+//           omitted/undefined/null default to .env, invalid-type throws)
+//   #3052 — process.emit("error", ...) unhandled-error throwing semantics
+//   #3108 — process.sourceMapsEnabled + setSourceMapsEnabled(bool) toggle
+//
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+function show(label: string, fn: () => void): void {
+  try {
+    fn();
+    console.log(label, "OK");
+  } catch (err) {
+    const e = err as { name: string; code?: string; message: string };
+    console.log(label, "THROW", e.name, e.code, e.message.split("\n")[0]);
+  }
+}
+
+// ---- #3108: sourceMapsEnabled toggle round-trip ----
+console.log("sme typeof", typeof process.sourceMapsEnabled, typeof process.setSourceMapsEnabled);
+console.log("sme initial", process.sourceMapsEnabled);
+console.log("sme set true ret", process.setSourceMapsEnabled(true));
+console.log("sme after true", process.sourceMapsEnabled);
+console.log("sme set false ret", process.setSourceMapsEnabled(false));
+console.log("sme after false", process.sourceMapsEnabled);
+show("sme missing", () => process.setSourceMapsEnabled());
+show("sme null", () => process.setSourceMapsEnabled(null));
+show("sme number", () => process.setSourceMapsEnabled(1));
+show("sme string", () => process.setSourceMapsEnabled("x"));
+show("sme object", () => process.setSourceMapsEnabled({}));
+show("sme array", () => process.setSourceMapsEnabled([]));
+
+// ---- #3052: emit("error", ...) unhandled-error semantics ----
+show("err noarg", () => process.emit("error"));
+show("err string", () => process.emit("error", "boom"));
+show("err number", () => process.emit("error", 42));
+show("err null", () => process.emit("error", null));
+show("err bool", () => process.emit("error", true));
+
+const customErr = new Error("custom");
+(customErr as { code?: string }).code = "EFOO";
+let rethrown: unknown = undefined;
+try {
+  process.emit("error", customErr);
+} catch (e) {
+  rethrown = e;
+}
+console.log("err instance same", rethrown === customErr, (rethrown as { code?: string }).code);
+
+// With an error listener registered, emit fires it and returns true.
+let listenerSaw: unknown = "none";
+process.on("error", (v: unknown) => {
+  listenerSaw = v;
+});
+const emitRet = process.emit("error", "handled");
+console.log("err with listener", emitRet, listenerSaw);
+process.removeAllListeners("error");
+
+// ---- #3045: loadEnvFile path handling ----
+const dir = fs.mkdtempSync(path.join(process.cwd(), "perry-loadenv-"));
+const envPath = path.join(dir, "config.env");
+fs.writeFileSync(envPath, "PERRY_GAP_LOADENV=ok\n");
+
+show("loadenv string", () => {
+  delete process.env.PERRY_GAP_LOADENV;
+  process.loadEnvFile(envPath);
+});
+console.log("loadenv string value", process.env.PERRY_GAP_LOADENV);
+
+show("loadenv buffer", () => {
+  delete process.env.PERRY_GAP_LOADENV;
+  process.loadEnvFile(Buffer.from(envPath));
+});
+console.log("loadenv buffer value", process.env.PERRY_GAP_LOADENV);
+
+show("loadenv url", () => {
+  delete process.env.PERRY_GAP_LOADENV;
+  process.loadEnvFile(new URL("file://" + envPath));
+});
+console.log("loadenv url value", process.env.PERRY_GAP_LOADENV);
+
+// Invalid argument types throw ERR_INVALID_ARG_TYPE before opening .env.
+show("loadenv number", () => process.loadEnvFile(123));
+show("loadenv boolean", () => process.loadEnvFile(true));
+show("loadenv object", () => process.loadEnvFile({}));
+show("loadenv array", () => process.loadEnvFile([]));
+
+// Omitted / undefined / null default to ".env" in cwd (absent here → ENOENT).
+show("loadenv omitted", () => process.loadEnvFile());
+show("loadenv undefined", () => process.loadEnvFile(undefined));
+show("loadenv null", () => process.loadEnvFile(null));
+
+fs.rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Three node:process parity fixes, validated byte-for-byte against `node --experimental-strip-types`.

Closes #3045
Closes #3052
Closes #3108

## Implementation

- **#3045 — `loadEnvFile` path handling** was already implemented on `main`: the dispatch passes the full JS value to `js_process_load_env_file`, which defaults omitted/`undefined`/`null` to `.env`, accepts string/Buffer/`file:` URL via `decode_path_value`, and throws the exact Node `ERR_INVALID_ARG_TYPE` message for other types. This PR adds the gap-test coverage proving it byte-identical (string/Buffer/URL load, invalid types throw, default-`.env` ENOENT), so the issue is verified closed; no runtime change was required.
- **#3052 — unhandled `error` event** (`crates/perry-runtime/src/os.rs`): `emit_process_event` now routes the no-listener `error` case through `throw_unhandled_error_event`. An `Error` instance (or subclass, via `js_util_types_is_native_error`) is rethrown as-is, preserving identity/`code`. Any other value (including a missing argument) throws a fresh `Error` with `code: "ERR_UNHANDLED_ERROR"` and message `Unhandled error. (<util.inspect(arg)>)` — matching Node's `'boom'`, `42`, `null`, `true`, `undefined` formatting.
- **#3108 — sourceMaps toggle**: added a runtime `AtomicBool` flag plus `js_process_source_maps_enabled` (getter) and `js_process_set_source_maps_enabled` (setter with boolean validation → `ERR_INVALID_ARG_TYPE`) in `crates/perry-runtime/src/process.rs`, each pinned with a `#[used]` keepalive anchor for the auto-optimize whole-program link. Wired through codegen: native-table sigs (`node_core.rs`), runtime decls (`runtime_decls/strings.rs`), and HIR lowering (`expr_member.rs` getter arms → 0-arg `NativeMethodCall`, `expr_call/native_module.rs` setter → `NativeMethodCall` forwarding the argument). The flag starts `false` and round-trips through `setSourceMapsEnabled(true|false)`.

No new HIR `Expr` variant.

## Validation

`test-files/test_gap_process_misc_3045plus.ts` is byte-identical to Node v25.8.0 under the **default** auto-optimize compile (exercises the new `#[no_mangle]` FFIs end-to-end; link succeeds → keepalive anchors confirmed). Guards green: `./scripts/check_file_size.sh`, `cargo fmt --all -- --check`, `cargo test --release -p perry-runtime process`, `cargo test --release -p perry-hir` (132 passing incl. `expr_variant_stable_hash_tags_are_unique`).
