### PR TITLE
fix(node:http/https): client request/get argument-overload normalization

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/http.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/http.rs
@@ -11,13 +11,22 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
     // handle; the let-stmt arm in `crates/perry-hir/src/lower.rs` tags
     // the binding so `req.on/.end/.write/...` dispatch via the
     // class-filtered entries below.
+    // #3226/#3227/#3228 — client factory overloads. Node accepts
+    // `request(url[, cb])`, `request(options[, cb])`, and
+    // `request(url, options[, cb])` (same for `get`). A fixed
+    // `[NA_F64, NA_PTR]` shape mis-routed the options object into the
+    // callback slot and dropped the real callback in the three-arg form.
+    // Pass every user arg as a JS array (`NA_VARARGS`, mirroring the
+    // `listen()` rows) and let the runtime `*_overload` entry points
+    // resolve `(url, options, callback)` by value type. Runtime impls
+    // live in `crates/perry-ext-http/src/lib.rs`.
     NativeModSig {
         module: "http",
         has_receiver: false,
         method: "request",
         class_filter: None,
-        runtime: "js_http_request",
-        args: &[NA_F64, NA_PTR],
+        runtime: "js_http_request_overload",
+        args: &[NA_VARARGS],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -25,8 +34,8 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         has_receiver: false,
         method: "get",
         class_filter: None,
-        runtime: "js_http_get",
-        args: &[NA_F64, NA_PTR],
+        runtime: "js_http_get_overload",
+        args: &[NA_VARARGS],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -34,8 +43,8 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         has_receiver: false,
         method: "request",
         class_filter: None,
-        runtime: "js_https_request",
-        args: &[NA_F64, NA_PTR],
+        runtime: "js_https_request_overload",
+        args: &[NA_VARARGS],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -43,8 +52,8 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         has_receiver: false,
         method: "get",
         class_filter: None,
-        runtime: "js_https_get",
-        args: &[NA_F64, NA_PTR],
+        runtime: "js_https_get_overload",
+        args: &[NA_VARARGS],
         ret: NR_PTR,
     },
     // ClientRequest instance methods (`req.on/.end/.write/.setHeader/.setTimeout`).

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -15,6 +15,13 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_http_client_request_end", I64, &[I64, DOUBLE]);
     module.declare_function("js_http_client_request_write", I64, &[I64, DOUBLE]);
     module.declare_function("js_http_get", I64, &[DOUBLE, I64]);
+    // #3226/#3227/#3228 — overload-normalizing client factories take a
+    // single `NA_VARARGS` array (i64 ArrayHeader ptr) and return a
+    // ClientRequest handle.
+    module.declare_function("js_http_get_overload", I64, &[I64]);
+    module.declare_function("js_http_request_overload", I64, &[I64]);
+    module.declare_function("js_https_get_overload", I64, &[I64]);
+    module.declare_function("js_https_request_overload", I64, &[I64]);
     module.declare_function("js_http_on", I64, &[I64, I64, I64]);
     module.declare_function("js_http_request", I64, &[DOUBLE, I64]);
     module.declare_function("js_http_request_body", I64, &[I64]);

--- a/crates/perry-ext-http/src/client_overload.rs
+++ b/crates/perry-ext-http/src/client_overload.rs
@@ -1,0 +1,231 @@
+//! Client factory overload normalization for `http.request` /
+//! `http.get` / `https.request` / `https.get` (#3226 / #3227 / #3228).
+//!
+//! Codegen packs every user argument into a single JS array
+//! (`NA_VARARGS`); these helpers resolve `(url, options, callback)` by
+//! value type so all Node overloads work: `(url[, cb])`,
+//! `(options[, cb])`, and `(url, options[, cb])`. Extracted from
+//! `lib.rs` to keep that file under the 2000-line lint cap.
+
+use std::collections::HashMap;
+
+use perry_ffi::{ArrayHeader, Handle, JsValue};
+
+use super::{
+    agent, extract_string_value, headers_from_options, is_string_value, method_from_options,
+    parse_options_object, timeout_from_options, url_from_options, PTR_MASK, TAG_UNDEFINED,
+};
+
+// ------------------------------------------------------------------
+// Client factory overload normalization (#3226 / #3227 / #3228)
+// ------------------------------------------------------------------
+
+/// Resolved positional arguments for `request()` / `get()` after Node's
+/// type-directed overload handling. Mirrors `parse_listen_args` in
+/// `perry-ext-http-server`: codegen packs every user argument into a
+/// single JS array (`NA_VARARGS`) and we resolve each slot by value
+/// type so the callback is picked up wherever it floats.
+pub(crate) struct ClientArgs {
+    /// First string argument — the URL (`request(url, ...)` /
+    /// `get(url, ...)`). `undefined` when the caller passed only an
+    /// options object.
+    pub(crate) url: f64,
+    /// First object argument — the options bag (`request(options, ...)`
+    /// or the options half of `request(url, options, ...)`). `undefined`
+    /// when the caller passed only a URL.
+    pub(crate) opts: f64,
+    /// Raw `*const ClosureHeader` pointer for the response callback, or
+    /// `0` when no function argument was supplied.
+    pub(crate) callback: i64,
+}
+
+/// Normalize the JS-side `http.request(...)` / `http.get(...)` argument
+/// array into `(url, options, callback)`. Accepts every Node overload:
+/// `(url[, cb])`, `(options[, cb])`, and `(url, options[, cb])`. The
+/// single function argument is the response callback regardless of
+/// position; the first string is the URL; the first object is the
+/// options bag.
+///
+/// # Safety
+/// `args_array` must be `0`/null or a valid Perry-runtime `ArrayHeader`.
+pub(crate) unsafe fn parse_client_args(args_array: i64) -> ClientArgs {
+    let mut out = ClientArgs {
+        url: f64::from_bits(TAG_UNDEFINED),
+        opts: f64::from_bits(TAG_UNDEFINED),
+        callback: 0,
+    };
+    let arr_ptr = args_array as *const ArrayHeader;
+    if arr_ptr.is_null() {
+        return out;
+    }
+    // Codegen passes a clean raw pointer; reject a stray NaN-boxed value
+    // rather than dereferencing tag bits as an address.
+    if (args_array as u64) >> 48 != 0 {
+        return out;
+    }
+    let len = (*arr_ptr).length as usize;
+    let elements = (arr_ptr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const u64;
+    for i in 0..len {
+        let bits = *elements.add(i);
+        // The response callback is the (single) function argument — match
+        // it by value type, not position.
+        if js_value_is_closure(bits as i64) != 0 {
+            out.callback = (bits & PTR_MASK) as i64;
+            continue;
+        }
+        let f = f64::from_bits(bits);
+        let v = JsValue::from_bits(bits);
+        if is_string_value(f) {
+            if out.url.to_bits() == TAG_UNDEFINED {
+                out.url = f;
+            }
+        } else if !v.is_undefined() && !v.is_null() && v.is_pointer() {
+            // First non-string, non-callback pointer → options object.
+            // (A bare `URL` instance also lands here; `url_from_options`
+            // reads its `protocol`/`host`/`pathname` via JSON-stringify.)
+            if out.opts.to_bits() == TAG_UNDEFINED {
+                out.opts = f;
+            }
+        }
+    }
+    out
+}
+
+extern "C" {
+    /// `crates/perry-runtime/src/closure/dynamic_props.rs::js_value_is_closure`.
+    fn js_value_is_closure(value_bits: i64) -> i32;
+}
+
+/// Merge a URL string with an options object into the request fields.
+/// The URL supplies protocol / host / port / path; the options bag
+/// overrides method, headers, timeout, agent, and any explicitly-set
+/// protocol / host / port / path. When `url_f64` is `undefined`, this
+/// degenerates to the options-only path; when `opts_f64` is
+/// `undefined`, to the URL-only path.
+pub(crate) unsafe fn merge_url_and_options(
+    url_f64: f64,
+    opts_f64: f64,
+    default_protocol: &str,
+) -> (String, HashMap<String, String>, Option<u64>, Handle) {
+    let opts = parse_options_object(opts_f64);
+    let has_opts = opts.is_some();
+    let opts = opts.unwrap_or(serde_json::Value::Null);
+
+    let url = if is_string_value(url_f64) {
+        let raw = extract_string_value(url_f64).unwrap_or_default();
+        let base = if raw.starts_with("http://") || raw.starts_with("https://") {
+            raw
+        } else if !raw.is_empty() {
+            format!("{}://{}", default_protocol, raw)
+        } else {
+            String::new()
+        };
+        // When both a URL and an options object are given, options fields
+        // (protocol/host/port/path) override the URL-derived parts. Node
+        // merges this way; we mirror it by re-parsing the URL and letting
+        // present option keys win.
+        if has_opts {
+            merge_options_onto_url(&base, &opts, default_protocol)
+        } else {
+            base
+        }
+    } else {
+        url_from_options(&opts, default_protocol)
+    };
+
+    let headers = if has_opts {
+        headers_from_options(&opts)
+    } else {
+        HashMap::new()
+    };
+    let timeout = if has_opts {
+        timeout_from_options(&opts)
+    } else {
+        None
+    };
+    let agent_handle = if has_opts {
+        agent::agent_handle_from_options(opts_f64).unwrap_or(0)
+    } else {
+        0
+    };
+
+    (url, headers, timeout, agent_handle)
+}
+
+/// Rebuild a URL string, overriding its parts with any present option
+/// keys (`protocol` / `hostname` / `host` / `port` / `path`). Used for
+/// the `request(url, options, cb)` overload.
+fn merge_options_onto_url(
+    base_url: &str,
+    opts: &serde_json::Value,
+    default_protocol: &str,
+) -> String {
+    let parsed = reqwest::Url::parse(base_url).ok();
+
+    let protocol = opts
+        .get("protocol")
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim_end_matches(':').to_string())
+        .or_else(|| parsed.as_ref().map(|p| p.scheme().to_string()))
+        .unwrap_or_else(|| default_protocol.to_string());
+
+    let raw_host = opts
+        .get("hostname")
+        .and_then(|v| v.as_str())
+        .or_else(|| opts.get("host").and_then(|v| v.as_str()))
+        .map(|s| s.split(':').next().unwrap_or(s).to_string())
+        .or_else(|| parsed.as_ref().and_then(|p| p.host_str().map(String::from)))
+        .unwrap_or_else(|| "localhost".to_string());
+
+    let port = opts
+        .get("port")
+        .and_then(|v| {
+            v.as_str()
+                .map(String::from)
+                .or_else(|| v.as_i64().map(|n| n.to_string()))
+                .or_else(|| v.as_u64().map(|n| n.to_string()))
+                .or_else(|| v.as_f64().map(|n| (n as u64).to_string()))
+        })
+        .or_else(|| {
+            parsed
+                .as_ref()
+                .and_then(|p| p.port().map(|n| n.to_string()))
+        });
+
+    let path = opts
+        .get("path")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .or_else(|| {
+            parsed.as_ref().map(|p| {
+                let mut s = p.path().to_string();
+                if let Some(q) = p.query() {
+                    s.push('?');
+                    s.push_str(q);
+                }
+                if s.is_empty() {
+                    s.push('/');
+                }
+                s
+            })
+        })
+        .unwrap_or_else(|| "/".to_string());
+
+    match port {
+        Some(p) if !p.is_empty() => format!("{}://{}:{}{}", protocol, raw_host, p, path),
+        _ => format!("{}://{}{}", protocol, raw_host, path),
+    }
+}
+
+/// Resolve the request method for the merged overload: `force_get`
+/// (the `get()` factories) always yields `GET`; otherwise the options
+/// `method` field, defaulting to `GET`.
+pub(crate) unsafe fn method_for_overload(opts_f64: f64, force_get: bool) -> String {
+    if force_get {
+        return "GET".to_string();
+    }
+    match parse_options_object(opts_f64) {
+        Some(opts) => method_from_options(&opts),
+        None => "GET".to_string(),
+    }
+}

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -48,6 +48,11 @@ extern crate perry_ext_http_server as _server_link;
 mod agent;
 pub use agent::*;
 
+// Client factory overload normalization (#3226 / #3227 / #3228) —
+// extracted from this file to stay under the 2000-line lint cap.
+mod client_overload;
+use client_overload::{merge_url_and_options, method_for_overload, parse_client_args};
+
 use lazy_static::lazy_static;
 use perry_ffi::{
     alloc_string, gc_register_mutable_root_scanner_named, get_handle_mut, iter_handles_of_mut,
@@ -1070,6 +1075,53 @@ pub unsafe extern "C" fn js_http_get(arg_f64: f64, callback_i64: i64) -> Handle 
 #[no_mangle]
 pub unsafe extern "C" fn js_https_get(arg_f64: f64, callback_i64: i64) -> Handle {
     get_common(arg_f64, callback_i64, "https")
+}
+
+// ------------------------------------------------------------------
+// FFI: overload-normalizing client factories (#3226 / #3227 / #3228)
+//
+// Codegen routes `http.request` / `http.get` / `https.request` /
+// `https.get` to these `*_overload` entry points with a single
+// `NA_VARARGS` argument — a JS array holding every user argument.
+// `parse_client_args` resolves `(url, options, callback)` by value
+// type so all overloads work: `(url[, cb])`, `(options[, cb])`, and
+// `(url, options[, cb])`. The URL supplies protocol/host/port/path;
+// options override method/headers/timeout/agent (and any explicitly
+// set protocol/host/port/path).
+// ------------------------------------------------------------------
+
+unsafe fn request_overload(args_array: i64, default_protocol: &str, force_get: bool) -> Handle {
+    ensure_gc_scanner_registered();
+    let parsed = parse_client_args(args_array);
+    let method = method_for_overload(parsed.opts, force_get);
+    let (url, headers, timeout, agent_handle) =
+        merge_url_and_options(parsed.url, parsed.opts, default_protocol);
+    let handle = make_request_handle(method, url, headers, timeout, parsed.callback, agent_handle);
+    if force_get {
+        // `get()` auto-`end()`s, kicking off the request.
+        js_http_client_request_end(handle, f64::from_bits(TAG_UNDEFINED));
+    }
+    handle
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_http_request_overload(args_array: i64) -> Handle {
+    request_overload(args_array, "http", false)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_https_request_overload(args_array: i64) -> Handle {
+    request_overload(args_array, "https", false)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_http_get_overload(args_array: i64) -> Handle {
+    request_overload(args_array, "http", true)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_https_get_overload(args_array: i64) -> Handle {
+    request_overload(args_array, "https", true)
 }
 
 // http.Agent / https.Agent (#2129 / #2154) lives in `agent.rs`.

--- a/test-files/test_gap_http_overloads_3226plus.ts
+++ b/test-files/test_gap_http_overloads_3226plus.ts
@@ -1,0 +1,132 @@
+// Gap test: node:http client factory argument-overload normalization
+// (#3226 / #3227 / #3228). Byte-for-byte parity against
+// `node --experimental-strip-types`.
+//
+// Exercises every Node overload of http.request / http.get against a
+// LOCAL ephemeral-port server (no external network):
+//   - request(url, cb)
+//   - request(options, cb)
+//   - request(url, options, cb)   ← the form that previously dropped the
+//                                    callback / mis-routed the options object
+//   - get(url, cb)
+//   - get(options, cb)
+//   - get(url, options, cb)
+//
+// Each handler echoes the request method + url so the response proves the
+// URL and options merged correctly (e.g. `request(url, {method:"PUT"})`
+// must yield `PUT /c`, while `get(url, {...})` keeps `GET`). Requests run
+// sequentially via callback chaining so output is deterministic; the
+// server closes after the last response so the program exits.
+
+import * as http from "node:http";
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { "content-type": "text/plain" });
+  res.end(`${req.method} ${req.url}`);
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const addr: any = server.address();
+  const port = addr.port;
+  const base = `http://127.0.0.1:${port}`;
+  const lines: string[] = [];
+
+  function finish() {
+    for (const l of lines) console.log(l);
+    server.close();
+  }
+
+  // get(url, options, cb) — get() keeps method GET even with options.
+  function step6() {
+    const r = http.get(`${base}/f`, { headers: { "x-test": "1" } }, (res: any) => {
+      let body = "";
+      res.on("data", (c: any) => {
+        body += c.toString();
+      });
+      res.on("end", () => {
+        lines.push(`get(url,options,cb): status=${res.statusCode} body=${body}`);
+        finish();
+      });
+    });
+    r.on("error", () => finish());
+  }
+
+  // get(options, cb)
+  function step5() {
+    const r = http.get({ host: "127.0.0.1", port, path: "/e" }, (res: any) => {
+      let body = "";
+      res.on("data", (c: any) => {
+        body += c.toString();
+      });
+      res.on("end", () => {
+        lines.push(`get(options,cb): status=${res.statusCode} body=${body}`);
+        step6();
+      });
+    });
+    r.on("error", () => step6());
+  }
+
+  // get(url, cb)
+  function step4() {
+    const r = http.get(`${base}/d`, (res: any) => {
+      let body = "";
+      res.on("data", (c: any) => {
+        body += c.toString();
+      });
+      res.on("end", () => {
+        lines.push(`get(url,cb): status=${res.statusCode} body=${body}`);
+        step5();
+      });
+    });
+    r.on("error", () => step5());
+  }
+
+  // request(url, options, cb) — URL gives host/path, options give method.
+  function step3() {
+    const r = http.request(`${base}/c`, { method: "PUT" }, (res: any) => {
+      let body = "";
+      res.on("data", (c: any) => {
+        body += c.toString();
+      });
+      res.on("end", () => {
+        lines.push(`request(url,options,cb): status=${res.statusCode} body=${body}`);
+        step4();
+      });
+    });
+    r.on("error", () => step4());
+    r.end();
+  }
+
+  // request(options, cb)
+  function step2() {
+    const r = http.request(
+      { host: "127.0.0.1", port, path: "/b", method: "POST" },
+      (res: any) => {
+        let body = "";
+        res.on("data", (c: any) => {
+          body += c.toString();
+        });
+        res.on("end", () => {
+          lines.push(`request(options,cb): status=${res.statusCode} body=${body}`);
+          step3();
+        });
+      },
+    );
+    r.on("error", () => step3());
+    r.end();
+  }
+
+  // request(url, cb)
+  const r = http.request(`${base}/a`, (res: any) => {
+    let body = "";
+    res.on("data", (c: any) => {
+      body += c.toString();
+    });
+    res.on("end", () => {
+      lines.push(`request(url,cb): status=${res.statusCode} body=${body}`);
+      step2();
+    });
+  });
+  r.on("error", () => step2());
+  r.end();
+});


### PR DESCRIPTION
## Summary
Normalizes `http.request` / `http.get` / `https.request` / `https.get` argument overloads before building the `ClientRequest`. Node accepts `request(url[, cb])`, `request(options[, cb])`, and `request(url, options[, cb])` (same for `get()`), but Perry's fixed `[NA_F64, NA_PTR]` dispatch shape mis-routed the options object into the callback slot and dropped the real callback in the three-argument form.

Closes #3226
Closes #3227
Closes #3228

## Implementation
- **Codegen** (`native_table/http.rs`): the four client-factory rows now use `NA_VARARGS` (mirroring the existing `listen()` rows) and point at new runtime entry points `js_http_request_overload` / `js_http_get_overload` / `js_https_request_overload` / `js_https_get_overload`. No new HIR variant.
- **Runtime** (`perry-ext-http`): `parse_client_args` resolves `(url, options, callback)` by value type so the callback is picked up wherever it floats; the URL supplies protocol/host/port/path and options override method/headers/timeout/agent (and any explicitly set protocol/host/port/path). `get()` keeps method `GET`. Extracted into a new sibling module `client_overload.rs` to keep `lib.rs` under the 2000-line lint cap.
- `runtime_decls/stdlib_ffi.rs`: declares the four new `*_overload` symbols.

## Validation
New gap test `test-files/test_gap_http_overloads_3226plus.ts` starts a local server on an ephemeral port (`127.0.0.1:0`, no external network) and exercises all six overload forms (string url / options obj / url+options, for both `request` and `get`), echoing `${method} ${url}` back. Output is byte-for-byte **IDENTICAL** to `node --experimental-strip-types` under the default auto-optimize compile:

```
request(url,cb): status=200 body=GET /a
request(options,cb): status=200 body=POST /b
request(url,options,cb): status=200 body=PUT /c
get(url,cb): status=200 body=GET /d
get(options,cb): status=200 body=GET /e
get(url,options,cb): status=200 body=GET /f
```

Guards green: `check_file_size.sh` (OK), `cargo fmt --all -- --check` (clean), `cargo test -p perry-ext-http` / `-p perry-codegen` / `-p perry-hir` (all pass). No HIR variant added; no api-docs drift.

## Notes
- `https` shares the identical `request_overload` code path; the gap test stays http-only to avoid a self-signed-TLS fixture, but the https symbols are wired and link-verified.
- An orthogonal, pre-existing async gap (a response `IncomingMessage` passed *as a function parameter* doesn't dispatch `res.on(...)`; and `await`-ing an event-resolved Promise inside the `listen` callback hangs) is avoided in the test by inlining the response handlers — not part of this overload-normalization cut.
