### PR TITLE
fix(node:dns): avoid unavailable NI_MAXSERV constant

### DIFF
--- a/crates/perry-runtime/src/dns.rs
+++ b/crates/perry-runtime/src/dns.rs
@@ -325,8 +325,10 @@ fn lookup_service(address: &str, port: u16) -> Result<(String, String), String> 
 
 #[cfg(unix)]
 unsafe fn getnameinfo(sa: &SocketAddr) -> Result<(String, String), String> {
+    const NI_MAXSERV_FALLBACK: usize = 32;
+
     let mut host_buf = [0i8; libc::NI_MAXHOST as usize];
-    let mut serv_buf = [0i8; libc::NI_MAXSERV as usize];
+    let mut serv_buf = [0i8; NI_MAXSERV_FALLBACK];
 
     let (sa_ptr, sa_len): (*const libc::sockaddr, libc::socklen_t) = match sa {
         SocketAddr::V4(v4) => {


### PR DESCRIPTION
## Summary
- avoid depending on `libc::NI_MAXSERV` in the Unix `lookupService` getnameinfo buffer path
- use a fixed 32-byte service-name buffer, matching the POSIX service-name limit used by getnameinfo callers

## Tests
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `cargo test -p perry-codegen --test manifest_consistency`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`