### PR TITLE
fix(runtime): brand-check collection prototype methods (#3662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1045 — fix(runtime): brand-check collection prototype methods (#3662)
+
+`Set`/`Map`/`WeakSet`/`WeakMap` prototype methods reached as plain values —
+`Set.prototype.add.call(x, v)`, `Reflect.apply(Map.prototype.get, m, [k])`,
+method extraction, etc. — resolved to a shared no-op thunk
+(`global_this_builtin_noop_thunk`). The reflective path therefore did nothing
+and never performed the spec-mandated `this` brand check, so calling these
+methods on an incompatible receiver produced no exception. This was the
+largest single behavioral cluster in the #3662 parity sweep
+("Expected a … to be thrown but no exception was thrown at all").
+
+`populate_builtin_prototype_methods` now installs real per-method thunks for
+the four collection prototypes (`set_proto_*`, `map_proto_*`,
+`weakset_proto_*`, `weakmap_proto_*`). Each thunk:
+
+1. reads the `IMPLICIT_THIS` receiver (set by the `.call`/`.apply`/`.bind`
+   dispatch),
+2. brand-checks it — a registered `Set`/`Map` heap pointer, or the reserved
+   `CLASS_ID_WEAKMAP`/`CLASS_ID_WEAKSET` `class_id` — and throws a `TypeError`
+   ("Method `<proto>`.`<method>` called on incompatible receiver") on a
+   mismatched or primitive receiver, and
+3. otherwise dispatches to the existing runtime helper (`js_set_add`,
+   `js_map_get`, `js_weakmap_set`, …), so reflective collection calls now also
+   *work* on a correct receiver (previously they silently returned
+   `undefined`).
+
+The fast direct-call path (`s.add(v)`) is lowered straight to `js_set_add` by
+codegen and never touches these thunks, so it is unaffected — verified
+byte-identical against Node in both the `PERRY_NO_AUTO_OPTIMIZE` and
+auto-optimize build paths.
+
+New receiver-resolution helpers: `set::set_ptr_from_receiver_bits`,
+`map::map_ptr_from_receiver_bits`, `weakref::weak_class_id_from_receiver`
+(the latter pre-filters on `GcHeader.obj_type == GC_TYPE_OBJECT` before
+reading `class_id`, so a `Set`/`Map` pointer or primitive resolves to `None`
+without an out-of-bounds read). Covered by
+`test-files/test_gap_3662_collection_brand_check.ts`. The broader #3662
+cluster (Function.prototype apply/bind/hasInstance not-callable checks and the
+node-core fs/buffer/process/zlib arg-validation cases) remains open.
+
 ## v0.5.1044 — fix(fs): deliver EBADF to callback for bad fd in close/fsync/fdatasync/fchmod (#3332)
 
 The callback forms of `fs.close`, `fs.fsync`, `fs.fdatasync`, and `fs.fchmod`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1044
+**Current Version:** 0.5.1045
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4880,7 +4880,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "anyhow",
  "base64",
@@ -4935,14 +4935,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "cc",
  "libc",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "anyhow",
  "log",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "anyhow",
  "base64",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "serde",
  "serde_json",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1044"
+version = "0.5.1045"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "anyhow",
  "clap",
@@ -5056,14 +5056,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "chrono",
  "cron",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5162,14 +5162,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "base64",
  "image",
@@ -5354,14 +5354,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5388,7 +5388,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "brotli",
  "flate2",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "anyhow",
  "base64",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5571,14 +5571,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "base64",
  "itoa",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "base64",
  "block2",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "base64",
  "block2",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1044"
+version = "0.5.1045"
 
 [[package]]
 name = "perry-ui-test"
@@ -5667,11 +5667,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1044"
+version = "0.5.1045"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "base64",
  "block2",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "base64",
  "block2",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "block2",
  "libc",
@@ -5716,7 +5716,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "base64",
  "libc",
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1044"
+version = "0.5.1045"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1044"
+version = "0.5.1045"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -97,6 +97,27 @@ pub fn is_registered_map(addr: usize) -> bool {
     MAP_REGISTRY.with(|r| r.borrow().contains(&addr))
 }
 
+/// Resolve a NaN-boxed (or raw-i64) `this` receiver to a registered `Map`
+/// pointer, or `None` if the receiver is not a `Map`. Backs the reflective
+/// `Map.prototype.*` thunks so they can perform the spec brand check
+/// (`TypeError` on a non-`Map` receiver) before dispatching. See
+/// `set::set_ptr_from_receiver_bits` for the receiver-extraction rationale.
+pub fn map_ptr_from_receiver_bits(bits: u64) -> Option<*mut MapHeader> {
+    let jsv = crate::value::JSValue::from_bits(bits);
+    let addr = if jsv.is_pointer() {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else if bits >> 48 == 0 && bits > 0x10000 {
+        bits as usize
+    } else {
+        return None;
+    };
+    if is_registered_map(addr) {
+        Some(addr as *mut MapHeader)
+    } else {
+        None
+    }
+}
+
 /// Numeric-key index entry: hashed/compared by raw f64 bits only.
 /// Strings/object-pointer keys are NOT inserted here — those still go
 /// through the linear-scan fallback in `find_key_index`. The reason is

--- a/crates/perry-runtime/src/object/collection_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/collection_proto_thunks.rs
@@ -1,0 +1,296 @@
+//! Collection prototype-method thunks (#3662).
+//!
+//! `Set.prototype.add` & friends are reachable as plain values (e.g.
+//! `Set.prototype.add.call(x, v)`, `Reflect.apply`, method extraction). The
+//! fast path `s.add(v)` is lowered directly to `js_set_add` by codegen and
+//! never touches these thunks, so they only fire on the reflective path —
+//! which previously resolved to `global_this_builtin_noop_thunk` and silently
+//! did nothing. Per spec these methods must perform a `this` brand check and
+//! throw a `TypeError` when called on an incompatible receiver. The thunks
+//! below read the `IMPLICIT_THIS` receiver (set by the `.call`/`.apply`
+//! dispatch), brand-check it, throw on mismatch, and otherwise dispatch to the
+//! real runtime helper — so reflective collection calls now also *work*.
+//!
+//! Installed onto each collection's `.prototype` by
+//! `global_this::populate_builtin_prototype_methods`.
+
+use super::*;
+
+/// Throw `TypeError: Method <proto>.<method> called on incompatible receiver`.
+/// Mirrors V8's wording closely; Test262's brand-check tests assert only the
+/// error *type*, so the exact message is informational. Never returns.
+fn throw_incompatible_receiver(proto: &str, method: &str) -> ! {
+    let msg = format!("Method {proto}.{method} called on incompatible receiver");
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(f64::from_bits(
+        crate::value::JSValue::pointer(err as *const u8).bits(),
+    ))
+}
+
+#[inline]
+fn set_receiver_or_throw(method: &str) -> *mut crate::set::SetHeader {
+    let bits = IMPLICIT_THIS.with(|c| c.get());
+    match crate::set::set_ptr_from_receiver_bits(bits) {
+        Some(p) => p,
+        None => throw_incompatible_receiver("Set.prototype", method),
+    }
+}
+
+#[inline]
+fn map_receiver_or_throw(method: &str) -> *mut crate::map::MapHeader {
+    let bits = IMPLICIT_THIS.with(|c| c.get());
+    match crate::map::map_ptr_from_receiver_bits(bits) {
+        Some(p) => p,
+        None => throw_incompatible_receiver("Map.prototype", method),
+    }
+}
+
+#[inline]
+fn weak_receiver_or_throw(expected: u32, proto: &str, method: &str) -> f64 {
+    let receiver = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    match crate::weakref::weak_class_id_from_receiver(receiver) {
+        Some(cid) if cid == expected => receiver,
+        _ => throw_incompatible_receiver(proto, method),
+    }
+}
+
+pub(super) extern "C" fn set_proto_add_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    v: f64,
+) -> f64 {
+    let set = set_receiver_or_throw("add");
+    let r = crate::set::js_set_add(set, v);
+    f64::from_bits(crate::value::JSValue::pointer(r as *mut u8).bits())
+}
+
+pub(super) extern "C" fn set_proto_has_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    v: f64,
+) -> f64 {
+    let set = set_receiver_or_throw("has");
+    f64::from_bits(crate::value::JSValue::bool(crate::set::js_set_has(set, v) != 0).bits())
+}
+
+pub(super) extern "C" fn set_proto_delete_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    v: f64,
+) -> f64 {
+    let set = set_receiver_or_throw("delete");
+    f64::from_bits(crate::value::JSValue::bool(crate::set::js_set_delete(set, v) != 0).bits())
+}
+
+pub(super) extern "C" fn set_proto_clear_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _v: f64,
+) -> f64 {
+    let set = set_receiver_or_throw("clear");
+    crate::set::js_set_clear(set);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+pub(super) extern "C" fn set_proto_foreach_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    cb: f64,
+    this_arg: f64,
+) -> f64 {
+    let set = set_receiver_or_throw("forEach");
+    crate::set::js_set_foreach(set, cb, this_arg);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+pub(super) extern "C" fn set_proto_values_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _v: f64,
+) -> f64 {
+    let set = set_receiver_or_throw("values");
+    f64::from_bits(
+        crate::value::JSValue::pointer(
+            crate::collection_iter_object::js_set_values_iter_obj(set) as *mut u8
+        )
+        .bits(),
+    )
+}
+
+pub(super) extern "C" fn set_proto_keys_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _v: f64,
+) -> f64 {
+    let set = set_receiver_or_throw("keys");
+    f64::from_bits(
+        crate::value::JSValue::pointer(
+            crate::collection_iter_object::js_set_values_iter_obj(set) as *mut u8
+        )
+        .bits(),
+    )
+}
+
+pub(super) extern "C" fn set_proto_entries_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _v: f64,
+) -> f64 {
+    let set = set_receiver_or_throw("entries");
+    f64::from_bits(
+        crate::value::JSValue::pointer(
+            crate::collection_iter_object::js_set_entries_iter_obj(set) as *mut u8
+        )
+        .bits(),
+    )
+}
+
+pub(super) extern "C" fn map_proto_get_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    k: f64,
+) -> f64 {
+    let map = map_receiver_or_throw("get");
+    crate::map::js_map_get(map, k)
+}
+
+pub(super) extern "C" fn map_proto_set_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    k: f64,
+    v: f64,
+) -> f64 {
+    let map = map_receiver_or_throw("set");
+    let r = crate::map::js_map_set(map, k, v);
+    f64::from_bits(crate::value::JSValue::pointer(r as *mut u8).bits())
+}
+
+pub(super) extern "C" fn map_proto_has_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    k: f64,
+) -> f64 {
+    let map = map_receiver_or_throw("has");
+    f64::from_bits(crate::value::JSValue::bool(crate::map::js_map_has(map, k) != 0).bits())
+}
+
+pub(super) extern "C" fn map_proto_delete_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    k: f64,
+) -> f64 {
+    let map = map_receiver_or_throw("delete");
+    f64::from_bits(crate::value::JSValue::bool(crate::map::js_map_delete(map, k) != 0).bits())
+}
+
+pub(super) extern "C" fn map_proto_clear_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _v: f64,
+) -> f64 {
+    let map = map_receiver_or_throw("clear");
+    crate::map::js_map_clear(map);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+pub(super) extern "C" fn map_proto_foreach_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    cb: f64,
+    this_arg: f64,
+) -> f64 {
+    let map = map_receiver_or_throw("forEach");
+    crate::map::js_map_foreach(map, cb, this_arg);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+pub(super) extern "C" fn map_proto_keys_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _v: f64,
+) -> f64 {
+    let map = map_receiver_or_throw("keys");
+    f64::from_bits(
+        crate::value::JSValue::pointer(
+            crate::collection_iter_object::js_map_keys_iter_obj(map) as *mut u8
+        )
+        .bits(),
+    )
+}
+
+pub(super) extern "C" fn map_proto_values_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _v: f64,
+) -> f64 {
+    let map = map_receiver_or_throw("values");
+    f64::from_bits(
+        crate::value::JSValue::pointer(
+            crate::collection_iter_object::js_map_values_iter_obj(map) as *mut u8
+        )
+        .bits(),
+    )
+}
+
+pub(super) extern "C" fn map_proto_entries_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _v: f64,
+) -> f64 {
+    let map = map_receiver_or_throw("entries");
+    f64::from_bits(
+        crate::value::JSValue::pointer(
+            crate::collection_iter_object::js_map_entries_iter_obj(map) as *mut u8
+        )
+        .bits(),
+    )
+}
+
+pub(super) extern "C" fn weakset_proto_add_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    v: f64,
+) -> f64 {
+    let r = weak_receiver_or_throw(crate::weakref::CLASS_ID_WEAKSET, "WeakSet.prototype", "add");
+    crate::weakref::js_weakset_add(r, v)
+}
+
+pub(super) extern "C" fn weakset_proto_has_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    v: f64,
+) -> f64 {
+    let r = weak_receiver_or_throw(crate::weakref::CLASS_ID_WEAKSET, "WeakSet.prototype", "has");
+    crate::weakref::js_weakmap_has(r, v)
+}
+
+pub(super) extern "C" fn weakset_proto_delete_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    v: f64,
+) -> f64 {
+    let r = weak_receiver_or_throw(
+        crate::weakref::CLASS_ID_WEAKSET,
+        "WeakSet.prototype",
+        "delete",
+    );
+    crate::weakref::js_weakmap_delete(r, v)
+}
+
+pub(super) extern "C" fn weakmap_proto_get_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    k: f64,
+) -> f64 {
+    let r = weak_receiver_or_throw(crate::weakref::CLASS_ID_WEAKMAP, "WeakMap.prototype", "get");
+    crate::weakref::js_weakmap_get(r, k)
+}
+
+pub(super) extern "C" fn weakmap_proto_set_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    k: f64,
+    v: f64,
+) -> f64 {
+    let r = weak_receiver_or_throw(crate::weakref::CLASS_ID_WEAKMAP, "WeakMap.prototype", "set");
+    crate::weakref::js_weakmap_set(r, k, v)
+}
+
+pub(super) extern "C" fn weakmap_proto_has_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    k: f64,
+) -> f64 {
+    let r = weak_receiver_or_throw(crate::weakref::CLASS_ID_WEAKMAP, "WeakMap.prototype", "has");
+    crate::weakref::js_weakmap_has(r, k)
+}
+
+pub(super) extern "C" fn weakmap_proto_delete_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    k: f64,
+) -> f64 {
+    let r = weak_receiver_or_throw(
+        crate::weakref::CLASS_ID_WEAKMAP,
+        "WeakMap.prototype",
+        "delete",
+    );
+    crate::weakref::js_weakmap_delete(r, k)
+}

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -9,6 +9,10 @@
 
 use super::*;
 
+// #3662: per-method brand-checking thunks for the collection prototypes,
+// installed by `populate_builtin_prototype_methods` below.
+use super::collection_proto_thunks::*;
+
 /// Issue #611 (Effect): `globalThis[<computed>] = value` and the
 /// `(globalThis as any)[id] ??= new Map()` pattern (used by hono / Effect /
 /// most ESM libraries that ship a CJS-compat global side-store) wrote to
@@ -1681,47 +1685,77 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
         "Map" => {
-            install_noop_proto_methods(
+            // #3662: real thunks (brand-check `this` + dispatch) instead of
+            // no-ops, so reflective `Map.prototype.get.call(x, k)` throws a
+            // TypeError on a non-Map receiver (and works on a real Map).
+            install_proto_method(proto_obj, "clear", map_proto_clear_thunk as *const u8, 0);
+            install_proto_method(proto_obj, "delete", map_proto_delete_thunk as *const u8, 1);
+            install_proto_method(
                 proto_obj,
-                &[
-                    ("clear", 0),
-                    ("delete", 1),
-                    ("entries", 0),
-                    ("forEach", 1),
-                    ("get", 1),
-                    ("has", 1),
-                    ("keys", 0),
-                    ("set", 2),
-                    ("values", 0),
-                ],
+                "entries",
+                map_proto_entries_thunk as *const u8,
+                0,
             );
+            install_proto_method(
+                proto_obj,
+                "forEach",
+                map_proto_foreach_thunk as *const u8,
+                1,
+            );
+            install_proto_method(proto_obj, "get", map_proto_get_thunk as *const u8, 1);
+            install_proto_method(proto_obj, "has", map_proto_has_thunk as *const u8, 1);
+            install_proto_method(proto_obj, "keys", map_proto_keys_thunk as *const u8, 0);
+            install_proto_method(proto_obj, "set", map_proto_set_thunk as *const u8, 2);
+            install_proto_method(proto_obj, "values", map_proto_values_thunk as *const u8, 0);
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
         "Set" => {
-            install_noop_proto_methods(
+            // #3662: real thunks (brand-check `this` + dispatch) instead of
+            // no-ops; reflective `Set.prototype.add.call(x, v)` now throws a
+            // TypeError on a non-Set receiver (and works on a real Set).
+            install_proto_method(proto_obj, "add", set_proto_add_thunk as *const u8, 1);
+            install_proto_method(proto_obj, "clear", set_proto_clear_thunk as *const u8, 0);
+            install_proto_method(proto_obj, "delete", set_proto_delete_thunk as *const u8, 1);
+            install_proto_method(
                 proto_obj,
-                &[
-                    ("add", 1),
-                    ("clear", 0),
-                    ("delete", 1),
-                    ("entries", 0),
-                    ("forEach", 1),
-                    ("has", 1),
-                    ("keys", 0),
-                    ("values", 0),
-                ],
+                "entries",
+                set_proto_entries_thunk as *const u8,
+                0,
             );
+            install_proto_method(
+                proto_obj,
+                "forEach",
+                set_proto_foreach_thunk as *const u8,
+                1,
+            );
+            install_proto_method(proto_obj, "has", set_proto_has_thunk as *const u8, 1);
+            install_proto_method(proto_obj, "keys", set_proto_keys_thunk as *const u8, 0);
+            install_proto_method(proto_obj, "values", set_proto_values_thunk as *const u8, 0);
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
         "WeakMap" => {
-            install_noop_proto_methods(
+            // #3662: brand-checking thunks (non-WeakMap receiver -> TypeError).
+            install_proto_method(
                 proto_obj,
-                &[("delete", 1), ("get", 1), ("has", 1), ("set", 2)],
+                "delete",
+                weakmap_proto_delete_thunk as *const u8,
+                1,
             );
+            install_proto_method(proto_obj, "get", weakmap_proto_get_thunk as *const u8, 1);
+            install_proto_method(proto_obj, "has", weakmap_proto_has_thunk as *const u8, 1);
+            install_proto_method(proto_obj, "set", weakmap_proto_set_thunk as *const u8, 2);
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
         "WeakSet" => {
-            install_noop_proto_methods(proto_obj, &[("add", 1), ("delete", 1), ("has", 1)]);
+            // #3662: brand-checking thunks (non-WeakSet receiver -> TypeError).
+            install_proto_method(proto_obj, "add", weakset_proto_add_thunk as *const u8, 1);
+            install_proto_method(
+                proto_obj,
+                "delete",
+                weakset_proto_delete_thunk as *const u8,
+                1,
+            );
+            install_proto_method(proto_obj, "has", weakset_proto_has_thunk as *const u8, 1);
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
         "Error" | "TypeError" | "RangeError" | "SyntaxError" | "ReferenceError" | "EvalError"

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -30,6 +30,7 @@ mod class_constructors;
 mod class_gc_roots;
 mod class_handles;
 mod class_registry;
+mod collection_proto_thunks;
 mod delete_rest;
 mod descriptors;
 mod field_get_set;

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -121,6 +121,30 @@ pub fn is_registered_set(addr: usize) -> bool {
     SET_REGISTRY.with(|r| r.borrow().contains(&addr))
 }
 
+/// Resolve a NaN-boxed (or raw-i64) `this` receiver to a registered `Set`
+/// pointer, or `None` if the receiver is not a `Set`. Backs the reflective
+/// `Set.prototype.*` thunks so they can perform the spec brand check
+/// (`TypeError` on a non-`Set` receiver) before dispatching. Mirrors the
+/// receiver extraction used by the `Array.prototype.slice` thunk: a
+/// NaN-boxed pointer, or a bare raw-i64 pointer some module-init call sites
+/// stash in `IMPLICIT_THIS`. Primitives (undefined/null/number/string/bool)
+/// carry a non-zero tag in the top 16 bits and resolve to `None`.
+pub fn set_ptr_from_receiver_bits(bits: u64) -> Option<*mut SetHeader> {
+    let jsv = crate::value::JSValue::from_bits(bits);
+    let addr = if jsv.is_pointer() {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else if bits >> 48 == 0 && bits > 0x10000 {
+        bits as usize
+    } else {
+        return None;
+    };
+    if is_registered_set(addr) {
+        Some(addr as *mut SetHeader)
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn test_clear_set_roots() {
     SET_REGISTRY.with(|r| r.borrow_mut().clear());

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -337,6 +337,32 @@ pub unsafe fn try_weak_method_dispatch(
     Some(result)
 }
 
+/// Return the reserved WeakMap/WeakSet `class_id` of `receiver` if it is one
+/// of those collections, else `None`. Backs the reflective
+/// `WeakMap.prototype.*` / `WeakSet.prototype.*` thunks so they can perform
+/// the spec brand check (`TypeError` on a non-Weak* receiver) before
+/// dispatching. The `GcHeader.obj_type == GC_TYPE_OBJECT` pre-filter ensures
+/// the pointer is an `ObjectHeader`-backed allocation before `class_id` is
+/// read, so a `Set`/`Map` pointer (different `obj_type`) or a primitive
+/// (`js_nanbox_get_pointer` yields 0) safely resolves to `None`.
+pub fn weak_class_id_from_receiver(receiver: f64) -> Option<u32> {
+    let addr = js_nanbox_get_pointer(receiver) as usize;
+    if addr < 0x1000 + crate::gc::GC_HEADER_SIZE {
+        return None;
+    }
+    unsafe {
+        let header = (addr - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        if (*header).obj_type != crate::gc::GC_TYPE_OBJECT {
+            return None;
+        }
+        let cid = (*(addr as *const ObjectHeader)).class_id;
+        if cid == CLASS_ID_WEAKMAP || cid == CLASS_ID_WEAKSET {
+            return Some(cid);
+        }
+    }
+    None
+}
+
 unsafe fn entries_array(reg: *mut ObjectHeader) -> *mut ArrayHeader {
     let entries_key = crate::string::js_string_from_bytes(b"__perry_wk_entries".as_ptr(), 18);
     let entries_val = js_object_get_field_by_name(reg, entries_key);

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2132 entries across 99 modules
+// Coverage: 2134 entries across 99 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -1223,6 +1223,8 @@ declare module "events" {
   /** stdlib */
   export const errorMonitor: any;
   /** stdlib */
+  export const usingDomains: any;
+  /** stdlib */
   export function EventEmitter(...args: any[]): any;
   /** stdlib */
   export function addAbortListener(...args: any[]): any;
@@ -1230,6 +1232,8 @@ declare module "events" {
   export function getEventListeners(...args: any[]): any;
   /** stdlib */
   export function getMaxListeners(...args: any[]): any;
+  /** stdlib */
+  export function init(...args: any[]): any;
   /** stdlib */
   export function listenerCount(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2132 entries across 99 modules.
+Total: 2134 entries across 99 modules.
 
 ## Modules
 
@@ -986,6 +986,7 @@ Total: 2132 entries across 99 modules.
 - `getEventListeners` — module
 - `getMaxListeners` — instance
 - `getMaxListeners` — module
+- `init` — module
 - `listenerCount` — instance
 - `listenerCount` — module
 - `listeners` — instance
@@ -1008,6 +1009,7 @@ Total: 2132 entries across 99 modules.
 - `captureRejections`
 - `defaultMaxListeners`
 - `errorMonitor`
+- `usingDomains`
 
 ## `exponential-backoff`
 

--- a/test-files/test_gap_3662_collection_brand_check.ts
+++ b/test-files/test_gap_3662_collection_brand_check.ts
@@ -1,0 +1,64 @@
+// #3662 — built-in collection prototype methods must perform the spec `this`
+// brand check and throw a TypeError on an incompatible receiver, and must
+// actually work when invoked reflectively on a real collection.
+//
+// Pre-fix, `Set.prototype.add` & friends resolved to a shared no-op thunk:
+// reflective calls silently did nothing and never threw. This pins both the
+// brand-check throw (wrong `this` -> TypeError) and the now-working reflective
+// dispatch on a correct receiver. We print only error *types* / booleans so
+// the output is byte-identical to Node (engine error messages differ).
+
+function threw(fn: () => void): string {
+    try {
+        fn();
+        return "NO_THROW";
+    } catch (e: any) {
+        return e && e.name ? e.name : String(e);
+    }
+}
+
+// --- Brand check: wrong / primitive receiver must throw TypeError. ---
+console.log("Set.add{}:", threw(() => (Set.prototype.add as any).call({}, 1)));
+console.log("Set.has undef:", threw(() => (Set.prototype.has as any).call(undefined, 1)));
+console.log("Set.delete 5:", threw(() => (Set.prototype.delete as any).call(5, 1)));
+console.log("Set.forEach str:", threw(() => (Set.prototype.forEach as any).call("x", () => {})));
+console.log("Map.get{}:", threw(() => (Map.prototype.get as any).call({}, 1)));
+console.log("Map.set null:", threw(() => (Map.prototype.set as any).call(null, 1, 2)));
+console.log("Map.has{}:", threw(() => (Map.prototype.has as any).call({}, 1)));
+console.log("WeakSet.add{}:", threw(() => (WeakSet.prototype.add as any).call({}, {})));
+console.log("WeakSet.has 7:", threw(() => (WeakSet.prototype.has as any).call(7, {})));
+console.log("WeakMap.get{}:", threw(() => (WeakMap.prototype.get as any).call({}, {})));
+console.log("WeakMap.set undef:", threw(() => (WeakMap.prototype.set as any).call(undefined, {}, 1)));
+
+// Cross-brand: a Set is not a Map (and vice-versa) -> TypeError.
+console.log("Map.get on Set:", threw(() => (Map.prototype.get as any).call(new Set(), 1)));
+console.log("Set.add on Map:", threw(() => (Set.prototype.add as any).call(new Map(), 1)));
+console.log("WeakMap.get on WeakSet:", threw(() => (WeakMap.prototype.get as any).call(new WeakSet(), {})));
+
+// --- Correct receiver: reflective dispatch must actually work. ---
+const s = new Set<number>();
+(Set.prototype.add as any).call(s, 42);
+console.log("reflective Set.add -> has(42):", (Set.prototype.has as any).call(s, 42));
+console.log("reflective Set.delete:", (Set.prototype.delete as any).call(s, 42));
+console.log("after delete has(42):", s.has(42));
+
+const m = new Map<string, number>();
+(Map.prototype.set as any).call(m, "k", 7);
+console.log("reflective Map.get:", (Map.prototype.get as any).call(m, "k"));
+console.log("reflective Map.has:", (Map.prototype.has as any).call(m, "k"));
+
+const wm = new WeakMap<object, number>();
+const key = {};
+(WeakMap.prototype.set as any).call(wm, key, 99);
+console.log("reflective WeakMap.get:", (WeakMap.prototype.get as any).call(wm, key));
+console.log("reflective WeakMap.has:", (WeakMap.prototype.has as any).call(wm, key));
+
+const ws = new WeakSet<object>();
+const v = {};
+(WeakSet.prototype.add as any).call(ws, v);
+console.log("reflective WeakSet.has:", (WeakSet.prototype.has as any).call(ws, v));
+
+// --- Sanity: the fast direct-call path is unchanged. ---
+const s2 = new Set<number>();
+s2.add(1).add(2).add(2);
+console.log("direct Set size:", s2.size, "has(1):", s2.has(1));


### PR DESCRIPTION
## Summary

Closes the largest behavioral cluster in #3662: built-in **collection prototype methods now perform the spec `this` brand check** and throw a `TypeError` on an incompatible receiver.

`Set`/`Map`/`WeakSet`/`WeakMap` prototype methods reached as plain values — `Set.prototype.add.call(x, v)`, `Reflect.apply(Map.prototype.get, m, [k])`, method extraction, etc. — resolved to a shared no-op thunk (`global_this_builtin_noop_thunk`). The reflective path therefore did nothing and never brand-checked `this`, so an incompatible receiver produced **no exception** (the #3662 "no exception was thrown at all" cluster).

## What changed

`populate_builtin_prototype_methods` now installs real per-method thunks for the four collection prototypes. Each thunk:

1. reads the `IMPLICIT_THIS` receiver (set by the `.call`/`.apply`/`.bind` dispatch),
2. brand-checks it — a registered `Set`/`Map` heap pointer, or the reserved `CLASS_ID_WEAKMAP`/`CLASS_ID_WEAKSET` `class_id` — and throws a `TypeError` on a mismatched or primitive receiver, and
3. otherwise dispatches to the existing runtime helper (`js_set_add`, `js_map_get`, `js_weakmap_set`, …) — so reflective collection calls now also **work** on a correct receiver (previously they silently returned `undefined`).

New receiver-resolution helpers: `set::set_ptr_from_receiver_bits`, `map::map_ptr_from_receiver_bits`, `weakref::weak_class_id_from_receiver` (the last pre-filters on `GcHeader.obj_type == GC_TYPE_OBJECT` before reading `class_id`, so a `Set`/`Map` pointer or primitive resolves to `None` without an out-of-bounds read).

## Why it's safe

The fast direct-call path (`s.add(v)`) is lowered straight to `js_set_add` by codegen and **never touches these thunks**, so it is unaffected. A wrong `this` is only reachable via the reflective path, which previously no-op'd — so this is strictly additive.

## Verification

- `test-files/test_gap_3662_collection_brand_check.ts` (new) — **byte-identical to Node** in both `PERRY_NO_AUTO_OPTIMIZE` and auto-optimize build paths. Covers wrong/primitive receivers (TypeError), cross-brand receivers (Set↔Map, WeakMap↔WeakSet), working reflective dispatch on correct receivers, and the unchanged direct-call path.
- 14/14 existing collection/iterator gap tests byte-identical.
- `cargo test -p perry-runtime` → 930 passed.
- `cargo fmt --all --check` clean.

## Scope / follow-up

This PR covers the collection brand-check sub-cluster. The rest of #3662 remains open: `Function.prototype` apply/bind/`Symbol.hasInstance` not-callable checks, and the node-core `ERR_INVALID_ARG_TYPE`/`ERR_OUT_OF_RANGE` arg-validation cases across fs/buffer/process/zlib/ArrayBuffer.
