### PR TITLE
fix(runtime): closure delete honors non-configurable prototype (#3655 follow-up)

### DIFF
--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -16,18 +16,23 @@ pub extern "C" fn js_object_delete_field(
         return 1;
     }
     unsafe {
-        // #3655: `delete fn.name` / `delete fn.prototype` / `delete fn.userProp`.
-        // Functions/closures aren't `ObjectHeader`s — reading `keys_array` off
-        // one is out of bounds. Built-in slots (`name`/`length`/`prototype`)
-        // are `configurable: true`, so record the deletion in the closure
-        // deleted-key side table (consulted by hasOwnProperty/getOwnProperty*/
-        // value reads); user-attached props are dropped from the dynamic-prop
-        // table outright. Either way delete succeeds (returns 1).
+        // #3655: `delete fn.name` / `delete fn.userProp`. Functions/closures
+        // aren't `ObjectHeader`s — reading `keys_array` off one is out of
+        // bounds. The built-in `name`/`length` slots are `configurable:true`,
+        // so a delete records the key in the closure deleted-key side table
+        // (consulted by hasOwnProperty/getOwnProperty*/value reads);
+        // user-attached props are dropped from the dynamic-prop table outright.
         if crate::closure::is_closure_ptr(obj as usize) {
             if let Some(name) = super::has_own_helpers::str_from_string_header(key) {
-                // Drop any user-attached own prop, and mark the key deleted so
-                // a synthesized built-in slot (`name`/`length`/`prototype`)
-                // stops reporting from the registries on later reads.
+                // A non-configurable slot — e.g. a constructor's `prototype`,
+                // which #3655 registers as `{configurable:false}` — can't be
+                // deleted: leave it intact and report failure (strict mode
+                // throws on the `false` return; sloppy mode no-ops).
+                if let Some(attrs) = get_property_attrs(obj as usize, name) {
+                    if !attrs.configurable() {
+                        return 0;
+                    }
+                }
                 crate::closure::closure_delete_own_dynamic_prop(obj as usize, name);
                 crate::closure::closure_mark_key_deleted(obj as usize, name);
             }

--- a/test-parity/node-suite/globals/builtin-constructor-own-name-length.ts
+++ b/test-parity/node-suite/globals/builtin-constructor-own-name-length.ts
@@ -50,6 +50,16 @@ function probe(o: any, label: string) {
   delete o.name;
   console.log("after delete hasOwn name", o.hasOwnProperty("name"));
   console.log("after delete desc", JSON.stringify(Object.getOwnPropertyDescriptor(o, "name")));
+
+  // `prototype` is non-configurable: delete must fail (strict mode throws, so
+  // catch it) and leave the property intact.
+  let protoDeleted = true;
+  try {
+    protoDeleted = delete o.prototype;
+  } catch {
+    protoDeleted = false;
+  }
+  console.log("delete prototype", protoDeleted, "still own", o.hasOwnProperty("prototype"));
 }
 
 // A representative spread of constructor arities: 0 (Map), 1 (DataView/BigInt),


### PR DESCRIPTION
## Summary

Follow-up to #3715 (merged). That PR registers a constructor's `prototype`
slot as `{ writable:false, enumerable:false, configurable:false }`, but the
closure arm of `js_object_delete_field` returned success and recorded the
deletion for **any** key — so `delete DataView.prototype` wrongly *succeeded*
and dropped the (non-configurable) `prototype`:

```js
const C = DataView;
delete C.prototype;        // before: true (and prototype removed!)  →  after: false
C.hasOwnProperty('prototype');  // before: false  →  after: true
```

Pre-#3655 this was a harmless vacuous no-op; #3715's `prototype` registration
turned it into an actual (if edge-case) mutation. The fix mirrors the
ordinary-object delete path: consult the registered descriptor and, when the
slot is non-configurable, leave it intact and return `0` (strict mode throws
on the `false` result; sloppy mode no-ops). `name` / `length` stay
`configurable:true` and continue to delete.

> The configurability check was part of my original #3655 work but was dropped
> when the PR was rebased at merge time; this re-lands just that hunk.

## Tests

Extends `test-parity/node-suite/globals/builtin-constructor-own-name-length.ts`
with a `delete Ctor.prototype` assertion (delete fails, property stays own) —
**byte-identical to Node** across all probed constructors.

`cargo build --release -p perry-runtime` and `cargo fmt --all -- --check`
are clean.
