### PR TITLE
fix(runtime): guard hasOwnProperty against misaligned non-object receivers (#3527)

### DIFF
--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -656,7 +656,15 @@ pub(crate) unsafe fn extract_obj_ptr(value: f64) -> *mut ObjectHeader {
         jsval.as_pointer::<ObjectHeader>() as *mut ObjectHeader
     } else {
         let bits = value.to_bits();
-        if bits != 0 && bits <= 0x0000_FFFF_FFFF_FFFF && bits > 0x10000 {
+        // Raw-I64-pointer fallback (module-level array/object vars store the
+        // untagged pointer directly). Every GC allocation is `align.max(8)`-
+        // aligned, so a real object pointer always has its low 3 bits clear.
+        // Requiring alignment here rejects non-object values whose raw bits
+        // merely *land* in the address range — e.g. a native-module namespace
+        // sentinel (`require('buffer')`) reaching a generic object op like
+        // `hasOwnProperty`. Without it, callers deref `[ptr-8]` for the
+        // GcHeader on a misaligned garbage address → SIGBUS (#3527).
+        if bits != 0 && bits <= 0x0000_FFFF_FFFF_FFFF && bits > 0x10000 && bits & 0x7 == 0 {
             bits as *mut ObjectHeader
         } else {
             ptr::null_mut()
@@ -1161,7 +1169,12 @@ pub(crate) unsafe fn own_key_present(
     obj: *mut ObjectHeader,
     key: *const crate::StringHeader,
 ) -> bool {
-    if obj.is_null() || (obj as usize) < 0x10000 || key.is_null() {
+    // Every GC allocation is `align.max(8)`-aligned, so a real object pointer
+    // has its low 3 bits clear. Rejecting misaligned `obj` keeps a non-object
+    // value (e.g. a native-module namespace sentinel reaching `hasOwnProperty`
+    // via a caller that didn't route through `extract_obj_ptr`) from being
+    // dereferenced as an ObjectHeader. (#3527)
+    if obj.is_null() || (obj as usize) < 0x10000 || (obj as usize) & 0x7 != 0 || key.is_null() {
         return false;
     }
     let keys = (*obj).keys_array;
@@ -1169,7 +1182,11 @@ pub(crate) unsafe fn own_key_present(
         return false;
     }
     let keys_ptr = keys as usize;
-    if (keys_ptr as u64) >> 48 != 0 || keys_ptr < 0x10000 {
+    // Same alignment invariant for the keys_array pointer: when `obj` is not a
+    // genuine object its `keys_array` field holds garbage that may land in the
+    // address range yet be misaligned. Without this guard the `[keys-8]`
+    // GcHeader read below SIGBUSes on that garbage. (#3527)
+    if (keys_ptr as u64) >> 48 != 0 || keys_ptr < 0x10000 || keys_ptr & 0x7 != 0 {
         return false;
     }
     // Validate keys_array GC header
@@ -1895,6 +1912,37 @@ mod sso_tests_1781 {
             assert!(
                 !own_key_present(obj, incoming_other),
                 "absent key 'tag' must not match"
+            );
+        }
+    }
+
+    /// #3527: a non-object value reaching `own_key_present` must return
+    /// `false`, never SIGBUS. Two shapes seen compiling Express: (a) a
+    /// misaligned receiver pointer, and (b) a real-looking object whose
+    /// `keys_array` field holds misaligned garbage (the value read from a
+    /// native-module namespace sentinel mis-treated as an object). Both are
+    /// rejected by the low-3-bits alignment guard — every genuine GC pointer
+    /// is `align.max(8)`-aligned.
+    #[test]
+    fn own_key_present_rejects_misaligned_pointers() {
+        unsafe {
+            let key = crate::string::js_string_from_bytes(b"x".as_ptr(), 1);
+
+            // (a) misaligned receiver — would deref `[obj-8]`/`(*obj).keys_array`
+            // on garbage without the guard.
+            let misaligned_obj = 0x2800_0203usize as *mut ObjectHeader;
+            assert!(
+                !own_key_present(misaligned_obj, key),
+                "misaligned receiver must return false, not crash"
+            );
+
+            // (b) aligned real object, but its keys_array points at misaligned
+            // garbage — the exact Express crash shape.
+            let obj = super::super::alloc::js_object_alloc(0, 4);
+            (*obj).keys_array = 0x2800_0203usize as *mut _;
+            assert!(
+                !own_key_present(obj, key),
+                "misaligned keys_array must return false, not crash"
             );
         }
     }


### PR DESCRIPTION
## Summary

Compiling a standard Express app (issue #3527, with the documented eval/unimplemented escape hatches) **SIGBUS'd during module init**, before any user code ran. This fixes that crash — the app now advances past the init segfault.

## Root cause

`own_key_present` (backing `Object.prototype.hasOwnProperty`) dereferenced a `GcHeader` at `[ptr-8]` on a value that isn't a real GC object. Two shapes hit it:

- **(a)** a misaligned receiver pointer, and
- **(b)** a real-looking object whose `keys_array` field held misaligned garbage — the value read when a native-module namespace sentinel is mis-treated as an object. The trigger in the Express tree is `safer-buffer`:
  ```js
  var buffer = require('buffer')
  for (var key in buffer) { if (!buffer.hasOwnProperty(key)) continue; … }
  ```

The existing guards checked null / `< 0x10000` / upper-bits, but **not alignment**, so a garbage address like `0x280000203` slipped through to the `[keys-8]` header read → `EXC_BAD_ACCESS`.

## Fix

Every GC allocation is `align.max(8)`-aligned, so a genuine object pointer always has its low 3 bits clear. Add that invariant as a guard in:
- **`extract_obj_ptr`**'s raw-I64-pointer fallback (root cause: stops a misaligned non-object value from being handed out as an `ObjectHeader` at all), and
- **`own_key_present`**'s receiver and `keys_array` checks (defense at the deref sites — the crash reached it via a caller that bypasses `extract_obj_ptr`).

A non-object receiver now correctly returns `false` (a non-object has no own properties) instead of crashing.

## Verification

- Express 5.2.1 app: **init-time SIGBUS gone** — now runs module init and surfaces a normal catchable JS error instead of a segfault.
- New regression test `own_key_present_rejects_misaligned_pointers` covers both misaligned shapes (receiver + `keys_array`).
- Full `cargo test -p perry-runtime` green (two unrelated tests are pre-existing parallel-execution flakes — both pass in isolation). `cargo fmt --check` clean.

## Context

Part of the #3527 Express-compile chain. Prior merged: #3537/#3543/#3546 (codegen) + #3551 (`"*"` wildcard routing). This clears the first *runtime* blocker. Next frontier (separate): a JS-level `TypeError` deeper in Express init under the escape hatches.

No version bump / changelog — folded in at merge per the worktree-PR convention.
