### PR TITLE
fix(ext-http): bool_f64 returns plain 1.0/0.0 (unblocks main cargo-test)

### DIFF
--- a/crates/perry-ext-http/src/agent.rs
+++ b/crates/perry-ext-http/src/agent.rs
@@ -62,7 +62,11 @@ extern "C" {
 }
 
 fn bool_f64(value: bool) -> f64 {
-    f64::from_bits(JsValue::from_bool(value).bits())
+    if value {
+        1.0
+    } else {
+        0.0
+    }
 }
 
 fn bind_agent_method(handle: Handle, name: &'static [u8]) -> i64 {


### PR DESCRIPTION
main is RED on cargo-test: `perry-ext-http` agent tests (`destroy_marks_destroyed`, `setters_apply_new_values`) panic with `left: NaN, right: 0.0/1.0`, blocking every open PR.

Root cause: #3660's merge rewrote `js_http_agent_destroyed`/`js_http_agent_keep_alive` to use a new `bool_f64` helper that returned a **NaN-boxed** bool (`f64::from_bits(JsValue::from_bool(value).bits())`). A NaN-boxed value's raw f64 bits are NaN, so these accessors returned NaN instead of 1.0/0.0. Pre-#3660 they returned plain `if value {1.0} else {0.0}`.

Fix: `bool_f64` returns plain 1.0/0.0 (consistent with the numeric accessors like `max_sockets`; the dispatch layer NaN-boxes as needed). All 13 perry-ext-http tests pass; fmt clean.