### PR TITLE
fix(runtime,codegen): make Object.hasOwn a real first-class value (#3527)

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -639,6 +639,39 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &[(I64, &ctor_handle), (I64, &key_raw)],
                     ));
                 }
+                // #3527: `Object.hasOwn` read as a VALUE (not a direct call) —
+                // e.g. iconv-lite's merge-exports does
+                // `var hasOwn = typeof Object.hasOwn === "undefined" ? … :
+                // Object.hasOwn` then `hasOwn(obj, key)`. The ternary defeats
+                // the const-alias call-fold, so the value must be a real
+                // callable. Mirror the `Error.captureStackTrace` shape above:
+                // resolve the reified `Object` constructor closure and read the
+                // `hasOwn` static (installed by `install_builtin_constructor_statics`)
+                // off it, instead of falling through to the `0.0` sentinel.
+                if property == "hasOwn" {
+                    let object_idx = ctx.strings.intern("Object");
+                    let object_bytes_global =
+                        format!("@{}", ctx.strings.entry(object_idx).bytes_global);
+                    let object_len = "Object".len().to_string();
+                    let object_ctor = ctx.block().call(
+                        DOUBLE,
+                        "js_get_global_this_builtin_value",
+                        &[(PTR, &object_bytes_global), (I64, &object_len)],
+                    );
+                    let key_idx = ctx.strings.intern(property);
+                    let key_handle_global =
+                        format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                    let blk = ctx.block();
+                    let ctor_handle = unbox_to_i64(blk, &object_ctor);
+                    let key_box = blk.load(DOUBLE, &key_handle_global);
+                    let key_bits = blk.bitcast_double_to_i64(&key_box);
+                    let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
+                    return Ok(blk.call(
+                        DOUBLE,
+                        "js_object_get_field_by_name_f64",
+                        &[(I64, &ctor_handle), (I64, &key_raw)],
+                    ));
+                }
                 if property == "f16round" {
                     let math_idx = ctx.strings.intern("Math");
                     let math_bytes_global =

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1276,6 +1276,19 @@ extern "C" fn object_assign_thunk(
     validated
 }
 
+/// `Object.hasOwn(obj, key)` (ES2022) reified as a callable value so the
+/// feature-detect idiom `typeof Object.hasOwn === "undefined" ? … :
+/// Object.hasOwn` (iconv-lite's merge-exports, #3527) binds a real callable
+/// instead of a non-callable handle. Backed by the same runtime helper as
+/// `Object.prototype.hasOwnProperty.call(obj, key)`.
+extern "C" fn object_hasown_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    obj: f64,
+    key: f64,
+) -> f64 {
+    super::object_ops::js_object_has_own(obj, key)
+}
+
 extern "C" fn array_is_array_thunk(
     _closure: *const crate::closure::ClosureHeader,
     value: f64,
@@ -1401,6 +1414,7 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
                 false,
             );
             install_constructor_static(ctor, "assign", object_assign_thunk as *const u8, 1, true);
+            install_constructor_static(ctor, "hasOwn", object_hasown_thunk as *const u8, 2, false);
         }
         "Array" => {
             install_constructor_static(

--- a/test-files/test_gap_object_methods.ts
+++ b/test-files/test_gap_object_methods.ts
@@ -51,6 +51,18 @@ nullProto.key = "value";
 console.log("hasOwn null proto:", Object.hasOwn(nullProto, "key")); // true
 console.log("hasOwn null proto missing:", Object.hasOwn(nullProto, "other")); // false
 
+// #3527: Object.hasOwn as a first-class VALUE (not a direct call). The
+// feature-detect idiom in iconv-lite's merge-exports stores it in a var via a
+// ternary, which defeats the const-alias call-fold, so the value itself must be
+// a real callable. typeof must agree, and the bound value must compute hasOwn.
+console.log("hasOwn typeof value:", typeof Object.hasOwn); // function
+const hasOwnVal = typeof Object.hasOwn === "undefined" ? null : Object.hasOwn;
+console.log("hasOwn via var:", hasOwnVal!(hasOwnObj, "name"), hasOwnVal!(hasOwnObj, "missing")); // true false
+const hasOwnArr: Array<(o: object, k: string) => boolean> = [Object.hasOwn];
+console.log("hasOwn via array:", hasOwnArr[0](hasOwnObj, "version")); // true
+const ReboundO: any = Object;
+console.log("hasOwn rebound:", ReboundO.hasOwn(hasOwnObj, "name")); // true
+
 // --- Object.defineProperty ---
 const defObj: Record<string, unknown> = {};
 Object.defineProperty(defObj, "readOnly", {


### PR DESCRIPTION
## Summary

`Object.hasOwn` (ES2022) worked as a **direct call** but not as a **first-class value**: `typeof Object.hasOwn` folded to `"function"`, yet reading the value produced the `0.0`/undefined sentinel — a non-callable. This fixes that, unblocking the next layer of the #3527 Express compile.

## Why it matters

The const-alias call-fold (`const k = Object.hasOwn; k(o, x)`) hid the gap, but iconv-lite's `merge-exports.js` assigns it through a ternary into a `var`:

```js
var hasOwn = typeof Object.hasOwn === "undefined"
  ? Function.call.bind(Object.prototype.hasOwnProperty)
  : Object.hasOwn
...
if (hasOwn(module, key)) target[key] = module[key]
```

The ternary defeats the fold, so `hasOwn` held a non-callable and `hasOwn(module, key)` threw `TypeError: value is not a function` during iconv-lite init — a hard blocker compiling Express. (Localized via a debug-symbol build + `b print_uncaught` → backtrace pointing at `merge-exports.js`.)

## Fix (two parts)

- **Runtime** (`global_this.rs`): reify `Object.hasOwn` as a callable static on the `Object` constructor closure (`object_hasown_thunk` → existing `js_object_has_own`), alongside the existing `keys`/`values`/`assign`/… thunks. Makes the rebound form (`const O = Object; O.hasOwn(o, x)`) dispatch correctly.
- **Codegen** (`property_get.rs`): when `Object.hasOwn` is read as a VALUE (`PropertyGet { GlobalGet(0), "hasOwn" }`), resolve the reified `Object` constructor closure and read the `hasOwn` static off it — mirroring the existing `Error.captureStackTrace` value path — instead of emitting the `0.0` sentinel.

## Verification

- `typeof Object.hasOwn === "function"`; the value computes correctly whether called directly, stored in a `var` via a ternary, passed through an array, or rebound (`const O = Object`).
- `test_gap_object_methods.ts` extended with the as-value cases — **byte-identical to `node --experimental-strip-types`**.
- No regression: direct `Object.hasOwn(o,k)`, `Object.keys`, and `typeof Error.isError` all still correct. `cargo fmt --check` clean.
- The Express compile now advances **past** iconv-lite's merge-exports to the next blocker.

## Scope

The broader "`Object.keys`/`values`/… as escaping values" gap (a pre-existing known limitation) is unchanged; this fixes the ES2022 `hasOwn` case that Express's dependency tree actually exercises.

Part of the #3527 chain (prior: #3537/#3543/#3546 codegen, #3551 wildcard, #3733 hasOwnProperty SIGBUS). No version bump / changelog — folded in at merge per the worktree-PR convention.
