### PR TITLE
fix(ext-http): bool_f64 NaN-boxes the bool (unblocks main cargo-test)

### DIFF
--- a/crates/perry-ext-http/src/agent.rs
+++ b/crates/perry-ext-http/src/agent.rs
@@ -62,11 +62,7 @@ extern "C" {
 }
 
 fn bool_f64(value: bool) -> f64 {
-    if value {
-        1.0
-    } else {
-        0.0
-    }
+    f64::from_bits(JsValue::from_bool(value).bits())
 }
 
 fn bind_agent_method(handle: Handle, name: &'static [u8]) -> i64 {


### PR DESCRIPTION
main is RED on cargo-test (perry-ext-http `destroy_marks_destroyed`/`setters_apply_new_values`). #3627 changed those tests to expect a NaN-boxed JS bool (`assert_js_bool` → `JsValue::to_bool()`), but `bool_f64` was still plain 1.0/0.0 from #3749. Restoring the NaN-boxed contract so the accessors return a real JS bool. All 13 perry-ext-http tests pass; fmt clean. (Supersedes #3749.)