### PR TITLE
fix(node:url): preserve pathToFileURL trailing slash

### DIFF
--- a/crates/perry-runtime/src/url/node_compat.rs
+++ b/crates/perry-runtime/src/url/node_compat.rs
@@ -94,6 +94,14 @@ fn throw_invalid_legacy_url_arg(value: f64) -> ! {
     throw_url_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
 }
 
+fn resolve_path_to_file_url_posix(path: &str) -> String {
+    let mut resolved = crate::path::resolve_posix_str(path);
+    if !path.is_empty() && path.ends_with('/') && !resolved.ends_with('/') {
+        resolved.push('/');
+    }
+    resolved
+}
+
 /// Read the `windows` option from a `{ windows }` options argument (#2975).
 /// Node treats a `true` value as force-Windows, anything else (including a
 /// missing/undefined options arg or `{ windows: false }`) as POSIX. Returns
@@ -347,7 +355,7 @@ pub extern "C" fn js_url_path_to_file_url(path_f64: f64, options_f64: f64) -> f6
             }
         }
     } else {
-        let resolved = crate::path::resolve_posix_str(&path);
+        let resolved = resolve_path_to_file_url_posix(&path);
         let encoded = encode_file_url_path(&resolved);
         if encoded.starts_with('/') {
             format!("file://{}", encoded)

--- a/test-parity/node-suite/url/module/path-to-file-url-relative.ts
+++ b/test-parity/node-suite/url/module/path-to-file-url-relative.ts
@@ -1,5 +1,13 @@
 import { pathToFileURL } from "node:url";
 
-for (const p of ["relative/path", "./relative/../target #?.txt", "relative/", ""]) {
+for (const p of [
+  "relative/path",
+  "./relative/../target #?.txt",
+  "relative/",
+  "relative//",
+  "relative/./",
+  "./",
+  "",
+]) {
   console.log("pathToFileURL:", JSON.stringify(p), "=>", pathToFileURL(p).href);
 }


### PR DESCRIPTION
## Summary

Closes #3750.

- Preserve a trailing POSIX directory slash in `url.pathToFileURL()` after resolving relative paths.
- Expand the existing relative `pathToFileURL()` parity fixture to cover repeated trailing slash, `./` segment directory inputs, and `./` itself.

## Why This Cut

This is a focused runtime-output mismatch in the existing `node:url` path/file URL helper. It shares the existing URL parity fixture and does not mix in the larger remaining URL namespace-tail work.

## Verification

- Pre-fix: `PERRY_NO_AUTO_OPTIMIZE=1 PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module url --filter path-to-file-url-relative` failed with `relative/` missing the trailing slash.
- `PERRY_NO_AUTO_OPTIMIZE=1 PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module url --filter path-to-file-url-relative` - 1 pass, 0 fail
- `PERRY_NO_AUTO_OPTIMIZE=1 PATH=/home/github-runner/actions-runner/externals/node24/bin:$PATH ./run_parity_tests.sh --suite node-suite --module url` - 66 pass, 0 fail
- `TMPDIR="$PWD/target/tmp" CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo check -p perry-runtime -p perry-codegen -p perry-api-manifest` - passed with existing warnings
- `cargo fmt --all -- --check`
- `git diff --check HEAD`
- `./scripts/check_file_size.sh`

## Known Limitations / Non-goals

- Does not implement the remaining `node:url` namespace tail such as `URLPattern`, legacy `Url`, or `resolveObject`.
- Does not change `path.resolve()` trailing-slash behavior; the slash preservation is scoped to `pathToFileURL()`.
