### PR TITLE
fix(hir): infer `bool && value` as the value's type, not Boolean (#3527)

### DIFF
--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -198,13 +198,24 @@ pub(crate) fn infer_type_from_expr(expr: &ast::Expr, ctx: &LoweringContext) -> T
                 // Bitwise operators → Number
                 BitAnd | BitOr | BitXor | LShift | RShift | ZeroFillRShift => Type::Number,
 
-                // Logical operators → type of operands (simplified)
+                // Logical operators → type of operands (simplified).
+                //
+                // `A && B` yields B's value when A is truthy (else A); `A || B`
+                // yields B when A is falsy (else A). So when B has a concrete
+                // type we approximate the result as that type. But when B is
+                // `Any` we must NOT fall back to A's type: #3527 hit
+                // `var hasMap = typeof Map === "function" && Map.prototype`,
+                // where A is a boolean compare and B (`Map.prototype`) is `Any`.
+                // Returning A's `Boolean` mistyped `hasMap` as a boolean even
+                // though it holds an object, so a later `hasMap && d && d.get`
+                // chain miscompiled and dereferenced `null`. The result can be
+                // the (unknown) right value, so `Any` is the only sound type.
                 LogicalAnd | LogicalOr => {
                     let right = infer_type_from_expr(&bin.right, ctx);
                     if !matches!(right, Type::Any) {
                         right
                     } else {
-                        infer_type_from_expr(&bin.left, ctx)
+                        Type::Any
                     }
                 }
                 NullishCoalescing => {

--- a/test-files/test_gap_logical_and_value_type.ts
+++ b/test-files/test_gap_logical_and_value_type.ts
@@ -1,0 +1,25 @@
+// #3527: `var x = <boolean-expr> && <object/any-value>` must keep `x` usable as
+// the right-hand value, not be mistyped as Boolean. Mirrors object-inspect's
+// `var hasMap = typeof Map === "function" && Map.prototype; hasMap && d && d.get`.
+const hasMap = typeof Map === "function" && Map.prototype;
+console.log("hasMap typeof:", typeof hasMap);
+
+const d: any = null;
+const mapSize = hasMap && d && typeof d.get === "function" ? d.get : "none";
+console.log("mapSize:", mapSize);
+
+// && returns the right operand's value when left is truthy
+const cfg = true && { port: 3000, host: "localhost" };
+console.log("cfg.port:", (cfg as any).port, "host:", (cfg as any).host);
+
+// || returns the right value when left is falsy
+const fallback = (undefined as any) || { name: "default" };
+console.log("fallback.name:", fallback.name);
+
+// chained && guarding a property access short-circuits correctly
+const obj: any = { inner: { val: 42 } };
+const got = obj && obj.inner && obj.inner.val;
+console.log("got:", got);
+const missing: any = { inner: null };
+const safe = missing && missing.inner && missing.inner.val;
+console.log("safe:", safe);


### PR DESCRIPTION
## Summary

`infer_type_from_expr` mis-typed a logical `A && B` / `A || B` as **A's type** whenever B inferred to `Any`. But `&&` yields B's value when A is truthy, so the result can be the (unknown) right value — A's type is wrong. This advances the #3527 Express compile past object-inspect.

## Root cause

A textbook feature-detect idiom:
```js
var hasMap = typeof Map === "function" && Map.prototype;  // inferred Boolean (!)
```
`hasMap` holds an **object** at runtime but was typed `Boolean` (the left operand's type). Codegen then treated it as a boolean in object-inspect's later chain:
```js
var mapSize = hasMap && d && typeof d.get === "function" ? d.get : null;
```
miscompiling the short-circuit and dereferencing `null` → `TypeError: Cannot read properties of null (reading 'get')` during init while compiling Express. (Minimal repro: `var hm = typeof Map === "function" && Map.prototype; hm && null && (null).get` throws; the same chain with `hm` typed `any` does not.)

## Fix

In `lower_types.rs`, for `LogicalAnd | LogicalOr`: when the right operand is `Any`, the result is `Any` (the value could be that right operand), **not** the left operand's type. The concrete-right heuristic (`x && knownTyped` → `knownTyped`) is unchanged. This only makes the inferred type more dynamic — always codegen-safe, never less.

## Verification

- object-inspect's init now works; the Express tree advances **past** it.
- New gap test `test_gap_logical_and_value_type.ts` (the `hasMap` idiom, `&&`/`||` returning the right value, chained property guards) — **byte-identical to Node**.
- `cargo test -p perry-hir` green. Pre-existing failures (`bind_replace`, async_hooks/perf_hooks timestamp nondeterminism) verified identical on baseline — not caused by this change. `cargo fmt --check` clean.

Part of the #3527 chain (prior: #3537/#3543/#3546, #3551, #3733, #3751, #3764). No version bump / changelog — folded in at merge per the worktree-PR convention.
