### PR TITLE
fix(hir): resolve bare `eval` as a value instead of ReferenceError (#3527)

### DIFF
--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -98,6 +98,15 @@ fn is_known_global_identifier_name(name: &str) -> bool {
             | "btoa"
             | "BigInt"
             | "WebAssembly"
+            // #3527: `eval` as a VALUE (not a call). Libraries build intrinsic
+            // tables that reference it bare — get-intrinsic's
+            // `'%eval%': eval` — and would otherwise throw `ReferenceError:
+            // identifier is not defined` at module init. `eval(...)` *calls*
+            // keep their dedicated eval-surface classification in
+            // `expr_call::intrinsics` (which matches the callee name before the
+            // callee is lowered through this arm), so this only affects the
+            // value read, which lowers to the `GlobalGet(0)` sentinel.
+            | "eval"
     ) || is_builtin_global_value_name(name)
 }
 

--- a/test-files/test_gap_eval_as_value.ts
+++ b/test-files/test_gap_eval_as_value.ts
@@ -1,0 +1,13 @@
+// #3527: `eval` referenced as a VALUE (not called) must not throw a
+// ReferenceError at lowering. Libraries build intrinsic tables that read it
+// bare — get-intrinsic's `'%eval%': eval`. (`eval(...)` calls remain gated by
+// the eval-surface classifier; this only covers the value read.)
+const intrinsics: Record<string, unknown> = {
+  "%Array%": Array,
+  "%eval%": eval,
+  "%Math%": Math,
+};
+console.log("has eval key:", "%eval%" in intrinsics);
+console.log("Array is fn:", typeof intrinsics["%Array%"] === "function");
+const e = eval;
+console.log("got eval value without throwing:", e !== Symbol.for("unreachable"));


### PR DESCRIPTION
## Summary

`eval` referenced as a **value** (not called) threw `ReferenceError: identifier is not defined` at module init — `eval` was absent from `is_known_global_identifier_name`, so a bare read hit the unresolved-identifier throw. get-intrinsic (a near-universal dependency) builds its intrinsics table with `'%eval%': eval`, aborting Express's init before any user code (#3527).

## Fix

Add `eval` to the known-global identifier set, so a bare read lowers to the `GlobalGet(0)` sentinel (a harmless value) like other globals without a materialized value — instead of throwing.

`eval(...)` **calls** are unaffected: `expr_call::intrinsics::check_eval_function_call` classifies the eval surface by the callee name *before* the callee is lowered through this arm, so the eval-removal gate still applies. Only the value read changes.

## Verification

- get-intrinsic's intrinsics-table init no longer throws; the Express tree advances **past** it (next blocker is an unrelated backreference/lookahead regex — a separate known categorical gap).
- `cargo test -p perry-hir` green.
- New gap test `test_gap_eval_as_value.ts` — **byte-identical to Node**.
- `cargo fmt --check` clean.

Part of the #3527 chain (prior: #3537/#3543/#3546, #3551, #3733, #3751, #3764, #3771). No version bump / changelog — folded in at merge per the worktree-PR convention.
