### PR TITLE
fix(regex): escape literal `[` inside character classes (#3527)

### DIFF
--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -212,6 +212,10 @@ fn js_regex_to_rust(pattern: &str) -> String {
     let mut result = String::with_capacity(pattern.len());
     let chars: Vec<char> = pattern.chars().collect();
     let mut i = 0;
+    // Whether we're inside a `[...]` character class. JS and the Rust
+    // `regex`/`fancy-regex` engines disagree on a couple of constructs there,
+    // so we track it to translate them.
+    let mut in_class = false;
     while i < chars.len() {
         if chars[i] == '\\' && i + 1 < chars.len() {
             match chars[i + 1] {
@@ -220,16 +224,38 @@ fn js_regex_to_rust(pattern: &str) -> String {
                     result.push('/');
                     i += 2;
                 }
-                // Pass through all other backslash sequences as-is
+                // Pass through all other backslash sequences as-is. (An escaped
+                // `\]` inside a class does NOT close the class — handled here
+                // before the `]` class-close branch below.)
                 _ => {
                     result.push('\\');
                     result.push(chars[i + 1]);
                     i += 2;
                 }
             }
-        } else if chars[i] == '(' && i + 2 < chars.len() && chars[i + 1] == '?' {
+        } else if chars[i] == '[' {
+            // #3527: JS treats a literal `[` *inside* a character class as a
+            // plain character, but the `regex`/`fancy-regex` engines reject the
+            // unescaped form ("invalid character class"). get-intrinsic's
+            // path-split pattern `[^%.[\]]` hit this — and, because the same
+            // translated string feeds both engines, an otherwise fancy-regex-
+            // compatible pattern (backreferences + lookahead) was rejected
+            // outright. Escape the inner `[`; the opening `[` starts the class.
+            if in_class {
+                result.push_str("\\[");
+            } else {
+                in_class = true;
+                result.push('[');
+            }
+            i += 1;
+        } else if chars[i] == ']' && in_class {
+            in_class = false;
+            result.push(']');
+            i += 1;
+        } else if !in_class && chars[i] == '(' && i + 2 < chars.len() && chars[i + 1] == '?' {
             // Check for JS named group (?<name>...) — convert to (?P<name>...)
-            // But NOT (?<=...) (lookbehind) or (?<!...) (negative lookbehind)
+            // But NOT (?<=...) (lookbehind) or (?<!...) (negative lookbehind).
+            // Only meaningful outside a character class, where `(` is literal.
             if chars[i + 2] == '<'
                 && i + 3 < chars.len()
                 && chars[i + 3] != '='
@@ -1807,6 +1833,30 @@ mod tests {
         let c3 = re3.captures(s3).unwrap();
         assert_eq!(expand_js_replacement("$1$2$3", &c3, s3, false), "ab"); // $2 unmatched → ""
         assert_eq!(expand_js_replacement("$10", &c3, s3, false), "a0"); // no group 10 → $1 then '0'
+    }
+
+    #[test]
+    fn js_regex_to_rust_escapes_literal_bracket_in_class() {
+        // #3527: a literal `[` inside a character class is valid in JS but must
+        // be escaped for the Rust `regex`/`fancy-regex` engines. get-intrinsic's
+        // path-split pattern starts with `[^%.[\]]`.
+        assert_eq!(js_regex_to_rust(r"[^%.[\]]"), r"[^%.\[\]]");
+        // The inner `[` is escaped; the opening/closing brackets and the
+        // already-escaped `\]` are preserved.
+        assert_eq!(js_regex_to_rust(r"[a[b]"), r"[a\[b]");
+        // `[` outside a class is left alone (it opens the class).
+        assert_eq!(js_regex_to_rust(r"a[bc]d"), r"a[bc]d");
+        // `(?<name>...)` named-group rewrite still fires outside a class…
+        assert_eq!(js_regex_to_rust(r"(?<y>\d+)"), r"(?P<y>\d+)");
+        // …but a `[` inside a class is not mistaken for group syntax, and the
+        // whole get-intrinsic pattern now compiles under fancy-regex.
+        let translated = js_regex_to_rust(
+            r#"[^%.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|%$))"#,
+        );
+        assert!(
+            fancy_regex::Regex::new(&translated).is_ok(),
+            "translated get-intrinsic pattern must compile under fancy-regex: {translated}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A literal unescaped `[` inside a `[...]` character class is valid in JS (a plain `[`), but **both** Rust engines — the `regex` crate and the `fancy-regex` fallback — reject it as "invalid character class". `js_regex_to_rust` passed it through unchanged.

## Why this mattered (and why it's NOT an engine limitation)

Perry already has a `fancy-regex` fallback that supports backreferences, lookahead, and lookbehind. But the *same* translated pattern string feeds both engines: when the `regex` crate bails on an advanced construct and the code falls back to `fancy-regex`, an unescaped `[` makes fancy-regex reject the pattern too — even though it fully supports the rest.

get-intrinsic's path-split pattern is exactly this shape:
```
[^%.[\]]+|\[(?:(-?\d+...)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])...)
```
It has backreferences (`\2`) and lookahead (`(?=...)`) — both fancy-regex-compatible — but the leading `[^%.[\]]` class with a literal `[` made it throw `SyntaxError: Invalid regular expression: …: invalid pattern` at init while compiling Express (#3527). Escaping the `[` → the whole pattern compiles under fancy-regex and matches correctly.

## Fix

Track character-class depth in `js_regex_to_rust` and escape a literal `[` found inside a class to `\[` (semantics-preserving in both engines). Also gate the `(?<name>...)` named-group rewrite on being *outside* a class, where `(` is literal.

## Verification

- The get-intrinsic pattern now compiles under fancy-regex and matches (`%Array.prototype.push%` → `Array`); the Express tree advances **past** it.
- Unit test `js_regex_to_rust_escapes_literal_bracket_in_class` covers the escaping, the named-group interaction, and end-to-end compilation of the full pattern. `cargo fmt --check` clean.

Part of the #3527 chain (prior: #3537/#3543/#3546, #3551, #3733, #3751, #3764, #3771, #3776). No version bump / changelog — folded in at merge per the worktree-PR convention.
