### PR TITLE
fix(perf_hooks): expose Performance class shapes

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -3728,6 +3728,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("perf_hooks", "nodeTiming"),
     property("perf_hooks", "performance"),
     property("perf_hooks", "constants"),
+    class("perf_hooks", "Performance"),
     class("perf_hooks", "PerformanceObserver"),
     // PerformanceObserver.supportedEntryTypes — static array of entry-type
     // names. Read inline (`PerformanceObserver.supportedEntryTypes.includes(...)`)
@@ -3736,6 +3737,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     class("perf_hooks", "PerformanceEntry"),
     class("perf_hooks", "PerformanceMark"),
     class("perf_hooks", "PerformanceMeasure"),
+    class("perf_hooks", "PerformanceObserverEntryList"),
+    class("perf_hooks", "PerformanceResourceTiming"),
     method("perf_hooks", "observe", true, Some("PerformanceObserver")),
     method(
         "perf_hooks",

--- a/crates/perry-codegen/src/expr/helpers.rs
+++ b/crates/perry-codegen/src/expr/helpers.rs
@@ -309,6 +309,13 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
             | "Request"
             | "Response"
             | "FinalizationRegistry"
+            | "Performance"
+            | "PerformanceEntry"
+            | "PerformanceMark"
+            | "PerformanceMeasure"
+            | "PerformanceObserver"
+            | "PerformanceObserverEntryList"
+            | "PerformanceResourceTiming"
             // #2875: TC39 explicit-resource-management global constructors.
             | "DisposableStack"
             | "AsyncDisposableStack"

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -153,9 +153,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 "TransformStream" => 0xFFFF0062u32,
                 // node:perf_hooks entry classes. Runtime classifies the
                 // shaped entry objects returned by performance.mark/measure.
+                "Performance" => 0xFFFF0087u32,
                 "PerformanceEntry" => 0xFFFF0080u32,
                 "PerformanceMark" => 0xFFFF0081u32,
                 "PerformanceMeasure" => 0xFFFF0082u32,
+                "PerformanceObserverEntryList" => 0xFFFF0088u32,
+                "PerformanceResourceTiming" => 0xFFFF0086u32,
                 "Console" => 0xFFFF0083u32,
                 "ReadStream" | "tty.ReadStream" => 0xFFFF0084u32,
                 "WriteStream" | "tty.WriteStream" => 0xFFFF0085u32,

--- a/crates/perry-hir/src/analysis/builtins.rs
+++ b/crates/perry-hir/src/analysis/builtins.rs
@@ -88,6 +88,13 @@ pub(crate) fn is_builtin_global_value_name(name: &str) -> bool {
             | "Request"
             | "Response"
             | "FinalizationRegistry"
+            | "Performance"
+            | "PerformanceEntry"
+            | "PerformanceMark"
+            | "PerformanceMeasure"
+            | "PerformanceObserver"
+            | "PerformanceObserverEntryList"
+            | "PerformanceResourceTiming"
             // #2875: TC39 explicit-resource-management globals.
             | "DisposableStack"
             | "AsyncDisposableStack"

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1175,6 +1175,20 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         let pval = crate::perf_hooks::performance_namespace();
         js_object_set_field_by_name(singleton, pkey, pval);
     }
+    // Perf_hooks constructors are globals identical to the module exports.
+    for name in [
+        "Performance",
+        "PerformanceEntry",
+        "PerformanceMark",
+        "PerformanceMeasure",
+        "PerformanceObserver",
+        "PerformanceObserverEntryList",
+        "PerformanceResourceTiming",
+    ] {
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let value = super::native_module::bound_native_callable_export_value("perf_hooks", name);
+        js_object_set_field_by_name(singleton, key, value);
+    }
     // #2923: `globalThis.navigator` — Node's browser-compatible runtime
     // metadata object. typeof is "object". Built once per process.
     {

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -74,9 +74,16 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
         }
         if module == "perf_hooks" {
             let class_id = match method.as_str() {
+                "Performance" => crate::perf_hooks::CLASS_ID_PERFORMANCE,
                 "PerformanceEntry" => crate::perf_hooks::CLASS_ID_PERFORMANCE_ENTRY,
                 "PerformanceMark" => crate::perf_hooks::CLASS_ID_PERFORMANCE_MARK,
                 "PerformanceMeasure" => crate::perf_hooks::CLASS_ID_PERFORMANCE_MEASURE,
+                "PerformanceObserverEntryList" => {
+                    crate::perf_hooks::CLASS_ID_PERFORMANCE_OBSERVER_ENTRY_LIST
+                }
+                "PerformanceResourceTiming" => {
+                    crate::perf_hooks::CLASS_ID_PERFORMANCE_RESOURCE_TIMING
+                }
                 _ => 0,
             };
             if class_id != 0 {
@@ -576,6 +583,11 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
         }
 
         if gc_type == crate::gc::GC_TYPE_OBJECT {
+            if let Some(matches) =
+                crate::perf_hooks::is_perf_hooks_shape_instance_of(value, class_id)
+            {
+                return if matches { true_val } else { false_val };
+            }
             if let Some(matches) =
                 crate::perf_hooks::is_perf_entry_object_instance_of(obj_ptr, class_id)
             {

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1285,6 +1285,13 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ("dns" | "dns/promises", "Resolver") => Some(0),
         ("events", "init") => Some(1),
         ("wasi", "WASI") => Some(0),
+        ("perf_hooks", "Performance") => Some(0),
+        ("perf_hooks", "PerformanceEntry") => Some(0),
+        ("perf_hooks", "PerformanceMark") => Some(1),
+        ("perf_hooks", "PerformanceMeasure") => Some(0),
+        ("perf_hooks", "PerformanceObserver") => Some(1),
+        ("perf_hooks", "PerformanceObserverEntryList") => Some(0),
+        ("perf_hooks", "PerformanceResourceTiming") => Some(0),
         // #3119/#3126/#3263 node:module helpers.
         ("module", "createRequire") => Some(1),
         ("module", "enableCompileCache") => Some(1),
@@ -2059,10 +2066,13 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("buffer.Buffer", "isEncoding")
             | ("buffer.Buffer", "byteLength")
             | ("buffer.Buffer", "compare")
+            | ("perf_hooks", "Performance")
             | ("perf_hooks", "PerformanceObserver")
             | ("perf_hooks", "PerformanceEntry")
             | ("perf_hooks", "PerformanceMark")
             | ("perf_hooks", "PerformanceMeasure")
+            | ("perf_hooks", "PerformanceObserverEntryList")
+            | ("perf_hooks", "PerformanceResourceTiming")
             | ("perf_observer", "observe")
             | ("perf_observer", "disconnect")
             | ("perf_observer", "takeRecords")

--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -35,6 +35,9 @@ const ENTRY_TYPE_FUNCTION: u8 = 3;
 pub(crate) const CLASS_ID_PERFORMANCE_ENTRY: u32 = 0xFFFF_0080;
 pub(crate) const CLASS_ID_PERFORMANCE_MARK: u32 = 0xFFFF_0081;
 pub(crate) const CLASS_ID_PERFORMANCE_MEASURE: u32 = 0xFFFF_0082;
+pub(crate) const CLASS_ID_PERFORMANCE_RESOURCE_TIMING: u32 = 0xFFFF_0086;
+pub(crate) const CLASS_ID_PERFORMANCE: u32 = 0xFFFF_0087;
+pub(crate) const CLASS_ID_PERFORMANCE_OBSERVER_ENTRY_LIST: u32 = 0xFFFF_0088;
 
 /// Shape id for the `{ name, entryType, startTime, duration, detail }` object
 /// returned by mark/measure and the getEntries* arrays.
@@ -52,13 +55,18 @@ const PERF_ENTRY_JSON_SHAPE: u32 = 0x7FFF_FF42;
 const ELU_SHAPE: u32 = 0x7FFF_FF41;
 const ELU_KEYS: &[u8] = b"idle\0active\0utilization\0";
 
-/// Shape id for the `{ timeOrigin }` snapshot returned by `performance.toJSON()`.
-const TOJSON_SHAPE: u32 = 0x7FFF_FF42;
-const TOJSON_KEYS: &[u8] = b"timeOrigin\0";
+/// Shape id for the `{ eventLoopUtilization, nodeTiming, timeOrigin }`
+/// snapshot returned by `performance.toJSON()`.
+const TOJSON_SHAPE: u32 = 0x7FFF_FF50;
+const TOJSON_KEYS: &[u8] = b"eventLoopUtilization\0nodeTiming\0timeOrigin\0";
 
 /// Shape id + keys for `performance.nodeTiming` (PerformanceNodeTiming entry).
 const NODE_TIMING_SHAPE: u32 = 0x7FFF_FF43;
-const NODE_TIMING_KEYS: &[u8] = b"name\0entryType\0startTime\0duration\0nodeStart\0v8Start\0bootstrapComplete\0environment\0loopStart\0loopExit\0idleTime\0";
+const NODE_TIMING_KEYS: &[u8] = b"name\0entryType\0startTime\0duration\0nodeStart\0v8Start\0bootstrapComplete\0environment\0loopStart\0loopExit\0idleTime\0uvMetricsInfo\0";
+
+/// Shape id + keys for `performance.nodeTiming.uvMetricsInfo`.
+const UV_METRICS_INFO_SHAPE: u32 = 0x7FFF_FF51;
+const UV_METRICS_INFO_KEYS: &[u8] = b"loopCount\0events\0eventsWaiting\0";
 
 #[derive(Clone)]
 struct PerfEntry {
@@ -109,6 +117,8 @@ unsafe fn perf_entry_type(obj: *const crate::object::ObjectHeader) -> Option<u8>
     match entry_type.as_str() {
         "mark" => Some(ENTRY_TYPE_MARK),
         "measure" => Some(ENTRY_TYPE_MEASURE),
+        "resource" => Some(ENTRY_TYPE_RESOURCE),
+        "function" => Some(ENTRY_TYPE_FUNCTION),
         _ => None,
     }
 }
@@ -121,6 +131,7 @@ pub(crate) unsafe fn is_perf_entry_object_instance_of(
         CLASS_ID_PERFORMANCE_ENTRY => None,
         CLASS_ID_PERFORMANCE_MARK => Some(ENTRY_TYPE_MARK),
         CLASS_ID_PERFORMANCE_MEASURE => Some(ENTRY_TYPE_MEASURE),
+        CLASS_ID_PERFORMANCE_RESOURCE_TIMING => Some(ENTRY_TYPE_RESOURCE),
         _ => return None,
     };
     if !is_perf_entry_object(obj) {
@@ -130,6 +141,32 @@ pub(crate) unsafe fn is_perf_entry_object_instance_of(
         None => true,
         Some(kind) => perf_entry_type(obj) == Some(kind),
     })
+}
+
+pub(crate) fn is_performance_object_value(value: f64) -> bool {
+    let bits = value.to_bits();
+    PERFORMANCE_NS.with(|c| {
+        let cached = c.get();
+        cached != 0 && cached == bits
+    })
+}
+
+pub(crate) fn is_perf_observer_list_value(value: f64) -> bool {
+    unsafe {
+        let Some(obj) = as_object_ptr(value) else {
+            return false;
+        };
+        let module = js_object_get_field(obj, 0);
+        string_of(module).as_deref() == Some("perf_observer_list")
+    }
+}
+
+pub(crate) fn is_perf_hooks_shape_instance_of(value: f64, class_id: u32) -> Option<bool> {
+    match class_id {
+        CLASS_ID_PERFORMANCE => Some(is_performance_object_value(value)),
+        CLASS_ID_PERFORMANCE_OBSERVER_ENTRY_LIST => Some(is_perf_observer_list_value(value)),
+        _ => None,
+    }
 }
 
 /// Build the plain object returned by `PerformanceEntry#toJSON()` — a copy of
@@ -798,19 +835,31 @@ unsafe fn read_elu_idle_active(value: f64) -> Option<(f64, f64)> {
 
 // ── performance.toJSON() ─────────────────────────────────────────────────────
 /// A JSON snapshot of the performance object. Node returns
-/// `{ nodeTiming, timeOrigin, ... }`; Perry currently surfaces `timeOrigin`
-/// (a positive ms value), which is the field user code reads when serializing
-/// `performance`. Forward-compatible with adding `nodeTiming` later (#1337).
+/// `{ eventLoopUtilization, nodeTiming, timeOrigin }`; Perry keeps the same
+/// property names and numeric subfield types while using deterministic fallback
+/// values for libuv-specific counters.
 #[no_mangle]
 pub extern "C" fn js_perf_to_json() -> f64 {
     unsafe {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let (idle, active) = cumulative_idle_active();
+        let elu = make_elu_object(idle, active);
+        let elu_handle = scope.root_nanbox_f64(elu);
+        let node_timing = js_perf_node_timing();
+        let node_timing_handle = scope.root_nanbox_f64(node_timing);
         let obj = js_object_alloc_with_shape(
             TOJSON_SHAPE,
-            1,
+            3,
             TOJSON_KEYS.as_ptr(),
             TOJSON_KEYS.len() as u32,
         );
-        js_object_set_field(obj, 0, JSValue::number(time_origin_ms()));
+        js_object_set_field(obj, 0, JSValue::from_bits(elu_handle.get_nanbox_u64()));
+        js_object_set_field(
+            obj,
+            1,
+            JSValue::from_bits(node_timing_handle.get_nanbox_u64()),
+        );
+        js_object_set_field(obj, 2, JSValue::number(time_origin_ms()));
         crate::value::js_nanbox_pointer(obj as i64)
     }
 }
@@ -824,14 +873,20 @@ pub extern "C" fn js_perf_to_json() -> f64 {
 #[no_mangle]
 pub extern "C" fn js_perf_node_timing() -> f64 {
     unsafe {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let node_name = str_value("node");
+        let node_name_handle = scope.root_nanbox_u64(node_name.bits());
+        let uv_metrics = make_uv_metrics_info_object();
+        let uv_metrics_handle = scope.root_nanbox_f64(uv_metrics);
         let obj = js_object_alloc_with_shape(
             NODE_TIMING_SHAPE,
-            11,
+            12,
             NODE_TIMING_KEYS.as_ptr(),
             NODE_TIMING_KEYS.len() as u32,
         );
-        js_object_set_field(obj, 0, str_value("node")); // name
-        js_object_set_field(obj, 1, str_value("node")); // entryType
+        let node_name = JSValue::from_bits(node_name_handle.get_nanbox_u64());
+        js_object_set_field(obj, 0, node_name); // name
+        js_object_set_field(obj, 1, node_name); // entryType
         js_object_set_field(obj, 2, JSValue::number(0.0)); // startTime
         js_object_set_field(obj, 3, JSValue::number(0.0)); // duration
         js_object_set_field(obj, 4, JSValue::number(0.0)); // nodeStart
@@ -841,8 +896,28 @@ pub extern "C" fn js_perf_node_timing() -> f64 {
         js_object_set_field(obj, 8, JSValue::number(perf_now().max(0.0))); // loopStart
         js_object_set_field(obj, 9, JSValue::number(-1.0)); // loopExit (loop running)
         js_object_set_field(obj, 10, JSValue::number(0.0)); // idleTime
+        js_object_set_field(
+            obj,
+            11,
+            JSValue::from_bits(uv_metrics_handle.get_nanbox_u64()),
+        );
         crate::value::js_nanbox_pointer(obj as i64)
     }
+}
+
+unsafe fn make_uv_metrics_info_object() -> f64 {
+    let obj = js_object_alloc_with_shape(
+        UV_METRICS_INFO_SHAPE,
+        3,
+        UV_METRICS_INFO_KEYS.as_ptr(),
+        UV_METRICS_INFO_KEYS.len() as u32,
+    );
+    // Perry does not expose libuv counters; retain Node's property names and
+    // numeric field types with deterministic zero counters.
+    js_object_set_field(obj, 0, JSValue::number(0.0)); // loopCount
+    js_object_set_field(obj, 1, JSValue::number(0.0)); // events
+    js_object_set_field(obj, 2, JSValue::number(0.0)); // eventsWaiting
+    crate::value::js_nanbox_pointer(obj as i64)
 }
 
 // ── clearResourceTimings() / setResourceTimingBufferSize(n) ──────────────────

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2365 entries across 103 modules
+// Coverage: 2368 entries across 103 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -2063,6 +2063,8 @@ declare module "path/win32" {
 
 declare module "perf_hooks" {
   /** stdlib */
+  export class Performance { [key: string]: any; }
+  /** stdlib */
   export class PerformanceEntry { [key: string]: any; }
   /** stdlib */
   export class PerformanceMark { [key: string]: any; }
@@ -2070,6 +2072,10 @@ declare module "perf_hooks" {
   export class PerformanceMeasure { [key: string]: any; }
   /** stdlib */
   export class PerformanceObserver { [key: string]: any; }
+  /** stdlib */
+  export class PerformanceObserverEntryList { [key: string]: any; }
+  /** stdlib */
+  export class PerformanceResourceTiming { [key: string]: any; }
   /** stdlib */
   export const constants: any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2365 entries across 103 modules.
+Total: 2368 entries across 103 modules.
 
 ## Modules
 
@@ -1954,10 +1954,13 @@ Total: 2365 entries across 103 modules.
 
 ### Classes
 
+- `Performance`
 - `PerformanceEntry`
 - `PerformanceMark`
 - `PerformanceMeasure`
 - `PerformanceObserver`
+- `PerformanceObserverEntryList`
+- `PerformanceResourceTiming`
 
 ### Methods
 

--- a/test-parity/node-suite/perf_hooks/global/class-constructors.ts
+++ b/test-parity/node-suite/perf_hooks/global/class-constructors.ts
@@ -1,0 +1,86 @@
+import {
+  performance,
+  Performance,
+  PerformanceEntry,
+  PerformanceMark,
+  PerformanceMeasure,
+  PerformanceObserver,
+  PerformanceObserverEntryList,
+  PerformanceResourceTiming,
+} from "node:perf_hooks";
+
+const g: any = globalThis;
+
+console.log(
+  "Performance:",
+  typeof Performance,
+  typeof g.Performance,
+  Performance === g.Performance,
+  Performance.name,
+  Performance.length,
+);
+console.log(
+  "PerformanceEntry:",
+  typeof PerformanceEntry,
+  typeof g.PerformanceEntry,
+  PerformanceEntry === g.PerformanceEntry,
+  PerformanceEntry.name,
+  PerformanceEntry.length,
+);
+console.log(
+  "PerformanceMark:",
+  typeof PerformanceMark,
+  typeof g.PerformanceMark,
+  PerformanceMark === g.PerformanceMark,
+  PerformanceMark.name,
+  PerformanceMark.length,
+);
+console.log(
+  "PerformanceMeasure:",
+  typeof PerformanceMeasure,
+  typeof g.PerformanceMeasure,
+  PerformanceMeasure === g.PerformanceMeasure,
+  PerformanceMeasure.name,
+  PerformanceMeasure.length,
+);
+console.log(
+  "PerformanceObserver:",
+  typeof PerformanceObserver,
+  typeof g.PerformanceObserver,
+  PerformanceObserver === g.PerformanceObserver,
+  PerformanceObserver.name,
+  PerformanceObserver.length,
+);
+console.log(
+  "PerformanceObserverEntryList:",
+  typeof PerformanceObserverEntryList,
+  typeof g.PerformanceObserverEntryList,
+  PerformanceObserverEntryList === g.PerformanceObserverEntryList,
+  PerformanceObserverEntryList.name,
+  PerformanceObserverEntryList.length,
+);
+console.log(
+  "PerformanceResourceTiming:",
+  typeof PerformanceResourceTiming,
+  typeof g.PerformanceResourceTiming,
+  PerformanceResourceTiming === g.PerformanceResourceTiming,
+  PerformanceResourceTiming.name,
+  PerformanceResourceTiming.length,
+);
+
+console.log("performance same:", g.performance === performance);
+console.log("performance instanceof Performance:", performance instanceof Performance);
+
+const mark = performance.mark("class-constructors-mark");
+console.log(
+  "mark instances:",
+  mark instanceof PerformanceEntry,
+  mark instanceof PerformanceMark,
+  mark instanceof PerformanceMeasure,
+  mark instanceof PerformanceResourceTiming,
+);
+console.log(
+  "observer static:",
+  Array.isArray(PerformanceObserver.supportedEntryTypes),
+  PerformanceObserver.supportedEntryTypes.includes("mark"),
+);

--- a/test-parity/node-suite/perf_hooks/observer/list-instanceof.ts
+++ b/test-parity/node-suite/perf_hooks/observer/list-instanceof.ts
@@ -1,0 +1,22 @@
+import {
+  performance,
+  PerformanceObserver,
+  PerformanceObserverEntryList,
+} from "node:perf_hooks";
+
+await new Promise<void>((resolve) => {
+  const obs = new PerformanceObserver((list, observer) => {
+    console.log("list instanceof:", list instanceof PerformanceObserverEntryList);
+    console.log(
+      "list methods:",
+      typeof list.getEntries,
+      typeof list.getEntriesByName,
+      typeof list.getEntriesByType,
+    );
+    console.log("observer same:", observer === obs);
+    obs.disconnect();
+    resolve();
+  });
+  obs.observe({ entryTypes: ["mark"] });
+  performance.mark("list-instanceof-mark");
+});

--- a/test-parity/node-suite/perf_hooks/to-json/snapshot-shape.ts
+++ b/test-parity/node-suite/perf_hooks/to-json/snapshot-shape.ts
@@ -1,0 +1,22 @@
+import { performance } from "node:perf_hooks";
+
+const json = performance.toJSON();
+const nodeTiming = performance.nodeTiming;
+
+console.log("toJSON keys:", Object.keys(json).sort().join(","));
+console.log("toJSON elu keys:", Object.keys(json.eventLoopUtilization).sort().join(","));
+console.log("toJSON nodeTiming keys:", Object.keys(json.nodeTiming).sort().join(","));
+console.log("nodeTiming keys:", Object.keys(nodeTiming).sort().join(","));
+console.log("uv keys:", Object.keys(nodeTiming.uvMetricsInfo).sort().join(","));
+console.log(
+  "elu numeric:",
+  ["active", "idle", "utilization"].every(
+    (key) => typeof json.eventLoopUtilization[key] === "number",
+  ),
+);
+console.log(
+  "uv numeric:",
+  ["events", "eventsWaiting", "loopCount"].every(
+    (key) => typeof nodeTiming.uvMetricsInfo[key] === "number",
+  ),
+);


### PR DESCRIPTION
## Summary
- expose the missing `perf_hooks` constructor/class values through module exports, `globalThis`, manifests, generated docs, and dynamic `instanceof` classification
- make `performance instanceof Performance` and observer entry-list `instanceof PerformanceObserverEntryList` match Node
- expand the deterministic `performance.toJSON()` / `performance.nodeTiming` shape with `eventLoopUtilization`, `timeOrigin`, and `uvMetricsInfo`

Closes #2579
Closes #2562

## Why Batched
Both issues hit the same `node:perf_hooks` class-surface path: native module export binding, global constructor installation, runtime shape classification, manifest/docs generation, and parity coverage for observable object shapes.

## Tests Added
- `test-parity/node-suite/perf_hooks/global/class-constructors.ts`
- `test-parity/node-suite/perf_hooks/observer/list-instanceof.ts`
- `test-parity/node-suite/perf_hooks/to-json/snapshot-shape.ts`

## Verification
- `./scripts/regen_api_docs.sh`
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- `./scripts/check_file_size.sh`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module perf_hooks`
  - 83 pass, 0 fail, 0 compile fail, 0 skipped

## Known Limitations / Non-Goals
- `uvMetricsInfo` currently exposes deterministic zero counters instead of live libuv metrics.
- This does not add new resource-timing data collection.
- This does not expand `timerify` or histogram semantics.
- This does not attempt broader illegal-constructor or `new` semantics beyond exposing the missing class values and matching the covered shape checks.