### PR TITLE
fix(runtime): node:sys default export is the util namespace object (unblocks main)

### DIFF
--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -1553,7 +1553,14 @@ mod tests {
     }
 
     #[test]
-    fn sys_default_export_is_util_namespace() {
+    fn sys_default_export_is_util_default_export() {
+        // `sys` is a deprecated alias of `util`, so its CJS default export must
+        // be pointer-identical to `util`'s default export. In Node:
+        //   import sysDefault from "node:sys";  import utilDefault from "node:util";
+        //   sysDefault === utilDefault           // true
+        //   sysDefault === (util namespace)      // false
+        // (#3741 made `util`'s default export a distinct synthetic namespace
+        // object rather than the `util` namespace itself; `sys` must follow it.)
         let sys_default = unsafe {
             js_node_submodule_export_as_function(
                 b"sys".as_ptr(),
@@ -1562,8 +1569,14 @@ mod tests {
                 "default".len() as u32,
             )
         };
-        let util_default =
-            crate::object::js_create_native_module_namespace(b"util".as_ptr(), "util".len());
+        let util_default = unsafe {
+            crate::object::js_native_module_property_by_name(
+                b"util".as_ptr(),
+                "util".len(),
+                b"default".as_ptr(),
+                "default".len(),
+            )
+        };
 
         assert_eq!(sys_default.to_bits(), util_default.to_bits());
     }


### PR DESCRIPTION
## Root cause

`origin/main` was RED on cargo-test: `node_submodules::tests::sys_default_export_is_util_namespace` failed.

The test was added in #2660 and asserted that node:sys's default export is pointer-identical to the **util namespace** object. #3741 (align core cjs default exports) made util's CJS default export a *distinct* synthetic namespace object (cached under `"util.default"`) rather than the util namespace itself, and correctly routed `sys.default` through util's default export. That left the pre-existing test asserting the old, now-incorrect identity — blocking every open PR.

## Correct behavior (verified against real Node)

```
import sysDefault from 'node:sys';
import utilDefault, * as utilNs from 'node:util';
sysDefault === utilDefault   // true
sysDefault === utilNs        // false  (namespace, not default)
```

## Fix

Test-only. Updates the stale assertion (renamed to `sys_default_export_is_util_default_export`) to compare `sys.default` against util's **default export** (`js_native_module_property_by_name("util","default")`) instead of the util namespace. Restores green and matches #3741's intentional design plus the `cjs-default-exports` parity fixture. No runtime/codegen change.

## Verification

- failing test → passes
- `cargo test -p perry-runtime node_submodules` → 30 passed
- `cargo test -p perry-runtime` (full) → 945 passed, 0 failed
- `cargo test -p perry-api-manifest` → ok; `cargo test -p perry-codegen --test manifest_consistency` → ok
- build of perry-runtime/stdlib/codegen/hir → ok; `cargo fmt --check` → clean; `check_file_size.sh` → OK
