### PR TITLE
fix(runtime): materialize function arguments object (indices/length/iteration)

### DIFF
--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1681,7 +1681,16 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
         let gc_header = raw_ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
         let gc_type = (*gc_header).obj_type;
         if gc_type == crate::gc::GC_TYPE_ARRAY || gc_type == crate::gc::GC_TYPE_LAZY_ARRAY {
-            let bytes = b"[object Array]";
+            // #3553: a function's `arguments` object is represented as an array
+            // carrying the GC_ARRAY_ARGUMENTS_OBJECT flag. Node tags it
+            // `[object Arguments]`, not `[object Array]`.
+            let bytes: &[u8] = if crate::array::array_has_arguments_object_flag(
+                raw_addr as *const crate::array::ArrayHeader,
+            ) {
+                b"[object Arguments]"
+            } else {
+                b"[object Array]"
+            };
             let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
             return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
         }

--- a/test-files/test_gap_arguments_object_3553plus.ts
+++ b/test-files/test_gap_arguments_object_3553plus.ts
@@ -1,0 +1,55 @@
+// Gap test: ordinary function `arguments` object materialization (#3553).
+// Covers indexed access, .length, iteration, spread, Array.from, the
+// [object Arguments] toStringTag, and Object.keys. Compared byte-for-byte
+// against `node --experimental-strip-types`.
+
+function lenFn() {
+  return arguments.length;
+}
+console.log(lenFn(1, 2, 3));
+console.log(lenFn());
+console.log(lenFn("a", "b"));
+
+function idxFn() {
+  return arguments[0] + ":" + arguments[1];
+}
+console.log(idxFn("x", "y"));
+
+function spreadFn() {
+  return [...arguments];
+}
+console.log(spreadFn(1, 2, 3));
+
+function fromFn() {
+  return Array.from(arguments);
+}
+console.log(fromFn(4, 5));
+
+function tagFn() {
+  return Object.prototype.toString.call(arguments);
+}
+console.log(tagFn(1));
+
+function typeFn() {
+  return typeof arguments;
+}
+console.log(typeFn(1));
+
+function iterFn() {
+  const out: number[] = [];
+  for (const x of arguments) out.push((x as number) * 2);
+  return out;
+}
+console.log(iterFn(1, 2, 3));
+
+function keysFn() {
+  return Object.keys(arguments);
+}
+console.log(keysFn("a", "b", "c"));
+
+// arguments.length reflects ALL passed args, not the declared arity.
+function dualFn(a: number, b: number) {
+  return arguments.length;
+}
+console.log(dualFn(1, 2, 3, 4));
+console.log(dualFn(1));


### PR DESCRIPTION
Closes #3553

## Implementation

Ordinary non-arrow functions in Perry already materialize an `arguments`
binding: HIR lowering (`fn_decl.rs`, `expr_function.rs`, class/object
methods) synthesizes a trailing `...arguments` rest parameter when the
body references `arguments`, and both the static call-site bundling path
(`lower_call/func_ref.rs`) and the dynamic closure-dispatch path
(`closure/registry.rs`) mark the resulting array with the
`GC_ARRAY_ARGUMENTS_OBJECT` flag. That gives correct indexed access,
`.length` (counting **all** passed args regardless of declared arity),
iteration, spread, `Array.from`, `Object.keys`, and `typeof`.

The one observable divergence was `Object.prototype.toString.call(arguments)`:
the array branch of `js_object_to_string` (`object/mod.rs`)
unconditionally returned `"[object Array]"`. It now consults
`array_has_arguments_object_flag` and returns `"[object Arguments]"` for
arguments objects, matching Node. Normal arrays, lazy (`JSON.parse`)
arrays, and plain objects are untouched.

## Validation

`test-files/test_gap_arguments_object_3553plus.ts` is **byte-identical**
to `node --experimental-strip-types` under the default compile:

```
3 / 0 / 2            lenFn(...) — .length over varied arity
x:y                  arguments[0]/[1] indexed access
[ 1, 2, 3 ]          [...arguments] spread
[ 4, 5 ]             Array.from(arguments)
[object Arguments]   Object.prototype.toString.call(arguments)
object               typeof arguments
[ 2, 4, 6 ]          for-of iteration
[ '0', '1', '2' ]    Object.keys(arguments)
4 / 1                arguments.length reflects all passed args, not arity
```

`diff` against Node output is empty (IDENTICAL).

## Regression evidence

- 6 existing function/closure gap tests byte-identical to Node:
  `test_gap_closures`, `test_closure_complex`, `test_function_apply_call`,
  `test_edge_rest_spread_defaults`, `test_gap_function_name_inference_2076`,
  `test_iife_arrow`.
- `Object.prototype.toString.call` for normal `[1,2,3]`, `[]`, `{}`, and
  `JSON.parse("[1,2]")` still match Node (`[object Array]` / `[object Object]`).
- `cargo test -p perry-runtime` (945 pass; the single `gc::barrier`
  ordering-flaky test passes in isolation and is unrelated — change only
  touches the toString array branch). `cargo test -p perry-hir` green.
- `./scripts/check_file_size.sh` OK; `cargo fmt --all -- --check` clean.

No new HIR variant added (reused existing arguments-synthesis machinery),
so no stable-hash tag needed.

## Dropped (with notes)

- **#3554** (own-property descriptors for `length`/indices, `"length" in
  arguments`): blocked on a general array-property-model gap —
  `Object.getOwnPropertyDescriptor([1,2,3], "length")` and `(arr, 0)`
  return `undefined` for *plain* arrays too, and `"length" in arr` is
  `false`. Fixing this for arguments requires implementing array
  index/length as descriptor-visible own properties globally — a large,
  risky change beyond arguments materialization.
- **#3555** (sloppy-mode mapped aliasing, strict `callee`/`caller`
  throws): TypeScript strips to strict mode, so mapped aliasing is moot;
  strict `callee` throwing requires per-arguments-object accessor
  installation tied to the descriptor model in #3554.
