### PR TITLE
fix(stdlib): compile node:domain without bundled-events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1046 — fix(stdlib): compile node:domain without bundled-events
+
+**Hotfix — main default-feature build was broken.** `crates/perry-stdlib/src/domain.rs` (added by #3535) called `crate::events::{is_event_emitter_handle, js_event_emitter_get_domain, js_event_emitter_set_domain}` unconditionally at six sites, but `mod events` is `#[cfg(feature = "bundled-events")]`-gated (since v0.5.546, so the well-known bindings table can flip `import 'events'` to `perry-ext-events`). `mod domain` itself is **not** feature-gated, so any build with `bundled-events` off — notably the auto-optimize compile path the `compiler-output-regression` CI gate exercises — failed with `error[E0433]: cannot find 'events' in 'crate'`. `cargo-test` masked it because the test build pulls `full` (which includes `bundled-events`).
+
+Fix: route all six call sites through three small feature-gated shims (`ee_is_event_emitter_handle`, `ee_get_domain`, `ee_set_domain`). With `bundled-events` on they delegate to `crate::events::*` as before; with it off they degrade to inert no-ops (`false`/`0`/`()`), so the domain↔EventEmitter integration is simply absent in that build (where events lives in `perry-ext-events`). Verified both feature configurations compile cleanly.
+
 ## v0.5.1045 — fix(runtime): brand-check collection prototype methods (#3662)
 
 `Set`/`Map`/`WeakSet`/`WeakMap` prototype methods reached as plain values —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1045
+**Current Version:** 0.5.1046
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4880,7 +4880,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "anyhow",
  "base64",
@@ -4935,14 +4935,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "cc",
  "libc",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "anyhow",
  "log",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "anyhow",
  "base64",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "serde",
  "serde_json",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1045"
+version = "0.5.1046"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "anyhow",
  "clap",
@@ -5056,14 +5056,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "chrono",
  "cron",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5162,14 +5162,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "base64",
  "image",
@@ -5354,14 +5354,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5388,7 +5388,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "brotli",
  "flate2",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "anyhow",
  "base64",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5571,14 +5571,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "base64",
  "itoa",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "base64",
  "block2",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "base64",
  "block2",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1045"
+version = "0.5.1046"
 
 [[package]]
 name = "perry-ui-test"
@@ -5667,11 +5667,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1045"
+version = "0.5.1046"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "base64",
  "block2",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "base64",
  "block2",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "block2",
  "libc",
@@ -5716,7 +5716,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "base64",
  "libc",
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1045"
+version = "0.5.1046"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1045"
+version = "0.5.1046"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-stdlib/src/domain.rs
+++ b/crates/perry-stdlib/src/domain.rs
@@ -10,6 +10,43 @@ use std::collections::HashMap;
 use std::os::raw::c_int;
 use std::sync::Once;
 
+// `events` is feature-gated behind `bundled-events`; when the well-known
+// bindings table routes `import 'events'` to perry-ext-events the in-tree
+// module is configured out (and the default auto-optimize build compiles
+// without it). The domain<->EventEmitter integration degrades to inert
+// no-ops in that build — these shims keep `mod domain` (which is NOT
+// feature-gated) compiling either way.
+#[cfg(feature = "bundled-events")]
+#[inline]
+fn ee_is_event_emitter_handle(handle: Handle) -> bool {
+    crate::events::is_event_emitter_handle(handle)
+}
+#[cfg(not(feature = "bundled-events"))]
+#[inline]
+fn ee_is_event_emitter_handle(_handle: Handle) -> bool {
+    false
+}
+
+#[cfg(feature = "bundled-events")]
+#[inline]
+fn ee_get_domain(handle: Handle) -> Handle {
+    crate::events::js_event_emitter_get_domain(handle)
+}
+#[cfg(not(feature = "bundled-events"))]
+#[inline]
+fn ee_get_domain(_handle: Handle) -> Handle {
+    0
+}
+
+#[cfg(feature = "bundled-events")]
+#[inline]
+fn ee_set_domain(handle: Handle, domain: Handle) {
+    let _ = crate::events::js_event_emitter_set_domain(handle, domain);
+}
+#[cfg(not(feature = "bundled-events"))]
+#[inline]
+fn ee_set_domain(_handle: Handle, _domain: Handle) {}
+
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
 
@@ -323,8 +360,8 @@ pub unsafe extern "C" fn js_domain_add(handle: Handle, member: f64) -> Handle {
         }
     }
     let member_handle = handle_from_value(member);
-    if crate::events::is_event_emitter_handle(member_handle) {
-        let _ = crate::events::js_event_emitter_set_domain(member_handle, handle);
+    if ee_is_event_emitter_handle(member_handle) {
+        ee_set_domain(member_handle, handle);
     }
     handle
 }
@@ -337,10 +374,8 @@ pub unsafe extern "C" fn js_domain_remove(handle: Handle, member: f64) -> Handle
             .retain(|candidate| candidate.to_bits() != member.to_bits());
     }
     let member_handle = handle_from_value(member);
-    if crate::events::is_event_emitter_handle(member_handle)
-        && crate::events::js_event_emitter_get_domain(member_handle) == handle
-    {
-        let _ = crate::events::js_event_emitter_set_domain(member_handle, 0);
+    if ee_is_event_emitter_handle(member_handle) && ee_get_domain(member_handle) == handle {
+        ee_set_domain(member_handle, 0);
     }
     handle
 }
@@ -432,8 +467,8 @@ pub unsafe fn dispatch_domain_method(handle: Handle, method: &str, args: &[f64])
 }
 
 pub fn dispatch_domain_property(handle: Handle, property: &str) -> Option<f64> {
-    if crate::events::is_event_emitter_handle(handle) && property == "domain" {
-        let domain = crate::events::js_event_emitter_get_domain(handle);
+    if ee_is_event_emitter_handle(handle) && property == "domain" {
+        let domain = ee_get_domain(handle);
         return Some(if domain == 0 {
             null()
         } else {


### PR DESCRIPTION
**Hotfix — main's default-feature build is broken.**

`crates/perry-stdlib/src/domain.rs` (added by #3535) calls `crate::events::{is_event_emitter_handle, js_event_emitter_get_domain, js_event_emitter_set_domain}` unconditionally at six sites, but `mod events` is `#[cfg(feature = "bundled-events")]`-gated (since v0.5.546) while `mod domain` is **not** gated. Any build with `bundled-events` off — notably the auto-optimize compile path the `compiler-output-regression` gate exercises — fails with `error[E0433]: cannot find 'events' in 'crate'`. `cargo-test` masks it because it builds `full` (includes `bundled-events`).

Fix: route the six call sites through three feature-gated shims (`ee_is_event_emitter_handle` / `ee_get_domain` / `ee_set_domain`) that delegate to `crate::events::*` when bundled and no-op (`false`/`0`/`()`) when not. Verified both feature configs compile.
