### PR TITLE
fix(node:fs): align cp advanced semantics

### DIFF
--- a/crates/perry-runtime/src/fs/cp.rs
+++ b/crates/perry-runtime/src/fs/cp.rs
@@ -13,7 +13,9 @@ pub(crate) struct FsCopyOptions {
     dereference: bool,
     verbatim_symlinks: bool,
     recursive: bool,
+    mode: i32,
     filter: f64,
+    sync_filter: bool,
     sync_symlink_resolution: bool,
 }
 
@@ -30,9 +32,11 @@ pub(crate) unsafe fn fs_copy_options_from_value(options_value: f64) -> FsCopyOpt
         dereference: options_bool_field(options_value, b"dereference"),
         verbatim_symlinks: options_bool_field(options_value, b"verbatimSymlinks"),
         recursive: options_bool_field(options_value, b"recursive"),
+        mode: options_number_field(options_value, b"mode").unwrap_or(0.0) as i32,
         filter: options_field_value(options_value, b"filter")
             .map(|v| f64::from_bits(v.bits()))
             .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED)),
+        sync_filter: false,
         sync_symlink_resolution: false,
     }
 }
@@ -58,23 +62,105 @@ fn resolve_copied_symlink_target(src: &Path, target: PathBuf, opts: FsCopyOption
     }
 }
 
-pub(crate) fn copy_filter_allows(src: &Path, dst: &Path, opts: FsCopyOptions) -> bool {
+unsafe fn build_cp_error_value(
+    message: &str,
+    code: &'static str,
+    syscall: Option<&'static str>,
+    path: Option<String>,
+) -> f64 {
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_error_new_with_message(msg);
+    crate::node_submodules::register_error_code_pub(msg, code);
+    if let Some(syscall) = syscall {
+        crate::node_submodules::register_error_syscall(msg, syscall);
+    }
+    if let Some(path) = path {
+        crate::node_submodules::register_error_path(msg, path);
+    }
+    crate::value::js_nanbox_pointer(err as i64)
+}
+
+unsafe fn build_cp_type_error_value(message: &str, code: &'static str) -> f64 {
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::node_submodules::register_error_code_pub(msg, code);
+    crate::value::js_nanbox_pointer(err as i64)
+}
+
+unsafe fn build_cp_eexist_error(dst: &Path) -> f64 {
+    let path = dst.to_string_lossy().into_owned();
+    let message =
+        format!("Target already exists: cp returned EEXIST ({path} already exists) {path}");
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_error_new_with_message(msg);
+    crate::node_submodules::register_error_code_pub(msg, "ERR_FS_CP_EEXIST");
+    crate::node_submodules::register_error_syscall(msg, "cp");
+    crate::node_submodules::register_error_path(msg, path);
+    #[cfg(unix)]
+    crate::node_submodules::set_error_user_prop(err as usize, "errno", libc::EEXIST as f64);
+    crate::value::js_nanbox_pointer(err as i64)
+}
+
+unsafe fn build_invalid_filter_return_error() -> f64 {
+    build_cp_type_error_value(
+        "Expected boolean to be returned from the \"filter\" function but got an instance of Promise.",
+        "ERR_INVALID_RETURN_VALUE",
+    )
+}
+
+unsafe fn promise_ptr_from_value(value: f64) -> Option<*mut crate::promise::Promise> {
+    if crate::promise::js_value_is_promise(value) == 0 {
+        return None;
+    }
+    let js_value = crate::value::JSValue::from_bits(value.to_bits());
+    if js_value.is_pointer() {
+        Some(js_value.as_pointer::<crate::promise::Promise>() as *mut crate::promise::Promise)
+    } else {
+        None
+    }
+}
+
+unsafe fn copy_filter_promise_result(promise: *mut crate::promise::Promise) -> Result<f64, f64> {
+    for _ in 0..64 {
+        match crate::promise::js_promise_state(promise) {
+            1 => return Ok(crate::promise::js_promise_value(promise)),
+            2 => return Err(crate::promise::js_promise_reason(promise)),
+            _ => {
+                if crate::promise::js_promise_run_microtasks() == 0 {
+                    break;
+                }
+            }
+        }
+    }
+    match crate::promise::js_promise_state(promise) {
+        1 => Ok(crate::promise::js_promise_value(promise)),
+        2 => Err(crate::promise::js_promise_reason(promise)),
+        _ => Ok(f64::from_bits(crate::value::TAG_TRUE)),
+    }
+}
+
+pub(crate) fn copy_filter_allows(src: &Path, dst: &Path, opts: FsCopyOptions) -> Result<bool, f64> {
     let filter = extract_closure_ptr(opts.filter);
     if filter.is_null() {
-        return true;
+        return Ok(true);
     }
     let src_string = src.to_string_lossy();
     let dst_string = dst.to_string_lossy();
-    let src_value = unsafe {
-        let s = js_string_from_bytes(src_string.as_bytes().as_ptr(), src_string.len() as u32);
-        crate::value::js_nanbox_string(s as i64)
-    };
-    let dst_value = unsafe {
-        let s = js_string_from_bytes(dst_string.as_bytes().as_ptr(), dst_string.len() as u32);
-        crate::value::js_nanbox_string(s as i64)
-    };
+    let s = js_string_from_bytes(src_string.as_bytes().as_ptr(), src_string.len() as u32);
+    let src_value = crate::value::js_nanbox_string(s as i64);
+    let s = js_string_from_bytes(dst_string.as_bytes().as_ptr(), dst_string.len() as u32);
+    let dst_value = crate::value::js_nanbox_string(s as i64);
     let result = crate::closure::js_closure_call2(filter, src_value, dst_value);
-    crate::value::js_is_truthy(result) != 0
+    unsafe {
+        if let Some(promise) = promise_ptr_from_value(result) {
+            if opts.sync_filter {
+                return Err(build_invalid_filter_return_error());
+            }
+            let value = copy_filter_promise_result(promise)?;
+            return Ok(crate::value::js_is_truthy(value) != 0);
+        }
+    }
+    Ok(crate::value::js_is_truthy(result) != 0)
 }
 
 pub(crate) fn copy_preserve_timestamps(src: &Path, dst: &Path, follow: bool) {
@@ -114,25 +200,50 @@ pub(crate) fn copy_file_with_options(
     src: &Path,
     dst: &Path,
     opts: FsCopyOptions,
-) -> std::io::Result<()> {
-    if !copy_filter_allows(src, dst, opts) {
+) -> Result<(), f64> {
+    let _mode = opts.mode;
+    if !copy_filter_allows(src, dst, opts)? {
         return Ok(());
     }
-    if dst.exists() {
-        if !opts.force {
-            if opts.error_on_exist {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::AlreadyExists,
-                    "destination exists",
-                ));
-            }
-            return Ok(());
+    match fs::symlink_metadata(dst) {
+        Ok(meta) if meta.is_dir() => {
+            return Err(unsafe {
+                let message = format!(
+                    "Cannot overwrite directory {} with non-directory {}",
+                    dst.to_string_lossy(),
+                    src.to_string_lossy()
+                );
+                build_cp_error_value(&message, "ERR_FS_CP_NON_DIR_TO_DIR", None, None)
+            });
         }
-    } else if let Some(parent) = dst.parent() {
-        fs::create_dir_all(parent)?;
+        Ok(_) => {
+            if !opts.force {
+                if opts.error_on_exist {
+                    return Err(unsafe { build_cp_eexist_error(dst) });
+                }
+                return Ok(());
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            if let Some(parent) = dst.parent() {
+                fs::create_dir_all(parent).map_err(|err| unsafe {
+                    build_fs_error_value(&err, "mkdir", &parent.to_string_lossy())
+                })?;
+            }
+        }
+        Err(err) => {
+            return Err(unsafe { build_fs_error_value(&err, "lstat", &dst.to_string_lossy()) });
+        }
     }
 
-    fs::copy(src, dst)?;
+    fs::copy(src, dst).map_err(|err| unsafe {
+        build_fs_error_value_with_dest(
+            &err,
+            "copyfile",
+            &src.to_string_lossy(),
+            &dst.to_string_lossy(),
+        )
+    })?;
     if opts.preserve_timestamps {
         copy_preserve_timestamps(src, dst, opts.dereference);
     }
@@ -143,37 +254,83 @@ pub(crate) fn copy_symlink_with_options(
     src: &Path,
     dst: &Path,
     opts: FsCopyOptions,
-) -> std::io::Result<()> {
-    if !copy_filter_allows(src, dst, opts) {
+) -> Result<(), f64> {
+    copy_symlink_with_options_depth(src, dst, opts, 0)
+}
+
+fn copy_symlink_with_options_depth(
+    src: &Path,
+    dst: &Path,
+    opts: FsCopyOptions,
+    depth: u32,
+) -> Result<(), f64> {
+    if !copy_filter_allows(src, dst, opts)? {
         return Ok(());
     }
     if opts.dereference && !opts.sync_symlink_resolution {
-        let target_meta = fs::metadata(src)?;
+        let target_meta = fs::metadata(src)
+            .map_err(|err| unsafe { build_fs_error_value(&err, "stat", &src.to_string_lossy()) })?;
         if target_meta.is_dir() {
-            copy_dir_recursive(src, dst, opts)
+            copy_dir_recursive_depth(src, dst, opts, depth + 1)
         } else {
             copy_file_with_options(src, dst, opts)
         }
     } else {
-        if dst.exists() {
-            if !opts.force {
-                if opts.error_on_exist {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::AlreadyExists,
-                        "destination exists",
-                    ));
-                }
-                return Ok(());
+        match fs::symlink_metadata(dst) {
+            Ok(meta) if meta.is_dir() => {
+                return Err(unsafe {
+                    let message = format!(
+                        "Cannot overwrite directory {} with non-directory {}",
+                        dst.to_string_lossy(),
+                        src.to_string_lossy()
+                    );
+                    build_cp_error_value(&message, "ERR_FS_CP_NON_DIR_TO_DIR", None, None)
+                });
             }
-            let _ = fs::remove_file(dst);
-        } else if let Some(parent) = dst.parent() {
-            fs::create_dir_all(parent)?;
+            Ok(_) => {
+                if !opts.force {
+                    if opts.error_on_exist {
+                        return Err(unsafe { build_cp_eexist_error(dst) });
+                    }
+                    return Ok(());
+                }
+                fs::remove_file(dst).map_err(|err| unsafe {
+                    build_fs_error_value(&err, "unlink", &dst.to_string_lossy())
+                })?;
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                if let Some(parent) = dst.parent() {
+                    fs::create_dir_all(parent).map_err(|err| unsafe {
+                        build_fs_error_value(&err, "mkdir", &parent.to_string_lossy())
+                    })?;
+                }
+            }
+            Err(err) => {
+                return Err(unsafe { build_fs_error_value(&err, "lstat", &dst.to_string_lossy()) });
+            }
         }
-        let target = resolve_copied_symlink_target(src, fs::read_link(src)?, opts);
+        let target = fs::read_link(src).map_err(|err| unsafe {
+            build_fs_error_value(&err, "readlink", &src.to_string_lossy())
+        })?;
+        let target = resolve_copied_symlink_target(src, target, opts);
         #[cfg(unix)]
-        std::os::unix::fs::symlink(target, dst)?;
+        std::os::unix::fs::symlink(target, dst).map_err(|err| unsafe {
+            build_fs_error_value_with_dest(
+                &err,
+                "symlink",
+                &src.to_string_lossy(),
+                &dst.to_string_lossy(),
+            )
+        })?;
         #[cfg(windows)]
-        std::os::windows::fs::symlink_file(target, dst)?;
+        std::os::windows::fs::symlink_file(target, dst).map_err(|err| unsafe {
+            build_fs_error_value_with_dest(
+                &err,
+                "symlink",
+                &src.to_string_lossy(),
+                &dst.to_string_lossy(),
+            )
+        })?;
         if opts.preserve_timestamps {
             copy_preserve_timestamps(src, dst, false);
         }
@@ -181,11 +338,7 @@ pub(crate) fn copy_symlink_with_options(
     }
 }
 
-pub(crate) fn copy_dir_recursive(
-    from: &Path,
-    to: &Path,
-    opts: FsCopyOptions,
-) -> std::io::Result<()> {
+pub(crate) fn copy_dir_recursive(from: &Path, to: &Path, opts: FsCopyOptions) -> Result<(), f64> {
     copy_dir_recursive_depth(from, to, opts, 0)
 }
 
@@ -199,28 +352,58 @@ pub(crate) fn copy_dir_recursive_depth(
     to: &Path,
     opts: FsCopyOptions,
     depth: u32,
-) -> std::io::Result<()> {
+) -> Result<(), f64> {
     if depth >= COPY_DIR_MAX_DEPTH {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "cpSync: directory nesting exceeds limit (possible symlink cycle)",
-        ));
+        return Err(unsafe {
+            build_cp_error_value(
+                "Directory nesting exceeds limit while copying (possible symlink cycle)",
+                "ELOOP",
+                Some("cp"),
+                Some(from.to_string_lossy().into_owned()),
+            )
+        });
     }
-    if !copy_filter_allows(from, to, opts) {
+    if !copy_filter_allows(from, to, opts)? {
         return Ok(());
     }
-    fs::create_dir_all(to)?;
-    for entry in fs::read_dir(from)? {
-        let entry = entry?;
+    match fs::symlink_metadata(to) {
+        Ok(meta) if !meta.is_dir() => {
+            return Err(unsafe {
+                let message = format!(
+                    "Cannot overwrite non-directory {} with directory {}",
+                    to.to_string_lossy(),
+                    from.to_string_lossy()
+                );
+                build_cp_error_value(&message, "ERR_FS_CP_DIR_TO_NON_DIR", None, None)
+            });
+        }
+        Ok(_) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            fs::create_dir_all(to).map_err(|err| unsafe {
+                build_fs_error_value(&err, "mkdir", &to.to_string_lossy())
+            })?;
+        }
+        Err(err) => {
+            return Err(unsafe { build_fs_error_value(&err, "lstat", &to.to_string_lossy()) });
+        }
+    }
+    let entries = fs::read_dir(from)
+        .map_err(|err| unsafe { build_fs_error_value(&err, "scandir", &from.to_string_lossy()) })?;
+    for entry in entries {
+        let entry = entry.map_err(|err| unsafe {
+            build_fs_error_value(&err, "scandir", &from.to_string_lossy())
+        })?;
         let src = entry.path();
         let dst = to.join(entry.file_name());
-        let file_type = entry.file_type()?;
+        let file_type = entry.file_type().map_err(|err| unsafe {
+            build_fs_error_value(&err, "lstat", &src.to_string_lossy())
+        })?;
         if file_type.is_dir() {
             copy_dir_recursive_depth(&src, &dst, opts, depth + 1)?;
         } else if file_type.is_file() {
             copy_file_with_options(&src, &dst, opts)?;
         } else if file_type.is_symlink() {
-            copy_symlink_with_options(&src, &dst, opts)?;
+            copy_symlink_with_options_depth(&src, &dst, opts, depth + 1)?;
         }
     }
     if opts.preserve_timestamps {
@@ -243,7 +426,7 @@ pub extern "C" fn js_fs_cp_sync(from_value: f64, to_value: f64) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn js_fs_cp_sync_options(from_value: f64, to_value: f64, options_value: f64) -> i32 {
-    match js_fs_cp_options_result(from_value, to_value, options_value, true) {
+    match js_fs_cp_options_result(from_value, to_value, options_value, true, true) {
         Ok(()) => 1,
         Err(err) => crate::exception::js_throw(err),
     }
@@ -261,7 +444,68 @@ pub(crate) fn js_fs_cp_async_result(
     to_value: f64,
     options_value: f64,
 ) -> Result<(), f64> {
-    js_fs_cp_options_result(from_value, to_value, options_value, false)
+    js_fs_cp_options_result(from_value, to_value, options_value, false, false)
+}
+
+fn absolute_normalized_path(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    };
+    lexical_normalize_path(absolute)
+}
+
+fn path_is_inside(parent: &Path, child: &Path) -> bool {
+    let parent_lex = absolute_normalized_path(parent);
+    let child_abs = absolute_normalized_path(child);
+    if child_abs != parent_lex && child_abs.starts_with(&parent_lex) {
+        return true;
+    }
+    let parent_abs = fs::canonicalize(parent).unwrap_or_else(|_| absolute_normalized_path(parent));
+    child_abs != parent_abs && child_abs.starts_with(&parent_abs)
+}
+
+unsafe fn build_cp_same_path_error(src: &Path) -> f64 {
+    let message = format!("src and dest cannot be the same {}", src.to_string_lossy());
+    build_cp_error_value(&message, "ERR_FS_CP_EINVAL", None, None)
+}
+
+unsafe fn build_cp_subdir_error(src: &Path, dst: &Path) -> f64 {
+    let message = format!(
+        "Cannot copy {} to a subdirectory of self {}",
+        src.to_string_lossy(),
+        dst.to_string_lossy()
+    );
+    build_cp_error_value(&message, "ERR_FS_CP_EINVAL", None, None)
+}
+
+unsafe fn build_cp_dir_to_non_dir_error(src: &Path, dst: &Path) -> f64 {
+    let message = format!(
+        "Cannot overwrite non-directory {} with directory {}",
+        dst.to_string_lossy(),
+        src.to_string_lossy()
+    );
+    build_cp_error_value(&message, "ERR_FS_CP_DIR_TO_NON_DIR", None, None)
+}
+
+unsafe fn build_cp_non_dir_to_dir_error(src: &Path, dst: &Path) -> f64 {
+    let message = format!(
+        "Cannot overwrite directory {} with non-directory {}",
+        dst.to_string_lossy(),
+        src.to_string_lossy()
+    );
+    build_cp_error_value(&message, "ERR_FS_CP_NON_DIR_TO_DIR", None, None)
+}
+
+unsafe fn build_cp_eisdir_error(src: &Path) -> f64 {
+    let message = format!(
+        "Recursive option not enabled, cannot copy a directory: {}/",
+        src.to_string_lossy()
+    );
+    build_cp_error_value(&message, "ERR_FS_EISDIR", None, None)
 }
 
 fn js_fs_cp_options_result(
@@ -269,6 +513,7 @@ fn js_fs_cp_options_result(
     to_value: f64,
     options_value: f64,
     sync_symlink_resolution: bool,
+    sync_filter: bool,
 ) -> Result<(), f64> {
     validate::validate_path("src", from_value);
     validate::validate_path("dest", to_value);
@@ -286,42 +531,48 @@ fn js_fs_cp_options_result(
         let dst = Path::new(&to);
         let mut opts = fs_copy_options_from_value(options_value);
         opts.sync_symlink_resolution = sync_symlink_resolution;
-        if let (Ok(canon_src), Ok(canon_dst)) = (fs::canonicalize(src), fs::canonicalize(dst)) {
-            if canon_src == canon_dst {
-                let err = std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "src and dest are the same",
-                );
-                return Err(build_fs_error_value(&err, "cp", &from));
-            }
-        }
-        let meta = if opts.dereference {
-            fs::metadata(src)
+        opts.sync_filter = sync_filter;
+
+        let src_meta = if opts.dereference {
+            fs::metadata(src).map_err(|err| build_fs_error_value(&err, "stat", &from))?
         } else {
-            fs::symlink_metadata(src)
+            fs::symlink_metadata(src).map_err(|err| build_fs_error_value(&err, "lstat", &from))?
         };
-        // Node requires `{ recursive: true }` to copy directories; otherwise
-        // it throws ERR_FS_EISDIR. Surface the same gate via `js_throw` so
-        // `try/catch` around `cpSync` actually fires.
-        if matches!(meta, Ok(ref m) if m.is_dir()) && !opts.recursive {
-            let bytes = b"ERR_FS_EISDIR: cpSync: src is a directory (use { recursive: true })";
-            let msg = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
-            let err = crate::error::js_error_new_with_message(msg);
-            let err_val = crate::value::js_nanbox_pointer(err as i64);
-            crate::exception::js_throw(err_val);
+        let src_is_dir = src_meta.is_dir();
+        if src_is_dir && !opts.recursive {
+            return Err(build_cp_eisdir_error(src));
         }
-        let result = match meta {
-            Ok(meta) if meta.is_dir() => copy_dir_recursive(src, dst, opts),
-            Ok(meta) if meta.file_type().is_symlink() => copy_symlink_with_options(src, dst, opts),
-            Ok(_) => copy_file_with_options(src, dst, opts),
-            Err(err) => {
-                let syscall = if opts.dereference { "stat" } else { "lstat" };
-                return Err(build_fs_error_value(&err, syscall, &from));
-            }
+
+        let dst_meta = match fs::symlink_metadata(dst) {
+            Ok(meta) => Some(meta),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+            Err(err) => return Err(build_fs_error_value(&err, "lstat", &to)),
         };
-        match result {
-            Ok(()) => Ok(()),
-            Err(err) => Err(build_fs_error_value_with_dest(&err, "cp", &from, &to)),
+        if dst_meta.is_some() {
+            if let (Ok(canon_src), Ok(canon_dst)) = (fs::canonicalize(src), fs::canonicalize(dst)) {
+                if canon_src == canon_dst {
+                    return Err(build_cp_same_path_error(src));
+                }
+            }
+        }
+        if src_is_dir && path_is_inside(src, dst) {
+            return Err(build_cp_subdir_error(src, dst));
+        }
+        if let Some(dst_meta) = dst_meta {
+            if src_is_dir && !dst_meta.is_dir() {
+                return Err(build_cp_dir_to_non_dir_error(src, dst));
+            }
+            if !src_is_dir && dst_meta.is_dir() {
+                return Err(build_cp_non_dir_to_dir_error(src, dst));
+            }
+        }
+
+        if src_is_dir {
+            copy_dir_recursive(src, dst, opts)
+        } else if src_meta.file_type().is_symlink() {
+            copy_symlink_with_options(src, dst, opts)
+        } else {
+            copy_file_with_options(src, dst, opts)
         }
     }
 }

--- a/crates/perry-runtime/src/fs/errors.rs
+++ b/crates/perry-runtime/src/fs/errors.rs
@@ -16,6 +16,7 @@ pub(crate) fn io_error_code(err: &std::io::Error) -> &'static str {
             code if code == libc::EISDIR => return "EISDIR",
             code if code == libc::EPERM => return "EPERM",
             code if code == libc::EINVAL => return "EINVAL",
+            code if code == libc::ELOOP => return "ELOOP",
             code if code == libc::EINTR => return "EINTR",
             code if code == libc::ENOSPC => return "ENOSPC",
             code if code == libc::ETIMEDOUT => return "ETIMEDOUT",

--- a/crates/perry-runtime/src/node_submodules/fs_promises.rs
+++ b/crates/perry-runtime/src/node_submodules/fs_promises.rs
@@ -294,9 +294,10 @@ pub(crate) extern "C" fn thunk_fs_promises_cp(
     to: f64,
     options: f64,
 ) -> f64 {
-    promise_from_sync_undefined(|| {
-        let _ = crate::fs::js_fs_cp_async_options(from, to, options);
-    })
+    match crate::fs::js_fs_cp_async_result(from, to, options) {
+        Ok(()) => promise_undefined(),
+        Err(err_val) => promise_rejected(err_val),
+    }
 }
 
 pub(crate) extern "C" fn thunk_fs_promises_truncate(

--- a/test-parity/node-suite/fs-promises/cp/advanced-semantics.ts
+++ b/test-parity/node-suite/fs-promises/cp/advanced-semantics.ts
@@ -1,0 +1,132 @@
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+
+const ROOT = "/tmp/perry_node_suite_fs_promises_cp_advanced_semantics";
+try { await fsp.rm(ROOT, { recursive: true, force: true }); } catch (_e) {}
+await fsp.mkdir(ROOT, { recursive: true });
+
+async function reset(name: string) {
+  const dir = ROOT + "/" + name;
+  try { await fsp.rm(dir, { recursive: true, force: true }); } catch (_e) {}
+  await fsp.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+function showCode(label: string, err: unknown, code: string) {
+  const fsErr = err as any;
+  console.log(label + " is Error:", err instanceof Error);
+  console.log(label + " code:", fsErr && fsErr.code);
+  console.log(label + " code matches:", fsErr && fsErr.code === code);
+}
+
+function showCpExist(label: string, err: unknown, path: string) {
+  showCode(label, err, "ERR_FS_CP_EEXIST");
+  const fsErr = err as any;
+  console.log(label + " syscall matches:", fsErr && fsErr.syscall === "cp");
+  console.log(label + " path matches:", fsErr && fsErr.path === path);
+  console.log(label + " errno number:", typeof (fsErr && fsErr.errno) === "number");
+}
+
+{
+  const dir = await reset("promise-subdir");
+  await fsp.mkdir(dir + "/src");
+  await fsp.writeFile(dir + "/src/file.txt", "file");
+  try {
+    await fsp.cp(dir + "/src", dir + "/src/child", { recursive: true });
+    console.log("cp promise subdir unexpectedly resolved");
+  } catch (err) {
+    showCode("cp promise subdir", err, "ERR_FS_CP_EINVAL");
+  }
+  console.log("cp promise subdir not created:", !fs.existsSync(dir + "/src/child"));
+}
+
+{
+  const dir = await reset("promise-conflicts");
+  await fsp.writeFile(dir + "/file.txt", "file");
+  await fsp.mkdir(dir + "/src-dir");
+  await fsp.mkdir(dir + "/dest-dir");
+  await fsp.writeFile(dir + "/dest-file.txt", "dest");
+  try {
+    await fsp.cp(dir + "/file.txt", dir + "/file.txt");
+    console.log("cp promise same file unexpectedly resolved");
+  } catch (err) {
+    showCode("cp promise same file", err, "ERR_FS_CP_EINVAL");
+  }
+  try {
+    await fsp.cp(dir + "/src-dir", dir + "/out-dir");
+    console.log("cp promise dir no recursive unexpectedly resolved");
+  } catch (err) {
+    showCode("cp promise dir no recursive", err, "ERR_FS_EISDIR");
+  }
+  try {
+    await fsp.cp(dir + "/src-dir", dir + "/dest-file.txt", { recursive: true });
+    console.log("cp promise dir to file unexpectedly resolved");
+  } catch (err) {
+    showCode("cp promise dir to file", err, "ERR_FS_CP_DIR_TO_NON_DIR");
+  }
+  try {
+    await fsp.cp(dir + "/file.txt", dir + "/dest-dir");
+    console.log("cp promise file to dir unexpectedly resolved");
+  } catch (err) {
+    showCode("cp promise file to dir", err, "ERR_FS_CP_NON_DIR_TO_DIR");
+  }
+}
+
+{
+  const dir = await reset("promise-exists");
+  const src = dir + "/src.txt";
+  const dest = dir + "/dest.txt";
+  await fsp.writeFile(src, "new");
+  await fsp.writeFile(dest, "old");
+  try {
+    await fsp.cp(src, dest, { force: false, errorOnExist: true });
+    console.log("cp promise errorOnExist unexpectedly resolved");
+  } catch (err) {
+    showCpExist("cp promise errorOnExist", err, dest);
+  }
+  console.log("cp promise errorOnExist preserved:", await fsp.readFile(dest, "utf8"));
+  await fsp.cp(src, dest, { force: false });
+  console.log("cp promise force false skipped:", await fsp.readFile(dest, "utf8"));
+}
+
+{
+  const dir = await reset("promise-filter-mode");
+  await fsp.mkdir(dir + "/src/a", { recursive: true });
+  await fsp.writeFile(dir + "/src/keep.txt", "keep");
+  await fsp.writeFile(dir + "/src/drop.md", "drop");
+  await fsp.writeFile(dir + "/src/a/nested.txt", "nested");
+  await fsp.writeFile(dir + "/src/a/nested.md", "nested drop");
+  let calls = 0;
+  await fsp.cp(dir + "/src", dir + "/dst", {
+    recursive: true,
+    filter: (src) => {
+      calls++;
+      return Promise.resolve(fs.statSync(src).isDirectory() || src.endsWith(".txt"));
+    },
+  });
+  console.log("cp promise async filter called:", calls > 0);
+  console.log("cp promise async filter keep:", fs.existsSync(dir + "/dst/keep.txt"));
+  console.log("cp promise async filter drop:", fs.existsSync(dir + "/dst/drop.md"));
+  console.log("cp promise async filter nested keep:", fs.existsSync(dir + "/dst/a/nested.txt"));
+  console.log("cp promise async filter nested drop:", fs.existsSync(dir + "/dst/a/nested.md"));
+
+  await fsp.cp(dir + "/src/keep.txt", dir + "/mode-copy.txt", {
+    mode: fs.constants.COPYFILE_FICLONE,
+  });
+  console.log("cp promise mode ficlone copied:", await fsp.readFile(dir + "/mode-copy.txt", "utf8"));
+}
+
+{
+  const dir = await reset("promise-eloop");
+  await fsp.symlink("self-link", dir + "/self-link");
+  try {
+    await fsp.cp(dir + "/self-link", dir + "/out", { recursive: true, dereference: true });
+    console.log("cp promise eloop unexpectedly resolved");
+  } catch (err) {
+    showCode("cp promise eloop", err, "ELOOP");
+    const fsErr = err as any;
+    console.log("cp promise eloop syscall:", fsErr && fsErr.syscall);
+  }
+}
+
+try { await fsp.rm(ROOT, { recursive: true, force: true }); } catch (_e) {}

--- a/test-parity/node-suite/fs/cp/advanced-semantics.ts
+++ b/test-parity/node-suite/fs/cp/advanced-semantics.ts
@@ -1,0 +1,165 @@
+import * as fs from "node:fs";
+
+const ROOT = "/tmp/perry_node_suite_fs_cp_advanced_semantics";
+try { fs.rmSync(ROOT, { recursive: true, force: true }); } catch (_e) {}
+fs.mkdirSync(ROOT, { recursive: true });
+
+function reset(name: string) {
+  const dir = ROOT + "/" + name;
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_e) {}
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function showCode(label: string, err: unknown, code: string) {
+  const fsErr = err as any;
+  console.log(label + " is Error:", err instanceof Error);
+  console.log(label + " code:", fsErr && fsErr.code);
+  console.log(label + " code matches:", fsErr && fsErr.code === code);
+}
+
+function showCpExist(label: string, err: unknown, path: string) {
+  showCode(label, err, "ERR_FS_CP_EEXIST");
+  const fsErr = err as any;
+  console.log(label + " syscall matches:", fsErr && fsErr.syscall === "cp");
+  console.log(label + " path matches:", fsErr && fsErr.path === path);
+  console.log(label + " errno number:", typeof (fsErr && fsErr.errno) === "number");
+}
+
+{
+  const dir = reset("sync-subdir");
+  fs.mkdirSync(dir + "/src");
+  fs.writeFileSync(dir + "/src/file.txt", "file");
+  try {
+    fs.cpSync(dir + "/src", dir + "/src/child", { recursive: true });
+    console.log("cp sync subdir unexpectedly succeeded");
+  } catch (err) {
+    showCode("cp sync subdir", err, "ERR_FS_CP_EINVAL");
+  }
+  console.log("cp sync subdir not created:", !fs.existsSync(dir + "/src/child"));
+}
+
+{
+  const dir = reset("sync-conflicts");
+  fs.writeFileSync(dir + "/file.txt", "file");
+  fs.mkdirSync(dir + "/src-dir");
+  fs.mkdirSync(dir + "/dest-dir");
+  fs.writeFileSync(dir + "/dest-file.txt", "dest");
+  try {
+    fs.cpSync(dir + "/file.txt", dir + "/file.txt");
+    console.log("cp sync same file unexpectedly succeeded");
+  } catch (err) {
+    showCode("cp sync same file", err, "ERR_FS_CP_EINVAL");
+  }
+  try {
+    fs.cpSync(dir + "/src-dir", dir + "/out-dir");
+    console.log("cp sync dir no recursive unexpectedly succeeded");
+  } catch (err) {
+    showCode("cp sync dir no recursive", err, "ERR_FS_EISDIR");
+  }
+  try {
+    fs.cpSync(dir + "/src-dir", dir + "/dest-file.txt", { recursive: true });
+    console.log("cp sync dir to file unexpectedly succeeded");
+  } catch (err) {
+    showCode("cp sync dir to file", err, "ERR_FS_CP_DIR_TO_NON_DIR");
+  }
+  try {
+    fs.cpSync(dir + "/file.txt", dir + "/dest-dir");
+    console.log("cp sync file to dir unexpectedly succeeded");
+  } catch (err) {
+    showCode("cp sync file to dir", err, "ERR_FS_CP_NON_DIR_TO_DIR");
+  }
+}
+
+{
+  const dir = reset("sync-exists");
+  const src = dir + "/src.txt";
+  const dest = dir + "/dest.txt";
+  fs.writeFileSync(src, "new");
+  fs.writeFileSync(dest, "old");
+  try {
+    fs.cpSync(src, dest, { force: false, errorOnExist: true });
+    console.log("cp sync errorOnExist unexpectedly succeeded");
+  } catch (err) {
+    showCpExist("cp sync errorOnExist", err, dest);
+  }
+  console.log("cp sync errorOnExist preserved:", fs.readFileSync(dest, "utf8"));
+  fs.cpSync(src, dest, { force: false });
+  console.log("cp sync force false skipped:", fs.readFileSync(dest, "utf8"));
+}
+
+{
+  const dir = reset("sync-filter-mode");
+  fs.mkdirSync(dir + "/src");
+  fs.writeFileSync(dir + "/src/file.txt", "file");
+  try {
+    fs.cpSync(dir + "/src", dir + "/dst", {
+      recursive: true,
+      filter: () => Promise.resolve(true),
+    });
+    console.log("cp sync promise filter unexpectedly succeeded");
+  } catch (err) {
+    showCode("cp sync promise filter", err, "ERR_INVALID_RETURN_VALUE");
+  }
+  fs.cpSync(dir + "/src/file.txt", dir + "/mode-copy.txt", {
+    mode: fs.constants.COPYFILE_FICLONE,
+  });
+  console.log("cp sync mode ficlone copied:", fs.readFileSync(dir + "/mode-copy.txt", "utf8"));
+}
+
+{
+  const dir = reset("sync-eloop");
+  fs.symlinkSync("self-link", dir + "/self-link");
+  try {
+    fs.cpSync(dir + "/self-link", dir + "/out", { recursive: true, dereference: true });
+    console.log("cp sync eloop unexpectedly succeeded");
+  } catch (err) {
+    showCode("cp sync eloop", err, "ELOOP");
+    const fsErr = err as any;
+    console.log("cp sync eloop syscall:", fsErr && fsErr.syscall);
+  }
+}
+
+{
+  const dir = reset("callback-filter");
+  fs.mkdirSync(dir + "/src/a", { recursive: true });
+  fs.writeFileSync(dir + "/src/keep.txt", "keep");
+  fs.writeFileSync(dir + "/src/drop.md", "drop");
+  fs.writeFileSync(dir + "/src/a/nested.txt", "nested");
+  fs.writeFileSync(dir + "/src/a/nested.md", "nested drop");
+  let calls = 0;
+  await new Promise<void>((resolve) => {
+    fs.cp(dir + "/src", dir + "/dst", {
+      recursive: true,
+      filter: (src) => {
+        calls++;
+        return Promise.resolve(fs.statSync(src).isDirectory() || src.endsWith(".txt"));
+      },
+    }, (err) => {
+      console.log("cp callback async filter err null:", err === null);
+      console.log("cp callback async filter called:", calls > 0);
+      console.log("cp callback async filter keep:", fs.existsSync(dir + "/dst/keep.txt"));
+      console.log("cp callback async filter drop:", fs.existsSync(dir + "/dst/drop.md"));
+      console.log("cp callback async filter nested keep:", fs.existsSync(dir + "/dst/a/nested.txt"));
+      console.log("cp callback async filter nested drop:", fs.existsSync(dir + "/dst/a/nested.md"));
+      resolve();
+    });
+  });
+}
+
+{
+  const dir = reset("callback-error");
+  const src = dir + "/src.txt";
+  const dest = dir + "/dest.txt";
+  fs.writeFileSync(src, "new");
+  fs.writeFileSync(dest, "old");
+  await new Promise<void>((resolve) => {
+    fs.cp(src, dest, { force: false, errorOnExist: true }, (err) => {
+      showCpExist("cp callback errorOnExist", err, dest);
+      console.log("cp callback errorOnExist preserved:", fs.readFileSync(dest, "utf8"));
+      resolve();
+    });
+  });
+}
+
+try { fs.rmSync(ROOT, { recursive: true, force: true }); } catch (_e) {}


### PR DESCRIPTION
Summary:\n- Propagate fs.cp/cpSync/fs.promises.cp copy failures through Node-shaped errors instead of sentinel success/failure values.\n- Add cp conflict, subdirectory, async filter, mode flag, and ELOOP parity coverage across sync, callback, and promises forms.\n- Verified existing rename/copyFile/link/symlink destination error parity remains intact.\n\nTests:\n- cargo test -p perry-runtime -p perry-api-manifest\n- ./run_parity_tests.sh --suite node-suite --module fs --filter cp\n- ./run_parity_tests.sh --suite node-suite --module fs-promises --filter cp\n- ./run_parity_tests.sh --suite node-suite --module fs --filter path-mutator-errors