### PR TITLE
fix(path): dispatch default namespace aliases

### DIFF
--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -138,6 +138,12 @@ pub(crate) unsafe fn dispatch_native_module_method(
     let module_name = match module_name {
         "path/posix" => "path.posix",
         "path/win32" => "path.win32",
+        "async_hooks.default" => "async_hooks",
+        "os.default" => "os",
+        "path.default" => "path",
+        "querystring.default" => "querystring",
+        "url.default" => "url",
+        "util.default" => "util",
         _ => module_name,
     };
     // Helper: get arg N as f64

--- a/test-parity/node-suite/path/toNamespacedPath/make-long-alias.ts
+++ b/test-parity/node-suite/path/toNamespacedPath/make-long-alias.ts
@@ -14,5 +14,6 @@ console.log("posix equality:", posix._makeLong === path.posix.toNamespacedPath);
 console.log("win32 equality:", win32._makeLong === path.win32.toNamespacedPath);
 console.log("named result:", _makeLong("/tmp/a"));
 console.log("default result:", top._makeLong("/tmp/a"));
+console.log("default toNamespaced result:", top.toNamespacedPath("/tmp/a"));
 console.log("posix result:", posix._makeLong("/tmp/a"));
 console.log("win32 result:", win32._makeLong("C:\\tmp\\a"));


### PR DESCRIPTION
## Summary

Refs #3822.

- Normalizes CJS-style native default namespace names in the runtime method dispatcher, so receivers like `path.default` dispatch through the base `path` implementation.
- Extends the existing `_makeLong` / `toNamespacedPath` fixture to cover direct calls through a default-object alias.
- Keeps `path._makeLong`, `path.toNamespacedPath`, `path.posix`, and `path.win32` callable identity/result behavior aligned with Node.

## Why Batched

This PR is the focused reproducible cut from #3822. Current `origin/main` had the path suite at 91/92 with a single mismatch in `path/toNamespacedPath/make-long-alias`; the fix is shared by the default namespace method-dispatch path rather than broader lexical path behavior.

## Tests

- `/tmp/perry-node25-bin/node --experimental-strip-types test-parity/node-suite/path/toNamespacedPath/make-long-alias.ts`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module path --filter make-long-alias`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module path`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module os --filter imports/default-import`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module util --filter imports/default-import`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module node-core --filter imports/cjs-default-exports`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module querystring --filter imports`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`

`vendor/nodejs` is not present in this worktree, so the upstream `node_core_subset.py` radar command from #3822 was not runnable here.

## Limitations / Non-goals

- Does not change path lexical algorithms, glob matching, or `path.posix` / `path.win32` semantics beyond preserving existing green behavior.
- Does not attempt to close every remaining item in #3822; this is the currently reproducible `_makeLong` / default namespace dispatch cut.
