### PR TITLE
fix(node:fs): complete glob advanced semantics

### DIFF
--- a/crates/perry-codegen/src/lower_call/native/native_fs_branch.rs
+++ b/crates/perry-codegen/src/lower_call/native/native_fs_branch.rs
@@ -572,7 +572,16 @@
             }
             "globSync" if !args.is_empty() => {
                 let p = lower_expr(ctx, &args[0])?;
-                let raw = ctx.block().call(DOUBLE, "js_fs_glob_sync", &[(DOUBLE, &p)]);
+                let options = if args.len() >= 2 {
+                    lower_expr(ctx, &args[1])?
+                } else {
+                    double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                };
+                let raw = ctx.block().call(
+                    DOUBLE,
+                    "js_fs_glob_sync_options",
+                    &[(DOUBLE, &p), (DOUBLE, &options)],
+                );
                 let raw_bits = ctx.block().bitcast_double_to_i64(&raw);
                 return Ok(crate::expr::nanbox_pointer_inline(ctx.block(), &raw_bits));
             }

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -122,6 +122,49 @@ fn is_filehandle_readlines_for_await_target(ctx: &LoweringContext, expr: &ast::E
     )
 }
 
+fn is_fs_promises_glob_for_await_target(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    let ast::Expr::Call(call) = strip_for_of_expr_wrappers(expr) else {
+        return false;
+    };
+    let ast::Callee::Expr(callee_expr) = &call.callee else {
+        return false;
+    };
+    match strip_for_of_expr_wrappers(callee_expr.as_ref()) {
+        ast::Expr::Ident(ident) => {
+            ctx.lookup_native_module(ident.sym.as_ref())
+                .is_some_and(|(module, method)| {
+                    module.strip_prefix("node:").unwrap_or(module) == "fs/promises"
+                        && method == Some("glob")
+                })
+                || ctx.lookup_imported_func(ident.sym.as_ref()) == Some("glob")
+        }
+        ast::Expr::Member(member) => {
+            let ast::MemberProp::Ident(prop) = &member.prop else {
+                return false;
+            };
+            if prop.sym.as_ref() != "glob" {
+                return false;
+            }
+            match strip_for_of_expr_wrappers(&member.obj) {
+                ast::Expr::Ident(obj) => {
+                    ctx.lookup_native_module(obj.sym.as_ref())
+                        .is_some_and(|(module, method)| {
+                            method.is_none()
+                                && module.strip_prefix("node:").unwrap_or(module) == "fs/promises"
+                        })
+                        || ctx
+                            .lookup_builtin_module_alias(obj.sym.as_ref())
+                            .is_some_and(|module| {
+                                module.strip_prefix("node:").unwrap_or(module) == "fs/promises"
+                            })
+                }
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
 fn async_iterator_method_call(iterable: Expr) -> Expr {
     Expr::Call {
         callee: Box::new(Expr::IndexGet {
@@ -292,12 +335,15 @@ pub(crate) fn lower_stmt_for_of(
         for_of_stmt.is_await && is_node_readable_for_await_target(ctx, &for_of_stmt.right);
     let is_filehandle_readlines_for_await =
         for_of_stmt.is_await && is_filehandle_readlines_for_await_target(ctx, &for_of_stmt.right);
+    let is_fs_promises_glob_for_await =
+        for_of_stmt.is_await && is_fs_promises_glob_for_await_target(ctx, &for_of_stmt.right);
 
     if is_generator_call
         || iter_from_class.is_some()
         || is_timer_promises_interval_call
         || is_node_readable_for_await
         || is_filehandle_readlines_for_await
+        || is_fs_promises_glob_for_await
     {
         // Lower to iterator protocol:
         //   let __iter = genFunc(...);                     // generator-fn path

--- a/crates/perry-runtime/src/fs/callbacks.rs
+++ b/crates/perry-runtime/src/fs/callbacks.rs
@@ -1,6 +1,7 @@
 //! Callback-style fs APIs — pre-flight probe + (err, value) dispatch.
 
 use crate::closure::ClosureHeader;
+use std::os::raw::c_int;
 
 use super::*;
 
@@ -95,6 +96,21 @@ fn callback_from_options_arg(options: f64, callback: f64) -> *const ClosureHeade
         } else {
             required_callback(options)
         }
+    }
+}
+
+fn catch_callback_throw(call: impl FnOnce() -> f64) -> Result<f64, f64> {
+    let trap_buf = crate::exception::js_try_push();
+    let jumped = unsafe { crate::ffi::setjmp::setjmp(trap_buf as *mut c_int) };
+    if jumped == 0 {
+        let value = call();
+        crate::exception::js_try_end();
+        Ok(value)
+    } else {
+        let err = crate::exception::js_get_exception();
+        crate::exception::js_clear_exception();
+        crate::exception::js_try_end();
+        Err(err)
     }
 }
 
@@ -410,10 +426,16 @@ pub extern "C" fn js_fs_glob_callback(pattern_value: f64, arg1: f64, arg2: f64) 
         f64::from_bits(TAG_UNDEFINED)
     };
     let cb = callback_or_arg2(arg1, arg2);
-    let raw = js_fs_glob_sync_options(pattern_value, options);
-    let entries = f64::from_bits(crate::value::JSValue::pointer(raw.to_bits() as *const u8).bits());
-    if !cb.is_null() {
-        crate::closure::js_closure_call2(cb, f64::from_bits(TAG_NULL), entries);
+    match catch_callback_throw(|| {
+        let raw = js_fs_glob_sync_options(pattern_value, options);
+        f64::from_bits(crate::value::JSValue::pointer(raw.to_bits() as *const u8).bits())
+    }) {
+        Ok(entries) => {
+            if !cb.is_null() {
+                crate::closure::js_closure_call2(cb, f64::from_bits(TAG_NULL), entries);
+            }
+        }
+        Err(err) => unsafe { call_cb_err2(cb, err) },
     }
     f64::from_bits(TAG_UNDEFINED)
 }

--- a/crates/perry-runtime/src/fs/dir_glob_watch.rs
+++ b/crates/perry-runtime/src/fs/dir_glob_watch.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Once;
 
 use crate::closure::{
@@ -66,17 +66,421 @@ fn js_fs_opendir_value_inner(path_value: f64, include_path: bool) -> Result<f64,
     }
 }
 
-pub(crate) fn glob_regex_from_pattern(pattern: &str) -> Option<regex::Regex> {
-    let normalized = pattern.replace('\\', "/");
-    let mut out = String::from("^");
-    let mut chars = normalized.chars().peekable();
-    while let Some(ch) = chars.next() {
+#[derive(Clone)]
+pub(crate) struct FsGlobMatch {
+    output: String,
+    actual_path: String,
+    dirent_name: String,
+    dirent_parent: String,
+    kind: DirentKind,
+}
+
+struct FsGlobRun {
+    matches: Vec<FsGlobMatch>,
+    with_file_types: bool,
+}
+
+struct FsGlobOptions {
+    cwd_actual: String,
+    cwd_display: String,
+    with_file_types: bool,
+    follow_symlinks: bool,
+    exclude_patterns: Vec<fancy_regex::Regex>,
+    exclude_fn: Option<*const ClosureHeader>,
+}
+
+struct GlobCandidate {
+    actual_path: String,
+    kind: DirentKind,
+}
+
+fn normalize_slashes(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+fn pathbuf_to_slashes(path: PathBuf) -> String {
+    normalize_slashes(&path.to_string_lossy())
+}
+
+fn current_dir_slashes() -> String {
+    std::env::current_dir()
+        .map(pathbuf_to_slashes)
+        .unwrap_or_else(|_| ".".to_string())
+}
+
+fn trim_trailing_slashes(path: &str) -> &str {
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        path
+    } else {
+        trimmed
+    }
+}
+
+fn join_slash(base: &str, child: &str) -> String {
+    if child.is_empty() || child == "." {
+        return normalize_slashes(base);
+    }
+    if Path::new(child).is_absolute() {
+        return normalize_slashes(child);
+    }
+    let base = trim_trailing_slashes(base);
+    if base.is_empty() || base == "." {
+        normalize_slashes(child)
+    } else if base == "/" {
+        format!("/{}", child.trim_start_matches('/'))
+    } else {
+        format!("{}/{}", base, child.trim_start_matches('/'))
+    }
+}
+
+fn absolutize_slash(path: &str) -> String {
+    let normalized = normalize_slashes(path);
+    if Path::new(&normalized).is_absolute() {
+        normalized
+    } else {
+        join_slash(&current_dir_slashes(), &normalized)
+    }
+}
+
+fn relative_to_base(path: &str, base: &str) -> String {
+    let path = normalize_slashes(path);
+    let base = normalize_slashes(base);
+    let base_trim = trim_trailing_slashes(&base);
+    if path == base_trim {
+        return ".".to_string();
+    }
+    let prefix = if base_trim == "/" {
+        "/".to_string()
+    } else {
+        format!("{base_trim}/")
+    };
+    path.strip_prefix(&prefix).unwrap_or(&path).to_string()
+}
+
+fn parent_display_for_relative(cwd_display: &str, rel_parent: &str) -> String {
+    if rel_parent == "." || rel_parent.is_empty() {
+        if cwd_display.is_empty() {
+            ".".to_string()
+        } else {
+            cwd_display.to_string()
+        }
+    } else if cwd_display == "." || cwd_display.is_empty() {
+        rel_parent.to_string()
+    } else {
+        join_slash(cwd_display, rel_parent)
+    }
+}
+
+fn decode_string_value(value: f64) -> Option<String> {
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let (ptr, len) = crate::string::str_bytes_from_jsvalue(value, &mut scratch)?;
+    if ptr.is_null() {
+        return Some(String::new());
+    }
+    Some(
+        String::from_utf8_lossy(unsafe { std::slice::from_raw_parts(ptr, len as usize) })
+            .into_owned(),
+    )
+}
+
+fn decode_string_or_file_url(value: f64) -> Option<String> {
+    if let Some(s) = decode_string_value(value) {
+        return Some(s);
+    }
+    let jsval = crate::value::JSValue::from_bits(value.to_bits());
+    if !jsval.is_pointer() {
+        return None;
+    }
+    let obj = jsval.as_pointer::<crate::object::ObjectHeader>();
+    if obj.is_null() {
+        return None;
+    }
+    let protocol = crate::url::get_string_content(crate::object::js_object_get_field_f64(
+        obj,
+        crate::url::parse::URL_PROTOCOL,
+    ));
+    if protocol != "file:" {
+        return None;
+    }
+    let pathname = crate::url::get_string_content(crate::object::js_object_get_field_f64(
+        obj,
+        crate::url::parse::URL_PATHNAME,
+    ));
+    if pathname.is_empty() {
+        return None;
+    }
+    Some(crate::url::search_params::url_decode(&pathname))
+}
+
+fn array_ptr_from_value(value: f64) -> Option<*const crate::array::ArrayHeader> {
+    if crate::array::js_array_is_array(value).to_bits() != crate::value::TAG_TRUE {
+        return None;
+    }
+    let jsval = crate::value::JSValue::from_bits(value.to_bits());
+    if !jsval.is_pointer() {
+        return None;
+    }
+    let ptr = jsval.as_pointer::<crate::array::ArrayHeader>();
+    if ptr.is_null() {
+        None
+    } else {
+        Some(ptr)
+    }
+}
+
+fn throw_glob_pattern_string(arg_name: &str, value: f64) -> ! {
+    let message = format!(
+        "The \"{arg_name}\" argument must be of type string. Received {}",
+        validate::describe_received(value)
+    );
+    validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn throw_glob_patterns_array(value: f64) -> ! {
+    let message = format!(
+        "The \"patterns\" argument must be an instance of Array. Received {}",
+        validate::describe_received(value)
+    );
+    validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn glob_patterns_from_value(pattern_value: f64) -> Vec<String> {
+    if let Some(pattern) = decode_string_value(pattern_value) {
+        return vec![normalize_slashes(&pattern)];
+    }
+    if let Some(arr) = array_ptr_from_value(pattern_value) {
+        let len = crate::array::js_array_length(arr) as usize;
+        let mut patterns = Vec::with_capacity(len);
+        for i in 0..len {
+            let value = crate::array::js_array_get_f64(arr, i as u32);
+            let Some(pattern) = decode_string_value(value) else {
+                throw_glob_pattern_string(&format!("patterns[{i}]"), value);
+            };
+            patterns.push(normalize_slashes(&pattern));
+        }
+        return patterns;
+    }
+    let js = crate::value::JSValue::from_bits(pattern_value.to_bits());
+    if js.is_null() || js.is_pointer() {
+        throw_glob_patterns_array(pattern_value);
+    }
+    throw_glob_pattern_string("patterns", pattern_value);
+}
+
+fn compile_exclude_patterns(exclude_value: f64, cwd_actual: &str) -> Vec<fancy_regex::Regex> {
+    let Some(arr) = array_ptr_from_value(exclude_value) else {
+        let message = format!(
+            "The \"options.exclude\" property must be of type function or string[]. Received {}",
+            validate::describe_received(exclude_value)
+        );
+        validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    };
+    let len = crate::array::js_array_length(arr) as usize;
+    let mut patterns = Vec::with_capacity(len);
+    for i in 0..len {
+        let value = crate::array::js_array_get_f64(arr, i as u32);
+        let Some(pattern) = decode_string_value(value) else {
+            let message = format!(
+                "The \"options.exclude[{i}]\" property must be of type string. Received {}",
+                validate::describe_received(value)
+            );
+            validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+        };
+        let normalized = normalize_slashes(&pattern);
+        let absolute = if Path::new(&normalized).is_absolute() {
+            normalized
+        } else {
+            join_slash(cwd_actual, &normalized)
+        };
+        if let Some(re) = glob_regex_from_pattern(&absolute) {
+            patterns.push(re);
+        }
+    }
+    patterns
+}
+
+fn glob_options_from_value(options_value: f64) -> FsGlobOptions {
+    validate::validate_object_options("options", options_value);
+    let mut cwd_actual = current_dir_slashes();
+    let mut cwd_display = ".".to_string();
+    unsafe {
+        if let Some(cwd) = options_field_value(options_value, b"cwd") {
+            let cwd_value = f64::from_bits(cwd.bits());
+            if !is_nullish(cwd_value) {
+                let Some(cwd_raw) = decode_string_or_file_url(cwd_value) else {
+                    let message = format!(
+                        "The \"paths[0]\" argument must be of type string. Received {}",
+                        validate::describe_received(cwd_value)
+                    );
+                    validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+                };
+                let cwd_norm = normalize_slashes(&cwd_raw);
+                cwd_actual = absolutize_slash(&cwd_norm);
+                cwd_display = cwd_norm;
+            }
+        }
+    }
+    let with_file_types = unsafe { options_bool_field(options_value, b"withFileTypes") };
+    let follow_symlinks = unsafe { options_bool_field(options_value, b"followSymlinks") };
+    let mut exclude_patterns = Vec::new();
+    let mut exclude_fn = None;
+    unsafe {
+        if let Some(exclude) = options_field_value(options_value, b"exclude") {
+            let exclude_value = f64::from_bits(exclude.bits());
+            if !is_nullish(exclude_value) {
+                let callable = extract_closure_ptr(exclude_value);
+                if callable.is_null() {
+                    exclude_patterns = compile_exclude_patterns(exclude_value, &cwd_actual);
+                } else {
+                    exclude_fn = Some(callable);
+                }
+            }
+        }
+    }
+    FsGlobOptions {
+        cwd_actual,
+        cwd_display,
+        with_file_types,
+        follow_symlinks,
+        exclude_patterns,
+        exclude_fn,
+    }
+}
+
+fn regex_escape_char(out: &mut String, ch: char) {
+    if matches!(
+        ch,
+        '.' | '+' | '(' | ')' | '|' | '^' | '$' | '{' | '}' | '[' | ']' | '\\'
+    ) {
+        out.push('\\');
+    }
+    out.push(ch);
+}
+
+fn split_top_level(input: &str, separator: char) -> Vec<String> {
+    let chars: Vec<char> = input.chars().collect();
+    let mut parts = Vec::new();
+    let mut start = 0usize;
+    let mut brace_depth = 0i32;
+    let mut paren_depth = 0i32;
+    let mut i = 0usize;
+    while i < chars.len() {
+        match chars[i] {
+            '[' => {
+                i += 1;
+                while i < chars.len() && chars[i] != ']' {
+                    i += 1;
+                }
+            }
+            '{' => brace_depth += 1,
+            '}' if brace_depth > 0 => brace_depth -= 1,
+            '(' => paren_depth += 1,
+            ')' if paren_depth > 0 => paren_depth -= 1,
+            ch if ch == separator && brace_depth == 0 && paren_depth == 0 => {
+                parts.push(chars[start..i].iter().collect());
+                start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    parts.push(chars[start..].iter().collect());
+    parts
+}
+
+fn take_balanced(chars: &[char], pos: &mut usize, open: char, close: char) -> Option<String> {
+    let mut depth = 1i32;
+    let start = *pos;
+    let mut i = *pos;
+    while i < chars.len() {
+        match chars[i] {
+            '[' => {
+                i += 1;
+                while i < chars.len() && chars[i] != ']' {
+                    i += 1;
+                }
+            }
+            ch if ch == open => depth += 1,
+            ch if ch == close => {
+                depth -= 1;
+                if depth == 0 {
+                    let inner: String = chars[start..i].iter().collect();
+                    *pos = i + 1;
+                    return Some(inner);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+fn parse_char_class(chars: &[char], pos: &mut usize) -> String {
+    let start = pos.saturating_sub(1);
+    let mut class = String::from("[");
+    if *pos < chars.len() && matches!(chars[*pos], '!' | '^') {
+        class.push('^');
+        *pos += 1;
+    }
+    if *pos < chars.len() && chars[*pos] == ']' {
+        class.push(']');
+        *pos += 1;
+    }
+    while *pos < chars.len() {
+        let ch = chars[*pos];
+        *pos += 1;
+        if ch == ']' {
+            class.push(']');
+            return class;
+        }
+        if ch == '\\' {
+            class.push('\\');
+            class.push('\\');
+        } else {
+            class.push(ch);
+        }
+    }
+    let literal: String = chars[start..*pos].iter().collect();
+    regex::escape(&literal)
+}
+
+fn glob_fragment_to_regex(pattern: &str) -> Option<String> {
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut pos = 0usize;
+    parse_glob_chars(&chars, &mut pos)
+}
+
+fn parse_glob_chars(chars: &[char], pos: &mut usize) -> Option<String> {
+    let mut out = String::new();
+    while *pos < chars.len() {
+        let ch = chars[*pos];
+        if matches!(ch, '@' | '+' | '*' | '?' | '!') && chars.get(*pos + 1) == Some(&'(') {
+            *pos += 2;
+            let inner = take_balanced(chars, pos, '(', ')')?;
+            let alternatives: Vec<String> = split_top_level(&inner, '|')
+                .into_iter()
+                .map(|part| glob_fragment_to_regex(&part))
+                .collect::<Option<Vec<_>>>()?;
+            let joined = alternatives.join("|");
+            match ch {
+                '@' => out.push_str(&format!("(?:{joined})")),
+                '?' => out.push_str(&format!("(?:{joined})?")),
+                '+' => out.push_str(&format!("(?:{joined})+")),
+                '*' => out.push_str(&format!("(?:{joined})*")),
+                '!' => out.push_str(&format!("(?!(?:{joined})(?:/|$))[^/]*")),
+                _ => {}
+            }
+            continue;
+        }
+        *pos += 1;
         match ch {
             '*' => {
-                if chars.peek() == Some(&'*') {
-                    let _ = chars.next();
-                    if chars.peek() == Some(&'/') {
-                        let _ = chars.next();
+                if chars.get(*pos) == Some(&'*') {
+                    *pos += 1;
+                    if chars.get(*pos) == Some(&'/') {
+                        *pos += 1;
                         out.push_str("(?:.*/)?");
                     } else {
                         out.push_str(".*");
@@ -86,23 +490,44 @@ pub(crate) fn glob_regex_from_pattern(pattern: &str) -> Option<regex::Regex> {
                 }
             }
             '?' => out.push_str("[^/]"),
-            '.' | '+' | '(' | ')' | '|' | '^' | '$' | '{' | '}' | '[' | ']' | '\\' => {
-                out.push('\\');
-                out.push(ch);
+            '{' => {
+                let inner = take_balanced(chars, pos, '{', '}')?;
+                let alternatives: Vec<String> = split_top_level(&inner, ',')
+                    .into_iter()
+                    .map(|part| glob_fragment_to_regex(&part))
+                    .collect::<Option<Vec<_>>>()?;
+                out.push_str(&format!("(?:{})", alternatives.join("|")));
             }
+            '[' => out.push_str(&parse_char_class(chars, pos)),
             '/' => out.push('/'),
-            other => out.push(other),
+            other => regex_escape_char(&mut out, other),
         }
     }
-    out.push('$');
-    regex::Regex::new(&out).ok()
+    Some(out)
+}
+
+pub(crate) fn glob_regex_from_pattern(pattern: &str) -> Option<fancy_regex::Regex> {
+    let normalized = normalize_slashes(pattern);
+    let body = glob_fragment_to_regex(&normalized)?;
+    fancy_regex::Regex::new(&format!("^{body}$")).ok()
+}
+
+fn first_glob_meta(pattern: &str) -> usize {
+    let chars: Vec<(usize, char)> = pattern.char_indices().collect();
+    for (idx, (byte_idx, ch)) in chars.iter().enumerate() {
+        if matches!(ch, '*' | '?' | '[' | '{') {
+            return *byte_idx;
+        }
+        if matches!(ch, '@' | '+' | '!') && chars.get(idx + 1).map(|(_, next)| *next) == Some('(') {
+            return *byte_idx;
+        }
+    }
+    pattern.len()
 }
 
 pub(crate) fn glob_search_root(pattern: &str) -> String {
-    let normalized = pattern.replace('\\', "/");
-    let first_meta = normalized
-        .find(|c| matches!(c, '*' | '?' | '[' | '{'))
-        .unwrap_or(normalized.len());
+    let normalized = normalize_slashes(pattern);
+    let first_meta = first_glob_meta(&normalized);
     let prefix = &normalized[..first_meta];
     match prefix.rfind('/') {
         Some(0) => "/".to_string(),
@@ -111,81 +536,165 @@ pub(crate) fn glob_search_root(pattern: &str) -> String {
     }
 }
 
-pub(crate) fn walk_paths_for_glob(dir: &Path, out: &mut Vec<String>) {
+fn walk_paths_for_glob(dir: &Path, follow_symlinks: bool, out: &mut Vec<GlobCandidate>) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
-    let mut paths: Vec<std::path::PathBuf> = entries.flatten().map(|e| e.path()).collect();
-    paths.sort();
-    for path in paths {
-        out.push(path.to_string_lossy().replace('\\', "/"));
-        if path.is_dir() {
-            walk_paths_for_glob(&path, out);
+    let mut entries: Vec<_> = entries.flatten().collect();
+    entries.sort_by(|a, b| a.path().cmp(&b.path()));
+    for entry in entries {
+        let path = entry.path();
+        let Ok(ft) = entry.file_type() else {
+            continue;
+        };
+        let kind = DirentKind::from_file_type(&ft);
+        out.push(GlobCandidate {
+            actual_path: path.to_string_lossy().replace('\\', "/"),
+            kind,
+        });
+        if ft.is_dir() || (follow_symlinks && path.is_dir()) {
+            walk_paths_for_glob(&path, follow_symlinks, out);
         }
     }
 }
 
-/// `fs.globSync(pattern)` — deterministic subset covering `*`, `?`, and `**`.
+fn glob_match_from_candidate(
+    candidate: &GlobCandidate,
+    pattern_is_absolute: bool,
+    options: &FsGlobOptions,
+) -> Option<FsGlobMatch> {
+    let actual_path = normalize_slashes(&candidate.actual_path);
+    let rel_output = relative_to_base(&actual_path, &options.cwd_actual);
+    let output = if pattern_is_absolute {
+        actual_path.clone()
+    } else {
+        rel_output.clone()
+    };
+    let name = Path::new(&actual_path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("")
+        .to_string();
+    if name.is_empty() {
+        return None;
+    }
+    let dirent_parent = if pattern_is_absolute {
+        Path::new(&actual_path)
+            .parent()
+            .map(|p| p.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_else(|| ".".to_string())
+    } else {
+        let rel_parent = Path::new(&rel_output)
+            .parent()
+            .map(|p| p.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_else(|| ".".to_string());
+        parent_display_for_relative(&options.cwd_display, &rel_parent)
+    };
+    Some(FsGlobMatch {
+        output,
+        actual_path,
+        dirent_name: name,
+        dirent_parent,
+        kind: candidate.kind,
+    })
+}
+
+fn excluded_by_patterns(path: &str, options: &FsGlobOptions) -> bool {
+    options
+        .exclude_patterns
+        .iter()
+        .any(|re| re.is_match(path).unwrap_or(false))
+}
+
+fn excluded_by_function(entry: &FsGlobMatch, options: &FsGlobOptions) -> bool {
+    let Some(callback) = options.exclude_fn else {
+        return false;
+    };
+    let arg = if options.with_file_types {
+        unsafe { build_dirent_object(&entry.dirent_name, &entry.dirent_parent, entry.kind) }
+    } else {
+        string_value(entry.output.as_bytes())
+    };
+    crate::value::js_is_truthy(crate::closure::js_closure_call1(callback, arg)) != 0
+}
+
+fn glob_entry_value(entry: &FsGlobMatch, with_file_types: bool) -> f64 {
+    if with_file_types {
+        unsafe { build_dirent_object(&entry.dirent_name, &entry.dirent_parent, entry.kind) }
+    } else {
+        string_value(entry.output.as_bytes())
+    }
+}
+
+fn run_fs_glob(pattern_value: f64, options_value: f64) -> FsGlobRun {
+    let patterns = glob_patterns_from_value(pattern_value);
+    let options = glob_options_from_value(options_value);
+    let mut matches: BTreeMap<String, FsGlobMatch> = BTreeMap::new();
+    for pattern in patterns {
+        let pattern_is_absolute = Path::new(&pattern).is_absolute();
+        let pattern_for_match = if pattern_is_absolute {
+            normalize_slashes(&pattern)
+        } else {
+            normalize_slashes(&pattern)
+        };
+        let Some(re) = glob_regex_from_pattern(&pattern_for_match) else {
+            continue;
+        };
+        let root = glob_search_root(&pattern_for_match);
+        let root_actual = if pattern_is_absolute {
+            root
+        } else {
+            join_slash(&options.cwd_actual, &root)
+        };
+        let mut candidates = Vec::new();
+        walk_paths_for_glob(
+            Path::new(&root_actual),
+            options.follow_symlinks,
+            &mut candidates,
+        );
+        for candidate in &candidates {
+            let target = if pattern_is_absolute {
+                candidate.actual_path.clone()
+            } else {
+                relative_to_base(&candidate.actual_path, &options.cwd_actual)
+            };
+            if !re.is_match(&target).unwrap_or(false) {
+                continue;
+            }
+            let Some(entry) = glob_match_from_candidate(candidate, pattern_is_absolute, &options)
+            else {
+                continue;
+            };
+            if excluded_by_patterns(&entry.actual_path, &options)
+                || excluded_by_function(&entry, &options)
+            {
+                continue;
+            }
+            matches.entry(entry.output.clone()).or_insert(entry);
+        }
+    }
+    FsGlobRun {
+        matches: matches.into_values().collect(),
+        with_file_types: options.with_file_types,
+    }
+}
+
+/// `fs.globSync(pattern)` — deterministic Node-compatible glob subset.
 #[no_mangle]
 pub extern "C" fn js_fs_glob_sync(pattern_value: f64) -> f64 {
     js_fs_glob_sync_options(pattern_value, f64::from_bits(crate::value::TAG_UNDEFINED))
 }
 
-pub(crate) fn glob_cwd_from_options(options_value: f64) -> Option<String> {
-    unsafe {
-        let cwd = options_field_value(options_value, b"cwd")?;
-        decode_path_value(f64::from_bits(cwd.bits())).map(|s| s.to_string())
-    }
-}
-
 #[no_mangle]
 pub extern "C" fn js_fs_glob_sync_options(pattern_value: f64, options_value: f64) -> f64 {
     use crate::array::{js_array_alloc, js_array_push_f64};
-    use crate::value::js_nanbox_string;
 
-    unsafe {
-        let pattern = match decode_path_value(pattern_value) {
-            Some(s) => s,
-            None => {
-                let arr = js_array_alloc(0);
-                return f64::from_bits(i64::cast_unsigned(arr as i64));
-            }
-        };
-        let cwd = glob_cwd_from_options(options_value);
-        let pattern_for_match = if let Some(cwd) = &cwd {
-            if Path::new(&pattern).is_absolute() {
-                pattern.to_string()
-            } else {
-                format!("{}/{}", cwd.trim_end_matches('/'), pattern)
-            }
-        } else {
-            pattern.to_string()
-        }
-        .replace('\\', "/");
-        let Some(re) = glob_regex_from_pattern(&pattern_for_match) else {
-            let arr = js_array_alloc(0);
-            return f64::from_bits(i64::cast_unsigned(arr as i64));
-        };
-        let root = glob_search_root(&pattern_for_match);
-        let mut candidates = Vec::new();
-        walk_paths_for_glob(Path::new(&root), &mut candidates);
-        let mut matches: Vec<String> = candidates.into_iter().filter(|p| re.is_match(p)).collect();
-        matches.sort();
-
-        let mut arr = js_array_alloc(matches.len() as u32);
-        for path in &matches {
-            let output = if let Some(cwd) = &cwd {
-                let prefix = format!("{}/", cwd.trim_end_matches('/')).replace('\\', "/");
-                path.strip_prefix(&prefix).unwrap_or(path).to_string()
-            } else {
-                path.clone()
-            };
-            let bytes = output.as_bytes();
-            let s = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
-            arr = js_array_push_f64(arr, js_nanbox_string(s as i64));
-        }
-        f64::from_bits(i64::cast_unsigned(arr as i64))
+    let run = run_fs_glob(pattern_value, options_value);
+    let mut arr = js_array_alloc(run.matches.len() as u32);
+    for entry in &run.matches {
+        arr = js_array_push_f64(arr, glob_entry_value(entry, run.with_file_types));
     }
+    f64::from_bits(i64::cast_unsigned(arr as i64))
 }
 
 const FS_WATCH_POLL_INTERVAL_MS: f64 = 25.0;
@@ -268,16 +777,34 @@ struct PromiseWatchState {
     abort_reason: Option<f64>,
 }
 
+struct GlobIteratorState {
+    entries: Vec<FsGlobMatch>,
+    index: usize,
+    with_file_types: bool,
+    closed: bool,
+}
+
 thread_local! {
     static NEXT_WATCH_ID: RefCell<usize> = const { RefCell::new(1) };
+    static NEXT_GLOB_ITERATOR_ID: RefCell<usize> = const { RefCell::new(1) };
     static FS_WATCHERS: RefCell<HashMap<usize, FsWatchState>> = RefCell::new(HashMap::new());
     static WATCH_FILE_STATES: RefCell<HashMap<usize, WatchFileState>> = RefCell::new(HashMap::new());
     static WATCH_FILE_PATHS: RefCell<HashMap<String, usize>> = RefCell::new(HashMap::new());
     static PROMISE_WATCHERS: RefCell<HashMap<usize, PromiseWatchState>> = RefCell::new(HashMap::new());
+    static GLOB_ITERATORS: RefCell<HashMap<usize, GlobIteratorState>> = RefCell::new(HashMap::new());
 }
 
 fn next_watch_id() -> usize {
     NEXT_WATCH_ID.with(|next| {
+        let mut next = next.borrow_mut();
+        let id = *next;
+        *next = next.saturating_add(1);
+        id
+    })
+}
+
+fn next_glob_iterator_id() -> usize {
+    NEXT_GLOB_ITERATOR_ID.with(|next| {
         let mut next = next.borrow_mut();
         let id = *next;
         *next = next.saturating_add(1);
@@ -1157,6 +1684,46 @@ enum PromiseNextAction {
     Pending,
 }
 
+enum GlobNextAction {
+    Done,
+    Entry(FsGlobMatch, bool),
+}
+
+extern "C" fn glob_iterator_next_impl(closure: *const ClosureHeader) -> f64 {
+    let id = js_closure_get_capture_f64(closure, 0) as usize;
+    let action = GLOB_ITERATORS.with(|iterators| {
+        let mut iterators = iterators.borrow_mut();
+        let Some(state) = iterators.get_mut(&id) else {
+            return GlobNextAction::Done;
+        };
+        if state.closed || state.index >= state.entries.len() {
+            state.closed = true;
+            return GlobNextAction::Done;
+        }
+        let entry = state.entries[state.index].clone();
+        state.index += 1;
+        GlobNextAction::Entry(entry, state.with_file_types)
+    });
+    match action {
+        GlobNextAction::Done => resolved_iterator_promise(undefined_value(), true),
+        GlobNextAction::Entry(entry, with_file_types) => {
+            resolved_iterator_promise(glob_entry_value(&entry, with_file_types), false)
+        }
+    }
+}
+
+extern "C" fn glob_iterator_return_impl(closure: *const ClosureHeader) -> f64 {
+    let id = js_closure_get_capture_f64(closure, 0) as usize;
+    GLOB_ITERATORS.with(|iterators| {
+        iterators.borrow_mut().remove(&id);
+    });
+    resolved_iterator_promise(undefined_value(), true)
+}
+
+extern "C" fn glob_iterator_self_impl(closure: *const ClosureHeader) -> f64 {
+    js_closure_get_capture_f64(closure, 1)
+}
+
 extern "C" fn promise_watcher_next_impl(closure: *const ClosureHeader) -> f64 {
     let id = js_closure_get_capture_f64(closure, 0) as usize;
     let action = PROMISE_WATCHERS.with(|watchers| {
@@ -1229,6 +1796,9 @@ fn ensure_watch_method_arities() {
         js_register_closure_arity(promise_watcher_next_impl as *const u8, 0);
         js_register_closure_arity(promise_watcher_return_impl as *const u8, 0);
         js_register_closure_arity(promise_watcher_self_impl as *const u8, 0);
+        js_register_closure_arity(glob_iterator_next_impl as *const u8, 0);
+        js_register_closure_arity(glob_iterator_return_impl as *const u8, 0);
+        js_register_closure_arity(glob_iterator_self_impl as *const u8, 0);
     });
 }
 
@@ -1357,6 +1927,48 @@ fn build_promise_watcher_object(id: usize) -> f64 {
         }
     }
     self_value
+}
+
+fn build_glob_iterator_object(id: usize) -> f64 {
+    ensure_watch_method_arities();
+    let obj = crate::object::js_object_alloc(0, 3);
+    let self_value = boxed_ptr(obj as *const u8);
+    set_named_field(
+        obj,
+        b"next",
+        method_value(glob_iterator_next_impl as *const u8, id, self_value),
+    );
+    set_named_field(
+        obj,
+        b"return",
+        method_value(glob_iterator_return_impl as *const u8, id, self_value),
+    );
+    let async_iterator = crate::symbol::well_known_symbol("asyncIterator");
+    if !async_iterator.is_null() {
+        let symbol_value = boxed_ptr(async_iterator as *const u8);
+        let method = method_value(glob_iterator_self_impl as *const u8, id, self_value);
+        unsafe {
+            crate::symbol::js_object_set_symbol_property(self_value, symbol_value, method);
+        }
+    }
+    self_value
+}
+
+pub(crate) fn js_fs_promises_glob_iterator(pattern_value: f64, options_value: f64) -> f64 {
+    let run = run_fs_glob(pattern_value, options_value);
+    let id = next_glob_iterator_id();
+    GLOB_ITERATORS.with(|iterators| {
+        iterators.borrow_mut().insert(
+            id,
+            GlobIteratorState {
+                entries: run.matches,
+                index: 0,
+                with_file_types: run.with_file_types,
+                closed: false,
+            },
+        );
+    });
+    build_glob_iterator_object(id)
 }
 
 fn normalized_watch_args(arg1: f64, arg2: f64) -> (f64, Option<f64>) {

--- a/crates/perry-runtime/src/node_submodules/fs_promises.rs
+++ b/crates/perry-runtime/src/node_submodules/fs_promises.rs
@@ -410,10 +410,7 @@ pub(crate) extern "C" fn thunk_fs_promises_glob(
     pattern: f64,
     options: f64,
 ) -> f64 {
-    promise_from_sync_value(|| {
-        let raw = crate::fs::js_fs_glob_sync_options(pattern, options);
-        f64::from_bits(JSValue::pointer(raw.to_bits() as *const u8).bits())
-    })
+    crate::fs::js_fs_promises_glob_iterator(pattern, options)
 }
 
 pub(crate) extern "C" fn thunk_fs_promises_watch(

--- a/test-parity/node-suite/fs-promises/glob/async-iterator.ts
+++ b/test-parity/node-suite/fs-promises/glob/async-iterator.ts
@@ -1,0 +1,55 @@
+(process as any).emitWarning = () => {};
+import * as fs from "node:fs";
+import { glob } from "node:fs/promises";
+
+const ROOT = "/tmp/perry_node_suite_fs_promises_glob_async_iterator";
+try { fs.rmSync(ROOT, { recursive: true, force: true }); } catch (_e) {}
+fs.mkdirSync(ROOT + "/a", { recursive: true });
+fs.mkdirSync(ROOT + "/dist", { recursive: true });
+fs.writeFileSync(ROOT + "/top.txt", "top");
+fs.writeFileSync(ROOT + "/a/nested.txt", "nested");
+fs.writeFileSync(ROOT + "/a/x.js", "x");
+fs.writeFileSync(ROOT + "/a/y.ts", "y");
+fs.writeFileSync(ROOT + "/dist/out.js", "out");
+
+const list = (value: string[]) => value.slice().sort().join(",");
+
+const manual = glob("top.txt", { cwd: ROOT }) as any;
+console.log("glob iterator self:", String(manual[Symbol.asyncIterator]() === manual));
+console.log("glob iterator methods:", `${typeof manual.next}:${typeof manual.return}`);
+const first = await manual.next();
+console.log("glob manual next:", JSON.stringify({ value: first.value, done: first.done }));
+const returned = await manual.return();
+console.log("glob return:", JSON.stringify({ done: returned.done, value: returned.value ?? null }));
+const afterReturn = await manual.next();
+console.log("glob after return:", JSON.stringify({ done: afterReturn.done, value: afterReturn.value ?? null }));
+
+const txtMatches: string[] = [];
+for await (const entry of glob("**/*.txt", { cwd: ROOT })) {
+  txtMatches.push(entry);
+}
+console.log("glob for await:", list(txtMatches));
+
+const advanced: string[] = [];
+for await (const entry of glob("**/*.{js,ts}", { cwd: ROOT, exclude: ["dist/**"] })) {
+  advanced.push(entry);
+}
+console.log("glob advanced exclude:", list(advanced));
+
+const dirents: string[] = [];
+for await (const entry of glob("a/*.js", { cwd: ROOT, withFileTypes: true }) as AsyncIterable<fs.Dirent>) {
+  dirents.push(`${entry.name}:${entry.isFile()}:${entry.isDirectory()}:${typeof (entry as any).parentPath}`);
+}
+console.log("glob dirent:", dirents.join(","));
+
+async function nextCode(pattern: any, options?: any): Promise<string> {
+  try {
+    await (glob(pattern, options) as any).next();
+    return "ok";
+  } catch (err) {
+    return (err as any).code || (err as Error).name;
+  }
+}
+
+console.log("glob invalid pattern:", await nextCode(42));
+console.log("glob invalid options:", await nextCode("*", null));

--- a/test-parity/node-suite/fs/glob/advanced.ts
+++ b/test-parity/node-suite/fs/glob/advanced.ts
@@ -1,0 +1,68 @@
+(process as any).emitWarning = () => {};
+import * as fs from "node:fs";
+
+const ROOT = "/tmp/perry_node_suite_fs_glob_advanced";
+try { fs.rmSync(ROOT, { recursive: true, force: true }); } catch (_e) {}
+fs.mkdirSync(ROOT + "/a/b", { recursive: true });
+fs.mkdirSync(ROOT + "/node_modules/pkg", { recursive: true });
+fs.mkdirSync(ROOT + "/dist", { recursive: true });
+fs.writeFileSync(ROOT + "/root.txt", "root");
+fs.writeFileSync(ROOT + "/a/three.txt", "three");
+fs.writeFileSync(ROOT + "/a/one.js", "one");
+fs.writeFileSync(ROOT + "/a/two.ts", "two");
+fs.writeFileSync(ROOT + "/a/b/two.txt", "nested");
+fs.writeFileSync(ROOT + "/a/b/skip.md", "skip");
+fs.writeFileSync(ROOT + "/node_modules/pkg/mod.js", "mod");
+fs.writeFileSync(ROOT + "/dist/out.js", "out");
+
+const list = (value: string[]) => value.slice().sort().join(",");
+
+if (typeof fs.globSync === "function") {
+  const arrayMatches = fs.globSync(["a/**/*.txt", "**/*.txt", "a/b/two.txt"], { cwd: ROOT });
+  console.log("globSync array dedupe:", list(arrayMatches));
+
+  const excluded = fs.globSync("**/*.js", {
+    cwd: ROOT,
+    exclude: ["node_modules/**", "dist/**"],
+  });
+  console.log("globSync exclude:", list(excluded));
+
+  console.log("globSync brace:", list(fs.globSync("a/*.{js,ts}", { cwd: ROOT })));
+  console.log("globSync class:", list(fs.globSync("a/[ot]*.t?", { cwd: ROOT })));
+  console.log("globSync extglob:", list(fs.globSync("a/@(one|two).+(js|ts)", { cwd: ROOT })));
+
+  const abs = fs.globSync(ROOT + "/a/*.{js,ts}", { cwd: ROOT })
+    .map((p) => p.slice(ROOT.length + 1));
+  console.log("globSync absolute pattern:", list(abs));
+
+  const dirents = fs.globSync("a/*.js", { cwd: ROOT, withFileTypes: true }) as fs.Dirent[];
+  console.log(
+    "globSync dirent:",
+    dirents.map((d) => `${d.name}:${d.isFile()}:${d.isDirectory()}:${typeof (d as any).parentPath}`).join(","),
+  );
+}
+
+if (typeof fs.glob === "function") {
+  await new Promise<void>((resolve) => {
+    fs.glob("**/*.{js,ts}", {
+      cwd: ROOT,
+      exclude: ["dist/**", "node_modules/**"],
+    }, (err, matches) => {
+      console.log("glob callback advanced err:", String(err === null));
+      console.log("glob callback advanced:", list(matches));
+      resolve();
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    fs.glob("a/*.js", { cwd: ROOT, withFileTypes: true }, (err, matches) => {
+      const dirents = matches as fs.Dirent[];
+      console.log("glob callback dirent err:", String(err === null));
+      console.log(
+        "glob callback dirent:",
+        dirents.map((d) => `${d.name}:${d.isFile()}:${d.isDirectory()}`).join(","),
+      );
+      resolve();
+    });
+  });
+}

--- a/test-parity/node-suite/fs/glob/validation.ts
+++ b/test-parity/node-suite/fs/glob/validation.ts
@@ -1,0 +1,34 @@
+(process as any).emitWarning = () => {};
+import * as fs from "node:fs";
+
+const ROOT = "/tmp/perry_node_suite_fs_glob_validation";
+try { fs.rmSync(ROOT, { recursive: true, force: true }); } catch (_e) {}
+fs.mkdirSync(ROOT, { recursive: true });
+fs.writeFileSync(ROOT + "/x.txt", "x");
+
+function codeOf(fn: () => unknown): string {
+  try {
+    fn();
+    return "ok";
+  } catch (err) {
+    return (err as any).code || (err as Error).name;
+  }
+}
+
+if (typeof fs.globSync === "function") {
+  console.log("globSync invalid pattern:", codeOf(() => fs.globSync(42 as any)));
+  console.log("globSync invalid options:", codeOf(() => fs.globSync("*", null as any)));
+  console.log("globSync invalid cwd:", codeOf(() => fs.globSync("*", { cwd: 42 as any })));
+  console.log("globSync invalid exclude:", codeOf(() => fs.globSync("*", { exclude: "x.txt" as any })));
+  console.log("globSync invalid exclude item:", codeOf(() => fs.globSync("*", { exclude: ["x.txt", 42 as any] })));
+}
+
+if (typeof fs.glob === "function") {
+  console.log("glob callback missing:", codeOf(() => fs.glob("*", null as any)));
+  await new Promise<void>((resolve) => {
+    fs.glob("*", { cwd: 42 as any }, (err) => {
+      console.log("glob callback cwd err:", (err as any)?.code || "none");
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
Summary:
- Expands fs glob matching for pattern arrays, cwd, exclude, withFileTypes, braces/extglob, and validation.
- Makes fs.promises.glob behave as an async iterable for covered Node-compatible cases.
- Adds sync/callback and promises parity fixtures for advanced glob behavior.

Tests:
- cargo fmt --check
- cargo check -p perry-runtime -p perry-api-manifest -p perry-codegen -p perry-hir
- ./run_parity_tests.sh --suite node-suite --module fs --filter glob
- ./run_parity_tests.sh --suite node-suite --module fs-promises --filter glob