### PR TITLE
feat(node:fs): implement openAsBlob

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -3230,6 +3230,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("fs", "unlinkSync", false, None),
     method("fs", "openSync", false, None),
     method("fs", "open", false, None),
+    method("fs", "openAsBlob", false, None),
     method("fs", "closeSync", false, None),
     method("fs", "close", false, None),
     method("fs", "fstatSync", false, None),

--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -1889,6 +1889,23 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &[(DOUBLE, &p), (DOUBLE, &options)],
                     ))
                 }
+                "openAsBlob" => {
+                    let p = if let Some(arg) = args.first() {
+                        lower_expr(ctx, arg)?
+                    } else {
+                        double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                    };
+                    let options = if args.len() >= 2 {
+                        lower_expr(ctx, &args[1])?
+                    } else {
+                        double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                    };
+                    Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_fs_open_as_blob",
+                        &[(DOUBLE, &p), (DOUBLE, &options)],
+                    ))
+                }
                 "statSync" if !args.is_empty() => {
                     let p = lower_expr(ctx, &args[0])?;
                     let options = if args.len() >= 2 {

--- a/crates/perry-codegen/src/lower_call/native/native_fs_branch.rs
+++ b/crates/perry-codegen/src/lower_call/native/native_fs_branch.rs
@@ -262,6 +262,23 @@
                     &[(DOUBLE, &path), (DOUBLE, &options)],
                 ));
             }
+            "openAsBlob" => {
+                let path = if let Some(arg) = args.first() {
+                    lower_expr(ctx, arg)?
+                } else {
+                    double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                };
+                let options = if args.len() >= 2 {
+                    lower_expr(ctx, &args[1])?
+                } else {
+                    double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                };
+                return Ok(ctx.block().call(
+                    DOUBLE,
+                    "js_fs_open_as_blob",
+                    &[(DOUBLE, &path), (DOUBLE, &options)],
+                ));
+            }
             "readdirSync" if !args.is_empty() => {
                 // Issue #631: forward the optional `options` arg
                 // (e.g. `{withFileTypes:true}`) so the runtime can

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -326,6 +326,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // fs.readFileSync(path, encoding) — returns a raw *mut StringHeader i64.
     module.declare_function("js_fs_read_file_sync", I64, &[DOUBLE]);
     module.declare_function("js_fs_read_file_dispatch", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_fs_open_as_blob", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_fs_promises_read_file", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function(
         "js_fs_promises_write_file",

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -33,7 +33,9 @@ mod stats;
 pub use stats::*;
 mod dirent;
 pub use dirent::*;
+mod open_as_blob;
 mod time;
+pub use open_as_blob::*;
 pub mod validate;
 pub use time::js_fs_to_unix_timestamp;
 

--- a/crates/perry-runtime/src/fs/open_as_blob.rs
+++ b/crates/perry-runtime/src/fs/open_as_blob.rs
@@ -1,0 +1,51 @@
+//! `fs.openAsBlob(path[, options])`.
+
+use super::*;
+
+#[no_mangle]
+pub extern "C" fn js_fs_open_as_blob(path_value: f64, options_value: f64) -> f64 {
+    unsafe {
+        validate::validate_object_options("options", options_value);
+        let content_type = open_as_blob_content_type(options_value);
+
+        validate::validate_path("path", path_value);
+        let path = match decode_path_value(path_value) {
+            Some(path) => path,
+            None => validate::throw_invalid_path_arg("path", path_value),
+        };
+        let metadata = fs::metadata(&path).unwrap_or_else(|_| throw_open_as_blob_error());
+        if metadata.is_file() && fs::File::open(&path).is_err() {
+            throw_open_as_blob_error();
+        }
+
+        let blob =
+            crate::node_submodules::blob::blob_value_from_file_path(&path, &metadata, content_type);
+        let promise = crate::promise::js_promise_resolved(blob);
+        f64::from_bits(crate::value::JSValue::pointer(promise as *const u8).bits())
+    }
+}
+
+unsafe fn open_as_blob_content_type(options_value: f64) -> String {
+    let Some(value) = options_field_value(options_value, b"type") else {
+        return String::new();
+    };
+    let type_value = f64::from_bits(value.bits());
+    if let Some(content_type) = crate::node_submodules::blob::string_from_value(type_value) {
+        return content_type;
+    }
+    if crate::value::js_is_truthy(type_value) == 0 {
+        return String::new();
+    }
+    let message = format!(
+        "The \"options.type\" property must be of type string. Received {}",
+        validate::describe_received(type_value)
+    );
+    validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
+fn throw_open_as_blob_error() -> ! {
+    crate::exception::js_throw(validate::build_type_error_with_code_value(
+        "Unable to open file as blob",
+        "ERR_INVALID_ARG_VALUE",
+    ))
+}

--- a/crates/perry-runtime/src/node_submodules/blob.rs
+++ b/crates/perry-runtime/src/node_submodules/blob.rs
@@ -8,7 +8,7 @@
 use super::consumers::{
     buffer_from_bytes, bytes_to_array_buffer_value, bytes_to_text_value, bytes_to_uint8_array_value,
 };
-use super::fs_promises::promise_value;
+use super::fs_promises::{promise_rejected, promise_value};
 use crate::closure::{
     js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr,
     js_register_closure_arity, ClosureHeader,
@@ -16,8 +16,61 @@ use crate::closure::{
 use crate::object::{js_object_alloc, js_object_set_field_by_name, ObjectHeader};
 use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::fs;
+use std::io::{Read, Seek, SeekFrom};
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+#[cfg(not(unix))]
+use std::time::UNIX_EPOCH;
 
 const CLASS_ID_BLOB: u32 = 0xFFFF0026;
+
+#[derive(Clone)]
+struct FileBlobState {
+    path: String,
+    fingerprint: FileBlobFingerprint,
+    offset: u64,
+    length: u64,
+    content_type: String,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct FileBlobFingerprint {
+    len: u64,
+    is_file: bool,
+    is_dir: bool,
+    #[cfg(unix)]
+    dev: u64,
+    #[cfg(unix)]
+    ino: u64,
+    #[cfg(unix)]
+    mode: u32,
+    #[cfg(unix)]
+    mtime: i64,
+    #[cfg(unix)]
+    mtime_nsec: i64,
+    #[cfg(unix)]
+    ctime: i64,
+    #[cfg(unix)]
+    ctime_nsec: i64,
+    #[cfg(not(unix))]
+    modified_ns: u128,
+}
+
+#[derive(Clone, Copy)]
+struct FileBlobStreamState {
+    blob_id: usize,
+    consumed: bool,
+}
+
+thread_local! {
+    static FILE_BLOBS: RefCell<HashMap<usize, FileBlobState>> = RefCell::new(HashMap::new());
+    static NEXT_FILE_BLOB_ID: RefCell<usize> = const { RefCell::new(1) };
+    static FILE_BLOB_STREAMS: RefCell<HashMap<usize, FileBlobStreamState>> = RefCell::new(HashMap::new());
+    static NEXT_FILE_BLOB_STREAM_ID: RefCell<usize> = const { RefCell::new(1) };
+}
 
 extern "C" fn blob_text_method(closure: *const ClosureHeader) -> f64 {
     let bytes = captured_blob_bytes(closure);
@@ -65,6 +118,140 @@ extern "C" fn blob_stream_method(closure: *const ClosureHeader) -> f64 {
     crate::node_stream::js_node_stream_readable_from(bytes_to_uint8_array_value(&bytes))
 }
 
+extern "C" fn file_blob_text_method(closure: *const ClosureHeader) -> f64 {
+    match read_file_blob_bytes(captured_file_blob_id(closure)) {
+        Ok(bytes) => promise_value(bytes_to_text_value(&bytes)),
+        Err(reason) => promise_rejected(reason),
+    }
+}
+
+extern "C" fn file_blob_array_buffer_method(closure: *const ClosureHeader) -> f64 {
+    match read_file_blob_bytes(captured_file_blob_id(closure)) {
+        Ok(bytes) => promise_value(bytes_to_array_buffer_value(&bytes)),
+        Err(reason) => promise_rejected(reason),
+    }
+}
+
+extern "C" fn file_blob_bytes_method(closure: *const ClosureHeader) -> f64 {
+    match read_file_blob_bytes(captured_file_blob_id(closure)) {
+        Ok(bytes) => promise_value(bytes_to_uint8_array_value(&bytes)),
+        Err(reason) => promise_rejected(reason),
+    }
+}
+
+extern "C" fn file_blob_slice_method(
+    closure: *const ClosureHeader,
+    start: f64,
+    end: f64,
+    content_type: f64,
+) -> f64 {
+    let id = captured_file_blob_id(closure);
+    let Some(state) = file_blob_state(id) else {
+        return blob_value_from_bytes_and_type(&[], "");
+    };
+    let len = state.length as i64;
+    let normalize = |value: f64, default: i64| -> i64 {
+        if value.is_nan() || value.to_bits() == crate::value::TAG_UNDEFINED {
+            return default;
+        }
+        let n = value as i64;
+        if n < 0 {
+            (len + n).max(0)
+        } else {
+            n.min(len)
+        }
+    };
+    let lo = normalize(start, 0);
+    let hi = normalize(end, len);
+    let (lo, hi) = if hi < lo { (lo, lo) } else { (lo, hi) };
+    let content_type = string_from_value(content_type)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let child = FileBlobState {
+        path: state.path,
+        fingerprint: state.fingerprint,
+        offset: state.offset.saturating_add(lo as u64),
+        length: (hi - lo) as u64,
+        content_type,
+    };
+    blob_value_from_file_state(child)
+}
+
+extern "C" fn file_blob_stream_method(closure: *const ClosureHeader) -> f64 {
+    file_blob_stream_value(captured_file_blob_id(closure))
+}
+
+extern "C" fn file_blob_stream_get_reader_method(closure: *const ClosureHeader) -> f64 {
+    let stream_id = captured_file_blob_stream_id(closure);
+    let obj = js_object_alloc(0, 4);
+    set_named_value(
+        obj,
+        b"read",
+        file_blob_stream_method_value(file_blob_stream_next_method as *const u8, 0, stream_id),
+    );
+    set_named_value(
+        obj,
+        b"releaseLock",
+        file_blob_stream_method_value(file_blob_stream_undefined_method as *const u8, 0, stream_id),
+    );
+    set_named_value(
+        obj,
+        b"cancel",
+        file_blob_stream_method_value(file_blob_stream_cancel_method as *const u8, 1, stream_id),
+    );
+    set_named_value(
+        obj,
+        b"closed",
+        promise_value(f64::from_bits(crate::value::TAG_UNDEFINED)),
+    );
+    object_value(obj)
+}
+
+extern "C" fn file_blob_stream_next_method(closure: *const ClosureHeader) -> f64 {
+    file_blob_stream_next(captured_file_blob_stream_id(closure))
+}
+
+extern "C" fn file_blob_stream_return_method(closure: *const ClosureHeader) -> f64 {
+    let stream_id = captured_file_blob_stream_id(closure);
+    FILE_BLOB_STREAMS.with(|streams| {
+        if let Some(state) = streams.borrow_mut().get_mut(&stream_id) {
+            state.consumed = true;
+        }
+    });
+    resolved_iterator_promise(f64::from_bits(crate::value::TAG_UNDEFINED), true)
+}
+
+extern "C" fn file_blob_stream_values_method(closure: *const ClosureHeader, _options: f64) -> f64 {
+    let _ = closure;
+    crate::object::js_implicit_this_get()
+}
+
+extern "C" fn file_blob_stream_async_iterator_method(_closure: *const ClosureHeader) -> f64 {
+    crate::object::js_implicit_this_get()
+}
+
+extern "C" fn file_blob_stream_undefined_method(_closure: *const ClosureHeader) -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+extern "C" fn file_blob_stream_cancel_method(closure: *const ClosureHeader, _reason: f64) -> f64 {
+    let stream_id = captured_file_blob_stream_id(closure);
+    FILE_BLOB_STREAMS.with(|streams| {
+        if let Some(state) = streams.borrow_mut().get_mut(&stream_id) {
+            state.consumed = true;
+        }
+    });
+    promise_value(f64::from_bits(crate::value::TAG_UNDEFINED))
+}
+
+fn captured_file_blob_id(closure: *const ClosureHeader) -> usize {
+    js_closure_get_capture_ptr(closure, 0) as usize
+}
+
+fn captured_file_blob_stream_id(closure: *const ClosureHeader) -> usize {
+    js_closure_get_capture_ptr(closure, 0) as usize
+}
+
 fn captured_blob_bytes(closure: *const ClosureHeader) -> Vec<u8> {
     let raw = js_closure_get_capture_ptr(closure, 0) as usize;
     if raw < 0x10000 || !crate::buffer::is_registered_buffer(raw) {
@@ -83,6 +270,10 @@ fn set_named_value(obj: *mut ObjectHeader, name: &[u8], value: f64) {
     js_object_set_field_by_name(obj, key, value);
 }
 
+fn object_value(obj: *mut ObjectHeader) -> f64 {
+    f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+}
+
 #[allow(clippy::missing_transmute_annotations)]
 fn blob_method_value(
     func: *const u8,
@@ -92,6 +283,29 @@ fn blob_method_value(
     js_register_closure_arity(func, arity);
     let closure = js_closure_alloc(func, 1);
     js_closure_set_capture_ptr(closure, 0, backing as i64);
+    f64::from_bits(JSValue::pointer(closure as *const u8).bits())
+}
+
+#[allow(clippy::missing_transmute_annotations)]
+fn file_blob_method_value(func: *const u8, arity: u32, id: usize) -> f64 {
+    js_register_closure_arity(func, arity);
+    let closure = js_closure_alloc(func, 1);
+    js_closure_set_capture_ptr(closure, 0, id as i64);
+    f64::from_bits(JSValue::pointer(closure as *const u8).bits())
+}
+
+#[allow(clippy::missing_transmute_annotations)]
+fn file_blob_stream_method_value(func: *const u8, arity: u32, id: usize) -> f64 {
+    js_register_closure_arity(func, arity);
+    let closure = js_closure_alloc(func, 1);
+    js_closure_set_capture_ptr(closure, 0, id as i64);
+    f64::from_bits(JSValue::pointer(closure as *const u8).bits())
+}
+
+#[allow(clippy::missing_transmute_annotations)]
+fn file_blob_stream_self_method_value(func: *const u8, arity: u32) -> f64 {
+    js_register_closure_arity(func, arity);
+    let closure = js_closure_alloc(func, 0);
     f64::from_bits(JSValue::pointer(closure as *const u8).bits())
 }
 
@@ -132,6 +346,55 @@ fn blob_value_from_bytes_and_type(bytes: &[u8], content_type: &str) -> f64 {
     f64::from_bits(JSValue::pointer(obj as *const u8).bits())
 }
 
+pub(crate) fn blob_value_from_file_path(
+    path: &str,
+    metadata: &fs::Metadata,
+    content_type: String,
+) -> f64 {
+    blob_value_from_file_state(FileBlobState {
+        path: path.to_string(),
+        fingerprint: FileBlobFingerprint::from_metadata(metadata),
+        offset: 0,
+        length: metadata.len(),
+        content_type,
+    })
+}
+
+fn blob_value_from_file_state(state: FileBlobState) -> f64 {
+    let size = state.length as f64;
+    let content_type = state.content_type.clone();
+    let id = register_file_blob_state(state);
+    let obj = js_object_alloc(CLASS_ID_BLOB, 7);
+    set_named_value(obj, b"size", size);
+    set_named_value(obj, b"type", bytes_to_text_value(content_type.as_bytes()));
+    set_named_value(
+        obj,
+        b"text",
+        file_blob_method_value(file_blob_text_method as *const u8, 0, id),
+    );
+    set_named_value(
+        obj,
+        b"arrayBuffer",
+        file_blob_method_value(file_blob_array_buffer_method as *const u8, 0, id),
+    );
+    set_named_value(
+        obj,
+        b"bytes",
+        file_blob_method_value(file_blob_bytes_method as *const u8, 0, id),
+    );
+    set_named_value(
+        obj,
+        b"slice",
+        file_blob_method_value(file_blob_slice_method as *const u8, 3, id),
+    );
+    set_named_value(
+        obj,
+        b"stream",
+        file_blob_method_value(file_blob_stream_method as *const u8, 0, id),
+    );
+    object_value(obj)
+}
+
 pub(crate) fn string_from_value(value: f64) -> Option<String> {
     let jsval = JSValue::from_bits(value.to_bits());
     if !jsval.is_any_string() {
@@ -145,5 +408,214 @@ pub(crate) fn string_from_value(value: f64) -> Option<String> {
         let len = (*ptr).byte_len as usize;
         let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
         Some(String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned())
+    }
+}
+
+impl FileBlobFingerprint {
+    fn from_metadata(metadata: &fs::Metadata) -> Self {
+        Self {
+            len: metadata.len(),
+            is_file: metadata.is_file(),
+            is_dir: metadata.is_dir(),
+            #[cfg(unix)]
+            dev: metadata.dev(),
+            #[cfg(unix)]
+            ino: metadata.ino(),
+            #[cfg(unix)]
+            mode: metadata.mode(),
+            #[cfg(unix)]
+            mtime: metadata.mtime(),
+            #[cfg(unix)]
+            mtime_nsec: metadata.mtime_nsec(),
+            #[cfg(unix)]
+            ctime: metadata.ctime(),
+            #[cfg(unix)]
+            ctime_nsec: metadata.ctime_nsec(),
+            #[cfg(not(unix))]
+            modified_ns: metadata
+                .modified()
+                .ok()
+                .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_nanos())
+                .unwrap_or(0),
+        }
+    }
+}
+
+fn register_file_blob_state(state: FileBlobState) -> usize {
+    let id = NEXT_FILE_BLOB_ID.with(|next| {
+        let mut next = next.borrow_mut();
+        let id = *next;
+        *next = next.saturating_add(1).max(1);
+        id
+    });
+    FILE_BLOBS.with(|blobs| {
+        blobs.borrow_mut().insert(id, state);
+    });
+    id
+}
+
+fn file_blob_state(id: usize) -> Option<FileBlobState> {
+    FILE_BLOBS.with(|blobs| blobs.borrow().get(&id).cloned())
+}
+
+fn validate_file_blob_state(state: &FileBlobState) -> Result<(), f64> {
+    let metadata = fs::metadata(&state.path).map_err(|_| not_readable_error_value())?;
+    if FileBlobFingerprint::from_metadata(&metadata) != state.fingerprint {
+        return Err(not_readable_error_value());
+    }
+    if !metadata.is_file() {
+        return Err(not_readable_error_value());
+    }
+    if fs::File::open(&state.path).is_err() {
+        return Err(not_readable_error_value());
+    }
+    Ok(())
+}
+
+fn read_file_blob_bytes(id: usize) -> Result<Vec<u8>, f64> {
+    let state = file_blob_state(id).ok_or_else(not_readable_error_value)?;
+    validate_file_blob_state(&state)?;
+    let len = usize::try_from(state.length).map_err(|_| not_readable_error_value())?;
+    let mut file = fs::File::open(&state.path).map_err(|_| not_readable_error_value())?;
+    file.seek(SeekFrom::Start(state.offset))
+        .map_err(|_| not_readable_error_value())?;
+    let mut bytes = vec![0u8; len];
+    file.read_exact(&mut bytes)
+        .map_err(|_| not_readable_error_value())?;
+    Ok(bytes)
+}
+
+fn not_readable_error_value() -> f64 {
+    let obj = js_object_alloc(0, 4);
+    set_named_value(obj, b"name", bytes_to_text_value(b"NotReadableError"));
+    set_named_value(
+        obj,
+        b"message",
+        bytes_to_text_value(b"The blob could not be read"),
+    );
+    set_named_value(obj, b"code", 0.0);
+    set_named_value(obj, b"stack", bytes_to_text_value(b""));
+    object_value(obj)
+}
+
+fn bool_value(value: bool) -> f64 {
+    f64::from_bits(if value {
+        crate::value::TAG_TRUE
+    } else {
+        crate::value::TAG_FALSE
+    })
+}
+
+fn iterator_result(value: f64, done: bool) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value = scope.root_nanbox_f64(value);
+    let obj = js_object_alloc(0, 2);
+    set_named_value(obj, b"value", value.get_nanbox_f64());
+    set_named_value(obj, b"done", bool_value(done));
+    object_value(obj)
+}
+
+fn resolved_iterator_promise(value: f64, done: bool) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let result = iterator_result(value, done);
+    let result = scope.root_nanbox_f64(result);
+    let promise = crate::promise::js_promise_resolved(result.get_nanbox_f64());
+    f64::from_bits(JSValue::pointer(promise as *const u8).bits())
+}
+
+fn file_blob_stream_value(blob_id: usize) -> f64 {
+    let stream_id = NEXT_FILE_BLOB_STREAM_ID.with(|next| {
+        let mut next = next.borrow_mut();
+        let id = *next;
+        *next = next.saturating_add(1).max(1);
+        id
+    });
+    FILE_BLOB_STREAMS.with(|streams| {
+        streams.borrow_mut().insert(
+            stream_id,
+            FileBlobStreamState {
+                blob_id,
+                consumed: false,
+            },
+        );
+    });
+
+    let obj = js_object_alloc(0, 8);
+    set_named_value(
+        obj,
+        b"getReader",
+        file_blob_stream_method_value(
+            file_blob_stream_get_reader_method as *const u8,
+            0,
+            stream_id,
+        ),
+    );
+    set_named_value(
+        obj,
+        b"next",
+        file_blob_stream_method_value(file_blob_stream_next_method as *const u8, 0, stream_id),
+    );
+    set_named_value(
+        obj,
+        b"return",
+        file_blob_stream_method_value(file_blob_stream_return_method as *const u8, 0, stream_id),
+    );
+    set_named_value(
+        obj,
+        b"values",
+        file_blob_stream_self_method_value(file_blob_stream_values_method as *const u8, 1),
+    );
+    set_named_value(
+        obj,
+        b"cancel",
+        file_blob_stream_method_value(file_blob_stream_cancel_method as *const u8, 1, stream_id),
+    );
+    set_named_value(obj, b"locked", bool_value(false));
+    let obj_value = object_value(obj);
+    let sym = crate::symbol::well_known_symbol("asyncIterator");
+    if !sym.is_null() {
+        let sym_value = f64::from_bits(JSValue::pointer(sym as *const u8).bits());
+        unsafe {
+            crate::symbol::js_object_set_symbol_property(
+                obj_value,
+                sym_value,
+                file_blob_stream_self_method_value(
+                    file_blob_stream_async_iterator_method as *const u8,
+                    0,
+                ),
+            );
+        }
+    }
+    obj_value
+}
+
+fn file_blob_stream_next(stream_id: usize) -> f64 {
+    let action = FILE_BLOB_STREAMS.with(|streams| {
+        let mut streams = streams.borrow_mut();
+        let Some(state) = streams.get_mut(&stream_id) else {
+            return None;
+        };
+        if state.consumed {
+            return Some((state.blob_id, true));
+        }
+        state.consumed = true;
+        Some((state.blob_id, false))
+    });
+    let Some((blob_id, already_done)) = action else {
+        return resolved_iterator_promise(f64::from_bits(crate::value::TAG_UNDEFINED), true);
+    };
+    if already_done {
+        return resolved_iterator_promise(f64::from_bits(crate::value::TAG_UNDEFINED), true);
+    }
+    let Some(state) = file_blob_state(blob_id) else {
+        return promise_rejected(not_readable_error_value());
+    };
+    if state.length == 0 {
+        return resolved_iterator_promise(f64::from_bits(crate::value::TAG_UNDEFINED), true);
+    }
+    match read_file_blob_bytes(blob_id) {
+        Ok(bytes) => resolved_iterator_promise(bytes_to_uint8_array_value(&bytes), false),
+        Err(reason) => promise_rejected(reason),
     }
 }

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -104,7 +104,7 @@ macro_rules! thunk {
     };
 }
 
-mod blob;
+pub(crate) mod blob;
 mod consumers;
 mod fs_promises;
 mod hono_jsx;

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1066,6 +1066,7 @@ const FS_NAMESPACE_EXPORT_KEYS: &[&[u8]] = &[
     b"mkdtempDisposableSync",
     b"mkdtempSync",
     b"open",
+    b"openAsBlob",
     b"openSync",
     b"readdir",
     b"readdirSync",
@@ -1643,6 +1644,7 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ("fs", "Dir" | "Dirent") => Some(3),
         ("fs", "Stats") => Some(14),
         ("fs", "mkdtempDisposableSync") => Some(2),
+        ("fs", "openAsBlob") => Some(1),
         ("fs", "_toUnixTimestamp") => Some(1),
         ("events", "init") => Some(1),
         ("wasi", "WASI") => Some(0),
@@ -2361,6 +2363,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("fs", "mkdtemp")
             | ("fs", "openSync")
             | ("fs", "open")
+            | ("fs", "openAsBlob")
             | ("fs", "opendir")
             | ("fs", "opendirSync")
             | ("fs", "readFile")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -867,6 +867,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("fs", "symlinkSync") => bool_to_f64(crate::fs::js_fs_symlink_sync(arg(0), arg(1))),
         ("fs", "readlinkSync") => crate::fs::js_fs_readlink_dispatch(arg(0), arg(1)),
         ("fs", "openSync") => crate::fs::js_fs_open_sync(arg(0), arg(1)),
+        ("fs", "openAsBlob") => crate::fs::js_fs_open_as_blob(arg(0), arg(1)),
         ("fs", "closeSync") => bool_to_f64(crate::fs::js_fs_close_sync(arg(0))),
         ("fs", "readSync") if args_len == 3 => {
             crate::fs::js_fs_read_sync_options(arg(0), arg(1), arg(2))

--- a/test-parity/node-suite/fs/imports/default-import.ts
+++ b/test-parity/node-suite/fs/imports/default-import.ts
@@ -4,3 +4,4 @@ console.log("default object:", fs !== null && typeof fs === "object");
 console.log("existsSync function:", typeof fs.existsSync);
 console.log("mkdirSync function:", typeof fs.mkdirSync);
 console.log("readdirSync function:", typeof fs.readdirSync);
+console.log("openAsBlob function:", typeof fs.openAsBlob, fs.openAsBlob.length);

--- a/test-parity/node-suite/fs/imports/named-imports.ts
+++ b/test-parity/node-suite/fs/imports/named-imports.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, chownSync, lchownSync, link, symlink, stat, readlink, realpath, mkdtemp } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, chownSync, lchownSync, link, symlink, stat, readlink, realpath, mkdtemp, openAsBlob } from "node:fs";
 
 const ROOT = "/tmp/perry_node_suite_fs_named";
 try { mkdirSync(ROOT); } catch (_e) {}
@@ -17,3 +17,4 @@ console.log("named stat type:", typeof stat);
 console.log("named readlink type:", typeof readlink);
 console.log("named realpath type:", typeof realpath);
 console.log("named mkdtemp type:", typeof mkdtemp);
+console.log("named openAsBlob type:", typeof openAsBlob, openAsBlob.length);

--- a/test-parity/node-suite/fs/imports/namespace-exports.ts
+++ b/test-parity/node-suite/fs/imports/namespace-exports.ts
@@ -51,6 +51,7 @@ const existingDefaultDescriptor = Object.getOwnPropertyDescriptor(
   fsDefault,
   "readFileSync",
 );
+const openAsBlobDescriptor = Object.getOwnPropertyDescriptor(fs, "openAsBlob");
 console.log(
   "existing readFileSync export:",
   Object.keys(fs).includes("readFileSync"),
@@ -67,6 +68,15 @@ console.log(
   existingDefaultDescriptor?.enumerable,
   existingDefaultDescriptor?.configurable,
   typeof existingDefaultDescriptor?.value,
+);
+console.log(
+  "openAsBlob export:",
+  Object.keys(fs).includes("openAsBlob"),
+  Object.prototype.propertyIsEnumerable.call(fs, "openAsBlob"),
+  !!openAsBlobDescriptor,
+  openAsBlobDescriptor?.enumerable,
+  typeof openAsBlobDescriptor?.value,
+  fs.openAsBlob.length,
 );
 
 function descriptorKind(name: string) {

--- a/test-parity/node-suite/fs/imports/namespace-import.ts
+++ b/test-parity/node-suite/fs/imports/namespace-import.ts
@@ -3,4 +3,5 @@ import * as fs from "node:fs";
 console.log("namespace object:", fs !== null && typeof fs === "object");
 console.log("readFileSync function:", typeof fs.readFileSync);
 console.log("writeFileSync function:", typeof fs.writeFileSync);
+console.log("openAsBlob function:", typeof fs.openAsBlob, fs.openAsBlob.length);
 console.log("constants object:", fs.constants !== null && typeof fs.constants === "object");

--- a/test-parity/node-suite/fs/imports/prefixless-import.ts
+++ b/test-parity/node-suite/fs/imports/prefixless-import.ts
@@ -2,4 +2,5 @@ import * as fs from "fs";
 
 console.log("prefixless object:", fs !== null && typeof fs === "object");
 console.log("prefixless readFileSync:", typeof fs.readFileSync);
+console.log("prefixless openAsBlob:", typeof fs.openAsBlob);
 console.log("prefixless constants:", typeof fs.constants.F_OK);

--- a/test-parity/node-suite/fs/open-as-blob/basic.ts
+++ b/test-parity/node-suite/fs/open-as-blob/basic.ts
@@ -1,0 +1,29 @@
+import * as fs from "node:fs";
+import { Buffer } from "node:buffer";
+
+const ROOT = "/tmp/perry_node_suite_fs_open_as_blob_basic";
+try {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+} catch (_e) {}
+fs.mkdirSync(ROOT, { recursive: true });
+
+const file = ROOT + "/file.txt";
+fs.writeFileSync(file, "hello blob");
+
+const promise = fs.openAsBlob(file, { type: "Text/Plain" });
+console.log("return promise:", promise instanceof Promise);
+
+const blob = await promise;
+console.log("blob shape:", blob.size, blob.type, typeof blob.text, typeof blob.stream);
+console.log("text:", await blob.text());
+console.log("arrayBuffer:", Buffer.from(await blob.arrayBuffer()).toString());
+console.log("bytes:", Buffer.from(await blob.bytes()).toString());
+
+const slice = blob.slice(1, 6, "Slice/Type");
+console.log("slice:", slice.size, slice.type, await slice.text());
+
+const reader = blob.stream().getReader();
+const first = await reader.read();
+const second = await reader.read();
+console.log("stream first:", Buffer.from(first.value ?? []).toString(), first.done);
+console.log("stream second:", second.value, second.done);

--- a/test-parity/node-suite/fs/open-as-blob/pathlike.ts
+++ b/test-parity/node-suite/fs/open-as-blob/pathlike.ts
@@ -1,0 +1,23 @@
+import * as fs from "node:fs";
+import { Buffer } from "node:buffer";
+
+const ROOT = "/tmp/perry_node_suite_fs_open_as_blob_pathlike";
+try {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+} catch (_e) {}
+fs.mkdirSync(ROOT, { recursive: true });
+
+const file = ROOT + "/file.txt";
+fs.writeFileSync(file, "pathlike");
+
+console.log("string:", await (await fs.openAsBlob(file)).text());
+console.log("buffer:", await (await fs.openAsBlob(Buffer.from(file))).text());
+console.log("url:", await (await fs.openAsBlob(new URL("file://" + file))).text());
+
+const link = ROOT + "/link.txt";
+try {
+  fs.symlinkSync(file, link);
+  console.log("symlink:", await (await fs.openAsBlob(link)).text());
+} catch (e: any) {
+  console.log("symlink error:", e?.code ?? e?.name);
+}

--- a/test-parity/node-suite/fs/open-as-blob/read-failures.ts
+++ b/test-parity/node-suite/fs/open-as-blob/read-failures.ts
@@ -1,0 +1,35 @@
+import * as fs from "node:fs";
+
+const ROOT = "/tmp/perry_node_suite_fs_open_as_blob_read_failures";
+try {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+} catch (_e) {}
+fs.mkdirSync(ROOT, { recursive: true });
+
+async function reportReject(label: string, promise: Promise<unknown>) {
+  try {
+    await promise;
+    console.log(label, "ok");
+  } catch (e: any) {
+    console.log(label, "reject", e.name, e.message);
+  }
+}
+
+const dirBlob = await fs.openAsBlob(ROOT);
+console.log("dir blob:", typeof dirBlob.size, dirBlob.type);
+await reportReject("dir text", dirBlob.text());
+
+const mutateFile = ROOT + "/mutate.txt";
+fs.writeFileSync(mutateFile, "before");
+const mutateBlob = await fs.openAsBlob(mutateFile);
+fs.writeFileSync(mutateFile, "changed content");
+console.log("mutate size remains:", mutateBlob.size);
+await reportReject("mutate text", mutateBlob.text());
+await reportReject("mutate bytes", mutateBlob.bytes());
+
+const streamFile = ROOT + "/stream.txt";
+fs.writeFileSync(streamFile, "stream before");
+const streamBlob = await fs.openAsBlob(streamFile);
+const stream = streamBlob.stream();
+fs.writeFileSync(streamFile, "x");
+await reportReject("stream lazy read", stream.getReader().read());

--- a/test-parity/node-suite/fs/open-as-blob/validation.ts
+++ b/test-parity/node-suite/fs/open-as-blob/validation.ts
@@ -1,0 +1,39 @@
+import * as fs from "node:fs";
+
+const ROOT = "/tmp/perry_node_suite_fs_open_as_blob_validation";
+try {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+} catch (_e) {}
+fs.mkdirSync(ROOT, { recursive: true });
+
+const file = ROOT + "/file.txt";
+fs.writeFileSync(file, "valid");
+
+function reportThrow(label: string, fn: () => unknown) {
+  try {
+    const value = fn();
+    console.log(label, "ok", value instanceof Promise);
+  } catch (e: any) {
+    console.log(label, "throw", e.name, e.code, e.message);
+  }
+}
+
+reportThrow("bad path", () => fs.openAsBlob(1 as never));
+reportThrow("missing path arg", () => fs.openAsBlob());
+reportThrow("bad options before bad path", () => fs.openAsBlob(1 as never, null as never));
+reportThrow("bad type before bad path", () => fs.openAsBlob(1 as never, { type: true } as never));
+reportThrow("bad options null", () => fs.openAsBlob(file, null as never));
+reportThrow("bad options array", () => fs.openAsBlob(file, [] as never));
+reportThrow("bad type true", () => fs.openAsBlob(file, { type: true } as never));
+reportThrow("bad type number", () => fs.openAsBlob(file, { type: 1 } as never));
+reportThrow("bad type object", () => fs.openAsBlob(file, { type: {} } as never));
+reportThrow("missing", () => fs.openAsBlob(ROOT + "/missing.txt"));
+
+for (const type of [undefined, null, false, 0, NaN, ""]) {
+  const blob = await fs.openAsBlob(file, { type } as never);
+  console.log("falsy type:", String(type), JSON.stringify(blob.type));
+}
+
+const typed = await fs.openAsBlob(file, { type: "Text/Plain" });
+console.log("type casing:", typed.type);
+console.log("promises openAsBlob:", "openAsBlob" in fs.promises, typeof (fs.promises as any).openAsBlob);


### PR DESCRIPTION
Summary:
- Adds fs.openAsBlob runtime, namespace/dispatch registration, manifest entry, and import coverage.
- Backs file blobs through the existing Blob/Web API helpers for text, arrayBuffer, bytes, and stream reads.
- Adds pathlike, validation, read-failure, and namespace parity fixtures.

Tests:
- cargo fmt --check
- cargo check -p perry-runtime -p perry-api-manifest -p perry-codegen -p perry-hir
- ./run_parity_tests.sh --suite node-suite --module fs --filter open-as-blob
- ./run_parity_tests.sh --suite node-suite --module fs --filter imports