### PR TITLE
fix(api-manifest): make platform constants OS-independent so api-docs-drift is deterministic

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2690,14 +2690,11 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("constants", "O_NOFOLLOW"),
     property("constants", "O_NOCTTY"),
     property("constants", "O_DIRECTORY"),
-    #[cfg(target_os = "linux")]
     property("constants", "O_DIRECT"),
-    #[cfg(target_os = "linux")]
     property("constants", "O_NOATIME"),
     property("constants", "O_NONBLOCK"),
     property("constants", "O_SYNC"),
     property("constants", "O_DSYNC"),
-    #[cfg(target_os = "macos")]
     property("constants", "O_SYMLINK"),
     property("constants", "O_CREAT"),
     property("constants", "O_TRUNC"),
@@ -2757,7 +2754,6 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("constants", "SIGALRM"),
     property("constants", "SIGTERM"),
     property("constants", "SIGCHLD"),
-    #[cfg(target_os = "linux")]
     property("constants", "SIGSTKFLT"),
     property("constants", "SIGCONT"),
     property("constants", "SIGSTOP"),
@@ -2771,12 +2767,9 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("constants", "SIGPROF"),
     property("constants", "SIGWINCH"),
     property("constants", "SIGIO"),
-    #[cfg(any(target_os = "linux", target_os = "android"))]
     property("constants", "SIGPOLL"),
-    #[cfg(target_os = "linux")]
     property("constants", "SIGPWR"),
     property("constants", "SIGSYS"),
-    #[cfg(target_os = "macos")]
     property("constants", "SIGINFO"),
     property("constants", "E2BIG"),
     property("constants", "EACCES"),
@@ -2867,7 +2860,6 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("constants", "RTLD_NOW"),
     property("constants", "RTLD_GLOBAL"),
     property("constants", "RTLD_LOCAL"),
-    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     property("constants", "RTLD_DEEPBIND"),
     property("constants", "OPENSSL_VERSION_NUMBER"),
     property("constants", "SSL_OP_ALL"),

--- a/crates/perry-api-manifest/src/lib.rs
+++ b/crates/perry-api-manifest/src/lib.rs
@@ -652,14 +652,20 @@ mod tests {
             assert!(matches!(entry.kind, ApiKind::Property));
         }
 
+        // Platform-specific constants are listed in the manifest
+        // unconditionally so the generated docs (`docs/api/perry.d.ts`,
+        // `docs/src/api/reference.md`) are byte-identical regardless of the
+        // host OS the generator runs on — otherwise `api-docs-drift` fails for
+        // every PR whenever the committed docs were regenerated on a different
+        // OS than CI (macOS vs Linux). RTLD_DEEPBIND is therefore present on
+        // all platforms; the runtime `constants` module still only exposes a
+        // real value where the OS provides one.
         let rtld_deepbind = module_has_symbol("node:constants", "RTLD_DEEPBIND");
-        assert_eq!(
+        assert!(
             rtld_deepbind.is_some(),
-            cfg!(all(target_os = "linux", target_env = "gnu"))
+            "RTLD_DEEPBIND should be in the manifest on every platform"
         );
-        if let Some(entry) = rtld_deepbind {
-            assert!(matches!(entry.kind, ApiKind::Property));
-        }
+        assert!(matches!(rtld_deepbind.unwrap().kind, ApiKind::Property));
     }
 
     #[test]

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2403 entries across 104 modules
+// Coverage: 2409 entries across 104 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -567,11 +567,15 @@ declare module "constants" {
   /** stdlib */
   export const O_CREAT: any;
   /** stdlib */
+  export const O_DIRECT: any;
+  /** stdlib */
   export const O_DIRECTORY: any;
   /** stdlib */
   export const O_DSYNC: any;
   /** stdlib */
   export const O_EXCL: any;
+  /** stdlib */
+  export const O_NOATIME: any;
   /** stdlib */
   export const O_NOCTTY: any;
   /** stdlib */
@@ -625,6 +629,8 @@ declare module "constants" {
   /** stdlib */
   export const RSA_X931_PADDING: any;
   /** stdlib */
+  export const RTLD_DEEPBIND: any;
+  /** stdlib */
   export const RTLD_GLOBAL: any;
   /** stdlib */
   export const RTLD_LAZY: any;
@@ -663,11 +669,17 @@ declare module "constants" {
   /** stdlib */
   export const SIGPIPE: any;
   /** stdlib */
+  export const SIGPOLL: any;
+  /** stdlib */
   export const SIGPROF: any;
+  /** stdlib */
+  export const SIGPWR: any;
   /** stdlib */
   export const SIGQUIT: any;
   /** stdlib */
   export const SIGSEGV: any;
+  /** stdlib */
+  export const SIGSTKFLT: any;
   /** stdlib */
   export const SIGSTOP: any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2403 entries across 104 modules.
+Total: 2409 entries across 104 modules.
 
 ## Modules
 
@@ -515,9 +515,11 @@ Total: 2403 entries across 104 modules.
 - `OPENSSL_VERSION_NUMBER`
 - `O_APPEND`
 - `O_CREAT`
+- `O_DIRECT`
 - `O_DIRECTORY`
 - `O_DSYNC`
 - `O_EXCL`
+- `O_NOATIME`
 - `O_NOCTTY`
 - `O_NOFOLLOW`
 - `O_NONBLOCK`
@@ -544,6 +546,7 @@ Total: 2403 entries across 104 modules.
 - `RSA_PSS_SALTLEN_DIGEST`
 - `RSA_PSS_SALTLEN_MAX_SIGN`
 - `RSA_X931_PADDING`
+- `RTLD_DEEPBIND`
 - `RTLD_GLOBAL`
 - `RTLD_LAZY`
 - `RTLD_LOCAL`
@@ -563,9 +566,12 @@ Total: 2403 entries across 104 modules.
 - `SIGIOT`
 - `SIGKILL`
 - `SIGPIPE`
+- `SIGPOLL`
 - `SIGPROF`
+- `SIGPWR`
 - `SIGQUIT`
 - `SIGSEGV`
+- `SIGSTKFLT`
 - `SIGSTOP`
 - `SIGSYS`
 - `SIGTERM`


### PR DESCRIPTION
## Summary

`api-docs-drift` currently fails for **every open PR** — including ones whose only change is unrelated runtime code (e.g. #3733). Root cause: the `constants` manifest entries for OS-specific values are `#[cfg(target_os = ...)]`-gated, so the **compiled manifest differs by build OS**, and the generated docs (`docs/api/perry.d.ts`, `docs/src/api/reference.md`) differ depending on which platform ran the generator.

CI regenerates on **Linux** and fails on any diff. The moment the committed docs are regenerated on **macOS** (a maintainer's machine), the OS-specific constants flip:

| Gated to Linux | Gated to macOS |
|---|---|
| `O_DIRECT`, `O_NOATIME`, `SIGSTKFLT`, `SIGPOLL`, `SIGPWR`, `RTLD_DEEPBIND` | `O_SYMLINK`, `SIGINFO` |

…and `api-docs-drift` then fails for all subsequent PRs until the docs are regenerated on Linux again. (Diagnosed while trying to land #3733: its only change is `object_ops.rs`, yet CI showed a `constants`-module doc diff adding the Linux constants and removing the macOS ones.)

## Fix

List all eight platform-specific constants **unconditionally** in the manifest, so the manifest — and the generated docs — are byte-identical on every host. This documents the cross-platform superset (the convention Node's own `@types` follow). The runtime `constants` module still only exposes a real value where the OS provides one, so behavior is unchanged: an absent constant reads as `undefined`, matching Node.

## Verification

- Docs regenerated on macOS now contain **both** the Linux and macOS constants (the deterministic union), so a Linux CI regen produces the identical output → no drift. This PR's own `api-docs-drift` should pass, and it unblocks the check for all PRs going forward.
- The manifest test that asserted the old gating (`RTLD_DEEPBIND.is_some() == cfg!(linux-gnu)`) is updated to assert unconditional presence; all 25 `perry-api-manifest` tests pass. `cargo fmt --check` clean.

## Impact

Unblocks the `api-docs-drift` required check repo-wide. After this merges, the #3527 chain PRs (#3733 and the regex fix #3777) rebase green.
