### PR TITLE
fix(process): refresh getBuiltinModule builtin surfaces

### DIFF
--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -741,6 +741,11 @@ thread_local! {
     /// namespace object itself.
     static DEFAULT_OBJECT_SINGLETONS: RefCell<std::collections::HashMap<usize, *mut ObjectHeader>> =
         RefCell::new(std::collections::HashMap::new());
+
+    /// `node:timers/promises.scheduler` is a non-callable object with
+    /// function-valued `wait` and `yield` properties.
+    static TIMERS_PROMISES_SCHEDULER_OBJECT: RefCell<Option<*mut ObjectHeader>> =
+        const { RefCell::new(None) };
 }
 
 // We also need a process-wide "any singleton allocated?" flag so the
@@ -807,9 +812,40 @@ fn fs_constants_namespace_value() -> f64 {
     }
 }
 
+fn timers_promises_scheduler_value() -> f64 {
+    TIMERS_PROMISES_SCHEDULER_OBJECT.with(|slot| {
+        if let Some(cached) = *slot.borrow() {
+            return f64::from_bits(JSValue::pointer(cached as *const u8).bits());
+        }
+
+        let obj = js_object_alloc(0, 2);
+
+        let wait = js_closure_alloc(timers_promises_scheduler_wait as *const u8, 0);
+        crate::closure::js_register_closure_arity(timers_promises_scheduler_wait as *const u8, 2);
+        set_named_value(
+            obj,
+            "wait",
+            f64::from_bits(JSValue::pointer(wait as *const u8).bits()),
+        );
+
+        let yield_fn = js_closure_alloc(timers_promises_scheduler_yield as *const u8, 0);
+        crate::closure::js_register_closure_arity(timers_promises_scheduler_yield as *const u8, 0);
+        set_named_value(
+            obj,
+            "yield",
+            f64::from_bits(JSValue::pointer(yield_fn as *const u8).bits()),
+        );
+
+        *slot.borrow_mut() = Some(obj);
+        ANY_SINGLETON_ALLOCATED.store(1, Ordering::Release);
+        f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+    })
+}
+
 fn special_export_value(submod_key: &str, name: &str) -> Option<f64> {
     let value = match submod_key {
         "fs_promises" if name == "constants" => Some(fs_constants_namespace_value()),
+        "timers_promises" if name == "scheduler" => Some(timers_promises_scheduler_value()),
         "test" => test::test_special_export_value(name),
         _ => None,
     };
@@ -1040,6 +1076,11 @@ pub fn scan_node_submodule_singleton_roots_mut(visitor: &mut crate::gc::RuntimeR
     DEFAULT_OBJECT_SINGLETONS.with(|m| {
         for obj_ptr in m.borrow_mut().values_mut() {
             visitor.visit_raw_mut_ptr_slot(obj_ptr);
+        }
+    });
+    TIMERS_PROMISES_SCHEDULER_OBJECT.with(|slot| {
+        if let Some(ptr) = slot.borrow_mut().as_mut() {
+            visitor.visit_raw_mut_ptr_slot(ptr);
         }
     });
     // #906 follow-up: the no-op closure shared by every TracingChannel /

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -601,6 +601,32 @@ const ASYNC_HOOKS_NAMESPACE_KEYS: &[&[u8]] = &[
     b"triggerAsyncId",
 ];
 
+const BUFFER_NAMESPACE_KEYS: &[&[u8]] = &[
+    b"Buffer",
+    b"transcode",
+    b"isUtf8",
+    b"isAscii",
+    b"kMaxLength",
+    b"kStringMaxLength",
+    b"btoa",
+    b"atob",
+    b"constants",
+    b"INSPECT_MAX_BYTES",
+    b"Blob",
+    b"resolveObjectURL",
+    b"File",
+];
+
+const TIMERS_NAMESPACE_KEYS: &[&[u8]] = &[
+    b"setTimeout",
+    b"clearTimeout",
+    b"setImmediate",
+    b"clearImmediate",
+    b"setInterval",
+    b"clearInterval",
+    b"promises",
+];
+
 const OS_DEFAULT_KEYS: &[&[u8]] = &[
     b"arch",
     b"availableParallelism",
@@ -1160,8 +1186,10 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
         "path.posix" | "path.win32" => Some(&[b"_makeLong"]),
         "fs" => Some(FS_NAMESPACE_KEYS),
         "constants" => Some(deprecated_constants_keys()),
+        "buffer" => Some(BUFFER_NAMESPACE_KEYS),
         "querystring" => Some(QUERYSTRING_NAMESPACE_KEYS),
         "querystring.default" => Some(QUERYSTRING_DEFAULT_KEYS),
+        "timers" => Some(TIMERS_NAMESPACE_KEYS),
         "os" => Some(OS_NAMESPACE_KEYS),
         "os.default" => Some(OS_DEFAULT_KEYS),
         "url" => Some(URL_NAMESPACE_KEYS),
@@ -2486,6 +2514,8 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("cluster", "setupMaster")
             | ("cluster", "Worker")
             | ("buffer.Buffer", "copyBytesFrom")
+            | ("buffer", "isAscii")
+            | ("buffer", "isUtf8")
             | ("buffer", "atob")
             | ("buffer", "btoa")
             | ("util", "convertProcessSignalToExitCode")
@@ -4057,6 +4087,15 @@ pub(crate) unsafe fn get_native_module_constant(
             "kMaxLength" => Some(9_007_199_254_740_991.0),
             "kStringMaxLength" => Some(536870888.0),
             "INSPECT_MAX_BYTES" => Some(50.0),
+            _ => None,
+        },
+        "timers" => match property {
+            "promises" => Some(unsafe {
+                crate::node_submodules::js_node_submodule_namespace(
+                    b"timers_promises".as_ptr(),
+                    "timers_promises".len() as u32,
+                )
+            }),
             _ => None,
         },
         "buffer.constants" => match property {

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -415,6 +415,8 @@ pub(crate) unsafe fn dispatch_native_module_method(
                 0.0
             }
         }
+        ("buffer", "isAscii") => crate::buffer::js_buffer_is_ascii(arg(0)),
+        ("buffer", "isUtf8") => crate::buffer::js_buffer_is_utf8(arg(0)),
 
         // ── process EventEmitter API ──
         ("process", "on") => crate::os::js_process_on(arg_bits(0), arg_bits(1)),

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -549,6 +549,14 @@ pub extern "C" fn js_process_get_builtin_module(id: f64) -> f64 {
     let Some(module_name) = supported_builtin_module_name(name) else {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     };
+    if module_name == "timers/promises" {
+        return unsafe {
+            crate::node_submodules::js_node_submodule_namespace(
+                b"timers_promises".as_ptr(),
+                "timers_promises".len() as u32,
+            )
+        };
+    }
     crate::object::js_create_native_module_namespace(module_name.as_ptr(), module_name.len())
 }
 

--- a/test-parity/node-suite/process/methods/get-builtin-module-surfaces.ts
+++ b/test-parity/node-suite/process/methods/get-builtin-module-surfaces.ts
@@ -1,0 +1,27 @@
+import process from "node:process";
+
+const bufferMod = process.getBuiltinModule("buffer") as any;
+const timersMod = process.getBuiltinModule("timers") as any;
+const timersPromisesMod = process.getBuiltinModule("timers/promises") as any;
+
+console.log("buffer object:", bufferMod !== undefined && typeof bufferMod === "object");
+console.log("buffer Buffer:", typeof bufferMod?.Buffer);
+console.log("buffer isAscii:", typeof bufferMod?.isAscii);
+console.log("buffer isUtf8:", typeof bufferMod?.isUtf8);
+console.log("buffer ascii result:", bufferMod?.isAscii?.(bufferMod.Buffer.from("hi")));
+console.log("buffer keys include isAscii:", Object.keys(bufferMod ?? {}).includes("isAscii"));
+console.log("buffer keys include isUtf8:", Object.keys(bufferMod ?? {}).includes("isUtf8"));
+
+console.log("timers object:", timersMod !== undefined && typeof timersMod === "object");
+console.log("timers setTimeout:", typeof timersMod?.setTimeout);
+console.log("timers promises:", typeof timersMod?.promises);
+console.log("timers promises setTimeout:", typeof timersMod?.promises?.setTimeout);
+console.log("timers promises scheduler:", typeof timersMod?.promises?.scheduler);
+console.log("timers promises scheduler.wait:", typeof timersMod?.promises?.scheduler?.wait);
+console.log("timers promises scheduler.yield:", typeof timersMod?.promises?.scheduler?.yield);
+console.log("timers keys include promises:", Object.keys(timersMod ?? {}).includes("promises"));
+
+console.log("direct timers promises object:", timersPromisesMod !== undefined && typeof timersPromisesMod === "object");
+console.log("direct timers promises setTimeout:", typeof timersPromisesMod?.setTimeout);
+console.log("direct timers promises scheduler:", typeof timersPromisesMod?.scheduler);
+console.log("direct timers promises scheduler.wait:", typeof timersPromisesMod?.scheduler?.wait);


### PR DESCRIPTION
## Summary

- Align `process.getBuiltinModule("buffer")` with newer `node:buffer` query exports by exposing callable `isAscii` and `isUtf8` values.
- Add `timers.promises` to the native `node:timers` namespace and route it to the existing `timers/promises` submodule object, including `scheduler.wait` and `scheduler.yield`.
- Return the same populated submodule object for `process.getBuiltinModule("timers/promises")`.

Closes #3668

## PR Cut

This batches one coherent `process.getBuiltinModule()` surface drift: stale `buffer` callable exports and stale `timers` / `timers/promises` namespace aliases. Both flow through the native module namespace/runtime dispatch layer and share the same parity fixture.

## Tests

- `PATH=/tmp/perry-node25-bin:$PATH node --experimental-strip-types test-parity/node-suite/process/methods/get-builtin-module-surfaces.ts`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module process --filter get-builtin-module-surfaces`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module process --filter get-builtin-module`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module buffer --filter is-ascii-utf8`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module buffer --filter namespace-import`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module timers --filter namespace/import-surface`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module timers --filter scheduler`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module timers --filter promises/imports`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`

## Known Limitations

- Full `buffer --filter namespace` was not used as evidence because the unrelated `buffer/blob-file/namespace-constructors.ts` compile did not finish locally; the targeted `buffer/imports/namespace-import` fixture passed.
- This does not broaden `process.getBuiltinModule()` to every builtin submodule with custom stdlib-backed namespace behavior.

## Non-Goals

- No `node:stream/web`, web adapter, or `node:stream/promises` changes.
- No public API signature changes.
