### PR TITLE
fix(runtime): Function.prototype.call.bind(method) uncurry-this (#3716)

### DIFF
--- a/crates/perry-runtime/src/closure/dispatch.rs
+++ b/crates/perry-runtime/src/closure/dispatch.rs
@@ -133,6 +133,35 @@ pub unsafe extern "C" fn js_function_bind(
 static KEEP_JS_FUNCTION_BIND: unsafe extern "C" fn(f64, *const f64, usize) -> f64 =
     js_function_bind;
 
+/// Reify a `Function.prototype.{bind,call,apply}` (or any function method)
+/// *read off a closure as a value* into a callable BOUND_METHOD closure. When
+/// invoked it routes through `js_native_call_method(receiver, method, …)`, so
+/// `f.bind`, `f.call`, `f.apply` behave as real functions instead of reading
+/// back `undefined`.
+///
+/// Fixes the "uncurry-this" idiom `Function.prototype.call.bind(method)`
+/// (#3716): reading `.bind` off the reified `Function.prototype.call` value
+/// previously returned `undefined`, so the bound function was never created.
+/// `receiver` must be a NaN-boxed closure pointer; `method` is a `'static`
+/// byte slice (`b"bind"` / `b"call"` / `b"apply"`) whose pointer the
+/// BOUND_METHOD captures verbatim.
+pub(crate) unsafe fn reify_function_method_value(receiver: f64, method: &'static [u8]) -> f64 {
+    let closure = js_closure_alloc(BOUND_METHOD_FUNC_PTR, 3);
+    if closure.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    js_closure_set_capture_f64(closure, 0, receiver);
+    js_closure_set_capture_ptr(closure, 1, method.as_ptr() as i64);
+    js_closure_set_capture_ptr(closure, 2, method.len() as i64);
+    // `.name` = the method name so `typeof v === "function"` and `v.name`
+    // read back sensibly (e.g. `"bind"`).
+    if let Ok(name) = std::str::from_utf8(method) {
+        crate::object::set_bound_native_closure_name(closure, name);
+    }
+    crate::gc::runtime_write_barrier_root_heap_word(closure as u64);
+    f64::from_bits(crate::value::JSValue::pointer(closure as *mut u8).bits())
+}
+
 /// Issue #648: calling a value that isn't a function (most commonly the
 /// result of a property lookup that returned undefined, e.g.
 /// `obj.missingFn()`) must throw a TypeError that user code can catch via
@@ -1124,6 +1153,16 @@ pub unsafe extern "C" fn js_native_call_value(
     if closure.is_null() {
         // Return undefined for null/invalid closures
         return f64::from_bits(JSValue::undefined().bits());
+    }
+
+    // #3716: a built-in prototype method invoked *as a value* (the uncurry-this
+    // idiom `Function.prototype.call.bind(method)`) lands here as a no-op-backed
+    // closure that would just return `undefined`. Re-dispatch it by name through
+    // `js_native_call_method`, with the receiver taken from `IMPLICIT_THIS`.
+    if let Some(result) =
+        crate::object::try_dispatch_value_called_proto_method(closure, args_ptr, args_len)
+    {
+        return result;
     }
 
     // Refs #421: when the closure body declares more params than the call site

--- a/crates/perry-runtime/src/closure/mod.rs
+++ b/crates/perry-runtime/src/closure/mod.rs
@@ -42,7 +42,9 @@ pub use dispatch::{
     js_closure_call8, js_closure_call9, js_closure_call_apply_with_spread, js_closure_call_array,
     js_function_bind, js_native_call_value, throw_not_callable,
 };
-pub(crate) use dispatch::{reset_throw_not_callable_counter, resolve_call2_direct};
+pub(crate) use dispatch::{
+    reify_function_method_value, reset_throw_not_callable_counter, resolve_call2_direct,
+};
 
 #[cfg(test)]
 pub(crate) use dynamic_props::test_clear_closure_side_tables;

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2053,6 +2053,28 @@ pub extern "C" fn js_object_get_field_by_name(
                             crate::string::js_string_from_bytes(fname.as_ptr(), fname.len() as u32);
                         return JSValue::from_bits(crate::js_nanbox_string(s as i64).to_bits());
                     }
+                    // #3716: reading `f.bind` / `f.call` / `f.apply` *as a value*
+                    // off any function must yield a real callable, not
+                    // `undefined`. Reify it into a BOUND_METHOD closure bound to
+                    // this function as receiver; invoking it routes back through
+                    // `js_native_call_method(f, "<method>", …)`. This is what makes
+                    // the "uncurry-this" idiom
+                    // `Function.prototype.call.bind(method)` work — reading `.bind`
+                    // off the reified `Function.prototype.call` previously read
+                    // back `undefined`, so the bound function was never produced.
+                    let reified: Option<&'static [u8]> = match name_str {
+                        "bind" => Some(b"bind"),
+                        "call" => Some(b"call"),
+                        "apply" => Some(b"apply"),
+                        _ => None,
+                    };
+                    if let Some(method) = reified {
+                        let receiver =
+                            f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+                        return JSValue::from_bits(
+                            crate::closure::reify_function_method_value(receiver, method).to_bits(),
+                        );
+                    }
                     return JSValue::from_bits(val.to_bits());
                 }
             }

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -555,6 +555,55 @@ unsafe fn dispatch_typed_array_method(
     Some(r)
 }
 
+/// #3716: a built-in *prototype method* read off its prototype and called *as
+/// a value* (rather than as `recv.method(...)`) routes through
+/// `js_native_call_value`, which would invoke the shared no-op thunk
+/// (`global_this_builtin_noop_thunk`) and return `undefined`. This is the final
+/// link in the "uncurry-this" idiom `Function.prototype.call.bind(method)`: the
+/// `Function.prototype.call` thunk stashes the intended receiver in
+/// `IMPLICIT_THIS`, then calls the bound `method` value — which until now no-op'd.
+///
+/// When the invoked closure is a no-op-backed built-in proto method, recover its
+/// recorded method name and re-dispatch through the real `js_native_call_method`
+/// tower using the current `IMPLICIT_THIS` as the receiver. Returns `None` for
+/// any other closure so normal dispatch proceeds untouched.
+///
+/// Gated on a recorded built-in `.length` so bare no-op-backed global
+/// constructors (`const O = SomeCtor; O()`), which never call
+/// `set_builtin_closure_length`, are excluded.
+pub(crate) unsafe fn try_dispatch_value_called_proto_method(
+    closure: *const crate::closure::ClosureHeader,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> Option<f64> {
+    if closure.is_null() {
+        return None;
+    }
+    if (*closure).func_ptr != super::global_this::global_this_builtin_noop_thunk as *const u8 {
+        return None;
+    }
+    if super::native_module::builtin_closure_length(closure as usize).is_none() {
+        return None;
+    }
+    let name_val = crate::closure::closure_get_dynamic_prop(closure as usize, "name");
+    let name_jsv = JSValue::from_bits(name_val.to_bits());
+    if !name_jsv.is_any_string() {
+        return None;
+    }
+    // `js_string_coerce` normalizes SSO short strings (e.g. "bind", "join") to a
+    // heap StringHeader so the byte read below is valid for inline-stored names.
+    let name_hdr = crate::builtins::js_string_coerce(name_val);
+    let name = super::has_own_helpers::str_from_string_header(name_hdr)?;
+    let receiver = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    Some(js_native_call_method(
+        receiver,
+        name.as_ptr() as *const i8,
+        name.len(),
+        args_ptr,
+        args_len,
+    ))
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn js_native_call_method(
     object: f64,

--- a/test-files/test_gap_3716_uncurry_this.ts
+++ b/test-files/test_gap_3716_uncurry_this.ts
@@ -1,0 +1,46 @@
+// #3716 — the "uncurry-this" idiom `Function.prototype.call.bind(method)`.
+//
+// Reading `.bind` *as a value* off the reified `Function.prototype.call`
+// previously returned `undefined`, so the bound function was never created,
+// and even when the `call.bind(...)` call form produced a function, the bound
+// `this` (the target method) was never applied — the result was `undefined`.
+//
+// This is the exact shape test262's `harness/propertyHelper.js` uses:
+//   var __hasOwnProperty = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+//   var __join           = Function.prototype.call.bind(Array.prototype.join);
+// so fixing it unblocks every `verifyProperty`-based positive case at once.
+
+// Headline repro: hasOwnProperty via call-uncurry.
+const hop = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+console.log("hop({a:1}, 'a'):", hop({ a: 1 }, "a")); // true
+console.log("hop({a:1}, 'b'):", hop({ a: 1 }, "b")); // false
+
+// Array.prototype.join via call-uncurry (noop-backed proto method).
+const join = Function.prototype.call.bind(Array.prototype.join);
+console.log("join([1,2,3], '-'):", join([1, 2, 3], "-")); // 1-2-3
+
+// Array.prototype.slice via call-uncurry (dedicated thunk).
+const slice = Function.prototype.call.bind(Array.prototype.slice);
+console.log("slice([1,2,3], 1):", slice([1, 2, 3], 1)); // [ 2, 3 ]
+
+// Object.prototype.toString via call-uncurry.
+const toStr = Function.prototype.call.bind(Object.prototype.toString);
+console.log("toStr([]):", toStr([])); // [object Array]
+
+// apply-uncurry: args supplied as an array.
+const applyHop = Function.prototype.apply.bind(Object.prototype.hasOwnProperty);
+console.log("applyHop({x:5}, ['x']):", applyHop({ x: 5 }, ["x"])); // true
+
+// Reading `.bind` / `.call` / `.apply` off the reified call as values.
+const call = Function.prototype.call;
+console.log("typeof call:", typeof call); // function
+console.log("typeof call.bind:", typeof call.bind); // function
+const b = call.bind(Object.prototype.hasOwnProperty);
+console.log("typeof b:", typeof b); // function
+console.log("b({a:1}, 'a'):", b({ a: 1 }, "a")); // true
+
+// Sanity: ordinary user-function `.bind` still works.
+function f(this: any, x: number) {
+    return this.v + x;
+}
+console.log("f.bind({v:10})(5):", f.bind({ v: 10 })(5)); // 15


### PR DESCRIPTION
## Summary

Fixes #3716 — the **"uncurry-this"** idiom `Function.prototype.call.bind(method)` returned `undefined` even for plain objects:

```js
const hop = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
hop({a:1}, "a");   // before: undefined   after: true  (matches Node)
```

Two distinct gaps were involved:

1. **Reading `.bind`/`.call`/`.apply` as a *value* off a function returned `undefined`.** The reified `Function.prototype.call` is a real callable, but `call.bind` (read, not called) resolved to `undefined`, so the bound function was never produced.
2. **The bound function never applied the bound `this`.** Even when the `call.bind(target)` *call* form produced a function, invoking it routed the target method through the shared no-op thunk, which returns `undefined`.

## Fix (runtime-only)

- **`object/field_get_set.rs`** — reading `.bind`/`.call`/`.apply` off any closure now reifies a `BOUND_METHOD` closure bound to that function as receiver (`reify_function_method_value`). The value is a real callable (`typeof === "function"`) that routes back through `js_native_call_method(fn, "<method>", …)`.
- **`closure/dispatch.rs` (`js_native_call_value`)** — a built-in prototype method invoked *as a value* (backed by the shared `global_this_builtin_noop_thunk`) is re-dispatched **by name** through `js_native_call_method`, with the receiver taken from `IMPLICIT_THIS` (set by the `Function.prototype.call`/`.apply` thunk). Gated on a recorded built-in `.length` so bare no-op-backed global constructors (`const O = SomeCtor; O()`) are excluded.

## Why it's high-leverage

This is the exact shape test262's `harness/propertyHelper.js` uses:

```js
var __hasOwnProperty = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
var __join           = Function.prototype.call.bind(Array.prototype.join);
```

`verifyProperty` calls `__hasOwnProperty(obj, name)` as its **first** assertion, so fixing this unblocks the entire `propertyHelper.js`-based slice of the suite at once.

## Scope note

Object / Array / Function receivers (everything `propertyHelper.js` needs) work. Primitive-receiver uncurry (`Function.prototype.call.bind(Number.prototype.toFixed)`) still throws a `TypeError`, because `js_native_call_method` has no primitive-method dispatcher — that's a separate, larger gap and is left untouched.

## Validation

- New `test-files/test_gap_3716_uncurry_this.ts` is **byte-identical to `node --experimental-strip-types`** on both the default (auto-optimize) and `PERRY_NO_AUTO_OPTIMIZE=1` paths.
- Existing `test_gap_2143_builtin_bind.ts` and a sampling of closure/method gap tests still pass.
- `cargo test -p perry-runtime`: 946 pass; the lone failure each run is a known order-dependent GC/typed-array isolation flake (a *different* test fails each run, all pass in isolation).
- `cargo fmt --all --check` clean.
