### PR TITLE
fix(hir): builtin array/string method bound to a var is callable via .call/.apply (#3144)

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -97,6 +97,7 @@ impl LoweringContext {
             iterator_func_for_class: std::collections::HashMap::new(),
             regex_exec_locals: HashSet::new(),
             proxy_locals: HashSet::new(),
+            builtin_proto_method_locals: HashMap::new(),
             wasm_instance_locals: HashSet::new(),
             plain_object_locals: HashSet::new(),
             proxy_revoke_locals: HashMap::new(),

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1016,17 +1016,39 @@ pub(super) fn try_builtin_prototype_method_apply_call(
         "call" => false,
         _ => return Ok(None),
     };
-    // Inner member: `<recv>.<method>` where `<method>` is a plain name and
-    // `<recv>` is a builtin-prototype reference or array/string literal.
-    let ast::Expr::Member(inner) = outer.obj.as_ref() else {
-        return Ok(None);
+    // Resolve the builtin prototype method name from the thing we're calling
+    // `.call`/`.apply` ON. Two shapes are supported:
+    //   * `<recv>.<method>.call(...)` — a member whose object is a builtin
+    //     prototype receiver (array/string literal or `<Ctor>.prototype`).
+    //   * `local.call(...)` — an identifier previously bound to such a method
+    //     ref, e.g. `const m = [].map` (#3144).
+    // `method_prop` is the `IdentName` for the resolved method; we reuse it as
+    // the synthesized member's `.prop`.
+    let method_prop: ast::IdentName = match outer.obj.as_ref() {
+        ast::Expr::Member(inner) => {
+            let ast::MemberProp::Ident(method_ident) = &inner.prop else {
+                return Ok(None);
+            };
+            if !is_builtin_prototype_receiver(ctx, inner.obj.as_ref()) {
+                return Ok(None);
+            }
+            method_ident.clone()
+        }
+        ast::Expr::Ident(id) => match ctx.builtin_proto_method_locals.get(id.sym.as_ref()) {
+            Some(name) => {
+                // Build the method `.prop` IdentName by cloning the outer
+                // `.call`/`.apply` IdentName and overwriting its `sym`
+                // (avoids needing a synthetic span).
+                let mut prop = outer_prop.clone();
+                prop.sym = name.as_str().into();
+                prop
+            }
+            // Not a tracked builtin-method local: leave unrelated
+            // `someFn.call(...)` untouched.
+            None => return Ok(None),
+        },
+        _ => return Ok(None),
     };
-    if !matches!(&inner.prop, ast::MemberProp::Ident(_)) {
-        return Ok(None);
-    }
-    if !is_builtin_prototype_receiver(ctx, inner.obj.as_ref()) {
-        return Ok(None);
-    }
 
     // `.call`/`.apply` need at least the `thisArg` (the new receiver). A
     // spread in the `thisArg` slot can't be statically resolved to a receiver.
@@ -1061,15 +1083,51 @@ pub(super) fn try_builtin_prototype_method_apply_call(
         call.args.iter().skip(1).cloned().collect()
     };
 
-    // Synthesize `(thisArg).<method>(rest_args)`: keep the original method
-    // name, swap the prototype/literal receiver for the real `thisArg`, drop
-    // the `.apply`/`.call` wrapper, and re-dispatch.
-    let mut synth_member = inner.clone();
-    synth_member.obj = this_arg.expr.clone();
+    // Synthesize `(thisArg).<method>(rest_args)`: use the resolved method
+    // name, make the receiver the real `thisArg`, drop the `.apply`/`.call`
+    // wrapper, and re-dispatch.
+    let synth_member = ast::MemberExpr {
+        span: outer.span,
+        obj: this_arg.expr.clone(),
+        prop: ast::MemberProp::Ident(method_prop),
+    };
     let mut synth_call = call.clone();
     synth_call.callee = ast::Callee::Expr(Box::new(ast::Expr::Member(synth_member)));
     synth_call.args = rest_args;
     Ok(Some(super::lower_call(ctx, &synth_call)?))
+}
+
+/// #3144: if `init` is a value-read of a builtin prototype method whose
+/// receiver passes [`is_builtin_prototype_receiver`] (e.g. `[].map`,
+/// `"".slice`, `Array.prototype.filter`), return the method name. Used to
+/// track locals like `const m = [].map` so a later `m.call(arr, ...)` /
+/// `m.apply(arr, [...])` can be rewritten to a direct call.
+pub(crate) fn as_builtin_proto_method_ref(
+    ctx: &LoweringContext,
+    init: &ast::Expr,
+) -> Option<String> {
+    let ast::Expr::Member(member) = init else {
+        return None;
+    };
+    let ast::MemberProp::Ident(method) = &member.prop else {
+        return None;
+    };
+    if !is_builtin_prototype_receiver(ctx, &member.obj) {
+        return None;
+    }
+    // For a `<Ctor>.prototype` receiver, any method ident is accepted (mirrors
+    // the existing `.call`/`.apply` rewrite, which doesn't gate on the method
+    // name). For an array/string literal receiver, gate on the known
+    // array/string prototype-method predicates so we don't track unrelated
+    // member reads.
+    let is_proto_base = matches!(&*member.obj, ast::Expr::Member(_));
+    let known = crate::lower::array_fold::is_known_array_prototype_method(method.sym.as_ref())
+        || crate::lower::array_fold::is_known_string_prototype_method(method.sym.as_ref());
+    if is_proto_base || known {
+        Some(method.sym.to_string())
+    } else {
+        None
+    }
 }
 
 /// True when `recv` is a builtin constructor's `.prototype` (and that

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -31,7 +31,7 @@ mod crypto;
 mod globals;
 mod imported_array_methods;
 mod inline_array_methods;
-mod intrinsics;
+pub(crate) mod intrinsics;
 mod local_array_methods;
 mod module_class_static;
 mod module_static;

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -294,6 +294,11 @@ pub struct LoweringContext {
     /// HIR variants which read the runtime's thread-local exec metadata.
     pub(crate) regex_exec_locals: HashSet<String>,
     pub(crate) proxy_locals: HashSet<String>,
+    /// #3144: local name -> builtin prototype method name, for bindings like
+    /// `const m = [].map` / `const s = "".slice`. Lets the `.call`/`.apply`
+    /// rewrite recognize `m.call(arr, ...)` (the receiver of `.call` is a plain
+    /// identifier, not a member/literal) and synthesize `arr.map(...)`.
+    pub(crate) builtin_proto_method_locals: HashMap<String, String>,
     /// Issue #76 — locals known to hold a WebAssembly instance handle (i.e.
     /// `const x = WebAssembly.instantiate(...)`). Used to route
     /// `x.exports.<method>(...)` to `Expr::WebAssemblyCallExport` only when

--- a/crates/perry-hir/src/lower/pre_scan.rs
+++ b/crates/perry-hir/src/lower/pre_scan.rs
@@ -95,6 +95,20 @@ pub(crate) fn pre_scan_weakref_locals(ast_module: &ast::Module, ctx: &mut Loweri
                         );
                     }
                 }
+                // #3144: `const m = [].map` / `const s = "".slice` /
+                // `const f = Array.prototype.filter` — track the local so a
+                // later `m.call(arr, ...)` / `m.apply(arr, [...])` rewrites to a
+                // direct call. Uses the same receiver rule as the existing
+                // `.call`/`.apply` builtin-prototype rewrite.
+                if let Some(method) =
+                    crate::lower::expr_call::intrinsics::as_builtin_proto_method_ref(
+                        ctx,
+                        init_unwrapped,
+                    )
+                {
+                    ctx.builtin_proto_method_locals
+                        .insert(ident.id.sym.to_string(), method);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #3144. A builtin array/string prototype method bound to a variable and then invoked through `Function.prototype.call`/`apply` now works instead of throwing.

```ts
const m = [].map;
m.call([1, 2, 3], x => x * 2);   // before: TypeError (undefined)   after: [2,4,6]
const r = [].reduce;
r.call([1, 2, 3, 4], (a, b) => a + b, 0);   // before: TypeError   after: 10
```

## Root cause

Reading a builtin prototype method as a *value* (`const m = [].map`) lowers to `undefined` — builtin proto methods aren't reified as first-class values. The only thing that worked was the **syntactic** rewrite `try_builtin_prototype_method_apply_call` (HIR), which turns `[].map.call(t, …)` / `Array.prototype.map.call(t, …)` into `(t).map(…)`. That rewrite only matched a member/literal receiver, so once the method was bound to a variable (`m.call(…)`, receiver is a plain `Ident`) it bailed and the call hit `undefined`.

## Fix (HIR-only)

- Add `LoweringContext.builtin_proto_method_locals: HashMap<String, String>` (local name → method name).
- Populate it in the pre-scan when a binding's initializer is a builtin-prototype-method ref (`[].<m>` / `Array|String|Number|Boolean|Function.prototype.<m>` / `"".<m>`, method recognized + receiver unshadowed), mirroring the existing weakref/proxy local tracking.
- Extend `try_builtin_prototype_method_apply_call` so that when the `.call`/`.apply` receiver is such an identifier, it synthesizes `(thisArg).<method>(rest)` and re-lowers — reusing the proven argument-shuffling and the working `js_array_*` / string dispatch.

No runtime changes.

## Verification — byte-identical to `node --experimental-strip-types`

| Case | Result |
|------|--------|
| `const m=[].map; m.call([1,2,3], x=>x*2)` → `[2,4,6]` | PASS |
| `const f=[].filter; f.call([1,2,3,4], x=>x%2===0)` → `[2,4]` | PASS |
| `const r=[].reduce; r.call([1,2,3,4],(a,b)=>a+b,0)` → `10` | PASS |
| `const e=[].forEach; e.call([1,2,3], log)` → `1,2,3` | PASS |
| `const m=[].map; m.apply([1,2,3],[x=>x*2])` → `[2,4,6]` | PASS |
| `const s="".slice; s.call("hello",1,3)` → `el` | PASS |
| no-reg: `Array.prototype.filter.call([1,2,3], x=>x>1)` → `2,3` | PASS |
| no-reg: `[1,2,3].map(x=>x*2)` | PASS |
| no-reg: plain function value `h.call(null)` → `42` | PASS |
| no-reg: object-method value `g.call(obj)` → `ok` | PASS |

`cargo fmt --all -- --check` clean; `cargo test -p perry-hir` passes.

## Out of scope / follow-ups

- Higher-order passing the bare value (`arr.map(m)`).
- `.apply` with a non-literal args array.
- Reading other props on the value form (`[].map.constructor`) — a separate pre-existing gap, not a `.call`/`.apply` case.
