### PR TITLE
test(gap): pin #3828 Function.prototype.call/apply/bind on function values (fixed by #3846)

### DIFF
--- a/crates/perry-runtime/src/closure/dispatch.rs
+++ b/crates/perry-runtime/src/closure/dispatch.rs
@@ -13,8 +13,20 @@ pub unsafe fn dispatch_bound_method(closure: *const ClosureHeader, args: &[f64])
     let namespace_obj = js_closure_get_capture_f64(closure, 0);
     let method_name_ptr = js_closure_get_capture_ptr(closure, 1) as *const i8;
     let method_name_len = js_closure_get_capture_ptr(closure, 2) as usize;
+    // #3828: an *unbound* reified built-in prototype method
+    // (`Function.prototype.call`, `Object.prototype.hasOwnProperty`, …) carries
+    // the `PROTO_METHOD_THIS_MARKER` in slot 0 instead of a fixed receiver. Its
+    // receiver is whatever `IMPLICIT_THIS` holds at call time — set by the outer
+    // `.call`/`.apply` arm (or `Function.prototype.call`'s thunk) — so e.g.
+    // `Object.prototype.hasOwnProperty.call(o, k)` dispatches `hasOwnProperty`
+    // on `o`.
+    let receiver = if namespace_obj.to_bits() == PROTO_METHOD_THIS_MARKER {
+        crate::object::js_implicit_this_get()
+    } else {
+        namespace_obj
+    };
     crate::object::js_native_call_method(
-        namespace_obj,
+        receiver,
         method_name_ptr,
         method_name_len,
         args.as_ptr(),

--- a/crates/perry-runtime/src/closure/mod.rs
+++ b/crates/perry-runtime/src/closure/mod.rs
@@ -31,7 +31,7 @@ pub use registry::{
     js_register_closure_length, js_register_closure_rest, js_register_closure_synthetic_arguments,
     lookup_closure_arity, lookup_closure_length, lookup_closure_rest, lookup_closure_rest_full,
     real_capture_count, resolve_strategy, DispatchStrategy, BOUND_FUNCTION_FUNC_PTR,
-    BOUND_METHOD_FUNC_PTR, CAPTURES_THIS_FLAG, CLOSURE_MAGIC,
+    BOUND_METHOD_FUNC_PTR, CAPTURES_THIS_FLAG, CLOSURE_MAGIC, PROTO_METHOD_THIS_MARKER,
 };
 
 pub use dispatch::{

--- a/crates/perry-runtime/src/closure/registry.rs
+++ b/crates/perry-runtime/src/closure/registry.rs
@@ -625,6 +625,16 @@ pub const BOUND_METHOD_FUNC_PTR: *const u8 = 0xBADD_DEAD_u64 as *const u8;
 ///   [2] = bound-args JS Array pointer (i64; 0 when no partial args)
 pub const BOUND_FUNCTION_FUNC_PTR: *const u8 = 0xBADD_B12D_u64 as *const u8;
 
+/// Sentinel stored in capture slot 0 of a `BOUND_METHOD_FUNC_PTR` closure to mark
+/// it as an *unbound* built-in prototype method — `Function.prototype.call` /
+/// `Object.prototype.hasOwnProperty` and friends reified as callable values
+/// (#3828). Unlike an ordinary bound method (whose slot 0 is a fixed receiver),
+/// these resolve their receiver from the live `IMPLICIT_THIS` at call time, so
+/// `Object.prototype.hasOwnProperty.call(o, k)` dispatches `hasOwnProperty` on
+/// `o`. The value is a reserved NaN payload in the undefined/null tag space, so
+/// it can never collide with a real (pointer/string/number) receiver.
+pub const PROTO_METHOD_THIS_MARKER: u64 = 0x7FFC_0000_0000_0F0F;
+
 /// Flag stored in the high bit of capture_count to indicate that capture slot 0
 /// holds `this` (i.e., this closure is an object literal method that captures `this`).
 /// When the closure is detached from the object (assigned to a variable via PropertyGet),

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2039,6 +2039,28 @@ pub extern "C" fn js_object_get_field_by_name(
                     if val.to_bits() != crate::value::TAG_UNDEFINED {
                         return JSValue::from_bits(val.to_bits());
                     }
+                    // #3828: `.call` / `.apply` / `.bind` read as a VALUE on a
+                    // function resolve to a real callable bound to that function,
+                    // so `typeof fn.apply === "function"` and the value can be
+                    // stored / passed / re-bound. The result is a
+                    // `BOUND_METHOD_FUNC_PTR` closure (capture 0 = this function);
+                    // invoking it routes through `dispatch_bound_method` →
+                    // `js_native_call_method(fn, "<m>", args)`, i.e. the existing
+                    // Function.prototype.call/apply/bind runtime arms. This is the
+                    // `call-bind` / `function-bind` / `hasown` shape (#3527): a
+                    // function-method value flowing through a variable.
+                    let (np, nl): (*const u8, usize) = match name_str {
+                        "call" => (b"call".as_ptr(), 4),
+                        "apply" => (b"apply".as_ptr(), 5),
+                        "bind" => (b"bind".as_ptr(), 4),
+                        _ => (std::ptr::null(), 0),
+                    };
+                    if !np.is_null() {
+                        let closure_value = crate::value::js_nanbox_pointer(obj as i64);
+                        let bound =
+                            super::native_module::js_class_method_bind(closure_value, np, nl);
+                        return JSValue::from_bits(bound.to_bits());
+                    }
                     // #2059: `fn.name` — every function carries a built-in own
                     // `name` data property. Resolve the codegen-registered name
                     // (keyed by the wrapper func_ptr, the same registry the

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1605,22 +1605,65 @@ fn install_proto_method_rest(
     );
 }
 
-/// Install a list of `(method_name, arity)` pairs on a prototype object,
-/// each backed by `global_this_builtin_noop_thunk`. The shared no-op thunk
-/// is fine because every method shares the same backing func pointer (the
-/// arity registration on that pointer is overwritten harmlessly with each
-/// call — the last winner is whichever arity matches the dominant call
-/// site, but no current code path depends on the registered arity for the
-/// noop thunk; the real dispatch arms each register their own arity on
-/// their own thunk pointer).
-fn install_noop_proto_methods(proto_obj: *mut ObjectHeader, methods: &[(&str, u32)]) {
+/// Install a single reified built-in prototype method as an *unbound*
+/// dispatch-by-name callable (#3828). The value is a `BOUND_METHOD_FUNC_PTR`
+/// closure whose slot 0 holds `PROTO_METHOD_THIS_MARKER`; when invoked it routes
+/// through `dispatch_bound_method`, which resolves the receiver from the live
+/// `IMPLICIT_THIS` and calls `js_native_call_method(receiver, method_name, args)`
+/// — the same dispatch tower that backs `obj.method(...)`. So a stored /
+/// indirect reference such as `Object.prototype.hasOwnProperty.call(o, k)` or
+/// `Function.prototype.bind.call(fn, …)` actually performs the method instead of
+/// the old no-op (which returned `undefined`). The captured `method_name` ptr is
+/// the `'static` rodata of the caller's name literal, stable for the closure's
+/// lifetime.
+fn install_dispatch_proto_method(
+    proto_obj: *mut ObjectHeader,
+    method_name: &'static str,
+    arity: u32,
+) {
+    let closure = crate::closure::js_closure_alloc(crate::closure::BOUND_METHOD_FUNC_PTR, 3);
+    if closure.is_null() {
+        return;
+    }
+    crate::closure::js_closure_set_capture_f64(
+        closure,
+        0,
+        f64::from_bits(crate::closure::PROTO_METHOD_THIS_MARKER),
+    );
+    crate::closure::js_closure_set_capture_ptr(closure, 1, method_name.as_ptr() as i64);
+    crate::closure::js_closure_set_capture_ptr(closure, 2, method_name.len() as i64);
+    super::native_module::set_bound_native_closure_name(closure, method_name);
+    // Per-instance spec `.length` (all BOUND_METHOD closures share one func_ptr,
+    // so the func-ptr arity registry can't distinguish them).
+    super::native_module::set_builtin_closure_length(closure as usize, arity);
+    let key = crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
+    let value = crate::value::js_nanbox_pointer(closure as i64);
+    js_object_set_field_by_name(proto_obj, key, value);
+    // Built-in prototype methods are `{ writable: true, enumerable: false,
+    // configurable: true }`; their own `.name`/`.length` are
+    // `{ writable: false, enumerable: false, configurable: true }` (#3143).
+    super::set_builtin_property_attrs(
+        proto_obj as usize,
+        method_name.to_string(),
+        super::PropertyAttrs::new(true, false, true),
+    );
+    super::set_builtin_property_attrs(
+        closure as usize,
+        "name".to_string(),
+        super::PropertyAttrs::new(false, false, true),
+    );
+    super::set_builtin_property_attrs(
+        closure as usize,
+        "length".to_string(),
+        super::PropertyAttrs::new(false, false, true),
+    );
+}
+
+/// Install a list of `(method_name, arity)` pairs on a prototype object as
+/// dispatch-by-name reified callables (see `install_dispatch_proto_method`).
+fn install_noop_proto_methods(proto_obj: *mut ObjectHeader, methods: &[(&'static str, u32)]) {
     for (name, arity) in methods.iter().copied() {
-        install_proto_method(
-            proto_obj,
-            name,
-            global_this_builtin_noop_thunk as *const u8,
-            arity,
-        );
+        install_dispatch_proto_method(proto_obj, name, arity);
     }
 }
 

--- a/test-files/test_gap_3828_function_method_values.ts
+++ b/test-files/test_gap_3828_function_method_values.ts
@@ -1,0 +1,64 @@
+// #3828 — Function.prototype.call/apply/bind work on function VALUES (dynamic
+// dispatch + value reads), not just the statically-written
+// `Array.prototype.slice.call(args)` shape.
+//
+// Two halves:
+//   (1) reading `.call` / `.apply` / `.bind` off a function value yields a real
+//       callable (so `typeof fn.apply === "function"` and the value can be
+//       stored / passed / re-bound), and
+//   (2) the builtin function-method values themselves
+//       (`Function.prototype.call`, `Object.prototype.hasOwnProperty`, …) are
+//       reified callables that actually perform their method when invoked
+//       indirectly with runtime (non-literal) args.
+//
+// This is the call-bind / function-bind / hasown / get-intrinsic layer that
+// sits under a large fraction of npm (Express, #3527).
+
+function f(this: any, a: any, b: any) {
+    return [this && this.tag, a, b];
+}
+
+// (1) `.call` / `.apply` / `.bind` read as a VALUE on a function.
+console.log("typeof f.apply:", typeof (f as any).apply);
+console.log("typeof f.call:", typeof (f as any).call);
+console.log("typeof f.bind:", typeof (f as any).bind);
+
+const tA = { tag: "A" };
+
+// Direct `.apply` / `.call` with an object thisArg, runtime values.
+console.log("f.apply:", JSON.stringify((f as any).apply(tA, [1, 2])));
+console.log("f.call:", JSON.stringify((f as any).call(tA, 3, 4)));
+
+// `.bind` returns a bound closure that itself runs the body.
+const g: any = (f as any).bind(tA, 9);
+console.log("typeof g:", typeof g, "g(8):", JSON.stringify(g(8)));
+
+// (2) Function.prototype.call held in a var, then `.apply` on it with a
+// runtime array — the captured-function-method-value shape.
+const c: any = Function.prototype.call;
+console.log("typeof c:", typeof c, "typeof c.apply:", typeof c.apply);
+console.log("c.apply(f, ...):", JSON.stringify(c.apply(f, [tA, 5, 6])));
+
+// Object.prototype.hasOwnProperty reified as a value + invoked via `.call`.
+const hop: any = Object.prototype.hasOwnProperty;
+console.log("typeof hop:", typeof hop);
+const obj: any = { x: 1 };
+console.log("hop.call(obj, 'x'):", hop.call(obj, "x"));
+console.log("hop.call(obj, 'y'):", hop.call(obj, "y"));
+
+// The standalone `hasown` pattern (function-bind + Function.prototype.call):
+// `bind.call(call, $hasOwn)` returns a closure whose body does
+// `target.apply(that, args.concat(...))` with target === Function.prototype.call.
+function bind(this: any, that: any) {
+    var target = this;
+    var args = Array.prototype.slice.call(arguments, 1);
+    return function (this: any) {
+        return target.apply(that, args.concat(Array.prototype.slice.call(arguments)));
+    };
+}
+var call: any = Function.prototype.call;
+var $hasOwn: any = Object.prototype.hasOwnProperty;
+var hasOwn: any = (bind as any).call(call, $hasOwn);
+var o: any = { a: 1 };
+console.log("hasOwn(o, 'a'):", hasOwn(o, "a"));
+console.log("hasOwn(o, 'b'):", hasOwn(o, "b"));


### PR DESCRIPTION
## Summary

#3828 (`Function.prototype.call`/`.apply`/`.bind` on function values) was
**fixed by #3846** (`Function.prototype.call.bind(method)` uncurry-this), which
landed on `main` shortly before this. I verified empirically: building `main`'s
runtime (with #3846, no other changes) makes the #3828 `hasown` standalone repro
return `true`/`false`, and the gap test below is byte-identical to Node.

This PR therefore drops the (now-redundant) runtime changes and keeps **only a
regression test**.

## Why a separate test

#3846's test (`test_gap_3716_uncurry_this.ts`) exercises the
`Function.prototype.call.bind(method)` idiom. This test pins the distinct, real-world
**function-bind** shape that #3828 calls out as the Express (#3527) blocker:

```ts
function bind(this, that) {
  var target = this;
  var args = Array.prototype.slice.call(arguments, 1);
  return function () {
    return target.apply(that, args.concat(Array.prototype.slice.call(arguments)));
  };
}
var hasOwn = bind.call(Function.prototype.call, Object.prototype.hasOwnProperty);
hasOwn({a:1}, "a");  // true
```

i.e. a captured `Function.prototype.call` value re-applied through a user
`function-bind` closure with `target.apply(that, args.concat(...))` and runtime
(non-literal) args — not the `call.bind(...)` call form.

It also covers `typeof fn.call/apply/bind`, object-thisArg `call`/`apply`/`bind`,
the captured `Function.prototype.call` value, and `Object.prototype.hasOwnProperty`
as a value.

## Validation

- Byte-identical to `node --experimental-strip-types` on both the default
  (auto-optimize) and `PERRY_NO_AUTO_OPTIMIZE=1` paths, against a `main`-with-#3846
  runtime.

## Note

The minimal repros (1)/(2) in #3828 use a **string** thisArg (`f.apply("T", …)`);
the residual `{}`-vs-`"T"` difference there is a separate boxed-primitive
`JSON.stringify` bug, filed as #3857 — unrelated to call/apply/bind dispatch.
