### PR TITLE
fix(diagnostics_channel): add Node 26 tail APIs

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -3318,7 +3318,9 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("fs", "constants"),
     // --- node:diagnostics_channel direct submodule.
     property("diagnostics_channel", "default"),
+    class("diagnostics_channel", "BoundedChannel"),
     class("diagnostics_channel", "Channel"),
+    method("diagnostics_channel", "boundedChannel", false, None),
     method("diagnostics_channel", "channel", false, None),
     method("diagnostics_channel", "hasSubscribers", false, None),
     method("diagnostics_channel", "subscribe", false, None),

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -68,7 +68,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 ));
             }
             if let Some((submod_key, exported_name)) = ctx.import_function_node_submodule.get(ty) {
-                if submod_key == "diagnostics_channel" && exported_name == "Channel" {
+                if submod_key == "diagnostics_channel"
+                    && matches!(exported_name.as_str(), "Channel" | "BoundedChannel")
+                {
                     let submod_label = emit_string_literal_global(ctx, submod_key);
                     let name_label = emit_string_literal_global(ctx, exported_name);
                     let submod_len = submod_key.len();

--- a/crates/perry-runtime/src/node_submodules/diagnostics.rs
+++ b/crates/perry-runtime/src/node_submodules/diagnostics.rs
@@ -63,13 +63,14 @@ pub(crate) enum DiagChannelKey {
 
 /// The `transform` argument remembered by `bindStore(store, transform)`.
 ///
-/// Node distinguishes three cases (#3085): an omitted/`undefined` transform
-/// (the store context is just the published `data`), a callable transform
-/// (its return value becomes the context), and a *non-callable, non-undefined*
-/// transform value (`null`, a number, a string, …). The last case is retained
-/// — during `runStores` Node attempts to call it, fails, runs the callback
-/// with no store context, and reports an uncaught `TypeError: transform is not
-/// a function`. Discarding it (treating it like `undefined`) was the bug.
+/// Node distinguishes three cases (#3085): an omitted/`undefined`/`null`
+/// transform (the store context is just the published `data`), a callable
+/// transform (its return value becomes the context), and a *non-callable,
+/// non-nullish* transform value (a number, a string, …). The last case is
+/// retained — during `runStores` Node attempts to call it, fails, runs the
+/// callback with no store context, and reports an uncaught
+/// `TypeError: transform is not a function`. Discarding it (treating it like
+/// `undefined`) was the bug.
 #[derive(Clone, Copy)]
 pub(crate) enum StoreTransform {
     /// No transform: context is the published `data` value.
@@ -764,6 +765,7 @@ pub(crate) fn update_channel_active(id: i64) {
         }
     });
     update_all_tracing_active();
+    super::diagnostics_tail::update_all_bounded_active();
 }
 
 pub(crate) fn update_all_tracing_active() {
@@ -845,7 +847,7 @@ pub(crate) fn ensure_channel(name: f64) -> i64 {
     }
     evict_inactive_diag_channels_if_needed();
     let id = next_diag_id();
-    let obj = js_object_alloc(0, 9);
+    let obj = js_object_alloc(0, 10);
     let has_global_subscribers = global_active_count(&key) > 0;
     set_field_value(obj, "name", name);
     set_field_value(obj, "hasSubscribers", bool_value(has_global_subscribers));
@@ -875,6 +877,15 @@ pub(crate) fn ensure_channel(name: f64) -> i64 {
         method_closure(cast1(diag_channel_unbind_store), 1, id),
     );
     set_field_value(obj, "runStores", run_stores_method_closure(id));
+    set_field_value(
+        obj,
+        "withStoreScope",
+        method_closure(
+            cast1(super::diagnostics_tail::diag_channel_with_store_scope),
+            1,
+            id,
+        ),
+    );
     DIAG_CHANNEL_BY_KEY.with(|m| {
         m.borrow_mut().insert(key, id);
     });
@@ -1101,11 +1112,11 @@ pub(crate) extern "C" fn diag_channel_bind_store(
 ) -> f64 {
     ensure_subscriber_owner_thread();
     let id = method_id(closure);
-    // An omitted or explicit `undefined` transform is the no-transform case;
-    // a callable is stored as-is; any other value is remembered as a
-    // non-callable transform so `runStores` can reproduce Node's uncaught
-    // `TypeError: transform is not a function` (#3085).
-    let transform = if transform.to_bits() == TAG_UNDEFINED {
+    // An omitted, explicit `undefined`, or `null` transform is the
+    // no-transform case in Node 26; a callable is stored as-is; any other
+    // value is remembered as a non-callable transform so `runStores` can
+    // reproduce Node's uncaught `TypeError: transform is not a function`.
+    let transform = if matches!(transform.to_bits(), TAG_UNDEFINED | crate::value::TAG_NULL) {
         StoreTransform::None
     } else if valid_closure_value(transform) {
         StoreTransform::Callable(transform)
@@ -1585,8 +1596,6 @@ pub(crate) extern "C" fn diag_trace_promise(
             "result",
             result,
         );
-        publish_channel(events[2], context);
-        publish_channel(events[3], context);
         return result;
     }
 }

--- a/crates/perry-runtime/src/node_submodules/diagnostics_tail.rs
+++ b/crates/perry-runtime/src/node_submodules/diagnostics_tail.rs
@@ -1,0 +1,352 @@
+//! Node 26 diagnostics_channel tail APIs: BoundedChannel and store scopes.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::array::{js_array_get_f64, js_array_length};
+use crate::closure::{
+    js_closure_alloc, js_closure_call1, js_closure_get_capture_ptr, js_closure_set_capture_ptr,
+    js_register_closure_arity, js_register_closure_synthetic_arguments, ClosureHeader,
+};
+use crate::object::{js_object_alloc, ObjectHeader};
+use crate::value::{js_nanbox_get_pointer, JSValue};
+
+use super::diagnostics::*;
+
+struct DiagBoundedState {
+    obj: *mut ObjectHeader,
+    events: [i64; 2],
+}
+
+struct DiagStoreScopeState {
+    handles: Vec<i64>,
+    disposed: bool,
+}
+
+thread_local! {
+    static DIAG_BOUNDED_CHANNELS: RefCell<HashMap<i64, DiagBoundedState>> = RefCell::new(HashMap::new());
+    static DIAG_STORE_SCOPES: RefCell<HashMap<i64, DiagStoreScopeState>> = RefCell::new(HashMap::new());
+}
+
+pub(crate) fn scan_diagnostics_tail_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    DIAG_BOUNDED_CHANNELS.with(|m| {
+        for state in m.borrow_mut().values_mut() {
+            visitor.visit_raw_mut_ptr_slot(&mut state.obj);
+        }
+    });
+}
+
+pub(crate) fn diagnostics_bounded_channel_is_instance_value(value: f64) -> bool {
+    let js_value = JSValue::from_bits(value.to_bits());
+    if !js_value.is_pointer() {
+        return false;
+    }
+    let ptr = js_value.as_pointer::<ObjectHeader>();
+    DIAG_BOUNDED_CHANNELS.with(|channels| {
+        channels
+            .borrow()
+            .values()
+            .any(|channel| std::ptr::eq(channel.obj, ptr))
+    })
+}
+
+fn unbox_arg_array(arr_value: f64) -> Vec<f64> {
+    let arr = js_nanbox_get_pointer(arr_value) as *const crate::array::ArrayHeader;
+    if arr.is_null() {
+        return Vec::new();
+    }
+    let len = js_array_length(arr);
+    let mut out = Vec::with_capacity(len as usize);
+    for i in 0..len {
+        out.push(js_array_get_f64(arr, i));
+    }
+    out
+}
+
+fn is_symbol_value(value: f64) -> bool {
+    let bits = value.to_bits();
+    let tag = bits & 0xFFFF_0000_0000_0000;
+    tag == crate::value::POINTER_TAG && unsafe { crate::symbol::js_is_symbol(value) } != 0
+}
+
+fn store_handle(store: f64) -> Option<i64> {
+    let bits = store.to_bits();
+    if bits & crate::value::TAG_MASK == crate::value::INT32_TAG {
+        return Some((bits & crate::value::INT32_MASK) as i32 as i64);
+    }
+    if bits & crate::value::TAG_MASK == crate::value::POINTER_TAG {
+        let raw = (bits & crate::value::POINTER_MASK) as i64;
+        if raw > 0 && raw < 0x10000 {
+            return Some(raw);
+        }
+    }
+    if store.is_finite() {
+        return Some(store as i64);
+    }
+    None
+}
+
+fn install_dispose(obj: *mut ObjectHeader, method: f64) {
+    set_field_value(obj, "__perry_dispose__", method);
+    set_field_value(obj, "@@__perry_wk_dispose", method);
+    let dispose = crate::symbol::well_known_symbol("dispose");
+    if !dispose.is_null() {
+        let obj_value = boxed_ptr(obj);
+        let symbol_value = f64::from_bits(JSValue::pointer(dispose as *const u8).bits());
+        unsafe {
+            crate::symbol::js_object_set_symbol_property(obj_value, symbol_value, method);
+        }
+    }
+}
+
+pub(crate) extern "C" fn diag_store_scope_dispose(closure: *const ClosureHeader) -> f64 {
+    let scope_id = js_closure_get_capture_ptr(closure, 0);
+    let handles = DIAG_STORE_SCOPES.with(|m| {
+        let mut m = m.borrow_mut();
+        let Some(scope) = m.get_mut(&scope_id) else {
+            return Vec::new();
+        };
+        if scope.disposed {
+            return Vec::new();
+        }
+        scope.disposed = true;
+        scope.handles.clone()
+    });
+    for handle in handles.into_iter().rev() {
+        crate::async_context::pop_store(handle);
+    }
+    undefined()
+}
+
+pub(crate) extern "C" fn diag_channel_with_store_scope(
+    closure: *const ClosureHeader,
+    data: f64,
+) -> f64 {
+    let id = method_id(closure);
+    let stores = DIAG_CHANNELS.with(|m| {
+        m.borrow()
+            .get(&id)
+            .map(|c| c.stores.clone())
+            .unwrap_or_default()
+    });
+    let mut handles = Vec::new();
+    for (store, transform) in stores {
+        let context = match transform {
+            StoreTransform::Callable(t) => {
+                match catch_js(|| js_closure_call1(closure_ptr(t), data)) {
+                    Ok(context) => context,
+                    Err(err) => {
+                        schedule_uncaught(err);
+                        continue;
+                    }
+                }
+            }
+            StoreTransform::NonCallable => {
+                schedule_uncaught(make_transform_not_a_function_error());
+                continue;
+            }
+            StoreTransform::None => data,
+        };
+        if let Some(handle) = store_handle(store) {
+            crate::async_context::push_store(handle, context);
+            handles.push(handle);
+        }
+    }
+
+    let scope_id = next_diag_id();
+    DIAG_STORE_SCOPES.with(|m| {
+        m.borrow_mut().insert(
+            scope_id,
+            DiagStoreScopeState {
+                handles,
+                disposed: false,
+            },
+        );
+    });
+    let obj = js_object_alloc(0, 3);
+    let dispose = js_closure_alloc(cast0(diag_store_scope_dispose), 1);
+    js_closure_set_capture_ptr(dispose, 0, scope_id);
+    js_register_closure_arity(cast0(diag_store_scope_dispose), 0);
+    let dispose_value = boxed_ptr(dispose);
+    install_dispose(obj, dispose_value);
+    boxed_ptr(obj)
+}
+
+fn bounded_events(id: i64) -> [i64; 2] {
+    DIAG_BOUNDED_CHANNELS.with(|m| {
+        m.borrow()
+            .get(&id)
+            .map(|bounded| bounded.events)
+            .unwrap_or([0; 2])
+    })
+}
+
+fn bounded_active(events: [i64; 2]) -> bool {
+    DIAG_CHANNELS.with(|channels| {
+        let channels = channels.borrow();
+        events.iter().copied().any(|id| {
+            channels.get(&id).is_some_and(|channel| {
+                get_field_value(channel.obj, "hasSubscribers").to_bits() == TAG_TRUE
+                    || !channel.subscribers.is_empty()
+                    || !channel.stores.is_empty()
+            })
+        })
+    })
+}
+
+pub(crate) fn update_all_bounded_active() {
+    DIAG_BOUNDED_CHANNELS.with(|bounded| {
+        for state in bounded.borrow_mut().values_mut() {
+            set_field_value(
+                state.obj,
+                "hasSubscribers",
+                bool_value(bounded_active(state.events)),
+            );
+        }
+    });
+}
+
+pub(crate) extern "C" fn diag_bounded_subscribe(
+    closure: *const ClosureHeader,
+    handlers: f64,
+) -> f64 {
+    let events = bounded_events(method_id(closure));
+    for (idx, name) in ["start", "end"].iter().enumerate() {
+        let h = get_field_value(js_nanbox_get_pointer(handlers) as *mut ObjectHeader, name);
+        let h_bits = h.to_bits();
+        if h_bits == TAG_UNDEFINED || h_bits == crate::value::TAG_NULL {
+            continue;
+        }
+        if !valid_closure_value(h) {
+            throw_invalid_arg();
+        }
+        add_subscriber(events[idx], h);
+    }
+    undefined()
+}
+
+pub(crate) extern "C" fn diag_bounded_unsubscribe(
+    closure: *const ClosureHeader,
+    handlers: f64,
+) -> f64 {
+    let events = bounded_events(method_id(closure));
+    let mut ok = true;
+    for (idx, name) in ["start", "end"].iter().enumerate() {
+        let h = get_field_value(js_nanbox_get_pointer(handlers) as *mut ObjectHeader, name);
+        if valid_closure_value(h) && !remove_subscriber(events[idx], h) {
+            ok = false;
+        }
+    }
+    bool_value(ok)
+}
+
+pub(crate) extern "C" fn diag_bounded_run(closure: *const ClosureHeader, all_args: f64) -> f64 {
+    let all = unbox_arg_array(all_args);
+    let undef = undefined();
+    let context = all.first().copied().unwrap_or(undef);
+    let fn_value = all.get(1).copied().unwrap_or(undef);
+    let this_arg = all.get(2).copied().unwrap_or(undef);
+    let args: Vec<f64> = if all.len() > 3 {
+        all[3..].to_vec()
+    } else {
+        Vec::new()
+    };
+    if !valid_closure_value(fn_value) {
+        crate::closure::throw_not_callable();
+    }
+    let events = bounded_events(method_id(closure));
+    publish_channel(events[0], context);
+    match catch_js(|| call_fn_value(fn_value, this_arg, &args)) {
+        Ok(result) => {
+            publish_channel(events[1], context);
+            result
+        }
+        Err(err) => {
+            publish_channel(events[1], context);
+            crate::exception::js_throw(err)
+        }
+    }
+}
+
+pub(crate) extern "C" fn diag_bounded_scope_dispose(closure: *const ClosureHeader) -> f64 {
+    if js_closure_get_capture_ptr(closure, 2) != 0 {
+        return undefined();
+    }
+    let end = js_closure_get_capture_ptr(closure, 0);
+    let context = f64::from_bits(js_closure_get_capture_ptr(closure, 1) as u64);
+    js_closure_set_capture_ptr(closure as *mut ClosureHeader, 2, 1);
+    publish_channel(end, context);
+    undefined()
+}
+
+pub(crate) extern "C" fn diag_bounded_with_scope(
+    closure: *const ClosureHeader,
+    context: f64,
+) -> f64 {
+    let events = bounded_events(method_id(closure));
+    publish_channel(events[0], context);
+    let obj = js_object_alloc(0, 3);
+    let dispose = js_closure_alloc(cast0(diag_bounded_scope_dispose), 3);
+    js_closure_set_capture_ptr(dispose, 0, events[1]);
+    js_closure_set_capture_ptr(dispose, 1, context.to_bits() as i64);
+    js_closure_set_capture_ptr(dispose, 2, 0);
+    js_register_closure_arity(cast0(diag_bounded_scope_dispose), 0);
+    let dispose_value = boxed_ptr(dispose);
+    install_dispose(obj, dispose_value);
+    boxed_ptr(obj)
+}
+
+fn bounded_run_method_closure(id: i64) -> f64 {
+    let func = cast1(diag_bounded_run);
+    let c = js_closure_alloc(func, 1);
+    js_closure_set_capture_ptr(c, 0, id);
+    js_register_closure_synthetic_arguments(func, 0);
+    boxed_ptr(c)
+}
+
+pub(crate) extern "C" fn thunk_diag_bounded_channel(
+    _closure: *const ClosureHeader,
+    name_or_channels: f64,
+) -> f64 {
+    if is_symbol_value(name_or_channels) {
+        throw_invalid_arg();
+    }
+    let events = if decode_string_value(name_or_channels).is_some() {
+        [
+            ensure_channel(tracing_event_name(name_or_channels, "start")),
+            ensure_channel(tracing_event_name(name_or_channels, "end")),
+        ]
+    } else if (name_or_channels.to_bits() & crate::value::TAG_MASK) == crate::value::POINTER_TAG {
+        [
+            channel_from_object_property(name_or_channels, "start"),
+            channel_from_object_property(name_or_channels, "end"),
+        ]
+    } else {
+        throw_invalid_arg();
+    };
+    let id = next_diag_id();
+    let obj = js_object_alloc(0, 7);
+    set_field_value(obj, "start", channel_obj(events[0]));
+    set_field_value(obj, "end", channel_obj(events[1]));
+    set_field_value(obj, "hasSubscribers", bool_value(bounded_active(events)));
+    set_field_value(
+        obj,
+        "subscribe",
+        method_closure(cast1(diag_bounded_subscribe), 1, id),
+    );
+    set_field_value(
+        obj,
+        "unsubscribe",
+        method_closure(cast1(diag_bounded_unsubscribe), 1, id),
+    );
+    set_field_value(obj, "run", bounded_run_method_closure(id));
+    set_field_value(
+        obj,
+        "withScope",
+        method_closure(cast1(diag_bounded_with_scope), 1, id),
+    );
+    DIAG_BOUNDED_CHANNELS.with(|m| {
+        m.borrow_mut().insert(id, DiagBoundedState { obj, events });
+    });
+    boxed_ptr(obj)
+}

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -37,6 +37,8 @@ use crate::value::JSValue;
 
 pub(crate) mod diagnostics;
 pub use diagnostics::*;
+pub(crate) mod diagnostics_tail;
+pub(crate) use diagnostics_tail::*;
 
 /// One entry per named export of one submodule.
 struct ExportSpec {
@@ -598,6 +600,10 @@ const SUBMODULES: &[SubmoduleSpec] = &[
                 thunk: ExportThunk::Fn1(thunk_diag_tracing_channel),
             },
             ExportSpec {
+                name: "boundedChannel",
+                thunk: ExportThunk::Fn1(thunk_diag_bounded_channel),
+            },
+            ExportSpec {
                 name: "channel",
                 thunk: ExportThunk::Fn1(thunk_diag_channel),
             },
@@ -616,6 +622,10 @@ const SUBMODULES: &[SubmoduleSpec] = &[
             ExportSpec {
                 name: "Channel",
                 thunk: ExportThunk::Fn1(thunk_diag_noop),
+            },
+            ExportSpec {
+                name: "BoundedChannel",
+                thunk: ExportThunk::Fn1(thunk_diag_bounded_channel),
             },
         ],
     },
@@ -956,6 +966,22 @@ pub(crate) fn is_diagnostics_channel_constructor_value(value: f64) -> bool {
     EXPORT_SINGLETONS.with(|m| m.borrow().get(&key).copied() == Some(ptr))
 }
 
+pub(crate) fn is_diagnostics_bounded_channel_constructor_value(value: f64) -> bool {
+    let js_value = JSValue::from_bits(value.to_bits());
+    if !js_value.is_pointer() {
+        return false;
+    }
+    let ptr = js_value.as_pointer::<ClosureHeader>() as *mut ClosureHeader;
+    let Some(submod) = find_submodule("diagnostics_channel") else {
+        return false;
+    };
+    let Some(export) = find_export(submod, "BoundedChannel") else {
+        return false;
+    };
+    let key = (submod.key.as_ptr() as usize, export.name.as_ptr() as usize);
+    EXPORT_SINGLETONS.with(|m| m.borrow().get(&key).copied() == Some(ptr))
+}
+
 fn ensure_namespace_singleton(submod: &'static SubmoduleSpec) -> *mut ObjectHeader {
     let key = submod.key.as_ptr() as usize;
     if let Some(cached) = NAMESPACE_SINGLETONS.with(|m| m.borrow().get(&key).copied()) {
@@ -1072,6 +1098,7 @@ pub fn scan_node_submodule_singleton_roots_mut(visitor: &mut crate::gc::RuntimeR
             visitor.visit_raw_mut_ptr_slot(&mut trace.obj);
         }
     });
+    diagnostics_tail::scan_diagnostics_tail_roots_mut(visitor);
     trace_events::scan_trace_events_roots_mut(visitor);
     test::scan_test_module_roots_mut(visitor);
 }

--- a/crates/perry-runtime/src/node_submodules/tests.rs
+++ b/crates/perry-runtime/src/node_submodules/tests.rs
@@ -304,8 +304,8 @@ fn namespace_member_missing_export_returns_undefined() {
         js_node_submodule_namespace_member(
             b"diagnostics_channel".as_ptr(),
             "diagnostics_channel".len() as u32,
-            b"boundedChannel".as_ptr(),
-            "boundedChannel".len() as u32,
+            b"notARealExport".as_ptr(),
+            "notARealExport".len() as u32,
         )
     };
 
@@ -318,8 +318,8 @@ fn direct_missing_export_keeps_legacy_true_sentinel() {
         js_node_submodule_export_as_function(
             b"diagnostics_channel".as_ptr(),
             "diagnostics_channel".len() as u32,
-            b"boundedChannel".as_ptr(),
-            "boundedChannel".len() as u32,
+            b"notARealExport".as_ptr(),
+            "notARealExport".len() as u32,
         )
     };
 

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -131,6 +131,13 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
             f64::from_bits(TAG_FALSE)
         };
     }
+    if crate::node_submodules::is_diagnostics_bounded_channel_constructor_value(type_ref) {
+        return if crate::node_submodules::diagnostics_bounded_channel_is_instance_value(value) {
+            f64::from_bits(crate::value::TAG_TRUE)
+        } else {
+            f64::from_bits(TAG_FALSE)
+        };
+    }
     // ES5 function constructors: `x instanceof Foo` where `Foo` is a plain
     // function used with `new`. `js_new_function_construct` stamps each
     // instance with `synthetic_class_id_for_function(Foo)`; derive the same

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -3023,21 +3023,7 @@ pub fn run_with_parse_cache(
                             // with CommonJS-style default objects route through
                             // the explicit "default" export below.
                             //
-                            // For `node:diagnostics_channel`, the CJS-wrap
-                            // converts `require('node:diagnostics_channel')`
-                            // into `import diagChan from 'node:diagnostics_channel'`
-                            // and pino then reads `diagChan.tracingChannel(...)`.
-                            // Route the default-import local to the namespace
-                            // stub so the receiver is a real object whose
-                            // `tracingChannel` slot is a callable thunk —
-                            // not the function-singleton form, which would
-                            // produce `(function).tracingChannel is not a
-                            // function` because functions don't carry the
-                            // module's exported methods.
-                            if matches!(
-                                submod_key.as_str(),
-                                "diagnostics_channel" | "timers" | "sys" | "trace_events"
-                            ) {
+                            if matches!(submod_key.as_str(), "timers" | "sys" | "trace_events") {
                                 // Default imports of these modules are module
                                 // objects — route to the namespace so they work
                                 // like `import * as ...` (#1213, #2629).

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -141,26 +141,6 @@ Selected highlights (full list in `runtime-parity.md`):
 - `module.evaluate([options])`
 - … and 20 more
 
-### node:diagnostics_channel
-
-**Total APIs: 30** · Perry covers: 0 · Gap: 30
-
-Selected highlights (full list in `runtime-parity.md`):
-
-- `diagnostics_channel.hasSubscribers(name)`
-- `diagnostics_channel.channel(name)`
-- `diagnostics_channel.subscribe(name, onMessage)`
-- `diagnostics_channel.unsubscribe(name, onMessage)`
-- `diagnostics_channel.tracingChannel(nameOrChannels)`
-- `diagnostics_channel.boundedChannel(nameOrChannels)`
-- `channel.hasSubscribers`
-- `channel.publish(message)`
-- `channel.subscribe(onMessage)`
-- `channel.unsubscribe(onMessage)`
-- `channel.bindStore(store[, transform])`
-- `channel.unbindStore(store)`
-- … and 18 more
-
 ### node:dgram
 
 **Total APIs: 28** · Perry covers: 27 · Gap: 1

--- a/docs/runtime-parity.md
+++ b/docs/runtime-parity.md
@@ -3757,7 +3757,7 @@ Bun status: 🟢 Fully implemented.
 | `diagnostics_channel.subscribe(name, onMessage)` | ✓ | ✓ |  |
 | `diagnostics_channel.unsubscribe(name, onMessage)` | ✓ | ✓ |  |
 | `diagnostics_channel.tracingChannel(nameOrChannels)` | ✓ | ✓ | experimental |
-| `diagnostics_channel.boundedChannel(nameOrChannels)` | ✓ | ⚠ | v26.1.0 experimental |
+| `diagnostics_channel.boundedChannel(nameOrChannels)` | ✓ | ✓ | v26.1.0 experimental |
 
 #### Class: Channel
 
@@ -3770,7 +3770,7 @@ Bun status: 🟢 Fully implemented.
 | `channel.bindStore(store[, transform])` | ✓ | ✓ | experimental |
 | `channel.unbindStore(store)` | ✓ | ✓ | experimental |
 | `channel.runStores(context, fn[, thisArg[, ...args]])` | ✓ | ✓ | experimental |
-| `channel.withStoreScope(data)` | ✓ | ⚠ | v26.1.0 experimental |
+| `channel.withStoreScope(data)` | ✓ | ✓ | v26.1.0 experimental |
 
 #### Class: TracingChannel
 
@@ -3787,11 +3787,11 @@ Bun status: 🟢 Fully implemented.
 
 | Member | Node.js | Bun | Notes |
 |--------|---------|-----|-------|
-| `boundedChannel.hasSubscribers` | ✓ | ⚠ |  |
-| `boundedChannel.subscribe(handlers)` | ✓ | ⚠ |  |
-| `boundedChannel.unsubscribe(handlers)` | ✓ | ⚠ |  |
-| `boundedChannel.run(context, fn[, thisArg[, ...args]])` | ✓ | ⚠ |  |
-| `boundedChannel.withScope([context])` | ✓ | ⚠ |  |
+| `boundedChannel.hasSubscribers` | ✓ | ✓ |  |
+| `boundedChannel.subscribe(handlers)` | ✓ | ✓ |  |
+| `boundedChannel.unsubscribe(handlers)` | ✓ | ✓ |  |
+| `boundedChannel.run(context, fn[, thisArg[, ...args]])` | ✓ | ✓ |  |
+| `boundedChannel.withScope([context])` | ✓ | ✓ |  |
 
 #### TracingChannel Subscriber Hooks
 

--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -252,6 +252,7 @@ for raw in sys.stdin:
         sed -E '/^\(node:[0-9]+\) ExperimentalWarning: Type Stripping is an experimental feature/d' | \
         sed -E '/^\(node:[0-9]+\) ExperimentalWarning: glob is an experimental feature/d' | \
         sed -E '/^\(node:[0-9]+\) ExperimentalWarning: WASI is an experimental feature/d' | \
+        sed -E '/^\(node:[0-9]+\) Warning: tracePromise was called with the function .* returned a non-thenable\.$/d' | \
         sed -E 's/^\(node:[0-9]+\) (Timeout(Overflow|Negative|NaN)Warning:)/(node:<pid>) \1/' | \
         sed -E '/^Timeout duration was set to [0-9]+\.$/d' | \
         sed -E '/^\(Use `node --trace-deprecation/d' | \

--- a/test-parity/node-suite/diagnostics_channel/bounded/run-and-scope.ts
+++ b/test-parity/node-suite/diagnostics_channel/bounded/run-and-scope.ts
@@ -1,0 +1,38 @@
+import { boundedChannel, BoundedChannel, channel } from "node:diagnostics_channel";
+
+const bounded = boundedChannel("dc-bounded-run");
+const events: string[] = [];
+const handlers = {
+  start(message: any) {
+    events.push(`start:${message.value}`);
+  },
+  end(message: any) {
+    events.push(`end:${message.value}`);
+  },
+};
+
+console.log("boundedChannel typeof:", typeof boundedChannel);
+console.log("BoundedChannel typeof:", typeof BoundedChannel);
+console.log("instanceof BoundedChannel:", bounded instanceof BoundedChannel);
+console.log("start channel identity:", bounded.start === channel("tracing:dc-bounded-run:start"));
+console.log("end channel identity:", bounded.end === channel("tracing:dc-bounded-run:end"));
+console.log("initial hasSubscribers:", bounded.hasSubscribers);
+console.log("methods:", [typeof bounded.subscribe, typeof bounded.unsubscribe, typeof bounded.run, typeof bounded.withScope].join(","));
+console.log("subscribe return:", bounded.subscribe(handlers));
+console.log("after subscribe:", bounded.hasSubscribers);
+
+const thisArg = { marker: "thisArg" };
+const result = bounded.run({ value: 7 }, function (this: any, a: string, b: string) {
+  events.push(`fn:${this === thisArg}:${a}:${b}`);
+  return 42;
+}, thisArg, "a", "b");
+
+{
+  using scope = bounded.withScope({ value: 9 });
+  events.push(`scope:${bounded.hasSubscribers}`);
+}
+
+console.log("run result:", result);
+console.log("events:", events.join("|"));
+console.log("unsubscribe return:", bounded.unsubscribe(handlers));
+console.log("after unsubscribe:", bounded.hasSubscribers);

--- a/test-parity/node-suite/diagnostics_channel/imports/missing-export-undefined.ts
+++ b/test-parity/node-suite/diagnostics_channel/imports/missing-export-undefined.ts
@@ -1,4 +1,4 @@
 import dcDefault, * as dc from "node:diagnostics_channel";
 
-console.log("namespace boundedChannel typeof:", typeof (dc as any).boundedChannel);
-console.log("default boundedChannel typeof:", typeof (dcDefault as any).boundedChannel);
+console.log("namespace missing typeof:", typeof (dc as any).notARealExport);
+console.log("default missing typeof:", typeof (dcDefault as any).notARealExport);

--- a/test-parity/node-suite/diagnostics_channel/stores/with-store-scope.ts
+++ b/test-parity/node-suite/diagnostics_channel/stores/with-store-scope.ts
@@ -1,0 +1,34 @@
+import { channel } from "node:diagnostics_channel";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const ch = channel("dc-with-store-scope");
+const store1 = new AsyncLocalStorage();
+const store2 = new AsyncLocalStorage();
+
+ch.bindStore(store1);
+ch.bindStore(store2, (data: any) => ({ wrapped: data.value }));
+
+console.log("withStoreScope typeof:", typeof (ch as any).withStoreScope);
+console.log("before:", store1.getStore(), store2.getStore());
+
+let inside: string;
+let nested: string;
+let afterNested: string;
+let disposeReturn: any;
+
+{
+  using scope = (ch as any).withStoreScope({ value: "outer" });
+  inside = [store1.getStore()?.value, store2.getStore()?.wrapped].join(",");
+  {
+    using nestedScope = (ch as any).withStoreScope({ value: "inner" });
+    nested = [store1.getStore()?.value, store2.getStore()?.wrapped].join(",");
+  }
+  afterNested = [store1.getStore()?.value, store2.getStore()?.wrapped].join(",");
+  disposeReturn = (scope as any)[Symbol.dispose]();
+}
+
+console.log("inside:", inside);
+console.log("nested:", nested);
+console.log("after nested:", afterNested);
+console.log("manual dispose return:", disposeReturn);
+console.log("after:", store1.getStore(), store2.getStore());


### PR DESCRIPTION
## Summary

Adds the Node 26 diagnostics_channel tail surface for bounded channels and disposable store scopes.

- Implement `boundedChannel()` / `BoundedChannel` with start/end channel identity, subscriber active tracking, `run()`, and disposable `withScope()`.
- Add `Channel#withStoreScope()` over the existing diagnostics store machinery and align nearby Node 26 behavior for `bindStore(..., null)`, non-thenable `tracePromise()`, and diagnostics_channel default imports.
- Update API manifest/docs and add parity fixtures for bounded channels and store scopes.

## Linked issues

Closes #2630
Closes #2632
Updates #3839

## Why batched

These APIs share the diagnostics_channel channel registry, subscriber accounting, store context, disposal, and import/manifest surface. Implementing them together keeps the Node 26 namespace and lifecycle behavior consistent.

## Tests

- `npx -y node@26.2.0 --experimental-strip-types test-parity/node-suite/diagnostics_channel/bounded/run-and-scope.ts`
- `npx -y node@26.2.0 --experimental-strip-types test-parity/node-suite/diagnostics_channel/stores/with-store-scope.ts`
- `PATH=/tmp/perry-node26-bin:$PATH ./run_parity_tests.sh --suite node-suite --module diagnostics_channel` (66 pass / 2 expected-output mismatches)
- `cargo test -p perry-runtime node_submodules`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`

## Known limitations

The full diagnostics_channel parity module still has two existing `perry/thread` extension expected-output mismatches: `thread/worker-main-publish` and `thread/worker-subscriber-policy`. Both fail from unsettled top-level await handling in the Perry extension worker fixtures and remain outside this Node 26 tail-API cut.

## Non-goals

No changes to node:stream, node:stream/web, node:stream/promises, or unrelated diagnostics_channel worker scheduling semantics.