### PR TITLE
fix(crypto): expose Cipheriv/Decipheriv constructor exports (#3726)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2644,6 +2644,15 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // (no NATIVE_MODULE_TABLE entry — direct dispatch like createHash).
     method("crypto", "createCipheriv", false, None),
     method("crypto", "createDecipheriv", false, None),
+    // `crypto.Cipheriv` / `crypto.Decipheriv` — the constructor exports
+    // behind the `createCipheriv()` / `createDecipheriv()` factories
+    // (#3726). Node exposes them as enumerable constructor functions
+    // (length 4). Perry reads them as callable handles via
+    // `is_native_module_callable_export` / `native_callable_export_arity`;
+    // the actual cipher behavior continues to flow through the
+    // factory-helper codegen path.
+    class("crypto", "Cipheriv"),
+    class("crypto", "Decipheriv"),
     // `crypto.createSign(alg)` / `createVerify(alg)` — RSA PKCS#1 v1.5 sign /
     // verify over the SHA family (#1364). SignHandle dispatched like createHash
     // (no NATIVE_MODULE_TABLE entry — direct codegen dispatch in expr/calls.rs).

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1835,6 +1835,9 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         }
         ("tls", "checkServerIdentity") => Some(2),
         ("tls", "SecureContext") => Some(1),
+        // #3726: `crypto.Cipheriv` / `crypto.Decipheriv` constructor exports —
+        // `(cipher, key, iv, options)` arity matches Node's length 4.
+        ("crypto", "Cipheriv" | "Decipheriv") => Some(4),
         ("url", "Url") => Some(0),
         ("url", "resolveObject") => Some(2),
         ("process", "setSourceMapsEnabled") => Some(1),
@@ -3245,6 +3248,10 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("crypto", "getRandomValues")
             | ("crypto", "createCipheriv")
             | ("crypto", "createDecipheriv")
+            // #3726: the constructor exports behind the factories read as
+            // callable functions so `typeof crypto.Cipheriv === "function"`.
+            | ("crypto", "Cipheriv")
+            | ("crypto", "Decipheriv")
             | ("crypto", "createSecretKey")
             | ("crypto.Certificate", "verifySpkac")
             | ("crypto.Certificate", "exportPublicKey")

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2488 entries across 106 modules
+// Coverage: 2490 entries across 106 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -851,6 +851,10 @@ declare module "cron" {
 }
 
 declare module "crypto" {
+  /** stdlib */
+  export class Cipheriv { [key: string]: any; }
+  /** stdlib */
+  export class Decipheriv { [key: string]: any; }
   /** stdlib */
   export class ECDH { [key: string]: any; }
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2488 entries across 106 modules.
+Total: 2490 entries across 106 modules.
 
 ## Modules
 
@@ -670,6 +670,8 @@ Total: 2488 entries across 106 modules.
 
 ### Classes
 
+- `Cipheriv`
+- `Decipheriv`
 - `ECDH`
 - `X509Certificate`
 

--- a/test-parity/node-suite/crypto/cipher/constructor-exports.ts
+++ b/test-parity/node-suite/crypto/cipher/constructor-exports.ts
@@ -1,0 +1,14 @@
+// #3726: node:crypto exposes `Cipheriv` / `Decipheriv` as constructor
+// exports alongside the `createCipheriv()` / `createDecipheriv()` factory
+// helpers. Mirror Node's observable module shape: both read as callable
+// functions with length 4 and a matching `name`.
+import * as crypto from "node:crypto";
+
+console.log("Cipheriv typeof:", typeof crypto.Cipheriv);
+console.log("Decipheriv typeof:", typeof crypto.Decipheriv);
+console.log("createCipheriv typeof:", typeof crypto.createCipheriv);
+console.log("createDecipheriv typeof:", typeof crypto.createDecipheriv);
+console.log("Cipheriv name:", crypto.Cipheriv.name);
+console.log("Decipheriv name:", crypto.Decipheriv.name);
+console.log("Cipheriv length:", crypto.Cipheriv.length);
+console.log("Decipheriv length:", crypto.Decipheriv.length);


### PR DESCRIPTION
## Summary

Closes #3726.

Node's `node:crypto` namespace exposes `Cipheriv` and `Decipheriv` as enumerable constructor functions (`length` 4) alongside the `createCipheriv()` / `createDecipheriv()` factory helpers. Perry's manifest claimed only the factories, so reading `crypto.Cipheriv` tripped the strict-API gate (#463) and `typeof` / `length` diverged from Node.

## Changes

- **api-manifest** (`entries.rs`): add `class` entries for `crypto.Cipheriv` / `crypto.Decipheriv`.
- **runtime** (`native_module.rs`): list them in `is_native_module_callable_export` and give `native_callable_export_arity` a length of `4`, so the value-read shape matches Node (`typeof` function, matching `name`, `length` 4).
- **docs**: regenerate `reference.md` + `perry.d.ts` from the manifest.
- **parity**: add `node-suite/crypto/cipher/constructor-exports.ts`.

The actual cipher behavior continues to flow through the existing factory-helper codegen path; this only completes the observable export shape.

## Verification

New fixture is byte-identical to `node --experimental-strip-types`:

```
Cipheriv typeof: function
Decipheriv typeof: function
createCipheriv typeof: function
createDecipheriv typeof: function
Cipheriv name: Cipheriv
Decipheriv name: Decipheriv
Cipheriv length: 4
Decipheriv length: 4
```

Existing `crypto/cipher` fixtures (`method-properties`, `aes-256-cbc-roundtrip`, `aes-256-gcm-roundtrip`) still match Node. `cargo fmt --all -- --check` clean.
