### PR TITLE
hotfix: resolve native_module.rs punycode/timers conflict marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1057 — hotfix: resolve native_module.rs conflict marker (build break)
+
+A batch of admin-merges left an unresolved git conflict marker in
+`crates/perry-runtime/src/object/native_module.rs` (the `namespace_keys_for`
+match, punycode-vs-timers arms), leaving `main` uncompilable
+(`error: expected one of ... found "punycode"`). Resolved as the union of both
+sides: keep the punycode namespace-key arms (HEAD) and the `timers` arm
+(origin/main). All referenced `PUNYCODE_*_KEYS` / `TIMERS_NAMESPACE_KEYS`
+consts already exist. Verified `cargo build --release` (runtime/stdlib/codegen/
+hir/perry) -> exit 0.
+
 ## v0.5.1047 — fix(node): expose net.Stream / timers.promises / zlib.codes namespace aliases
 
 External contributor PR #3509 (Andrew DiZenzo), rebased onto current `main` and merged with the metadata folded in. Closes #2689, #2682, #2688.

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1325,13 +1325,10 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
         "buffer" => Some(BUFFER_NAMESPACE_KEYS),
         "querystring" => Some(QUERYSTRING_NAMESPACE_KEYS),
         "querystring.default" => Some(QUERYSTRING_DEFAULT_KEYS),
-<<<<<<< HEAD
         "punycode" => Some(PUNYCODE_NAMESPACE_KEYS),
         "punycode.default" => Some(PUNYCODE_DEFAULT_KEYS),
         "punycode.ucs2" => Some(PUNYCODE_UCS2_KEYS),
-=======
         "timers" => Some(TIMERS_NAMESPACE_KEYS),
->>>>>>> origin/main
         "os" => Some(OS_NAMESPACE_KEYS),
         "os.default" => Some(OS_DEFAULT_KEYS),
         "url" => Some(URL_NAMESPACE_KEYS),


### PR DESCRIPTION
## Hotfix: unbreak `main` build

A batch of admin-merges left an **unresolved git conflict marker** in `crates/perry-runtime/src/object/native_module.rs` (the `namespace_keys_for` match), leaving `main` uncompilable:

```
error: expected one of `!`, `(`, `+`, `::`, `<`, `>`, or `as`, found `"punycode"`
error: could not compile `perry-runtime`
```

### Fix
Resolved the marker as the **union** of both sides of the `namespace_keys_for` match:

```rust
"punycode" => Some(PUNYCODE_NAMESPACE_KEYS),
"punycode.default" => Some(PUNYCODE_DEFAULT_KEYS),
"punycode.ucs2" => Some(PUNYCODE_UCS2_KEYS),
"timers" => Some(TIMERS_NAMESPACE_KEYS),
```

All referenced consts (`PUNYCODE_*_KEYS`, `TIMERS_NAMESPACE_KEYS`) already exist in the file. The duplicate `"timers"` arm is pre-existing on `origin/main` (warning, not error).

Verified: `cargo build --release -p perry-runtime -p perry-stdlib -p perry-codegen -p perry-hir -p perry` → **exit 0**. Tree is marker-free.
