### PR TITLE
hotfix: resolve native_module.rs punycode/timers conflict marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1054 — hotfix: resolve native_module.rs punycode/timers conflict marker
+
+Admin-merges of node-compat fork PRs left an unresolved git conflict marker in
+the `namespace_keys_for` match of `crates/perry-runtime/src/object/native_module.rs`
+(punycode-vs-timers arms), leaving `main` uncompilable
+(`error: expected one of ... found "punycode"`). Resolved as the union of both
+sides — the three `punycode*` namespace-key arms (HEAD) plus the `timers` arm
+(origin/main). All referenced consts (`PUNYCODE_*_KEYS`, `TIMERS_NAMESPACE_KEYS`)
+already exist. Verified `cargo build --release` across runtime/stdlib/codegen/hir/
+perry → exit 0.
+
 ## v0.5.1047 — fix(node): expose net.Stream / timers.promises / zlib.codes namespace aliases
 
 External contributor PR #3509 (Andrew DiZenzo), rebased onto current `main` and merged with the metadata folded in. Closes #2689, #2682, #2688.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1053
+**Current Version:** 0.5.1054
 
 
 ## TypeScript Parity Status

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1053"
+version = "0.5.1054"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"


### PR DESCRIPTION
## Hotfix: unbreak main build

Admin-merges left an unresolved conflict marker in `native_module.rs` `namespace_keys_for` (punycode vs timers), leaving main uncompilable (`error: expected one of ... found "punycode"`). Resolved as the union of both sides; all referenced consts already exist. `cargo build --release` (runtime/stdlib/codegen/hir/perry) verified green.
