### PR TITLE
hotfix: actually remove native_module.rs conflict marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1055 — hotfix: actually remove native_module.rs conflict marker
+
+The v0.5.1054 hotfix bumped the version but its source edit failed to apply,
+so the punycode/timers conflict marker in `namespace_keys_for` remained and
+`main` stayed unbuildable. This commit removes the marker for real — union of
+both arms (punycode namespace keys + timers) — and was verified with a full
+`cargo build --release` (runtime/stdlib/codegen/hir/perry) → exit 0.
+
 ## v0.5.1054 — hotfix: resolve native_module.rs punycode/timers conflict marker
 
 Admin-merges of node-compat fork PRs left an unresolved git conflict marker in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1054
+**Current Version:** 0.5.1055
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1053"
+version = "0.5.1054"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5260,7 +5260,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5303,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5322,7 +5322,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "bson",
  "futures-util",
@@ -5342,7 +5342,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5352,7 +5352,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5373,7 +5373,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5391,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "base64",
  "image",
@@ -5417,14 +5417,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5451,7 +5451,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5463,7 +5463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "brotli",
  "flate2",
@@ -5472,7 +5472,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5481,7 +5481,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5498,7 +5498,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "anyhow",
  "base64",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5626,7 +5626,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5634,14 +5634,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "base64",
  "itoa",
@@ -5658,7 +5658,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "base64",
  "block2",
@@ -5707,7 +5707,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "base64",
  "block2",
@@ -5722,7 +5722,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1053"
+version = "0.5.1054"
 
 [[package]]
 name = "perry-ui-test"
@@ -5730,11 +5730,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1053"
+version = "0.5.1054"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "base64",
  "block2",
@@ -5750,7 +5750,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "base64",
  "block2",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "block2",
  "libc",
@@ -5779,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "base64",
  "libc",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1053"
+version = "0.5.1054"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1054"
+version = "0.5.1055"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1325,13 +1325,10 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
         "buffer" => Some(BUFFER_NAMESPACE_KEYS),
         "querystring" => Some(QUERYSTRING_NAMESPACE_KEYS),
         "querystring.default" => Some(QUERYSTRING_DEFAULT_KEYS),
-<<<<<<< HEAD
         "punycode" => Some(PUNYCODE_NAMESPACE_KEYS),
         "punycode.default" => Some(PUNYCODE_DEFAULT_KEYS),
         "punycode.ucs2" => Some(PUNYCODE_UCS2_KEYS),
-=======
         "timers" => Some(TIMERS_NAMESPACE_KEYS),
->>>>>>> origin/main
         "os" => Some(OS_NAMESPACE_KEYS),
         "os.default" => Some(OS_DEFAULT_KEYS),
         "url" => Some(URL_NAMESPACE_KEYS),


### PR DESCRIPTION
## Hotfix: actually remove the native_module.rs conflict marker

The v0.5.1054 hotfix (#3882) bumped the version but its source edit failed to apply, so the punycode/timers conflict marker in `namespace_keys_for` remained and `main` stayed unbuildable (`error: expected one of ... found "punycode"`).

This removes the marker for real — union of both arms (the three `punycode*` namespace-key arms + the `timers` arm). All referenced consts already exist. Verified with a full `cargo build --release` (runtime/stdlib/codegen/hir/perry) -> exit 0; tree is marker-free.
