### PR TITLE
fix(stream): complete callback pipeline and duplex iterator surface

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -840,7 +840,7 @@ extern "C" fn pipe_finish_destination_callback(closure: *const ClosureHeader) ->
         return f64::from_bits(TAG_UNDEFINED);
     }
     let dest = js_closure_get_capture_f64(closure, 0);
-    if stream_destroyed(dest) || has_truthy_hidden(dest, hidden_end_emitted_key()) {
+    if stream_destroyed(dest) || has_truthy_hidden(dest, hidden_finish_emitted_key()) {
         return f64::from_bits(TAG_UNDEFINED);
     }
     if writable_length(dest) > 0.0 {
@@ -1701,6 +1701,10 @@ pub use pipeline::*;
 #[path = "node_stream_readwrite.rs"]
 mod readwrite;
 pub use readwrite::*;
+
+#[path = "node_stream_duplex_methods.rs"]
+mod duplex_method_table;
+pub use duplex_method_table::*;
 
 #[path = "node_stream_compose_live.rs"]
 mod compose_live;

--- a/crates/perry-runtime/src/node_stream_compose_live.rs
+++ b/crates/perry-runtime/src/node_stream_compose_live.rs
@@ -1,13 +1,12 @@
-//! node:stream — compose() live-pipe consume helpers (split out of
+//! node:stream — live-pipe consume helpers (split out of
 //! node_stream_readwrite.rs for the 2000-line file-size gate). These mark a
-//! readable as a live compose pipe source and consume its buffered front when
-//! it re-emits, so multi-stage `stream.compose(...)` chains don't double-emit
-//! the same buffered chunk. Shares the parent module's hidden-key accessors and
-//! state primitives via `use super::*`.
+//! readable as a live pipe participant and consume its buffered front when it
+//! re-emits, so `pipe()`, `pipeline()`, and `compose()` chains don't replay the
+//! same flowing chunk from retained readable storage.
 #![allow(unused_imports)]
 use super::*;
 
-pub(super) fn mark_compose_live_pipe_consume_on_emit(stream: f64) {
+pub(super) fn mark_live_pipe_consume_on_emit(stream: f64) {
     if get_hidden_value(stream, hidden_readable_flag_key()).is_some() {
         set_hidden_value(
             stream,

--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -500,6 +500,7 @@ pub extern "C" fn js_node_stream_writable_subclass_init(this: f64, opts: f64) ->
 
 #[no_mangle]
 pub extern "C" fn js_node_stream_duplex_new(opts: f64) -> f64 {
+    register_iter_helper_arities();
     let methods = duplex_methods();
     let obj = build_object(&methods, DUPLEX_SHAPE_ID + methods.len() as u32);
     let duplex = f64::from_bits(JSValue::pointer(obj as *const u8).bits());

--- a/crates/perry-runtime/src/node_stream_duplex_methods.rs
+++ b/crates/perry-runtime/src/node_stream_duplex_methods.rs
@@ -1,0 +1,56 @@
+//! node:stream — Duplex prototype method table. Split out of
+//! node_stream_readwrite.rs for the 2000-line file-size gate.
+#![allow(unused_imports)]
+use super::*;
+
+pub(super) fn duplex_methods() -> [(&'static str, StubFn); 44] {
+    // Union of readable + writable, deduped (`on/once/off/addListener/
+    // removeListener/removeAllListeners/emit/listenerCount/listeners/
+    // destroy` appear once each).
+    [
+        ("on", cast2(ns_on2)),
+        ("once", cast2(ns_once2)),
+        ("prependListener", cast2(ns_prepend_listener2)),
+        ("prependOnceListener", cast2(ns_prepend_once_listener2)),
+        ("off", cast2(ns_off2)),
+        ("addListener", cast2(ns_on2)),
+        ("removeListener", cast2(ns_remove_listener2)),
+        ("removeAllListeners", cast1(ns_remove_all_listeners1)),
+        ("emit", cast2(ns_emit_rest)),
+        ("setMaxListeners", cast1(ns_set_max_listeners)),
+        ("getMaxListeners", cast0(ns_get_max_listeners)),
+        ("eventNames", cast0(ns_event_names)),
+        ("listenerCount", cast1(ns_listener_count)),
+        ("listeners", cast1(ns_listeners)),
+        ("rawListeners", cast1(ns_raw_listeners)),
+        ("read", cast1(ns_read1)),
+        ("pipe", cast2(ns_pipe2)),
+        ("unpipe", cast1(ns_unpipe1)),
+        ("wrap", cast1(ns_wrap1)),
+        ("pause", cast0(ns_pause0)),
+        ("resume", cast0(ns_resume0)),
+        ("setEncoding", cast1(ns_set_encoding1)),
+        ("isPaused", cast0(ns_is_paused0)),
+        ("toArray", cast1(ns_iter_to_array)),
+        ("map", cast2(ns_iter_map)),
+        ("filter", cast2(ns_iter_filter)),
+        ("reduce", cast3(ns_iter_reduce)),
+        ("forEach", cast2(ns_iter_for_each)),
+        ("find", cast2(ns_iter_find)),
+        ("some", cast2(ns_iter_some)),
+        ("every", cast2(ns_iter_every)),
+        ("flatMap", cast2(ns_iter_flat_map)),
+        ("take", cast1(ns_iter_take)),
+        ("drop", cast1(ns_iter_drop)),
+        ("iterator", cast1(async_iterator::ns_iterator1)),
+        ("push", cast1(ns_push1)),
+        ("unshift", cast1(ns_unshift1)),
+        ("compose", cast1(ns_compose1)),
+        ("write", cast3(ns_write3)),
+        ("end", cast3(ns_end3)),
+        ("cork", cast0(ns_cork0)),
+        ("uncork", cast0(ns_uncork0)),
+        ("destroy", cast1(ns_destroy1)),
+        ("setDefaultEncoding", cast1(ns_chain1)),
+    ]
+}

--- a/crates/perry-runtime/src/node_stream_pipeline.rs
+++ b/crates/perry-runtime/src/node_stream_pipeline.rs
@@ -250,6 +250,8 @@ pub(super) fn add_pipeline_callback_listeners(
 
 pub(super) fn wire_pipeline_pair(src: f64, dest: f64, end_dest: bool) {
     add_pipe_destination(src, dest);
+    mark_live_pipe_consume_on_emit(src);
+    mark_live_pipe_consume_on_emit(dest);
     if !end_dest {
         add_pipe_no_end_destination(src, dest);
     }
@@ -395,11 +397,7 @@ pub(super) fn collect_pipeline_chunks(value: f64) -> Result<f64, f64> {
         _ => {}
     }
     if let Some(result) = js_node_stream_collect_chunks_result(value) {
-        let chunks = result?;
-        if pipeline_should_coalesce_chunks(value) {
-            return Ok(pipeline_coalesce_chunks(chunks));
-        }
-        return Ok(chunks);
+        return result;
     }
     let raw = raw_ptr_from_value(value);
     if let Some(chunks) = collection_iterable_chunks(raw) {
@@ -419,43 +417,6 @@ pub(super) fn collect_pipeline_chunks(value: f64) -> Result<f64, f64> {
         return Ok(pipeline_single_chunk(value));
     }
     Ok(pipeline_empty_chunks())
-}
-
-pub(super) fn pipeline_should_coalesce_chunks(value: f64) -> bool {
-    is_transform_stream(value)
-        && !has_truthy_hidden(value, hidden_key(b"readableObjectMode"))
-        && !has_truthy_hidden(value, hidden_writable_object_mode_key())
-}
-
-pub(super) fn pipeline_value_to_string(value: f64) -> String {
-    let ptr = crate::value::js_jsvalue_to_string(value);
-    if ptr.is_null() {
-        return String::new();
-    }
-    unsafe {
-        let len = (*ptr).byte_len as usize;
-        let data = (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-        String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned()
-    }
-}
-
-pub(super) fn pipeline_coalesce_chunks(chunks: f64) -> f64 {
-    if !is_array_like_value(chunks) {
-        return chunks;
-    }
-    let arr = raw_ptr_from_value(chunks) as *const crate::array::ArrayHeader;
-    let len = crate::array::js_array_length(arr);
-    if len <= 1 {
-        return chunks;
-    }
-    let mut joined = String::new();
-    for i in 0..len {
-        joined.push_str(&pipeline_value_to_string(crate::array::js_array_get_f64(
-            arr, i,
-        )));
-    }
-    let value = string_value(joined.as_bytes());
-    pipeline_single_chunk(value)
 }
 
 pub(super) fn pipeline_chunks_vec(chunks: f64) -> Vec<f64> {
@@ -757,41 +718,14 @@ fn compose_copy_chunks(chunks: f64) -> f64 {
     box_pointer(out as *const u8)
 }
 
-fn compose_is_buffer_chunk(chunk: f64) -> bool {
-    crate::buffer::js_buffer_is_buffer(chunk.to_bits() as i64) == 1
-}
-
-fn compose_coalesce_stage_output(stage: f64, chunks: f64) -> f64 {
-    if !pipeline_should_coalesce_chunks(stage) {
-        return chunks;
-    }
-    let values = pipeline_chunks_vec(chunks);
-    if values.len() <= 1 {
-        return chunks;
-    }
-    if values.iter().all(|chunk| compose_is_buffer_chunk(*chunk)) {
-        let mut arr = crate::array::js_array_alloc(values.len() as u32);
-        for value in values {
-            arr = crate::array::js_array_push_f64(arr, value);
-        }
-        let joined = crate::buffer::js_buffer_concat(arr as *const crate::array::ArrayHeader);
-        return pipeline_single_chunk(box_pointer(joined as *const u8));
-    }
-    if values.iter().any(|chunk| compose_is_buffer_chunk(*chunk)) {
-        return chunks;
-    }
-    pipeline_coalesce_chunks(chunks)
-}
-
 fn compose_take_stage_output(stage: f64) -> Result<f64, f64> {
     drain_compose_stream_stage(stage);
     if let Some(err) = readable_hidden_error(stage) {
         return Err(err);
     }
-    let mut chunks = readable_hidden_chunks(stage)
+    let chunks = readable_hidden_chunks(stage)
         .map(compose_copy_chunks)
         .unwrap_or_else(compose_empty_chunks);
-    chunks = compose_coalesce_stage_output(stage, chunks);
     clear_readable_buffer(stage);
     clear_pending_readable_chunks(stage);
     if let Some(err) = readable_hidden_error(stage) {

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -552,7 +552,7 @@ pub(super) fn end_pipe_destinations(stream: f64) {
         dests.push(crate::array::js_array_get_f64(arr, i));
     }
     for dest in dests {
-        if stream_destroyed(dest) || has_truthy_hidden(dest, hidden_end_emitted_key()) {
+        if stream_destroyed(dest) || has_truthy_hidden(dest, hidden_finish_emitted_key()) {
             continue;
         }
         if pipe_no_end_destination_contains(stream, dest) {
@@ -1949,45 +1949,5 @@ pub(super) fn writable_methods() -> [(&'static str, StubFn); 22] {
         ("destroy", cast1(ns_destroy1)),
         ("setDefaultEncoding", cast1(ns_chain1)),
         ("_write", cast3(ns_chain3)),
-    ]
-}
-
-pub(super) fn duplex_methods() -> [(&'static str, StubFn); 32] {
-    // Union of readable + writable, deduped (`on/once/off/addListener/
-    // removeListener/removeAllListeners/emit/listenerCount/listeners/
-    // destroy` appear once each).
-    [
-        ("on", cast2(ns_on2)),
-        ("once", cast2(ns_once2)),
-        ("prependListener", cast2(ns_prepend_listener2)),
-        ("prependOnceListener", cast2(ns_prepend_once_listener2)),
-        ("off", cast2(ns_off2)),
-        ("addListener", cast2(ns_on2)),
-        ("removeListener", cast2(ns_remove_listener2)),
-        ("removeAllListeners", cast1(ns_remove_all_listeners1)),
-        ("emit", cast2(ns_emit_rest)),
-        ("setMaxListeners", cast1(ns_set_max_listeners)),
-        ("getMaxListeners", cast0(ns_get_max_listeners)),
-        ("eventNames", cast0(ns_event_names)),
-        ("listenerCount", cast1(ns_listener_count)),
-        ("listeners", cast1(ns_listeners)),
-        ("rawListeners", cast1(ns_raw_listeners)),
-        ("read", cast1(ns_read1)),
-        ("pipe", cast2(ns_pipe2)),
-        ("unpipe", cast1(ns_unpipe1)),
-        ("wrap", cast1(ns_wrap1)),
-        ("pause", cast0(ns_pause0)),
-        ("resume", cast0(ns_resume0)),
-        ("setEncoding", cast1(ns_set_encoding1)),
-        ("isPaused", cast0(ns_is_paused0)),
-        ("push", cast1(ns_push1)),
-        ("unshift", cast1(ns_unshift1)),
-        ("compose", cast1(ns_compose1)),
-        ("write", cast3(ns_write3)),
-        ("end", cast3(ns_end3)),
-        ("cork", cast0(ns_cork0)),
-        ("uncork", cast0(ns_uncork0)),
-        ("destroy", cast1(ns_destroy1)),
-        ("setDefaultEncoding", cast1(ns_chain1)),
     ]
 }


### PR DESCRIPTION
## Summary

- Complete callback `stream.pipeline()` data forwarding and completion by distinguishing readable `end` from writable `finish` on Duplex/Transform destinations.
- Mark live pipe participants so flowing chunks are not replayed from retained readable storage.
- Expose readable iterator helpers on Duplex streams, including `Readable.compose()` results, and preserve stream chunk boundaries in pipeline/compose collection.
- Split the Duplex method table out of `node_stream_readwrite.rs` to stay under the Rust file-size gate.

## Issue Cluster

Batched because both failures share classic `node:stream` Duplex/pipe lifecycle state: callback pipeline needed correct finish handling and composed Duplex results needed the readable helper surface plus chunk-boundary preservation.

Closes #3861
Closes #3862

## Tests

- `cargo fmt --all -- --check`
- `git diff --check HEAD~2..HEAD`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `rg -n '^<{7}|^={7}$|^>{7}' crates test-parity scripts`
- `cargo check -p perry-runtime --quiet`
- `cargo test -p perry-runtime node_stream --quiet`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- `PATH=/tmp/perry-node26-bin:$PATH ./run_parity_tests.sh --suite node-suite --module stream --filter stream/pipeline`
- `PATH=/tmp/perry-node26-bin:$PATH ./run_parity_tests.sh --suite node-suite --module stream --filter stream/iter-helpers`
- `PATH=/tmp/perry-node26-bin:$PATH ./run_parity_tests.sh --suite node-suite --module stream --filter stream/compose`
- `PATH=/tmp/perry-node26-bin:$PATH ./run_parity_tests.sh --suite node-suite --module stream --filter stream/promises`

## Non-goals

- No `node:stream/web` or web adapter changes.
- No `node:stream/promises` API changes beyond preserving chunk boundaries through the shared pipeline collection path.
