### PR TITLE
fix(util): implement native inherits

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -1543,6 +1543,15 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "util",
         has_receiver: false,
+        method: "inherits",
+        class_filter: None,
+        runtime: "js_util_inherits",
+        args: &[NA_F64, NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "util",
+        has_receiver: false,
         method: "isArray",
         class_filter: None,
         runtime: "js_array_is_array",

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -563,6 +563,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_util_inspect", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_util_debuglog", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_util_diff", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_util_inherits", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_util_is_deep_strict_equal", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_util_strip_vt_control_characters", DOUBLE, &[DOUBLE]);
     module.declare_function("js_util_style_text", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -165,6 +165,7 @@ pub mod util_abort;
 pub mod util_call_sites;
 pub mod util_debuglog;
 pub mod util_diff;
+pub mod util_inherits;
 pub mod util_mime;
 pub mod util_parse_args;
 pub mod util_parse_env;

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -174,7 +174,10 @@ fn global_object_prototype_bits() -> Option<u64> {
     }
 }
 
-fn ensure_function_prototype_object(func_value: f64, class_id: u32) -> *mut ObjectHeader {
+pub(crate) fn ensure_function_prototype_object(
+    func_value: f64,
+    class_id: u32,
+) -> *mut ObjectHeader {
     if class_id == 0 {
         return std::ptr::null_mut();
     }

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -86,7 +86,7 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                         return f64::from_bits(crate::value::TAG_UNDEFINED);
                     }
 
-                    // (value, writable, configurable). `name`/`length` are the
+                    // (value, writable, enumerable, configurable). `name`/`length` are the
                     // built-in own data slots; anything else falls back to the
                     // user-attached dynamic-property side table.
                     // Built-in `name`/`length` are spec'd `{ writable: false,
@@ -96,7 +96,7 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                     let registered = super::get_property_attrs(ptr, name);
                     let writable_default = registered.map(|a| a.writable());
                     let configurable_default = registered.map(|a| a.configurable()).unwrap_or(true);
-                    let resolved: Option<(f64, bool, bool)> = match name {
+                    let resolved: Option<(f64, bool, bool, bool)> = match name {
                         "length" => {
                             let closure_value = crate::value::js_nanbox_pointer(ptr as i64);
                             let arity = if let Some(arity) =
@@ -120,6 +120,7 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                             Some((
                                 arity as f64,
                                 writable_default.unwrap_or(false),
+                                false,
                                 configurable_default,
                             ))
                         }
@@ -133,6 +134,7 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                                 Some((
                                     dynv,
                                     writable_default.unwrap_or(false),
+                                    false,
                                     configurable_default,
                                 ))
                             } else {
@@ -145,23 +147,28 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                                     fname.as_ptr(),
                                     fname.len() as u32,
                                 );
-                                Some((crate::js_nanbox_string(s as i64), false, true))
+                                Some((crate::js_nanbox_string(s as i64), false, false, true))
                             }
                         }
                         _ => {
                             let dynv = crate::closure::closure_get_dynamic_prop(ptr, name);
                             if dynv.to_bits() != crate::value::TAG_UNDEFINED {
-                                Some((dynv, true, true))
+                                let attrs = registered
+                                    .unwrap_or(super::PropertyAttrs::new(true, true, true));
+                                Some((
+                                    dynv,
+                                    attrs.writable(),
+                                    attrs.enumerable(),
+                                    attrs.configurable(),
+                                ))
                             } else {
                                 None
                             }
                         }
                     };
-                    let Some((value, writable, configurable)) = resolved else {
+                    let Some((value, writable, enumerable, configurable)) = resolved else {
                         return f64::from_bits(crate::value::TAG_UNDEFINED);
                     };
-                    // `name`/`length` are non-enumerable; user data props are.
-                    let enumerable = !matches!(name, "name" | "length");
                     let packed = b"value\0writable\0enumerable\0configurable";
                     let desc = js_object_alloc_with_shape(
                         0x0D_E5_C0,

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1830,7 +1830,7 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ) => Some(1),
         ("process", "hasUncaughtExceptionCaptureCallback") => Some(0),
         ("fs", "_toUnixTimestamp") => Some(1),
-        ("util", "debug" | "debuglog") => Some(2),
+        ("util", "debug" | "debuglog" | "inherits") => Some(2),
         ("util", "MIMEParams") => Some(0),
         ("util", "MIMEType") => Some(1),
         ("net", "createServer" | "Server") => Some(2),

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1127,6 +1127,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("util", "debuglog") | ("util", "debug") => {
             crate::util_debuglog::js_util_debuglog(arg(0), arg(1))
         }
+        ("util", "inherits") => crate::util_inherits::js_util_inherits(arg(0), arg(1)),
         ("util", "_extend") => crate::util_mime::js_util_extend(arg(0), arg(1)),
         ("util", "_errnoException") => {
             crate::util_mime::js_util_errno_exception(arg(0), arg(1), arg(2))

--- a/crates/perry-runtime/src/util_debuglog.rs
+++ b/crates/perry-runtime/src/util_debuglog.rs
@@ -268,6 +268,11 @@ pub extern "C" fn js_util_debuglog(section: f64, callback: f64) -> f64 {
     );
 
     crate::object::set_bound_native_closure_name(closure_handle.get_raw_mut_ptr(), "logger");
+    crate::object::set_property_attrs(
+        closure_handle.get_raw_const_ptr::<ClosureHeader>() as usize,
+        "name".to_string(),
+        crate::object::PropertyAttrs::new(false, false, true),
+    );
     crate::closure::closure_set_dynamic_prop(
         closure_handle.get_raw_const_ptr::<ClosureHeader>() as usize,
         "enabled",

--- a/crates/perry-runtime/src/util_inherits.rs
+++ b/crates/perry-runtime/src/util_inherits.rs
@@ -1,0 +1,141 @@
+//! `util.inherits(constructor, superConstructor)`.
+
+use crate::closure::ClosureHeader;
+use crate::object::{ObjectHeader, PropertyAttrs};
+use crate::value::JSValue;
+
+const TAG_UNDEFINED_F64: f64 = f64::from_bits(crate::value::TAG_UNDEFINED);
+
+fn named_key(name: &[u8]) -> *const crate::string::StringHeader {
+    crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32)
+}
+
+fn invalid_arg_type(name: &str, expected: &str, value: f64) -> ! {
+    let received = crate::fs::validate::describe_received(value);
+    let message =
+        format!("The \"{name}\" argument must be of type {expected}. Received {received}");
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn invalid_super_prototype(value: f64) -> ! {
+    let received = crate::fs::validate::describe_received(value);
+    let message =
+        format!("The \"superCtor.prototype\" property must be of type object. Received {received}");
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn is_nullish(value: f64) -> bool {
+    let jv = JSValue::from_bits(value.to_bits());
+    jv.is_null() || jv.is_undefined()
+}
+
+fn closure_ptr(value: f64) -> usize {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return 0;
+    }
+    let ptr = jv.as_pointer::<ClosureHeader>() as usize;
+    if ptr >= 0x1000 && crate::closure::is_closure_ptr(ptr) {
+        ptr
+    } else {
+        0
+    }
+}
+
+fn object_ptr(value: f64) -> *mut ObjectHeader {
+    let jv = JSValue::from_bits(value.to_bits());
+    let ptr = if jv.is_pointer() {
+        jv.as_pointer::<ObjectHeader>() as *mut ObjectHeader
+    } else {
+        let bits = value.to_bits();
+        if bits != 0 && bits <= crate::value::POINTER_MASK && bits > 0x10000 {
+            bits as *mut ObjectHeader
+        } else {
+            std::ptr::null_mut()
+        }
+    };
+    if ptr.is_null() || crate::closure::is_closure_ptr(ptr as usize) {
+        return std::ptr::null_mut();
+    }
+    if crate::object::is_valid_obj_ptr(ptr as *const u8) {
+        ptr
+    } else {
+        std::ptr::null_mut()
+    }
+}
+
+fn get_property(value: f64, name: &[u8]) -> f64 {
+    unsafe { crate::value::js_get_property(value, name.as_ptr() as i64, name.len() as i64) }
+}
+
+fn ensure_function_prototype(value: f64) -> f64 {
+    let current = get_property(value, b"prototype");
+    if current.to_bits() != crate::value::TAG_UNDEFINED {
+        return current;
+    }
+    if closure_ptr(value) == 0 {
+        return current;
+    }
+    let class_id = crate::object::synthetic_class_id_for_function(value);
+    if class_id == 0 {
+        return current;
+    }
+    let proto = crate::object::ensure_function_prototype_object(value, class_id);
+    if proto.is_null() {
+        current
+    } else {
+        crate::value::js_nanbox_pointer(proto as i64)
+    }
+}
+
+fn set_super_property(ctor: f64, super_ctor: f64) {
+    let key = named_key(b"super_");
+    let attrs = PropertyAttrs::new(true, false, true);
+    let ctor_closure = closure_ptr(ctor);
+    if ctor_closure != 0 {
+        crate::closure::closure_set_dynamic_prop(ctor_closure, "super_", super_ctor);
+        crate::object::set_property_attrs(ctor_closure, "super_".to_string(), attrs);
+        return;
+    }
+
+    let obj = object_ptr(ctor);
+    if obj.is_null() {
+        crate::object::throw_object_type_error(b"Object.defineProperty called on non-object");
+    }
+    crate::object::js_object_set_field_by_name(obj, key, super_ctor);
+    crate::object::set_property_attrs(obj as usize, "super_".to_string(), attrs);
+}
+
+fn register_function_parent(ctor: f64, super_ctor: f64) {
+    if closure_ptr(ctor) == 0 || closure_ptr(super_ctor) == 0 {
+        return;
+    }
+    let ctor_class = crate::object::synthetic_class_id_for_function(ctor);
+    let super_class = crate::object::synthetic_class_id_for_function(super_ctor);
+    if ctor_class != 0 && super_class != 0 && ctor_class != super_class {
+        crate::object::register_class(ctor_class, super_class);
+    }
+}
+
+/// `util.inherits(constructor, superConstructor)` -> undefined.
+#[no_mangle]
+pub extern "C" fn js_util_inherits(ctor: f64, super_ctor: f64) -> f64 {
+    if is_nullish(ctor) {
+        invalid_arg_type("ctor", "function", ctor);
+    }
+    if is_nullish(super_ctor) {
+        invalid_arg_type("superCtor", "function", super_ctor);
+    }
+
+    let super_proto = ensure_function_prototype(super_ctor);
+    if JSValue::from_bits(super_proto.to_bits()).is_undefined() {
+        invalid_super_prototype(super_proto);
+    }
+
+    let ctor_proto = ensure_function_prototype(ctor);
+    set_super_property(ctor, super_ctor);
+    crate::object::js_object_set_prototype_of(ctor_proto, super_proto);
+    register_function_parent(ctor, super_ctor);
+
+    TAG_UNDEFINED_F64
+}

--- a/test-parity/node-suite/util/debuglog/basic.ts
+++ b/test-parity/node-suite/util/debuglog/basic.ts
@@ -27,6 +27,14 @@ const wildcard = util.debug("foobar");
 console.log("logger typeof:", typeof logger);
 console.log("logger enabled:", logger.enabled);
 console.log("logger keys:", Object.keys(logger).join(","));
+const loggerNameDescriptor = Object.getOwnPropertyDescriptor(logger, "name");
+console.log(
+  "logger name descriptor:",
+  loggerNameDescriptor?.value,
+  loggerNameDescriptor?.writable,
+  loggerNameDescriptor?.enumerable,
+  loggerNameDescriptor?.configurable,
+);
 console.log("wildcard enabled:", wildcard.enabled);
 
 const writes = [];

--- a/test-parity/node-suite/util/inherits/basic.ts
+++ b/test-parity/node-suite/util/inherits/basic.ts
@@ -1,0 +1,48 @@
+import util, { inherits } from "node:util";
+
+function Base() {
+  this.base = true;
+}
+
+Base.prototype.answer = function () {
+  return 42;
+};
+
+function Sub() {
+  Base.call(this);
+}
+
+console.log(
+  "inherits meta:",
+  typeof util.inherits,
+  util.inherits.length,
+  util.inherits.name,
+  util.inherits === inherits,
+);
+console.log("inherits return:", util.inherits(Sub, Base));
+
+const sub = new Sub();
+console.log(
+  "inherits result:",
+  sub instanceof Sub,
+  sub instanceof Base,
+  sub.base,
+  sub.answer(),
+  Sub.super_ === Base,
+);
+console.log(
+  "prototype result:",
+  Object.getPrototypeOf(Sub.prototype) === Base.prototype,
+);
+console.log("sub keys:", Object.keys(Sub).join(",") || "none");
+
+function Leaf() {}
+inherits(Leaf, Base);
+
+const leaf = new Leaf();
+console.log(
+  "named import result:",
+  leaf instanceof Leaf,
+  leaf instanceof Base,
+  typeof leaf.answer,
+);

--- a/test-parity/node-suite/util/inherits/validation.ts
+++ b/test-parity/node-suite/util/inherits/validation.ts
@@ -1,0 +1,34 @@
+import { inherits } from "node:util";
+
+function Base() {}
+function Sub() {}
+
+function record(label, fn) {
+  try {
+    console.log(label, fn());
+  } catch (error) {
+    console.log(label, error.name, error.code, error.message);
+  }
+}
+
+record("ctor-null:", () => inherits(null, Base));
+record("ctor-undefined:", () => inherits(undefined, Base));
+record("super-null:", () => inherits(Sub, null));
+record("super-undefined:", () => inherits(Sub, undefined));
+record("super-object:", () => inherits(Sub, {}));
+
+function NullableSub() {}
+const nullableSuper = { prototype: null };
+console.log("nullable return:", inherits(NullableSub, nullableSuper));
+console.log(
+  "nullable result:",
+  NullableSub.super_ === nullableSuper,
+  Object.getPrototypeOf(NullableSub.prototype) === null,
+);
+const superDescriptor = Object.getOwnPropertyDescriptor(NullableSub, "super_");
+console.log(
+  "super descriptor:",
+  superDescriptor?.writable,
+  superDescriptor?.enumerable,
+  superDescriptor?.configurable,
+);


### PR DESCRIPTION
## Summary
- Wire `util.inherits` through native module dispatch and direct native-codegen lowering.
- Implement runtime prototype chaining, `ctor.super_`, and synthetic function-class parent registration so direct `node:util` imports behave like Node.
- Preserve closure dynamic-property descriptor attributes, including the non-enumerable `util.debuglog()` logger `name` property.

## Issue Cluster
Closes #2673.
Closes #3885.
Refs #2514.

These issues share the `node:util` native export path and closure/function descriptor behavior, so batching them keeps the runtime and parity coverage coherent.

## Tests Added
- `test-parity/node-suite/util/inherits/basic.ts`
- `test-parity/node-suite/util/inherits/validation.ts`
- Extended `test-parity/node-suite/util/debuglog/basic.ts` for the logger `name` descriptor.

## Verification
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/util/inherits/basic.ts`
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/util/inherits/validation.ts`
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/util/debuglog/basic.ts`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module util --filter util/inherits`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module util --filter util/debuglog/basic`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module util`
- `cargo check -p perry-runtime --quiet`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`

## Known Limitations / Non-Goals
- This does not change `node:stream` inheritance or any `node:stream` compose behavior.
- This does not attempt a broader cleanup of existing Rust warnings emitted by the checked crates.
