### PR TITLE
fix(http): quiet empty secure-server options

### DIFF
--- a/crates/perry-ext-http-server/src/http2_server.rs
+++ b/crates/perry-ext-http-server/src/http2_server.rs
@@ -40,7 +40,8 @@ use crate::request::{
 use crate::response::{alloc_server_response, HyperResponseShape, ResponseBody};
 use crate::server::{synthesize_default_response_if_needed, HttpPendingRequest, HttpServer};
 use crate::tls::{
-    build_server_config, json_value_to_pem_bytes, parse_cert_chain, parse_private_key,
+    build_server_config, has_pem_material, json_value_to_pem_bytes, parse_cert_chain,
+    parse_private_key,
 };
 
 /// Decode `{ key, cert }` from a NaN-boxed JsValue object. Mirrors
@@ -87,6 +88,7 @@ pub unsafe extern "C" fn js_node_http2_create_secure_server(opts_f64: f64, handl
 
     let (key_pem, cert_pem) = parse_h2_opts(opts_f64);
     let cert_chain = parse_cert_chain(&cert_pem);
+    let has_tls_material = has_pem_material(&key_pem, &cert_pem);
     let private_key = parse_private_key(&key_pem);
 
     let tls_config = match private_key {
@@ -98,7 +100,9 @@ pub unsafe extern "C" fn js_node_http2_create_secure_server(opts_f64: f64, handl
             }
         },
         None => {
-            eprintln!("[node:http2] no recognized PEM private key");
+            if has_tls_material {
+                eprintln!("[node:http2] no recognized PEM private key");
+            }
             None
         }
     };

--- a/crates/perry-ext-http-server/src/https_server.rs
+++ b/crates/perry-ext-http-server/src/https_server.rs
@@ -30,7 +30,8 @@ use crate::request::{
 use crate::response::{alloc_server_response, HyperResponseShape, ResponseBody};
 use crate::server::{HttpPendingRequest, HttpServer};
 use crate::tls::{
-    build_server_config, json_value_to_pem_bytes, parse_cert_chain, parse_private_key,
+    build_server_config, has_pem_material, json_value_to_pem_bytes, parse_cert_chain,
+    parse_private_key,
 };
 
 /// Decode `{ key, cert, alpnProtocols? }` from a NaN-boxed JsValue
@@ -91,10 +92,13 @@ pub unsafe extern "C" fn js_node_https_create_server(opts_f64: f64, handler: i64
     crate::server::apply_server_options(&mut base, opts_f64);
 
     let cert_chain = parse_cert_chain(&cert_pem);
+    let has_tls_material = has_pem_material(&key_pem, &cert_pem);
     let private_key = match parse_private_key(&key_pem) {
         Some(k) => k,
         None => {
-            eprintln!("[node:https] no recognized PEM private key");
+            if has_tls_material {
+                eprintln!("[node:https] no recognized PEM private key");
+            }
             // Still register the handle so the user gets a `.listen`
             // call that fails with a clear bind error rather than a
             // silent zero-handle.

--- a/crates/perry-ext-http-server/src/tls.rs
+++ b/crates/perry-ext-http-server/src/tls.rs
@@ -43,6 +43,13 @@ pub fn json_value_to_pem_bytes(v: Option<&serde_json::Value>) -> Vec<u8> {
     Vec::new()
 }
 
+/// True when a secure-server options object supplied key/cert material worth
+/// parsing. Empty options, omitted fields, and explicitly empty strings all
+/// construct quietly in Node; errors surface later when the server is used.
+pub fn has_pem_material(key_pem: &[u8], cert_pem: &[u8]) -> bool {
+    !key_pem.is_empty() || !cert_pem.is_empty()
+}
+
 /// Parse PEM-encoded certificate chain bytes into rustls
 /// `CertificateDer`s. Returns an empty vec on parse failure (caller
 /// must check for emptiness before building a ServerConfig — empty
@@ -124,6 +131,13 @@ mod tests {
         assert!(json_value_to_pem_bytes(None).is_empty());
         assert!(json_value_to_pem_bytes(Some(&json!(42))).is_empty());
         assert!(json_value_to_pem_bytes(Some(&json!({"foo": "bar"}))).is_empty());
+    }
+
+    #[test]
+    fn pem_material_detection_matches_empty_options_behavior() {
+        assert!(!super::has_pem_material(b"", b""));
+        assert!(super::has_pem_material(b"not pem", b""));
+        assert!(super::has_pem_material(b"", b"not cert"));
     }
 }
 

--- a/test-parity/node-suite/http2/server/empty-secure-options.ts
+++ b/test-parity/node-suite/http2/server/empty-secure-options.ts
@@ -1,0 +1,9 @@
+import * as http2 from "node:http2";
+
+const bare = http2.createSecureServer({});
+console.log("http2 empty secure options typeof:", typeof bare);
+bare.close();
+
+const withListener = http2.createSecureServer({}, (_req: any, _res: any) => {});
+console.log("http2 empty secure options listener typeof:", typeof withListener);
+withListener.close();

--- a/test-parity/node-suite/https/server/empty-options.ts
+++ b/test-parity/node-suite/https/server/empty-options.ts
@@ -1,0 +1,9 @@
+import * as https from "node:https";
+
+const bare = https.createServer({});
+console.log("https empty options typeof:", typeof bare);
+bare.close();
+
+const withListener = https.createServer({}, (_req: any, _res: any) => {});
+console.log("https empty options listener typeof:", typeof withListener);
+withListener.close();


### PR DESCRIPTION
## Summary
- Quiet constructor-time PEM parse warnings for `https.createServer({})` and `http2.createSecureServer({})` when no key/cert material is supplied.
- Keep registering closeable server handles with no TLS config for empty options, preserving the existing listen-time refusal path if the server is actually used.
- Keep warnings for non-empty key/cert material that Perry still attempts to parse.

## Linked Issues
Closes #3849.
Closes #3884.

## Why Batched
Both issues are the same Node compatibility behavior in adjacent secure-server constructors: empty options are valid at construction time and should not trigger PEM parsing output. The fix lives in the shared TLS option/material path used by `node:https` and `node:http2`.

## Tests Added
- `test-parity/node-suite/https/server/empty-options.ts`
- `test-parity/node-suite/http2/server/empty-secure-options.ts`

## Verification
- `npx -y node@25.9.0 --experimental-strip-types test-files/test_parity_https.ts`
- `npx -y node@25.9.0 --experimental-strip-types test-files/test_parity_http2.ts`
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/https/server/empty-options.ts`
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/http2/server/empty-secure-options.ts`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module https --filter empty-options`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module http2 --filter empty-secure-options`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module http2 --filter server`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --filter test_parity_https`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --filter test_parity_http2` fails on existing plaintext `http2.createServer` absence, not the PEM warning.
- `cargo test -p perry-ext-http-server tls --quiet`
- `cargo check -p perry-ext-http-server --quiet`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib -p perry-ext-http-server`

## Known Limitations
- This does not implement plaintext `http2.createServer`; the broad `test_parity_http2` fixture still fails there.
- Full `node-suite` HTTPS coverage still has an unrelated `mirror-surface` mismatch outside this constructor-warning cut.

## Non-Goals
- No changes to TLS handshake behavior, certificate validation fidelity, or invalid non-empty PEM error shapes.
- No HTTP/2 session/stream implementation work.
