### PR TITLE
fix(net): expose Server asyncDispose

### DIFF
--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -1731,6 +1731,18 @@ pub fn is_net_server_handle(handle: i64) -> bool {
     statics::servers().lock().unwrap().contains_key(&handle)
 }
 
+/// `server.listening` — boolean state exposed through handle property dispatch.
+#[no_mangle]
+pub extern "C" fn js_net_server_listening(handle: i64) -> i32 {
+    match statics::servers().lock() {
+        Ok(servers) => servers
+            .get(&handle)
+            .map(|server| if server.listening { 1 } else { 0 })
+            .unwrap_or(0),
+        Err(_) => 0,
+    }
+}
+
 /// `extern "C"` form of `is_net_socket_handle` — used by
 /// perry-stdlib's `common::dispatch::dispatch_handle_method`
 /// (HANDLE_METHOD_DISPATCH) when bundled-net is stripped and

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -1170,6 +1170,29 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
             }
         }
     }
+    // Generic small-handle `Symbol.asyncDispose` support. This must run before
+    // pointer-backed symbol property lookup so small native handles are not
+    // interpreted as heap pointers when the dispatcher owns the method.
+    if (bits >> 48) == 0x7FFD {
+        let id = (bits & 0x0000_FFFF_FFFF_FFFF) as i64;
+        if id > 0 && id < 0x100000 {
+            let async_dispose = well_known_symbol("asyncDispose");
+            if !async_dispose.is_null() {
+                let async_dispose_f64 = f64::from_bits(
+                    crate::value::JSValue::pointer(async_dispose as *const u8).bits(),
+                );
+                if sym_key_from_f64(sym_f64) == sym_key_from_f64(async_dispose_f64) {
+                    if let Some(dispatch) = crate::object::handle_property_dispatch() {
+                        let method = b"@@__perry_wk_asyncDispose";
+                        let v = dispatch(id, method.as_ptr(), method.len());
+                        if v.to_bits() != TAG_UNDEFINED {
+                            return v;
+                        }
+                    }
+                }
+            }
+        }
+    }
     // Web Fetch and other stdlib handle-backed values are small ids
     // NaN-boxed as POINTER. A computed `handle[Symbol.iterator]` reaches the
     // symbol resolver directly, bypassing the normal string-key handle

--- a/crates/perry-stdlib/src/common/net_method_values.rs
+++ b/crates/perry-stdlib/src/common/net_method_values.rs
@@ -24,6 +24,19 @@ fn null() -> f64 {
     f64::from_bits(0x7FFC_0000_0000_0002)
 }
 
+#[cfg(all(
+    not(feature = "bundled-net"),
+    feature = "external-net-pump",
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+fn bool_value(value: bool) -> f64 {
+    const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
+    const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
+
+    f64::from_bits(if value { TAG_TRUE } else { TAG_FALSE })
+}
+
 fn bind_handle_method(handle: i64, name: &'static [u8]) -> f64 {
     extern "C" {
         fn js_class_method_bind(
@@ -107,6 +120,7 @@ fn net_server_method_name(prop: &str) -> Option<&'static [u8]> {
         "listen" => Some(b"listen"),
         "ref" => Some(b"ref"),
         "unref" => Some(b"unref"),
+        "@@__perry_wk_asyncDispose" => Some(b"@@__perry_wk_asyncDispose"),
         "on" => Some(b"on"),
         "addListener" => Some(b"addListener"),
         "once" => Some(b"once"),
@@ -163,6 +177,22 @@ pub(crate) fn dispatch_property(handle: i64, property_name: &str) -> Option<f64>
         }
     }
 
+    #[cfg(all(
+        not(feature = "bundled-net"),
+        feature = "external-net-pump",
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
+    if property_name == "listening" {
+        extern "C" {
+            fn js_ext_net_is_server_handle(handle: i64) -> i32;
+            fn js_net_server_listening(handle: i64) -> i32;
+        }
+        if unsafe { js_ext_net_is_server_handle(handle) } != 0 {
+            return Some(bool_value(unsafe { js_net_server_listening(handle) } != 0));
+        }
+    }
+
     None
 }
 
@@ -211,6 +241,11 @@ pub(crate) unsafe fn dispatch_external_server_method(
             let callback = args.first().copied().map(unbox_to_i64).unwrap_or(0);
             js_net_server_close(handle, callback);
             nanbox_handle(handle)
+        }
+        "@@__perry_wk_asyncDispose" => {
+            js_net_server_close(handle, 0);
+            let promise = perry_runtime::js_promise_resolved(undefined());
+            perry_runtime::js_nanbox_pointer(promise as i64)
         }
         "address" => json_str_to_value(js_net_server_address(handle)),
         "on" | "addListener" if args.len() >= 2 => {

--- a/test-parity/node-suite/net/method-values/server-async-dispose.ts
+++ b/test-parity/node-suite/net/method-values/server-async-dispose.ts
@@ -1,0 +1,12 @@
+import * as net from "node:net";
+
+const server = new net.Server();
+
+console.log("asyncDispose typeof:", typeof server[Symbol.asyncDispose]);
+console.log("listening before:", (server as any)["listening"]);
+
+const result = server[Symbol.asyncDispose]();
+console.log("asyncDispose result then:", typeof result?.then);
+
+await result;
+console.log("asyncDispose resolved:", (server as any)["listening"], (server as any).closed);


### PR DESCRIPTION
## Summary
- Closes #3850.
- Routes small native handles through `Symbol.asyncDispose` property dispatch before pointer-backed symbol lookup.
- Adds `net.Server` async-dispose dispatch that closes the server and returns a resolved promise.
- Exposes dynamic `server["listening"]` as a boolean through the external-net handle property dispatcher so async-dispose lifecycle probes match Node.

## PR cut
This is a single-issue cut because #3850 is a focused crash in computed well-known-symbol lookup for `node:net` server handles. Broader `node:net` surface gaps use different implementation paths and are left out of scope.

## Tests
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/net/method-values/server-async-dispose.ts`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module net --filter server-async-dispose`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module net --filter method-values`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module net`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --filter test_parity_net` (still mismatches existing BlockList/SocketAddress and dotted `server.listening` gaps, but no longer segfaults at `Server[Symbol.asyncDispose]`)
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib -p perry-ext-net`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`

## Known limitations
- This does not implement the remaining `node:net` BlockList, SocketAddress, socket TOS, or typed dotted `server.listening` parity gaps.

## Non-goals
- No changes to `node:stream`, `node:stream/web`, or `node:stream/promises`.
- No broad `node:net` surface expansion beyond the async-dispose crash path.