### PR TITLE
Fix global URL constructor values

### DIFF
--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -10,6 +10,16 @@ use crate::native_value::{
 };
 use crate::types::{I32, I64, I8, PTR};
 
+fn is_global_this_value(expr: &perry_hir::Expr) -> bool {
+    matches!(expr, perry_hir::Expr::GlobalGet(_))
+        || matches!(
+            expr,
+            perry_hir::Expr::PropertyGet { object, property }
+                if matches!(object.as_ref(), perry_hir::Expr::GlobalGet(_))
+                    && property == "globalThis"
+        )
+}
+
 pub(crate) fn lower_let(
     ctx: &mut FnCtx<'_>,
     id: u32,
@@ -99,10 +109,16 @@ pub(crate) fn lower_let(
         // X to a class alias so `new X(args)` dispatches to the
         // real class instead of the empty-object placeholder.
         Some(perry_hir::Expr::PropertyGet { object, property }) => {
-            if matches!(object.as_ref(), perry_hir::Expr::GlobalGet(_))
+            if is_global_this_value(object.as_ref())
                 && matches!(
                     property.as_str(),
-                    "TextEncoderStream" | "TextDecoderStream" | "File"
+                    "URL"
+                        | "URLSearchParams"
+                        | "TextEncoder"
+                        | "TextDecoder"
+                        | "TextEncoderStream"
+                        | "TextDecoderStream"
+                        | "File"
                 )
             {
                 ctx.local_class_aliases

--- a/crates/perry-hir/src/destructuring/pattern_binding.rs
+++ b/crates/perry-hir/src/destructuring/pattern_binding.rs
@@ -2,6 +2,16 @@
 
 use super::*;
 
+fn is_global_this_value(expr: &Expr) -> bool {
+    matches!(expr, Expr::GlobalGet(_))
+        || matches!(
+            expr,
+            Expr::PropertyGet { object, property }
+                if matches!(object.as_ref(), Expr::GlobalGet(_))
+                    && property == "globalThis"
+        )
+}
+
 /// Recursively lower a binding pattern against a source expression, producing
 /// `Let` statements that declare each bound variable.
 ///
@@ -121,6 +131,7 @@ pub(crate) fn lower_pattern_binding_into(
         }
         ast::Pat::Object(obj_pat) => {
             // Materialize source into a temp
+            let source_is_global_this = is_global_this_value(&source);
             let obj_ty = obj_pat
                 .type_ann
                 .as_ref()
@@ -147,6 +158,19 @@ pub(crate) fn lower_pattern_binding_into(
                             ast::PropName::Ident(ident) => {
                                 let key = ident.sym.to_string();
                                 static_keys.push(key.clone());
+                                if source_is_global_this
+                                    && matches!(
+                                        key.as_str(),
+                                        "URL" | "URLSearchParams" | "TextEncoder" | "TextDecoder"
+                                    )
+                                {
+                                    if let ast::Pat::Ident(alias) = kv.value.as_ref() {
+                                        ctx.register_let_class_alias(
+                                            alias.id.sym.to_string(),
+                                            key.clone(),
+                                        );
+                                    }
+                                }
                                 Expr::PropertyGet {
                                     object: Box::new(Expr::LocalGet(tmp_id)),
                                     property: key,
@@ -155,6 +179,19 @@ pub(crate) fn lower_pattern_binding_into(
                             ast::PropName::Str(s) => {
                                 let key = s.value.as_str().unwrap_or("").to_string();
                                 static_keys.push(key.clone());
+                                if source_is_global_this
+                                    && matches!(
+                                        key.as_str(),
+                                        "URL" | "URLSearchParams" | "TextEncoder" | "TextDecoder"
+                                    )
+                                {
+                                    if let ast::Pat::Ident(alias) = kv.value.as_ref() {
+                                        ctx.register_let_class_alias(
+                                            alias.id.sym.to_string(),
+                                            key.clone(),
+                                        );
+                                    }
+                                }
                                 Expr::PropertyGet {
                                     object: Box::new(Expr::LocalGet(tmp_id)),
                                     property: key,
@@ -185,6 +222,14 @@ pub(crate) fn lower_pattern_binding_into(
                         // Shorthand { key } or { key = default }
                         let name = assign.key.sym.to_string();
                         static_keys.push(name.clone());
+                        if source_is_global_this
+                            && matches!(
+                                name.as_str(),
+                                "URL" | "URLSearchParams" | "TextEncoder" | "TextDecoder"
+                            )
+                        {
+                            ctx.register_let_class_alias(name.clone(), name.clone());
+                        }
                         let ty = assign
                             .key
                             .type_ann

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -2,6 +2,16 @@
 
 use super::*;
 
+fn is_global_this_value(expr: &Expr) -> bool {
+    matches!(expr, Expr::GlobalGet(_))
+        || matches!(
+            expr,
+            Expr::PropertyGet { object, property }
+                if matches!(object.as_ref(), Expr::GlobalGet(_))
+                    && property == "globalThis"
+        )
+}
+
 /// Lower a variable declaration, handling array destructuring patterns.
 /// Returns a vector of statements (multiple for destructuring, single for simple bindings).
 pub(crate) fn lower_var_decl_with_destructuring(
@@ -1589,11 +1599,21 @@ pub(crate) fn lower_var_decl_with_destructuring(
                         }
                     }
                     Expr::PropertyGet { object, property }
-                        if matches!(object.as_ref(), Expr::GlobalGet(_))
-                            && matches!(property.as_str(), "Blob" | "File") =>
+                        if is_global_this_value(object.as_ref())
+                            && matches!(
+                                property.as_str(),
+                                "URL"
+                                    | "URLSearchParams"
+                                    | "TextEncoder"
+                                    | "TextDecoder"
+                                    | "Blob"
+                                    | "File"
+                            ) =>
                     {
                         ctx.register_let_class_alias(name.clone(), property.clone());
-                        ctx.uses_fetch = true;
+                        if matches!(property.as_str(), "Blob" | "File") {
+                            ctx.uses_fetch = true;
+                        }
                     }
                     Expr::PropertyGet { object, property }
                         if matches!(object.as_ref(), Expr::NativeModuleRef(module)

--- a/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
@@ -16,15 +16,21 @@ use super::super::{
     resolve_typed_parse_ty, LoweringContext,
 };
 
-fn new_callee_name<'a>(ctx: &LoweringContext, new_expr: &'a ast::NewExpr) -> Option<&'a str> {
+fn new_callee_name(ctx: &LoweringContext, new_expr: &ast::NewExpr) -> Option<String> {
     match new_expr.callee.as_ref() {
-        ast::Expr::Ident(class_ident) => Some(class_ident.sym.as_ref()),
+        ast::Expr::Ident(class_ident) => {
+            let raw = class_ident.sym.as_ref();
+            Some(
+                ctx.resolve_class_alias(raw)
+                    .unwrap_or_else(|| raw.to_string()),
+            )
+        }
         ast::Expr::Member(member)
             if matches!(member.obj.as_ref(), ast::Expr::Ident(obj) if obj.sym.as_ref() == "globalThis")
                 && ctx.lookup_local("globalThis").is_none() =>
         {
             match &member.prop {
-                ast::MemberProp::Ident(prop_ident) => Some(prop_ident.sym.as_ref()),
+                ast::MemberProp::Ident(prop_ident) => Some(prop_ident.sym.to_string()),
                 _ => None,
             }
         }

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -140,6 +140,13 @@ fn lower_url_encoding_constructor(
     }
 }
 
+fn is_url_encoding_constructor_name(name: &str) -> bool {
+    matches!(
+        name,
+        "URL" | "URLSearchParams" | "TextEncoder" | "TextDecoder"
+    )
+}
+
 fn module_constructor_name(module_name: &str, method_name: Option<&str>) -> Option<&'static str> {
     match (module_name, method_name) {
         ("url", Some("URL")) => Some("URL"),
@@ -630,6 +637,16 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 if let Some(class_name) = module_constructor_name(module_name, method_name) {
                     if let Some(expr) =
                         lower_url_encoding_constructor(ctx, class_name, new_expr.args.as_deref())?
+                    {
+                        return Ok(expr);
+                    }
+                }
+            }
+
+            if let Some(resolved) = ctx.resolve_class_alias(&class_name) {
+                if is_url_encoding_constructor_name(&resolved) {
+                    if let Some(expr) =
+                        lower_url_encoding_constructor(ctx, &resolved, new_expr.args.as_deref())?
                     {
                         return Ok(expr);
                     }

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -154,6 +154,11 @@ fn url_encoding_constructor_type(ctx: &LoweringContext, callee: &ast::Expr) -> O
             if let Some(ty) = class_type(name) {
                 return Some(ty);
             }
+            if let Some(resolved) = ctx.resolve_class_alias(name) {
+                if let Some(ty) = class_type(&resolved) {
+                    return Some(ty);
+                }
+            }
             ctx.lookup_native_module(name)
                 .and_then(|(module_name, method_name)| {
                     module_constructor_type(module_name, method_name)

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1125,6 +1125,11 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         let name_key =
             crate::string::js_string_from_bytes(name_bytes.as_ptr(), name_bytes.len() as u32);
         js_object_set_field_by_name(singleton, name_key, ctor_value);
+        super::set_builtin_property_attrs(
+            singleton as usize,
+            name.to_string(),
+            super::PropertyAttrs::new(true, false, true),
+        );
     }
     // Callable global functions: ClosureHeader-backed values with real
     // dispatch so direct property reads and rebound calls match bare calls.
@@ -1423,6 +1428,40 @@ extern "C" fn array_of_thunk(_closure: *const crate::closure::ClosureHeader, res
     crate::value::js_nanbox_pointer(arr as i64)
 }
 
+extern "C" fn url_can_parse_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    input: f64,
+    base: f64,
+) -> f64 {
+    let input_ptr = crate::url::js_url_coerce_string(input);
+    let ok = if base.to_bits() == crate::value::TAG_UNDEFINED {
+        crate::url::js_url_can_parse(input_ptr)
+    } else {
+        let base_ptr = crate::url::js_url_coerce_string(base);
+        crate::url::js_url_can_parse_with_base(input_ptr, base_ptr)
+    };
+    f64::from_bits(crate::value::JSValue::bool(ok != 0).bits())
+}
+
+extern "C" fn url_parse_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    input: f64,
+    base: f64,
+) -> f64 {
+    let input_ptr = crate::url::js_url_coerce_string(input);
+    let url = if base.to_bits() == crate::value::TAG_UNDEFINED {
+        crate::url::js_url_parse(input_ptr)
+    } else {
+        let base_ptr = crate::url::js_url_coerce_string(base);
+        crate::url::js_url_parse_with_base(input_ptr, base_ptr)
+    };
+    if url.is_null() {
+        f64::from_bits(crate::value::TAG_NULL)
+    } else {
+        crate::value::js_nanbox_pointer(url as i64)
+    }
+}
+
 /// Install a single callable static method on a constructor closure as a
 /// `{ writable: true, enumerable: false, configurable: true }` data property
 /// (matching Node's descriptors for built-in statics). `has_rest` registers
@@ -1536,6 +1575,16 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
             );
             install_constructor_static(ctor, "from", array_from_thunk as *const u8, 1, false);
             install_constructor_static(ctor, "of", array_of_thunk as *const u8, 0, true);
+        }
+        "URL" => {
+            install_constructor_static(
+                ctor,
+                "canParse",
+                url_can_parse_thunk as *const u8,
+                1,
+                false,
+            );
+            install_constructor_static(ctor, "parse", url_parse_thunk as *const u8, 1, false);
         }
         _ => {}
     }

--- a/test-parity/node-suite/globals/url-constructor-values.ts
+++ b/test-parity/node-suite/globals/url-constructor-values.ts
@@ -1,0 +1,45 @@
+import { URL as ModuleURL, URLSearchParams as ModuleURLSearchParams } from "node:url";
+
+const g = globalThis as any;
+
+for (const name of ["URL", "URLSearchParams"]) {
+  const desc = Object.getOwnPropertyDescriptor(globalThis, name)!;
+  console.log(
+    name,
+    "descriptor:",
+    desc.writable,
+    desc.enumerable,
+    desc.configurable,
+    typeof desc.value,
+    desc.value.name,
+    Object.keys(globalThis).includes(name),
+  );
+}
+
+console.log("URL identity:", ModuleURL === URL, ModuleURL === g.URL);
+console.log(
+  "URLSearchParams identity:",
+  ModuleURLSearchParams === URLSearchParams,
+  ModuleURLSearchParams === g.URLSearchParams,
+);
+
+console.log(
+  "global canParse:",
+  g.URL.canParse("https://example.com/a"),
+  typeof g.URL.canParse("https://example.com/a"),
+  g.URL.canParse("not a url"),
+);
+console.log("global parse invalid:", g.URL.parse("not a url"));
+console.log("global parse valid:", g.URL.parse("https://example.com/a?b=1")?.href);
+
+const ReboundURL = globalThis.URL;
+const ReboundURLSearchParams = globalThis.URLSearchParams;
+console.log("rebound URL:", new ReboundURL("/p", "https://example.com/base").href);
+console.log("rebound params:", new ReboundURLSearchParams("a=1").get("a"));
+
+const { URL: DestructuredURL, URLSearchParams: DestructuredURLSearchParams } = globalThis as any;
+console.log("destructured URL:", new DestructuredURL("https://example.com/d").href);
+console.log("destructured params:", new DestructuredURLSearchParams("b=2").get("b"));
+
+console.log("chained rebound params:", new ReboundURLSearchParams("c=3").get("c"));
+console.log("chained destructured params:", new DestructuredURLSearchParams("d=4").get("d"));


### PR DESCRIPTION
Closes #2586

## Summary
- install global URL and URLSearchParams constructors with Node-like non-enumerable global descriptors
- expose global URL.canParse and URL.parse as real constructor statics returning Node-shaped values
- recognize rebound and destructured global URL/URLSearchParams constructor aliases so `new USP("a=1").get("a")` lowers correctly
- add a focused globals parity fixture for descriptors, constructor identity, URL static invariants, and rebound/destructured constructor behavior

## DeepWiki
- Reference saved at `/tmp/perry-deepwiki-2586-url-globals.md`

## Verification
- `node --experimental-strip-types test-parity/node-suite/globals/url-constructor-values.ts`
- `./run_parity_tests.sh --suite node-suite --module globals --filter url-constructor-values`
- `./run_parity_tests.sh --suite node-suite --module url --filter static-can-parse`
- `./run_parity_tests.sh --suite node-suite --module url --filter static-parse`
- `./run_parity_tests.sh --suite node-suite --module globals --filter url-encoding-global-constructors`
- `cargo check -p perry-runtime -p perry-hir -p perry-codegen`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known limitations
- None known.