### PR TITLE
Reject invalid node:http2 named imports (#3922)

### DIFF
--- a/crates/perry-api-manifest/src/lib.rs
+++ b/crates/perry-api-manifest/src/lib.rs
@@ -369,7 +369,10 @@ fn is_node_core_private_named_export(module: &str, name: &str) -> bool {
         "url" => matches!(name, "createObjectURL" | "revokeObjectURL"),
         "worker_threads" => name == "getWorkerData",
         "https" => matches!(name, "ClientRequest" | "IncomingMessage" | "ServerResponse"),
-        "http2" => name == "Http2SecureServer",
+        "http2" => matches!(
+            name,
+            "Http2SecureServer" | "listen" | "close" | "on" | "address"
+        ),
         "child_process" => name == "Stream",
         "cluster" => matches!(name, "addListener" | "on" | "worker"),
         "stream" => matches!(name, "from" | "fromWeb" | "prototype" | "toWeb"),
@@ -895,7 +898,10 @@ mod tests {
                 "https",
                 &["ClientRequest", "IncomingMessage", "ServerResponse"][..],
             ),
-            ("http2", &["Http2SecureServer"][..]),
+            (
+                "http2",
+                &["Http2SecureServer", "listen", "close", "on", "address"][..],
+            ),
             ("child_process", &["Stream"][..]),
             ("cluster", &["addListener", "on", "worker"][..]),
             ("stream", &["from", "fromWeb", "prototype", "toWeb"][..]),

--- a/crates/perry-hir/tests/node_named_export_hygiene.rs
+++ b/crates/perry-hir/tests/node_named_export_hygiene.rs
@@ -59,6 +59,10 @@ fn invalid_node_named_imports_are_rejected() {
             r#"import { Http2SecureServer } from "node:http2"; console.log(Http2SecureServer);"#,
         ),
         (
+            "http2 receiver methods",
+            r#"import { listen, close, on, address } from "node:http2"; console.log("should-not-run", listen, close, on, address);"#,
+        ),
+        (
             "child_process",
             r#"import { Stream } from "node:child_process"; console.log(Stream);"#,
         ),

--- a/tests/test_issue_3922_http2_named_imports.sh
+++ b/tests/test_issue_3922_http2_named_imports.sh
@@ -23,13 +23,18 @@ MARKER="$TMPDIR/executed"
 cat >"$TMPDIR/invalid-http2-imports.ts" <<TS
 import { Http2SecureServer, listen, close, on, address } from "node:http2";
 import { writeFileSync } from "node:fs";
+import { env } from "node:process";
 
-writeFileSync(${MARKER@Q}, "executed");
+const marker = env.ISSUE_3922_MARKER;
+if (marker === undefined) {
+    throw new Error("missing ISSUE_3922_MARKER");
+}
+writeFileSync(marker, "executed");
 console.log(Http2SecureServer, listen, close, on, address);
 TS
 
 set +e
-env PERRY_NO_AUTO_OPTIMIZE=1 "$PERRY" compile --no-cache \
+env PERRY_NO_AUTO_OPTIMIZE=1 ISSUE_3922_MARKER="$MARKER" "$PERRY" compile --no-cache \
     "$TMPDIR/invalid-http2-imports.ts" -o "$TMPDIR/invalid-http2-imports" \
     >"$TMPDIR/compile.log" 2>&1
 compile_rc=$?

--- a/tests/test_issue_3922_http2_named_imports.sh
+++ b/tests/test_issue_3922_http2_named_imports.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Regression for #3922: invalid node:http2 named imports must fail during
+# import validation, before a compiled program can execute.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build --release -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+MARKER="$TMPDIR/executed"
+cat >"$TMPDIR/invalid-http2-imports.ts" <<TS
+import { Http2SecureServer, listen, close, on, address } from "node:http2";
+import { writeFileSync } from "node:fs";
+
+writeFileSync(${MARKER@Q}, "executed");
+console.log(Http2SecureServer, listen, close, on, address);
+TS
+
+set +e
+env PERRY_NO_AUTO_OPTIMIZE=1 "$PERRY" compile --no-cache \
+    "$TMPDIR/invalid-http2-imports.ts" -o "$TMPDIR/invalid-http2-imports" \
+    >"$TMPDIR/compile.log" 2>&1
+compile_rc=$?
+set -e
+
+if [[ "$compile_rc" -eq 0 ]]; then
+    echo "FAIL: invalid node:http2 named imports compiled"
+    exit 1
+fi
+
+if [[ -e "$MARKER" ]]; then
+    echo "FAIL: invalid node:http2 named import fixture executed"
+    exit 1
+fi
+
+if ! grep -q "does not provide an export named" "$TMPDIR/compile.log"; then
+    echo "FAIL: compile failed for the wrong reason"
+    sed 's/^/    /' "$TMPDIR/compile.log" | tail -80
+    exit 1
+fi
+
+echo "PASS"


### PR DESCRIPTION
Summary:
- Mark node:http2 Http2SecureServer and receiver methods as private named exports.
- Extend named-export hygiene coverage for invalid http2 receiver-method imports.
- Add a shell regression that asserts invalid http2 named imports fail during compile/import validation before execution.
- Make the shell regression portable to Bash 3.2 by passing the marker path through ISSUE_3922_MARKER instead of using ${var@Q} expansion.

Tests:
- bash -n tests/test_issue_3922_http2_named_imports.sh
- cargo fmt --all -- --check
- cargo test -p perry-api-manifest dispatch_only_node_members_are_not_module_exports
- cargo test -p perry-hir node_named_export_hygiene (completed; Cargo filter matched 0 tests)
- cargo test -p perry-hir --test node_named_export_hygiene
- cargo build -p perry
- PERRY=target/debug/perry ./tests/test_issue_3922_http2_named_imports.sh
- git diff --check