### PR TITLE
Fix crypto.generateKeySync AES KeyObject metadata (#3927)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -3121,6 +3121,13 @@ pub extern "C" fn js_object_get_field_ic_miss(
         if let Some(val) = closure_dynamic_prop_by_key(obj as usize, key) {
             return val;
         }
+        // Buffers have no GcHeader. The generic IC-miss object path below may
+        // inspect GC/object metadata, so mirror js_object_get_field_by_name's
+        // buffer-first dispatch here.
+        if crate::buffer::is_registered_buffer(obj as usize) {
+            let value = js_object_get_field_by_name(obj, key);
+            return f64::from_bits(value.bits());
+        }
     }
     // Issue #340: small-handle receivers (axios, fastify, ioredis,
     // ...) are passed here from the codegen IC miss path with the
@@ -3315,6 +3322,60 @@ mod sso_tests_1781 {
                 0,
                 "absent SSO key 'zz' should not be found"
             );
+        }
+    }
+}
+
+#[cfg(test)]
+mod buffer_ic_miss_tests {
+    use super::*;
+
+    unsafe fn key(bytes: &[u8]) -> *const crate::StringHeader {
+        crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
+    }
+
+    unsafe fn string_value_bytes(value: f64) -> Vec<u8> {
+        let bits = value.to_bits();
+        assert_eq!((bits >> 48) as u16, 0x7fff);
+        let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const crate::StringHeader;
+        let data = (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        std::slice::from_raw_parts(data, (*ptr).byte_len as usize).to_vec()
+    }
+
+    unsafe fn secret_buffer(len: usize) -> *mut crate::buffer::BufferHeader {
+        let buf = crate::buffer::buffer_alloc(len as u32);
+        (*buf).length = len as u32;
+        crate::buffer::mark_as_uint8array(buf as usize);
+        crate::buffer::mark_as_secret_key(buf as usize);
+        buf
+    }
+
+    #[test]
+    fn secret_key_buffer_metadata_survives_ic_miss_for_aes_sizes() {
+        unsafe {
+            for len in [16usize, 24, 32] {
+                let buf = secret_buffer(len);
+                let mut cache = [0i64; 2];
+
+                let ty = js_object_get_field_ic_miss(
+                    buf as *const ObjectHeader,
+                    key(b"type"),
+                    &mut cache,
+                );
+                assert_eq!(string_value_bytes(ty), b"secret");
+
+                let size = js_object_get_field_ic_miss(
+                    buf as *const ObjectHeader,
+                    key(b"symmetricKeySize"),
+                    &mut cache,
+                );
+                assert_eq!(size, len as f64);
+
+                let raw = dispatch_buffer_method(buf as usize, "export", std::ptr::null(), 0);
+                let raw_addr = (raw.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *const ObjectHeader;
+                let raw_len = js_object_get_field_ic_miss(raw_addr, key(b"length"), &mut cache);
+                assert_eq!(raw_len, len as f64);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- route buffer receivers through buffer-aware property lookup on inline-cache misses before any GC/object metadata inspection
- add a focused runtime regression covering 16/24/32-byte secret keys for type, symmetricKeySize, and raw export length

## Tests
- cargo test -p perry-runtime secret_key_buffer_metadata_survives_ic_miss_for_aes_sizes
- node test-parity/node-suite/crypto/secret-key/generate-key-sync.ts

## Notes
- The Perry parity fixture compile was attempted with the debug compiler path, but this container only has clang 14, which rejects the generated opaque-pointer LLVM IR before linking. No release build was run.