### PR TITLE
fix(path): expose submodule default namespaces

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
+++ b/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
@@ -464,6 +464,14 @@ fn is_path_root(ctx: &LoweringContext, root_name: &str) -> bool {
             .unwrap_or(false)
 }
 
+fn path_submodule_name(module_name: &str) -> Option<&'static str> {
+    match module_name {
+        "path/posix" | "path.posix" => Some("posix"),
+        "path/win32" | "path.win32" => Some("win32"),
+        _ => None,
+    }
+}
+
 /// Core dispatch for `path.<sub>.<method>(...)` where `sub` is `"win32"` or
 /// `"posix"`. Shared by the direct member form and the aliased-local form
 /// (`const w = path.win32; w.<method>(...)`, #1750). Returns `Err(args)` when
@@ -640,10 +648,23 @@ pub(super) fn try_path_subnamespace(
     // root identifier resolves to the path module.
     if let ast::Expr::Member(inner_member) = outer_member.obj.as_ref() {
         if let ast::Expr::Ident(root_ident) = inner_member.obj.as_ref() {
-            if is_path_root(ctx, root_ident.sym.as_ref()) {
-                if let ast::MemberProp::Ident(sub_prop) = &inner_member.prop {
-                    let sub = sub_prop.sym.as_ref();
+            if let ast::MemberProp::Ident(sub_prop) = &inner_member.prop {
+                let sub = sub_prop.sym.as_ref();
+                let root_name = root_ident.sym.as_ref();
+                if is_path_root(ctx, root_name) {
                     if sub == "posix" || sub == "win32" {
+                        return dispatch_path_subnamespace(sub, method, args);
+                    }
+                }
+                if let Some((module_name, _)) = ctx.lookup_native_module(root_name) {
+                    if let Some(root_sub) = path_submodule_name(
+                        module_name.strip_prefix("node:").unwrap_or(module_name),
+                    ) {
+                        let sub = match sub {
+                            "default" => root_sub,
+                            "posix" | "win32" => sub,
+                            _ => return Err(args),
+                        };
                         return dispatch_path_subnamespace(sub, method, args);
                     }
                 }

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -117,6 +117,8 @@ fn is_cjs_style_native_default_import(module_name: &str) -> bool {
             | "events"
             | "os"
             | "path"
+            | "path/posix"
+            | "path/win32"
             | "punycode"
             | "querystring"
             | "sys"

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -21,6 +21,8 @@ fn is_cjs_style_native_default_import(module_name: &str) -> bool {
             | "events"
             | "os"
             | "path"
+            | "path/posix"
+            | "path/win32"
             | "punycode"
             | "querystring"
             | "sys"

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1318,8 +1318,8 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
         // Deprecated path alias enumerable on the top-level and style
         // sub-namespaces, matching Node's `Object.keys(...).includes`.
         "path" => Some(PATH_NAMESPACE_KEYS),
-        "path.default" => Some(PATH_DEFAULT_KEYS),
-        "path.posix" | "path.win32" => Some(&[b"_makeLong"]),
+        "path.default" | "path.posix.default" | "path.win32.default" => Some(PATH_DEFAULT_KEYS),
+        "path.posix" | "path.win32" => Some(PATH_NAMESPACE_KEYS),
         "fs" => Some(FS_NAMESPACE_KEYS),
         "constants" => Some(deprecated_constants_keys()),
         "buffer" => Some(BUFFER_NAMESPACE_KEYS),
@@ -1386,6 +1386,8 @@ fn cjs_default_base_module(module_name: &str) -> Option<&'static str> {
         "async_hooks.default" => Some("async_hooks"),
         "os.default" => Some("os"),
         "path.default" => Some("path"),
+        "path.posix.default" => Some("path.posix"),
+        "path.win32.default" => Some("path.win32"),
         "punycode.default" => Some("punycode"),
         "querystring.default" => Some("querystring"),
         "url.default" => Some("url"),
@@ -1399,6 +1401,8 @@ fn cjs_default_namespace_name(module_name: &str) -> Option<&'static str> {
         "async_hooks" => Some("async_hooks.default"),
         "os" => Some("os.default"),
         "path" => Some("path.default"),
+        "path.posix" => Some("path.posix.default"),
+        "path.win32" => Some("path.win32.default"),
         "punycode" => Some("punycode.default"),
         "querystring" => Some("querystring.default"),
         "url" => Some("url.default"),
@@ -1415,9 +1419,8 @@ fn create_cjs_default_namespace(module_name: &str) -> Option<f64> {
 fn cjs_default_export_value(module_name: &str) -> Option<f64> {
     match module_name {
         "events" => Some(bound_native_callable_export_value("events", "EventEmitter")),
-        "async_hooks" | "os" | "path" | "punycode" | "querystring" | "url" | "util" => {
-            create_cjs_default_namespace(module_name)
-        }
+        "async_hooks" | "os" | "path" | "path.posix" | "path.win32" | "punycode"
+        | "querystring" | "url" | "util" => create_cjs_default_namespace(module_name),
         _ => None,
     }
 }
@@ -1446,6 +1449,8 @@ fn should_cache_native_module_namespace(module_name: &str) -> bool {
             | "os.default"
             | "path"
             | "path.default"
+            | "path.posix.default"
+            | "path.win32.default"
             | "punycode"
             | "punycode.default"
             | "punycode.ucs2"
@@ -4584,30 +4589,32 @@ pub(crate) unsafe fn get_native_module_constant(
                 "path",
                 "toNamespacedPath",
             )),
-            "posix" => Some(create_sub_namespace("path.posix")),
-            "win32" => Some(create_sub_namespace("path.win32")),
+            "posix" => cjs_default_export_value("path.posix"),
+            "win32" => cjs_default_export_value("path.win32"),
             _ => None,
         },
         "path.posix" => match property {
+            "default" if !is_cjs_default_object => cjs_default_export_value("path.posix"),
             "sep" => Some(str_val("/")),
             "delimiter" => Some(str_val(":")),
             "toNamespacedPath" | "_makeLong" => Some(bound_native_callable_export_value(
                 "path.posix",
                 "toNamespacedPath",
             )),
-            "posix" => Some(native_namespace_or_create("path.posix", namespace_obj)),
-            "win32" => Some(create_sub_namespace("path.win32")),
+            "posix" => cjs_default_export_value("path.posix"),
+            "win32" => cjs_default_export_value("path.win32"),
             _ => None,
         },
         "path.win32" => match property {
+            "default" if !is_cjs_default_object => cjs_default_export_value("path.win32"),
             "sep" => Some(str_val("\\")),
             "delimiter" => Some(str_val(";")),
             "toNamespacedPath" | "_makeLong" => Some(bound_native_callable_export_value(
                 "path.win32",
                 "toNamespacedPath",
             )),
-            "posix" => Some(create_sub_namespace("path.posix")),
-            "win32" => Some(native_namespace_or_create("path.win32", namespace_obj)),
+            "posix" => cjs_default_export_value("path.posix"),
+            "win32" => cjs_default_export_value("path.win32"),
             _ => None,
         },
         "fs" => match property {

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -141,6 +141,8 @@ pub(crate) unsafe fn dispatch_native_module_method(
         "async_hooks.default" => "async_hooks",
         "os.default" => "os",
         "path.default" => "path",
+        "path.posix.default" => "path.posix",
+        "path.win32.default" => "path.win32",
         "querystring.default" => "querystring",
         "url.default" => "url",
         "util.default" => "util",

--- a/test-parity/node-suite/path/submodules/direct-imports.ts
+++ b/test-parity/node-suite/path/submodules/direct-imports.ts
@@ -18,3 +18,19 @@ console.log(
   win32Ns.win32 === win32Default,
 );
 console.log("default methods:", posixDefault.normalize("/a//b"), win32Default.join("C:\\a", "b"));
+console.log(
+  "namespace default identity:",
+  posixNs.default === posixDefault,
+  win32Ns.default === win32Default,
+);
+console.log("namespace default methods:", posixNs.default.join("a", "b"), win32Ns.default.join("a", "b"));
+console.log(
+  "namespace keys:",
+  Object.keys(posixNs).slice(0, 4).join(","),
+  Object.keys(win32Ns).slice(0, 4).join(","),
+);
+console.log(
+  "default keys:",
+  Object.keys(posixDefault).slice(0, 4).join(","),
+  Object.keys(win32Default).slice(0, 4).join(","),
+);


### PR DESCRIPTION
Summary:
- Add CJS default namespace objects for `node:path/posix` and `node:path/win32`.
- Make submodule default imports, `namespace.default`, and `path.posix` / `path.win32` cross-links converge on the same default objects with Node-compatible enumerable keys.
- Extend path subnamespace call lowering so `posixNs.default.join(...)` and related cross-links dispatch through the existing POSIX/Win32 path paths.

Why this cut:
- The affected behavior is one coherent `node:path` submodule export shape: default identity, enumerable namespace/default keys, and method calls through those default objects.

Tests:
- `/tmp/perry-node25-bin/node --experimental-strip-types --no-deprecation test-parity/node-suite/path/submodules/direct-imports.ts`
- `target/release/perry test-parity/node-suite/path/submodules/direct-imports.ts && ./direct-imports`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module path --filter direct-imports`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module path --filter default-import`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module path --filter local-alias`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module path --filter method-dispatch`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module path --filter normalize-format`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

Known limitations / non-goals:
- This does not change path algorithm semantics; it only fixes submodule namespace/default object wiring and dispatch through those objects.
- `test-parity/known_failures.json` is unchanged.

Closes #3934
