### PR TITLE
fix(module): hide wrapper helpers from named exports

### DIFF
--- a/crates/perry-api-manifest/src/lib.rs
+++ b/crates/perry-api-manifest/src/lib.rs
@@ -292,7 +292,7 @@ pub fn is_node_core_module(module: &str) -> bool {
 }
 
 /// Public named-export filter shared by the import gate and docs emitters.
-pub(crate) fn entry_is_public_named_export(entry: &ApiEntry) -> bool {
+pub fn entry_is_public_named_export(entry: &ApiEntry) -> bool {
     if is_node_core_private_named_export(entry.module, entry.name) {
         return false;
     }
@@ -367,6 +367,7 @@ fn is_node_core_private_named_export(module: &str, name: &str) -> bool {
                 | "setMaxListeners"
         ),
         "url" => matches!(name, "createObjectURL" | "revokeObjectURL"),
+        "module" => matches!(name, "wrap" | "wrapper"),
         "worker_threads" => name == "getWorkerData",
         "https" => matches!(name, "ClientRequest" | "IncomingMessage" | "ServerResponse"),
         "http2" => name == "Http2SecureServer",
@@ -518,6 +519,8 @@ mod tests {
             ("node:tty", "clearLine"),
             ("node:process", "on"),
             ("node:process", "emit"),
+            ("node:module", "wrap"),
+            ("node:module", "wrapper"),
             ("node:url", "createObjectURL"),
             ("node:worker_threads", "getWorkerData"),
             ("node:https", "ClientRequest"),
@@ -549,6 +552,8 @@ mod tests {
             ("node:tty", "ReadStream"),
             ("node:process", "cwd"),
             ("node:process", "env"),
+            ("node:module", "builtinModules"),
+            ("node:module", "createRequire"),
             ("node:url", "URL"),
             ("node:url", "fileURLToPath"),
             ("node:worker_threads", "workerData"),
@@ -885,6 +890,7 @@ mod tests {
                 "string_decoder",
                 &["encoding", "lastChar", "lastNeed", "lastTotal"][..],
             ),
+            ("module", &["wrap", "wrapper"][..]),
             (
                 "tty",
                 &["clearLine", "clearScreenDown", "cursorTo", "moveCursor"][..],
@@ -934,6 +940,10 @@ mod tests {
                 ][..],
             ),
             ("process", &["cwd", "env", "pid", "version"][..]),
+            (
+                "module",
+                &["builtinModules", "constants", "createRequire"][..],
+            ),
             ("string_decoder", &["StringDecoder"][..]),
             ("tty", &["ReadStream", "WriteStream", "isatty"][..]),
             ("url", &["URL", "URLSearchParams", "fileURLToPath"][..]),

--- a/crates/perry-hir/tests/unimplemented_api_check.rs
+++ b/crates/perry-hir/tests/unimplemented_api_check.rs
@@ -106,6 +106,8 @@ fn node_builtin_dispatch_only_named_imports_are_rejected() {
         ("node:tty", "clearLine", "clearLine"),
         ("node:process", "on", "processOn"),
         ("node:process", "setMaxListeners", "setMaxListeners"),
+        ("node:module", "wrap", "moduleWrap"),
+        ("module", "wrapper", "moduleWrapper"),
         ("node:url", "createObjectURL", "createObjectURL"),
         ("node:worker_threads", "getWorkerData", "getWorkerData"),
         ("node:https", "ClientRequest", "HttpsClientRequest"),
@@ -146,6 +148,7 @@ fn node_builtin_real_named_exports_still_compile() {
         import { StringDecoder } from "node:string_decoder";
         import { isatty, ReadStream, WriteStream } from "node:tty";
         import { cwd, env } from "node:process";
+        import { builtinModules, createRequire } from "node:module";
         import { URL, fileURLToPath } from "node:url";
         import { Worker, workerData, parentPort } from "node:worker_threads";
         import { Agent, Server as HttpsServer } from "node:https";

--- a/crates/perry/src/main.rs
+++ b/crates/perry/src/main.rs
@@ -326,7 +326,20 @@ fn main_inner() -> Result<()> {
         let version = env!("CARGO_PKG_VERSION");
         match format {
             ApiManifestFormat::Json => {
-                let entries: Vec<_> = perry_api_manifest::iter_entries().collect();
+                let entries: Vec<serde_json::Value> = perry_api_manifest::iter_entries()
+                    .map(|entry| {
+                        let mut value = serde_json::to_value(entry)?;
+                        if let Some(object) = value.as_object_mut() {
+                            object.insert(
+                                "module_export".to_string(),
+                                serde_json::json!(
+                                    perry_api_manifest::entry_is_public_named_export(entry)
+                                ),
+                            );
+                        }
+                        Ok::<_, serde_json::Error>(value)
+                    })
+                    .collect::<Result<_, _>>()?;
                 let payload = serde_json::json!({
                     "version": version,
                     "entries": entries,

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1802,10 +1802,6 @@ declare module "module" {
   /** stdlib */
   export const constants: any;
   /** stdlib */
-  export const wrap: any;
-  /** stdlib */
-  export const wrapper: any;
-  /** stdlib */
   export function SourceMap(...args: any[]): any;
   /** stdlib */
   export function createRequire(...args: any[]): any;

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -1679,8 +1679,6 @@ Total: 2482 entries across 106 modules.
 
 - `builtinModules`
 - `constants`
-- `wrap`
-- `wrapper`
 
 ## `moment`
 


### PR DESCRIPTION
## Summary

- reject `wrap` and `wrapper` as ESM named imports from `node:module` / `module`
- keep the entries available for namespace/member lookup while marking them non-public in JSON manifest output
- add manifest and HIR regression coverage so real module exports stay importable

Closes #3910

## Verification

- `cargo test -p perry-api-manifest node_core_named_export_view --quiet`
- `cargo test -p perry-api-manifest dispatch_only_node_members_are_not_module_exports --quiet`
- `cargo test -p perry-api-manifest representative_node_module_exports_stay_public --quiet`
- `cargo test -p perry-hir node_builtin --quiet`
- `cargo build --release --quiet -p perry -p perry-api-manifest`
- `target/release/perry check /tmp/perry-module-wrap/test.ts --no-color`
- `target/release/perry check /tmp/perry-module-wrapper/test.ts --no-color`
- `target/release/perry --print-api-manifest=json | jq ...` confirms `wrap=false`, `wrapper=false`, `createRequire=true`
- `PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module module --filter imports`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Notes

This is intentionally limited to the ESM named-export boundary. CommonJS `Module.wrap` / `Module.wrapper` behavior remains part of the broader module runtime work.