### PR TITLE
Fix #3941: node:zlib: codes export still resolves undefined after closed parity cut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1054"
+version = "0.5.1055"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5260,7 +5260,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5303,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5322,7 +5322,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "bson",
  "futures-util",
@@ -5342,7 +5342,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5352,7 +5352,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5373,7 +5373,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5391,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "base64",
  "image",
@@ -5417,14 +5417,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5451,7 +5451,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5463,7 +5463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "brotli",
  "flate2",
@@ -5472,7 +5472,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5481,7 +5481,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5498,7 +5498,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "anyhow",
  "base64",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5626,7 +5626,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5634,14 +5634,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "base64",
  "itoa",
@@ -5658,7 +5658,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "base64",
  "block2",
@@ -5707,7 +5707,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "base64",
  "block2",
@@ -5722,7 +5722,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1054"
+version = "0.5.1055"
 
 [[package]]
 name = "perry-ui-test"
@@ -5730,11 +5730,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1054"
+version = "0.5.1055"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "base64",
  "block2",
@@ -5750,7 +5750,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "base64",
  "block2",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "block2",
  "libc",
@@ -5779,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "base64",
  "libc",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1054"
+version = "0.5.1055"
 dependencies = [
  "wasmi",
 ]

--- a/crates/perry-api-manifest/src/lib.rs
+++ b/crates/perry-api-manifest/src/lib.rs
@@ -596,6 +596,17 @@ mod tests {
     }
 
     #[test]
+    fn zlib_codes_is_manifest_named_export_property() {
+        let entry =
+            module_has_symbol("node:zlib", "codes").expect("zlib.codes should be in the manifest");
+        assert!(matches!(entry.kind, ApiKind::Property));
+        assert!(
+            module_has_public_named_export("node:zlib", "codes"),
+            "zlib.codes should be available to named imports"
+        );
+    }
+
+    #[test]
     fn fs_promises_manifest_matches_runtime_backed_exports() {
         assert!(is_known_module("fs/promises"));
         assert!(is_known_module("node:fs/promises"));

--- a/crates/perry-runtime/src/node_submodules/tests.rs
+++ b/crates/perry-runtime/src/node_submodules/tests.rs
@@ -278,6 +278,49 @@ fn fs_promises_constants_reuses_fs_constants_namespace() {
 }
 
 #[test]
+fn zlib_codes_export_resolves_to_return_code_map() {
+    let codes = unsafe {
+        crate::object::js_native_module_property_by_name(
+            b"zlib".as_ptr(),
+            "zlib".len(),
+            b"codes".as_ptr(),
+            "codes".len(),
+        )
+    };
+    let namespace =
+        crate::object::js_create_native_module_namespace(b"zlib".as_ptr(), "zlib".len());
+    let namespace_codes =
+        get_object_property(namespace, b"codes").expect("zlib namespace should expose codes");
+
+    assert_eq!(
+        namespace_codes.to_bits(),
+        codes.to_bits(),
+        "direct and namespace zlib.codes reads should share the same object"
+    );
+    assert_eq!(
+        JSValue::from_bits(get_object_property(codes, b"Z_OK").unwrap().to_bits()).as_number(),
+        0.0
+    );
+    assert_eq!(
+        JSValue::from_bits(
+            get_object_property(codes, b"Z_DATA_ERROR")
+                .unwrap()
+                .to_bits()
+        )
+        .as_number(),
+        -3.0
+    );
+    assert_eq!(
+        string_from_value(get_object_property(codes, b"0").unwrap()).as_deref(),
+        Some("Z_OK")
+    );
+    assert_eq!(
+        string_from_value(get_object_property(codes, b"-6").unwrap()).as_deref(),
+        Some("Z_VERSION_ERROR")
+    );
+}
+
+#[test]
 fn stream_promises_default_export_exposes_namespace() {
     let value = unsafe {
         js_node_submodule_export_as_function(

--- a/test-parity/node-suite/zlib/constants/codes.ts
+++ b/test-parity/node-suite/zlib/constants/codes.ts
@@ -1,7 +1,10 @@
 import * as zlib from "node:zlib";
+import { codes } from "node:zlib";
 
 console.log("zlib keys includes codes:", Object.keys(zlib).includes("codes"));
 console.log("codes type:", typeof (zlib as any).codes);
+console.log("named codes type:", typeof codes);
+console.log("named codes identity:", codes === (zlib as any).codes);
 console.log("codes stable identity:", (zlib as any).codes === (zlib as any).codes);
 console.log("codes keys:", JSON.stringify(Object.keys((zlib as any).codes)));
 console.log(


### PR DESCRIPTION
Fixes #3941.

Modal fast-path run:
- issue runner elapsed: 613.3s
- Codex elapsed: 604.7s
- release build avoided: yes
- full workspace test avoided: yes

Codex summary:
Implemented and committed locally:

`f6c54124f test: cover zlib codes export`

Files changed:
- `Cargo.lock`
- `crates/perry-api-manifest/src/lib.rs`
- `crates/perry-runtime/src/node_submodules/tests.rs`
- `test-parity/node-suite/zlib/constants/codes.ts`

Verification:
- `cargo test -p perry-api-manifest zlib`  
  Result: passed, `1 passed; 0 failed`
- `cargo test -p perry-runtime zlib`  
  Result: passed, `1 passed; 0 failed` with existing warnings
- `cargo fmt --check`  
  Result: passed
- `git diff --check`  
  Result: passed

I did not run the full parity suite or any release build. The parity runner expects `target/release/perry`, so I avoided it per the Modal rules.
