### PR TITLE
test(node:http2): cover settings helper trio (#3654)

### DIFF
--- a/test-parity/node-suite/http2/settings/settings-helpers.ts
+++ b/test-parity/node-suite/http2/settings/settings-helpers.ts
@@ -1,0 +1,22 @@
+// #3654: node:http2 exposes the settings helper trio
+// `getDefaultSettings`, `getPackedSettings`, and `getUnpackedSettings`
+// alongside the server factories. Lock in Node's observable shape and
+// round-trip behavior so the export surface can't silently regress.
+import * as http2 from "node:http2";
+import { Buffer } from "node:buffer";
+
+console.log("typeof getDefaultSettings:", typeof http2.getDefaultSettings);
+console.log("typeof getPackedSettings:", typeof http2.getPackedSettings);
+console.log("typeof getUnpackedSettings:", typeof http2.getUnpackedSettings);
+
+const defaults = http2.getDefaultSettings();
+console.log("defaults type:", typeof defaults);
+console.log("enablePush:", defaults.enablePush);
+console.log("initialWindowSize:", defaults.initialWindowSize);
+
+const packed = http2.getPackedSettings({ enablePush: false, initialWindowSize: 1024 });
+console.log("packed is Buffer:", Buffer.isBuffer(packed));
+
+const unpacked = http2.getUnpackedSettings(packed);
+console.log("round-trip enablePush:", unpacked.enablePush);
+console.log("round-trip initialWindowSize:", unpacked.initialWindowSize);


### PR DESCRIPTION
## Summary

Closes #3654.

`node:http2`'s settings helper trio — `getDefaultSettings`, `getPackedSettings`, `getUnpackedSettings` — is already claimed by the manifest (`entries.rs`) and works at runtime on `main`. This adds the missing **focused parity fixture** so the export surface and behavior can't silently regress.

## Verification

The new `test-parity/node-suite/http2/settings/settings-helpers.ts` is byte-identical to `node --experimental-strip-types`:

```
typeof getDefaultSettings: function
typeof getPackedSettings: function
typeof getUnpackedSettings: function
defaults type: object
enablePush: true
initialWindowSize: 65535
packed is Buffer: true
round-trip enablePush: false
round-trip initialWindowSize: 1024
```

Fixture-only change (no manifest/runtime edits needed — `main` already implements these).
