### PR TITLE
fix(node:http2): expose performServerHandshake module export (#3720)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -4720,6 +4720,12 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("http2", "getDefaultSettings", false, None),
     method("http2", "getPackedSettings", false, None),
     method("http2", "getUnpackedSettings", false, None),
+    // `http2.performServerHandshake(socket[, options])` — Node's module-level
+    // helper for adopting an already-connected socket as an HTTP/2 server
+    // session (#3720). Exposed as a callable export (length 1) so the value
+    // read matches Node's `typeof` / `name` / `length` shape; wired through
+    // `is_native_module_callable_export` / `native_callable_export_arity`.
+    method("http2", "performServerHandshake", false, None),
     internal_class("http2", "Http2SecureServer"),
     class("http2", "Http2ServerRequest"),
     class("http2", "Http2ServerResponse"),

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1852,6 +1852,8 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ("util", "MIMEType") => Some(1),
         ("net", "createServer" | "Server") => Some(2),
         ("net", "Socket") => Some(1),
+        // #3720: `http2.performServerHandshake(socket[, options])` — length 1.
+        ("http2", "performServerHandshake") => Some(1),
         ("net", "_normalizeArgs") => Some(1),
         ("net", "_createServerHandle") => Some(5),
         ("domain", "Domain" | "createDomain" | "create") => Some(0),
@@ -3317,6 +3319,8 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("http2", "createServer")
             | ("http2", "createSecureServer")
             | ("http2", "Server")
+            // #3720: module-level handshake helper reads as a function.
+            | ("http2", "performServerHandshake")
             // #3680/#3679: node:v8 class constructors + diagnostic-control
             // helpers read as callable values (`typeof v8.Serializer ===
             // "function"`). Construction routes through new_dynamic.rs; the

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2490 entries across 106 modules
+// Coverage: 2491 entries across 106 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -1694,6 +1694,8 @@ declare module "http2" {
   export function getPackedSettings(...args: any[]): any;
   /** stdlib */
   export function getUnpackedSettings(...args: any[]): any;
+  /** stdlib */
+  export function performServerHandshake(...args: any[]): any;
 }
 
 declare module "https" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2490 entries across 106 modules.
+Total: 2491 entries across 106 modules.
 
 ## Modules
 
@@ -1517,6 +1517,7 @@ Total: 2490 entries across 106 modules.
 - `getUnpackedSettings` — module
 - `listen` — instance *(class: `Http2SecureServer`)*
 - `on` — instance *(class: `Http2SecureServer`)*
+- `performServerHandshake` — module
 
 ### Properties
 

--- a/test-parity/node-suite/http2/exports/performServerHandshake.ts
+++ b/test-parity/node-suite/http2/exports/performServerHandshake.ts
@@ -1,0 +1,8 @@
+// #3720: node:http2 exposes the module-level `performServerHandshake`
+// helper alongside the server factories. Lock in Node's observable
+// export shape (callable, name, length) so it can't silently regress.
+import * as http2 from "node:http2";
+
+console.log("typeof:", typeof http2.performServerHandshake);
+console.log("name:", http2.performServerHandshake.name);
+console.log("length:", http2.performServerHandshake.length);


### PR DESCRIPTION
## Summary

Closes #3720.

Node's `node:http2` namespace exposes the module-level `performServerHandshake` helper (`typeof` function, `name`, `length` 1) alongside the server factories, but Perry's manifest omitted it, so reading `http2.performServerHandshake` tripped the strict-API gate (#463).

## Changes

- **api-manifest** (`entries.rs`): add `method` entry for `http2.performServerHandshake`.
- **runtime** (`native_module.rs`): list it in `is_native_module_callable_export` and give `native_callable_export_arity` a length of `1`, so the value-read shape matches Node (`typeof` function, matching `name`, `length` 1).
- **docs**: regenerate `reference.md` + `perry.d.ts` from the manifest.
- **parity**: add `node-suite/http2/exports/performServerHandshake.ts`.

## Verification

New fixture is byte-identical to `node --experimental-strip-types`:

```
typeof: function
name: performServerHandshake
length: 1
```

`cargo fmt --all -- --check` clean.
