### PR TITLE
test(node:fs): cover class/constructor export tail (#3711)

### DIFF
--- a/test-parity/node-suite/fs/exports/class-export-tail.ts
+++ b/test-parity/node-suite/fs/exports/class-export-tail.ts
@@ -1,0 +1,18 @@
+// #3711: node:fs exposes a class/constructor + newer-helper export tail
+// (Dir, Dirent, Stats, the ReadStream/WriteStream constructors and their
+// FileReadStream/FileWriteStream aliases, Utf8Stream, _toUnixTimestamp,
+// mkdtempDisposableSync, openAsBlob). Lock in Node's observable export
+// shape so the surface can't silently regress.
+import * as fs from "node:fs";
+
+console.log("Dir:", typeof fs.Dir);
+console.log("Dirent:", typeof fs.Dirent);
+console.log("Stats:", typeof fs.Stats);
+console.log("ReadStream:", typeof fs.ReadStream);
+console.log("WriteStream:", typeof fs.WriteStream);
+console.log("FileReadStream:", typeof fs.FileReadStream);
+console.log("FileWriteStream:", typeof fs.FileWriteStream);
+console.log("Utf8Stream:", typeof fs.Utf8Stream);
+console.log("_toUnixTimestamp:", typeof fs._toUnixTimestamp);
+console.log("mkdtempDisposableSync:", typeof fs.mkdtempDisposableSync);
+console.log("openAsBlob:", typeof fs.openAsBlob);


### PR DESCRIPTION
## Summary

Closes #3711.

`node:fs`'s class/constructor + newer-helper export tail — `Dir`, `Dirent`, `Stats`, the `ReadStream`/`WriteStream` constructors and their `FileReadStream`/`FileWriteStream` aliases, `Utf8Stream`, `_toUnixTimestamp`, `mkdtempDisposableSync`, `openAsBlob` — is already claimed by the manifest and reads as callable at runtime on `main`, matching Node. This adds the missing **focused parity fixture** so the export surface can't silently regress.

## Verification

The new `test-parity/node-suite/fs/exports/class-export-tail.ts` is byte-identical to `node --experimental-strip-types`:

```
Dir: function
Dirent: function
Stats: function
ReadStream: function
WriteStream: function
FileReadStream: function
FileWriteStream: function
Utf8Stream: function
_toUnixTimestamp: function
mkdtempDisposableSync: function
openAsBlob: function
```

Fixture-only change (no manifest/runtime edits needed — `main` already implements these).
