### PR TITLE
Add verbose progress diagnostics for large graphs

### DIFF
--- a/crates/perry/src/commands/check.rs
+++ b/crates/perry/src/commands/check.rs
@@ -17,6 +17,7 @@ use super::deps::{
 };
 use super::fix_applier::FixApplier;
 use super::fixer::{Confidence, Fixer};
+use super::progress::{ProgressSnapshot, VerboseProgress};
 use crate::OutputFormat;
 
 #[derive(Args, Debug)]
@@ -148,6 +149,7 @@ pub fn run(args: CheckArgs, format: OutputFormat, use_color: bool, verbose: u8) 
     let mut visited = HashSet::new();
     let mut dep_resolver = DependencyResolver::new(project_root.clone());
     let mut fix_applier = FixApplier::new();
+    let progress = VerboseProgress::new(format, verbose);
     let min_confidence = if args.fix_unsafe {
         Confidence::Medium
     } else {
@@ -178,6 +180,13 @@ pub fn run(args: CheckArgs, format: OutputFormat, use_color: bool, verbose: u8) 
         let filename = canonical.to_string_lossy().to_string();
 
         // Parse with diagnostics
+        progress.record(ProgressSnapshot {
+            stage: "check-parse",
+            module_path: Some(&canonical),
+            visited: Some(checked_files + 1),
+            total: Some(files.len()),
+            ..Default::default()
+        });
         let parse_result = match perry_parser::parse_typescript_with_cache(
             &source,
             &filename,
@@ -222,7 +231,14 @@ pub fn run(args: CheckArgs, format: OutputFormat, use_color: bool, verbose: u8) 
 
         // Extract imports from AST even before lowering (for dependency checking)
         if args.check_deps {
-            extract_imports_from_ast(&parse_result.module, &canonical, &mut dep_resolver);
+            extract_imports_from_ast(
+                &parse_result.module,
+                &canonical,
+                &mut dep_resolver,
+                &progress,
+                checked_files + 1,
+                files.len(),
+            );
         }
 
         // Stub scan (#464): warn on imports of `perry/ui` /
@@ -251,6 +267,13 @@ pub fn run(args: CheckArgs, format: OutputFormat, use_color: bool, verbose: u8) 
         // #503: stash the source text so the dynamic-dispatch check can
         // resolve `// @perry-allow-dynamic` annotations during `perry check`
         // the same way it does during a real build.
+        progress.record(ProgressSnapshot {
+            stage: "check-lower",
+            module_path: Some(&canonical),
+            visited: Some(checked_files + 1),
+            total: Some(files.len()),
+            ..Default::default()
+        });
         perry_hir::set_current_module_source(source.clone());
         let lower_outcome = perry_hir::lower_module(&parse_result.module, &filename, &filename);
         perry_hir::clear_current_module_source();
@@ -533,6 +556,9 @@ fn extract_imports_from_ast(
     module: &perry_parser::swc_ecma_ast::Module,
     file_path: &PathBuf,
     dep_resolver: &mut DependencyResolver,
+    progress: &VerboseProgress,
+    visited: usize,
+    total: usize,
 ) {
     use perry_parser::swc_ecma_ast::{ModuleDecl, ModuleItem};
 
@@ -542,16 +568,40 @@ fn extract_imports_from_ast(
                 ModuleDecl::Import(import) => {
                     // Use as_str() to get &str from the Wtf8Atom
                     let source = import.src.value.as_str().unwrap_or("");
+                    progress.record(ProgressSnapshot {
+                        stage: "check-resolve-import",
+                        module_path: Some(file_path),
+                        import_specifier: Some(source),
+                        visited: Some(visited),
+                        total: Some(total),
+                        ..Default::default()
+                    });
                     dep_resolver.record_import(source, file_path);
                 }
                 ModuleDecl::ExportNamed(export) => {
                     if let Some(src) = &export.src {
                         let source = src.value.as_str().unwrap_or("");
+                        progress.record(ProgressSnapshot {
+                            stage: "check-resolve-import",
+                            module_path: Some(file_path),
+                            import_specifier: Some(source),
+                            visited: Some(visited),
+                            total: Some(total),
+                            ..Default::default()
+                        });
                         dep_resolver.record_import(source, file_path);
                     }
                 }
                 ModuleDecl::ExportAll(export) => {
                     let source = export.src.value.as_str().unwrap_or("");
+                    progress.record(ProgressSnapshot {
+                        stage: "check-resolve-import",
+                        module_path: Some(file_path),
+                        import_specifier: Some(source),
+                        visited: Some(visited),
+                        total: Some(total),
+                        ..Default::default()
+                    });
                     dep_resolver.record_import(source, file_path);
                 }
                 _ => {}

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -8,6 +8,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::OutputFormat;
 
@@ -96,6 +97,8 @@ use targets::{
     compile_for_watchos_widget, compile_for_wearos_tile, find_visionos_swift_runtime,
     find_watchos_swift_runtime, generate_embedded_js_object, generate_js_bundle,
 };
+
+use super::progress::{ProgressSnapshot, VerboseProgress};
 
 mod types;
 pub use types::*;
@@ -242,6 +245,7 @@ pub fn run_with_parse_cache(
     let mut visited = HashSet::new();
     let mut next_class_id: perry_hir::ClassId = 1; // Start at 1, 0 is reserved for "no parent"
     let skip_transforms = matches!(args.target.as_deref(), Some("web") | Some("wasm"));
+    let progress = VerboseProgress::new(format, verbose);
 
     // Issue #444: canonicalize the user's entry path once so collect_modules
     // can compare every module's canonical path against it and set
@@ -262,6 +266,7 @@ pub fn run_with_parse_cache(
         args.target.as_deref(),
         &mut next_class_id,
         skip_transforms,
+        &progress,
         parse_cache.as_deref_mut(),
     )?;
 
@@ -275,6 +280,7 @@ pub fn run_with_parse_cache(
                 &mut visited,
                 &mut next_class_id,
                 skip_transforms,
+                &progress,
                 parse_cache.as_deref_mut(),
                 format,
             )?
@@ -288,6 +294,7 @@ pub fn run_with_parse_cache(
         &mut visited,
         &mut next_class_id,
         skip_transforms,
+        &progress,
         parse_cache.as_deref_mut(),
         format,
     )?;
@@ -1789,12 +1796,24 @@ pub fn run_with_parse_cache(
         }
     }
 
+    let total_codegen_modules = ctx.native_modules.len();
+    let codegen_modules_started = AtomicUsize::new(0);
     let compile_results: Vec<Result<(PathBuf, Vec<u8>), String>> = ctx
         .native_modules
         .par_iter()
         .map(|(path, hir_module)| {
             // Compile this module to LLVM IR (or .ll text in bitcode-link mode)
             // and return the object bytes for the linker to consume.
+            let codegen_index = codegen_modules_started.fetch_add(1, Ordering::Relaxed) + 1;
+            progress.record(ProgressSnapshot {
+                stage: "codegen",
+                module_path: Some(path),
+                module_name: Some(&hir_module.name),
+                visited: Some(codegen_index),
+                total: Some(total_codegen_modules),
+                collected: Some(total_codegen_modules),
+                ..Default::default()
+            });
             let is_entry = path == &entry_path;
             // Compute the prefix list of non-entry modules so the
             // entry main can call each `<prefix>__init` in order.
@@ -2044,7 +2063,7 @@ pub fn run_with_parse_cache(
                 }
                 for spec in &import.specifiers {
                     if let perry_hir::ImportSpecifier::Namespace { local } = spec {
-                        if !namespace_imports.contains(local) {
+                        if !namespace_imports.contains(&local) {
                             namespace_imports.push(local.clone());
                         }
                     }
@@ -3029,7 +3048,7 @@ pub fn run_with_parse_cache(
                                 // like `import * as ...` (#1213, #2629).
                                 namespace_node_submodules
                                     .insert(local.clone(), submod_key.clone());
-                                if !namespace_imports.contains(local) {
+                                if !namespace_imports.contains(&local) {
                                     namespace_imports.push(local.clone());
                                 }
                             } else {
@@ -3711,6 +3730,15 @@ pub fn run_with_parse_cache(
                             }
                         }
                     }
+                    progress.heartbeat(ProgressSnapshot {
+                        stage: "codegen",
+                        module_path: Some(path),
+                        module_name: Some(&hir_module.name),
+                        visited: Some(codegen_index),
+                        total: Some(total_codegen_modules),
+                        collected: Some(total_codegen_modules),
+                        ..Default::default()
+                    });
                     let bytes = perry_codegen::compile_module(hir_module, opts).map_err(|e| {
                         format!(
                             "Error compiling module '{}' ({}) with --backend llvm: {:#}",

--- a/crates/perry/src/commands/compile/bootstrap.rs
+++ b/crates/perry/src/commands/compile/bootstrap.rs
@@ -32,6 +32,8 @@ use crate::OutputFormat;
 use super::audit_manifest::write_audit_manifest_logging_failures;
 use super::collect_modules::collect_modules;
 use super::resolve::discover_extension_entries;
+use crate::commands::progress::VerboseProgress;
+
 use super::{CompilationContext, CompileArgs, ParseCache};
 
 // ============================================================================
@@ -101,6 +103,7 @@ pub(super) fn bundle_extensions_into_ctx(
     visited: &mut HashSet<PathBuf>,
     next_class_id: &mut perry_hir::ClassId,
     skip_transforms: bool,
+    progress: &VerboseProgress,
     mut parse_cache: Option<&mut ParseCache>,
     format: OutputFormat,
 ) -> Result<Vec<(PathBuf, String)>> {
@@ -125,6 +128,7 @@ pub(super) fn bundle_extensions_into_ctx(
             args.target.as_deref(),
             next_class_id,
             skip_transforms,
+            progress,
             parse_cache.as_deref_mut(),
         )?;
         bundled_extensions.push((entry_path.canonicalize()?, plugin_id.clone()));
@@ -151,6 +155,7 @@ pub(super) fn rerun_collect_with_class_field_types(
     visited: &mut HashSet<PathBuf>,
     next_class_id: &mut perry_hir::ClassId,
     skip_transforms: bool,
+    progress: &VerboseProgress,
     mut parse_cache: Option<&mut ParseCache>,
     format: OutputFormat,
 ) -> Result<()> {
@@ -183,6 +188,7 @@ pub(super) fn rerun_collect_with_class_field_types(
         args.target.as_deref(),
         next_class_id,
         skip_transforms,
+        progress,
         parse_cache.as_deref_mut(),
     )?;
     if let Some(ext_dir) = &args.bundle_extensions {
@@ -196,6 +202,7 @@ pub(super) fn rerun_collect_with_class_field_types(
                 args.target.as_deref(),
                 next_class_id,
                 skip_transforms,
+                progress,
                 parse_cache.as_deref_mut(),
             )?;
         }

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -20,6 +20,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 
+use crate::commands::progress::{ProgressSnapshot, VerboseProgress};
 use crate::OutputFormat;
 
 use super::{
@@ -372,6 +373,7 @@ pub(super) fn collect_modules(
     target: Option<&str>,
     next_class_id: &mut perry_hir::ClassId,
     skip_transforms: bool,
+    progress: &VerboseProgress,
     mut parse_cache: Option<&mut ParseCache>,
 ) -> Result<()> {
     let canonical = entry_path
@@ -382,6 +384,13 @@ pub(super) fn collect_modules(
         return Ok(());
     }
     visited.insert(canonical.clone());
+    progress.record(ProgressSnapshot {
+        stage: "collect-module",
+        module_path: Some(&canonical),
+        visited: Some(visited.len()),
+        collected: Some(ctx.native_modules.len() + ctx.js_modules.len()),
+        ..Default::default()
+    });
 
     // Check if this file should be handled by JS runtime instead of native compilation
     // This includes: JS files, declaration files (.d.ts), JSON files, or any file in node_modules when JS runtime is enabled
@@ -440,6 +449,13 @@ pub(super) fn collect_modules(
 
         let source = fs::read_to_string(&canonical)
             .map_err(|e| anyhow!("Failed to read {}: {}", canonical.display(), e))?;
+        progress.record(ProgressSnapshot {
+            stage: "collect-js-module",
+            module_path: Some(&canonical),
+            visited: Some(visited.len()),
+            collected: Some(ctx.native_modules.len() + ctx.js_modules.len()),
+            ..Default::default()
+        });
 
         let specifier = canonical.to_string_lossy().to_string();
         // Issue #818: walk transitive ESM imports for JS modules so the
@@ -505,6 +521,7 @@ pub(super) fn collect_modules(
                 target,
                 next_class_id,
                 skip_transforms,
+                progress,
                 parse_cache.as_deref_mut(),
             )?;
         }
@@ -559,6 +576,14 @@ pub(super) fn collect_modules(
     // Parse via the optional in-memory cache (only populated by `perry dev`).
     // On a cache hit, we reuse the AST from the previous rebuild — the single
     // largest time sink in the hot rebuild path on unchanged files.
+    progress.record(ProgressSnapshot {
+        stage: "parse",
+        module_path: Some(&canonical),
+        module_name: Some(&module_name),
+        visited: Some(visited.len()),
+        collected: Some(ctx.native_modules.len() + ctx.js_modules.len()),
+        ..Default::default()
+    });
     let ast_module_owned: swc_ecma_ast::Module;
     let ast_module: &swc_ecma_ast::Module = match parse_cache.as_deref_mut() {
         Some(cache) => match parse_cached(cache, &canonical, &source, filename) {
@@ -686,6 +711,14 @@ pub(super) fn collect_modules(
     if !ctx.precompile_results.is_empty() {
         perry_hir::set_precompile_results(ctx.precompile_results.clone());
     }
+    progress.record(ProgressSnapshot {
+        stage: "lower",
+        module_path: Some(&canonical),
+        module_name: Some(&module_name),
+        visited: Some(visited.len()),
+        collected: Some(ctx.native_modules.len() + ctx.js_modules.len()),
+        ..Default::default()
+    });
     let lower_result = perry_hir::lower_module_full(
         ast_module,
         &module_name,
@@ -696,6 +729,14 @@ pub(super) fn collect_modules(
         is_entry_module,
         is_external_module,
     );
+    progress.heartbeat(ProgressSnapshot {
+        stage: "lower",
+        module_path: Some(&canonical),
+        module_name: Some(&module_name),
+        visited: Some(visited.len()),
+        collected: Some(ctx.native_modules.len() + ctx.js_modules.len()),
+        ..Default::default()
+    });
     perry_hir::clear_compile_packages_override();
     perry_hir::clear_current_module_source();
     perry_hir::clear_precompile_state();
@@ -748,10 +789,11 @@ pub(super) fn collect_modules(
                 perry_hir::Resolution::Set(set) => {
                     if set.len() > perry_hir::DYNAMIC_IMPORT_PATH_CAP {
                         dyn_errors.push(format!(
-                            "dynamic import() in module {}: resolves to {} possible paths \
+                            "dynamic import() in module {} ({}): resolves to {} possible paths \
                              (limit: {})\n  note: consider enumerating with a ternary or \
                              registry object",
                             module_name,
+                            canonical.display(),
                             set.len(),
                             perry_hir::DYNAMIC_IMPORT_PATH_CAP
                         ));
@@ -780,9 +822,10 @@ pub(super) fn collect_modules(
                         );
                         if matches.len() > perry_hir::DYNAMIC_IMPORT_PATH_CAP {
                             dyn_errors.push(format!(
-                                "dynamic import() in module {}: glob '{}*{}' matched {} files \
+                                "dynamic import() in module {} ({}): glob '{}*{}' matched {} files \
                                  (limit: {})",
                                 module_name,
+                                canonical.display(),
                                 prefix,
                                 suffix,
                                 matches.len(),
@@ -801,8 +844,10 @@ pub(super) fn collect_modules(
                         }
                     }
                     dyn_errors.push(format!(
-                        "dynamic import() in module {}: {}",
-                        module_name, reason
+                        "dynamic import() in module {} ({}): {}",
+                        module_name,
+                        canonical.display(),
+                        reason
                     ));
                 }
             }
@@ -866,6 +911,15 @@ pub(super) fn collect_modules(
         if import.type_only {
             continue;
         }
+        progress.record(ProgressSnapshot {
+            stage: "resolve-import",
+            module_path: Some(&canonical),
+            module_name: Some(&module_name),
+            import_specifier: Some(&import.source),
+            visited: Some(visited.len()),
+            collected: Some(ctx.native_modules.len() + ctx.js_modules.len()),
+            ..Default::default()
+        });
 
         // Apply package alias (e.g., @parse/node-apn → perry-push from perry.packageAliases)
         if let Some(alias) = ctx.package_aliases.get(import.source.as_str()).cloned() {
@@ -1070,7 +1124,12 @@ pub(super) fn collect_modules(
                                     if let Err(msg) =
                                         super::resolve::validate_abi_version(&manifest)
                                     {
-                                        return Err(anyhow::anyhow!("{}", msg));
+                                        return Err(anyhow::anyhow!(
+                                            "{}\n  in module: {}\n  import: {}",
+                                            msg,
+                                            canonical.display(),
+                                            import.source
+                                        ));
                                     }
                                     // #497: gate transitive
                                     // `perry.nativeLibrary` linkage on
@@ -1100,9 +1159,13 @@ pub(super) fn collect_modules(
                                              \n\
                                              For a one-off build, set \
                                              `PERRY_ALLOW_PERRY_FEATURES=1` in the environment. \
-                                             (#497)",
+                                             (#497)\n\
+                                             \n\
+                                             Caused by import `{}` in module `{}`.",
                                             manifest.module,
                                             manifest.module,
+                                            import.source,
+                                            canonical.display(),
                                         );
                                     }
                                     match format {
@@ -1129,6 +1192,7 @@ pub(super) fn collect_modules(
                         target,
                         next_class_id,
                         skip_transforms,
+                        progress,
                         parse_cache.as_deref_mut(),
                     )?;
                 }
@@ -1172,7 +1236,12 @@ pub(super) fn collect_modules(
                                     if let Err(msg) =
                                         super::resolve::validate_abi_version(&manifest)
                                     {
-                                        return Err(anyhow::anyhow!("{}", msg));
+                                        return Err(anyhow::anyhow!(
+                                            "{}\n  in module: {}\n  import: {}",
+                                            msg,
+                                            canonical.display(),
+                                            module_name
+                                        ));
                                     }
                                     // #497: gate transitive
                                     // `perry.nativeLibrary` linkage on
@@ -1202,9 +1271,13 @@ pub(super) fn collect_modules(
                                              \n\
                                              For a one-off build, set \
                                              `PERRY_ALLOW_PERRY_FEATURES=1` in the environment. \
-                                             (#497)",
+                                             (#497)\n\
+                                             \n\
+                                             Caused by import `{}` in module `{}`.",
                                             manifest.module,
                                             manifest.module,
+                                            module_name,
+                                            canonical.display(),
                                         );
                                     }
                                     match format {
@@ -1243,6 +1316,7 @@ pub(super) fn collect_modules(
                         target,
                         next_class_id,
                         skip_transforms,
+                        progress,
                         parse_cache.as_deref_mut(),
                     )?;
                 }
@@ -1275,7 +1349,7 @@ pub(super) fn collect_modules(
             // through to that runtime helper.
             if has_namespace_specifier && known_node_submodule_key(&import.source).is_none() {
                 return Err(anyhow::anyhow!(
-                    "Could not resolve namespace import `import * as ... from \"{source}\"` in {filename}.\n\
+                    "Could not resolve namespace import `import * as ... from \"{source}\"` in {filename} ({path}).\n\
                      Perry has no stdlib bindings for this module path, so the namespace would compile to an empty object \
                      — every method call on it would silently no-op at runtime. Pick one:\n  \
                        • switch to named imports: `import {{ foo }} from \"{source}\"` (still resolves through whatever backing exists, but fails fast at the actual missing binding),\n  \
@@ -1283,6 +1357,7 @@ pub(super) fn collect_modules(
                        • or add the module to perry-stdlib / perry-ext-* / perry.compilePackages.",
                     source = import.source,
                     filename = filename,
+                    path = canonical.display(),
                 ));
             }
             if !import.is_native && known_node_submodule_key(&import.source).is_none() {
@@ -1314,6 +1389,15 @@ pub(super) fn collect_modules(
             perry_hir::Export::Named { .. } => None,
         };
         if let Some(src) = source {
+            progress.record(ProgressSnapshot {
+                stage: "resolve-re-export",
+                module_path: Some(&canonical),
+                module_name: Some(&module_name),
+                import_specifier: Some(src),
+                visited: Some(visited.len()),
+                collected: Some(ctx.native_modules.len() + ctx.js_modules.len()),
+                ..Default::default()
+            });
             if let Some((resolved_path, kind)) =
                 cached_resolve_import(src.as_str(), &canonical, ctx)
             {
@@ -1350,7 +1434,12 @@ pub(super) fn collect_modules(
                                 parse_native_library_manifest(dir, &src_str, target)?
                             {
                                 if let Err(msg) = super::resolve::validate_abi_version(&manifest) {
-                                    return Err(anyhow::anyhow!("{}", msg));
+                                    return Err(anyhow::anyhow!(
+                                        "{}\n  in module: {}\n  re-export: {}",
+                                        msg,
+                                        canonical.display(),
+                                        src_str
+                                    ));
                                 }
                                 if !super::allowlist_matches(
                                     &manifest.module,
@@ -1374,9 +1463,13 @@ pub(super) fn collect_modules(
                                          \n\
                                          For a one-off build, set \
                                          `PERRY_ALLOW_PERRY_FEATURES=1` in the environment. \
-                                         (#497)",
+                                         (#497)\n\
+                                         \n\
+                                         Caused by re-export `{}` in module `{}`.",
                                         manifest.module,
                                         manifest.module,
+                                        src_str,
+                                        canonical.display(),
                                     );
                                 }
                                 match format {
@@ -1405,6 +1498,7 @@ pub(super) fn collect_modules(
                             target,
                             next_class_id,
                             skip_transforms,
+                            progress,
                             parse_cache.as_deref_mut(),
                         )?;
                     }
@@ -1441,6 +1535,14 @@ pub(super) fn collect_modules(
     // and BEFORE `transform_generators` (which consumes the generator
     // shape it produces). Issue #256.
     if !skip_transforms {
+        progress.record(ProgressSnapshot {
+            stage: "transform",
+            module_path: Some(&canonical),
+            module_name: Some(&module_name),
+            visited: Some(visited.len()),
+            collected: Some(ctx.native_modules.len() + ctx.js_modules.len()),
+            ..Default::default()
+        });
         let mut extra_methods: std::collections::HashMap<(String, String), MethodCandidate> =
             std::collections::HashMap::new();
         if std::env::var("PERRY_INLINE_DEBUG").is_ok() {
@@ -1629,6 +1731,15 @@ pub(super) fn collect_modules(
         ctx.native_module_imports.insert("ioredis".to_string());
     }
 
+    let collected_after_insert = ctx.native_modules.len() + ctx.js_modules.len() + 1;
+    progress.record(ProgressSnapshot {
+        stage: "collected",
+        module_path: Some(&canonical),
+        module_name: Some(&module_name),
+        visited: Some(visited.len()),
+        collected: Some(collected_after_insert),
+        ..Default::default()
+    });
     ctx.native_modules.insert(canonical, hir_module);
     Ok(())
 }

--- a/crates/perry/src/commands/mod.rs
+++ b/crates/perry/src/commands/mod.rs
@@ -20,6 +20,7 @@ pub mod lock;
 pub mod login;
 pub mod native;
 pub mod perry_lock;
+pub(crate) mod progress;
 pub mod publish;
 pub mod run;
 pub mod sandbox_profile;

--- a/crates/perry/src/commands/progress.rs
+++ b/crates/perry/src/commands/progress.rs
@@ -1,0 +1,138 @@
+use std::path::Path;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use crate::OutputFormat;
+
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+
+#[derive(Debug)]
+pub(crate) struct VerboseProgress {
+    enabled: bool,
+    last_heartbeat: Mutex<Instant>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ProgressSnapshot<'a> {
+    pub stage: &'a str,
+    pub module_path: Option<&'a Path>,
+    pub module_name: Option<&'a str>,
+    pub import_specifier: Option<&'a str>,
+    pub api: Option<&'a str>,
+    pub visited: Option<usize>,
+    pub total: Option<usize>,
+    pub collected: Option<usize>,
+}
+
+impl VerboseProgress {
+    pub(crate) fn new(format: OutputFormat, verbose: u8) -> Self {
+        Self {
+            enabled: verbose > 0 && matches!(format, OutputFormat::Text),
+            last_heartbeat: Mutex::new(Instant::now()),
+        }
+    }
+
+    pub(crate) fn record(&self, snapshot: ProgressSnapshot<'_>) {
+        if self.enabled {
+            eprintln!("{}", format_progress_line(&snapshot, false));
+        }
+    }
+
+    pub(crate) fn heartbeat(&self, snapshot: ProgressSnapshot<'_>) {
+        if !self.enabled {
+            return;
+        }
+
+        let Ok(mut last) = self.last_heartbeat.lock() else {
+            return;
+        };
+        if last.elapsed() >= HEARTBEAT_INTERVAL {
+            *last = Instant::now();
+            eprintln!("{}", format_progress_line(&snapshot, true));
+        }
+    }
+}
+
+pub(crate) fn format_progress_line(snapshot: &ProgressSnapshot<'_>, heartbeat: bool) -> String {
+    let mut out = if heartbeat {
+        format!("[progress] heartbeat stage={}", snapshot.stage)
+    } else {
+        format!("[progress] stage={}", snapshot.stage)
+    };
+
+    if let Some(path) = snapshot.module_path {
+        out.push_str(" module=");
+        out.push_str(&path.display().to_string());
+    }
+    if let Some(name) = snapshot.module_name {
+        out.push_str(" name=");
+        out.push_str(name);
+    }
+    if let Some(import_specifier) = snapshot.import_specifier {
+        out.push_str(" import=");
+        out.push_str(import_specifier);
+    }
+    if let Some(api) = snapshot.api {
+        out.push_str(" api=");
+        out.push_str(api);
+    }
+    if let Some(visited) = snapshot.visited {
+        out.push_str(" visited=");
+        out.push_str(&visited.to_string());
+        if let Some(total) = snapshot.total {
+            out.push('/');
+            out.push_str(&total.to_string());
+        }
+    }
+    if let Some(collected) = snapshot.collected {
+        out.push_str(" collected=");
+        out.push_str(&collected.to_string());
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn progress_line_includes_stage_module_import_and_counts() {
+        let path = Path::new("/repo/src/main.ts");
+        let snapshot = ProgressSnapshot {
+            stage: "resolve-import",
+            module_path: Some(path),
+            module_name: Some("src/main.ts"),
+            import_specifier: Some("./dep"),
+            api: None,
+            visited: Some(7),
+            total: Some(12),
+            collected: Some(6),
+        };
+
+        assert_eq!(
+            format_progress_line(&snapshot, false),
+            "[progress] stage=resolve-import module=/repo/src/main.ts name=src/main.ts import=./dep visited=7/12 collected=6"
+        );
+    }
+
+    #[test]
+    fn heartbeat_line_is_identifiable_but_keeps_context() {
+        let path = Path::new("/repo/src/main.ts");
+        let snapshot = ProgressSnapshot {
+            stage: "lower",
+            module_path: Some(path),
+            module_name: None,
+            import_specifier: None,
+            api: Some("WebAssembly.instantiate"),
+            visited: Some(3),
+            total: None,
+            collected: None,
+        };
+
+        assert_eq!(
+            format_progress_line(&snapshot, true),
+            "[progress] heartbeat stage=lower module=/repo/src/main.ts api=WebAssembly.instantiate visited=3"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3963

## Summary
- Add a text-only verbose progress helper used by `perry check -v` and `perry compile -v`.
- Report parse/lower/import-resolution/module-collection/codegen progress with current module path/name, import specifier where available, and visited/collected counts.
- Include module/import context in dynamic-import, namespace-import, and native-library blocker diagnostics while keeping non-verbose output concise.

## Verification
- `cargo fmt`
- `CARGO_INCREMENTAL=0 cargo check -p perry`
- `CARGO_INCREMENTAL=0 cargo test -p perry progress`
- CLI smoke: `perry check` and `perry compile --no-link` normal mode emitted no `[progress]`; verbose mode emitted parse/lower/resolve-import/collect/codegen progress for a two-module fixture.

Note: initial focused test retries had hit ENOSPC before the coordinator freed disk space; the listed checks were rerun successfully afterward.