### PR TITLE
fix(#3917): (num: number).toLocaleString() printed 1970 date string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1056 — fix(#3917): `(num: number).toLocaleString()` printed a 1970 date string
+
+`const num: number = 20; console.log(num.toLocaleString('en-US'))` printed
+`"12/31/1969, 4:00:00 PM"` (or the local-time equivalent) instead of `"20"`.
+The HIR lowers every `x.toLocaleString()` to the (misnamed) `Expr::DateToLocaleString`
+variant; the LLVM arm in `crates/perry-codegen/src/expr/env_clones.rs` is supposed
+to disambiguate Number-receivers vs Date-receivers by inspecting the receiver's
+static type. The disambiguator only called `refine_type_from_init`, which inspects
+AST shape (literals, arithmetic, `new T(...)`) and has no `LocalGet` arm — so for
+the common `let n: number = …; n.toLocaleString()` shape it returned `None` and
+the call fell through to `js_date_to_locale_string`, treating the number as a
+millisecond epoch.
+
+Fixed by falling back to `static_type_of` (which already reads `local_types`)
+when the structural refinement comes up empty. `static_type_of` resolves
+`LocalGet(id) → ctx.local_types[id]`, so a `number`-typed local now routes to
+`js_number_to_locale_string` and formats with thousands separators
+(`"1,234,567"`, etc.). Verified with literal, integer-local, and decimal-local
+receivers, plus `new Date(0).toLocaleString('en-US')` still emits the date
+string. The user-reported repro (Windows 11, perry 0.5.1025) was platform-agnostic
+— a HIR/codegen routing bug, not a runtime issue.
+
 ## v0.5.1055 — hotfix: actually remove native_module.rs conflict marker
 
 The v0.5.1054 hotfix bumped the version but its source edit failed to apply,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1055
+**Current Version:** 0.5.1056
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1055"
+version = "0.5.1056"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1055"
+version = "0.5.1056"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1055"
+version = "0.5.1056"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1055"
+version = "0.5.1056"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1055"
+version = "0.5.1056"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/env_clones.rs
+++ b/crates/perry-codegen/src/expr/env_clones.rs
@@ -77,13 +77,19 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // type. The HIR variant is misnamed — it covers BOTH
             // `(12345).toLocaleString()` (number) and
             // `new Date(...).toLocaleString()` (date) — so the LLVM
-            // arm has to disambiguate. `refine_type_from_init` returns
-            // a HirType for a small set of literal / built-in shapes;
-            // `Number` / `Integer` route to `js_number_to_locale_string`
-            // (formats with thousands separators). Anything else falls
-            // through to `js_date_to_locale_string`.
+            // arm has to disambiguate.
+            //
+            // #3917: a `LocalGet` whose declared type is `number` was
+            // falling through to `js_date_to_locale_string` and printing
+            // a 1970-epoch date string. `refine_type_from_init` only
+            // inspects AST shapes (literals, arithmetic, `new T(...)`)
+            // and has no `LocalGet` arm, so it returned `None` for
+            // `const num: number = 20; num.toLocaleString(...)`. Fall
+            // back to `static_type_of`, which DOES read `local_types`,
+            // when the structural refinement comes up empty.
             let v = lower_expr(ctx, d)?;
-            let inferred = crate::type_analysis::refine_type_from_init(ctx, d);
+            let inferred = crate::type_analysis::refine_type_from_init(ctx, d)
+                .or_else(|| crate::type_analysis::static_type_of(ctx, d));
             let rt_fn = match inferred {
                 Some(perry_types::Type::Number) | Some(perry_types::Type::Int32) => {
                     "js_number_to_locale_string"


### PR DESCRIPTION
## Summary

- `const num: number = 20; console.log(num.toLocaleString('en-US'))` printed `"12/31/1969, 4:00:00 PM"` instead of `"20"`. The HIR lowers every `x.toLocaleString()` to `Expr::DateToLocaleString`; the codegen arm in `env_clones.rs` disambiguates Number vs Date by `refine_type_from_init`, which only inspects AST shape and has no `LocalGet` arm — so a `number`-typed local fell through to `js_date_to_locale_string`.
- Fall back to `static_type_of` (which reads `ctx.local_types`) when the structural refinement returns `None`. Number locals now route to `js_number_to_locale_string` (thousands separators, fraction-digits trimming); Date receivers still route to `js_date_to_locale_string`.

Closes #3917.

## Test plan

- [x] `const num: number = 20; num.toLocaleString('en-US')` → `"20"`
- [x] `const big: number = 1234567; big.toLocaleString('en-US')` → `"1,234,567"`
- [x] `const dec: number = 3.14159; dec.toLocaleString('en-US')` → `"3.142"`
- [x] `(54321).toLocaleString('en-US')` (literal receiver) → `"54,321"`
- [x] `new Date(0).toLocaleString('en-US')` → `"1/1/1970, 1:00:00 AM"` (still date)
- [x] `cargo build --release -p perry` clean