### PR TITLE
fix: run real Hono apps natively (regex char-class, destructured-param mutability, ReadableStream Response body)

### DIFF
--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -777,8 +777,15 @@ pub(super) fn lower_builtin_new(
         }
         "Response" => {
             // new Response(body?, init?) — init = { status?, statusText?, headers? }
+            // Route the body through js_response_body_init_ptr (not the plain
+            // string coercion) so a ReadableStream body — e.g. Hono's
+            // `new Response(res.body, res)` header re-wrap — is drained to its
+            // bytes instead of stringified to its numeric stream handle.
+            // Non-stream bodies coerce exactly as get_raw_string_ptr did.
             let body_ptr = if !args.is_empty() {
-                get_raw_string_ptr(ctx, &args[0])?
+                let v = lower_expr(ctx, &args[0])?;
+                let blk = ctx.block();
+                blk.call(I64, "js_response_body_init_ptr", &[(DOUBLE, &v)])
             } else {
                 "0".to_string()
             };

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -769,6 +769,9 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     // ──────────────────────────────────────────────────────────────────
     // new Response(body_ptr, status, status_text_ptr, headers_handle) -> f64
     module.declare_function("js_response_new", DOUBLE, &[I64, DOUBLE, I64, DOUBLE]);
+    // js_response_body_init_ptr(body_value_f64) -> string_ptr (i64): drains a
+    // ReadableStream body to bytes, else falls back to string coercion.
+    module.declare_function("js_response_body_init_ptr", I64, &[DOUBLE]);
     // new Headers() -> f64
     module.declare_function("js_headers_new", DOUBLE, &[]);
     // headers.set(handle_f64, key_ptr, val_ptr) -> f64 (undefined-tag)

--- a/crates/perry-hir/src/lower_patterns.rs
+++ b/crates/perry-hir/src/lower_patterns.rs
@@ -215,7 +215,12 @@ pub(crate) fn generate_param_destructuring_stmts(
 ) -> Result<Vec<Stmt>> {
     match pat {
         ast::Pat::Array(_) | ast::Pat::Object(_) => {
-            crate::destructuring::lower_pattern_binding(ctx, pat, Expr::LocalGet(param_id), false)
+            // Function parameters are mutable bindings (like `let`), so the
+            // destructured locals must be mutable too — JS lets you reassign a
+            // destructured param (`([a, b]) => { b -= 1 }`). Passing `false`
+            // here marked them `const` and made any such reassignment throw
+            // "Assignment to constant variable" (hit by Hono's RegExpRouter).
+            crate::destructuring::lower_pattern_binding(ctx, pat, Expr::LocalGet(param_id), true)
         }
         _ => Ok(Vec::new()),
     }

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -212,6 +212,10 @@ fn js_regex_to_rust(pattern: &str) -> String {
     let mut result = String::with_capacity(pattern.len());
     let chars: Vec<char> = pattern.chars().collect();
     let mut i = 0;
+    // Track whether we're inside a `[...]` character class. JS and the Rust
+    // `regex` crate disagree on how a bare `[` inside a class is read, so we
+    // reconcile it below.
+    let mut in_class = false;
     while i < chars.len() {
         if chars[i] == '\\' && i + 1 < chars.len() {
             match chars[i + 1] {
@@ -220,16 +224,38 @@ fn js_regex_to_rust(pattern: &str) -> String {
                     result.push('/');
                     i += 2;
                 }
-                // Pass through all other backslash sequences as-is
+                // Pass through all other backslash sequences as-is. (An escaped
+                // `\[` / `\]` is consumed here and so never toggles `in_class`.)
                 _ => {
                     result.push('\\');
                     result.push(chars[i + 1]);
                     i += 2;
                 }
             }
-        } else if chars[i] == '(' && i + 2 < chars.len() && chars[i + 1] == '?' {
+        } else if chars[i] == '[' {
+            // In JS, an unescaped `[` inside a character class is a literal `[`
+            // (e.g. `/[[]/` matches a single `[`). The Rust `regex` crate rejects
+            // a bare `[` inside `[...]`, so escape it. A `[` outside a class opens
+            // one. This is what Hono's RegExpRouter relies on
+            // (`/[.\\+*[^\]$()]/g`), so every Hono app hit it before this fix.
+            if in_class {
+                result.push('\\');
+                result.push('[');
+            } else {
+                in_class = true;
+                result.push('[');
+            }
+            i += 1;
+        } else if chars[i] == ']' {
+            // An unescaped `]` closes the current class (an escaped `\]` was
+            // consumed by the backslash branch above and never reaches here).
+            in_class = false;
+            result.push(']');
+            i += 1;
+        } else if !in_class && chars[i] == '(' && i + 2 < chars.len() && chars[i + 1] == '?' {
             // Check for JS named group (?<name>...) — convert to (?P<name>...)
-            // But NOT (?<=...) (lookbehind) or (?<!...) (negative lookbehind)
+            // But NOT (?<=...) (lookbehind) or (?<!...) (negative lookbehind).
+            // Parens inside a character class are literals, so only outside a class.
             if chars[i + 2] == '<'
                 && i + 3 < chars.len()
                 && chars[i + 3] != '='

--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -16,6 +16,32 @@
 //! Request id never collides with a Response/Headers/Blob id.
 
 use super::*;
+use perry_runtime::js_get_string_pointer_unified;
+
+/// Coerce a `Response` body-init value to a `*const StringHeader` (returned as
+/// i64, mirroring `js_get_string_pointer_unified`).
+///
+/// A `ReadableStream` handle — e.g. another Response's `.body` — is a plain
+/// numeric f64 id allocated from `0x40000` with no NaN-box tag, so the generic
+/// string coercion would stringify the handle to its number (`"262144"`) and
+/// discard the real bytes. Hono re-wraps responses to mutate headers via
+/// `new Response(res.body, res)`, so the body must be DRAINED from the stream's
+/// buffered chunks instead. Any non-stream value falls back to the normal
+/// coercion, so plain string bodies (`c.json`/`c.text`) are unaffected.
+#[no_mangle]
+pub extern "C" fn js_response_body_init_ptr(value: f64) -> i64 {
+    // Stream ids live in [0x40000, 0x100000); a non-integral or out-of-range
+    // value can't be one, so we skip the registry probe for the common cases.
+    if value.is_finite() && value.fract() == 0.0 && (262144.0..1048576.0).contains(&value) {
+        let id = value as usize;
+        // kind == 1 ⇒ live ReadableStream.
+        if crate::streams::js_stream_handle_kind(id) == 1 {
+            let bytes = crate::streams::drain_readable_into_bytes(id);
+            return unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) } as i64;
+        }
+    }
+    js_get_string_pointer_unified(value)
+}
 
 // ----------------- Untyped property dispatch (refs #421) -----------------
 //


### PR DESCRIPTION
Three independent AOT/runtime bugs that together stopped a real Hono app (the Skelpo CMS) from serving a single request when compiled with Perry. Each was reduced to a minimal repro and verified; commits are split one-per-fix.

### 1. `fix(regex)` — literal `[` inside a character class
`js_regex_to_rust` passed JS character classes unchanged to the Rust `regex` crate, which rejects a bare `[` inside `[...]` (JS, without the `v` flag, treats it as a literal). So `/[[]/` — valid in Node — threw "invalid pattern". Hono's `RegExpRouter` escapes path segments with `/[.\\+*[^\]$()]/g`, so **every** Hono app threw on its first request. Fix tracks class state and escapes an unescaped `[` to `\[`.

### 2. `fix(hir)` — destructured function params bound as `const`
`generate_param_destructuring_stmts` lowered array/object param patterns as immutable, so reassigning a destructured parameter threw "Assignment to constant variable". Parameters are mutable bindings (like `let`). Hono hit this in `handlers.map(([h, paramCount]) => { paramCount -= 1; … })`. Fix passes `mutable: true` (matching the function's own doc comment).

### 3. `fix(fetch)` — ReadableStream body dropped by the Response constructor
`new Response(body, init)` stringified the body value; a `ReadableStream` handle is a plain numeric f64 id, so it was coerced to its number (`"262144"`) and the real bytes were dropped. Hono re-wraps responses to mutate headers via `new Response(c.res.body, c.res)`, so responses came out corrupt (and surfaced downstream as a bare thrown `Symbol()`). Fix adds `js_response_body_init_ptr`, which drains a live readable stream via the existing `drain_readable_into_bytes` and otherwise falls back to the normal string coercion (plain `c.json`/`c.text` bodies unaffected).

### Validation
Built `perry` from this branch (driver + auto-optimized runtime/stdlib) and compiled the CMS: it now boots and serves correct native responses (`GET /`, `/healthz`, `/readyz` incl. a live MySQL ping, `/nope` 404). Each fix also has a standalone minimal repro.

Note: per CONTRIBUTING, this branch does **not** touch `version` / `CHANGELOG.md` / `CLAUDE.md` — leaving the version + changelog fold-in to the maintainer at merge.