### PR TITLE
fix(node): API-surface hygiene batch (#3925, #3946, #3857, #3962, #3938)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1058 — fix(node): API-surface hygiene batch (#3925, #3946, #3857, #3962, #3938)
+
+Five Node-parity fixes for the `node:*` builtin surface:
+
+- **#3925 — `node:punycode.ucs2` phantom submodule.** Perry advertised
+  `node:punycode.ucs2` as an importable builtin; Node throws
+  `ERR_UNKNOWN_BUILTIN_MODULE` (`ucs2` is a *property* of `node:punycode`, not a
+  module). The HIR import gate (`lower/module_decl.rs`) now rejects any
+  `node:`-prefixed specifier that isn't a real Node builtin
+  (`NODE_BUILTIN_MODULES`) or a resolvable native module — also closing the
+  more general "`node:bogusmod` checks clean" gap. `punycode.ucs2` stays in
+  `NODE_SUBMODULES` as a Perry-internal dispatch namespace so
+  `punycode.ucs2.decode/encode` member access keeps working.
+- **#3946 — `node:process` core properties via named/namespace import.**
+  `import { pid, arch, platform, … } from "node:process"` and
+  `import * as p from "node:process"; p.pid` resolved to `undefined` (only the
+  default import and global `process` worked). Named imports now route process
+  *properties* through the dedicated `ProcessPid`/`OsArch`/… lowerings, and the
+  `process.<prop>` member path also fires for namespace/default import locals.
+- **#3857 — `JSON.stringify` of boxed primitive wrappers.**
+  `JSON.stringify(new String("hi"))` returned `{}` instead of `"hi"`; the same
+  applied to `new Number`/`new Boolean` and to wrappers nested in objects and
+  arrays, and the 3-arg pretty form crashed. Stringify now unwraps boxed
+  String/Number/Boolean/BigInt wrappers to their primitive across the compact,
+  array (fast + slow), and pretty paths.
+- **#3962 — `process.stdin` listener-removal + lifecycle for TUI teardown.**
+  `process.stdin` lacked `removeListener`/`off`/`addListener`/
+  `removeAllListeners`/`pause`/`resume`/`unref`/`destroy`. They're now present;
+  on stdin, `pause`/`unref`/`destroy` detach the readline reader so the event
+  loop can quiesce after teardown (readline `has_active` consults the new
+  `stdin_is_detached()` flag) without an explicit `process.exit()`.
+- **#3938 — literal dynamic import of slash submodules.**
+  `await import("node:util/types")` / `"node:path/posix"` /
+  `"node:stream/promises"` emitted invalid LLVM (a `@__perry_ns_…/…` global with
+  a slash). The dead extern-global/init declarations for `__native_mod__` /
+  `__node_submod__` sentinel prefixes (resolved at the dispatch site via runtime
+  namespace builders) are no longer emitted.
+
+Regression coverage: `node-suite` fixtures for #3857/#3946/#3938/#3925 and a
+`perry-hir` unknown-builtin-module rejection test.
+
 ## v0.5.1057 — fix(#2169): perry-ui-windows LNK4006 / LNK4088 + windows-rs 0.58 drift
 
 The user-reported repro (Windows 10, perry 0.5.1025) failed silently with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1057
+**Current Version:** 0.5.1058
 
 
 ## TypeScript Parity Status

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1057"
+version = "0.5.1058"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -151,6 +151,13 @@ pub const NODE_SUBMODULES: &[&str] = &[
     "stream/consumers",
     "stream/web",
     "readline/promises",
+    // #3925: `punycode.ucs2` is a Perry-internal dispatch namespace backing
+    // `punycode.ucs2.decode/encode` member access — NOT a real Node builtin.
+    // Node has no `node:punycode.ucs2` module (`ucs2` is a property of
+    // `punycode`), so the import gate in `perry-hir` rejects the specifier even
+    // though it stays registered here for member dispatch + manifest
+    // consistency.
+    "punycode.ucs2",
     "sys",
     "test",
     "test/reporters",

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -151,7 +151,6 @@ pub const NODE_SUBMODULES: &[&str] = &[
     "stream/consumers",
     "stream/web",
     "readline/promises",
-    "punycode.ucs2",
     "sys",
     "test",
     "test/reporters",

--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -1075,6 +1075,17 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
             }
         }
         for prefix in foreign_prefixes {
+            // #3938: `__native_mod__<name>` / `__node_submod__<key>` sentinel
+            // prefixes are resolved at the `Expr::DynamicImport` dispatch site
+            // via runtime namespace builders (`js_create_native_module_namespace`
+            // / `js_node_submodule_namespace`); they have no compiled-module
+            // `@__perry_ns_<prefix>` global or `<prefix>__init` function, so the
+            // extern decls below are dead. Worse, for slash-bearing submodule
+            // names (`node:path/posix`, `node:util/types`) the `/` is illegal in
+            // an LLVM global identifier and broke the whole module. Skip them.
+            if prefix.starts_with("__native_mod__") || prefix.starts_with("__node_submod__") {
+                continue;
+            }
             let ns_name = format!("__perry_ns_{}", prefix);
             llmod.add_external_global(&ns_name, DOUBLE);
             // Issue #753: declare each dynamic-import target's `__init`

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -48,6 +48,35 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
     result
 }
 
+/// #3946: lower a value-read of a `node:process` core property imported by
+/// name (`import { pid, arch } from "node:process"`) or read off a namespace
+/// local. Mirrors the dedicated `process.<prop>` variants used by the global
+/// member-access path so named/namespace forms agree with `process.<prop>`
+/// instead of resolving to `undefined`. Methods (`cwd`, `exit`, …) return
+/// `None` so the caller keeps lowering them to a callable native-module ref.
+pub(crate) fn lower_process_named_property(prop: &str) -> Option<Expr> {
+    Some(match prop {
+        "argv" => Expr::ProcessArgv,
+        "platform" => Expr::OsPlatform,
+        "arch" => Expr::OsArch,
+        "pid" => Expr::ProcessPid,
+        "ppid" => Expr::ProcessPpid,
+        "version" => Expr::ProcessVersion,
+        "versions" => Expr::ProcessVersions,
+        "env" => Expr::ProcessEnv,
+        "stdin" => Expr::ProcessStdin,
+        "stdout" => Expr::ProcessStdout,
+        "stderr" => Expr::ProcessStderr,
+        "execArgv" | "moduleLoadList" => Expr::Array(Vec::new()),
+        "title" => Expr::ProcessTitle,
+        "argv0" | "execPath" => Expr::IndexGet {
+            object: Box::new(Expr::ProcessArgv),
+            index: Box::new(Expr::Number(0.0)),
+        },
+        _ => return None,
+    })
+}
+
 fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Result<Expr> {
     // Issue #444: `import.meta.<prop>` folds directly to a literal at
     // lowering time. Routing through the bare-`import.meta` Object
@@ -137,7 +166,18 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
 
     // Check if this is process.* property access
     if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
-        if obj_ident.sym.as_ref() == "process" {
+        // #3946: the global `process`, and also a namespace/default import
+        // local (`import * as p from "node:process"; p.pid` /
+        // `import p from "node:process"; p.pid`) both route through the same
+        // dedicated process-property lowering — otherwise the namespace form
+        // fell through to a generic native-module PropertyGet that resolved
+        // `pid`/`arch`/`platform`/… to `undefined`.
+        let is_process_obj = obj_ident.sym.as_ref() == "process"
+            || matches!(
+                ctx.lookup_native_module(obj_ident.sym.as_ref()),
+                Some(("process", None))
+            );
+        if is_process_obj {
             if let ast::MemberProp::Ident(prop_ident) = &member.prop {
                 match prop_ident.sym.as_ref() {
                     "argv" => return Ok(Expr::ProcessArgv),

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -286,6 +286,16 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                     }
                 }
                 if let Some(method) = method_name {
+                    // #3946: a `node:process` *property* imported by name
+                    // (`import { pid, arch } from "node:process"`) must read
+                    // the live process value, not a generic native-module
+                    // PropertyGet (which resolved to `undefined`). Methods
+                    // fall through to the callable native-module ref below.
+                    if module_name == "process" {
+                        if let Some(e) = expr_member::lower_process_named_property(method) {
+                            return Ok(e);
+                        }
+                    }
                     return Ok(Expr::PropertyGet {
                         object: Box::new(Expr::NativeModuleRef(module_name.to_string())),
                         property: method.to_string(),

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -58,18 +58,18 @@ pub(crate) fn lower_module_decl(
             // Check if this is a native module import
             let is_native = is_native_module(&source);
 
-            // #3925: `node:`-prefixed specifiers must name a real Node built-in.
-            // Node throws `ERR_UNKNOWN_BUILTIN_MODULE` for anything else (e.g.
-            // `node:punycode.ucs2`, where `ucs2` is a *property* of
-            // `node:punycode`, not a module). Reject only specifiers that are
-            // neither a Node built-in nor something Perry already resolves, so
-            // implemented submodules (`node:fs/promises`, `node:util/types`, …)
-            // keep working.
+            // #3925: a `node:`-prefixed specifier must name a real Node
+            // built-in module. Node throws `ERR_UNKNOWN_BUILTIN_MODULE` for
+            // anything else — e.g. `node:punycode.ucs2`, where `ucs2` is a
+            // *property* of `node:punycode`, not a module. (`punycode.ucs2`
+            // stays in `NODE_SUBMODULES` as a Perry-internal dispatch namespace,
+            // so the check keys off `NODE_BUILTIN_MODULES` — the real Node
+            // surface — not `is_known_module`.) `is_native` keeps any
+            // node:-prefixed NATIVE_MODULES entry resolvable.
             if raw_source.starts_with("node:")
                 && !import_decl.type_only
                 && !is_node_builtin_module(&source)
                 && !is_native
-                && !perry_api_manifest::is_known_module(&source)
             {
                 crate::lower_bail!(
                     import_decl.span,

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -58,6 +58,27 @@ pub(crate) fn lower_module_decl(
             // Check if this is a native module import
             let is_native = is_native_module(&source);
 
+            // #3925: `node:`-prefixed specifiers must name a real Node built-in.
+            // Node throws `ERR_UNKNOWN_BUILTIN_MODULE` for anything else (e.g.
+            // `node:punycode.ucs2`, where `ucs2` is a *property* of
+            // `node:punycode`, not a module). Reject only specifiers that are
+            // neither a Node built-in nor something Perry already resolves, so
+            // implemented submodules (`node:fs/promises`, `node:util/types`, …)
+            // keep working.
+            if raw_source.starts_with("node:")
+                && !import_decl.type_only
+                && !is_node_builtin_module(&source)
+                && !is_native
+                && !perry_api_manifest::is_known_module(&source)
+            {
+                crate::lower_bail!(
+                    import_decl.span,
+                    "Cannot find module '{}'. No such built-in module: {}",
+                    raw_source,
+                    raw_source
+                );
+            }
+
             // Native modules have no class metadata to extract — `node:fs`,
             // `node:path`, etc. produce no `ImportedClass` entries and the
             // runtime can't resolve type-only names anyway. Skip the whole

--- a/crates/perry-hir/tests/node_named_export_hygiene.rs
+++ b/crates/perry-hir/tests/node_named_export_hygiene.rs
@@ -105,9 +105,45 @@ fn invalid_node_named_imports_are_rejected() {
 }
 
 #[test]
+fn unknown_node_builtin_modules_are_rejected() {
+    // #3925: a `node:`-prefixed specifier that isn't a real Node built-in must
+    // be rejected (Node throws ERR_UNKNOWN_BUILTIN_MODULE). `punycode.ucs2` is
+    // the representative phantom submodule — `ucs2` is a *property* of
+    // `node:punycode`, not its own module — but it stays a Perry-internal
+    // dispatch namespace, so this guards the import path specifically.
+    let cases = [
+        r#"import { decode, encode } from "node:punycode.ucs2"; console.log(decode, encode);"#,
+        r#"import { foo } from "node:bogusmod"; console.log(foo);"#,
+        r#"import "node:punycode.ucs2";"#,
+    ];
+
+    let mut failures = Vec::new();
+    for src in cases {
+        match lower_result(src) {
+            Ok(_) => failures.push(format!("unknown builtin compiled: {src}")),
+            Err(err) => {
+                if !err.contains("No such built-in module") {
+                    failures.push(format!("unexpected error for {src}: {err}"));
+                }
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} unknown-builtin case(s) failed:\n  {}",
+        failures.len(),
+        failures.join("\n  ")
+    );
+}
+
+#[test]
 fn valid_node_named_imports_keep_compiling() {
     let cases = [
         r#"import { Buffer, atob, isUtf8 } from "node:buffer"; console.log(Buffer, atob, isUtf8);"#,
+        // #3925: real slash submodules must keep resolving past the new guard.
+        r#"import { isMap, isDataView } from "node:util/types"; console.log(isMap, isDataView);"#,
+        r#"import { readFile } from "node:fs/promises"; console.log(readFile);"#,
         r#"import { performance, PerformanceObserver, timerify } from "node:perf_hooks"; console.log(performance, PerformanceObserver, timerify);"#,
         r#"import { StringDecoder } from "node:string_decoder"; console.log(StringDecoder);"#,
         r#"import { isatty, ReadStream, WriteStream } from "node:tty"; console.log(isatty, ReadStream, WriteStream);"#,

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -12,7 +12,7 @@ use super::*;
 mod array_buffer;
 mod boxed_primitives;
 mod collection_equality;
-pub(crate) use boxed_primitives::boxed_primitive_payload;
+pub(crate) use boxed_primitives::{boxed_primitive_json_value, boxed_primitive_payload};
 pub use boxed_primitives::{
     js_boxed_bigint_new, js_boxed_boolean_new, js_boxed_number_new, js_boxed_string_new,
     js_boxed_symbol_new, scan_boxed_primitive_payload_roots_mut,

--- a/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
+++ b/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
@@ -92,6 +92,24 @@ pub fn scan_boxed_primitive_payload_roots_mut(visitor: &mut crate::gc::RuntimeRo
     });
 }
 
+/// #3857: `JSON.stringify` of a boxed primitive wrapper (`new String("hi")`,
+/// `new Number(5)`, `new Boolean(true)`, `Object(1n)`) serializes the
+/// *underlying primitive*, not the wrapper object's (empty) own-property set —
+/// otherwise it produced `{}`. Returns the NaN-boxed primitive payload for
+/// String/Number/Boolean/BigInt wrappers; `None` for Symbol wrappers (JSON
+/// omits symbols) and for any non-wrapper value.
+#[inline]
+pub(crate) fn boxed_primitive_json_value(value: f64) -> Option<f64> {
+    let (class_id, payload) = boxed_primitive_payload(value)?;
+    match class_id {
+        CLASS_ID_BOXED_STRING
+        | CLASS_ID_BOXED_NUMBER
+        | CLASS_ID_BOXED_BOOLEAN
+        | CLASS_ID_BOXED_BIGINT => Some(payload),
+        _ => None,
+    }
+}
+
 #[inline]
 pub(crate) fn boxed_primitive_payload(value: f64) -> Option<(u32, f64)> {
     let jv = crate::value::JSValue::from_bits(value.to_bits());

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -83,9 +83,9 @@ pub use formatting::{
 };
 
 pub(crate) use formatting::{
-    boxed_primitive_payload, format_finite_number_js, format_jsvalue, is_negative_zero,
-    jsvalue_string_content, InspectCompactGuard, InspectCustomInspectGuard, InspectDepthLimitGuard,
-    InspectGettersGuard, InspectShowHiddenGuard, InspectSortedGuard,
+    boxed_primitive_json_value, boxed_primitive_payload, format_finite_number_js, format_jsvalue,
+    is_negative_zero, jsvalue_string_content, InspectCompactGuard, InspectCustomInspectGuard,
+    InspectDepthLimitGuard, InspectGettersGuard, InspectShowHiddenGuard, InspectSortedGuard,
 };
 
 pub use globals::{

--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -488,6 +488,15 @@ pub(crate) unsafe fn stringify_value_pretty(
     }
 
     if let Some(ptr) = extract_pointer(bits) {
+        // #3857: a boxed primitive wrapper (`new String`/`Number`/`Boolean`,
+        // `Object(1n)`) serializes as its underlying primitive. Must run before
+        // the `is_object_pointer` probes below, which would deref the wrapper
+        // as a plain object (emitting `{}`) — and, in the 3-arg pretty form,
+        // crash on its empty key layout.
+        if let Some(prim) = crate::builtins::boxed_primitive_json_value(value) {
+            stringify_value_pretty(prim, TYPE_UNKNOWN, buf, indent, depth);
+            return;
+        }
         // Buffer / Map / Set / Error have non-ObjectHeader layouts; detect them
         // before the `is_object_pointer` probes below, which would deref their
         // internals as a `keys_array` and segfault. Buffers (no GcHeader, so

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -505,6 +505,13 @@ pub(crate) unsafe fn stringify_value(value: f64, type_hint: u32, buf: &mut Strin
             buf.push_str("null");
             return;
         }
+        // #3857: a boxed primitive wrapper (`new String`/`Number`/`Boolean`,
+        // `Object(1n)`) serializes as its underlying primitive, not the empty
+        // wrapper object (which produced `{}`). Recurse on the unwrapped value.
+        if let Some(prim) = crate::builtins::boxed_primitive_json_value(value) {
+            stringify_value(prim, TYPE_UNKNOWN, buf);
+            return;
+        }
         // #2089: a Date is a NaN-boxed `DateCell` pointer — emit `toJSON()`
         // (ISO string, or `null` for an Invalid Date) per ECMA-262 25.5.2,
         // before any object/array deref of the small cell.
@@ -714,6 +721,12 @@ pub(crate) unsafe fn stringify_value_depth(
         // objects live far above this low-memory guard (matches gc_obj_type).
         if (ptr as usize) < 0x1000 {
             buf.push_str("null");
+            return;
+        }
+        // #3857: a boxed primitive wrapper serializes as its underlying
+        // primitive (see the matching branch in `stringify_value`).
+        if let Some(prim) = crate::builtins::boxed_primitive_json_value(value) {
+            stringify_value_depth(prim, TYPE_UNKNOWN, buf, depth);
             return;
         }
         // #2089: a Date is a NaN-boxed `DateCell` pointer. JSON.stringify must

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -1437,6 +1437,10 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
             // #2900: a raw-JSON wrapper must emit its stored text verbatim, not
             // be templated as a `{"rawJSON":...}` object.
             && !(first_ptr as usize >= 0x1000 && super::ptr_is_raw_json_wrapper(first_ptr))
+            // #3857: a boxed primitive wrapper has no own enumerable keys, so an
+            // object-shape template would render it (and the whole array) as
+            // `{}`. Fall through to per-element handling, which unwraps it.
+            && crate::builtins::boxed_primitive_json_value(*elements).is_none()
         {
             build_shape_prefix_template(first_bits)
         } else {
@@ -1510,6 +1514,12 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
             } else {
                 elem_bits as *const u8
             };
+            // #3857: a boxed primitive wrapper element serializes as its
+            // underlying primitive, not the empty wrapper object.
+            if let Some(prim) = crate::builtins::boxed_primitive_json_value(elem) {
+                stringify_value_depth(prim, TYPE_UNKNOWN, buf, depth);
+                continue;
+            }
             // #2089: a Date element → its toJSON() ISO string (or null),
             // before any object/array deref of the small cell.
             if crate::date::is_date_cell_addr(elem_ptr as usize) {

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -817,8 +817,8 @@ pub use signal::{js_process_kill, js_util_convert_process_signal_to_exit_code};
 #[path = "os_process_streams.rs"]
 mod process_streams;
 pub use process_streams::{
-    js_process_stderr, js_process_stdin, js_process_stdout, scan_process_stream_singleton_roots_mut,
-    stdin_is_detached,
+    js_process_stderr, js_process_stdin, js_process_stdout,
+    scan_process_stream_singleton_roots_mut, stdin_is_detached,
 };
 
 /// Get the operating system name

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -818,6 +818,7 @@ pub use signal::{js_process_kill, js_util_convert_process_signal_to_exit_code};
 mod process_streams;
 pub use process_streams::{
     js_process_stderr, js_process_stdin, js_process_stdout, scan_process_stream_singleton_roots_mut,
+    stdin_is_detached,
 };
 
 /// Get the operating system name

--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -70,6 +70,28 @@ extern "C" fn process_stream_on_once_stub(
     f64::from_bits(crate::value::TAG_UNDEFINED)
 }
 
+/// #3962: set when a TUI tears down stdin via `process.stdin.destroy()`,
+/// `.pause()`, or `.unref()`. `perry-stdlib`'s readline `has_active` consults
+/// `stdin_is_detached()` so the runtime stops holding the event loop open for
+/// the stdin reader, letting the process quiesce after teardown without an
+/// explicit `process.exit()`.
+static STDIN_DETACHED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// True once `process.stdin` has been detached (`destroy`/`pause`/`unref`).
+pub fn stdin_is_detached() -> bool {
+    STDIN_DETACHED.load(std::sync::atomic::Ordering::Acquire)
+}
+
+/// `destroy`/`pause`/`unref` impl for `process.stdin` — releases the stdin
+/// reader's hold on the event loop. No-op return (`undefined`).
+extern "C" fn process_stdin_detach_stub(
+    _closure: *const crate::closure::ClosureHeader,
+    _arg: f64,
+) -> f64 {
+    STDIN_DETACHED.store(true, std::sync::atomic::Ordering::Release);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
 thread_local! {
     static STDIN_STREAM_SINGLETON: RefCell<usize> = const { RefCell::new(0) };
     static STDOUT_STREAM_SINGLETON: RefCell<usize> = const { RefCell::new(0) };
@@ -121,21 +143,30 @@ fn build_stream_object_with_write(
         );
     }
 
-    let (class_id, packed, field_count) = if is_tty && fd_i == 0 {
-        (
-            crate::tty::CLASS_ID_TTY_READ_STREAM,
-            b"write\0fd\0emit\0on\0once\0writable\0isRaw\0isTTY\0".as_slice(),
-            8,
-        )
-    } else if is_tty {
-        (
-            crate::tty::CLASS_ID_TTY_WRITE_STREAM,
-            b"write\0fd\0emit\0on\0once\0writable\0addListener\0removeListener\0off\0removeAllListeners\0".as_slice(),
-            10,
-        )
-    } else {
-        (0, b"write\0fd\0emit\0on\0once\0writable\0".as_slice(), 6)
-    };
+    // #3962: EventEmitter listener-removal + lifecycle surface appended to the
+    // stdin shapes (the TTY read stream and the generic non-TTY stream, which
+    // also backs piped stdin/stdout/stderr). The TTY *write* stream keeps its
+    // existing shape. `teardown_start` is the field index where these begin, or
+    // `None` for the TTY write stream.
+    const TEARDOWN_KEYS: &[u8] =
+        b"addListener\0removeListener\0off\0removeAllListeners\0pause\0resume\0unref\0destroy\0";
+    let (class_id, packed, field_count, teardown_start): (u32, Vec<u8>, u32, Option<u32>) =
+        if is_tty && fd_i == 0 {
+            let mut keys = b"write\0fd\0emit\0on\0once\0writable\0isRaw\0isTTY\0".to_vec();
+            keys.extend_from_slice(TEARDOWN_KEYS);
+            (crate::tty::CLASS_ID_TTY_READ_STREAM, keys, 16, Some(8))
+        } else if is_tty {
+            (
+                crate::tty::CLASS_ID_TTY_WRITE_STREAM,
+                b"write\0fd\0emit\0on\0once\0writable\0addListener\0removeListener\0off\0removeAllListeners\0".to_vec(),
+                10,
+                None,
+            )
+        } else {
+            let mut keys = b"write\0fd\0emit\0on\0once\0writable\0".to_vec();
+            keys.extend_from_slice(TEARDOWN_KEYS);
+            (0, keys, 14, Some(6))
+        };
     let obj = if class_id == 0 {
         js_object_alloc_with_shape(
             0x7FFF_FF22,
@@ -200,6 +231,32 @@ fn build_stream_object_with_write(
             9,
             JSValue::from_bits(crate::tty::tty_listener_remove_all_value().to_bits()),
         );
+    }
+    // #3962: install the appended listener-removal + lifecycle methods.
+    // `on`/`once` above are no-ops here, so `addListener`/`removeListener`/
+    // `off`/`removeAllListeners`/`resume` are no-ops too. On *stdin* (fd 0),
+    // `pause`/`unref`/`destroy` additionally detach the reader so the loop can
+    // quiesce after TUI teardown; on stdout/stderr they stay no-ops.
+    if let Some(start) = teardown_start {
+        let set_field_with_stub =
+            |idx: u32, stub: extern "C" fn(*const crate::closure::ClosureHeader, f64) -> f64| {
+                let c = js_closure_alloc(stub as *const u8, 0);
+                js_object_set_field(obj, idx, JSValue::pointer(c as *const u8));
+            };
+        let lifecycle: extern "C" fn(*const crate::closure::ClosureHeader, f64) -> f64 =
+            if fd_i == 0 {
+                process_stdin_detach_stub
+            } else {
+                process_stream_on_once_stub
+            };
+        set_field_with_stub(start, process_stream_on_once_stub); // addListener
+        set_field_with_stub(start + 1, process_stream_on_once_stub); // removeListener
+        set_field_with_stub(start + 2, process_stream_on_once_stub); // off
+        set_field_with_stub(start + 3, process_stream_on_once_stub); // removeAllListeners
+        set_field_with_stub(start + 4, lifecycle); // pause
+        set_field_with_stub(start + 5, process_stream_on_once_stub); // resume
+        set_field_with_stub(start + 6, lifecycle); // unref
+        set_field_with_stub(start + 7, lifecycle); // destroy
     }
     obj
 }

--- a/crates/perry-stdlib/src/readline.rs
+++ b/crates/perry-stdlib/src/readline.rs
@@ -1096,6 +1096,11 @@ pub extern "C" fn js_readline_process_pending() -> i32 {
 /// keep running.
 #[no_mangle]
 pub extern "C" fn js_readline_has_active() -> i32 {
+    // #3962: a TUI that tore down stdin (`process.stdin.destroy()/.pause()/
+    // .unref()`) no longer pins the event loop, so the process can quiesce.
+    if perry_runtime::os::stdin_is_detached() {
+        return 0;
+    }
     let started = READER_STARTED.load(Ordering::Acquire);
     let eof = EOF_REACHED.load(Ordering::Acquire);
     let has_lines = PENDING_LINES.lock().map(|q| !q.is_empty()).unwrap_or(false);

--- a/test-parity/node-suite/globals/dynamic-import-node-submodules.ts
+++ b/test-parity/node-suite/globals/dynamic-import-node-submodules.ts
@@ -1,0 +1,6 @@
+// #3938: literal dynamic import of node:* submodules whose names contain "/"
+// resolves at compile time without emitting invalid LLVM.
+const utilTypes = await import("node:util/types");
+const pathPosix = await import("node:path/posix");
+console.log("util/types", typeof utilTypes.isMap, typeof utilTypes.isDataView);
+console.log("path/posix", typeof pathPosix.join, pathPosix.join("a", "b"));

--- a/test-parity/node-suite/globals/json-boxed-primitive-wrappers.ts
+++ b/test-parity/node-suite/globals/json-boxed-primitive-wrappers.ts
@@ -1,0 +1,8 @@
+// #3857: JSON.stringify of boxed primitive wrappers serializes the underlying
+// primitive, not the (empty) wrapper object.
+console.log(JSON.stringify(new String("hi")));
+console.log(JSON.stringify(new Number(5)));
+console.log(JSON.stringify(new Boolean(true)));
+console.log(JSON.stringify({ a: new String("x"), b: new Number(2), c: new Boolean(false) }));
+console.log(JSON.stringify([new String("a"), new Number(1), new Boolean(true)]));
+console.log(JSON.stringify({ n: new Number(3), s: new String("y") }, null, 2));

--- a/test-parity/node-suite/process/imports/core-property-imports.ts
+++ b/test-parity/node-suite/process/imports/core-property-imports.ts
@@ -1,0 +1,9 @@
+// #3946: node:process core properties resolve through named + namespace
+// imports, matching the global `process` object (not `undefined`).
+import { pid, ppid, arch, platform, version, versions, argv, env } from "node:process";
+import * as ns from "node:process";
+
+console.log("named", typeof pid, typeof ppid, typeof arch, typeof platform, typeof version, typeof versions, Array.isArray(argv), typeof env);
+console.log("namespace", typeof ns.pid, typeof ns.arch, typeof ns.platform, typeof ns.version);
+console.log("agree", arch === ns.arch, platform === ns.platform, version === ns.version);
+console.log("global-agree", pid === process.pid, arch === process.arch, platform === process.platform);

--- a/test-parity/node-suite/punycode/ucs2-member-namespace.ts
+++ b/test-parity/node-suite/punycode/ucs2-member-namespace.ts
@@ -1,0 +1,5 @@
+// #3925: `node:punycode.ucs2` is NOT an importable module, but `ucs2` is a
+// property of node:punycode exposing decode/encode.
+import punycode from "node:punycode";
+console.log(JSON.stringify(punycode.ucs2.decode("xy")));
+console.log(punycode.ucs2.encode([120, 121]));


### PR DESCRIPTION
## Summary

Five Node-parity fixes tightening the `node:*` builtin API surface. All verified byte-for-byte against `node --experimental-strip-types` and covered by new tests/fixtures.

| Issue | Fix |
|-------|-----|
| **#3925** | `node:punycode.ucs2` is no longer importable (Node throws `ERR_UNKNOWN_BUILTIN_MODULE`). The HIR import gate now rejects any `node:`-prefixed specifier that isn't a real Node builtin or resolvable native module (also closes the general `node:bogusmod`-checks-clean gap). `punycode.ucs2.decode/encode` member access still works. |
| **#3946** | `import { pid, arch, platform } from "node:process"` and `import * as p from "node:process"; p.pid` resolved to `undefined`; named/namespace process *property* imports now route to the same lowering as `process.<prop>`. |
| **#3857** | `JSON.stringify(new String/Number/Boolean)` returned `{}` (and the 3-arg pretty form crashed); boxed primitive wrappers now serialize as their primitive across compact, array, and pretty paths. |
| **#3962** | `process.stdin` gained `removeListener`/`off`/`addListener`/`removeAllListeners`/`pause`/`resume`/`unref`/`destroy`; on stdin, `pause`/`unref`/`destroy` detach the reader so the loop can quiesce after TUI teardown. |
| **#3938** | `await import("node:util/types"/"node:path/posix"/"node:stream/promises")` emitted invalid LLVM (slash in a global name); the dead extern-global/init decls for sentinel native/submodule prefixes are no longer emitted. |

## Testing

- All 5 repros verified against Node.
- `node-suite` fixtures added for #3857/#3946/#3938/#3925; new `perry-hir` unknown-builtin rejection test.
- Local suites green: `perry-api-manifest` (28), `perry-hir`, `perry-runtime` (953+81), `perry-stdlib`, `perry-codegen` (all). `cargo fmt --check` clean.

Closes #3925, #3946, #3857, #3962, #3938
