### PR TITLE
fix(buffer): materialize Buffer iterators via spread + Array.from (#3909)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1059 — fix(buffer): materialize Buffer iterators via spread + Array.from (#3909)
+
+`buf.keys()`, `buf.values()`, and `buf.entries()` already returned working
+iterator objects — `.next()` and `for...of` produced the right byte
+indices/values — but `[...buf.keys()]` and `Array.from(buf.values())` returned
+an empty array. `js_array_clone_for_spread` (the runtime helper behind array
+spread and `Array.from`) recognizes iterator objects by class id, but its
+`is_array_iterator` check listed only the array/map/set/iterator-helper class
+ids, not `BUFFER_ITERATOR_CLASS_ID`. A Buffer iterator therefore fell through to
+the array-like `.length`/`[i]` path (a Buffer iterator has neither), yielding
+nothing. Added the buffer iterator class id alongside the others, so spread and
+`Array.from` now drive its `.next()` protocol like every other iterator. Added a
+`node-suite/buffer/iterator-spread` regression fixture covering spread,
+`Array.from`, `.next()`, and `for...of`.
+
 ## v0.5.1058 — fix(node): API-surface hygiene batch (#3925, #3946, #3857, #3962, #3938)
 
 Five Node-parity fixes for the `node:*` builtin surface:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1058
+**Current Version:** 0.5.1059
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1057"
+version = "0.5.1059"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1057"
+version = "0.5.1059"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1057"
+version = "0.5.1059"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1057"
+version = "0.5.1059"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1058"
+version = "0.5.1059"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/array/flat_clone.rs
+++ b/crates/perry-runtime/src/array/flat_clone.rs
@@ -358,7 +358,12 @@ pub extern "C" fn js_array_clone(src: *const ArrayHeader) -> *mut ArrayHeader {
                     // #2874: lazy iterator-helper objects (`Iterator.from(x).map(f)`)
                     // dispatch `.next()` via class id, so `[...it]` / `Array.from(it)`
                     // must drive the iterator protocol.
-                    || (*obj).class_id == crate::iterator_helpers::ITERATOR_HELPER_CLASS_ID;
+                    || (*obj).class_id == crate::iterator_helpers::ITERATOR_HELPER_CLASS_ID
+                    // #3909: Buffer iterators (`buf.keys()`/`values()`/`entries()`)
+                    // dispatch `.next()` via class id too — without this `[...buf.keys()]`
+                    // / `Array.from(buf.values())` produced an empty array even though
+                    // `.next()` and `for...of` already worked.
+                    || (*obj).class_id == crate::buffer::BUFFER_ITERATOR_CLASS_ID;
                 let is_iterable = is_array_iterator || {
                     let iter_sym = crate::symbol::well_known_symbol("iterator");
                     if iter_sym.is_null() {

--- a/test-parity/node-suite/buffer/iterator-spread.ts
+++ b/test-parity/node-suite/buffer/iterator-spread.ts
@@ -1,0 +1,16 @@
+// #3909: Buffer keys()/values()/entries() iterators must materialize via
+// spread and Array.from (not just .next()/for-of), matching Node.
+const buf = Buffer.from([10, 20, 30]);
+console.log("spread keys", JSON.stringify([...buf.keys()]));
+console.log("spread values", JSON.stringify([...buf.values()]));
+console.log("spread entries", JSON.stringify([...buf.entries()]));
+console.log("from keys", JSON.stringify(Array.from(buf.keys())));
+console.log("from values", JSON.stringify(Array.from(buf.values())));
+console.log("from entries len", Array.from(buf.entries()).length);
+// .next() / for-of already worked — keep them covered so a regression in
+// either direction is caught.
+const it = buf.values();
+console.log("next", JSON.stringify(it.next()), JSON.stringify(it.next()));
+let sum = 0;
+for (const v of buf.values()) sum += v;
+console.log("for-of sum", sum);


### PR DESCRIPTION
## Summary

`buf.keys()`, `buf.values()`, and `buf.entries()` returned working iterator objects (`.next()` and `for...of` produced the right byte indices/values), but **`[...buf.keys()]` and `Array.from(buf.values())` returned an empty array**.

`js_array_clone_for_spread` — the runtime helper behind array spread and `Array.from` — recognizes iterator objects by class id, but its `is_array_iterator` check listed only the array/map/set/iterator-helper class ids, not `BUFFER_ITERATOR_CLASS_ID`. A Buffer iterator therefore fell through to the array-like `.length`/`[i]` materialization path (which a Buffer iterator doesn't support), yielding nothing. Added the buffer iterator class id alongside the others so spread and `Array.from` drive its `.next()` protocol like every other iterator.

## Testing

Verified byte-for-byte against `node --experimental-strip-types`:
```
[...buf.keys()]            → [0,1,2]
[...buf.values()]          → [byte values]
Array.from(buf.entries())  → [[i,v], …]
```
`.next()` and `for...of` (already working) stay covered. Added `node-suite/buffer/iterator-spread` regression fixture. Local suites green (`perry-runtime`, `perry-hir`), `cargo fmt --check` clean.

Closes #3909
