### PR TITLE
fix(worker_threads): workerData is value-only, not a callable method (#3899)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1061 — fix(worker_threads): workerData is value-only, not callable (#3899)
+
+`worker_threads.workerData` read as a function and `workerData()` returned a
+value, whereas Node exposes `workerData` as a value (the worker's data, or `null`
+on the main thread) and `workerData()` throws. Root cause: a leftover
+`internal_method_sig` row made `module_has_symbol("worker_threads", "workerData")`
+return a `Method`, so codegen's `typeof <module>.<member>` fold reported
+`"function"` (parentPort, which only had a property row, already read `"object"`),
+and the `native_table/extras.rs` row routed `workerData()` to a runtime getter.
+Dropping the method row + call routing lets workerData resolve through
+`property("worker_threads", "workerData")` (typeof `"object"`, value `null`) and
+makes `workerData()` throw a normal `TypeError`. Fixes the
+`worker_threads/main-thread/worker-data-surface` fixture; adds
+`worker_threads/workerdata-value-boundary`. `getWorkerData` is left in place: it
+is not a public named export, but fully removing it makes
+`worker_threads.getWorkerData()` trip the compile-time #463 gate instead of Node's
+runtime TypeError — that absent-member-read boundary is tracked by #3896.
+
 ## v0.5.1060 — fix(crypto): expose Hash/Hmac/Sign/Verify constructor exports (#3955)
 
 `import { Hash } from "node:crypto"` (and `Hmac`/`Sign`/`Verify`) failed `check`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1060
+**Current Version:** 0.5.1061
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1060"
+version = "0.5.1061"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1060"
+version = "0.5.1061"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1060"
+version = "0.5.1061"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1060"
+version = "0.5.1061"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1060"
+version = "0.5.1061"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2515,17 +2515,21 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         &[p_any("p0")],
         TypeSpec::Any,
     ),
+    // #3899: `workerData` is a value-only export (resolved to the worker's data,
+    // or `null` on the main thread, by the value-shaped property arm in
+    // `native_module.rs`). The old `internal_method_sig` row made
+    // `module_has_symbol("worker_threads", "workerData")` return a `Method`, so
+    // codegen's `typeof <module>.<member>` fold reported `"function"` (parentPort,
+    // which has only a property row, correctly read `"object"`). Dropping the
+    // method row lets workerData read through `property("worker_threads",
+    // "workerData")` below, and `workerData()` throws a normal TypeError —
+    // matching Node. (`getWorkerData` is kept for now: it is not a public named
+    // export, but removing it entirely makes `worker_threads.getWorkerData()`
+    // trip the #463 compile gate instead of Node's runtime TypeError — that
+    // absent-member-read boundary is tracked by #3896.)
     internal_method_sig(
         "worker_threads",
         "getWorkerData",
-        false,
-        None,
-        &[],
-        TypeSpec::Any,
-    ),
-    internal_method_sig(
-        "worker_threads",
-        "workerData",
         false,
         None,
         &[],

--- a/crates/perry-codegen/src/lower_call/native_table/extras.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/extras.rs
@@ -92,19 +92,15 @@ pub(super) const EXTRAS_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    // #3899: `workerData` is value-only (not a callable method) — dropping the
+    // call routing makes `workerData()` throw a normal TypeError (the value is
+    // not a function), matching Node. The value-shaped property arm in
+    // `native_module.rs` resolves `workerData` to `null` on the main thread.
+    // (`getWorkerData` keeps its routing; see the entries.rs note re: #3896.)
     NativeModSig {
         module: "worker_threads",
         has_receiver: false,
         method: "getWorkerData",
-        class_filter: None,
-        runtime: "js_worker_threads_get_worker_data",
-        args: &[],
-        ret: NR_F64,
-    },
-    NativeModSig {
-        module: "worker_threads",
-        has_receiver: false,
-        method: "workerData",
         class_filter: None,
         runtime: "js_worker_threads_get_worker_data",
         args: &[],

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2498 entries across 106 modules
+// Coverage: 2497 entries across 106 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -3676,8 +3676,6 @@ declare module "worker_threads" {
   export function receiveMessageOnPort(p0: any): any;
   /** stdlib */
   export function setEnvironmentData(p0: any, p1: any): void;
-  /** stdlib */
-  export function workerData(...args: any[]): any;
 }
 
 declare module "ws" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2498 entries across 106 modules.
+Total: 2497 entries across 106 modules.
 
 ## Modules
 
@@ -3227,7 +3227,6 @@ Total: 2498 entries across 106 modules.
 - `postMessageToThread` — module
 - `receiveMessageOnPort` — module
 - `setEnvironmentData` — module
-- `workerData` — module
 
 ### Properties
 

--- a/test-parity/node-suite/worker_threads/workerdata-value-boundary.ts
+++ b/test-parity/node-suite/worker_threads/workerdata-value-boundary.ts
@@ -1,0 +1,11 @@
+// #3899: `workerData` is a value-only export (null on the main thread), not a
+// callable method — `typeof workerData === "object"` and `workerData()` throws.
+import * as wt from "node:worker_threads";
+function codeOf(fn: () => unknown): string {
+  try { const v = fn(); return `ok:${typeof v}:${String(v)}`; }
+  catch (err: any) { return `${err?.name ?? "Error"}`; }
+}
+console.log("workerData:", typeof wt.workerData, String(wt.workerData));
+console.log("workerData()", codeOf(() => (wt as any).workerData()));
+console.log("parentPort:", typeof wt.parentPort, String(wt.parentPort));
+console.log("isMainThread:", wt.isMainThread, "threadId:", wt.threadId);


### PR DESCRIPTION
## Summary

`worker_threads.workerData` read as a function (`typeof === "function"`) and `workerData()` returned a value — whereas Node exposes `workerData` as a **value** (the worker's data, or `null` on the main thread) and `workerData()` throws.

Root cause: a leftover `internal_method_sig` row made `module_has_symbol("worker_threads", "workerData")` return a `Method`, so codegen's `typeof <module>.<member>` fold reported `"function"` (parentPort, which only had a property row, already read `"object"` correctly), and the `native_table/extras.rs` row routed `workerData()` to a runtime getter. Dropping the method row + call routing lets workerData resolve through the existing `property("worker_threads", "workerData")` (typeof `"object"`, value `null`) and makes `workerData()` throw a normal `TypeError`.

## Testing

Matches `node --experimental-strip-types` byte-for-byte:
```
workerData typeof: object   value: null
workerData call:   TypeError
parentPort typeof: object   value: null   (unregressed)
```
Fixes the existing `worker_threads/main-thread/worker-data-surface` fixture (was failing on main); adds `worker_threads/workerdata-value-boundary`. `perry-api-manifest` + `perry-codegen` suites green; `cargo fmt --check` clean; API docs regenerated. Manual deterministic diffs confirm no message-channel regressions (the harness's flagged failures match on both main and this branch — pre-existing async/shared-target noise).

## Related

Advances #3899 (workerData boundary). The remaining `getWorkerData()` runtime-TypeError behavior depends on the absent-namespace-member-read boundary tracked by #3896, so `getWorkerData` is left in place rather than tripping the compile-time #463 gate.
