### PR TITLE
fix(instanceof): support Response/Request/Headers/Blob fetch handles

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -151,6 +151,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // Promise values are raw promise allocations, not ObjectHeader
                 // instances with a class_id field.
                 "Promise" => 0xFFFF0027u32,
+                // WHATWG fetch types. Like Blob/streams these are pointer-tagged
+                // small-int handles; the runtime resolves them via the stdlib
+                // fetch kind-probe (`res instanceof Response`, etc.).
+                "Response" => 0xFFFF0028u32,
+                "Request" => 0xFFFF0029u32,
+                "Headers" => 0xFFFF002Au32,
                 // #1545: Web Streams. Handles are numeric ids; the runtime
                 // resolves these via the stdlib stream-kind probe rather than
                 // the class chain (`ts.readable instanceof ReadableStream`,

--- a/crates/perry-runtime/src/object/class_handles.rs
+++ b/crates/perry-runtime/src/object/class_handles.rs
@@ -57,6 +57,14 @@ pub type StreamHandleProbeFn = unsafe extern "C" fn(id: usize) -> bool;
 /// `Object.prototype.toString.call(handle)` recover Web stream tags.
 pub type StreamHandleKindProbeFn = unsafe extern "C" fn(id: usize) -> u8;
 
+/// Probe for WHATWG fetch handles (`Response`/`Request`/`Headers`/`Blob`),
+/// which are pointer-tagged small-integer ids, not heap objects with a class
+/// chain. Returns 0 = none, 1 = Response, 2 = Request, 3 = Headers, 4 = Blob.
+/// Lets `x instanceof Response` (etc.) resolve for fetch handles — Hono guards
+/// route fallbacks with `res instanceof Response`, so without this the bare
+/// handle fails the `instanceof` and the guard is skipped.
+pub type FetchHandleKindProbeFn = unsafe extern "C" fn(id: usize) -> u8;
+
 /// Probe for stdlib `events.EventEmitter` handles. The handles are returned as
 /// pointer-tagged small integers, so runtime `instanceof` cannot inspect them
 /// as heap objects.
@@ -84,6 +92,7 @@ static HANDLE_OWN_PROPERTY_NAMES_DISPATCH_PTR: AtomicPtr<()> = AtomicPtr::new(pt
 static HANDLE_PROTOTYPE_DISPATCH_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 static STREAM_HANDLE_PROBE_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 static STREAM_HANDLE_KIND_PROBE_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
+static FETCH_HANDLE_KIND_PROBE_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 static EVENT_EMITTER_HANDLE_PROBE_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 static EVENT_EMITTER_ASYNC_RESOURCE_HANDLE_PROBE_PTR: AtomicPtr<()> =
     AtomicPtr::new(ptr::null_mut());
@@ -178,6 +187,23 @@ pub fn stream_handle_kind_probe() -> Option<StreamHandleKindProbeFn> {
 #[no_mangle]
 pub unsafe extern "C" fn js_register_stream_handle_kind_probe(f: StreamHandleKindProbeFn) {
     STREAM_HANDLE_KIND_PROBE_PTR.store(f as *mut (), Ordering::Release);
+}
+
+/// Fetch-handle kind-probe getter — see `FetchHandleKindProbeFn`.
+#[inline]
+pub fn fetch_handle_kind_probe() -> Option<FetchHandleKindProbeFn> {
+    let p = FETCH_HANDLE_KIND_PROBE_PTR.load(Ordering::Acquire);
+    if p.is_null() {
+        None
+    } else {
+        Some(unsafe { std::mem::transmute::<*mut (), FetchHandleKindProbeFn>(p) })
+    }
+}
+
+/// Register the fetch-handle kind probe (called by the stdlib at init).
+#[no_mangle]
+pub unsafe extern "C" fn js_register_fetch_handle_kind_probe(f: FetchHandleKindProbeFn) {
+    FETCH_HANDLE_KIND_PROBE_PTR.store(f as *mut (), Ordering::Release);
 }
 
 #[inline]

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -12,18 +12,19 @@
 
 pub use super::class_handles::{
     event_emitter_async_resource_handle_probe, event_emitter_handle_probe, event_emitter_on,
-    handle_method_dispatch, handle_own_property_names_dispatch, handle_property_dispatch,
-    handle_property_set_dispatch, handle_prototype_dispatch,
+    fetch_handle_kind_probe, handle_method_dispatch, handle_own_property_names_dispatch,
+    handle_property_dispatch, handle_property_set_dispatch, handle_prototype_dispatch,
     js_register_event_emitter_async_resource_handle_probe, js_register_event_emitter_handle_probe,
-    js_register_event_emitter_on, js_register_handle_method_dispatch,
-    js_register_handle_own_property_names_dispatch, js_register_handle_property_dispatch,
-    js_register_handle_property_set_dispatch, js_register_handle_prototype_dispatch,
-    js_register_net_socket_handle_probe, js_register_stream_handle_kind_probe,
-    js_register_stream_handle_probe, net_socket_handle_probe, stream_handle_kind_probe,
-    stream_handle_probe, EventEmitterAsyncResourceHandleProbeFn, EventEmitterHandleProbeFn,
-    EventEmitterOnFn, HandleMethodDispatchFn, HandleOwnPropertyNamesDispatchFn,
-    HandlePropertyDispatchFn, HandlePropertySetDispatchFn, HandlePrototypeDispatchFn,
-    NetSocketHandleProbeFn, StreamHandleKindProbeFn, StreamHandleProbeFn,
+    js_register_event_emitter_on, js_register_fetch_handle_kind_probe,
+    js_register_handle_method_dispatch, js_register_handle_own_property_names_dispatch,
+    js_register_handle_property_dispatch, js_register_handle_property_set_dispatch,
+    js_register_handle_prototype_dispatch, js_register_net_socket_handle_probe,
+    js_register_stream_handle_kind_probe, js_register_stream_handle_probe, net_socket_handle_probe,
+    stream_handle_kind_probe, stream_handle_probe, EventEmitterAsyncResourceHandleProbeFn,
+    EventEmitterHandleProbeFn, EventEmitterOnFn, FetchHandleKindProbeFn, HandleMethodDispatchFn,
+    HandleOwnPropertyNamesDispatchFn, HandlePropertyDispatchFn, HandlePropertySetDispatchFn,
+    HandlePrototypeDispatchFn, NetSocketHandleProbeFn, StreamHandleKindProbeFn,
+    StreamHandleProbeFn,
 };
 use super::*;
 

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -557,6 +557,36 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
         return false_val;
     }
 
+    // WHATWG fetch: `instanceof Response` / `Request` / `Headers` / `Blob`.
+    // These are pointer-tagged small-integer handles (stdlib fetch registries),
+    // not heap objects, so consult the stdlib fetch kind-probe rather than the
+    // class chain. Without this, Hono's `res instanceof Response` route-fallback
+    // guard sees `false` and skips the fallback, escaping a bare sentinel.
+    const CLASS_ID_RESPONSE: u32 = 0xFFFF0028;
+    const CLASS_ID_REQUEST: u32 = 0xFFFF0029;
+    const CLASS_ID_HEADERS: u32 = 0xFFFF002A;
+    const CLASS_ID_BLOB: u32 = 0xFFFF0026;
+    if class_id == CLASS_ID_RESPONSE
+        || class_id == CLASS_ID_REQUEST
+        || class_id == CLASS_ID_HEADERS
+        || class_id == CLASS_ID_BLOB
+    {
+        if let Some(handle) = small_native_handle_id(value) {
+            if let Some(probe) = crate::object::fetch_handle_kind_probe() {
+                let want = match class_id {
+                    CLASS_ID_RESPONSE => 1u8,
+                    CLASS_ID_REQUEST => 2,
+                    CLASS_ID_HEADERS => 3,
+                    _ => 4, // CLASS_ID_BLOB
+                };
+                if unsafe { probe(handle as usize) } == want {
+                    return true_val;
+                }
+            }
+        }
+        return false_val;
+    }
+
     // Built-in JS types Map / Set / RegExp / Date — Perry doesn't define
     // user classes for these, so we use reserved class IDs and detect via
     // the per-type registries (MAP_REGISTRY / SET_REGISTRY / REGEX_POINTERS)

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -2298,4 +2298,18 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
             crate::streams::js_readable_stream_deferred_byte_source,
         );
     }
+
+    // `instanceof` for WHATWG fetch handles (Response/Request/Headers/Blob).
+    // They are pointer-tagged small-integer ids, not heap objects, so the
+    // runtime can't walk a prototype chain — register a kind-probe so
+    // `x instanceof Response` (Hono's route-fallback guard) resolves. Gated on
+    // the same feature as the fetch module itself.
+    #[cfg(feature = "http-client")]
+    {
+        extern "C" {
+            fn js_register_fetch_handle_kind_probe(f: unsafe extern "C" fn(usize) -> u8);
+            fn js_fetch_handle_kind(id: usize) -> u8;
+        }
+        js_register_fetch_handle_kind_probe(js_fetch_handle_kind);
+    }
 }

--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -76,6 +76,29 @@ fn form_data_bound_method_value(form_id: usize, method_name: &'static str) -> f6
     value
 }
 
+/// `instanceof` kind-probe for fetch handles (registered with the runtime at
+/// init via `js_register_fetch_handle_kind_probe`). Returns 0 = none,
+/// 1 = Response, 2 = Request, 3 = Headers, 4 = Blob. Lets `x instanceof
+/// Response` (etc.) resolve for the pointer-tagged small-integer handles these
+/// types use instead of heap objects. Lives here (not `mod.rs`) to keep that
+/// file under the 2,000-line lint gate.
+#[no_mangle]
+pub extern "C" fn js_fetch_handle_kind(id: usize) -> u8 {
+    if FETCH_RESPONSES.lock().unwrap().contains_key(&id) {
+        return 1;
+    }
+    if REQUEST_REGISTRY.lock().unwrap().contains_key(&id) {
+        return 2;
+    }
+    if HEADERS_REGISTRY.lock().unwrap().contains_key(&id) {
+        return 3;
+    }
+    if BLOB_REGISTRY.lock().unwrap().contains_key(&id) {
+        return 4;
+    }
+    0
+}
+
 // ----------------- Untyped property dispatch (refs #421) -----------------
 //
 // When user code accesses a property on a Web Fetch handle whose static type


### PR DESCRIPTION
`new Response(...) instanceof Response` returned `false` (likewise `Request`, `Headers`, `Blob`). These WHATWG fetch types are represented as pointer-tagged small-integer stdlib handles, not heap objects with a prototype chain, so `js_instanceof` rejected them at the small-handle guard and fell through to `false`.

Real-world impact: Hono's `SmartRouter` guards its route-fallback with `res instanceof Response`, and app code commonly does `if (x instanceof Response) return x`. Under Perry those guards silently failed — e.g. an admin auth gate that returns a redirect `Response` then reads `.user.id` off it, crashing every protected page. (Found bringing the Skelpo CMS up natively; the regex/param/Response-stream fixes that got it this far landed in #3971.)

### Fix
Follows the existing Web-Streams / EventEmitter handle-probe pattern:
- `fetch_handle_kind_probe` (runtime) + `js_fetch_handle_kind` (stdlib) — returns 0=none,1=Response,2=Request,3=Headers,4=Blob from the fetch registries; registered at init (gated on `http-client`, same as the fetch module).
- `js_instanceof` arm for reserved class ids `0xFFFF0028/29/2A` (+ existing `0xFFFF0026` for Blob) that consults the probe.
- Codegen name→class-id mappings for `Response`/`Request`/`Headers`.

### Verified
`new Response()/Request()/Headers() instanceof <same>` → `true`; cross-type stays `false` (Response is not a Request); `instanceof` via a function indirection works. Confirmed end-to-end: the CMS admin gate now redirects (302) instead of crashing, matching Node.