### PR TITLE
fix(perf_hooks): resolve class-id collision breaking Performance/observer-list instanceof (#3871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1062 — fix(perf_hooks): Performance/observer-list instanceof class-id collision (#3871)
+
+`performance instanceof Performance` and `list instanceof PerformanceObserverEntryList`
+returned `false` (mark/measure instanceof already worked). Root cause: the runtime
+class ids `CLASS_ID_PERFORMANCE` (0xFFFF0087), `CLASS_ID_PERFORMANCE_RESOURCE_TIMING`
+(0x86), and `CLASS_ID_PERFORMANCE_OBSERVER_ENTRY_LIST` (0x88) **collided** with
+`node:fs`'s `CLASS_ID_FS_DIRENT` / `CLASS_ID_FS_DIR` / `CLASS_ID_FS_READ_STREAM`. In
+`object/instanceof.rs`, the fs `Dir`/`Dirent`/`ReadStream` arms run *before* the
+perf-hooks shape check, so `js_instanceof(performance, 0x87)` hit
+`is_fs_dirent_instance_value` (→ false) and never reached `is_performance_object_value`.
+Moved the three perf ids to free slots (0x8D/0x8E/0x8F, past fs's 0x8C) in both
+`perf_hooks.rs` and the codegen `instanceof` map, and made `is_performance_object_value`
+recognize the `perf_hooks` namespace object by its stored module name (robust against
+the `PERFORMANCE_NS` pointer cache). Flips the `perf_hooks/global/class-constructors`
+and `perf_hooks/observer/list-instanceof` fixtures to green; `mark`/`measure` instanceof
+and `fs` `Dir`/`Dirent` instanceof are unregressed.
+
 ## v0.5.1061 — fix(worker_threads): workerData is value-only, not callable (#3899)
 
 `worker_threads.workerData` read as a function and `workerData()` returned a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1061
+**Current Version:** 0.5.1062
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1061"
+version = "0.5.1062"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1061"
+version = "0.5.1062"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1061"
+version = "0.5.1062"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1061"
+version = "0.5.1062"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1061"
+version = "0.5.1062"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -160,12 +160,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 "TransformStream" => 0xFFFF0062u32,
                 // node:perf_hooks entry classes. Runtime classifies the
                 // shaped entry objects returned by performance.mark/measure.
-                "Performance" => 0xFFFF0087u32,
+                // #3871: Performance / PerformanceObserverEntryList /
+                // PerformanceResourceTiming moved off 0x87/0x88/0x86 (which
+                // collided with fs Dirent/ReadStream/Dir) to 0x8E/0x8F/0x8D.
+                // Keep in sync with perry-runtime/src/perf_hooks.rs.
+                "Performance" => 0xFFFF008Eu32,
                 "PerformanceEntry" => 0xFFFF0080u32,
                 "PerformanceMark" => 0xFFFF0081u32,
                 "PerformanceMeasure" => 0xFFFF0082u32,
-                "PerformanceObserverEntryList" => 0xFFFF0088u32,
-                "PerformanceResourceTiming" => 0xFFFF0086u32,
+                "PerformanceObserverEntryList" => 0xFFFF008Fu32,
+                "PerformanceResourceTiming" => 0xFFFF008Du32,
                 "Console" => 0xFFFF0083u32,
                 "Event" | "globalThis.Event" => 0xFFFF2403u32,
                 "CustomEvent" | "globalThis.CustomEvent" => 0xFFFF2404u32,

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -358,7 +358,6 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
     if class_id == 0 {
         return false_val;
     }
-
     // Keep in sync with perry-codegen/src/expr/instance_misc1.rs.
     let classic_stream_name = match class_id {
         0xFFFF0070 => Some("Stream"),

--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -35,9 +35,17 @@ const ENTRY_TYPE_FUNCTION: u8 = 3;
 pub(crate) const CLASS_ID_PERFORMANCE_ENTRY: u32 = 0xFFFF_0080;
 pub(crate) const CLASS_ID_PERFORMANCE_MARK: u32 = 0xFFFF_0081;
 pub(crate) const CLASS_ID_PERFORMANCE_MEASURE: u32 = 0xFFFF_0082;
-pub(crate) const CLASS_ID_PERFORMANCE_RESOURCE_TIMING: u32 = 0xFFFF_0086;
-pub(crate) const CLASS_ID_PERFORMANCE: u32 = 0xFFFF_0087;
-pub(crate) const CLASS_ID_PERFORMANCE_OBSERVER_ENTRY_LIST: u32 = 0xFFFF_0088;
+// #3871: these three IDs previously collided with node:fs's CLASS_ID_FS_DIR
+// (0x86), CLASS_ID_FS_DIRENT (0x87), and CLASS_ID_FS_READ_STREAM (0x88), so
+// `performance instanceof Performance` / `list instanceof
+// PerformanceObserverEntryList` were intercepted by the fs Dir/Dirent/
+// ReadStream `instanceof` arms in `object/instanceof.rs` (which run before the
+// perf-hooks shape check) and returned false. Moved to free IDs past fs's range
+// (fs ends at 0x8C). Keep in sync with the literals in
+// `perry-codegen/src/expr/instance_misc1.rs`.
+pub(crate) const CLASS_ID_PERFORMANCE_RESOURCE_TIMING: u32 = 0xFFFF_008D;
+pub(crate) const CLASS_ID_PERFORMANCE: u32 = 0xFFFF_008E;
+pub(crate) const CLASS_ID_PERFORMANCE_OBSERVER_ENTRY_LIST: u32 = 0xFFFF_008F;
 
 /// Shape id for the `{ name, entryType, startTime, duration, detail }` object
 /// returned by mark/measure and the getEntries* arrays.
@@ -145,10 +153,29 @@ pub(crate) unsafe fn is_perf_entry_object_instance_of(
 
 pub(crate) fn is_performance_object_value(value: f64) -> bool {
     let bits = value.to_bits();
-    PERFORMANCE_NS.with(|c| {
+    // Fast path: the exact cached singleton pointer.
+    if PERFORMANCE_NS.with(|c| {
         let cached = c.get();
         cached != 0 && cached == bits
-    })
+    }) {
+        return true;
+    }
+    // #3871: `performance` (global + `node:perf_hooks` import) resolves to the
+    // `perf_hooks` native-module namespace object via
+    // `js_create_native_module_namespace`, whose pointer may differ from the
+    // `PERFORMANCE_NS` cell (the cell is only set by `performance_namespace()`).
+    // Recognize any `perf_hooks` namespace object by its stored module name so
+    // `performance instanceof Performance` holds — mirrors the field-0 name
+    // check used for the observer entry list below.
+    unsafe {
+        if let Some(obj) = as_object_ptr(value) {
+            let module = js_object_get_field(obj, 0);
+            if string_of(module).as_deref() == Some("perf_hooks") {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 pub(crate) fn is_perf_observer_list_value(value: f64) -> bool {


### PR DESCRIPTION
## Summary

`performance instanceof Performance` and `list instanceof PerformanceObserverEntryList` returned `false`, while `mark`/`measure` instanceof already worked.

**Root cause: a class-id collision.** The runtime ids `CLASS_ID_PERFORMANCE` (0xFFFF0087), `CLASS_ID_PERFORMANCE_RESOURCE_TIMING` (0x86), and `CLASS_ID_PERFORMANCE_OBSERVER_ENTRY_LIST` (0x88) were identical to `node:fs`'s `CLASS_ID_FS_DIRENT` / `CLASS_ID_FS_DIR` / `CLASS_ID_FS_READ_STREAM`. In `object/instanceof.rs`, the fs `Dir`/`Dirent`/`ReadStream` arms run **before** the perf-hooks shape check, so `js_instanceof(performance, 0x87)` matched `is_fs_dirent_instance_value` (→ false) and never reached `is_performance_object_value`. (mark/measure use 0x81/0x82, which don't collide — hence they worked.)

## Fix

Moved the three perf ids to free slots **0x8D/0x8E/0x8F** (past fs's 0x8C) in both `perf_hooks.rs` and the codegen `instanceof` map (`instance_misc1.rs`). Also made `is_performance_object_value` recognize the `perf_hooks` namespace object by its stored module name (robust vs the `PERFORMANCE_NS` pointer cache).

## Testing

Flips `perf_hooks/global/class-constructors` and `perf_hooks/observer/list-instanceof` (both failing on main) to green vs `node --experimental-strip-types`. Regression-checked: `perf_hooks/mark/instanceof`, `perf_hooks/measure/instanceof`, and `fs` `Dir`/`Dirent` instanceof fixtures all still match. `perry-runtime` + `perry-codegen` suites green; `cargo fmt --check` clean.

Closes #3871
