### PR TITLE
fix(json): materialize SSO short strings before JSON.parse (segfault)

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -1093,7 +1093,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::JsonParse(text) => {
             let s_box = lower_expr(ctx, text)?;
             let blk = ctx.block();
-            let s_handle = unbox_to_i64(blk, &s_box);
+            // Materialize the operand to a real heap `*StringHeader`. A bare
+            // `unbox_to_i64` passes an SSO short-string's INLINE bytes as the
+            // pointer, and `js_json_parse` then dereferences them as a
+            // StringHeader → SIGSEGV (e.g. `JSON.parse('e' + 'n')`, or any
+            // short runtime/`.slice`-derived string). `js_get_string_pointer_
+            // unified` returns the heap pointer for heap strings and
+            // materializes SSO / number receivers to the heap. Refs #214.
+            let s_handle = blk.call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &s_box)]);
             let result_i64 = blk.call(I64, "js_json_parse", &[(I64, &s_handle)]);
             Ok(blk.bitcast_i64_to_double(&result_i64))
         }
@@ -1124,7 +1131,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let packed = extract_array_of_object_shape(ty, ordered_keys.as_deref());
             let s_box = lower_expr(ctx, text)?;
             let blk = ctx.block();
-            let s_handle = unbox_to_i64(blk, &s_box);
+            // Same SSO-materialization fix as the generic JSON.parse arm above:
+            // a raw unbox would pass SSO inline bytes as a StringHeader pointer.
+            let s_handle = blk.call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &s_box)]);
             let result_i64 = match packed {
                 Some((packed_bytes, field_count)) if field_count > 0 => {
                     // Emit a per-call-site rodata constant. The IR


### PR DESCRIPTION
`JSON.parse(<short runtime string>)` **segfaults**. Minimal repro:

```ts
JSON.parse('e' + 'n');              // SIGSEGV
JSON.parse('enabled'.slice(0, 2));  // SIGSEGV
JSON.parse(String(1));              // SIGSEGV
```

### Cause
The `JSON.parse` codegen (`expr/instance_misc1.rs`) lowered its operand with `unbox_to_i64`, which just extracts the raw NaN-boxed bits. For a heap string that's the `StringHeader*` (works); for an **SSO short string** the bits are the **inline character bytes**, handed to `js_json_parse`, which dereferences them as a `*StringHeader` and reads `byte_len` off a garbage address (the fault address is literally the inline chars, e.g. `0x…6e65` = `"ne"`).

Heap strings (string literals, large concatenations) happened to work, so it hid until a workload parsed many short *runtime* values. Found bringing the Skelpo CMS up on Perry: `@perryts/mysql` decodes a JSON column, the app re-`JSON.parse`s the short results, and the whole HTTP service segfaults on `GET /api/v1/settings`.

### Fix
Lower both the generic and typed (`js_json_parse_typed_array`) `JSON.parse` arms through `js_get_string_pointer_unified` — it returns the heap pointer for heap strings and materializes SSO / number receivers to the heap first (the same coercion already used at other string FFI call sites).

### Verified
`JSON.parse('e'+'n')` now throws a catchable `SyntaxError` instead of crashing; `'1'`/`'42'`/`'true'` parse correctly. End-to-end: the CMS's `/api/v1/settings` (≈940 KB of JSON-column data) now returns 200 and matches Node, and a full 15-route Node-vs-Perry sweep is identical.