### PR TITLE
fix(crypto): wire crypto.generateKeySync so it's callable (#3927)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1063 — fix(crypto): wire crypto.generateKeySync (#3927)
+
+`crypto.generateKeySync("aes"|"hmac", { length })` was rejected by the #463
+unimplemented-API gate even though the runtime (`js_crypto_generate_key_sync`),
+the codegen dispatch (`expr/calls.rs`), and the AES-192/256 KeyObject metadata
+(fixed by #3930) were all already in place — `generateKeySync` was simply missing
+from the API manifest. Added the `method("crypto", "generateKeySync", …)` row so
+the dotted-form `crypto.generateKeySync(...)` reaches its dispatch, plus a
+named-import lowering arm in `expr_call/globals.rs` (mirroring `createSecretKey`)
+so the bare `import { generateKeySync } from "node:crypto"; generateKeySync(...)`
+shape rewrites to the dotted form too. Flips
+`node-suite/crypto/secret-key/generate-key-sync` to green (AES-128/192/256 + hmac
+all match `node --experimental-strip-types`). Remaining `node:crypto` node-suite
+failures (cipher invalid-state #3873, fips-api, prime) are unrelated and
+pre-existing.
+
 ## v0.5.1062 — fix(perf_hooks): Performance/observer-list instanceof class-id collision (#3871)
 
 `performance instanceof Performance` and `list instanceof PerformanceObserverEntryList`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1062
+**Current Version:** 0.5.1063
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1062"
+version = "0.5.1063"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1062"
+version = "0.5.1063"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1062"
+version = "0.5.1063"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1062"
+version = "0.5.1063"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1062"
+version = "0.5.1063"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2649,6 +2649,12 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("crypto", "createPrivateKey", false, None),
     method("crypto", "createPublicKey", false, None),
     method("crypto", "generateKeyPairSync", false, None),
+    // #3927: `crypto.generateKeySync("aes"|"hmac", { length })` — the codegen
+    // dispatch (expr/calls.rs → js_crypto_generate_key_sync) and the secret-key
+    // KeyObject metadata (type/symmetricKeySize/export, fixed for 192/256 by
+    // #3930) were already complete; only this manifest row was missing, so the
+    // #463 unimplemented-API gate rejected the call before codegen ran.
+    method("crypto", "generateKeySync", false, None),
     method("crypto", "createHmac", false, None),
     // `crypto.createCipheriv(alg, key, iv)` / `createDecipheriv(...)` —
     // issue #1075. Registers a CipherHandle dispatched via the

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -776,6 +776,27 @@ pub(super) fn try_global_builtins(
                             }));
                         }
                     }
+                    // #3927: `generateKeySync(alg, options)` from a named import.
+                    // Like createSecretKey above, rewrite to the dotted-form
+                    // `crypto.generateKeySync(...)` so the call reaches the
+                    // dedicated `js_crypto_generate_key_sync` dispatch in
+                    // `expr/calls.rs` (a generic NativeMethodCall has no runtime
+                    // dispatcher for it and returns undefined).
+                    "generateKeySync" => {
+                        if args.len() >= 2 {
+                            let mut iter = args.into_iter();
+                            let alg_arg = iter.next().unwrap();
+                            let options_arg = iter.next().unwrap();
+                            return Ok(Ok(Expr::Call {
+                                callee: Box::new(Expr::PropertyGet {
+                                    object: Box::new(Expr::NativeModuleRef("crypto".to_string())),
+                                    property: "generateKeySync".to_string(),
+                                }),
+                                args: vec![alg_arg, options_arg],
+                                type_args: vec![],
+                            }));
+                        }
+                    }
                     _ => {} // Fall through
                 }
             }

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2499 entries across 106 modules
+// Coverage: 2500 entries across 106 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -904,6 +904,8 @@ declare module "crypto" {
   export function createVerify(...args: any[]): any;
   /** stdlib */
   export function generateKeyPairSync(...args: any[]): any;
+  /** stdlib */
+  export function generateKeySync(...args: any[]): any;
   /** stdlib */
   export function getCiphers(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2499 entries across 106 modules.
+Total: 2500 entries across 106 modules.
 
 ## Modules
 
@@ -701,6 +701,7 @@ Total: 2499 entries across 106 modules.
 - `createVerify` — module
 - `generateKeyPairSync` — module
 - `generateKeyPairSync` — module
+- `generateKeySync` — module
 - `getCiphers` — module
 - `getCurves` — module
 - `getDiffieHellman` — module


### PR DESCRIPTION
## Summary

`crypto.generateKeySync("aes"|"hmac", { length })` was rejected by the #463 unimplemented-API gate, even though everything behind it was already in place: the runtime (`js_crypto_generate_key_sync`), the codegen dispatch (`expr/calls.rs`), and the AES-192/256 KeyObject metadata (fixed by #3930). It was simply **missing from the API manifest**, so the HIR gate rejected the call before codegen ran. (Confirmed: with `PERRY_ALLOW_UNIMPLEMENTED=1` the fixture already matched Node byte-for-byte.)

## Fix

- Added `method("crypto", "generateKeySync", …)` to the manifest so the dotted-form `crypto.generateKeySync(...)` passes the gate and reaches its dispatch.
- Added a named-import lowering arm in `expr_call/globals.rs` (mirroring the existing `createSecretKey` arm) so the bare `import { generateKeySync } from "node:crypto"; generateKeySync(...)` shape rewrites to the dotted form too. (A first attempt via `crypto.rs`'s `is_crypto_method` list broke the member form — generateKeySync is codegen-dispatched, not runtime-(module,method)-dispatched — so this is the correct spot.)

## Testing

Flips `node-suite/crypto/secret-key/generate-key-sync` to green (AES-128/192/256 metadata + jwk export + hmac all match `node --experimental-strip-types`); the bare named-import form returns the key too. `perry-api-manifest` + `perry-hir` suites green; `cargo fmt --check` clean; API docs regenerated. The remaining `node:crypto` node-suite fails (cipher invalid-state #3873, fips-api, prime) are unrelated/pre-existing.

Closes #3927
