### PR TITLE
fix(node): namespace reads of absent builtin members return undefined (#3896)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1064 — fix(node): namespace reads of absent builtin members → undefined (#3896)
+
+A bare value read of an absent member on a Node-core module namespace/default
+object — e.g. `import * as dnsp from "node:dns/promises"; dnsp.ADDRCONFIG` (Node
+exposes `ADDRCONFIG` on `dns` but not `dns/promises`) — tripped the #463
+unimplemented-API read gate and errored at compile time, whereas Node treats it
+as an ordinary property miss returning `undefined`. The call form (`ns.foo()`)
+must still reject as unimplemented. Fixed by threading a transient
+`lowering_call_callee` flag through `LoweringContext`: `lower_call` sets it around
+the callee-lowering, and `lower_member_inner` captures-and-clears it at entry, so
+the read gate keeps rejecting call callees while relaxing pure value reads to
+`undefined` — scoped to Node core modules only (npm packages keep the strict
+gate, and the tree-shaking-deferral path is unchanged). Updated the
+`unimplemented_api_check` member/crypto unit tests to the new behavior (the
+bogus-*call* rejection sweep stays green); added a
+`node-core/namespace-absent-member-read` fixture and flipped
+`dns/constants/error-aliases`. Baseline-compared across fs/dns/events/crypto/os/
+path/process node-suite — no regressions (the pre-existing fs arg-validation
+message-detail and crypto cipher/fips/prime fails are unrelated).
+
 ## v0.5.1063 — fix(crypto): wire crypto.generateKeySync (#3927)
 
 `crypto.generateKeySync("aes"|"hmac", { length })` was rejected by the #463

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1063
+**Current Version:** 0.5.1064
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1063"
+version = "0.5.1064"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1063"
+version = "0.5.1064"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1063"
+version = "0.5.1064"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1063"
+version = "0.5.1064"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1063"
+version = "0.5.1064"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -81,6 +81,7 @@ impl LoweringContext {
             uses_fetch: false,
             uses_webassembly: false,
             suppress_stdlib_dispatch_guard_once: false,
+            lowering_call_callee: false,
             unresolved_ident_as_global: false,
             var_hoisted_ids: HashSet::new(),
             functions_index: HashMap::new(),

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -449,7 +449,14 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
             // for known callees, fold namespace-function calls into
             // StaticMethodCall, and emit Call / CallSpread.
             // ---------------------------------------------------------------
-            let callee_expr = lower_expr(ctx, expr)?;
+            // #3896: mark the callee position so the expr_member read-gate
+            // keeps rejecting `ns.foo()` (absent member call) while relaxing a
+            // bare value read `ns.foo` to undefined for Node-core namespaces.
+            let prev_callee = ctx.lowering_call_callee;
+            ctx.lowering_call_callee = true;
+            let callee_expr = lower_expr(ctx, expr);
+            ctx.lowering_call_callee = prev_callee;
+            let callee_expr = callee_expr?;
 
             // Fill in default arguments if callee is a known function
             let mut args = args;

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -78,6 +78,12 @@ pub(crate) fn lower_process_named_property(prop: &str) -> Option<Expr> {
 }
 
 fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Result<Expr> {
+    // #3896: capture-and-clear the call-callee marker so it applies only to THIS
+    // member (the immediate callee), not to nested member-object reads lowered
+    // below. The #463 read-gate below uses `member_is_call_callee` to keep
+    // rejecting `ns.foo()` while relaxing a bare `ns.foo` value read.
+    let member_is_call_callee = ctx.lowering_call_callee;
+    ctx.lowering_call_callee = false;
     // Issue #444: `import.meta.<prop>` folds directly to a literal at
     // lowering time. Routing through the bare-`import.meta` Object
     // synthesis hits a long-standing module-level NaN-boxing bug where
@@ -1826,6 +1832,17 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
             // #2309: defer when tree-shaking (sink armed for this node_modules
             // module); re-raised only if the module survives pruning.
             if !crate::try_defer_refusal(msg.clone(), member.span.lo.0) {
+                // #3896: a bare *value read* of an absent member on a Node
+                // builtin module namespace/default object is an ordinary
+                // property miss → `undefined` (e.g. `dns/promises.ADDRCONFIG`,
+                // which Node also doesn't export but reads as undefined). Calls
+                // (`ns.foo()`) keep rejecting — `lower_call` set the callee
+                // marker, so `member_is_call_callee` is true there. Only Node
+                // core modules relax; unenumerated npm packages keep the strict
+                // gate (and the tree-shaking defer above).
+                if !member_is_call_callee && perry_api_manifest::is_node_core_module(module) {
+                    return Ok(Expr::Undefined);
+                }
                 crate::lower_bail!(member.span, "{}", msg);
             }
         }

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -234,6 +234,13 @@ pub struct LoweringContext {
     /// (clears) it on read so a dynamic key *inside the index* (`ns[fs[evil]]`)
     /// is still refused.
     pub(crate) suppress_stdlib_dispatch_guard_once: bool,
+    /// #3896: set while lowering the *callee* of a call expression. A namespace
+    /// read of an absent Node-core member (`ns.foo`) is an ordinary property
+    /// miss → `undefined` (matching Node), but `ns.foo()` must still reject via
+    /// the #463 gate. The expr_member read-gate consults this flag to relax only
+    /// value reads, not call callees. Captured-and-cleared at the top of
+    /// `lower_member_inner` so it scopes to the immediate callee member only.
+    pub(crate) lowering_call_callee: bool,
     /// Compatibility escape hatch for legacy member/global lowering. Bare
     /// unresolvable identifiers throw ReferenceError, but member receivers are
     /// still allowed to use the existing GlobalGet sentinel path.

--- a/crates/perry-hir/tests/unimplemented_api_check.rs
+++ b/crates/perry-hir/tests/unimplemented_api_check.rs
@@ -166,17 +166,31 @@ fn node_builtin_real_named_exports_still_compile() {
     );
 }
 
-/// Modules that have at least one manifest entry are strict — any
-/// unknown property errors. `crypto.foobar` is not implemented.
+/// #3896: a bare value read of an unknown member on a Node-core module
+/// namespace is an ordinary property miss → undefined (matching Node), but the
+/// *call* form must still reject as unimplemented.
 #[test]
 fn crypto_unknown_method_is_rejected() {
-    let result = lower_result(
+    let read = lower_result(
         r#"
         import * as crypto from "crypto";
         const x = crypto.foobar;
     "#,
     );
-    assert!(result.is_err(), "crypto.foobar should error");
+    assert!(
+        read.is_ok(),
+        "crypto.foobar value read should resolve to undefined (#3896), got {read:?}"
+    );
+    let call = lower_result(
+        r#"
+        import * as crypto from "crypto";
+        crypto.foobar();
+    "#,
+    );
+    assert!(
+        call.is_err(),
+        "crypto.foobar() call should still error as unimplemented"
+    );
 }
 
 /// `os.platform` is implemented; `os.totalmem` too. Both must continue
@@ -289,14 +303,27 @@ fn every_supported_module_rejects_bogus_member() {
             const x = m.__perry_known_bogus_member_513__;
         "#
         );
+        let is_core = perry_api_manifest::is_node_core_module(module);
         match lower_result(&src) {
             Ok(_) => {
-                failures.push(format!(
-                    "{module}: bogus member access did not error (strict mode not engaged)"
-                ));
+                // #3896: a bogus member *value read* on a Node-core module
+                // namespace is an ordinary property miss → undefined (matching
+                // Node). The call form `m.bogus()` still rejects — see
+                // `every_supported_module_rejects_bogus_call`. Only non-core
+                // (npm) modules keep the strict read-gate.
+                if !is_core {
+                    failures.push(format!(
+                        "{module}: bogus member access did not error (strict mode not engaged)"
+                    ));
+                }
             }
             Err(e) => {
-                if !(e.contains("not implemented") && e.contains("#463")) {
+                if is_core {
+                    failures.push(format!(
+                        "{module}: Node-core bogus member read should now resolve to undefined \
+                         (#3896), not error — got {e}"
+                    ));
+                } else if !(e.contains("not implemented") && e.contains("#463")) {
                     failures.push(format!(
                         "{module}: errored but not via the R005/#463 path — got {e}"
                     ));

--- a/test-parity/node-suite/node-core/namespace-absent-member-read.ts
+++ b/test-parity/node-suite/node-core/namespace-absent-member-read.ts
@@ -1,0 +1,10 @@
+// #3896: reading an absent member off a Node-core module namespace object is an
+// ordinary JavaScript property miss → undefined (matching Node), even though the
+// named import of that member is rejected. (The call form `ns.foo()` still
+// throws/errors as unimplemented — covered by the perry-hir unit tests.)
+import * as dnsp from "node:dns/promises";
+import * as os from "node:os";
+import * as crypto from "node:crypto";
+console.log("dns/promises:", typeof (dnsp as any).ADDRCONFIG, typeof (dnsp as any).V4MAPPED, typeof dnsp.lookup);
+console.log("os:", typeof (os as any).__definitelyNotAnOsMember__, typeof os.platform);
+console.log("crypto:", typeof (crypto as any).__definitelyNotACryptoMember__, typeof crypto.randomUUID);


### PR DESCRIPTION
## Summary

A bare value read of an absent member on a Node-core module namespace/default object — e.g. `import * as dnsp from "node:dns/promises"; dnsp.ADDRCONFIG` (Node exposes `ADDRCONFIG` on `dns` but **not** `dns/promises`) — tripped Perry's #463 unimplemented-API read gate and **errored at compile time**, whereas Node treats it as an ordinary property miss returning `undefined`. The named import of that member stays rejected (correct), and the **call** form `ns.foo()` must still reject as unimplemented.

## Fix

The #463 read gate in `expr_member` fires for both value reads and call callees (the callee `ns.foo` of `ns.foo()` is lowered through it), which is why a naive relaxation broke call-rejection in earlier attempts. Threaded a transient `lowering_call_callee` flag through `LoweringContext`:
- `lower_call` sets it around the callee-lowering (`expr_call/mod.rs`).
- `lower_member_inner` captures-and-clears it at entry (so it scopes to the immediate callee only).
- The read gate relaxes to `undefined` only when **not** a call callee **and** the module is a Node core module — npm packages keep the strict gate, and the tree-shaking deferral path is unchanged.

## Testing

- `dns/promises.ADDRCONFIG` read → `undefined`, `dnsp.lookup` → function, `dnsp.bogus()` → still rejects (matches `node --experimental-strip-types`).
- Updated `unimplemented_api_check` member/crypto unit tests; the bogus-**call** rejection sweep stays green (calls still reject across all modules).
- Added `node-core/namespace-absent-member-read` fixture; flipped `dns/constants/error-aliases`.
- **Baseline-compared** (built origin/main, manual deterministic diffs) across fs/dns/events/crypto/os/path/process node-suite — **no regressions**. The pre-existing fs arg-validation message-detail and crypto cipher/fips/prime fails are unrelated (fail identically on baseline).
- `perry-hir` + `perry-codegen` suites green; `cargo fmt --check` clean.

Closes #3896
