### PR TITLE
fix(node): submodule default imports resolve to module namespace (#3906)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1065 — node-builtin submodule default imports resolve to the module namespace (#3906, partial)
+
+Default-importing a non-native node-builtin submodule (e.g. `import tp from "node:timers/promises"`, `import sp from "node:stream/promises"`) previously lowered the binding down the generic JS-module-default path, producing a primitive (`typeof tp === "boolean"`) instead of an object — so `tp.setTimeout(...)` / `sp.finished(...)` were unreachable. In CommonJS terms the default export *is* `module.exports`, which for these modules is the module namespace itself.
+
+Fix (`crates/perry-hir/src/lower/module_decl.rs`): a default import whose source `is_node_builtin_module` but is not a `NATIVE_MODULES` entry now registers as a namespace binding and pushes an `ImportSpecifier::Namespace { local }` (with `continue`) instead of a `Default` specifier. That places the local into the codegen driver's `namespace_imports`, so `typeof local` folds to `"object"` and `local.member(...)` dispatches through the submodule namespace — identical to the `import * as local` shape. Native-module default imports (os/path/fs) and `import * as` namespaces are untouched (verified byte-identical to Node).
+
+Validated: `typeof tp` → `"object"`, `tp.setTimeout`/`sp.finished`/`sp.pipeline` → `"function"` (matches `node --experimental-strip-types`); native + namespace import smoke clean; `perry-hir` test suite green.
+
+Remaining #3906 work (left open): the `__module__`-only `Object.keys` enumeration for native modules (v8/tty/http2/perf_hooks/util.types) — a broader runtime↔manifest key-order reconciliation — is deferred.
+
 ## v0.5.1064 — fix(node): namespace reads of absent builtin members → undefined (#3896)
 
 A bare value read of an absent member on a Node-core module namespace/default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1064
+**Current Version:** 0.5.1065
 
 
 ## TypeScript Parity Status

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1064"
+version = "0.5.1065"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -277,6 +277,30 @@ pub(crate) fn lower_module_decl(
                                 source.clone(),
                                 native_method,
                             );
+                        } else if is_node_builtin_module(&source) {
+                            // #3906: a CJS-backed Node builtin *submodule* that
+                            // isn't in NATIVE_MODULES (e.g. `node:timers/promises`,
+                            // `node:stream/promises`). Its default export is the
+                            // module object — CJS `default === module.exports`,
+                            // the same value as the `import * as` namespace shape.
+                            // Without this it fell to the JS-module default path
+                            // below and resolved to an `ExternFuncRef` boolean
+                            // stub (`typeof === "boolean"`). Mirror the namespace
+                            // handling so the default binding is the module object.
+                            ctx.register_imported_func(local.clone(), local.clone());
+                            ctx.namespace_import_locals.insert(local.clone());
+                            if source == "fs/promises" {
+                                ctx.register_builtin_module_alias(local.clone(), source.clone());
+                            }
+                            // Treat the default binding as the module-namespace
+                            // object (CJS default === module.exports). Pushing a
+                            // Namespace specifier (not Default) puts `local` into
+                            // the driver's `namespace_imports`, so `typeof local`
+                            // folds to "object" and `local.member(...)` dispatches
+                            // through the submodule namespace — exactly like the
+                            // `import * as local` shape.
+                            specifiers.push(ImportSpecifier::Namespace { local: local.clone() });
+                            continue;
                         } else {
                             // Default import from JS module — register so calls resolve to
                             // ExternFuncRef. Use the LOCAL name as the original-name marker


### PR DESCRIPTION
## #3906 (partial): node-builtin submodule default imports resolve to the module namespace

`import tp from "node:timers/promises"` (and `node:stream/promises`, etc.) previously lowered the default binding down the generic JS-module-default path, producing a **primitive** — `typeof tp === "boolean"` — instead of an object, leaving `tp.setTimeout(...)` / `sp.finished(...)` unreachable.

In CommonJS terms the default export **is** `module.exports`, which for these submodules is the module namespace itself.

### Fix
`crates/perry-hir/src/lower/module_decl.rs`: a default import whose source `is_node_builtin_module` but is **not** a `NATIVE_MODULES` entry now registers as a namespace binding and pushes `ImportSpecifier::Namespace { local }` (with `continue`) instead of a `Default` specifier. That places the local into the codegen driver's `namespace_imports`, so:

- `typeof local` folds to `"object"`
- `local.member(...)` dispatches through the submodule namespace

…identical to the `import * as local` shape.

### Verified (vs `node --experimental-strip-types`)
- `typeof tp` → `"object"`; `tp.setTimeout`/`sp.finished`/`sp.pipeline` → `"function"` ✅
- Native default imports (`os`/`path`/`fs`) and `import * as` namespaces untouched — byte-identical ✅
- `perry-hir` test suite green ✅

### Deferred (issue left open)
The `__module__`-only `Object.keys` enumeration for **native** modules (v8/tty/http2/perf_hooks/util.types) is a broader runtime↔manifest key-order reconciliation and remains open under #3906.
