### PR TITLE
fix(node:constants): gate Linux-only constants out of import surface on macOS (#3902)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1066 — node:constants Linux-only constants gated out of the import surface on macOS (#3902)
+
+On macOS, Node's `node:constants` ESM namespace does not export six Linux-only constants (`O_DIRECT`, `O_NOATIME`, `RTLD_DEEPBIND`, `SIGPOLL`, `SIGPWR`, `SIGSTKFLT`), but Perry accepted all six as named imports and ran the program with each binding set to `undefined` — a false-positive surface: code that fails Node's ESM instantiation passed `perry check` and ran under Perry.
+
+Fix (`crates/perry-api-manifest/src/lib.rs`): a new `is_platform_unavailable_named_export` helper is consulted by `module_has_public_named_export` (the import gate behind the `U006` check). On a non-Linux host the six names are no longer valid named exports, so `perry check`/compile now rejects `import { O_DIRECT } from "node:constants"` with `error[U006] ... does not provide an export named 'O_DIRECT'`, matching Node. Valid constants (`O_RDONLY`, `O_DIRECTORY`, …) are unaffected.
+
+The entries deliberately stay in the static `API_MANIFEST` on every platform, so `--print-api-manifest` and the generated docs (`docs/api/perry.d.ts`, `docs/src/api/reference.md`) remain byte-identical regardless of the host OS the generator runs on — the existing `deprecated_constants_alias_has_manifest_entries` invariant (CI runs `api-docs-drift` on Linux). The gate touches only the import-validation path, not the docs/emit path. New test `platform_unavailable_constants_gate_the_import_surface` covers both halves.
+
+Also closed as already-fixed-on-main (stale mass-filed reports against an old baseline): **#3897** (node:buffer `Buffer.*` static methods misclassified as top-level exports — now `internal_method`, excluded) and **#3898** (node:perf_hooks `performance.*` singleton methods misclassified — now excluded). The current manifest's buffer/perf_hooks module exports already match Node.
+
 ## v0.5.1065 — node-builtin submodule default imports resolve to the module namespace (#3906, partial)
 
 Default-importing a non-native node-builtin submodule (e.g. `import tp from "node:timers/promises"`, `import sp from "node:stream/promises"`) previously lowered the binding down the generic JS-module-default path, producing a primitive (`typeof tp === "boolean"`) instead of an object — so `tp.setTimeout(...)` / `sp.finished(...)` were unreachable. In CommonJS terms the default export *is* `module.exports`, which for these modules is the module namespace itself.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1065
+**Current Version:** 0.5.1066
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1064"
+version = "0.5.1066"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1064"
+version = "0.5.1066"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1064"
+version = "0.5.1066"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1064"
+version = "0.5.1066"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1065"
+version = "0.5.1066"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-api-manifest/src/lib.rs
+++ b/crates/perry-api-manifest/src/lib.rs
@@ -226,9 +226,36 @@ pub fn module_has_public_named_export(module: &str, name: &str) -> bool {
     if name == "default" && is_node_core_module(module) {
         return true;
     }
+    if is_platform_unavailable_named_export(module, name) {
+        return false;
+    }
     API_MANIFEST.iter().any(|entry| {
         entry.module == module && entry.name == name && entry_is_public_named_export(entry)
     })
+}
+
+/// #3902: a handful of `node:constants` values are Linux-only — `O_DIRECT` /
+/// `O_NOATIME` (open(2) flags), `SIGPOLL` / `SIGPWR` / `SIGSTKFLT` (signals),
+/// and `RTLD_DEEPBIND` (a glibc-only dlopen(3) flag). Node's `node:constants`
+/// ESM namespace omits them on other platforms, so importing them there fails
+/// Node's module instantiation.
+///
+/// These entries stay in the static `API_MANIFEST` unconditionally so the
+/// generated docs (`docs/api/perry.d.ts`, `docs/src/api/reference.md`) and
+/// `--print-api-manifest` are byte-identical regardless of the host OS the
+/// generator runs on — otherwise `api-docs-drift` would fail on every PR (CI
+/// runs on Linux; the invariant is asserted by
+/// `deprecated_constants_alias_has_manifest_entries`). But the *import gate*
+/// must still match the host: on a non-Linux host these names are not valid
+/// named exports, so `perry check`/compile rejects them with `U006` instead of
+/// silently binding `undefined` and diverging from Node.
+fn is_platform_unavailable_named_export(module: &str, name: &str) -> bool {
+    let linux_only = module == "constants"
+        && matches!(
+            name,
+            "O_DIRECT" | "O_NOATIME" | "RTLD_DEEPBIND" | "SIGPOLL" | "SIGPWR" | "SIGSTKFLT"
+        );
+    linux_only && !cfg!(target_os = "linux")
 }
 
 /// True for Node.js built-in module specifiers that should use Node's public
@@ -702,6 +729,41 @@ mod tests {
             "RTLD_DEEPBIND should be in the manifest on every platform"
         );
         assert!(matches!(rtld_deepbind.unwrap().kind, ApiKind::Property));
+    }
+
+    #[test]
+    fn platform_unavailable_constants_gate_the_import_surface() {
+        // #3902: Linux-only `node:constants` values stay in the manifest
+        // (for portable docs) but the import gate must follow the host
+        // platform so `perry check` matches Node's ESM instantiation.
+        let linux_only = [
+            "O_DIRECT",
+            "O_NOATIME",
+            "RTLD_DEEPBIND",
+            "SIGPOLL",
+            "SIGPWR",
+            "SIGSTKFLT",
+        ];
+        for name in linux_only {
+            // Always present in the raw manifest (docs portability).
+            assert!(
+                module_has_symbol("node:constants", name).is_some(),
+                "{name} must remain in the manifest on every platform"
+            );
+            // Import gate tracks the host platform.
+            assert_eq!(
+                module_has_public_named_export("node:constants", name),
+                cfg!(target_os = "linux"),
+                "{name} import availability must match the host platform"
+            );
+        }
+        // Cross-platform constants are always importable.
+        for name in ["O_RDONLY", "O_DIRECTORY", "SIGINT"] {
+            assert!(
+                module_has_public_named_export("node:constants", name),
+                "{name} must be importable on every platform"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## #3902: gate Linux-only `node:constants` out of the import surface on macOS

On macOS, Node's `node:constants` ESM namespace does not export six Linux-only constants — `O_DIRECT`, `O_NOATIME` (open(2) flags), `SIGPOLL`, `SIGPWR`, `SIGSTKFLT` (signals), `RTLD_DEEPBIND` (glibc dlopen flag). Perry accepted all six as named imports and ran with each binding set to `undefined` — a **false-positive surface**: code that fails Node's ESM instantiation passed `perry check` and ran under Perry.

### Fix
`crates/perry-api-manifest/src/lib.rs`: a new `is_platform_unavailable_named_export` helper is consulted by `module_has_public_named_export` (the gate behind the `U006` import check). On a non-Linux host the six names are no longer valid named exports:

```
$ perry check bad.ts   # import { O_DIRECT } from "node:constants"
error[U006]: The requested module 'node:constants' does not provide an export named 'O_DIRECT'
```

…matching Node. Valid constants (`O_RDONLY`, `O_DIRECTORY`, …) are unaffected.

### Why not gate the manifest array itself
The six entries deliberately stay in the static `API_MANIFEST` on **every** platform, so `--print-api-manifest` and the generated docs (`docs/api/perry.d.ts`, `docs/src/api/reference.md`) stay byte-identical regardless of the host OS the generator runs on. That invariant is already asserted by `deprecated_constants_alias_has_manifest_entries` and exists because `api-docs-drift` runs on Linux CI — gating the array would break drift on every PR generated on macOS. This fix touches **only** the import-validation path, not the docs/emit path. New test `platform_unavailable_constants_gate_the_import_surface` covers both halves.

### Also closing as already-fixed (stale)
These two were mass-filed against an old baseline (`22824ba90abf`) and are already fixed on `main` — the current manifest's module exports match Node:
- **#3897** node:buffer `Buffer.*` statics (alloc/from/isBuffer/byteLength/…) are `internal_method` (excluded from top-level exports).
- **#3898** node:perf_hooks `performance.*` singleton methods (mark/measure/now/…) are excluded; only proper module exports remain.

### Validation
- `perry check`/`run` reject `O_DIRECT` (U006); `O_RDONLY`/`O_DIRECTORY` compile + run ✓
- `--print-api-manifest` still lists the superset (docs portability) ✓
- `cargo test -p perry-api-manifest` green (29 passed incl. new test) ✓
