### PR TITLE
fix(node:https/http): URL-object request/get overload no longer throws circular-JSON (#3880)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1067 — node:https/http: URL-object request/get overload no longer throws circular-JSON (#3880)
+
+`https.get(new URL(...), options, callback)` (and the `http`/`request` variants) threw `TypeError: Converting circular structure to JSON` before the request could be built. Root cause: `parse_client_args` classified arguments by value type, and a `URL` *instance* — a heap object, not a string — fell into the "first non-string pointer → options bag" branch. `parse_options_object` then JSON-stringified the URL, which throws on its `searchParams` ↔ owner back-reference, and the real options object was dropped.
+
+Fixes:
+- **`crates/perry-runtime/src/url/url_class.rs`** — new `js_url_href_if_url(value) -> f64` FFI: returns a `URL` instance's `href` (NaN-boxed string) via the existing `is_url_object_shape` check, else `undefined`.
+- **`crates/perry-ext-http/src/client_overload.rs`** — `parse_client_args` now routes a `URL`-object argument to the string-URL slot (`out.url = href`) instead of the options slot, so the following options object is parsed normally and the URL is never JSON-stringified.
+- Same file — `method_for_overload` no longer force-returns `GET` for `get()`. `http.get`/`https.get` differ from `request()` only by auto-`end()`ing; Node derives the method from `options.method || 'GET'` for both, so `https.get(url, { method: "POST" }, cb)` now correctly issues a POST.
+
+Validated against `node --experimental-strip-types`: the `node-suite/https/surface/mirror-surface` fixture is byte-identical, and all overload shapes match — `get(string)`, `request(string, cb)`, `request(options-only)`, `get(URL)`, `request(URL, {method})`. `perry-ext-http` + `perry-runtime` url unit tests green.
+
 ## v0.5.1066 — node:constants Linux-only constants gated out of the import surface on macOS (#3902)
 
 On macOS, Node's `node:constants` ESM namespace does not export six Linux-only constants (`O_DIRECT`, `O_NOATIME`, `RTLD_DEEPBIND`, `SIGPOLL`, `SIGPWR`, `SIGSTKFLT`), but Perry accepted all six as named imports and ran the program with each binding set to `undefined` — a false-positive surface: code that fails Node's ESM instantiation passed `perry check` and ran under Perry.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1066
+**Current Version:** 0.5.1067
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1066"
+version = "0.5.1067"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1066"
+version = "0.5.1067"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1066"
+version = "0.5.1067"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1066"
+version = "0.5.1067"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1066"
+version = "0.5.1067"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-ext-http/src/client_overload.rs
+++ b/crates/perry-ext-http/src/client_overload.rs
@@ -80,10 +80,18 @@ pub(crate) unsafe fn parse_client_args(args_array: i64) -> ClientArgs {
                 out.url = f;
             }
         } else if !v.is_undefined() && !v.is_null() && v.is_pointer() {
-            // First non-string, non-callback pointer → options object.
-            // (A bare `URL` instance also lands here; `url_from_options`
-            // reads its `protocol`/`host`/`pathname` via JSON-stringify.)
-            if out.opts.to_bits() == TAG_UNDEFINED {
+            // #3880: a `URL` *instance* is the URL argument, not the options
+            // bag. Route it to the string-URL path via its href. Otherwise it
+            // falls through to `parse_options_object`, which JSON-stringifies
+            // the URL and throws `Converting circular structure to JSON` on the
+            // URL's `searchParams` ↔ owner back-reference.
+            let href = js_url_href_if_url(f);
+            if is_string_value(href) {
+                if out.url.to_bits() == TAG_UNDEFINED {
+                    out.url = href;
+                }
+            } else if out.opts.to_bits() == TAG_UNDEFINED {
+                // First non-string, non-callback, non-URL pointer → options.
                 out.opts = f;
             }
         }
@@ -94,6 +102,11 @@ pub(crate) unsafe fn parse_client_args(args_array: i64) -> ClientArgs {
 extern "C" {
     /// `crates/perry-runtime/src/closure/dynamic_props.rs::js_value_is_closure`.
     fn js_value_is_closure(value_bits: i64) -> i32;
+    /// `crates/perry-runtime/src/url/url_class.rs::js_url_href_if_url` —
+    /// returns the URL's `href` (NaN-boxed string) for a `URL` instance,
+    /// else `undefined`. Used to route a `URL`-object request argument to
+    /// the string-URL path instead of mis-parsing it as options (#3880).
+    fn js_url_href_if_url(value: f64) -> f64;
 }
 
 /// Merge a URL string with an options object into the request fields.
@@ -220,10 +233,14 @@ fn merge_options_onto_url(
 /// Resolve the request method for the merged overload: `force_get`
 /// (the `get()` factories) always yields `GET`; otherwise the options
 /// `method` field, defaulting to `GET`.
-pub(crate) unsafe fn method_for_overload(opts_f64: f64, force_get: bool) -> String {
-    if force_get {
-        return "GET".to_string();
-    }
+/// Resolve the request method for an overload-normalized client call.
+///
+/// `get()` differs from `request()` only by auto-`end()`ing — it does **not**
+/// force the method to GET. Node derives the method from `options.method ||
+/// 'GET'` for both, so `https.get(url, { method: "POST" }, cb)` issues a POST
+/// (#3880). The method therefore comes purely from the options bag here,
+/// defaulting to GET when absent.
+pub(crate) unsafe fn method_for_overload(opts_f64: f64) -> String {
     match parse_options_object(opts_f64) {
         Some(opts) => method_from_options(&opts),
         None => "GET".to_string(),

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -1094,7 +1094,7 @@ pub unsafe extern "C" fn js_https_get(arg_f64: f64, callback_i64: i64) -> Handle
 unsafe fn request_overload(args_array: i64, default_protocol: &str, force_get: bool) -> Handle {
     ensure_gc_scanner_registered();
     let parsed = parse_client_args(args_array);
-    let method = method_for_overload(parsed.opts, force_get);
+    let method = method_for_overload(parsed.opts);
     let (url, headers, timeout, agent_handle) =
         merge_url_and_options(parsed.url, parsed.opts, default_protocol);
     let handle = make_request_handle(method, url, headers, timeout, parsed.callback, agent_handle);

--- a/crates/perry-runtime/src/url/url_class.rs
+++ b/crates/perry-runtime/src/url/url_class.rs
@@ -460,6 +460,27 @@ pub(crate) fn is_url_object_shape(url: *mut ObjectHeader) -> bool {
     }
 }
 
+/// #3880: If `value` (a NaN-boxed JSValue) is a WHATWG `URL` instance,
+/// return its `href` string (NaN-boxed); otherwise return `undefined`.
+///
+/// `perry-ext-http` uses this to route a `URL`-*object* first argument of
+/// `http.request` / `http.get` to the string-URL path. Without it, the
+/// overload parser treats the URL object as the options bag and
+/// `parse_options_object` JSON-stringifies it — which throws
+/// `Converting circular structure to JSON` on the URL's
+/// `searchParams` ↔ owner back-reference.
+#[no_mangle]
+pub extern "C" fn js_url_href_if_url(value: f64) -> f64 {
+    // Undefined NaN-box (matches the canonical TAG_UNDEFINED).
+    const UNDEFINED: f64 = f64::from_bits(0x7FFC_0000_0000_0001);
+    match object_from_f64(value) {
+        Some(obj) if is_url_object_shape(obj) => {
+            crate::object::js_object_get_field_f64(obj, URL_HREF)
+        }
+        _ => UNDEFINED,
+    }
+}
+
 /// Issue #650: `url.hash = value` setter. Stores the leading `#` when
 /// the value is non-empty; clears entirely when empty (matches WHATWG).
 #[no_mangle]


### PR DESCRIPTION
## #3880: `https.get(new URL(...), options, callback)` no longer throws circular-JSON

The `get(URL, options, cb)` / `request(URL, options, cb)` overload threw `TypeError: Converting circular structure to JSON` before the request shape could be observed:

```ts
https.get(new URL("https://127.0.0.1:1/get?b=2"), { method: "POST", timeout: 1 }, () => {});
// TypeError: Converting circular structure to JSON
```

### Root cause
`parse_client_args` resolves overloads by **value type**. A `URL` *instance* is a heap object (not a string), so it fell into the "first non-string pointer → options bag" branch. `parse_options_object` then JSON-stringified the URL, which throws on its `searchParams` ↔ owner back-reference — and the real `{ method, timeout }` object was dropped.

### Fix
- **`perry-runtime/src/url/url_class.rs`** — new `js_url_href_if_url(value) -> f64` FFI returns a `URL` instance's `href` (NaN-boxed string) via the existing `is_url_object_shape` shape check, else `undefined`.
- **`perry-ext-http/src/client_overload.rs`** — `parse_client_args` routes a `URL`-object argument to the string-URL slot via its href, so the URL is never JSON-stringified and the following options object parses normally.
- Same file — `method_for_overload` no longer force-returns `GET` for `get()`. `http.get`/`https.get` differ from `request()` only by auto-`end()`ing; Node derives the method from `options.method || 'GET'` for both, so `https.get(url, { method: "POST" }, cb)` now correctly issues a **POST**.

### Validation (vs `node --experimental-strip-types`)
- `node-suite/https/surface/mirror-surface` fixture — **byte-identical** ✅
- All overload shapes match: `get(string)` → GET, `request(string, cb)` → GET, `request(options-only)` → method honored, `get(URL)` → GET, `request(URL, {method:"DELETE"})` → DELETE ✅
- `perry-ext-http` (13) + `perry-runtime` url (10) unit tests green ✅
