### PR TITLE
runtime/array: fix Array exotic basics

### DIFF
--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -15,6 +15,23 @@ thread_local! {
     /// Both pointers are GC-rooted via `scan_template_raw_roots`.
     static TEMPLATE_RAW_MAP: RefCell<HashMap<usize, *mut ArrayHeader>> =
         RefCell::new(HashMap::new());
+
+    /// Own non-index properties for Array exotic objects.
+    ///
+    /// Perry's `ArrayHeader` intentionally stays compact: `length`,
+    /// `capacity`, then inline element slots. Treating that header as an
+    /// `ObjectHeader` corrupts reads of named keys, so array expandos live in
+    /// this side table keyed by the array allocation address. Numeric array
+    /// indices remain in element storage; canonical non-indices such as
+    /// `"4294967295"` are stored here per ECMA-262.
+    static ARRAY_NAMED_PROPS: RefCell<HashMap<usize, Vec<ArrayNamedProperty>>> =
+        RefCell::new(HashMap::new());
+}
+
+#[derive(Clone)]
+struct ArrayNamedProperty {
+    name: String,
+    value: f64,
 }
 
 #[repr(u8)]
@@ -80,6 +97,189 @@ pub fn scan_template_raw_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
             }
         }
     });
+    scan_array_named_property_roots_mut(visitor);
+}
+
+fn barrier_array_named_props(owner: usize, props: &mut [ArrayNamedProperty]) {
+    for prop in props.iter_mut() {
+        crate::gc::runtime_write_barrier_external_slot(
+            owner,
+            &mut prop.value as *mut f64 as usize,
+            prop.value.to_bits(),
+        );
+    }
+}
+
+fn merge_array_named_props(
+    props: &mut HashMap<usize, Vec<ArrayNamedProperty>>,
+    owner: usize,
+    owner_props: Vec<ArrayNamedProperty>,
+) {
+    let entry = props.entry(owner).or_default();
+    for prop in owner_props {
+        if let Some(existing) = entry.iter_mut().find(|existing| existing.name == prop.name) {
+            existing.value = prop.value;
+        } else {
+            entry.push(prop);
+        }
+    }
+    barrier_array_named_props(owner, entry);
+}
+
+pub(crate) fn scan_array_named_property_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    ARRAY_NAMED_PROPS.with(|m| {
+        let mut props = m.borrow_mut();
+        let mut moved = Vec::new();
+        for (&owner, owner_props) in props.iter_mut() {
+            let mut new_owner = owner;
+            if visitor.visit_metadata_usize_slot(&mut new_owner) {
+                moved.push((owner, new_owner));
+            }
+            for prop in owner_props.iter_mut() {
+                visitor.visit_nanbox_f64_slot(&mut prop.value);
+            }
+        }
+        for (old_owner, new_owner) in moved {
+            if let Some(old_props) = props.remove(&old_owner) {
+                merge_array_named_props(&mut props, new_owner, old_props);
+            }
+        }
+    });
+}
+
+unsafe fn string_header_as_str<'a>(key: *const crate::StringHeader) -> Option<&'a str> {
+    if key.is_null() {
+        return None;
+    }
+    let len = (*key).byte_len as usize;
+    let data = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    let bytes = std::slice::from_raw_parts(data, len);
+    std::str::from_utf8(bytes).ok()
+}
+
+pub(crate) unsafe fn array_named_property_set(
+    arr: *mut ArrayHeader,
+    key: *const crate::StringHeader,
+    value: f64,
+) {
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() {
+        return;
+    }
+    let Some(name) = string_header_as_str(key) else {
+        return;
+    };
+    let owner = arr as usize;
+    ARRAY_NAMED_PROPS.with(|m| {
+        let mut map = m.borrow_mut();
+        let props = map.entry(owner).or_default();
+        if let Some(prop) = props.iter_mut().find(|prop| prop.name == name) {
+            prop.value = value;
+        } else {
+            props.push(ArrayNamedProperty {
+                name: name.to_string(),
+                value,
+            });
+        }
+        barrier_array_named_props(owner, props);
+    });
+}
+
+pub(crate) unsafe fn array_named_property_get_by_name(
+    arr: *const ArrayHeader,
+    name: &str,
+) -> Option<f64> {
+    let arr = clean_arr_ptr(arr);
+    if arr.is_null() {
+        return None;
+    }
+    ARRAY_NAMED_PROPS.with(|m| {
+        m.borrow().get(&(arr as usize)).and_then(|props| {
+            props
+                .iter()
+                .find(|prop| prop.name == name)
+                .map(|prop| prop.value)
+        })
+    })
+}
+
+pub(crate) unsafe fn array_named_property_get(
+    arr: *const ArrayHeader,
+    key: *const crate::StringHeader,
+) -> Option<f64> {
+    let name = string_header_as_str(key)?;
+    array_named_property_get_by_name(arr, name)
+}
+
+pub(crate) unsafe fn array_named_property_has(
+    arr: *const ArrayHeader,
+    key: *const crate::StringHeader,
+) -> bool {
+    let Some(name) = string_header_as_str(key) else {
+        return false;
+    };
+    let arr = clean_arr_ptr(arr);
+    if arr.is_null() {
+        return false;
+    }
+    ARRAY_NAMED_PROPS.with(|m| {
+        m.borrow()
+            .get(&(arr as usize))
+            .map(|props| props.iter().any(|prop| prop.name == name))
+            .unwrap_or(false)
+    })
+}
+
+pub(crate) unsafe fn array_named_property_names(
+    arr: *const ArrayHeader,
+    enumerable_only: bool,
+) -> Vec<String> {
+    let arr = clean_arr_ptr(arr);
+    if arr.is_null() {
+        return Vec::new();
+    }
+    let owner = arr as usize;
+    ARRAY_NAMED_PROPS.with(|m| {
+        m.borrow()
+            .get(&owner)
+            .map(|props| {
+                props
+                    .iter()
+                    .filter(|prop| {
+                        !enumerable_only
+                            || crate::object::get_property_attrs(owner, &prop.name)
+                                .map(|attrs| attrs.enumerable())
+                                .unwrap_or(true)
+                    })
+                    .map(|prop| prop.name.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    })
+}
+
+pub(crate) unsafe fn array_named_property_delete(
+    arr: *const ArrayHeader,
+    key: *const crate::StringHeader,
+) -> bool {
+    let Some(name) = string_header_as_str(key) else {
+        return false;
+    };
+    let arr = clean_arr_ptr(arr);
+    if arr.is_null() {
+        return false;
+    }
+    ARRAY_NAMED_PROPS.with(|m| {
+        let mut map = m.borrow_mut();
+        let Some(props) = map.get_mut(&(arr as usize)) else {
+            return false;
+        };
+        let Some(index) = props.iter().position(|prop| prop.name == name) else {
+            return false;
+        };
+        props.remove(index);
+        true
+    })
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -329,6 +329,10 @@ pub extern "C" fn js_array_set_f64_extend(
     unsafe {
         let length = (*arr).length;
 
+        if index == u32::MAX {
+            return arr;
+        }
+
         // If index is within bounds, just set it
         if index < length {
             let value = canonicalize_array_numeric_store_value(arr, value);
@@ -449,7 +453,9 @@ pub extern "C" fn js_array_set_string_key(
     // Non-numeric string key — fall through to object-property set on the
     // array's expando map. Arrays with named properties are rare but spec-
     // legal.
-    crate::object::js_object_set_field_by_name(arr as *mut crate::object::ObjectHeader, key, value);
+    unsafe {
+        array_named_property_set(arr, key, value);
+    }
     arr
 }
 
@@ -489,19 +495,32 @@ pub extern "C" fn js_array_set_index_or_string(
             crate::value::js_get_string_pointer_unified(idx) as *const crate::StringHeader;
         return js_array_set_string_key(arr, str_ptr, value);
     }
-    // Treat as numeric (covers Int32 / plain f64 / other tags).
-    let idx_i32 = idx as i32;
-    if idx_i32 < 0 {
-        // Negative numeric key: per JS spec, becomes a string property on
-        // the array's expando map. Stringify and delegate.
-        let s = idx_i32.to_string();
-        let key = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
-        crate::object::js_object_set_field_by_name(
-            arr as *mut crate::object::ObjectHeader,
-            key,
-            value,
-        );
-        return arr;
+    // Treat numeric keys according to the array-index boundary. Only
+    // integers in 0..2^32-2 extend element storage; 2^32-1 and larger are
+    // ordinary string properties.
+    let numeric = if (bits & crate::value::TAG_MASK) == crate::value::INT32_TAG {
+        Some(crate::value::JSValue::from_bits(bits).as_int32() as f64)
+    } else if top16 < 0x7FF8 || top16 > 0x7FFF {
+        Some(idx)
+    } else {
+        None
+    };
+    if let Some(n) = numeric {
+        if n.is_finite() && n.trunc() == n && n >= 0.0 && n < u32::MAX as f64 {
+            return js_array_set_f64_extend(arr, n as u32, value);
+        }
+        if n.is_finite() && n.trunc() == n {
+            let s = if n == 0.0 {
+                "0".to_string()
+            } else {
+                format!("{:.0}", n)
+            };
+            let key = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+            unsafe {
+                array_named_property_set(arr, key, value);
+            }
+            return arr;
+        }
     }
-    js_array_set_f64_extend(arr, idx_i32 as u32, value)
+    arr
 }

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -93,7 +93,9 @@ pub use self::splice_slice::{
 pub(crate) use self::alloc::array_length_from_property_value_or_throw;
 pub(crate) use self::alloc::{js_array_from_arraylike, js_array_from_string_codepoints};
 pub(crate) use self::header::{
-    array_byte_size, array_numeric_raw_f64_get, array_numeric_raw_f64_push_inbounds,
+    array_byte_size, array_named_property_delete, array_named_property_get,
+    array_named_property_get_by_name, array_named_property_has, array_named_property_names,
+    array_named_property_set, array_numeric_raw_f64_get, array_numeric_raw_f64_push_inbounds,
     array_numeric_raw_f64_set_inbounds, canonicalize_array_numeric_store_value, clean_arr_ptr,
     clean_arr_ptr_mut, clear_array_numeric_layout, clear_array_numeric_layout_ptr,
     gc_element_slot_range, mark_array_layout_unknown, note_array_slot, note_array_slot_layout_only,

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -42,6 +42,29 @@ unsafe fn raw_slot_bits(arr: *mut ArrayHeader, index: usize) -> u64 {
     *elements.add(index)
 }
 
+fn string_key(name: &[u8]) -> *mut crate::StringHeader {
+    crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32)
+}
+
+fn boxed_pointer(ptr: *mut u8) -> f64 {
+    crate::value::js_nanbox_pointer(ptr as i64)
+}
+
+fn string_value(ptr: *mut crate::StringHeader) -> f64 {
+    f64::from_bits(crate::value::JSValue::string_ptr(ptr).bits())
+}
+
+fn array_keys_contain(keys: *mut ArrayHeader, name: &[u8]) -> bool {
+    let key = string_key(name);
+    for i in 0..js_array_length(keys) {
+        let stored = js_array_get(keys, i);
+        if unsafe { crate::string::js_string_key_matches(stored, key) } {
+            return true;
+        }
+    }
+    false
+}
+
 #[test]
 fn test_array_alloc_and_access() {
     let arr = js_array_alloc(5);
@@ -61,6 +84,117 @@ fn test_array_alloc_and_access() {
 
     // Out of bounds returns TAG_UNDEFINED (JS spec: arr[OOB] === undefined)
     assert_eq!(js_array_get_f64(arr, 5).to_bits(), 0x7FFC_0000_0000_0001u64);
+}
+
+#[test]
+fn test_array_exotic_named_indices_and_boundary_props() {
+    let mut arr = js_array_alloc(0);
+    let arr_obj = arr as *mut crate::object::ObjectHeader;
+
+    let idx2 = string_key(b"2");
+    arr = js_array_set_string_key(arr, idx2, 42.0);
+    assert_eq!(js_array_length(arr), 3);
+    assert_eq!(js_array_get_f64(arr, 2), 42.0);
+
+    let key0 = string_key(b"0");
+    let key2 = string_key(b"2");
+    assert_eq!(
+        crate::object::js_object_has_own(boxed_pointer(arr as *mut u8), string_value(key0))
+            .to_bits(),
+        crate::value::TAG_FALSE
+    );
+    assert_eq!(
+        crate::object::js_object_has_own(boxed_pointer(arr as *mut u8), string_value(key2))
+            .to_bits(),
+        crate::value::TAG_TRUE
+    );
+
+    let max_key = string_key(b"4294967295");
+    arr = js_array_set_string_key(arr, max_key, 99.0);
+    assert_eq!(js_array_length(arr), 3, "2^32-1 is not an array index");
+    assert_eq!(
+        crate::object::js_object_get_field_by_name(arr_obj, max_key).bits(),
+        99.0f64.to_bits()
+    );
+
+    let foo = string_key(b"foo");
+    crate::object::js_object_set_field_by_name(arr_obj, foo, 7.0);
+    assert_eq!(
+        crate::object::js_object_get_field_by_name(arr_obj, foo).bits(),
+        7.0f64.to_bits()
+    );
+
+    let keys = crate::object::js_object_keys(arr_obj);
+    assert!(array_keys_contain(keys, b"2"));
+    assert!(array_keys_contain(keys, b"foo"));
+    assert!(array_keys_contain(keys, b"4294967295"));
+    assert!(!array_keys_contain(keys, b"0"));
+}
+
+#[test]
+fn test_array_exotic_descriptors_and_global_prototype_identity() {
+    let arr = js_array_alloc(0);
+    let arr_box = boxed_pointer(arr as *mut u8);
+    let length_desc = crate::object::js_object_get_own_property_descriptor(
+        arr_box,
+        string_value(string_key(b"length")),
+    );
+    let value_key = string_key(b"value");
+    let writable_key = string_key(b"writable");
+    let enumerable_key = string_key(b"enumerable");
+    let length_desc_obj =
+        crate::value::js_nanbox_get_pointer(length_desc) as *const crate::object::ObjectHeader;
+    assert_eq!(
+        crate::object::js_object_get_field_by_name(length_desc_obj, value_key).bits(),
+        0.0f64.to_bits()
+    );
+    assert_eq!(
+        crate::object::js_object_get_field_by_name(length_desc_obj, writable_key).bits(),
+        crate::value::TAG_TRUE
+    );
+    assert_eq!(
+        crate::object::js_object_get_field_by_name(length_desc_obj, enumerable_key).bits(),
+        crate::value::TAG_FALSE
+    );
+
+    let global = crate::object::js_get_global_this();
+    let global_ptr =
+        crate::value::js_nanbox_get_pointer(global) as *const crate::object::ObjectHeader;
+    let array_ctor = crate::object::js_object_get_field_by_name(global_ptr, string_key(b"Array"));
+    let ctor_ptr = crate::value::js_nanbox_get_pointer(f64::from_bits(array_ctor.bits())) as usize;
+    let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
+    assert_eq!(js_array_is_array(proto).to_bits(), crate::value::TAG_TRUE);
+    let constructor_desc = crate::object::js_object_get_own_property_descriptor(
+        proto,
+        string_value(string_key(b"constructor")),
+    );
+    let constructor_desc_obj =
+        crate::value::js_nanbox_get_pointer(constructor_desc) as *const crate::object::ObjectHeader;
+    assert_eq!(
+        crate::object::js_object_get_field_by_name(constructor_desc_obj, value_key).bits(),
+        array_ctor.bits()
+    );
+
+    let literal_to_string = crate::object::js_object_get_field_by_name(
+        arr as *const crate::object::ObjectHeader,
+        string_key(b"toString"),
+    );
+    let proto_to_string = crate::object::js_object_get_field_by_name(
+        crate::value::js_nanbox_get_pointer(proto) as *const crate::object::ObjectHeader,
+        string_key(b"toString"),
+    );
+    assert_eq!(literal_to_string.bits(), proto_to_string.bits());
+
+    let array_from_call = unsafe {
+        let args = [0.0, 1.0, 0.0, 1.0];
+        crate::closure::js_native_call_value(
+            f64::from_bits(array_ctor.bits()),
+            args.as_ptr(),
+            args.len(),
+        )
+    };
+    let called_arr = crate::value::js_nanbox_get_pointer(array_from_call) as *const ArrayHeader;
+    assert_eq!(js_array_length(called_arr), 4);
 }
 
 #[test]

--- a/crates/perry-runtime/src/object/array_object_ops.rs
+++ b/crates/perry-runtime/src/object/array_object_ops.rs
@@ -1,0 +1,131 @@
+//! Array-specific branches for `Object.*` operations.
+//!
+//! Split out of `object_ops.rs` to keep that file under the repository
+//! line-count guard while preserving the public FFI entry points there.
+
+use super::*;
+
+unsafe fn is_array_object(obj: *const ObjectHeader) -> bool {
+    if obj.is_null() || (obj as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return false;
+    }
+    let gc_header = (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY
+}
+
+pub(crate) unsafe fn array_property_is_enumerable(
+    obj: *mut ObjectHeader,
+    key_str: *const crate::StringHeader,
+    key_name: &str,
+) -> Option<f64> {
+    const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
+    const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
+    if !is_array_object(obj) {
+        return None;
+    }
+    if key_name == "length" {
+        return Some(f64::from_bits(TAG_FALSE));
+    }
+    let arr = obj as *const crate::array::ArrayHeader;
+    if !super::has_own_helpers::array_own_key_present(arr, key_str) {
+        return Some(f64::from_bits(TAG_FALSE));
+    }
+    let enumerable = if super::canonical_array_index(key_name).is_some() {
+        true
+    } else {
+        super::get_property_attrs(obj as usize, key_name)
+            .map(|attrs| attrs.enumerable())
+            .unwrap_or(true)
+    };
+    Some(f64::from_bits(if enumerable {
+        TAG_TRUE
+    } else {
+        TAG_FALSE
+    }))
+}
+
+pub(crate) unsafe fn define_array_property(
+    obj: *mut ObjectHeader,
+    obj_value: f64,
+    key_str: *const crate::StringHeader,
+    key_name: Option<&str>,
+    descriptor_value: f64,
+) -> Option<f64> {
+    if !is_array_object(obj) {
+        return None;
+    }
+    let Some(key_name) = key_name else {
+        return Some(obj_value);
+    };
+    let desc_ptr = extract_obj_ptr(descriptor_value);
+    if desc_ptr.is_null() {
+        return Some(obj_value);
+    }
+    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+    let has_value = own_key_present(desc_ptr, value_key);
+    let value_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, value_key);
+    let value = if has_value {
+        f64::from_bits(value_field.bits())
+    } else {
+        f64::from_bits(crate::value::TAG_UNDEFINED)
+    };
+
+    if key_name == "length" {
+        if has_value {
+            crate::array::js_array_set_length(obj as *mut crate::array::ArrayHeader, value);
+        }
+        return Some(obj_value);
+    }
+    if let Some(index) = super::canonical_array_index(key_name) {
+        if has_value {
+            crate::array::js_array_set_f64_extend(
+                obj as *mut crate::array::ArrayHeader,
+                index,
+                value,
+            );
+        }
+        return Some(obj_value);
+    }
+
+    crate::array::array_named_property_set(obj as *mut crate::array::ArrayHeader, key_str, value);
+
+    let read_bool = |name: &[u8]| -> Option<bool> {
+        let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        if !own_key_present(desc_ptr, k) {
+            return None;
+        }
+        let v = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, k);
+        Some(crate::value::js_is_truthy(f64::from_bits(v.bits())) != 0)
+    };
+    let writable = read_bool(b"writable").unwrap_or(false);
+    let enumerable = read_bool(b"enumerable").unwrap_or(false);
+    let configurable = read_bool(b"configurable").unwrap_or(false);
+    set_property_attrs(
+        obj as usize,
+        key_name.to_string(),
+        PropertyAttrs::new(writable, enumerable, configurable),
+    );
+    Some(obj_value)
+}
+
+fn builtin_constructor_prototype_value(name: &[u8]) -> Option<f64> {
+    let ctor = js_get_global_this_builtin_value(name.as_ptr(), name.len());
+    let ctor_value = crate::value::JSValue::from_bits(ctor.to_bits());
+    if !ctor_value.is_pointer() {
+        return None;
+    }
+    let ctor_ptr = ctor_value.as_pointer::<u8>() as usize;
+    let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
+    let proto_value = crate::value::JSValue::from_bits(proto.to_bits());
+    proto_value.is_pointer().then_some(proto)
+}
+
+pub(crate) fn array_get_prototype_of_addr(raw_addr: usize) -> Option<f64> {
+    if let Some(array_proto) = builtin_constructor_prototype_value(b"Array") {
+        let proto_addr = crate::value::js_nanbox_get_pointer(array_proto) as usize;
+        if proto_addr != raw_addr {
+            return Some(array_proto);
+        }
+    }
+    builtin_constructor_prototype_value(b"Object")
+}

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -16,6 +16,30 @@ pub extern "C" fn js_object_delete_field(
         return 1;
     }
     unsafe {
+        if (obj as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+            let gc_header =
+                (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+            if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
+                if let Some(name) = super::has_own_helpers::str_from_string_header(key) {
+                    if let Some(attrs) = get_property_attrs(obj as usize, name) {
+                        if !attrs.configurable() {
+                            return 0;
+                        }
+                    }
+                    if let Some(index) = super::canonical_array_index(name) {
+                        return crate::array::js_array_delete(
+                            obj as *mut crate::array::ArrayHeader,
+                            index,
+                        );
+                    }
+                }
+                crate::array::array_named_property_delete(
+                    obj as *const crate::array::ArrayHeader,
+                    key,
+                );
+                return 1;
+            }
+        }
         // #3655: `delete fn.name` / `delete fn.userProp`. Functions/closures
         // aren't `ObjectHeader`s — reading `keys_array` off one is out of
         // bounds. The built-in `name`/`length` slots are `configurable:true`,

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -207,6 +207,43 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
             std::str::from_utf8(name_bytes).ok().map(|s| s.to_string())
         };
 
+        if (obj as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+            let gc_header =
+                (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+            if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
+                let arr = obj as *const crate::array::ArrayHeader;
+                let Some(ref name) = key_rust else {
+                    return f64::from_bits(crate::value::TAG_UNDEFINED);
+                };
+                if name == "length" {
+                    return build_data_descriptor(
+                        crate::array::js_array_length(arr) as f64,
+                        true,
+                        false,
+                        false,
+                    );
+                }
+                if let Some(index) = super::canonical_array_index(name) {
+                    if super::has_own_helpers::array_own_key_present(arr, key_str) {
+                        let value = crate::array::js_array_get_f64(arr, index);
+                        return build_data_descriptor(value, true, true, true);
+                    }
+                    return f64::from_bits(crate::value::TAG_UNDEFINED);
+                }
+                if let Some(value) = crate::array::array_named_property_get(arr, key_str) {
+                    let attrs = get_property_attrs(obj as usize, name)
+                        .unwrap_or(PropertyAttrs::new(true, true, true));
+                    return build_data_descriptor(
+                        value,
+                        attrs.writable(),
+                        attrs.enumerable(),
+                        attrs.configurable(),
+                    );
+                }
+                return f64::from_bits(crate::value::TAG_UNDEFINED);
+            }
+        }
+
         if (*obj).class_id == NATIVE_MODULE_CLASS_ID {
             if let (Some(module_name), Some(key_name)) =
                 (read_native_module_name(obj), key_rust.as_deref())
@@ -479,13 +516,34 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
             };
             if let Some(n) = n {
                 let result = crate::array::js_array_alloc(n + 1);
-                for i in 0..n {
-                    let s = i.to_string();
-                    let k = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
-                    crate::array::js_array_push(result, JSValue::string_ptr(k));
+                if crate::array::js_array_is_array(obj_value).to_bits() == TAG_TRUE_BITS {
+                    let ap = extract_obj_ptr(obj_value) as *const crate::array::ArrayHeader;
+                    for i in 0..n {
+                        if super::has_own_helpers::array_own_key_present(ap, {
+                            let s = i.to_string();
+                            crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32)
+                        }) {
+                            let s = i.to_string();
+                            let k = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+                            crate::array::js_array_push(result, JSValue::string_ptr(k));
+                        }
+                    }
+                    let lk = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
+                    crate::array::js_array_push(result, JSValue::string_ptr(lk));
+                    for name in crate::array::array_named_property_names(ap, false) {
+                        let k =
+                            crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                        crate::array::js_array_push(result, JSValue::string_ptr(k));
+                    }
+                } else {
+                    for i in 0..n {
+                        let s = i.to_string();
+                        let k = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+                        crate::array::js_array_push(result, JSValue::string_ptr(k));
+                    }
+                    let lk = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
+                    crate::array::js_array_push(result, JSValue::string_ptr(lk));
                 }
-                let lk = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
-                crate::array::js_array_push(result, JSValue::string_ptr(lk));
                 return f64::from_bits((result as u64) | 0x7FFD_0000_0000_0000);
             }
         }

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -149,6 +149,37 @@ unsafe fn primitive_object_prototype_accessor(name: &str, receiver: f64) -> Opti
     Some(invoke_accessor_getter(acc.get, receiver))
 }
 
+unsafe fn array_prototype_property_value(name: &str, receiver_addr: usize) -> Option<JSValue> {
+    let ctor = super::js_get_global_this_builtin_value(b"Array".as_ptr(), 5);
+    let ctor_value = JSValue::from_bits(ctor.to_bits());
+    if !ctor_value.is_pointer() {
+        return None;
+    }
+    let ctor_ptr = ctor_value.as_pointer::<u8>() as usize;
+    let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
+    let proto_value = JSValue::from_bits(proto.to_bits());
+    if !proto_value.is_pointer() {
+        return None;
+    }
+    let proto_ptr = proto_value.as_pointer::<u8>() as usize;
+    if proto_ptr == receiver_addr {
+        return None;
+    }
+    if let Some(v) = crate::array::array_named_property_get_by_name(
+        proto_ptr as *const crate::array::ArrayHeader,
+        name,
+    ) {
+        return Some(JSValue::from_bits(v.to_bits()));
+    }
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let v = js_object_get_field_by_name(proto_ptr as *const ObjectHeader, key);
+    if v.is_undefined() {
+        None
+    } else {
+        Some(v)
+    }
+}
+
 // Issue #922: Rate-limit and bound the [WARN_NULL_PTR] message stream
 // + abort the process when a runaway loop is detected.
 //
@@ -859,6 +890,10 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
                     let key_box = crate::string::js_string_new_sso(s.as_ptr(), s.len() as u32);
                     crate::array::js_array_push_f64(result, key_box);
                 }
+                for name in crate::array::array_named_property_names(arr, true) {
+                    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                    crate::array::js_array_push(result, JSValue::string_ptr(key));
+                }
                 return result;
             }
         }
@@ -1256,9 +1291,39 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                     }
                     return nanbox_true;
                 }
-                // Non-numeric key on an array: only `length` and inherited
-                // prototype methods would return true. Conservatively return
-                // false for now — out of scope for #323.
+                if key_val.is_any_string() {
+                    let key_str = crate::value::js_get_string_pointer_unified(key)
+                        as *const crate::StringHeader;
+                    if !key_str.is_null() {
+                        if let Some(key_name) =
+                            super::has_own_helpers::str_from_string_header(key_str)
+                        {
+                            if key_name == "length" {
+                                return nanbox_true;
+                            }
+                            if let Some(index) = super::canonical_array_index(key_name) {
+                                if index < length {
+                                    let elements = (arr as *const u8)
+                                        .add(std::mem::size_of::<crate::array::ArrayHeader>())
+                                        as *const u64;
+                                    if std::ptr::read(elements.add(index as usize))
+                                        != crate::value::TAG_HOLE
+                                    {
+                                        return nanbox_true;
+                                    }
+                                }
+                                return nanbox_false;
+                            }
+                            if crate::array::array_named_property_has(arr, key_str) {
+                                return nanbox_true;
+                            }
+                            if array_prototype_property_value(key_name, obj_ptr as usize).is_some()
+                            {
+                                return nanbox_true;
+                            }
+                        }
+                    }
+                }
                 return nanbox_false;
             }
             // #1758: a CLOSURE receiver (functions ARE objects in JS, so
@@ -2303,8 +2368,8 @@ pub extern "C" fn js_object_get_field_by_name(
                 let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                 let key_len = (*key).byte_len as usize;
                 let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
+                let arr = obj as *const crate::array::ArrayHeader;
                 if key_bytes == b"length" {
-                    let arr = obj as *const crate::array::ArrayHeader;
                     return JSValue::number(crate::array::js_array_length(arr) as f64);
                 }
                 // date-fns / drizzle / lodash duck-typing path:
@@ -2317,18 +2382,25 @@ pub extern "C" fn js_object_get_field_by_name(
                     let v = js_get_global_this_builtin_value(b"Array".as_ptr(), 5);
                     return JSValue::from_bits(v.to_bits());
                 }
+                if let Ok(name) = std::str::from_utf8(key_bytes) {
+                    if let Some(index) = super::canonical_array_index(name) {
+                        return JSValue::from_bits(
+                            crate::array::js_array_get_f64(arr, index).to_bits(),
+                        );
+                    }
+                    if let Some(v) = crate::array::array_named_property_get(arr, key) {
+                        return JSValue::from_bits(v.to_bits());
+                    }
+                    if let Some(v) = array_prototype_property_value(name, obj as usize) {
+                        return v;
+                    }
+                }
                 if is_array_method_value_name(key_bytes) {
-                    let heap_name = {
-                        let layout =
-                            std::alloc::Layout::from_size_align(key_bytes.len().max(1), 1).unwrap();
-                        let ptr = std::alloc::alloc(layout);
-                        std::ptr::copy_nonoverlapping(key_bytes.as_ptr(), ptr, key_bytes.len());
-                        ptr
-                    };
-                    let this_f64 =
-                        f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
-                    let result = js_class_method_bind(this_f64, heap_name, key_bytes.len());
-                    return JSValue::from_bits(result.to_bits());
+                    if let Ok(name) = std::str::from_utf8(key_bytes) {
+                        if let Some(v) = array_prototype_property_value(name, obj as usize) {
+                            return v;
+                        }
+                    }
                 }
             }
             return JSValue::undefined();

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -292,6 +292,34 @@ pub extern "C" fn js_object_set_field_by_name(
         let gc_header =
             (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
         let gc_type = (*gc_header).obj_type;
+        if gc_type == crate::gc::GC_TYPE_ARRAY {
+            if key.is_null() {
+                return;
+            }
+            let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+            let key_len = (*key).byte_len as usize;
+            let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
+            let name = match std::str::from_utf8(key_bytes) {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+            let arr = obj as *mut crate::array::ArrayHeader;
+            if name == "length" {
+                crate::array::js_array_set_length(arr, value);
+                return;
+            }
+            if let Some(index) = super::canonical_array_index(name) {
+                crate::array::js_array_set_f64_extend(arr, index, value);
+                return;
+            }
+            if let Some(attrs) = super::get_property_attrs(obj as usize, name) {
+                if !attrs.writable() {
+                    return;
+                }
+            }
+            crate::array::array_named_property_set(arr, key, value);
+            return;
+        }
         // Error objects have a fixed `#[repr(C)]` layout with no field-storage
         // region (`message`/`name`/`stack`/`cause`/`errors` are dedicated
         // slots), so a user assignment like `err.code = "X"` or

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -194,6 +194,33 @@ pub(crate) fn webcrypto_method_value(property_name: &str) -> Option<f64> {
     Some(crate::value::js_nanbox_pointer(closure as i64))
 }
 
+extern "C" fn global_this_array_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    let rest_value = crate::value::JSValue::from_bits(rest.to_bits());
+    let args_arr = if rest_value.is_pointer() {
+        rest_value.as_pointer::<crate::array::ArrayHeader>()
+    } else {
+        std::ptr::null()
+    };
+    let argc = crate::array::js_array_length(args_arr);
+    if argc == 1 {
+        let first = crate::array::js_array_get_f64(args_arr, 0);
+        let arr = crate::array::js_array_constructor_single(first);
+        return crate::value::js_nanbox_pointer(arr as i64);
+    }
+    let arr = crate::array::js_array_alloc(argc);
+    unsafe {
+        (*arr).length = argc;
+        for i in 0..argc {
+            let value = crate::array::js_array_get_f64(args_arr, i);
+            crate::array::js_array_set_f64(arr, i, value);
+        }
+    }
+    crate::value::js_nanbox_pointer(arr as i64)
+}
+
 extern "C" fn global_this_string_thunk(
     _closure: *const crate::closure::ClosureHeader,
     value: f64,
@@ -903,6 +930,7 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             continue;
         }
         let func_ptr = match name {
+            "Array" => global_this_array_thunk as *const u8,
             "Object" => global_this_object_thunk as *const u8,
             "String" => global_this_string_thunk as *const u8,
             // #2889: call-form `Number(x)` / `Boolean(x)` through a rebound
@@ -927,6 +955,9 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             continue;
         }
         match name {
+            "Array" => {
+                crate::closure::js_register_closure_rest(func_ptr, 0);
+            }
             "Object" | "String" | "Number" | "Boolean" | "BroadcastChannel" => {
                 crate::closure::js_register_closure_arity(func_ptr, 1);
             }
@@ -972,7 +1003,11 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         // `js_object_set_field_by_name` detects the CLOSURE_MAGIC tag
         // at offset 12 and dispatches into `closure_set_dynamic_prop`
         // for us; both reads and writes share that side table.
-        let proto_obj = js_object_alloc(0, 0);
+        let proto_obj = if name == "Array" {
+            crate::array::js_array_alloc(0) as *mut ObjectHeader
+        } else {
+            js_object_alloc(0, 0)
+        };
         if !proto_obj.is_null() {
             let proto_value = crate::value::js_nanbox_pointer(proto_obj as i64);
             js_object_set_field_by_name(closure_ptr as *mut ObjectHeader, proto_key, proto_value);
@@ -987,6 +1022,16 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
                     "constructor".len() as u32,
                 );
                 js_object_set_field_by_name(proto_obj, ctor_key, ctor_value);
+                super::set_builtin_property_attrs(
+                    proto_obj as usize,
+                    "constructor".to_string(),
+                    super::PropertyAttrs::new(true, false, true),
+                );
+            }
+            if name == "Array" {
+                let constructor_key =
+                    crate::string::js_string_from_bytes(b"constructor".as_ptr(), 11);
+                js_object_set_field_by_name(proto_obj, constructor_key, ctor_value);
                 super::set_builtin_property_attrs(
                     proto_obj as usize,
                     "constructor".to_string(),

--- a/crates/perry-runtime/src/object/has_own_helpers.rs
+++ b/crates/perry-runtime/src/object/has_own_helpers.rs
@@ -83,6 +83,9 @@ pub(super) unsafe fn array_own_key_present(
     if key_name == "length" {
         return true;
     }
+    if crate::array::array_named_property_has(arr, key) {
+        return true;
+    }
     let Some(index) = super::canonical_array_index(key_name) else {
         return false;
     };

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -23,6 +23,7 @@ use std::sync::RwLock;
 // surface (all `#[no_mangle]` FFI entry points keep their exact symbol).
 // ---------------------------------------------------------------------------
 mod alloc;
+mod array_object_ops;
 mod assert;
 mod bigint_dispatch;
 mod buffer_dispatch;
@@ -53,6 +54,7 @@ mod reflect_support;
 mod util_types;
 mod websocket_global;
 pub use alloc::*;
+pub(crate) use array_object_ops::*;
 pub use assert::*;
 pub(crate) use bigint_dispatch::*;
 pub use buffer_dispatch::*;

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1480,6 +1480,14 @@ pub unsafe extern "C" fn js_native_call_method(
                 || arr_obj_type == crate::gc::GC_TYPE_LAZY_ARRAY
             {
                 match method_name {
+                    "toString" => {
+                        let arr = raw_ptr as *const crate::array::ArrayHeader;
+                        let s = crate::array::js_array_join_value(
+                            arr,
+                            f64::from_bits(crate::value::TAG_UNDEFINED),
+                        );
+                        return f64::from_bits(JSValue::string_ptr(s).bits());
+                    }
                     "map" if args_len >= 1 && !args_ptr.is_null() => {
                         let arr = raw_ptr as *const crate::array::ArrayHeader;
                         let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
@@ -2620,6 +2628,17 @@ pub unsafe extern "C" fn js_native_call_method(
                         .unwrap_or(false);
                     return f64::from_bits(JSValue::bool(present).bits());
                 }
+                if raw >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+                    let gc_header = (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE)
+                        as *const crate::gc::GcHeader;
+                    if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
+                        let present = super::has_own_helpers::array_own_key_present(
+                            raw as *const crate::array::ArrayHeader,
+                            key_str,
+                        );
+                        return f64::from_bits(JSValue::bool(present).bits());
+                    }
+                }
                 let obj_ptr = jsval.as_pointer::<ObjectHeader>();
                 if !obj_ptr.is_null() && is_valid_obj_ptr(obj_ptr as *const u8) {
                     return f64::from_bits(
@@ -2669,6 +2688,33 @@ pub unsafe extern "C" fn js_native_call_method(
                     .map(|attrs| attrs.enumerable())
                     .unwrap_or(true);
                 return f64::from_bits(JSValue::bool(enumerable).bits());
+            }
+            if raw >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+                let gc_header =
+                    (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+                if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
+                    let Some(key_name) = super::has_own_helpers::str_from_string_header(key_str)
+                    else {
+                        return f64::from_bits(JSValue::bool(false).bits());
+                    };
+                    if key_name == "length" {
+                        return f64::from_bits(JSValue::bool(false).bits());
+                    }
+                    if !super::has_own_helpers::array_own_key_present(
+                        raw as *const crate::array::ArrayHeader,
+                        key_str,
+                    ) {
+                        return f64::from_bits(JSValue::bool(false).bits());
+                    }
+                    let enumerable = if crate::object::canonical_array_index(key_name).is_some() {
+                        true
+                    } else {
+                        get_property_attrs(raw, key_name)
+                            .map(|attrs| attrs.enumerable())
+                            .unwrap_or(true)
+                    };
+                    return f64::from_bits(JSValue::bool(enumerable).bits());
+                }
             }
             let obj_ptr = jsval.as_pointer::<ObjectHeader>();
             if obj_ptr.is_null() || !is_valid_obj_ptr(obj_ptr as *const u8) {

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -636,7 +636,7 @@ pub extern "C" fn js_object_property_is_enumerable(obj_value: f64, key_value: f6
         }
 
         let obj = extract_obj_ptr(obj_value);
-        if obj.is_null() || (obj as usize) < 0x10000 || !is_valid_obj_ptr(obj as *const u8) {
+        if obj.is_null() || (obj as usize) < 0x10000 {
             return f64::from_bits(TAG_FALSE);
         }
         let name_ptr = (key_str as *const u8).add(std::mem::size_of::<crate::StringHeader>());
@@ -645,6 +645,30 @@ pub extern "C" fn js_object_property_is_enumerable(obj_value: f64, key_value: f6
             Ok(s) => s,
             Err(_) => return f64::from_bits(TAG_FALSE),
         };
+        if (obj as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+            let gc_header =
+                (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+            if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
+                if key_name == "length" {
+                    return f64::from_bits(TAG_FALSE);
+                }
+                let arr = obj as *const crate::array::ArrayHeader;
+                if super::has_own_helpers::array_own_key_present(arr, key_str) {
+                    let enumerable = if super::canonical_array_index(key_name).is_some() {
+                        true
+                    } else {
+                        super::get_property_attrs(obj as usize, key_name)
+                            .map(|attrs| attrs.enumerable())
+                            .unwrap_or(true)
+                    };
+                    return f64::from_bits(if enumerable { TAG_TRUE } else { TAG_FALSE });
+                }
+                return f64::from_bits(TAG_FALSE);
+            }
+        }
+        if !is_valid_obj_ptr(obj as *const u8) {
+            return f64::from_bits(TAG_FALSE);
+        }
         if (*obj).class_id == NATIVE_MODULE_CLASS_ID {
             if let Some(module_name) = read_native_module_name(obj) {
                 return f64::from_bits(
@@ -889,6 +913,72 @@ pub extern "C" fn js_object_define_property(
             let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
             std::str::from_utf8(name_bytes).ok().map(|s| s.to_string())
         };
+        if (obj as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+            let gc_header =
+                (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+            if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
+                let Some(ref key_name) = key_rust else {
+                    return obj_value;
+                };
+                let desc_ptr = extract_obj_ptr(descriptor_value);
+                if desc_ptr.is_null() {
+                    return obj_value;
+                }
+                let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+                let has_value = own_key_present(desc_ptr, value_key);
+                let value_field =
+                    js_object_get_field_by_name(desc_ptr as *const ObjectHeader, value_key);
+                let value = if has_value {
+                    f64::from_bits(value_field.bits())
+                } else {
+                    f64::from_bits(crate::value::TAG_UNDEFINED)
+                };
+
+                if key_name == "length" {
+                    if has_value {
+                        crate::array::js_array_set_length(
+                            obj as *mut crate::array::ArrayHeader,
+                            value,
+                        );
+                    }
+                    return obj_value;
+                }
+                if let Some(index) = super::canonical_array_index(key_name) {
+                    if has_value {
+                        crate::array::js_array_set_f64_extend(
+                            obj as *mut crate::array::ArrayHeader,
+                            index,
+                            value,
+                        );
+                    }
+                    return obj_value;
+                }
+
+                crate::array::array_named_property_set(
+                    obj as *mut crate::array::ArrayHeader,
+                    key_str,
+                    value,
+                );
+
+                let read_bool = |name: &[u8]| -> Option<bool> {
+                    let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                    if !own_key_present(desc_ptr, k) {
+                        return None;
+                    }
+                    let v = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, k);
+                    Some(crate::value::js_is_truthy(f64::from_bits(v.bits())) != 0)
+                };
+                let writable = read_bool(b"writable").unwrap_or(false);
+                let enumerable = read_bool(b"enumerable").unwrap_or(false);
+                let configurable = read_bool(b"configurable").unwrap_or(false);
+                set_property_attrs(
+                    obj as usize,
+                    key_name.clone(),
+                    PropertyAttrs::new(writable, enumerable, configurable),
+                );
+                return obj_value;
+            }
+        }
         // #2843: enforce frozen / sealed / non-extensible invariants BEFORE any
         // mutation, so a rejected definition leaves the object untouched and the
         // thrown TypeError matches Node.
@@ -1342,6 +1432,18 @@ pub extern "C" fn js_get_global_this_builtin_value(name_ptr: *const u8, name_len
     f64::from_bits(bits)
 }
 
+fn builtin_constructor_prototype_value(name: &[u8]) -> Option<f64> {
+    let ctor = js_get_global_this_builtin_value(name.as_ptr(), name.len());
+    let ctor_value = crate::value::JSValue::from_bits(ctor.to_bits());
+    if !ctor_value.is_pointer() {
+        return None;
+    }
+    let ctor_ptr = ctor_value.as_pointer::<u8>() as usize;
+    let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
+    let proto_value = crate::value::JSValue::from_bits(proto.to_bits());
+    proto_value.is_pointer().then_some(proto)
+}
+
 /// Object.create(proto) — create empty object. Perry ignores prototype; Object.create(null) returns {}.
 #[no_mangle]
 pub extern "C" fn js_object_create(proto_value: f64) -> f64 {
@@ -1532,6 +1634,17 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                         return f64::from_bits(crate::value::js_nanbox_pointer(p as i64).to_bits());
                     }
                 }
+                if (*gc).obj_type == crate::gc::GC_TYPE_ARRAY {
+                    if let Some(array_proto) = builtin_constructor_prototype_value(b"Array") {
+                        let proto_addr = crate::value::js_nanbox_get_pointer(array_proto) as u64;
+                        if proto_addr != raw_addr {
+                            return array_proto;
+                        }
+                    }
+                    if let Some(object_proto) = builtin_constructor_prototype_value(b"Object") {
+                        return object_proto;
+                    }
+                }
                 // #489 / #2145: a function/constructor receiver has no
                 // walkable [[Prototype]] in Perry's model UNLESS its
                 // closure-static-prototype side-table has been set
@@ -1575,6 +1688,17 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                     let p = crate::object::typed_array_intrinsic_proto_ptr();
                     if !p.is_null() {
                         return f64::from_bits(crate::value::js_nanbox_pointer(p as i64).to_bits());
+                    }
+                }
+                if (*gc).obj_type == crate::gc::GC_TYPE_ARRAY {
+                    if let Some(array_proto) = builtin_constructor_prototype_value(b"Array") {
+                        let proto_addr = crate::value::js_nanbox_get_pointer(array_proto);
+                        if proto_addr != bits as i64 {
+                            return array_proto;
+                        }
+                    }
+                    if let Some(object_proto) = builtin_constructor_prototype_value(b"Object") {
+                        return object_proto;
                     }
                 }
                 // #489 / #2145: function/constructor receiver — see the

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -2,10 +2,6 @@
 //! `Object.fromEntries`/`groupBy`/`is`/`hasOwn`/`create`/`freeze`/`seal`/
 //! `defineProperty`/`getOwnPropertyDescriptor`/`getPrototypeOf`/... plus
 //! the `js_object_*` helpers backing them.
-//!
-//! Split out of `object.rs` (issue #1103). Pure relocation. The
-//! `globalThis` singleton subsystem stays in the parent module because
-//! it is also consumed by class/builtin-resolution code there.
 
 use super::*;
 
@@ -577,12 +573,7 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
     }
 }
 
-/// `Object.prototype.propertyIsEnumerable.call(obj, key)` (#2891) — true iff
-/// `key` is an OWN property of `obj` whose descriptor is enumerable. Inherited
-/// and absent keys return false. Nullish receivers throw `TypeError` per
-/// ToObject. Mirrors the ordinary-method branch in `native_call_method.rs`
-/// (which handles `obj.propertyIsEnumerable(key)`); this entry point is what
-/// the syntactic `.call` shapes lower to.
+/// `Object.prototype.propertyIsEnumerable.call(obj, key)` (#2891).
 #[no_mangle]
 pub extern "C" fn js_object_property_is_enumerable(obj_value: f64, key_value: f64) -> f64 {
     const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
@@ -645,26 +636,8 @@ pub extern "C" fn js_object_property_is_enumerable(obj_value: f64, key_value: f6
             Ok(s) => s,
             Err(_) => return f64::from_bits(TAG_FALSE),
         };
-        if (obj as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
-            let gc_header =
-                (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-            if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
-                if key_name == "length" {
-                    return f64::from_bits(TAG_FALSE);
-                }
-                let arr = obj as *const crate::array::ArrayHeader;
-                if super::has_own_helpers::array_own_key_present(arr, key_str) {
-                    let enumerable = if super::canonical_array_index(key_name).is_some() {
-                        true
-                    } else {
-                        super::get_property_attrs(obj as usize, key_name)
-                            .map(|attrs| attrs.enumerable())
-                            .unwrap_or(true)
-                    };
-                    return f64::from_bits(if enumerable { TAG_TRUE } else { TAG_FALSE });
-                }
-                return f64::from_bits(TAG_FALSE);
-            }
+        if let Some(result) = super::array_property_is_enumerable(obj, key_str, key_name) {
+            return result;
         }
         if !is_valid_obj_ptr(obj as *const u8) {
             return f64::from_bits(TAG_FALSE);
@@ -913,71 +886,14 @@ pub extern "C" fn js_object_define_property(
             let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
             std::str::from_utf8(name_bytes).ok().map(|s| s.to_string())
         };
-        if (obj as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
-            let gc_header =
-                (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-            if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
-                let Some(ref key_name) = key_rust else {
-                    return obj_value;
-                };
-                let desc_ptr = extract_obj_ptr(descriptor_value);
-                if desc_ptr.is_null() {
-                    return obj_value;
-                }
-                let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
-                let has_value = own_key_present(desc_ptr, value_key);
-                let value_field =
-                    js_object_get_field_by_name(desc_ptr as *const ObjectHeader, value_key);
-                let value = if has_value {
-                    f64::from_bits(value_field.bits())
-                } else {
-                    f64::from_bits(crate::value::TAG_UNDEFINED)
-                };
-
-                if key_name == "length" {
-                    if has_value {
-                        crate::array::js_array_set_length(
-                            obj as *mut crate::array::ArrayHeader,
-                            value,
-                        );
-                    }
-                    return obj_value;
-                }
-                if let Some(index) = super::canonical_array_index(key_name) {
-                    if has_value {
-                        crate::array::js_array_set_f64_extend(
-                            obj as *mut crate::array::ArrayHeader,
-                            index,
-                            value,
-                        );
-                    }
-                    return obj_value;
-                }
-
-                crate::array::array_named_property_set(
-                    obj as *mut crate::array::ArrayHeader,
-                    key_str,
-                    value,
-                );
-
-                let read_bool = |name: &[u8]| -> Option<bool> {
-                    let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-                    if !own_key_present(desc_ptr, k) {
-                        return None;
-                    }
-                    let v = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, k);
-                    Some(crate::value::js_is_truthy(f64::from_bits(v.bits())) != 0)
-                };
-                let writable = read_bool(b"writable").unwrap_or(false);
-                let enumerable = read_bool(b"enumerable").unwrap_or(false);
-                let configurable = read_bool(b"configurable").unwrap_or(false);
-                set_property_attrs(
-                    obj as usize,
-                    key_name.clone(),
-                    PropertyAttrs::new(writable, enumerable, configurable),
-                );
-                return obj_value;
-            }
+        if let Some(result) = super::define_array_property(
+            obj,
+            obj_value,
+            key_str,
+            key_rust.as_deref(),
+            descriptor_value,
+        ) {
+            return result;
         }
         // #2843: enforce frozen / sealed / non-extensible invariants BEFORE any
         // mutation, so a rejected definition leaves the object untouched and the
@@ -1432,18 +1348,6 @@ pub extern "C" fn js_get_global_this_builtin_value(name_ptr: *const u8, name_len
     f64::from_bits(bits)
 }
 
-fn builtin_constructor_prototype_value(name: &[u8]) -> Option<f64> {
-    let ctor = js_get_global_this_builtin_value(name.as_ptr(), name.len());
-    let ctor_value = crate::value::JSValue::from_bits(ctor.to_bits());
-    if !ctor_value.is_pointer() {
-        return None;
-    }
-    let ctor_ptr = ctor_value.as_pointer::<u8>() as usize;
-    let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
-    let proto_value = crate::value::JSValue::from_bits(proto.to_bits());
-    proto_value.is_pointer().then_some(proto)
-}
-
 /// Object.create(proto) — create empty object. Perry ignores prototype; Object.create(null) returns {}.
 #[no_mangle]
 pub extern "C" fn js_object_create(proto_value: f64) -> f64 {
@@ -1635,14 +1539,8 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                     }
                 }
                 if (*gc).obj_type == crate::gc::GC_TYPE_ARRAY {
-                    if let Some(array_proto) = builtin_constructor_prototype_value(b"Array") {
-                        let proto_addr = crate::value::js_nanbox_get_pointer(array_proto) as u64;
-                        if proto_addr != raw_addr {
-                            return array_proto;
-                        }
-                    }
-                    if let Some(object_proto) = builtin_constructor_prototype_value(b"Object") {
-                        return object_proto;
+                    if let Some(proto) = super::array_get_prototype_of_addr(raw_addr as usize) {
+                        return proto;
                     }
                 }
                 // #489 / #2145: a function/constructor receiver has no
@@ -1691,14 +1589,8 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                     }
                 }
                 if (*gc).obj_type == crate::gc::GC_TYPE_ARRAY {
-                    if let Some(array_proto) = builtin_constructor_prototype_value(b"Array") {
-                        let proto_addr = crate::value::js_nanbox_get_pointer(array_proto);
-                        if proto_addr != bits as i64 {
-                            return array_proto;
-                        }
-                    }
-                    if let Some(object_proto) = builtin_constructor_prototype_value(b"Object") {
-                        return object_proto;
+                    if let Some(proto) = super::array_get_prototype_of_addr(bits as usize) {
+                        return proto;
                     }
                 }
                 // #489 / #2145: function/constructor receiver — see the


### PR DESCRIPTION
## Summary

Fixes #3985.

This implements Perry's core Array exotic object behavior so ordinary JS/package code can rely on Array construction, prototype identity, indexed writes, non-index properties, length reflection, and `Array.isArray` behavior.

Changes include:
- add an ordered Array named-property side table with GC scanning for non-index expandos
- treat canonical array indices as element writes, while preserving `4294967295` and other non-indices as ordinary named properties
- expose correct Array own-property behavior for `length`, indexed elements, descriptors, `hasOwnProperty`, `propertyIsEnumerable`, `Object.keys`, `Object.getOwnPropertyNames`, `delete`, and `Object.defineProperty`
- make callable `Array(...)` construct arrays with correct zero/one/many argument behavior
- allocate `Array.prototype` as an Array exotic and wire prototype method identity so `[].toString === Array.prototype.toString`
- keep `Array.isArray(Array.prototype)` true

DeepWiki reference step was completed once against `boa-dev/boa`; the full markdown response is saved locally under `target/deepwiki/array-exotic-semantics.md` and intentionally not committed.

## Verification

Passed:
- `cargo test -p perry-runtime array_exotic -- --nocapture`
- `cargo check -p perry-runtime`
- `git diff --check`

Test262 subset commands were not run because `vendor/test262` is not present in this worktree, and `test-compat/test262` contains only metadata/preamble files rather than the vendored corpus.
