### PR TITLE
Implement object boxing and String wrappers

### DIFF
--- a/crates/perry-codegen-wasm/src/wasm_runtime.js
+++ b/crates/perry-codegen-wasm/src/wasm_runtime.js
@@ -262,10 +262,12 @@ function buildImports() {
       },
       // object_assign(target, source) -> target handle
       object_assign: (target, source) => {
-        const t = getHandle(target);
-        const s = getHandle(source);
-        if (t && s) Object.assign(t, s);
-        return target;
+        const rawTarget = toJsValue(target);
+        if (rawTarget == null) throw new TypeError('Cannot convert undefined or null to object');
+        const t = Object(rawTarget);
+        const s = toJsValue(source);
+        if (s != null) Object.assign(t, s);
+        return isPointer(target) ? target : fromJsValue(t);
       },
 
       // ===== Phase 1: Arrays =====
@@ -1683,8 +1685,10 @@ const __memDispatch = {
     return (key in obj) ? 1 : 0;
   },
   object_assign: (target, source) => {
-    if (target && source && typeof target === 'object' && typeof source === 'object') Object.assign(target, source);
-    return target;
+    if (target == null) throw new TypeError('Cannot convert undefined or null to object');
+    const t = Object(target);
+    if (source != null) Object.assign(t, source);
+    return t;
   },
 
   // Arrays — args are plain JS values (arr is the array itself, etc.)

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -714,6 +714,24 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
             }
 
             // Handle built-in types
+            if class_name == "Object"
+                && ctx.lookup_local("Object").is_none()
+                && ctx.lookup_func("Object").is_none()
+                && ctx.lookup_class("Object").is_none()
+            {
+                let mut args = new_expr
+                    .args
+                    .as_ref()
+                    .map(|args| {
+                        args.iter()
+                            .map(|a| lower_expr(ctx, &a.expr))
+                            .collect::<Result<Vec<_>>>()
+                    })
+                    .transpose()?
+                    .unwrap_or_default();
+                let arg = args.drain(..).next().unwrap_or(Expr::Undefined);
+                return Ok(Expr::ObjectCoerce(Box::new(arg)));
+            }
             if class_name == "Map" {
                 // new Map() or new Map(entries)
                 let args = new_expr

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -12,7 +12,9 @@ use super::*;
 mod array_buffer;
 mod boxed_primitives;
 mod collection_equality;
-pub(crate) use boxed_primitives::{boxed_primitive_json_value, boxed_primitive_payload};
+pub(crate) use boxed_primitives::{
+    boxed_primitive_json_value, boxed_primitive_payload, boxed_primitive_to_string_tag,
+};
 pub use boxed_primitives::{
     js_boxed_bigint_new, js_boxed_boolean_new, js_boxed_number_new, js_boxed_string_new,
     js_boxed_symbol_new, scan_boxed_primitive_payload_roots_mut,

--- a/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
+++ b/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
@@ -73,6 +73,54 @@ fn register_boxed_primitive_payload(obj: *mut crate::object::ObjectHeader, paylo
     });
 }
 
+fn boxed_constructor_name(class_id: u32) -> Option<&'static [u8]> {
+    match class_id {
+        CLASS_ID_BOXED_NUMBER => Some(b"Number"),
+        CLASS_ID_BOXED_STRING => Some(b"String"),
+        CLASS_ID_BOXED_BOOLEAN => Some(b"Boolean"),
+        CLASS_ID_BOXED_BIGINT => Some(b"BigInt"),
+        CLASS_ID_BOXED_SYMBOL => Some(b"Symbol"),
+        _ => None,
+    }
+}
+
+fn attach_boxed_primitive_prototype(obj: *mut crate::object::ObjectHeader, class_id: u32) {
+    if obj.is_null() {
+        return;
+    }
+    let Some(name) = boxed_constructor_name(class_id) else {
+        return;
+    };
+    let ctor = crate::object::js_get_global_this_builtin_value(name.as_ptr(), name.len());
+    let ctor_value = crate::value::JSValue::from_bits(ctor.to_bits());
+    if !ctor_value.is_pointer() {
+        return;
+    }
+    let ctor_ptr = ctor_value.as_pointer::<crate::closure::ClosureHeader>() as usize;
+    let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
+    let proto_value = crate::value::JSValue::from_bits(proto.to_bits());
+    if proto_value.is_pointer() {
+        crate::object::prototype_chain::object_set_static_prototype(obj as usize, proto.to_bits());
+    }
+}
+
+fn install_string_wrapper_length(
+    obj: *mut crate::object::ObjectHeader,
+    string_ptr: *const crate::string::StringHeader,
+) {
+    if obj.is_null() || string_ptr.is_null() {
+        return;
+    }
+    let key = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
+    let len = crate::string::js_string_length(string_ptr) as f64;
+    crate::object::js_object_set_field_by_name(obj, key, len);
+    crate::object::set_builtin_property_attrs(
+        obj as usize,
+        "length".to_string(),
+        crate::object::PropertyAttrs::new(false, false, false),
+    );
+}
+
 pub fn scan_boxed_primitive_payload_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     let mut moved = Vec::new();
     BOXED_PRIMITIVE_PAYLOADS.with(|m| {
@@ -113,14 +161,30 @@ pub(crate) fn boxed_primitive_json_value(value: f64) -> Option<f64> {
 #[inline]
 pub(crate) fn boxed_primitive_payload(value: f64) -> Option<(u32, f64)> {
     let jv = crate::value::JSValue::from_bits(value.to_bits());
-    if !jv.is_pointer() {
+    let bits = value.to_bits();
+    let ptr = if jv.is_pointer() {
+        jv.as_pointer::<crate::object::ObjectHeader>() as *mut crate::object::ObjectHeader
+    } else if (bits >> 48) == 0 && bits >= (crate::gc::GC_HEADER_SIZE as u64) + 0x1000 {
+        bits as *mut crate::object::ObjectHeader
+    } else {
         return None;
-    }
-    let ptr = jv.as_pointer::<crate::object::ObjectHeader>() as *mut crate::object::ObjectHeader;
+    };
     if ptr.is_null() || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
         return None;
     }
     unsafe { boxed_primitive_payload_for_object(ptr) }
+}
+
+pub(crate) fn boxed_primitive_to_string_tag(value: f64) -> Option<&'static str> {
+    let (class_id, _) = boxed_primitive_payload(value)?;
+    match class_id {
+        CLASS_ID_BOXED_NUMBER => Some("Number"),
+        CLASS_ID_BOXED_STRING => Some("String"),
+        CLASS_ID_BOXED_BOOLEAN => Some("Boolean"),
+        CLASS_ID_BOXED_BIGINT => Some("BigInt"),
+        CLASS_ID_BOXED_SYMBOL => Some("Symbol"),
+        _ => None,
+    }
 }
 
 #[no_mangle]
@@ -134,6 +198,7 @@ pub extern "C" fn js_boxed_number_new(value: f64) -> f64 {
         js_number_coerce(value)
     };
     register_boxed_primitive_payload(obj, payload);
+    attach_boxed_primitive_prototype(obj, CLASS_ID_BOXED_NUMBER);
     crate::value::js_nanbox_pointer(obj as i64)
 }
 
@@ -148,6 +213,8 @@ pub extern "C" fn js_boxed_string_new(value: f64) -> f64 {
     };
     let boxed = f64::from_bits(crate::value::JSValue::string_ptr(ptr).bits());
     register_boxed_primitive_payload(obj, boxed);
+    install_string_wrapper_length(obj, ptr);
+    attach_boxed_primitive_prototype(obj, CLASS_ID_BOXED_STRING);
     crate::value::js_nanbox_pointer(obj as i64)
 }
 
@@ -157,6 +224,7 @@ pub extern "C" fn js_boxed_boolean_new(value: f64) -> f64 {
     let boxed =
         f64::from_bits(crate::value::JSValue::bool(crate::value::js_is_truthy(value) != 0).bits());
     register_boxed_primitive_payload(obj, boxed);
+    attach_boxed_primitive_prototype(obj, CLASS_ID_BOXED_BOOLEAN);
     crate::value::js_nanbox_pointer(obj as i64)
 }
 
@@ -164,6 +232,7 @@ pub extern "C" fn js_boxed_boolean_new(value: f64) -> f64 {
 pub extern "C" fn js_boxed_bigint_new(value: f64) -> f64 {
     let obj = crate::object::js_object_alloc(CLASS_ID_BOXED_BIGINT, 0);
     register_boxed_primitive_payload(obj, value);
+    attach_boxed_primitive_prototype(obj, CLASS_ID_BOXED_BIGINT);
     crate::value::js_nanbox_pointer(obj as i64)
 }
 
@@ -171,5 +240,6 @@ pub extern "C" fn js_boxed_bigint_new(value: f64) -> f64 {
 pub extern "C" fn js_boxed_symbol_new(value: f64) -> f64 {
     let obj = crate::object::js_object_alloc(CLASS_ID_BOXED_SYMBOL, 0);
     register_boxed_primitive_payload(obj, value);
+    attach_boxed_primitive_prototype(obj, CLASS_ID_BOXED_SYMBOL);
     crate::value::js_nanbox_pointer(obj as i64)
 }

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -83,9 +83,10 @@ pub use formatting::{
 };
 
 pub(crate) use formatting::{
-    boxed_primitive_json_value, boxed_primitive_payload, format_finite_number_js, format_jsvalue,
-    is_negative_zero, jsvalue_string_content, InspectCompactGuard, InspectCustomInspectGuard,
-    InspectDepthLimitGuard, InspectGettersGuard, InspectShowHiddenGuard, InspectSortedGuard,
+    boxed_primitive_json_value, boxed_primitive_payload, boxed_primitive_to_string_tag,
+    format_finite_number_js, format_jsvalue, is_negative_zero, jsvalue_string_content,
+    InspectCompactGuard, InspectCustomInspectGuard, InspectDepthLimitGuard, InspectGettersGuard,
+    InspectShowHiddenGuard, InspectSortedGuard,
 };
 
 pub use globals::{

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -1218,6 +1218,9 @@ pub extern "C" fn js_date_get_utc_milliseconds(timestamp: f64) -> f64 {
 /// date.valueOf() — same as getTime(), returns ms timestamp.
 #[no_mangle]
 pub extern "C" fn js_date_value_of(timestamp: f64) -> f64 {
+    if let Some((_, payload)) = crate::builtins::boxed_primitive_payload(timestamp) {
+        return payload;
+    }
     let timestamp = date_cell_timestamp(timestamp);
     timestamp
 }

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -35,11 +35,9 @@ pub extern "C" fn js_object_alloc_null_proto(class_id: u32, field_count: u32) ->
 /// Takes and returns a NaN-boxed JSValue (`f64`):
 /// - `undefined` / `null` / no-arg → a fresh ordinary `{}`.
 /// - an existing object/array/function (any pointer value) → returned unchanged.
-/// - BigInt and Symbol primitives → boxed primitive wrapper objects so
-///   `util.types.isBigIntObject(Object(1n))` and
-///   `util.types.isSymbolObject(Object(Symbol()))` match Node.
-/// - other primitives → a fresh `{}`, which preserves
-///   `typeof Object(5) === "object"`.
+/// - primitive values → boxed primitive wrapper objects so
+///   `Object(true).valueOf()`, `Object(0).valueOf()`,
+///   `Object("x").valueOf()`, and util.types boxed checks match Node.
 ///
 /// The `new Object(value)` form is handled separately by
 /// `js_new_function_construct`'s `"Object"` arm; this is only the bare-call
@@ -48,6 +46,10 @@ pub extern "C" fn js_object_alloc_null_proto(class_id: u32, field_count: u32) ->
 #[no_mangle]
 pub extern "C" fn js_object_coerce(value: f64) -> f64 {
     let jsval = crate::value::JSValue::from_bits(value.to_bits());
+    if jsval.is_undefined() || jsval.is_null() {
+        let obj = js_object_alloc(0, 0);
+        return crate::value::js_nanbox_pointer(obj as i64);
+    }
     if jsval.is_bigint() {
         return crate::builtins::js_boxed_bigint_new(value);
     }
@@ -58,8 +60,13 @@ pub extern "C" fn js_object_coerce(value: f64) -> f64 {
         // Already an object/array/function — pass through unchanged.
         return value;
     }
-    let obj = js_object_alloc(0, 0);
-    crate::value::js_nanbox_pointer(obj as i64)
+    if jsval.is_bool() {
+        return crate::builtins::js_boxed_boolean_new(value);
+    }
+    if jsval.is_any_string() {
+        return crate::builtins::js_boxed_string_new(value);
+    }
+    crate::builtins::js_boxed_number_new(value)
 }
 
 /// Allocate a new object with class ID, parent class ID, and field count
@@ -648,7 +655,7 @@ pub unsafe extern "C" fn js_object_assign_validate_target(target_f64: f64) -> f6
     if target.is_undefined() || target.is_null() {
         throw_object_assign_nullish_target();
     }
-    target_f64
+    js_object_coerce(target_f64)
 }
 
 unsafe fn object_assign_set_string_key(
@@ -702,7 +709,7 @@ unsafe fn object_assign_string_source(
 /// properties (`Object.assign({}, "ab") -> {0:"a",1:"b"}`).
 #[no_mangle]
 pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) -> f64 {
-    js_object_assign_validate_target(target_f64);
+    let target_f64 = js_object_assign_validate_target(target_f64);
 
     let target_value = JSValue::from_bits(target_f64.to_bits());
     if !target_value.is_pointer() {
@@ -748,11 +755,7 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
     // Same alignment guard as the target above — `src` is dereferenced at
     // `(*src).keys_array` just below; an unaligned non-object source must
     // be skipped, not dereferenced.
-    if src_raw < 0x10000
-        || src_raw % 8 != 0
-        || src_raw == tgt_raw
-        || crate::symbol::is_registered_symbol(src_raw)
-    {
+    if src_raw < 0x10000 || src_raw % 8 != 0 || crate::symbol::is_registered_symbol(src_raw) {
         return target_f64;
     }
 
@@ -763,12 +766,8 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
     let src_keys = (*src).keys_array;
     if !src_keys.is_null() && (src_keys as usize) >= 0x10000 {
         let key_count = crate::array::js_array_length(src_keys) as usize;
-        let src_field_count = (*src).field_count as usize;
-        let alloc_limit = std::cmp::max(src_field_count, 8);
-        let header_size = std::mem::size_of::<ObjectHeader>();
-        let src_fields = (src as *const u8).add(header_size) as *const u64;
-        // Same overflow-aware iteration as `js_object_copy_own_fields`.
-        // #1781: SSO-aware — see the sibling helper above.
+        // Use the public [[Get]] path, not raw field slots, so accessors run
+        // and abrupt completions propagate the way Object.assign requires.
         for i in 0..key_count {
             let key_val = crate::array::js_array_get(src_keys, i as u32);
             if !key_val.is_any_string() {
@@ -780,13 +779,17 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
             if key_ptr.is_null() {
                 continue;
             }
-            let field_f64 = if i < alloc_limit {
-                let field_bits = *src_fields.add(i);
-                f64::from_bits(field_bits)
-            } else {
-                let v = js_object_get_field(src, i as u32);
-                f64::from_bits(v.bits())
-            };
+            let mut sso_buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+            if let Some(name_bytes) = crate::string::js_string_key_bytes(key_val, &mut sso_buf) {
+                if let Ok(name) = std::str::from_utf8(name_bytes) {
+                    if let Some(attrs) = get_property_attrs(src_raw, name) {
+                        if !attrs.enumerable() {
+                            continue;
+                        }
+                    }
+                }
+            }
+            let field_f64 = f64::from_bits(js_object_get_field_by_name(src, key_ptr).bits());
             object_assign_set_string_key(target, target_is_array, key_ptr, field_f64);
         }
     }

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -11,6 +11,8 @@ use super::*;
 const CLASS_ID_BOXED_NUMBER: u32 = 0xFFFF_0060;
 const CLASS_ID_BOXED_STRING: u32 = 0xFFFF_0061;
 const CLASS_ID_BOXED_BOOLEAN: u32 = 0xFFFF_0062;
+const CLASS_ID_BOXED_BIGINT: u32 = 0xFFFF_0063;
+const CLASS_ID_BOXED_SYMBOL: u32 = 0xFFFF_0064;
 
 /// Get a field from an object by index
 ///
@@ -2640,12 +2642,18 @@ pub extern "C" fn js_object_get_field_by_name(
                 let class_id = (*obj).class_id;
                 if matches!(
                     class_id,
-                    CLASS_ID_BOXED_NUMBER | CLASS_ID_BOXED_STRING | CLASS_ID_BOXED_BOOLEAN
+                    CLASS_ID_BOXED_NUMBER
+                        | CLASS_ID_BOXED_STRING
+                        | CLASS_ID_BOXED_BOOLEAN
+                        | CLASS_ID_BOXED_BIGINT
+                        | CLASS_ID_BOXED_SYMBOL
                 ) {
                     let name = match class_id {
                         CLASS_ID_BOXED_NUMBER => b"Number".as_slice(),
                         CLASS_ID_BOXED_STRING => b"String".as_slice(),
                         CLASS_ID_BOXED_BOOLEAN => b"Boolean".as_slice(),
+                        CLASS_ID_BOXED_BIGINT => b"BigInt".as_slice(),
+                        CLASS_ID_BOXED_SYMBOL => b"Symbol".as_slice(),
                         _ => unreachable!(),
                     };
                     let v = js_get_global_this_builtin_value(name.as_ptr(), name.len());

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -206,20 +206,7 @@ extern "C" fn global_this_object_thunk(
     _closure: *const crate::closure::ClosureHeader,
     value: f64,
 ) -> f64 {
-    let js_value = crate::value::JSValue::from_bits(value.to_bits());
-    if js_value.is_undefined() || js_value.is_null() {
-        return crate::value::js_nanbox_pointer(js_object_alloc(0, 0) as i64);
-    }
-    if js_value.is_bigint() {
-        return crate::builtins::js_boxed_bigint_new(value);
-    }
-    if unsafe { crate::symbol::js_is_symbol(value) } != 0 {
-        return crate::builtins::js_boxed_symbol_new(value);
-    }
-    if crate::value::js_nanbox_get_pointer(value) != 0 {
-        return value;
-    }
-    crate::value::js_nanbox_pointer(js_object_alloc(0, 0) as i64)
+    crate::object::js_object_coerce(value)
 }
 
 extern "C" fn global_this_structured_clone_thunk(
@@ -510,6 +497,12 @@ extern "C" fn object_prototype_to_string_thunk(
     use crate::value::JSValue;
     let this_bits = IMPLICIT_THIS.with(|c| c.get());
     if let Some(tag) = crate::object::web_stream_to_string_tag(f64::from_bits(this_bits)) {
+        let formatted = format!("[object {}]", tag);
+        let bytes = formatted.as_bytes();
+        let s = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+        return f64::from_bits(crate::js_nanbox_string(s as i64).to_bits());
+    }
+    if let Some(tag) = crate::builtins::boxed_primitive_to_string_tag(f64::from_bits(this_bits)) {
         let formatted = format!("[object {}]", tag);
         let bytes = formatted.as_bytes();
         let s = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
@@ -981,11 +974,17 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
                 "prototype".to_string(),
                 super::PropertyAttrs::new(false, false, false),
             );
+            let ctor_key = crate::string::js_string_from_bytes(
+                b"constructor".as_ptr(),
+                "constructor".len() as u32,
+            );
+            js_object_set_field_by_name(proto_obj, ctor_key, ctor_value);
+            super::set_builtin_property_attrs(
+                proto_obj as usize,
+                "constructor".to_string(),
+                super::PropertyAttrs::new(true, false, true),
+            );
             if is_web_fetch_constructor(name) {
-                let ctor_key = crate::string::js_string_from_bytes(
-                    b"constructor".as_ptr(),
-                    "constructor".len() as u32,
-                );
                 js_object_set_field_by_name(proto_obj, ctor_key, ctor_value);
                 super::set_builtin_property_attrs(
                     proto_obj as usize,

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1684,6 +1684,12 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
         let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
         return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
     }
+    if let Some(tag) = crate::builtins::boxed_primitive_to_string_tag(value) {
+        let formatted = format!("[object {}]", tag);
+        let bytes = formatted.as_bytes();
+        let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+        return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
+    }
     if jsv.is_int32() || jsv.is_number() {
         let bytes = b"[object Number]";
         let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -269,6 +269,9 @@ pub(crate) unsafe fn js_object_default_value_of(receiver: f64) -> f64 {
     if jsval.is_undefined() || jsval.is_null() {
         throw_object_value_of_nullish_receiver();
     }
+    if let Some((_, payload)) = crate::builtins::boxed_primitive_payload(receiver) {
+        return payload;
+    }
     receiver
 }
 
@@ -662,6 +665,61 @@ pub unsafe extern "C" fn js_native_call_method(
     }
 
     let jsval = JSValue::from_bits(object.to_bits());
+
+    if let Some((_, payload)) = crate::builtins::boxed_primitive_payload(object) {
+        match method_name {
+            "valueOf" => return payload,
+            "toString" | "toLocaleString" => {
+                let payload_jsv = JSValue::from_bits(payload.to_bits());
+                match crate::builtins::boxed_primitive_to_string_tag(object) {
+                    Some("String") => return payload,
+                    Some("Number") => {
+                        let n = if payload_jsv.is_number() {
+                            payload_jsv.as_number()
+                        } else {
+                            payload
+                        };
+                        let s = if n.fract() == 0.0 && n.abs() < (i64::MAX as f64) {
+                            (n as i64).to_string()
+                        } else {
+                            n.to_string()
+                        };
+                        let str_ptr =
+                            crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+                        return f64::from_bits(JSValue::string_ptr(str_ptr).bits());
+                    }
+                    Some("Boolean") => {
+                        let s = if payload_jsv.is_bool() && payload_jsv.as_bool() {
+                            b"true".as_slice()
+                        } else {
+                            b"false".as_slice()
+                        };
+                        let str_ptr =
+                            crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+                        return f64::from_bits(JSValue::string_ptr(str_ptr).bits());
+                    }
+                    Some("BigInt") => {
+                        let big = crate::value::JSValue::from_bits(payload.to_bits());
+                        if big.is_bigint() {
+                            let ptr = crate::bigint::clean_bigint_ptr(
+                                (payload.to_bits() & 0x0000_FFFF_FFFF_FFFF)
+                                    as *const crate::bigint::BigIntHeader,
+                            );
+                            let str_ptr = crate::bigint::js_bigint_to_string(ptr);
+                            return f64::from_bits(JSValue::string_ptr(str_ptr).bits());
+                        }
+                    }
+                    Some("Symbol") => {
+                        let str_ptr =
+                            crate::symbol::js_symbol_to_string(payload) as *mut crate::StringHeader;
+                        return f64::from_bits(JSValue::string_ptr(str_ptr).bits());
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
 
     if crate::web_storage::is_storage_value(object_handle.get_nanbox_f64()) {
         let args = refreshed_args();
@@ -2848,6 +2906,47 @@ pub unsafe extern "C" fn js_native_call_method(
 
         // Common string methods on string values
         "toString" => {
+            if let Some((_, payload)) = crate::builtins::boxed_primitive_payload(object) {
+                let payload_jsv = JSValue::from_bits(payload.to_bits());
+                match crate::builtins::boxed_primitive_to_string_tag(object) {
+                    Some("String") => return payload,
+                    Some("Number") => {
+                        let n = if payload_jsv.is_number() {
+                            payload_jsv.as_number()
+                        } else {
+                            payload
+                        };
+                        let s = if n.fract() == 0.0 && n.abs() < (i64::MAX as f64) {
+                            (n as i64).to_string()
+                        } else {
+                            n.to_string()
+                        };
+                        let str_ptr =
+                            crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+                        return f64::from_bits(JSValue::string_ptr(str_ptr).bits());
+                    }
+                    Some("Boolean") => {
+                        let s = if payload_jsv.is_bool() && payload_jsv.as_bool() {
+                            "true"
+                        } else {
+                            "false"
+                        };
+                        let str_ptr =
+                            crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+                        return f64::from_bits(JSValue::string_ptr(str_ptr).bits());
+                    }
+                    Some("BigInt") if payload_jsv.is_bigint() => {
+                        let ptr = payload_jsv.as_bigint_ptr();
+                        let str_ptr = crate::bigint::js_bigint_to_string(ptr);
+                        return f64::from_bits(JSValue::string_ptr(str_ptr).bits());
+                    }
+                    Some("Symbol") => {
+                        let str_ptr = crate::symbol::js_symbol_to_string(payload);
+                        return f64::from_bits(JSValue::string_ptr(str_ptr as *mut _).bits());
+                    }
+                    _ => {}
+                }
+            }
             if jsval.is_string() {
                 return object;
             } else if jsval.is_bigint() {

--- a/crates/perry-runtime/src/value/dynamic_object.rs
+++ b/crates/perry-runtime/src/value/dynamic_object.rs
@@ -17,6 +17,16 @@ use std::sync::atomic::Ordering;
 /// results without another conversion.
 #[no_mangle]
 pub extern "C" fn js_value_length_f64(value: f64) -> f64 {
+    if let Some((_, payload)) = crate::builtins::boxed_primitive_payload(value) {
+        if matches!(
+            crate::builtins::boxed_primitive_to_string_tag(value),
+            Some("String")
+        ) {
+            return js_value_length_f64(payload);
+        }
+        return 0.0;
+    }
+
     let bits = value.to_bits();
     let top16 = bits >> 48;
 

--- a/test-files/test_gap_object_string_wrappers.ts
+++ b/test-files/test_gap_object_string_wrappers.ts
@@ -1,0 +1,69 @@
+function check(label: string, condition: boolean): void {
+  if (!condition) {
+    throw new Error(label);
+  }
+}
+
+check("Object(true).valueOf", Object(true).valueOf() === true);
+check("Object(0).valueOf", Object(0).valueOf() === 0);
+check("Object string valueOf", Object("some string").valueOf() === "some string");
+check("Object no-arg object", typeof Object() === "object");
+
+const existing = { marker: 1 };
+check("Object existing identity", Object(existing) === existing);
+check("new Object existing identity", new Object(existing) === existing);
+check("new Object primitive value", new Object(false).valueOf() === false);
+
+const assignedStringTarget = Object.assign("x", { extra: 7 });
+check("assign string target boxes", typeof assignedStringTarget === "object");
+check("assign string target value", (assignedStringTarget as any).valueOf() === "x");
+check("assign string target prop", (assignedStringTarget as any).extra === 7);
+
+const source: any = { a: 1 };
+Object.defineProperty(source, "hidden", { value: 2, enumerable: false });
+const assigned = Object.assign({}, source);
+check("assign copies enumerable", (assigned as any).a === 1);
+check("assign skips non-enumerable", !Object.prototype.hasOwnProperty.call(assigned, "hidden"));
+
+let getterObserved = false;
+const getterSource = Object.defineProperty({}, "boom", {
+  enumerable: true,
+  get() {
+    getterObserved = true;
+    throw new Error("getter boom");
+  },
+});
+let getterThrew = false;
+try {
+  Object.assign({}, getterSource);
+} catch (e) {
+  getterThrew = String((e as Error).message).indexOf("getter boom") >= 0;
+}
+check("assign getter observed", getterObserved);
+check("assign getter abrupt", getterThrew);
+
+const readOnlyTarget = Object.defineProperty({}, "fixed", {
+  value: 1,
+  writable: false,
+});
+let readOnlyThrew = false;
+try {
+  Object.assign(readOnlyTarget, { fixed: 2 });
+} catch (_e) {
+  readOnlyThrew = true;
+}
+check("assign read-only target throws", readOnlyThrew);
+
+(String.prototype as any).fromProto = 42;
+const wrapped = new String("abc");
+check("string wrapper own length", Object.prototype.hasOwnProperty.call(wrapped, "length"));
+check("string wrapper length", wrapped.length === 3);
+check("string wrapper prototype", Object.getPrototypeOf(wrapped) === String.prototype);
+check("string wrapper inherits", (wrapped as any).fromProto === 42);
+check("string wrapper tag", Object.prototype.toString.call(wrapped) === "[object String]");
+check("string wrapper constructor", wrapped.constructor === String);
+check("String.prototype constructor", String.prototype.constructor === String);
+check("string wrapper toString", wrapped.toString() === "abc");
+delete (String.prototype as any).fromProto;
+
+console.log("object-string-wrappers ok");


### PR DESCRIPTION
## Summary
- implement shared ToObject/object boxing for `Object(value)` and unshadowed `new Object(value)` while preserving existing object identity
- add boxed primitive payload/prototype/tag handling, including String wrapper internal string data, own non-enumerable `length`, `constructor`, and inherited `String.prototype` behavior
- update `Object.assign` target/source coercion so primitive targets box, nullish sources skip, enumerable source getters run, and abrupt completions propagate
- align boxed primitive `valueOf`/`toString` through Perry native dispatch, broad valueOf lowering, and `.length` fallback paths

References #3986 and #3987. This intentionally limits #3987 coverage to the String-wrapper subset; String method-tail and formatting gaps remain out of scope.

## Verification
- `cargo build -p perry`
- `cargo check -p perry-runtime`
- `rustfmt --check crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs crates/perry-runtime/src/builtins/formatting.rs crates/perry-runtime/src/builtins/mod.rs crates/perry-runtime/src/date.rs crates/perry-runtime/src/object/alloc.rs crates/perry-runtime/src/object/field_get_set.rs crates/perry-runtime/src/object/global_this.rs crates/perry-runtime/src/object/mod.rs crates/perry-runtime/src/object/native_call_method.rs crates/perry-runtime/src/value/dynamic_object.rs crates/perry-hir/src/lower/expr_new.rs`
- `target/debug/perry test-files/test_gap_object_string_wrappers.ts && ./test_gap_object_string_wrappers`

## Not Run
- `scripts/test262_subset.py --root vendor/test262 --dir built-ins/Object --max 180 --timeout 10 --sample-cap 50 --report /tmp/perry-c262-builtins-object.json` because `vendor/test262` is not present in this worktree
- `scripts/test262_subset.py --root vendor/test262 --dir built-ins/String --max 180 --timeout 10 --sample-cap 50 --report /tmp/perry-c262-builtins-string.json` because `vendor/test262` is not present in this worktree

## Reference
- Required DeepWiki research was saved locally at `target/deepwiki/object-string-wrappers.md` (ignored, not committed).
