### PR TITLE
fix(timers/promises,stream/promises): abort rejects with AbortError code ABORT_ERR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1069 — timers/promises + stream/promises: abort rejects with AbortError code "ABORT_ERR"
+
+When a `timers/promises` (`setTimeout`/`setImmediate`/`scheduler.wait`/interval) or `stream/promises` (`finished`/`pipeline`) operation was aborted, Perry rejected with the signal's `.reason` — for a default `controller.abort()` that is a DOMException whose `.code` is the numeric `20`, so fixtures saw `code: 20` instead of Node's `"ABORT_ERR"`.
+
+Node always rejects these operations with a fresh internal `AbortError` (`name: "AbortError"`, `message: "The operation was aborted"`, `code: "ABORT_ERR"`) and ignores `signal.reason` entirely — verified against `node --experimental-strip-types` for a bare abort, a custom `abort(reason)`, and an `AbortSignal.timeout()` `TimeoutError` (all reject with `AbortError`/`"ABORT_ERR"`).
+
+Fix (`crates/perry-runtime/src/node_submodules/stream_promises.rs`): `signal_reason` now returns `abort_error_value()` (the string-coded `AbortError`) unconditionally instead of reading `signal.reason`. This is the single error source shared by every `timers/promises` and `stream/promises` abort-rejection path (immediate-abort checks and the deferred `abort` listener), so all of them now match Node.
+
+Validated: `node-suite/timers/promises` `abort-error-shape`, `abort-signal`, `scheduler-wait-abort`, and `set-immediate-signal` now match Node byte-for-byte; `stream/promises` `finished`/`pipeline` abort still report `"ABORT_ERR"`. The 2 remaining `timers`/`stream` promise failures (`timeout-value-and-ref` unsettled-top-level-await warning, `pipeline-with-transform-collect` transform-collect concat) are pre-existing and unrelated to abort errors. `perry-runtime` stream_promises unit tests green.
+
 ## v0.5.1068 — timers: drain microtasks between timer callbacks (#3870)
 
 Perry ran the microtask checkpoint only once after a whole batch of expired timers, not after each callback. So when a `setTimeout` callback queued a microtask *and* scheduled another zero-delay timeout, Perry fired the next timer before draining the microtask:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1068
+**Current Version:** 0.5.1069
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1068"
+version = "0.5.1069"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1068"
+version = "0.5.1069"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1068"
+version = "0.5.1069"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1068"
+version = "0.5.1069"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1068"
+version = "0.5.1069"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/node_submodules/stream_promises.rs
+++ b/crates/perry-runtime/src/node_submodules/stream_promises.rs
@@ -167,11 +167,18 @@ fn invalid_pipeline_body_error_value(body: f64) -> f64 {
     type_error_value_with_code(&message, "ERR_INVALID_ARG_TYPE")
 }
 
-pub(crate) fn signal_reason(signal: f64) -> f64 {
-    match get_object_property(signal, b"reason") {
-        Some(reason) if !JSValue::from_bits(reason.to_bits()).is_undefined() => reason,
-        _ => abort_error_value(),
-    }
+/// The error used to reject a pending `timers/promises` or `stream/promises`
+/// operation when its `AbortSignal` fires.
+///
+/// #3870-adjacent (abort-error-shape): Node ALWAYS rejects these with a fresh
+/// `AbortError` (`name: "AbortError"`, `message: "The operation was aborted"`,
+/// `code: "ABORT_ERR"`) and ignores `signal.reason` entirely — even a custom
+/// reason passed to `controller.abort(reason)` or the `TimeoutError` from
+/// `AbortSignal.timeout()`. Previously this returned `signal.reason` when set,
+/// which for a default `controller.abort()` is a DOMException whose `.code` is
+/// the numeric `20`, diverging from Node's string `"ABORT_ERR"`.
+pub(crate) fn signal_reason(_signal: f64) -> f64 {
+    abort_error_value()
 }
 
 extern "C" fn stream_promises_abort_listener(closure: *const ClosureHeader) -> f64 {


### PR DESCRIPTION
## timers/promises + stream/promises: abort rejects with `AbortError` code `"ABORT_ERR"`

When a `timers/promises` (`setTimeout`/`setImmediate`/`scheduler.wait`/interval) or `stream/promises` (`finished`/`pipeline`) operation was aborted, Perry rejected with the signal's `.reason`. For a default `controller.abort()` that reason is a DOMException whose `.code` is the numeric **`20`**, so callers saw `code: 20` instead of Node's string `"ABORT_ERR"`:

```
node:  wait abort: AbortError:ABORT_ERR
perry: wait abort: AbortError:20          (before)
```

### Node behavior (verified vs `node --experimental-strip-types`)
Node **always** rejects these operations with a fresh internal `AbortError` (`name: "AbortError"`, `message: "The operation was aborted"`, `code: "ABORT_ERR"`) and **ignores `signal.reason` entirely** — confirmed for a bare `abort()`, a custom `abort(reason)`, and an `AbortSignal.timeout()` `TimeoutError`. All reject with `AbortError`/`"ABORT_ERR"`.

### Fix
`crates/perry-runtime/src/node_submodules/stream_promises.rs`: `signal_reason` now returns `abort_error_value()` (the string-coded `AbortError`) unconditionally instead of reading `signal.reason`. It's the single error source shared by every `timers/promises` and `stream/promises` abort-rejection path (the immediate-abort checks and the deferred `abort` listener), so all of them now match Node.

### Validation
- `node-suite/timers/promises`: `abort-error-shape`, `abort-signal`, `scheduler-wait-abort`, `set-immediate-signal` now match Node byte-for-byte ✅
- `stream/promises` `finished`/`pipeline` abort still report `"ABORT_ERR"` ✅
- The 2 remaining promise-suite failures (`timeout-value-and-ref` unsettled-TLA warning, `pipeline-with-transform-collect` transform concat) are pre-existing and unrelated to abort errors.
- `perry-runtime` stream_promises unit tests green (15).
