### PR TITLE
fix(http): module-level header-validation / agent export tail (#3712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1071 — node:http: module-level header-validation / agent export tail (#3712)
+
+`node:http`'s manifest covered the server/client classes and request helpers but omitted a current Node export tail used for header validation and agent/feature detection. Compiling code that imported these names failed at module-collection (`<name> is not implemented in Perry`). Added:
+
+- **`http.maxHeaderSize`** — the 16 KiB (`16384`) default constant.
+- **`http.globalAgent`** — the shared `http.Agent` shape (`protocol: "http:"`, `defaultPort: 80`, keep-alive enabled to match Node 19+), distinct from the existing `https.globalAgent`.
+- **`http.validateHeaderName(name[, label])`** — throws `TypeError [ERR_INVALID_HTTP_TOKEN]` for a non-string / empty / non-token name (Node's `tokenRegExp` char set), else returns undefined.
+- **`http.validateHeaderValue(name, value)`** — throws `TypeError [ERR_HTTP_INVALID_HEADER_VALUE]` for an undefined value and `TypeError [ERR_INVALID_CHAR]` for control chars outside `\t` / `\x20-\x7e` / `\x80-\xff`, else returns undefined.
+- **`http.setMaxIdleHTTPParsers(max)`** / **`http.setGlobalProxyFromEnv([proxyEnv])`** — deterministic no-ops returning `undefined` (no shared parser pool / env-proxy state in Perry's runtime).
+
+Implementation:
+- **`crates/perry-api-manifest/src/entries.rs`** — six new `http` rows (two `property`, four `method`).
+- **`crates/perry-runtime/src/object/native_module.rs`** — `maxHeaderSize`/`globalAgent` property dispatch + `http_global_agent_object()`; the four helpers added to `is_native_module_callable_export` and `native_callable_export_arity`.
+- **`crates/perry-runtime/src/object/native_module_dispatch.rs`** — `js_http_validate_header_name` / `js_http_validate_header_value` / `js_http_setter_noop` FFI (Node-shaped error codes/messages) + dispatch arms.
+- **`crates/perry-codegen/src/lower_call/native_table/http.rs`** — static dispatch-table rows so the direct `http.validateHeaderName(...)` / named-import call forms dispatch (not just the value form).
+- **`test-parity/node-suite/http/exports/module-helper-tail.ts`** — new fixture covering export shape, `globalAgent` fields, `maxHeaderSize`, and the header-validation error cases; byte-identical to `node --experimental-strip-types`.
+
+Out of scope (tracked for follow-up): the class tail `http.OutgoingMessage`, `http.WebSocket`, `http.CloseEvent`, `http.MessageEvent`, and `http._connectionListener` are intentionally not yet claimed in the manifest pending an alias/implementation decision.
+
 ## v0.5.1070 — util.styleText rejects non-Node format aliases (ERR_INVALID_ARG_VALUE)
 
 `util.styleText(format, text)` validates `format` against `Object.keys(util.inspect.colors)` — exactly 44 names. Perry additionally accepted 12 British/camelCase aliases (`grey`, `bgGrey`, `blackBright`, `bgBlackBright`, `faint`, `crossedout`, `crossedOut`, `strikeThrough`, `conceal`, `swapColors`, `swapcolors`, `doubleUnderline`) that Node does not, applying ANSI codes where Node throws `TypeError [ERR_INVALID_ARG_VALUE]`.
@@ -32,6 +51,8 @@ perry: promise|timeout1|timeout2|micro-in-timeout   (before)
 Fix (`crates/perry-runtime/src/timer.rs`, `js_callback_timer_tick`): drain the microtask queue (`js_promise_run_microtasks`) after *each* timer callback rather than only once after the expired batch in the outer pump. In Node every timer callback is its own macrotask followed by a microtask checkpoint, so a `queueMicrotask`/`Promise.then` scheduled inside a timer callback now runs before the next timer fires.
 
 Validated against `node --experimental-strip-types`: all five `node-suite/timers/ordering` fixtures pass (the previously-failing `nested-order-extra` now matches). A 77-fixture sweep across `timers`/`promises`/`async-hooks` shows no regressions — the pre-existing failures (negative-delay warnings, `AbortError.code` shape, unsettled-top-level-await warnings) fail identically with and without this change (confirmed by a stashed-baseline rebuild) and are orthogonal to microtask ordering. `perry-runtime` timer + microtask unit tests green.
+
+## v0.5.1067 — node:https/http: URL-object request/get overload no longer throws circular-JSON (#3880)
 
 `https.get(new URL(...), options, callback)` (and the `http`/`request` variants) threw `TypeError: Converting circular structure to JSON` before the request could be built. Root cause: `parse_client_args` classified arguments by value type, and a `URL` *instance* — a heap object, not a string — fell into the "first non-string pointer → options bag" branch. `parse_options_object` then JSON-stringified the URL, which throws on its `searchParams` ↔ owner back-reference, and the real options object was dropped.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1070
+**Current Version:** 0.5.1071
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1070"
+version = "0.5.1071"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1070"
+version = "0.5.1071"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1070"
+version = "0.5.1071"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1070"
+version = "0.5.1071"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1070"
+version = "0.5.1071"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -4165,6 +4165,15 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("http", "get", false, None),
     property("http", "METHODS"),
     property("http", "STATUS_CODES"),
+    // #3712 — module-level helper/export tail. `maxHeaderSize` is the 16 KiB
+    // default constant; `globalAgent` is the shared http.Agent; the four
+    // helpers validate header tokens/values or are deterministic no-ops.
+    property("http", "maxHeaderSize"),
+    property("http", "globalAgent"),
+    method("http", "validateHeaderName", false, None),
+    method("http", "validateHeaderValue", false, None),
+    method("http", "setMaxIdleHTTPParsers", false, None),
+    method("http", "setGlobalProxyFromEnv", false, None),
     class("http", "Server"),
     class("http", "ClientRequest"),
     class("http", "IncomingMessage"),

--- a/crates/perry-codegen/src/lower_call/native_table/http.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/http.rs
@@ -56,6 +56,48 @@ pub(super) const HTTP_ROWS: &[NativeModSig] = &[
         args: &[NA_VARARGS],
         ret: NR_PTR,
     },
+    // #3712 — module-level header-validation / parser-proxy helpers. Runtime
+    // impls live in `crates/perry-runtime/src/object/native_module_dispatch.rs`.
+    // `validateHeaderName`/`validateHeaderValue` throw Node-shaped error codes
+    // on invalid input; the two setters are deterministic no-ops returning
+    // undefined. Args are passed as NaN-boxed f64 (the helpers coerce/probe
+    // them), return is the NaN-boxed undefined value.
+    NativeModSig {
+        module: "http",
+        has_receiver: false,
+        method: "validateHeaderName",
+        class_filter: None,
+        runtime: "js_http_validate_header_name",
+        args: &[NA_F64, NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: false,
+        method: "validateHeaderValue",
+        class_filter: None,
+        runtime: "js_http_validate_header_value",
+        args: &[NA_F64, NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: false,
+        method: "setMaxIdleHTTPParsers",
+        class_filter: None,
+        runtime: "js_http_setter_noop",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "http",
+        has_receiver: false,
+        method: "setGlobalProxyFromEnv",
+        class_filter: None,
+        runtime: "js_http_setter_noop",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     // ClientRequest instance methods (`req.on/.end/.write/.setHeader/.setTimeout`).
     // Shared between `http` and `https` factories — both register the
     // returned binding under module `"http"` in the HIR class table.

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -2178,6 +2178,9 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ("net", "Socket") => Some(1),
         // #3720: `http2.performServerHandshake(socket[, options])` — length 1.
         ("http2", "performServerHandshake") => Some(1),
+        // #3712: node:http module-level helper exports.
+        ("http", "validateHeaderName" | "validateHeaderValue") => Some(2),
+        ("http", "setMaxIdleHTTPParsers" | "setGlobalProxyFromEnv") => Some(1),
         ("net", "_normalizeArgs") => Some(1),
         ("net", "_createServerHandle") => Some(5),
         ("domain", "Domain" | "createDomain" | "create") => Some(0),
@@ -2958,6 +2961,14 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             // (#3196-#3200); only `connect` is in the api-manifest today, so
             // it's the only tls symbol exposed here.
             | ("tls", "connect")
+            // #3712: node:http module-level helper exports. `validateHeaderName`
+            // / `validateHeaderValue` perform Node's HTTP-token / header-value
+            // validation (throwing the matching error codes); the parser/proxy
+            // setters are deterministic no-ops in Perry's runtime.
+            | ("http", "validateHeaderName")
+            | ("http", "validateHeaderValue")
+            | ("http", "setMaxIdleHTTPParsers")
+            | ("http", "setGlobalProxyFromEnv")
             | ("module", "createRequire")
             | ("module", "findPackageJSON")
             | ("module", "findSourceMap")
@@ -5216,6 +5227,11 @@ pub(crate) unsafe fn get_native_module_constant(
         // pointer) and hand it back for every read.
         "http" => match property {
             "METHODS" => Some(unsafe { http_methods_array() }),
+            // #3712: Node's `http.maxHeaderSize` default is 16 KiB (16384).
+            "maxHeaderSize" => Some(16384.0),
+            // #3712: `http.globalAgent` is an http.Agent with protocol "http:"
+            // and defaultPort 80 (distinct from https.globalAgent above).
+            "globalAgent" => Some(unsafe { http_global_agent_object() }),
             _ => None,
         },
         "https" => match property {
@@ -5397,6 +5413,50 @@ unsafe fn https_global_agent_object() -> f64 {
         cache
             .borrow_mut()
             .insert("https.globalAgent".to_string(), result.to_bits());
+    });
+    result
+}
+
+/// #3712: `http.globalAgent` shape. Mirrors `https_global_agent_object` but
+/// with the http defaults (protocol "http:", defaultPort 80). Node 19+ ships
+/// the global agent with keep-alive enabled, so basic field reads match Node.
+unsafe fn http_global_agent_object() -> f64 {
+    if let Some(bits) =
+        NATIVE_MODULE_NAMESPACES.with(|cache| cache.borrow().get("http.globalAgent").copied())
+    {
+        return f64::from_bits(bits);
+    }
+
+    let field_names = [
+        "defaultPort",
+        "protocol",
+        "keepAlive",
+        "maxSockets",
+        "maxFreeSockets",
+    ];
+    let packed = field_names.join("\0");
+    let obj = js_object_alloc_with_shape(
+        0x7FFF_FF12,
+        field_names.len() as u32,
+        packed.as_ptr(),
+        packed.len() as u32,
+    );
+    if obj.is_null() {
+        return f64::from_bits(JSValue::undefined().bits());
+    }
+    js_object_set_field(obj, 0, JSValue::number(80.0));
+    let protocol = crate::string::js_string_from_bytes(b"http:".as_ptr(), 5);
+    js_object_set_field(obj, 1, JSValue::string_ptr(protocol));
+    // Node 19+ enables HTTP keep-alive on the global agent by default.
+    js_object_set_field(obj, 2, JSValue::bool(true));
+    js_object_set_field(obj, 3, JSValue::number(f64::INFINITY));
+    js_object_set_field(obj, 4, JSValue::number(256.0));
+
+    let result = crate::value::js_nanbox_pointer(obj as i64);
+    NATIVE_MODULE_NAMESPACES.with(|cache| {
+        cache
+            .borrow_mut()
+            .insert("http.globalAgent".to_string(), result.to_bits());
     });
     result
 }

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -116,6 +116,109 @@ unsafe fn crypto_random_fill_sync_dispatch(target: f64, offset_bits: f64, size_b
     crypto_random_fill_invalid_buf(target);
 }
 
+/// #3712: coerce a NaN-boxed value to an owned UTF-8 `String`, matching the
+/// `${val}` coercion Node applies before building HTTP error messages.
+unsafe fn http_value_to_owned_string(v: f64) -> String {
+    let ptr = crate::value::js_jsvalue_to_string(v);
+    if ptr.is_null() {
+        return String::new();
+    }
+    let len = (*ptr).byte_len as usize;
+    let data = (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned()
+}
+
+/// #3712: read the raw bytes of a string value, or `None` if it is not a
+/// string. `js_string_materialize_to_heap` returns null for non-strings (no
+/// coercion) and handles SSO short strings, so a genuine empty string yields
+/// `Some([])` while a number/object/undefined yields `None`.
+unsafe fn http_string_bytes(v: f64) -> Option<Vec<u8>> {
+    let ptr = crate::string::js_string_materialize_to_heap(v);
+    if ptr.is_null() {
+        return None;
+    }
+    let len = (*ptr).byte_len as usize;
+    let data = (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    Some(std::slice::from_raw_parts(data, len).to_vec())
+}
+
+/// Node's HTTP token char set (lib/_http_common `tokenRegExp`):
+/// `^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$`.
+fn http_is_token_byte(b: u8) -> bool {
+    matches!(b,
+        b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9'
+        | b'!' | b'#' | b'$' | b'%' | b'&' | b'\'' | b'*'
+        | b'+' | b'-' | b'.' | b'^' | b'_' | b'`' | b'|' | b'~')
+}
+
+/// #3712: `http.validateHeaderName(name[, label])`. Throws
+/// `TypeError [ERR_INVALID_HTTP_TOKEN]` for a non-string / empty / non-token
+/// name; otherwise returns undefined.
+///
+/// Exposed as a `#[no_mangle]` extern so codegen's static dispatch table can
+/// emit a direct call for `http.validateHeaderName(...)`; the bound-closure
+/// value form routes here too via `dispatch_native_module_method`.
+///
+/// # Safety
+/// `name`/`label` are NaN-boxed `JSValue` bits.
+#[no_mangle]
+pub unsafe extern "C" fn js_http_validate_header_name(name: f64, label: f64) -> f64 {
+    let valid = match http_string_bytes(name) {
+        Some(bytes) => !bytes.is_empty() && bytes.iter().all(|&b| http_is_token_byte(b)),
+        None => false,
+    };
+    if valid {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    // `label || 'Header name'` — fall back to the default for any falsy /
+    // non-string label.
+    let label_str = match http_string_bytes(label) {
+        Some(bytes) if !bytes.is_empty() => String::from_utf8_lossy(&bytes).into_owned(),
+        _ => "Header name".to_string(),
+    };
+    let display = http_value_to_owned_string(name);
+    let message = format!("{label_str} must be a valid HTTP token [\"{display}\"]");
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_HTTP_TOKEN")
+}
+
+/// #3712: `http.validateHeaderValue(name, value)`. Throws
+/// `TypeError [ERR_HTTP_INVALID_HEADER_VALUE]` for an undefined value and
+/// `TypeError [ERR_INVALID_CHAR]` for invalid header characters; otherwise
+/// returns undefined.
+///
+/// # Safety
+/// `name`/`value` are NaN-boxed `JSValue` bits.
+#[no_mangle]
+pub unsafe extern "C" fn js_http_validate_header_value(name: f64, value: f64) -> f64 {
+    if value.to_bits() == crate::value::TAG_UNDEFINED {
+        let name_disp = http_value_to_owned_string(name);
+        let message = format!("Invalid value \"undefined\" for header \"{name_disp}\"");
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_HTTP_INVALID_HEADER_VALUE");
+    }
+    // Node coerces the value to a string, then rejects control chars outside
+    // the `\t`, `\x20-\x7e`, `\x80-\xff` ranges (lib/_http_common
+    // `headerCharRegex`). Multi-byte UTF-8 bytes are all >= 0x80, so allowed.
+    let value_str = http_value_to_owned_string(value);
+    let has_invalid = value_str
+        .as_bytes()
+        .iter()
+        .any(|&b| (b < 0x20 && b != b'\t') || b == 0x7f);
+    if has_invalid {
+        let name_disp = http_value_to_owned_string(name);
+        let message = format!("Invalid character in header content [\"{name_disp}\"]");
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_CHAR");
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// #3712: `http.setMaxIdleHTTPParsers(max)` / `http.setGlobalProxyFromEnv(...)`
+/// — deterministic no-ops returning undefined (Perry has no shared parser pool
+/// or env-driven proxy state). Exposed for the static dispatch table.
+#[no_mangle]
+pub extern "C" fn js_http_setter_noop(_value: f64) -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
 /// Dispatch a method call on a native module namespace object.
 /// Extracts the module name from the object and dispatches to the appropriate
 /// runtime function based on (module_name, method_name).
@@ -515,6 +618,18 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("process", "loadEnvFile") => {
             crate::process::js_process_load_env_file(arg(0));
             f64::from_bits(crate::value::TAG_UNDEFINED)
+        }
+        // #3712: node:http module-level header validation helpers. These mirror
+        // Node's `validateHeaderName` / `validateHeaderValue` (lib/_http_common
+        // + lib/_http_outgoing): on invalid input they throw the matching error
+        // codes, otherwise they return undefined.
+        ("http", "validateHeaderName") => js_http_validate_header_name(arg(0), arg(1)),
+        ("http", "validateHeaderValue") => js_http_validate_header_value(arg(0), arg(1)),
+        // #3712: parser/proxy setters are deterministic no-ops in Perry's
+        // runtime (no shared parser pool / env-driven proxy state), matching
+        // Node's `undefined` return for valid inputs.
+        ("http", "setMaxIdleHTTPParsers") | ("http", "setGlobalProxyFromEnv") => {
+            js_http_setter_noop(arg(0))
         }
         ("events", "init") => f64::from_bits(crate::value::TAG_UNDEFINED),
         ("events", "EventEmitterAsyncResource") => {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1689,6 +1689,10 @@ declare module "http" {
   /** stdlib */
   export const STATUS_CODES: any;
   /** stdlib */
+  export const globalAgent: any;
+  /** stdlib */
+  export const maxHeaderSize: any;
+  /** stdlib */
   export function Agent(...args: any[]): any;
   /** stdlib */
   export function Server(...args: any[]): any;
@@ -1698,6 +1702,14 @@ declare module "http" {
   export function get(...args: any[]): any;
   /** stdlib */
   export function request(...args: any[]): any;
+  /** stdlib */
+  export function setGlobalProxyFromEnv(...args: any[]): any;
+  /** stdlib */
+  export function setMaxIdleHTTPParsers(...args: any[]): any;
+  /** stdlib */
+  export function validateHeaderName(...args: any[]): any;
+  /** stdlib */
+  export function validateHeaderValue(...args: any[]): any;
 }
 
 declare module "http2" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -1492,7 +1492,9 @@ Total: 2506 entries across 106 modules.
 - `resume` — instance *(class: `IncomingMessage`)*
 - `reuseSocket` — instance *(class: `Agent`)*
 - `setEncoding` — instance *(class: `IncomingMessage`)*
+- `setGlobalProxyFromEnv` — module
 - `setHeader` — instance *(class: `ServerResponse`)*
+- `setMaxIdleHTTPParsers` — module
 - `setStatus` — instance *(class: `ServerResponse`)*
 - `setTimeout` — instance *(class: `HttpServer`)*
 - `setTimeout` — instance *(class: `ClientRequest`)*
@@ -1502,6 +1504,8 @@ Total: 2506 entries across 106 modules.
 - `timeout` — instance *(class: `HttpServer`)*
 - `trailers` — instance *(class: `IncomingMessage`)*
 - `url` — instance *(class: `IncomingMessage`)*
+- `validateHeaderName` — module
+- `validateHeaderValue` — module
 - `write` — instance *(class: `ServerResponse`)*
 - `writeContinue` — instance *(class: `ServerResponse`)*
 - `writeHead` — instance *(class: `ServerResponse`)*
@@ -1511,6 +1515,8 @@ Total: 2506 entries across 106 modules.
 
 - `METHODS`
 - `STATUS_CODES`
+- `globalAgent`
+- `maxHeaderSize`
 
 ## `http2`
 

--- a/test-parity/node-suite/http/exports/module-helper-tail.ts
+++ b/test-parity/node-suite/http/exports/module-helper-tail.ts
@@ -1,0 +1,39 @@
+// #3712: node:http module-level helper/export tail — `maxHeaderSize`,
+// `globalAgent`, and the header validation / parser-proxy setter helpers.
+import * as http from "node:http";
+import {
+  validateHeaderName,
+  validateHeaderValue,
+  setMaxIdleHTTPParsers,
+  setGlobalProxyFromEnv,
+  globalAgent,
+  maxHeaderSize,
+} from "node:http";
+
+console.log("maxHeaderSize:", maxHeaderSize, typeof maxHeaderSize);
+console.log("namespace maxHeaderSize:", http.maxHeaderSize === maxHeaderSize);
+console.log("globalAgent type:", typeof globalAgent);
+console.log("globalAgent.protocol:", globalAgent.protocol);
+console.log("globalAgent.defaultPort:", globalAgent.defaultPort);
+console.log("globalAgent.keepAlive:", globalAgent.keepAlive);
+console.log("validateHeaderName:", typeof validateHeaderName);
+console.log("validateHeaderValue:", typeof validateHeaderValue);
+console.log("setMaxIdleHTTPParsers:", typeof setMaxIdleHTTPParsers);
+console.log("setGlobalProxyFromEnv:", typeof setGlobalProxyFromEnv);
+
+function check(label: string, fn: () => unknown) {
+  try {
+    const r = fn();
+    console.log(`${label}: ok ${String(r)}`);
+  } catch (e: any) {
+    console.log(`${label}: ${e.name} [${e.code}] ${e.message}`);
+  }
+}
+
+check("valid name", () => validateHeaderName("X-Foo"));
+check("empty name", () => validateHeaderName(""));
+check("space name", () => validateHeaderName("X Foo"));
+check("valid value", () => validateHeaderValue("X-Foo", "bar"));
+check("undefined value", () => validateHeaderValue("X-Foo", undefined as any));
+check("newline value", () => validateHeaderValue("X-Foo", "bad\nvalue"));
+check("setMaxIdleHTTPParsers", () => setMaxIdleHTTPParsers(4));


### PR DESCRIPTION
## Summary

Closes #3712. Adds the `node:http` module-level helper/export tail that packages use for header validation and agent/feature detection. Before this, importing any of these names failed at module collection (`<name> is not implemented in Perry`).

Added:
- **`http.maxHeaderSize`** — 16 KiB (`16384`) default constant.
- **`http.globalAgent`** — shared `http.Agent` shape (`protocol: "http:"`, `defaultPort: 80`, keep-alive enabled to match Node 19+), distinct from the existing `https.globalAgent`.
- **`http.validateHeaderName(name[, label])`** — throws `TypeError [ERR_INVALID_HTTP_TOKEN]` for a non-string / empty / non-token name (Node's `tokenRegExp` char set), else `undefined`.
- **`http.validateHeaderValue(name, value)`** — throws `TypeError [ERR_HTTP_INVALID_HEADER_VALUE]` for an undefined value and `TypeError [ERR_INVALID_CHAR]` for control chars outside `\t` / `\x20-\x7e` / `\x80-\xff`, else `undefined`.
- **`http.setMaxIdleHTTPParsers(max)`** / **`http.setGlobalProxyFromEnv([proxyEnv])`** — deterministic no-ops returning `undefined`.

## Implementation
- `crates/perry-api-manifest/src/entries.rs` — six new `http` manifest rows (two `property`, four `method`).
- `crates/perry-runtime/src/object/native_module.rs` — `maxHeaderSize`/`globalAgent` property dispatch + `http_global_agent_object()`; the four helpers registered in `is_native_module_callable_export` + `native_callable_export_arity`.
- `crates/perry-runtime/src/object/native_module_dispatch.rs` — `js_http_validate_header_name` / `js_http_validate_header_value` / `js_http_setter_noop` (`#[no_mangle]` FFI) + dispatch arms for the value-call form.
- `crates/perry-codegen/src/lower_call/native_table/http.rs` — static dispatch-table rows so the **direct** `http.validateHeaderName(...)` / named-import call forms dispatch (not just the `const f = http.validateHeaderName; f(...)` value form).
- `test-parity/node-suite/http/exports/module-helper-tail.ts` — new fixture; regenerated `docs/api/perry.d.ts` + `docs/src/api/reference.md`.

## Validation
- Fixture is **byte-identical** to `node --experimental-strip-types` in both no-opt and auto-optimize builds.
- `cargo test -p perry-codegen --test manifest_consistency` — all 5 pass (manifest ↔ dispatch-table drift guards).
- `cargo fmt --all -- --check` clean.
- Existing `http.createServer/request/get/METHODS` surface unchanged (change is purely additive).

## Out of scope (tracked follow-up)
The class tail `http.OutgoingMessage`, `http.WebSocket`, `http.CloseEvent`, `http.MessageEvent`, `http._connectionListener` is intentionally not yet claimed in the manifest, pending an alias/implementation decision — per the issue's own PR-boundary guidance.
