### PR TITLE
fix(modules): preserve identity of Symbol() locals re-exported via export { X }

### DIFF
--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -1360,6 +1360,15 @@ pub(crate) fn lower_module_decl(
                                             // pick it up via `imported_vars` (and route through the
                                             // getter, not as a closure pointer).
                                             | Expr::SymbolFor(_)
+                                            // Plain `const X = Symbol(); export { X }` — same as
+                                            // SymbolFor above, but for unregistered symbols. Without
+                                            // this the local isn't promoted to a shared module global,
+                                            // so an importer gets a DIFFERENT symbol than the defining
+                                            // module's binding and `imported === X` is false. Hono's
+                                            // RegExpRouter does exactly this with `PATH_ERROR`, so its
+                                            // `e === PATH_ERROR` route-fallback check failed and a bare
+                                            // Symbol escaped `app.fetch`.
+                                            | Expr::SymbolNew(_)
                                             // Issue #923: `const pool = mysql.createPool(...)`
                                             // followed by `export { pool }` lowers the init to
                                             // `Expr::NativeMethodCall` (not `Expr::Call`) because


### PR DESCRIPTION
`const X = Symbol(); export { X }` doesn't preserve the symbol's identity across modules. Minimal repro (two files in one compiled package):

```js
// node.js
var PATH_ERROR = Symbol();
function thrower() { throw PATH_ERROR; }
export { PATH_ERROR, thrower };
// index.js
import { PATH_ERROR, thrower } from "./node.js";
try { thrower(); } catch (e) { return e === PATH_ERROR; }  // → FALSE (should be true)
```

The importer gets a **different** symbol than the defining module's binding. `export var X = Symbol()` (inline) works; `Symbol.for(...)` works; only plain `Symbol()` re-exported via `export { X }` is broken.

### Cause
The `is_exportable` allowlist in `lower/module_decl.rs` decides whether an `export { name }` local is promoted to a shared module-global (so importers read it through the value-getter instead of a closure-pointer wrapper). It lists `Expr::SymbolFor` (added for drizzle's `entityKind`) but **not** plain `Expr::SymbolNew`. So an unregistered `Symbol()` local stays module-private and every importer re-binds to its own value.

### Why it matters
Hono's RegExpRouter is literally `var PATH_ERROR = /* @__PURE__ */ Symbol(); … export { PATH_ERROR }`, and SmartRouter's fallback does `throw e === PATH_ERROR ? new UnsupportedPathError(path) : e`. With the `===` false, the bare `PATH_ERROR` escaped `app.fetch` instead of triggering the TrieRouter fallback — every request 500'd once a route RegExpRouter can't represent was mounted (admin routes, in the case that surfaced this).

### Fix
One line: add `Expr::SymbolNew(_)` to the allowlist, next to `Expr::SymbolFor(_)`.

### Verified
The repro now returns `true`; and a real Hono app (Skelpo CMS) serves correctly on Hono's **stock default `SmartRouter`** — the `new Hono({ router: new TrieRouter() })` workaround is no longer needed. 15-route Node-vs-Perry sweep is identical.