### PR TITLE
fix(util): styleText rejects non-Node format aliases (ERR_INVALID_ARG_VALUE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1070 — util.styleText rejects non-Node format aliases (ERR_INVALID_ARG_VALUE)
+
+`util.styleText(format, text)` validates `format` against `Object.keys(util.inspect.colors)` — exactly 44 names. Perry additionally accepted 12 British/camelCase aliases (`grey`, `bgGrey`, `blackBright`, `bgBlackBright`, `faint`, `crossedout`, `crossedOut`, `strikeThrough`, `conceal`, `swapColors`, `swapcolors`, `doubleUnderline`) that Node does not, applying ANSI codes where Node throws `TypeError [ERR_INVALID_ARG_VALUE]`.
+
+Fix (`crates/perry-runtime/src/util_style_text.rs`): `style_for` now resolves only the 44 `INSPECT_COLOR_STYLES` (dropped the `STYLE_ALIASES` table from the lookup) and `VALID_FORMATS_MESSAGE` lists exactly Node's 44, so `styleText("grey", …)` etc. now throw `ERR_INVALID_ARG_VALUE` with Node's exact "must be one of: …" message. The canonical names (`gray`, `strikethrough`, `doubleunderline`, `framed`, `overlined`, `bgGray`, …) still produce identical ANSI output, and `util.inspect.colors` (built from the same 44) is unchanged.
+
+Validated against `node --experimental-strip-types`: every format in `node-suite/util/style-text/basic` matches (valid → same ANSI bytes; alias → `ERR_INVALID_ARG_VALUE`); a 12-format accept/throw matrix matches byte-for-byte.
+
 ## v0.5.1069 — timers/promises + stream/promises: abort rejects with AbortError code "ABORT_ERR"
 
 When a `timers/promises` (`setTimeout`/`setImmediate`/`scheduler.wait`/interval) or `stream/promises` (`finished`/`pipeline`) operation was aborted, Perry rejected with the signal's `.reason` — for a default `controller.abort()` that is a DOMException whose `.code` is the numeric `20`, so fixtures saw `code: 20` instead of Node's `"ABORT_ERR"`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1069
+**Current Version:** 0.5.1070
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1069"
+version = "0.5.1070"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1069"
+version = "0.5.1070"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1069"
+version = "0.5.1070"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1069"
+version = "0.5.1070"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1069"
+version = "0.5.1070"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/util_style_text.rs
+++ b/crates/perry-runtime/src/util_style_text.rs
@@ -240,68 +240,12 @@ pub(crate) const INSPECT_COLOR_STYLES: &[AnsiStyle] = &[
     },
 ];
 
-const STYLE_ALIASES: &[AnsiStyle] = &[
-    AnsiStyle {
-        name: "grey",
-        open: 90,
-        close: 39,
-    },
-    AnsiStyle {
-        name: "blackBright",
-        open: 90,
-        close: 39,
-    },
-    AnsiStyle {
-        name: "bgGrey",
-        open: 100,
-        close: 49,
-    },
-    AnsiStyle {
-        name: "bgBlackBright",
-        open: 100,
-        close: 49,
-    },
-    AnsiStyle {
-        name: "faint",
-        open: 2,
-        close: 22,
-    },
-    AnsiStyle {
-        name: "crossedout",
-        open: 9,
-        close: 29,
-    },
-    AnsiStyle {
-        name: "strikeThrough",
-        open: 9,
-        close: 29,
-    },
-    AnsiStyle {
-        name: "crossedOut",
-        open: 9,
-        close: 29,
-    },
-    AnsiStyle {
-        name: "conceal",
-        open: 8,
-        close: 28,
-    },
-    AnsiStyle {
-        name: "swapColors",
-        open: 7,
-        close: 27,
-    },
-    AnsiStyle {
-        name: "swapcolors",
-        open: 7,
-        close: 27,
-    },
-    AnsiStyle {
-        name: "doubleUnderline",
-        open: 21,
-        close: 24,
-    },
-];
+// #3870-adjacent (util/style-text): Node's `styleText` validates `format`
+// against `Object.keys(util.inspect.colors)` — exactly the 44 names in
+// `INSPECT_COLOR_STYLES`. It does NOT accept British/camelCase aliases
+// (`grey`, `bgGrey`, `strikeThrough`, `swapColors`, `doubleUnderline`,
+// `crossedout`, `conceal`, `faint`, `blackBright`, …); those throw
+// `ERR_INVALID_ARG_VALUE`. The previous alias table made Perry too lenient.
 
 const VALID_FORMATS_MESSAGE: &str = "'reset', 'bold', 'dim', 'italic', 'underline', 'blink', \
     'inverse', 'hidden', 'strikethrough', 'doubleunderline', 'black', 'red', 'green', \
@@ -310,14 +254,11 @@ const VALID_FORMATS_MESSAGE: &str = "'reset', 'bold', 'dim', 'italic', 'underlin
     'gray', 'redBright', 'greenBright', 'yellowBright', 'blueBright', 'magentaBright', \
     'cyanBright', 'whiteBright', 'bgGray', 'bgRedBright', 'bgGreenBright', \
     'bgYellowBright', 'bgBlueBright', 'bgMagentaBright', 'bgCyanBright', \
-    'bgWhiteBright', 'grey', 'blackBright', 'bgGrey', 'bgBlackBright', 'faint', \
-    'crossedout', 'strikeThrough', 'crossedOut', 'conceal', 'swapColors', \
-    'swapcolors', 'doubleUnderline'";
+    'bgWhiteBright'";
 
 fn style_for(name: &str) -> Option<AnsiStyle> {
     INSPECT_COLOR_STYLES
         .iter()
-        .chain(STYLE_ALIASES.iter())
         .find(|style| style.name == name)
         .copied()
 }


### PR DESCRIPTION
## util.styleText rejects non-Node format aliases

`util.styleText(format, text)` validates `format` against `Object.keys(util.inspect.colors)` — exactly **44** names. Perry additionally accepted **12** British/camelCase aliases that Node does **not**, applying ANSI codes where Node throws:

```
node:  styleText("grey", "x")  →  TypeError [ERR_INVALID_ARG_VALUE]
perry: styleText("grey", "x")  →  "[90mx[39m"   (before)
```

Offending aliases: `grey`, `bgGrey`, `blackBright`, `bgBlackBright`, `faint`, `crossedout`, `crossedOut`, `strikeThrough`, `conceal`, `swapColors`, `swapcolors`, `doubleUnderline`.

### Fix
`crates/perry-runtime/src/util_style_text.rs`: `style_for` now resolves only the 44 `INSPECT_COLOR_STYLES` (removed the `STYLE_ALIASES` table from the lookup), and `VALID_FORMATS_MESSAGE` lists exactly Node's 44. So `styleText("grey", …)` etc. now throw `ERR_INVALID_ARG_VALUE` with Node's exact "The argument 'format' must be one of: …" message. Canonical names (`gray`, `strikethrough`, `doubleunderline`, `framed`, `overlined`, `bgGray`, …) still produce identical ANSI output, and `util.inspect.colors` (built from the same 44) is unchanged.

### Validation (vs `node --experimental-strip-types`)
- `node-suite/util/style-text/basic` fixture stdout matches Node byte-for-byte (the fixture's uncaught throw on `'grey'` now fires in Perry too).
- 12-format accept/throw matrix matches: `red`/`gray`/`strikethrough`/`doubleunderline`/`framed`/`overlined`/`bgGray` → same ANSI; `grey`/`strikeThrough`/`swapColors`/`doubleUnderline`/`bgGrey` → `ERR_INVALID_ARG_VALUE`.
