### PR TITLE
runtime/collections: reify Map/Set semantics

### DIFF
--- a/crates/perry-runtime/src/collection_iter.rs
+++ b/crates/perry-runtime/src/collection_iter.rs
@@ -18,6 +18,7 @@
 
 use crate::array::ArrayHeader;
 use crate::value::{js_jsvalue_to_string, js_nanbox_get_pointer, JSValue, TAG_NULL, TAG_UNDEFINED};
+use std::os::raw::c_int;
 
 /// Outcome of classifying a constructor init argument.
 pub(crate) enum InitIter {
@@ -98,7 +99,7 @@ pub(crate) fn throw_not_iterable(value: f64) -> ! {
 /// True if `value` is a JS iterable (array, string, Map, Set, or any heap
 /// object carrying a callable `[Symbol.iterator]`). `null`/`undefined` are
 /// NOT iterable here (the caller handles them as empty before calling).
-fn is_iterable(value: f64) -> bool {
+pub(crate) fn is_iterable(value: f64) -> bool {
     let jsv = JSValue::from_bits(value.to_bits());
     if jsv.is_any_string() {
         return true;
@@ -129,6 +130,142 @@ fn is_iterable(value: f64) -> bool {
     }
     let fn_raw = js_nanbox_get_pointer(iter_fn);
     fn_raw != 0 && crate::closure::is_closure_ptr(fn_raw as usize)
+}
+
+pub(crate) fn is_null_or_undefined(value: f64) -> bool {
+    matches!(value.to_bits(), TAG_UNDEFINED | TAG_NULL)
+}
+
+pub(crate) fn throw_type_error(message: &str) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+}
+
+pub(crate) fn is_callable(value: f64) -> bool {
+    let raw = js_nanbox_get_pointer(value) & !0x7;
+    if raw >= 0x10000 {
+        return true;
+    }
+    crate::proxy::js_proxy_is_proxy(value) == 1
+}
+
+pub(crate) fn require_callable(value: f64, name: &str) -> f64 {
+    if is_callable(value) {
+        return value;
+    }
+    throw_type_error(&format!("{name} is not a function"));
+}
+
+pub(crate) fn normalize_callable_value(value: f64) -> f64 {
+    let raw = js_nanbox_get_pointer(value) & !0x7;
+    if raw >= 0x10000 {
+        return crate::value::js_nanbox_pointer(raw as i64);
+    }
+    value
+}
+
+pub(crate) fn builtin_prototype_method(builtin_name: &str, method_name: &str) -> f64 {
+    let key = crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
+    let proto = crate::object::builtin_prototype_value(builtin_name);
+    let proto_ptr = js_nanbox_get_pointer(proto) as *const crate::object::ObjectHeader;
+    if proto_ptr.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    unsafe {
+        crate::object::own_data_field_by_name(proto_ptr, key)
+            .map(|value| f64::from_bits(value.bits()))
+            .unwrap_or_else(|| f64::from_bits(TAG_UNDEFINED))
+    }
+}
+
+pub(crate) enum ConstructorIter {
+    Empty,
+    Array(f64),
+    Iterator(f64),
+}
+
+pub(crate) fn constructor_iter(value: f64) -> ConstructorIter {
+    if is_null_or_undefined(value) {
+        return ConstructorIter::Empty;
+    }
+    let jsv = JSValue::from_bits(value.to_bits());
+    let is_array = crate::array::js_array_is_array(value).to_bits() == crate::value::TAG_TRUE;
+    if is_array {
+        return ConstructorIter::Array(value);
+    }
+    if jsv.is_any_string() {
+        let arr_f64 = crate::array::js_for_of_to_array(value);
+        return ConstructorIter::Array(arr_f64);
+    }
+    if !is_iterable(value) {
+        throw_not_iterable(value);
+    }
+    let iter = crate::symbol::js_get_iterator(value);
+    ConstructorIter::Iterator(iter)
+}
+
+pub(crate) fn call_capturing_throw(call: impl FnOnce() -> f64) -> Result<f64, f64> {
+    let trap_buf = crate::exception::js_try_push();
+    let jumped = unsafe { crate::ffi::setjmp::setjmp(trap_buf as *mut c_int) };
+    let result = if jumped == 0 {
+        Ok(call())
+    } else {
+        let exc = crate::exception::js_get_exception();
+        crate::exception::js_clear_exception();
+        Err(exc)
+    };
+    crate::exception::js_try_end();
+    result
+}
+
+pub(crate) fn call_with_this_capturing_throw(
+    callee: f64,
+    this_value: f64,
+    args: &[f64],
+) -> Result<f64, f64> {
+    let prev_this = crate::object::js_implicit_this_set(this_value);
+    let result = call_capturing_throw(|| unsafe {
+        crate::closure::js_native_call_value(callee, args.as_ptr(), args.len())
+    });
+    crate::object::js_implicit_this_set(prev_this);
+    result
+}
+
+pub(crate) fn iterator_close(iter: f64) {
+    let _ = call_capturing_throw(|| unsafe {
+        crate::object::js_native_call_method(
+            iter,
+            b"return".as_ptr() as *const i8,
+            "return".len(),
+            std::ptr::null(),
+            0,
+        )
+    });
+}
+
+pub(crate) fn iterator_next_value(iter: f64) -> Option<f64> {
+    let result = unsafe {
+        crate::object::js_native_call_method(
+            iter,
+            b"next".as_ptr() as *const i8,
+            "next".len(),
+            std::ptr::null(),
+            0,
+        )
+    };
+    if !is_entry_object(result) {
+        throw_type_error("Iterator result is not an object");
+    }
+    let result_ptr = js_nanbox_get_pointer(result) as *const crate::object::ObjectHeader;
+    let done_key = crate::string::js_string_from_bytes(b"done".as_ptr(), 4);
+    let done = crate::object::js_object_get_field_by_name_f64(result_ptr, done_key);
+    if crate::value::js_is_truthy(done) != 0 {
+        return None;
+    }
+    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+    let value = crate::object::js_object_get_field_by_name_f64(result_ptr, value_key);
+    Some(value)
 }
 
 /// True if a yielded value is a JS *object* (array, plain object, function,

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -1292,43 +1292,97 @@ pub extern "C" fn js_map_from_array(arr: *const crate::array::ArrayHeader) -> *m
 /// (Maps materialize to their `[k, v]` pair arrays) inside `classify_init`.
 #[no_mangle]
 pub extern "C" fn js_map_from_iterable(value: f64) -> *mut MapHeader {
-    use crate::collection_iter::{classify_init, InitIter};
+    use crate::collection_iter::{constructor_iter, ConstructorIter};
 
     let scope = crate::gc::RuntimeHandleScope::new();
-    let arr_ptr = match classify_init(value) {
-        InitIter::Empty => return js_map_alloc(4),
-        InitIter::Values(p) => p,
-    };
-    let arr_handle = if arr_ptr.is_null() {
-        None
-    } else {
-        Some(scope.root_raw_mut_ptr(arr_ptr))
-    };
-    let map = js_map_alloc(4);
-    let map_handle = scope.root_raw_mut_ptr(map);
-    let Some(arr_handle) = arr_handle.as_ref() else {
-        return map_handle.get_raw_mut_ptr::<MapHeader>();
-    };
-    let len = {
-        let arr = arr_handle.get_raw_const_ptr::<crate::array::ArrayHeader>();
-        crate::array::js_array_length(arr)
-    };
-    for i in 0..len {
-        let entry = {
-            let arr = arr_handle.get_raw_const_ptr::<crate::array::ArrayHeader>();
-            crate::array::js_array_get_f64(arr, i)
-        };
-        // Each yielded value must be an object (array or plain object).
+    let value_handle = scope.root_nanbox_f64(value);
+
+    let adder = crate::collection_iter::require_callable(
+        crate::collection_iter::builtin_prototype_method("Map", "set"),
+        "Map.prototype.set",
+    );
+    let adder = crate::collection_iter::normalize_callable_value(adder);
+    let adder_handle = scope.root_nanbox_f64(adder);
+
+    fn add_entry(
+        map_handle: crate::gc::RuntimeHandle<'_>,
+        adder_handle: crate::gc::RuntimeHandle<'_>,
+        entry: f64,
+        iter_to_close: Option<f64>,
+    ) {
         if !crate::collection_iter::is_entry_object(entry) {
+            if let Some(iter) = iter_to_close {
+                crate::collection_iter::iterator_close(iter);
+            }
             crate::collection_iter::throw_not_entry_object(entry);
         }
         let entry_bits = entry.to_bits() as i64;
-        let key = crate::object::js_object_get_index_polymorphic(entry_bits, 0.0);
-        let val = crate::object::js_object_get_index_polymorphic(entry_bits, 1.0);
-        let map = map_handle.get_raw_mut_ptr::<MapHeader>();
-        js_map_set(map, key, val);
+        let pair = crate::collection_iter::call_capturing_throw(|| {
+            let key = crate::object::js_object_get_index_polymorphic(entry_bits, 0.0);
+            let val = crate::object::js_object_get_index_polymorphic(entry_bits, 1.0);
+            let args = [key, val];
+            let adder = adder_handle.get_nanbox_f64();
+            let map = map_handle.get_raw_mut_ptr::<MapHeader>();
+            if crate::object::is_builtin_map_set_value(adder) {
+                crate::map::js_map_set(map, key, val);
+                f64::from_bits(crate::value::TAG_UNDEFINED)
+            } else {
+                let map_value = crate::value::js_nanbox_pointer(map as i64);
+                crate::collection_iter::call_with_this_capturing_throw(adder, map_value, &args)
+                    .unwrap_or_else(|exc| crate::exception::js_throw(exc))
+            }
+        });
+        if let Err(exc) = pair {
+            if let Some(iter) = iter_to_close {
+                crate::collection_iter::iterator_close(iter);
+            }
+            crate::exception::js_throw(exc);
+        }
     }
-    map_handle.get_raw_mut_ptr::<MapHeader>()
+
+    match constructor_iter(value_handle.get_nanbox_f64()) {
+        ConstructorIter::Empty => {
+            let map = js_map_alloc(4);
+            return map;
+        }
+        ConstructorIter::Array(arr_value) => {
+            let arr_handle = scope.root_nanbox_f64(arr_value);
+            let map = js_map_alloc(4);
+            let map_handle = scope.root_raw_mut_ptr(map);
+            let arr_ptr = crate::value::js_nanbox_get_pointer(arr_handle.get_nanbox_f64())
+                as *mut crate::array::ArrayHeader;
+            if !arr_ptr.is_null() {
+                let len = {
+                    let arr = crate::value::js_nanbox_get_pointer(arr_handle.get_nanbox_f64())
+                        as *const crate::array::ArrayHeader;
+                    crate::array::js_array_length(arr)
+                };
+                for i in 0..len {
+                    let entry = {
+                        let arr = crate::value::js_nanbox_get_pointer(arr_handle.get_nanbox_f64())
+                            as *const crate::array::ArrayHeader;
+                        crate::array::js_array_get_f64(arr, i)
+                    };
+                    add_entry(map_handle, adder_handle, entry, None);
+                }
+            }
+            map_handle.get_raw_mut_ptr::<MapHeader>()
+        }
+        ConstructorIter::Iterator(iter) => {
+            let iter_handle = scope.root_nanbox_f64(iter);
+            let map = js_map_alloc(4);
+            let map_handle = scope.root_raw_mut_ptr(map);
+            loop {
+                let iter = iter_handle.get_nanbox_f64();
+                let next = crate::collection_iter::iterator_next_value(iter);
+                let Some(entry) = next else {
+                    break;
+                };
+                add_entry(map_handle, adder_handle, entry, Some(iter));
+            }
+            map_handle.get_raw_mut_ptr::<MapHeader>()
+        }
+    }
 }
 
 // #2770: `js_map_from_iterable` is only invoked from generated LLVM IR

--- a/crates/perry-runtime/src/object/collection_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/collection_proto_thunks.rs
@@ -16,6 +16,55 @@
 
 use super::*;
 
+thread_local! {
+    static BUILTIN_MAP_SET_VALUE_BITS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static BUILTIN_SET_ADD_VALUE_BITS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+pub(crate) fn is_builtin_map_set_value(value: f64) -> bool {
+    is_remembered_builtin_collection_method(value, &BUILTIN_MAP_SET_VALUE_BITS)
+}
+
+pub(crate) fn is_builtin_set_add_value(value: f64) -> bool {
+    is_remembered_builtin_collection_method(value, &BUILTIN_SET_ADD_VALUE_BITS)
+}
+
+fn is_remembered_builtin_collection_method(
+    value: f64,
+    cell: &'static std::thread::LocalKey<std::cell::Cell<u64>>,
+) -> bool {
+    let ptr = normalized_collection_method_ptr(value);
+    ptr != 0 && cell.with(|remembered| remembered.get() == ptr)
+}
+
+fn remember_builtin_collection_method(
+    proto_obj: *mut ObjectHeader,
+    method_name: &str,
+    value: f64,
+    cell: &'static std::thread::LocalKey<std::cell::Cell<u64>>,
+) {
+    let value = installed_collection_method_value(proto_obj, method_name).unwrap_or(value);
+    let ptr = normalized_collection_method_ptr(value);
+    cell.with(|remembered| remembered.set(ptr));
+}
+
+fn normalized_collection_method_ptr(value: f64) -> u64 {
+    (crate::value::js_nanbox_get_pointer(value) as u64) & !0x7
+}
+
+fn installed_collection_method_value(
+    proto_obj: *mut ObjectHeader,
+    method_name: &str,
+) -> Option<f64> {
+    if proto_obj.is_null() {
+        return None;
+    }
+    let key = crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
+    unsafe {
+        super::own_data_field_by_name(proto_obj, key).map(|value| f64::from_bits(value.bits()))
+    }
+}
+
 /// Install the brand-checking `.prototype` methods for the collection named
 /// `builtin_name` (`Map`/`Set`/`WeakMap`/`WeakSet`). Returns `true` when
 /// `builtin_name` is one of those collections — the caller then adds the
@@ -46,11 +95,22 @@ pub(super) fn install_collection_proto_methods(
             ipm(proto_obj, "get", map_proto_get_thunk as *const u8, 1);
             ipm(proto_obj, "has", map_proto_has_thunk as *const u8, 1);
             ipm(proto_obj, "keys", map_proto_keys_thunk as *const u8, 0);
-            ipm(proto_obj, "set", map_proto_set_thunk as *const u8, 2);
+            let set_value = ipm(proto_obj, "set", map_proto_set_thunk as *const u8, 2);
             ipm(proto_obj, "values", map_proto_values_thunk as *const u8, 0);
+            install_collection_size_getter(
+                proto_obj,
+                "size",
+                map_proto_size_getter_thunk as *const u8,
+            );
+            remember_builtin_collection_method(
+                proto_obj,
+                "set",
+                set_value,
+                &BUILTIN_MAP_SET_VALUE_BITS,
+            );
         }
         "Set" => {
-            ipm(proto_obj, "add", set_proto_add_thunk as *const u8, 1);
+            let add_value = ipm(proto_obj, "add", set_proto_add_thunk as *const u8, 1);
             ipm(proto_obj, "clear", set_proto_clear_thunk as *const u8, 0);
             ipm(proto_obj, "delete", set_proto_delete_thunk as *const u8, 1);
             ipm(
@@ -68,6 +128,17 @@ pub(super) fn install_collection_proto_methods(
             ipm(proto_obj, "has", set_proto_has_thunk as *const u8, 1);
             ipm(proto_obj, "keys", set_proto_keys_thunk as *const u8, 0);
             ipm(proto_obj, "values", set_proto_values_thunk as *const u8, 0);
+            install_collection_size_getter(
+                proto_obj,
+                "size",
+                set_proto_size_getter_thunk as *const u8,
+            );
+            remember_builtin_collection_method(
+                proto_obj,
+                "add",
+                add_value,
+                &BUILTIN_SET_ADD_VALUE_BITS,
+            );
         }
         "WeakMap" => {
             ipm(
@@ -93,6 +164,46 @@ pub(super) fn install_collection_proto_methods(
         _ => return false,
     }
     true
+}
+
+fn install_collection_size_getter(proto_obj: *mut ObjectHeader, name: &str, func_ptr: *const u8) {
+    if proto_obj.is_null() {
+        return;
+    }
+    unsafe {
+        crate::closure::js_register_closure_arity(func_ptr, 0);
+        let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+        if closure.is_null() {
+            return;
+        }
+        super::native_module::set_bound_native_closure_name(closure, "get size");
+        super::native_module::set_builtin_closure_length(closure as usize, 0);
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        super::object_ops::ensure_key_in_keys_array(proto_obj, key);
+        super::set_accessor_descriptor(
+            proto_obj as usize,
+            name.to_string(),
+            super::AccessorDescriptor {
+                get: crate::value::js_nanbox_pointer(closure as i64).to_bits(),
+                set: 0,
+            },
+        );
+        super::set_property_attrs(
+            proto_obj as usize,
+            name.to_string(),
+            super::PropertyAttrs::new(true, false, true),
+        );
+        super::set_builtin_property_attrs(
+            closure as usize,
+            "name".to_string(),
+            super::PropertyAttrs::new(false, false, true),
+        );
+        super::set_builtin_property_attrs(
+            closure as usize,
+            "length".to_string(),
+            super::PropertyAttrs::new(false, false, true),
+        );
+    }
 }
 
 /// Throw `TypeError: Method <proto>.<method> called on incompatible receiver`.
@@ -149,6 +260,13 @@ pub(super) extern "C" fn set_proto_has_thunk(
 ) -> f64 {
     let set = set_receiver_or_throw("has");
     f64::from_bits(crate::value::JSValue::bool(crate::set::js_set_has(set, v) != 0).bits())
+}
+
+pub(super) extern "C" fn set_proto_size_getter_thunk(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let set = set_receiver_or_throw("size");
+    crate::set::js_set_size(set) as f64
 }
 
 pub(super) extern "C" fn set_proto_delete_thunk(
@@ -241,6 +359,13 @@ pub(super) extern "C" fn map_proto_has_thunk(
 ) -> f64 {
     let map = map_receiver_or_throw("has");
     f64::from_bits(crate::value::JSValue::bool(crate::map::js_map_has(map, k) != 0).bits())
+}
+
+pub(super) extern "C" fn map_proto_size_getter_thunk(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let map = map_receiver_or_throw("size");
+    crate::map::js_map_size(map) as f64
 }
 
 pub(super) extern "C" fn map_proto_delete_thunk(

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -77,7 +77,7 @@ pub extern "C" fn js_object_get_field(obj: *const ObjectHeader, field_index: u32
     }
 }
 
-unsafe fn own_data_field_by_name(
+pub(crate) unsafe fn own_data_field_by_name(
     obj: *const ObjectHeader,
     key: *const crate::StringHeader,
 ) -> Option<JSValue> {

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -199,6 +199,19 @@ extern "C" fn uri_error_constructor_call_thunk(
     error_constructor_call(crate::error::ERROR_KIND_URI_ERROR, message)
 }
 
+pub(crate) fn builtin_prototype_value(name: &str) -> f64 {
+    let ctor = js_get_global_this_builtin_value(name.as_ptr(), name.len());
+    let ctor_bits = ctor.to_bits();
+    if (ctor_bits >> 48) != 0x7FFD {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let ctor_ptr = (ctor_bits & crate::value::POINTER_MASK) as usize;
+    if ctor_ptr == 0 {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype")
+}
+
 pub(crate) extern "C" fn webcrypto_illegal_constructor_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
@@ -2046,10 +2059,10 @@ pub(super) fn install_proto_method(
     method_name: &str,
     func_ptr: *const u8,
     arity: u32,
-) {
+) -> f64 {
     let closure = crate::closure::js_closure_alloc(func_ptr, 0);
     if closure.is_null() {
-        return;
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
     crate::closure::js_register_closure_arity(func_ptr, arity);
     super::native_module::set_bound_native_closure_name(closure, method_name);
@@ -2087,6 +2100,7 @@ pub(super) fn install_proto_method(
         "length".to_string(),
         super::PropertyAttrs::new(false, false, true),
     );
+    value
 }
 
 fn install_proto_method_rest(

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -65,6 +65,7 @@ pub(crate) use class_gc_roots::{
     test_seed_class_parent_closure_root,
 };
 pub use class_registry::*;
+pub(crate) use collection_proto_thunks::{is_builtin_map_set_value, is_builtin_set_add_value};
 pub(crate) use data_view_registry::extends_builtin_data_view;
 pub use delete_rest::*;
 pub use descriptors::*;

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1401,6 +1401,21 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
             return f64::from_bits(TAG_NULL);
         }
     }
+    let collection_prototype = |addr: usize| -> Option<f64> {
+        if crate::map::is_registered_map(addr) {
+            let proto = crate::object::builtin_prototype_value("Map");
+            if proto.to_bits() != crate::value::TAG_UNDEFINED {
+                return Some(proto);
+            }
+        }
+        if crate::set::is_registered_set(addr) {
+            let proto = crate::object::builtin_prototype_value("Set");
+            if proto.to_bits() != crate::value::TAG_UNDEFINED {
+                return Some(proto);
+            }
+        }
+        None
+    };
     if top16 == 0x7FFE {
         let class_id = (bits & 0xFFFF_FFFF) as u32;
         if let Some(parent_id) = get_parent_class_id(class_id) {
@@ -1431,6 +1446,9 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
     if top16 == 0x7FFD {
         let raw_addr = bits & 0x0000_FFFF_FFFF_FFFF;
         if raw_addr != 0 && raw_addr >= (crate::gc::GC_HEADER_SIZE as u64) + 0x1000 {
+            if let Some(proto) = collection_prototype(raw_addr as usize) {
+                return proto;
+            }
             // #2820: an explicit `Object.setPrototypeOf(obj, proto)` recorded
             // in the side-table takes precedence — return exactly what was set
             // (including `null`).
@@ -1508,6 +1526,9 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
     }
     if top16 == 0 {
         if bits >= (crate::gc::GC_HEADER_SIZE as u64) + 0x1000 {
+            if let Some(proto) = collection_prototype(bits as usize) {
+                return proto;
+            }
             // #2820: explicit setPrototypeOf side-table takes precedence.
             if let Some(proto_bits) = super::prototype_chain::object_static_prototype(bits as usize)
             {

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -824,40 +824,73 @@ pub extern "C" fn js_set_from_array(arr: *const crate::array::ArrayHeader) -> *m
 /// #2771 (arbitrary iterables + TypeError on non-iterables).
 #[no_mangle]
 pub extern "C" fn js_set_from_iterable(value: f64) -> *mut SetHeader {
-    use crate::collection_iter::{classify_init, InitIter};
+    use crate::collection_iter::{constructor_iter, ConstructorIter};
 
     let scope = crate::gc::RuntimeHandleScope::new();
-    // `classify_init` returns the materialized array of yielded values for any
-    // iterable (Array/String/Map/Set/custom iterator), an Empty marker for
-    // null/undefined, or throws the Node "not iterable" TypeError otherwise.
-    // For a Map it yields `[k, v]` pair arrays; for a String it yields
-    // single-codepoint strings — both match `[...new Set(x)]` in Node.
-    let arr_ptr = match classify_init(value) {
-        InitIter::Empty => return js_set_alloc(4),
-        InitIter::Values(p) => p,
-    };
-    let arr_handle = if arr_ptr.is_null() {
-        None
-    } else {
-        Some(scope.root_raw_mut_ptr(arr_ptr))
-    };
+    let value_handle = scope.root_nanbox_f64(value);
+    let adder = crate::collection_iter::require_callable(
+        crate::collection_iter::builtin_prototype_method("Set", "add"),
+        "Set.prototype.add",
+    );
+    let adder = crate::collection_iter::normalize_callable_value(adder);
+    let adder_handle = scope.root_nanbox_f64(adder);
+
     let set = js_set_alloc(4);
     let set_handle = scope.root_raw_mut_ptr(set);
-    let Some(arr_handle) = arr_handle.as_ref() else {
-        return set_handle.get_raw_mut_ptr::<SetHeader>();
-    };
-    maybe_force_helper_gc_for_test();
-    let len = {
-        let arr = arr_handle.get_raw_const_ptr::<crate::array::ArrayHeader>();
-        crate::array::js_array_length(arr)
-    };
-    for i in 0..len {
-        let element = {
-            let arr = arr_handle.get_raw_const_ptr::<crate::array::ArrayHeader>();
-            crate::array::js_array_get_f64(arr, i)
-        };
+
+    let add_value = |element: f64, iter_to_close: Option<f64>| {
+        let args = [element];
+        let adder = adder_handle.get_nanbox_f64();
         let set = set_handle.get_raw_mut_ptr::<SetHeader>();
-        js_set_add(set, element);
+        let result = if crate::object::is_builtin_set_add_value(adder) {
+            crate::set::js_set_add(set, element);
+            Ok(f64::from_bits(crate::value::TAG_UNDEFINED))
+        } else {
+            let set_value = crate::value::js_nanbox_pointer(set as i64);
+            crate::collection_iter::call_with_this_capturing_throw(adder, set_value, &args)
+        };
+        if let Err(exc) = result {
+            if let Some(iter) = iter_to_close {
+                crate::collection_iter::iterator_close(iter);
+            }
+            crate::exception::js_throw(exc);
+        }
+    };
+
+    match constructor_iter(value_handle.get_nanbox_f64()) {
+        ConstructorIter::Empty => {}
+        ConstructorIter::Array(arr_value) => {
+            let arr_handle = scope.root_nanbox_f64(arr_value);
+            let arr_ptr = crate::value::js_nanbox_get_pointer(arr_handle.get_nanbox_f64())
+                as *mut crate::array::ArrayHeader;
+            if !arr_ptr.is_null() {
+                maybe_force_helper_gc_for_test();
+                let len = {
+                    let arr = crate::value::js_nanbox_get_pointer(arr_handle.get_nanbox_f64())
+                        as *const crate::array::ArrayHeader;
+                    crate::array::js_array_length(arr)
+                };
+                for i in 0..len {
+                    let element = {
+                        let arr = crate::value::js_nanbox_get_pointer(arr_handle.get_nanbox_f64())
+                            as *const crate::array::ArrayHeader;
+                        crate::array::js_array_get_f64(arr, i)
+                    };
+                    add_value(element, None);
+                }
+            }
+        }
+        ConstructorIter::Iterator(iter) => {
+            let iter_handle = scope.root_nanbox_f64(iter);
+            loop {
+                let iter = iter_handle.get_nanbox_f64();
+                let next = crate::collection_iter::iterator_next_value(iter);
+                let Some(element) = next else {
+                    break;
+                };
+                add_value(element, Some(iter));
+            }
+        }
     }
     set_handle.get_raw_mut_ptr::<SetHeader>()
 }

--- a/tests/test_issue_3989_map_set_semantics.sh
+++ b/tests/test_issue_3989_map_set_semantics.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# Regression for #3989: Map/Set constructor iterable semantics and prototype shape.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/debug/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/release/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --bin perry)"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+cat > "$TMPDIR/main.ts" << 'EOF'
+function check(value: boolean, label: string) {
+  if (!value) {
+    throw label;
+  }
+}
+
+const mapClear = Object.getOwnPropertyDescriptor(Map.prototype, "clear");
+check(!!mapClear && typeof mapClear.value === "function", "Map.prototype.clear descriptor");
+check(mapClear.enumerable === false, "Map.prototype.clear non-enumerable");
+
+const mapSize = Object.getOwnPropertyDescriptor(Map.prototype, "size");
+check(!!mapSize && typeof mapSize.get === "function", "Map.prototype.size getter");
+let mapSizeThrew = false;
+try {
+  mapSize.get.call({});
+} catch (_e) {
+  mapSizeThrew = true;
+}
+check(mapSizeThrew, "Map.prototype.size brand check");
+
+const setSize = Object.getOwnPropertyDescriptor(Set.prototype, "size");
+check(!!setSize && typeof setSize.get === "function", "Set.prototype.size getter");
+let setSizeThrew = false;
+try {
+  setSize.get.call({});
+} catch (_e) {
+  setSizeThrew = true;
+}
+check(setSizeThrew, "Set.prototype.size brand check");
+
+check(Object.getPrototypeOf(new Map()) === Map.prototype, "Map instance prototype");
+check(Object.getPrototypeOf(new Set()) === Set.prototype, "Set instance prototype");
+check(Map.prototype.constructor === Map, "Map prototype constructor");
+check(Set.prototype.constructor === Set, "Set prototype constructor");
+check(new Map([[0, 1]]).size === 1, "Map default constructor inserts");
+check(new Set([0]).size === 1, "Set default constructor inserts");
+
+const originalMapSet = Map.prototype.set;
+let mapSetCalls = 0;
+Map.prototype.set = function(_k: any, _v: any) {
+  mapSetCalls = mapSetCalls + 1;
+  return this;
+};
+const observedMap = new Map([[1, 2], [3, 4]]);
+check(mapSetCalls === 2, "Map constructor calls overridden set");
+check(observedMap.size === 0, "Map constructor uses observable set result path");
+
+let mapClosed = false;
+Map.prototype.set = function(_k: any, _v: any) {
+  throw "map boom";
+};
+const mapIterable: any = {};
+mapIterable[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { done: false, value: [1, 2] };
+    },
+    return: function() {
+      mapClosed = true;
+      return { done: true };
+    }
+  };
+};
+try {
+  new Map(mapIterable);
+} catch (_e) {}
+check(mapClosed, "Map constructor closes iterator after set failure");
+Map.prototype.set = originalMapSet;
+
+const originalSetAdd = Set.prototype.add;
+let setAddCalls = 0;
+Set.prototype.add = function(_v: any) {
+  setAddCalls = setAddCalls + 1;
+  return this;
+};
+const observedSet = new Set([1, 2]);
+check(setAddCalls === 2, "Set constructor calls overridden add");
+check(observedSet.size === 0, "Set constructor uses observable add result path");
+
+let setClosed = false;
+Set.prototype.add = function(_v: any) {
+  throw "set boom";
+};
+const setIterable: any = {};
+setIterable[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { done: false, value: 1 };
+    },
+    return: function() {
+      setClosed = true;
+      return { done: true };
+    }
+  };
+};
+try {
+  new Set(setIterable);
+} catch (_e) {}
+check(setClosed, "Set constructor closes iterator after add failure");
+Set.prototype.add = originalSetAdd;
+
+console.log("ok");
+EOF
+
+cd "$TMPDIR"
+"$PERRY" compile main.ts --output test_bin >/dev/null
+RUN_OUTPUT=$(./test_bin 2>&1)
+
+if [ "$RUN_OUTPUT" = "ok" ]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: unexpected output"
+echo "$RUN_OUTPUT"
+exit 1


### PR DESCRIPTION
## Summary
- install real Map/Set prototype methods plus size accessors with internal-slot brand checks
- make Map/Set constructors consume iterables through observable `.set`/`.add` calls and close iterators on abrupt completion
- wire Map/Set prototype identity and constructor back-links

Fixes #3989

## Verification
- `cargo check -q -p perry-runtime`
- `cargo build -q --bin perry`
- `tests/test_issue_3989_map_set_semantics.sh`
- `git diff --cached --check`

## Notes
- DeepWiki reference saved locally at `target/deepwiki/map-set-semantics.md` (ignored).
- Test262 subset was not run because `vendor/test262` is not present in this worktree.