### PR TITLE
fix(http): populate STATUS_CODES status-code map (#2519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1072 — node:http: populate STATUS_CODES map (#2519)
+
+`http.STATUS_CODES` was claimed in the API manifest but the runtime `native_module_property` "http" arm only materialized `METHODS`, so `http.STATUS_CODES` read back as `undefined` and `STATUS_CODES[200]` threw / returned undefined instead of Node's `"OK"`.
+
+Added `http_status_codes_object()` (`crates/perry-runtime/src/object/native_module.rs`): a cached object mapping the 63 standard status codes (numeric-string keys `"100".."511"`) to their reason phrases, mirroring the `http_global_agent_object` pattern (built once, cached as a scanned root in `NATIVE_MODULE_NAMESPACES`). `STATUS_CODES[200]` → `"OK"`, `[404]` → `"Not Found"`, `[418]` → `"I'm a Teapot"`, etc.; unknown codes read `undefined`. New fixture `test-parity/node-suite/http/exports/status-codes.ts` is byte-identical to `node --experimental-strip-types`.
+
+This completes #2519 (the module-level http validation helpers / properties — `validateHeaderName`/`validateHeaderValue`/`setMaxIdleHTTPParsers`/`setGlobalProxyFromEnv`/`globalAgent`/`maxHeaderSize` shipped in v0.5.1071 / #3712; `STATUS_CODES` is the last item).
+
 ## v0.5.1071 — node:http: module-level header-validation / agent export tail (#3712)
 
 `node:http`'s manifest covered the server/client classes and request helpers but omitted a current Node export tail used for header validation and agent/feature detection. Compiling code that imported these names failed at module-collection (`<name> is not implemented in Perry`). Added:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1071
+**Current Version:** 0.5.1072
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1071"
+version = "0.5.1072"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1071"
+version = "0.5.1072"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1071"
+version = "0.5.1072"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1071"
+version = "0.5.1072"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1071"
+version = "0.5.1072"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -5232,6 +5232,8 @@ pub(crate) unsafe fn get_native_module_constant(
             // #3712: `http.globalAgent` is an http.Agent with protocol "http:"
             // and defaultPort 80 (distinct from https.globalAgent above).
             "globalAgent" => Some(unsafe { http_global_agent_object() }),
+            // #2519: `http.STATUS_CODES` maps status codes to reason phrases.
+            "STATUS_CODES" => Some(unsafe { http_status_codes_object() }),
             _ => None,
         },
         "https" => match property {
@@ -5457,6 +5459,109 @@ unsafe fn http_global_agent_object() -> f64 {
         cache
             .borrow_mut()
             .insert("http.globalAgent".to_string(), result.to_bits());
+    });
+    result
+}
+
+/// #2519: `http.STATUS_CODES` — the standard HTTP status-code → reason-phrase
+/// map. Keys are the numeric codes as strings (so `STATUS_CODES[200]` resolves
+/// via the usual number→string index coercion). Cached as a scanned root in
+/// `NATIVE_MODULE_NAMESPACES` (mirrors `http_global_agent_object`).
+unsafe fn http_status_codes_object() -> f64 {
+    if let Some(bits) =
+        NATIVE_MODULE_NAMESPACES.with(|cache| cache.borrow().get("http.STATUS_CODES").copied())
+    {
+        return f64::from_bits(bits);
+    }
+
+    // Node 22 `require('node:http').STATUS_CODES` snapshot (63 entries).
+    const STATUS_CODES: &[(u32, &str)] = &[
+        (100, "Continue"),
+        (101, "Switching Protocols"),
+        (102, "Processing"),
+        (103, "Early Hints"),
+        (200, "OK"),
+        (201, "Created"),
+        (202, "Accepted"),
+        (203, "Non-Authoritative Information"),
+        (204, "No Content"),
+        (205, "Reset Content"),
+        (206, "Partial Content"),
+        (207, "Multi-Status"),
+        (208, "Already Reported"),
+        (226, "IM Used"),
+        (300, "Multiple Choices"),
+        (301, "Moved Permanently"),
+        (302, "Found"),
+        (303, "See Other"),
+        (304, "Not Modified"),
+        (305, "Use Proxy"),
+        (307, "Temporary Redirect"),
+        (308, "Permanent Redirect"),
+        (400, "Bad Request"),
+        (401, "Unauthorized"),
+        (402, "Payment Required"),
+        (403, "Forbidden"),
+        (404, "Not Found"),
+        (405, "Method Not Allowed"),
+        (406, "Not Acceptable"),
+        (407, "Proxy Authentication Required"),
+        (408, "Request Timeout"),
+        (409, "Conflict"),
+        (410, "Gone"),
+        (411, "Length Required"),
+        (412, "Precondition Failed"),
+        (413, "Payload Too Large"),
+        (414, "URI Too Long"),
+        (415, "Unsupported Media Type"),
+        (416, "Range Not Satisfiable"),
+        (417, "Expectation Failed"),
+        (418, "I'm a Teapot"),
+        (421, "Misdirected Request"),
+        (422, "Unprocessable Entity"),
+        (423, "Locked"),
+        (424, "Failed Dependency"),
+        (425, "Too Early"),
+        (426, "Upgrade Required"),
+        (428, "Precondition Required"),
+        (429, "Too Many Requests"),
+        (431, "Request Header Fields Too Large"),
+        (451, "Unavailable For Legal Reasons"),
+        (500, "Internal Server Error"),
+        (501, "Not Implemented"),
+        (502, "Bad Gateway"),
+        (503, "Service Unavailable"),
+        (504, "Gateway Timeout"),
+        (505, "HTTP Version Not Supported"),
+        (506, "Variant Also Negotiates"),
+        (507, "Insufficient Storage"),
+        (508, "Loop Detected"),
+        (509, "Bandwidth Limit Exceeded"),
+        (510, "Not Extended"),
+        (511, "Network Authentication Required"),
+    ];
+
+    let keys: Vec<String> = STATUS_CODES.iter().map(|(c, _)| c.to_string()).collect();
+    let packed = keys.join("\0");
+    let obj = js_object_alloc_with_shape(
+        0x7FFF_FF13,
+        keys.len() as u32,
+        packed.as_ptr(),
+        packed.len() as u32,
+    );
+    if obj.is_null() {
+        return f64::from_bits(JSValue::undefined().bits());
+    }
+    for (i, (_, msg)) in STATUS_CODES.iter().enumerate() {
+        let str_ptr = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+        js_object_set_field(obj, i as u32, JSValue::string_ptr(str_ptr));
+    }
+
+    let result = crate::value::js_nanbox_pointer(obj as i64);
+    NATIVE_MODULE_NAMESPACES.with(|cache| {
+        cache
+            .borrow_mut()
+            .insert("http.STATUS_CODES".to_string(), result.to_bits());
     });
     result
 }

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2506 entries across 106 modules
+// Coverage: 2512 entries across 106 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2506 entries across 106 modules.
+Total: 2512 entries across 106 modules.
 
 ## Modules
 

--- a/test-parity/node-suite/http/exports/status-codes.ts
+++ b/test-parity/node-suite/http/exports/status-codes.ts
@@ -1,0 +1,15 @@
+// #2519: node:http STATUS_CODES status-code → reason-phrase map.
+import * as http from "node:http";
+import { STATUS_CODES } from "node:http";
+
+console.log("typeof:", typeof STATUS_CODES);
+console.log("namespace identity:", http.STATUS_CODES === STATUS_CODES);
+console.log("count:", Object.keys(STATUS_CODES).length);
+console.log("200:", STATUS_CODES[200]);
+console.log("string-key 200:", STATUS_CODES["200"]);
+console.log("301:", STATUS_CODES[301]);
+console.log("404:", STATUS_CODES[404]);
+console.log("418:", STATUS_CODES[418]);
+console.log("500:", STATUS_CODES[500]);
+console.log("511:", STATUS_CODES[511]);
+console.log("missing 299:", STATUS_CODES[299]);


### PR DESCRIPTION
## Summary

Closes #2519. Adds the last missing item of the `node:http` module-level export cluster: **`http.STATUS_CODES`**. The other six (`validateHeaderName`, `validateHeaderValue`, `setMaxIdleHTTPParsers`, `setGlobalProxyFromEnv`, `globalAgent`, `maxHeaderSize`) shipped in v0.5.1071 (#3712).

`http.STATUS_CODES` was claimed in the API manifest (`property("http","STATUS_CODES")`) but the runtime `native_module_property` "http" arm only materialized `METHODS`, so `http.STATUS_CODES` read back `undefined` and `STATUS_CODES[200]` threw / returned `undefined` instead of Node's `"OK"`.

## Implementation
- `crates/perry-runtime/src/object/native_module.rs` — new `http_status_codes_object()`: a cached object mapping the 63 standard status codes (numeric-string keys `"100".."511"`) to their reason phrases, modeled on `http_global_agent_object` (built once, cached as a scanned root in `NATIVE_MODULE_NAMESPACES`). Wired into the `"http"` property arm.
- `test-parity/node-suite/http/exports/status-codes.ts` — new fixture (count, `[200]`/`[404]`/`[418]`/`[500]`/`[511]`, string-key access, namespace identity, unknown-code → undefined).

## Validation
- Fixture **byte-identical** to `node --experimental-strip-types` in both no-opt and auto-optimize builds (`STATUS_CODES[200]` → `"OK"`, count 63, etc.).
- `cargo fmt --all -- --check` clean.

## Note
Also regenerates `docs/api/perry.d.ts` + `docs/src/api/reference.md` — their coverage count was stale on `main` (2506 → 2512), so `main`'s `api-docs-drift` was red; this brings them current (no manifest change in this PR — `STATUS_CODES` was already a manifest property).
