### PR TITLE
fix(test): add node:test assert and expectFailure named exports (#3719)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1073 — node:test: add `assert` and `expectFailure` named exports (#3719)
+
+Perry's `node:test` manifest claimed the registration helpers, `mock`, and `snapshot` but not Node's current `assert` (assertion-namespace object) or `expectFailure` (function) named exports, so `import { assert, expectFailure } from "node:test"` was rejected before codegen and the module-shape coverage could drift.
+
+- **`crates/perry-api-manifest/src/entries.rs`** — `method("test", "expectFailure")` + `property("test", "assert")`.
+- **`crates/perry-runtime/src/node_test.rs`** — `expectFailure` routes through the same submodule-function path as the other helpers (`typeof === "function"`); `assert` returns a `{ register }` object matching Node's shape (`assert.register` is a length-2 function stub).
+- **`test-parity/node-suite/test/imports/assert-expectfailure-shape.ts`** — new fixture; byte-identical to `node --experimental-strip-types` (`expectFailure`/`assert.register` → function, `assert` → object, `Object.keys(assert)` → `register`).
+
+This is the export-shape/manifest tail of #3719; deeper test-runner behavior is tracked separately.
+
 ## v0.5.1072 — node:http: populate STATUS_CODES map (#2519)
 
 `http.STATUS_CODES` was claimed in the API manifest but the runtime `native_module_property` "http" arm only materialized `METHODS`, so `http.STATUS_CODES` read back as `undefined` and `STATUS_CODES[200]` threw / returned undefined instead of Node's `"OK"`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1072
+**Current Version:** 0.5.1073
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1072"
+version = "0.5.1073"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1072"
+version = "0.5.1073"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1072"
+version = "0.5.1073"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1072"
+version = "0.5.1073"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1072"
+version = "0.5.1073"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -3117,6 +3117,10 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("test", "beforeEach", false, None),
     method("test", "afterEach", false, None),
     method("test", "run", false, None),
+    // #3719: Node's current `node:test` named exports — `expectFailure`
+    // (function) and `assert` (assertion namespace object with `register`).
+    method("test", "expectFailure", false, None),
+    property("test", "assert"),
     property("test", "mock"),
     method("test", "fn", false, Some("mock")),
     method("test", "method", false, Some("mock")),

--- a/crates/perry-runtime/src/node_test.rs
+++ b/crates/perry-runtime/src/node_test.rs
@@ -185,17 +185,34 @@ fn snapshot_object() -> *mut ObjectHeader {
 
 pub fn property(property: &str) -> Option<f64> {
     match property {
+        // #3719: `expectFailure` is a current Node `node:test` named export
+        // (a function); route it through the same submodule-function path as
+        // the other registration helpers.
         "default" | "test" | "skip" | "todo" | "only" | "suite" | "describe" | "it" | "before"
-        | "after" | "beforeEach" | "afterEach" | "run" | "mock" | "snapshot" => Some(unsafe {
-            crate::node_submodules::js_node_submodule_export_as_function(
-                b"test".as_ptr(),
-                4,
-                property.as_ptr(),
-                property.len() as u32,
-            )
-        }),
+        | "after" | "beforeEach" | "afterEach" | "run" | "mock" | "snapshot" | "expectFailure" => {
+            Some(unsafe {
+                crate::node_submodules::js_node_submodule_export_as_function(
+                    b"test".as_ptr(),
+                    4,
+                    property.as_ptr(),
+                    property.len() as u32,
+                )
+            })
+        }
+        // #3719: `test.assert` is an assertion-namespace object exposing
+        // `register` (a function). Match Node's `{ register }` shape.
+        "assert" => Some(test_assert_object()),
         _ => None,
     }
+}
+
+/// #3719: build the `node:test` `assert` namespace object — `{ register }`,
+/// mirroring Node's current shape.
+fn test_assert_object() -> f64 {
+    let obj = crate::object::js_object_alloc(0, 0);
+    // `assert.register(name, fn)` — length 2 in Node; stubbed (shape parity).
+    set(obj, "register", fn_value(noop3 as *const u8, "register", 2));
+    object_value(obj)
 }
 
 pub fn dispatch_object_method(class_id: u32, method_name: &str) -> Option<f64> {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2512 entries across 106 modules
+// Coverage: 2514 entries across 106 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -3250,6 +3250,8 @@ declare module "sys" {
 
 declare module "test" {
   /** stdlib */
+  export const assert: any;
+  /** stdlib */
   export const mock: any;
   /** stdlib */
   export const snapshot: any;
@@ -3265,6 +3267,8 @@ declare module "test" {
   export default function (...args: any[]): any;
   /** stdlib */
   export function describe(...args: any[]): any;
+  /** stdlib */
+  export function expectFailure(...args: any[]): any;
   /** stdlib */
   export function it(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2512 entries across 106 modules.
+Total: 2514 entries across 106 modules.
 
 ## Modules
 
@@ -2871,6 +2871,7 @@ Total: 2512 entries across 106 modules.
 - `default` — module
 - `describe` — module
 - `enable` — module *(class: `timers`)*
+- `expectFailure` — module
 - `fn` — module *(class: `mock`)*
 - `getter` — module *(class: `mock`)*
 - `it` — module
@@ -2893,6 +2894,7 @@ Total: 2512 entries across 106 modules.
 
 ### Properties
 
+- `assert`
 - `mock`
 - `snapshot`
 

--- a/test-parity/node-suite/test/imports/assert-expectfailure-shape.ts
+++ b/test-parity/node-suite/test/imports/assert-expectfailure-shape.ts
@@ -1,0 +1,11 @@
+// #3719: node:test current named exports — `assert` (object) + `expectFailure` (function).
+import * as t from "node:test";
+import { assert, expectFailure, test as namedTest } from "node:test";
+
+console.log("expectFailure:", typeof expectFailure);
+console.log("expectFailure namespace:", typeof t.expectFailure);
+console.log("assert:", typeof assert);
+console.log("assert namespace:", typeof t.assert);
+console.log("assert.register:", typeof assert.register);
+console.log("assert keys:", Object.keys(assert).sort().join(","));
+console.log("namedTest:", typeof namedTest);


### PR DESCRIPTION
## Summary

Closes #3719. Adds Node's current `node:test` named exports that Perry's manifest didn't claim: **`assert`** (assertion-namespace object) and **`expectFailure`** (function). Before this, `import { assert, expectFailure } from "node:test"` was rejected at module collection, and the module-shape coverage could drift.

## Implementation
- `crates/perry-api-manifest/src/entries.rs` — `method("test", "expectFailure")` + `property("test", "assert")`.
- `crates/perry-runtime/src/node_test.rs` — `expectFailure` routes through the same `js_node_submodule_export_as_function` path as the other registration helpers (`typeof === "function"`); `assert` returns a `{ register }` object matching Node's shape (`assert.register` is a length-2 function stub).
- `test-parity/node-suite/test/imports/assert-expectfailure-shape.ts` — new fixture; regenerated `docs/api/perry.d.ts` + `reference.md`.

## Validation
- Fixture **byte-identical** to `node --experimental-strip-types` in both no-opt and auto-optimize builds:
  ```
  expectFailure: function / assert: object / assert.register: function / assert keys: register
  ```
- `cargo test -p perry-codegen --test manifest_consistency` — 5/5 pass.
- `cargo fmt --all -- --check` clean.

## Scope
Export-shape / manifest tail of #3719 (the issue is explicitly narrower than deeper `node:test` runner behavior, which is tracked separately).
