### PR TITLE
fix(v8): startupSnapshot registrars throw plain Error, not TypeError (#3141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
-## v0.5.1073 — node:test: add `assert` and `expectFailure` named exports (#3719)
+## v0.5.1074 — node:v8: startupSnapshot registrars throw plain Error + parity fixture (#3141)
+
+`v8.startupSnapshot` (added in #3679) was complete except its `addSerializeCallback` / `addDeserializeCallback` / `setDeserializeMainFunction` registrars threw a `TypeError [ERR_NOT_BUILDING_SNAPSHOT]` outside snapshot-building mode, whereas Node throws a plain **`Error`** (`name === "Error"`) with that code.
+
+- **`crates/perry-runtime/src/node_v8.rs`** + **`crates/perry-runtime/src/object/native_module_dispatch.rs`** — both throw sites now use `throw_error_with_code` (plain `Error`) instead of `throw_type_error_with_code`, matching Node's error class.
+- **`test-parity/node-suite/v8/startup-snapshot/shape.ts`** — new fixture covering the namespace shape, `isBuildingSnapshot()` → `0`, and the three registrars throwing `Error`/`ERR_NOT_BUILDING_SNAPSHOT`; byte-identical to `node --experimental-strip-types`. Closes #3141 (the helper-state manifest/runtime surface was already present; this corrects the error class and adds the missing parity coverage).
 
 Perry's `node:test` manifest claimed the registration helpers, `mock`, and `snapshot` but not Node's current `assert` (assertion-namespace object) or `expectFailure` (function) named exports, so `import { assert, expectFailure } from "node:test"` was rejected before codegen and the module-shape coverage could drift.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1073
+**Current Version:** 0.5.1074
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1073"
+version = "0.5.1074"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1073"
+version = "0.5.1074"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1073"
+version = "0.5.1074"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1073"
+version = "0.5.1074"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1073"
+version = "0.5.1074"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/node_v8.rs
+++ b/crates/perry-runtime/src/node_v8.rs
@@ -477,7 +477,9 @@ pub extern "C" fn js_v8_namespace(name_ptr: *const u8, name_len: usize) -> f64 {
 /// context — Node throws `ERR_NOT_BUILDING_SNAPSHOT`.
 #[no_mangle]
 pub extern "C" fn js_v8_throw_not_building_snapshot() -> f64 {
-    crate::fs::validate::throw_type_error_with_code(
+    // #3141: Node's `ERR_NOT_BUILDING_SNAPSHOT` is a plain `Error` (name
+    // "Error"), not a `TypeError` — use the generic Error-with-code thrower.
+    crate::fs::validate::throw_error_with_code(
         "Operation not allowed when not building startup snapshot.",
         "ERR_NOT_BUILDING_SNAPSHOT",
     )

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1815,7 +1815,9 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("v8.startupSnapshot", m) => match m {
             "isBuildingSnapshot" => crate::node_v8::js_v8_is_building_snapshot(),
             "addSerializeCallback" | "addDeserializeCallback" | "setDeserializeMainFunction" => {
-                crate::fs::validate::throw_type_error_with_code(
+                // #3141: Node's `ERR_NOT_BUILDING_SNAPSHOT` is a plain `Error`,
+                // not a `TypeError`.
+                crate::fs::validate::throw_error_with_code(
                     "Operation not allowed when not building startup snapshot.",
                     "ERR_NOT_BUILDING_SNAPSHOT",
                 )

--- a/test-parity/node-suite/v8/startup-snapshot/shape.ts
+++ b/test-parity/node-suite/v8/startup-snapshot/shape.ts
@@ -1,0 +1,23 @@
+// #3141: node:v8 startupSnapshot helper namespace — shape + normal-runtime contract.
+import * as v8 from "node:v8";
+
+const s = v8.startupSnapshot;
+console.log("startupSnapshot:", typeof s);
+console.log("isBuildingSnapshot:", typeof s.isBuildingSnapshot);
+console.log("addSerializeCallback:", typeof s.addSerializeCallback);
+console.log("addDeserializeCallback:", typeof s.addDeserializeCallback);
+console.log("setDeserializeMainFunction:", typeof s.setDeserializeMainFunction);
+console.log("isBuildingSnapshot():", s.isBuildingSnapshot());
+
+for (const [name, fn] of [
+  ["addSerializeCallback", s.addSerializeCallback],
+  ["addDeserializeCallback", s.addDeserializeCallback],
+  ["setDeserializeMainFunction", s.setDeserializeMainFunction],
+] as const) {
+  try {
+    fn(() => {});
+    console.log(name + ": no throw");
+  } catch (e: any) {
+    console.log(name + ":", e.name, e.code);
+  }
+}


### PR DESCRIPTION
## Summary

Closes #3141. `v8.startupSnapshot` (added in #3679) already exposed the helper namespace + `isBuildingSnapshot`/`addSerializeCallback`/`addDeserializeCallback`/`setDeserializeMainFunction` with manifest coverage, but the three callback registrars threw a `TypeError [ERR_NOT_BUILDING_SNAPSHOT]` outside snapshot-building mode. Node throws a plain **`Error`** (`name === "Error"`) with that code.

## Changes
- `crates/perry-runtime/src/node_v8.rs` + `crates/perry-runtime/src/object/native_module_dispatch.rs` — both throw sites now use `throw_error_with_code` (plain `Error`) instead of `throw_type_error_with_code`, matching Node's error class.
- `test-parity/node-suite/v8/startup-snapshot/shape.ts` — new fixture (the acceptance test the issue asked for): namespace shape, `isBuildingSnapshot()` → `0`, and the three registrars throwing `Error` / `ERR_NOT_BUILDING_SNAPSHOT`.

## Validation
- Fixture **byte-identical** to `node --experimental-strip-types` in both no-opt and auto-optimize builds.
- `cargo fmt --all -- --check` clean. No manifest change (so no `.d.ts` diff).
