### PR TITLE
fix(runtime): Buffer no longer misidentified as a Date cell in property reads (#4003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1075 — fix(runtime): Buffer no longer misidentified as a Date cell in property reads (#4003)
+
+`gunzipSync(c).length` / `.byteLength` returned `undefined` for a bound-local Buffer input (Node: the decompressed byte length), while indexing, `.toString()`, `Buffer.isBuffer`, and `Buffer.byteLength(d)` all worked.
+
+Root cause: `Buffer`s are raw-`alloc`'d **without** a `GcHeader`, but `date::is_date_cell_addr(addr)` read the word at `addr - GC_HEADER_SIZE` and compared it to `GC_TYPE_DATE_CELL` — assuming every pointer has a valid GC header. For some buffer addresses (observed for the *first* `gunzipSync` result of a program) that adjacent word coincidentally held the `DATE_CELL` tag, so `js_object_get_field_by_name` took its Date branch and returned `undefined` for `.length`/`.byteLength`. It was call-ordinal/address-dependent (only the first result tripped it), which made it look like a GC stale-ref.
+
+Fix (`crates/perry-runtime/src/date.rs`): when the header byte matches `GC_TYPE_DATE_CELL`, `is_date_cell_addr` now also confirms the address is **not** a registered buffer (`!is_registered_buffer(addr)`) before reporting a Date cell. A registered buffer is never a `DateCell`. The extra lookup runs only in the rare tag-match case, so the common (non-Date) property-read hot path is unchanged, and this hardens every `is_date_cell_addr` caller (including `is_date_value`).
+
+Validated against `node --experimental-strip-types`: `gunzipSync(c).length`/`.byteLength` → 11 for all calls (was undefined on the first); `Date` reads (`getTime`/`constructor`/`getFullYear`/unknown-prop) unchanged; `perry-runtime` date (21) + buffer (41) unit tests green; buffer/zlib node-suite sweep clean except pre-existing, unrelated gaps (`new globalThis.File()` shape, zlib transform-stream output).
+
 ## v0.5.1074 — node:v8: startupSnapshot registrars throw plain Error + parity fixture (#3141)
 
 `v8.startupSnapshot` (added in #3679) was complete except its `addSerializeCallback` / `addDeserializeCallback` / `setDeserializeMainFunction` registrars threw a `TypeError [ERR_NOT_BUILDING_SNAPSHOT]` outside snapshot-building mode, whereas Node throws a plain **`Error`** (`name === "Error"`) with that code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1074
+**Current Version:** 0.5.1075
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1074"
+version = "0.5.1075"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1074"
+version = "0.5.1075"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1074"
+version = "0.5.1075"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1074"
+version = "0.5.1075"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1074"
+version = "0.5.1075"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -63,7 +63,18 @@ pub fn is_date_cell_addr(addr: usize) -> bool {
     }
     unsafe {
         let header = (addr - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-        (*header).obj_type == crate::gc::GC_TYPE_DATE_CELL
+        if (*header).obj_type != crate::gc::GC_TYPE_DATE_CELL {
+            return false;
+        }
+        // #4003: `Buffer`s are raw-`alloc`'d with NO `GcHeader`, so the word at
+        // `addr - GC_HEADER_SIZE` is unrelated heap memory that can
+        // coincidentally hold the `DATE_CELL` tag — observed for the first
+        // `gunzipSync` result, whose `.length`/`.byteLength` then mis-routed
+        // through the Date branch in `js_object_get_field_by_name` and returned
+        // `undefined`. A registered buffer is never a `DateCell`, so reject it.
+        // The lookup runs only in the rare tag-match case, keeping the common
+        // (non-Date) property-read path unchanged.
+        !crate::buffer::is_registered_buffer(addr)
     }
 }
 


### PR DESCRIPTION
## #4003: `gunzipSync(c).length`/`.byteLength` returned `undefined` for a bound-local Buffer

```ts
const c = gzipSync("hello world");
const d = gunzipSync(c);
console.log(d.length);      // undefined  (Node: 11)
console.log(d[0], Buffer.isBuffer(d), d.toString()); // 104, true, "hello world"  (all fine)
```

### Root cause (isolated via runtime probes)
Only the **first** `gunzipSync` result of a program tripped it (calls 2/3/4 fine) — which looked like a GC stale-ref but isn't. `Buffer`s are raw-`alloc`'d **without** a `GcHeader`, yet `date::is_date_cell_addr(addr)` read the word at `addr - GC_HEADER_SIZE` and compared it to `GC_TYPE_DATE_CELL`, assuming every pointer has a valid GC header. For some buffer addresses that adjacent word coincidentally held the `DATE_CELL` tag, so `js_object_get_field_by_name` took its **Date branch** and returned `undefined` for `.length`/`.byteLength` (the Date branch returns undefined for non-`constructor` keys). Indexing/`toString`/`isBuffer`/static `Buffer.byteLength` use other recognition paths, so they worked — matching the issue's exact symptom set.

### Fix
`crates/perry-runtime/src/date.rs`: when the header byte matches `GC_TYPE_DATE_CELL`, `is_date_cell_addr` now also confirms the address is **not** a registered buffer before reporting a Date cell — a registered buffer is never a `DateCell`. The `is_registered_buffer` lookup runs **only** in the rare tag-match case, so the common (non-Date) property-read hot path is unchanged. This hardens every `is_date_cell_addr` caller (including `is_date_value`).

### Validation (vs `node --experimental-strip-types`, clean isolated origin/main build)
- `gunzipSync(c).length`/`.byteLength` → **11** for all calls (was undefined on the first) ✅
- `Date` reads unchanged: `getTime`/`constructor`/`getFullYear`/unknown-prop all match Node ✅
- `perry-runtime` **date (21)** + **buffer (41)** unit tests green ✅
- buffer + zlib node-suite sweep: 184/187 pass; the 3 fails are pre-existing and unrelated (`new globalThis.File()` shape — separate WIP; two zlib transform-stream gaps) ✅
