### PR TITLE
fix(runtime): fold builtin static name/length descriptors

### DIFF
--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -10,8 +10,8 @@ use crate::walker::{walk_expr_children, walk_expr_children_mut};
 
 mod builtins;
 pub(crate) use builtins::{
-    builtin_constructor_length, is_builtin_function, is_builtin_global_value_name,
-    is_builtin_static_function_member,
+    builtin_constructor_length, builtin_static_function_length, is_builtin_function,
+    is_builtin_global_value_name, is_builtin_static_function_member,
 };
 
 mod uses_this;

--- a/crates/perry-hir/src/analysis/builtins.rs
+++ b/crates/perry-hir/src/analysis/builtins.rs
@@ -265,6 +265,7 @@ pub(crate) fn is_builtin_static_function_member(namespace: &str, member: &str) -
         "JSON" => matches!(member, "parse" | "stringify"),
         "Date" => matches!(member, "now" | "UTC" | "parse"),
         "ArrayBuffer" => matches!(member, "isView"),
+        "BigInt" => matches!(member, "asIntN" | "asUintN"),
         "Int8Array" | "Uint8Array" | "Uint8ClampedArray" | "Int16Array" | "Uint16Array"
         | "Int32Array" | "Uint32Array" | "Float16Array" | "Float32Array" | "Float64Array"
         | "BigInt64Array" | "BigUint64Array" => matches!(member, "from" | "of"),
@@ -290,4 +291,121 @@ pub(crate) fn is_builtin_static_function_member(namespace: &str, member: &str) -
         ),
         _ => false,
     }
+}
+
+/// Spec-defined `.length` for static *function* members recognized by
+/// [`is_builtin_static_function_member`].
+///
+/// Perry currently lowers many builtin static functions as intrinsics rather
+/// than first-class closure values, so direct `Builtin.method.length` reads and
+/// compile-time-folded descriptor probes need this central table just like
+/// constructors use [`builtin_constructor_length`].
+pub(crate) fn builtin_static_function_length(namespace: &str, member: &str) -> Option<u32> {
+    let len = match namespace {
+        "Math" => match member {
+            "random" => 0,
+            "atan2" | "hypot" | "imul" | "max" | "min" | "pow" => 2,
+            "abs" | "acos" | "acosh" | "asin" | "asinh" | "atan" | "atanh" | "cbrt" | "ceil"
+            | "clz32" | "cos" | "cosh" | "exp" | "expm1" | "floor" | "fround" | "f16round"
+            | "log" | "log10" | "log1p" | "log2" | "round" | "sign" | "sin" | "sinh" | "sqrt"
+            | "tan" | "tanh" | "trunc" => 1,
+            _ => return None,
+        },
+        "Promise" => match member {
+            "withResolvers" => 0,
+            "resolve" | "reject" | "all" | "race" | "allSettled" | "any" | "try" => 1,
+            _ => return None,
+        },
+        "Array" => match member {
+            "of" => 0,
+            "isArray" | "from" | "fromAsync" => 1,
+            _ => return None,
+        },
+        "Object" => match member {
+            "defineProperty" => 3,
+            "assign"
+            | "create"
+            | "defineProperties"
+            | "groupBy"
+            | "hasOwn"
+            | "is"
+            | "getOwnPropertyDescriptor"
+            | "setPrototypeOf" => 2,
+            "entries"
+            | "freeze"
+            | "fromEntries"
+            | "getOwnPropertyDescriptors"
+            | "getOwnPropertyNames"
+            | "getOwnPropertySymbols"
+            | "getPrototypeOf"
+            | "isExtensible"
+            | "isFrozen"
+            | "isSealed"
+            | "keys"
+            | "preventExtensions"
+            | "seal"
+            | "values" => 1,
+            _ => return None,
+        },
+        "Number" => match member {
+            "parseInt" => 2,
+            "isFinite" | "isInteger" | "isNaN" | "isSafeInteger" | "parseFloat" => 1,
+            _ => return None,
+        },
+        "String" => match member {
+            "fromCharCode" | "fromCodePoint" | "raw" => 1,
+            _ => return None,
+        },
+        "Symbol" => match member {
+            "for" | "keyFor" => 1,
+            _ => return None,
+        },
+        "JSON" => match member {
+            "parse" => 2,
+            "stringify" => 3,
+            _ => return None,
+        },
+        "Date" => match member {
+            "now" => 0,
+            "UTC" => 7,
+            "parse" => 1,
+            _ => return None,
+        },
+        "ArrayBuffer" => match member {
+            "isView" => 1,
+            _ => return None,
+        },
+        "BigInt" => match member {
+            "asIntN" | "asUintN" => 2,
+            _ => return None,
+        },
+        "Int8Array" | "Uint8Array" | "Uint8ClampedArray" | "Int16Array" | "Uint16Array"
+        | "Int32Array" | "Uint32Array" | "Float16Array" | "Float32Array" | "Float64Array"
+        | "BigInt64Array" | "BigUint64Array" => match member {
+            "from" => 1,
+            "of" => 0,
+            _ => return None,
+        },
+        "Reflect" => match member {
+            "apply" | "defineProperty" | "set" => 3,
+            "construct"
+            | "deleteProperty"
+            | "get"
+            | "getOwnPropertyDescriptor"
+            | "has"
+            | "setPrototypeOf" => 2,
+            "getPrototypeOf" | "isExtensible" | "ownKeys" | "preventExtensions" => 1,
+            _ => return None,
+        },
+        "WebAssembly" => match member {
+            "compile"
+            | "compileStreaming"
+            | "instantiate"
+            | "instantiateStreaming"
+            | "validate" => 1,
+            _ => return None,
+        },
+        _ => return None,
+    };
+    Some(len)
 }

--- a/crates/perry-hir/src/lower/expr_call/name_fold.rs
+++ b/crates/perry-hir/src/lower/expr_call/name_fold.rs
@@ -12,7 +12,9 @@
 
 use swc_ecma_ast as ast;
 
-use crate::analysis::{is_builtin_global_value_name, is_builtin_static_function_member};
+use crate::analysis::{
+    builtin_static_function_length, is_builtin_global_value_name, is_builtin_static_function_member,
+};
 use crate::ir::Expr;
 
 /// If `arg` is an AST shape we recognize as a built-in function value —
@@ -52,15 +54,38 @@ pub(super) fn builtin_fn_name_for_arg(arg: &ast::Expr) -> Option<String> {
     }
 }
 
-/// Build the spec-compliant data descriptor for a function `.name` property
-/// — `{ value, writable:false, enumerable:false, configurable:true }`.
+/// If `arg` is an AST shape we recognize as a built-in static function value,
+/// return its spec `.length`.
+pub(super) fn builtin_fn_length_for_arg(arg: &ast::Expr) -> Option<u32> {
+    match arg {
+        ast::Expr::Member(m) => {
+            if let (ast::Expr::Ident(ns_ident), ast::MemberProp::Ident(method_ident)) =
+                (m.obj.as_ref(), &m.prop)
+            {
+                return builtin_static_function_length(
+                    ns_ident.sym.as_ref(),
+                    method_ident.sym.as_ref(),
+                );
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Build the spec-compliant data descriptor for a function `.name` or `.length`
+/// property — `{ value, writable:false, enumerable:false, configurable:true }`.
 /// Mirrors `js_object_get_own_property_descriptor` in the runtime; the two
 /// must stay in sync.
-pub(super) fn name_data_descriptor(fname: String) -> Expr {
+pub(super) fn builtin_data_descriptor(value: Expr) -> Expr {
     Expr::Object(vec![
-        ("value".to_string(), Expr::String(fname)),
+        ("value".to_string(), value),
         ("writable".to_string(), Expr::Bool(false)),
         ("enumerable".to_string(), Expr::Bool(false)),
         ("configurable".to_string(), Expr::Bool(true)),
     ])
+}
+
+pub(super) fn name_data_descriptor(fname: String) -> Expr {
+    builtin_data_descriptor(Expr::String(fname))
 }

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -826,27 +826,26 @@ pub(super) fn try_native_module_methods(
                             )));
                         }
                         "getOwnPropertyDescriptor" => {
-                            // #2144: built-in function `.name` descriptor.
+                            // #2144/#3655: built-in function `.name` /
+                            // `.length` descriptors.
                             //
                             // `Object.getOwnPropertyDescriptor(<BuiltinCtor>,
-                            // "name")` and `…(<BuiltinNs>.<staticFn>, "name")`
-                            // — the runtime path returns `undefined` because
-                            // the bare ctor/static-fn lowers to a
-                            // `PropertyGet { GlobalGet(0), … }` whose value
-                            // is the 0 sentinel (no closure to read the
-                            // built-in `name` slot off of). Per spec the
-                            // descriptor is a non-writable, non-enumerable,
-                            // configurable data property whose value is the
-                            // function's name. Fold to an inline object
-                            // literal when we can statically recognize the
-                            // shape — same gating logic as the `.name` fold
-                            // in `expr_member.rs`.
+                            // "name"|"length")` and
+                            // `…(<BuiltinNs>.<staticFn>, "name"|"length")`
+                            // need a compile-time fold because those builtin
+                            // values are often intrinsic sentinels rather than
+                            // first-class closures. Per spec both descriptors
+                            // are non-writable, non-enumerable, configurable
+                            // data properties. Fold when we can statically
+                            // recognize the receiver shape — same gating logic
+                            // as the direct `.name` / `.length` folds in
+                            // `expr_member.rs`.
                             if call.args.len() >= 2 && args.len() >= 2 {
-                                let key_is_name = matches!(
-                                    call.args[1].expr.as_ref(),
-                                    ast::Expr::Lit(ast::Lit::Str(s)) if s.value.as_str() == Some("name")
-                                );
-                                if key_is_name {
+                                let key_name = match call.args[1].expr.as_ref() {
+                                    ast::Expr::Lit(ast::Lit::Str(s)) => s.value.as_str(),
+                                    _ => None,
+                                };
+                                if matches!(key_name, Some("name" | "length")) {
                                     let lowered_obj_is_global_intrinsic = match &args[0] {
                                         Expr::GlobalGet(0) => true,
                                         Expr::PropertyGet { object: inner, .. } => {
@@ -855,13 +854,44 @@ pub(super) fn try_native_module_methods(
                                         _ => false,
                                     };
                                     if lowered_obj_is_global_intrinsic {
-                                        let folded = super::name_fold::builtin_fn_name_for_arg(
-                                            call.args[0].expr.as_ref(),
-                                        );
-                                        if let Some(fname) = folded {
-                                            return Ok(Ok(super::name_fold::name_data_descriptor(
-                                                fname,
-                                            )));
+                                        match key_name {
+                                            Some("name") => {
+                                                let folded =
+                                                    super::name_fold::builtin_fn_name_for_arg(
+                                                        call.args[0].expr.as_ref(),
+                                                    );
+                                                if let Some(fname) = folded {
+                                                    return Ok(Ok(
+                                                        super::name_fold::name_data_descriptor(
+                                                            fname,
+                                                        ),
+                                                    ));
+                                                }
+                                            }
+                                            Some("length") => {
+                                                let folded =
+                                                    super::name_fold::builtin_fn_length_for_arg(
+                                                        call.args[0].expr.as_ref(),
+                                                    )
+                                                    .or_else(|| {
+                                                        super::name_fold::builtin_fn_name_for_arg(
+                                                            call.args[0].expr.as_ref(),
+                                                        )
+                                                        .and_then(|name| {
+                                                            crate::analysis::builtin_constructor_length(
+                                                                &name,
+                                                            )
+                                                        })
+                                                    });
+                                                if let Some(len) = folded {
+                                                    return Ok(Ok(
+                                                        super::name_fold::builtin_data_descriptor(
+                                                            Expr::Number(len as f64),
+                                                        ),
+                                                    ));
+                                                }
+                                            }
+                                            _ => {}
                                         }
                                     }
                                 }

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1693,6 +1693,29 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     }
                 }
             }
+            if let Expr::PropertyGet {
+                object: inner,
+                property,
+            } = &object_expr
+            {
+                if matches!(inner.as_ref(), Expr::GlobalGet(0)) {
+                    if let ast::Expr::Member(inner_member) = member.obj.as_ref() {
+                        if let (ast::Expr::Ident(ns_ident), ast::MemberProp::Ident(method_ident)) =
+                            (inner_member.obj.as_ref(), &inner_member.prop)
+                        {
+                            let ns = ns_ident.sym.as_ref();
+                            let method = method_ident.sym.as_ref();
+                            if method == property.as_str() {
+                                if let Some(len) =
+                                    crate::analysis::builtin_static_function_length(ns, method)
+                                {
+                                    return Ok(Expr::Number(len as f64));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/tests/test_issue_3655_builtin_static_name_length.sh
+++ b/tests/test_issue_3655_builtin_static_name_length.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/issue_3655.ts" <<'TS'
+let failures = 0;
+
+function check(label: string, actual: any, expected: any): void {
+  if (actual !== expected) {
+    console.log(label + ": expected " + String(expected) + ", got " + String(actual));
+    failures = failures + 1;
+  }
+}
+
+function checkDataDescriptor(label: string, desc: any, value: any): void {
+  if (desc === undefined) {
+    console.log(label + ": descriptor missing");
+    failures = failures + 1;
+    return;
+  }
+  check(label + ".value", desc.value, value);
+  check(label + ".writable", desc.writable, false);
+  check(label + ".enumerable", desc.enumerable, false);
+  check(label + ".configurable", desc.configurable, true);
+}
+
+checkDataDescriptor("Array.from.name", Object.getOwnPropertyDescriptor(Array.from, "name"), "from");
+checkDataDescriptor("Array.from.length", Object.getOwnPropertyDescriptor(Array.from, "length"), 1);
+check("BigInt.asIntN.length", BigInt.asIntN.length, 2);
+check("Reflect.apply.name", Reflect.apply.name, "apply");
+check("Reflect.apply.length", Reflect.apply.length, 3);
+checkDataDescriptor(
+  "Reflect.apply.length",
+  Object.getOwnPropertyDescriptor(Reflect.apply, "length"),
+  3,
+);
+checkDataDescriptor("Math.max.length", Object.getOwnPropertyDescriptor(Math.max, "length"), 2);
+checkDataDescriptor(
+  "ArrayBuffer.isView.name",
+  Object.getOwnPropertyDescriptor(ArrayBuffer.isView, "name"),
+  "isView",
+);
+
+checkDataDescriptor("Array.name", Object.getOwnPropertyDescriptor(Array, "name"), "Array");
+checkDataDescriptor("Array.length", Object.getOwnPropertyDescriptor(Array, "length"), 1);
+checkDataDescriptor("Map.name", Object.getOwnPropertyDescriptor(Map, "name"), "Map");
+checkDataDescriptor("Map.length", Object.getOwnPropertyDescriptor(Map, "length"), 0);
+checkDataDescriptor("Date.name", Object.getOwnPropertyDescriptor(Date, "name"), "Date");
+checkDataDescriptor("Date.length", Object.getOwnPropertyDescriptor(Date, "length"), 7);
+checkDataDescriptor("DataView.name", Object.getOwnPropertyDescriptor(DataView, "name"), "DataView");
+checkDataDescriptor("DataView.length", Object.getOwnPropertyDescriptor(DataView, "length"), 1);
+
+if (failures !== 0) {
+  throw new Error("builtin name/length descriptor parity failed");
+}
+
+console.log("builtin name/length descriptor parity ok");
+TS
+
+"$PERRY" compile --no-cache "$TMPDIR/issue_3655.ts" -o "$TMPDIR/issue_3655" \
+    >"$TMPDIR/compile.log" 2>&1 || {
+        echo "FAIL: compile failed"
+        sed 's/^/    /' "$TMPDIR/compile.log" | tail -80
+        exit 1
+    }
+
+"$TMPDIR/issue_3655" >"$TMPDIR/run.log" 2>&1 || {
+    echo "FAIL: program failed"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+}
+
+if ! grep -q "builtin name/length descriptor parity ok" "$TMPDIR/run.log"; then
+    echo "FAIL: expected success marker"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+fi
+
+echo "PASS: builtin name/length descriptor parity"


### PR DESCRIPTION
## Summary

Fixes #3655 for the remaining directly-inspected static builtin function cases by extending the existing #3143/#2144 builtin descriptor folding path instead of one-offing individual calls.

- adds a centralized `builtin_static_function_length(namespace, member)` table beside the existing static builtin function recognizer
- folds direct `Builtin.staticFn.length` reads for Array/BigInt/Reflect/Math/Object/etc.
- folds `Object.getOwnPropertyDescriptor(<Builtin.staticFn>, "name" | "length")` to spec-shaped data descriptors: `{ writable: false, enumerable: false, configurable: true }`
- keeps constructor descriptor behavior covered by the existing constructor length/name path

Final fetched base SHA: `15c1ef52a005d753414d8532f27f782171da928e`.

## Reference

DeepWiki was queried once for `boa-dev/boa` as the Rust ECMAScript reference. Full response saved at:

`target/deepwiki/builtin-name-length-descriptors.md`

That path is under ignored `target/` and is not committed.

## Reproduction Evidence

Before implementation on fetched `origin/main`/base, representative probe output included:

```text
Array.from.name desc: undefined
Array.from.length desc: undefined
BigInt.asIntN.length: undefined
Reflect.apply.name: apply
Reflect.apply.length: undefined
Array.name desc: value=Array,writable=false,enumerable=false,configurable=true
Array.length desc: value=1,writable=false,enumerable=false,configurable=true
Map.name desc: value=Map,writable=false,enumerable=false,configurable=true
Map.length desc: value=0,writable=false,enumerable=false,configurable=true
Date.name desc: value=Date,writable=false,enumerable=false,configurable=true
Date.length desc: value=7,writable=false,enumerable=false,configurable=true
DataView.name desc: value=DataView,writable=false,enumerable=false,configurable=true
DataView.length desc: value=1,writable=false,enumerable=false,configurable=true
```

After implementation, direct issue-shaped probes produce:

```text
Array.from.name desc: value=from,writable=false,enumerable=false,configurable=true
Array.from.length desc: value=1,writable=false,enumerable=false,configurable=true
BigInt.asIntN.length: 2
Reflect.apply.name: apply
Reflect.apply.length: 3
Array.name desc: value=Array,writable=false,enumerable=false,configurable=true
Array.length desc: value=1,writable=false,enumerable=false,configurable=true
Map.name desc: value=Map,writable=false,enumerable=false,configurable=true
Map.length desc: value=0,writable=false,enumerable=false,configurable=true
Date.name desc: value=Date,writable=false,enumerable=false,configurable=true
Date.length desc: value=7,writable=false,enumerable=false,configurable=true
DataView.name desc: value=DataView,writable=false,enumerable=false,configurable=true
DataView.length desc: value=1,writable=false,enumerable=false,configurable=true
```

Existing PR overlap checked before coding and before PR creation: #3715 and #3731 are already merged and cover constructor/delete follow-ups; this PR targets the remaining direct static builtin function descriptor folds.

## Tests

- `cargo fmt`
- `cargo check -p perry-hir`
- `cargo build -p perry`
- `PERRY=target/debug/perry tests/test_issue_3655_builtin_static_name_length.sh`
- manual direct probe via `target/debug/perry compile --no-cache target/repro/issue3655_direct_probe.ts -o target/repro/issue3655_direct_probe_after && target/repro/issue3655_direct_probe_after`

## Residual Risks

Static builtin functions are still not generally reified as first-class function objects when their builtin receiver context is erased, which matches the existing #3144 limitation. For example, passing `Array.from` through an arbitrary user helper before calling `Object.getOwnPropertyDescriptor(obj, "name")` still loses the `Array.from` identity and is not solved here. This PR covers the direct Test262-style/static reflection shape and centralized static arity metadata without mixing in broader static-method reification or semantic method behavior.
