### PR TITLE
fix(v8): expose modern diagnostics/profiler named exports (#3904)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1077 — node:v8: expose modern diagnostics/profiler named exports (#3904)
+
+Perry's `node:v8` manifest omitted several function-valued exports Node ships in the ESM namespace, so `import { queryObjects, getCppHeapStatistics, ... } from "node:v8"` failed `perry check` before runtime. Added `getCppHeapStatistics`, `getHeapSnapshot`, `isStringOneByteRepresentation`, `queryObjects`, `startCpuProfile`, and `writeHeapSnapshot` as function-valued exports (Node `.length` values preserved).
+
+- **`crates/perry-api-manifest/src/entries.rs`** — six `method("v8", …)` rows.
+- **`crates/perry-runtime/src/object/native_module.rs`** — the six added to `is_native_module_callable_export` (so the named/namespace reads are function-valued) and `native_callable_export_arity` (Node `.length`).
+- **`test-parity/node-suite/v8/exports/diagnostics-surface.ts`** — new fixture (typeof + `.length` + namespace identity); byte-identical to `node --experimental-strip-types`.
+
+Export-surface/manifest parity only; deeper behavior of `getHeapSnapshot`/`writeHeapSnapshot` remains tracked by #3140.
+
 ## v0.5.1076 — fix(fs): opendirSync compiles (add missing #[no_mangle])
 
 Any program using `fs.opendirSync(...)` failed to link with `Undefined symbols: _js_fs_opendir_sync`. The runtime `js_fs_opendir_sync` (`crates/perry-runtime/src/fs/dir_glob_watch.rs`) was declared in codegen (`runtime_decls/strings.rs`) and called by the unmangled symbol name, but the Rust function was missing `#[no_mangle]` — so its symbol was Rust-mangled and the linker couldn't resolve the codegen call. (Its sibling `js_fs_glob_sync`/`js_fs_glob_sync_options` both have `#[no_mangle]` and linked fine; the async/`fs.promises` Dir paths reach the shared `js_fs_opendir_value` helper directly, so only the sync entry point was broken.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1076
+**Current Version:** 0.5.1077
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1076"
+version = "0.5.1077"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1076"
+version = "0.5.1077"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1076"
+version = "0.5.1077"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1076"
+version = "0.5.1077"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1076"
+version = "0.5.1077"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -4073,6 +4073,15 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("v8", "takeCoverage", false, None),
     method("v8", "stopCoverage", false, None),
     method("v8", "setHeapSnapshotNearHeapLimit", false, None),
+    // #3904: modern V8 diagnostics/profiler named exports (function-valued in
+    // Node's ESM namespace). `getHeapSnapshot`/`writeHeapSnapshot` deeper
+    // behavior is tracked by #3140; here they're added to the export surface.
+    method("v8", "getCppHeapStatistics", false, None),
+    method("v8", "getHeapSnapshot", false, None),
+    method("v8", "isStringOneByteRepresentation", false, None),
+    method("v8", "queryObjects", false, None),
+    method("v8", "startCpuProfile", false, None),
+    method("v8", "writeHeapSnapshot", false, None),
     method("v8", "isBuildingSnapshot", true, Some("startupSnapshot")),
     method("v8", "addSerializeCallback", true, Some("startupSnapshot")),
     method(

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -2181,6 +2181,10 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         // #3712: node:http module-level helper exports.
         ("http", "validateHeaderName" | "validateHeaderValue") => Some(2),
         ("http", "setMaxIdleHTTPParsers" | "setGlobalProxyFromEnv") => Some(1),
+        // #3904: modern V8 diagnostics/profiler exports (Node .length values).
+        ("v8", "getCppHeapStatistics" | "startCpuProfile") => Some(0),
+        ("v8", "getHeapSnapshot" | "isStringOneByteRepresentation" | "queryObjects") => Some(1),
+        ("v8", "writeHeapSnapshot") => Some(2),
         ("net", "_normalizeArgs") => Some(1),
         ("net", "_createServerHandle") => Some(5),
         ("domain", "Domain" | "createDomain" | "create") => Some(0),
@@ -3683,6 +3687,13 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("v8", "takeCoverage")
             | ("v8", "stopCoverage")
             | ("v8", "setHeapSnapshotNearHeapLimit")
+            // #3904: modern V8 diagnostics/profiler named exports (function-valued).
+            | ("v8", "getCppHeapStatistics")
+            | ("v8", "getHeapSnapshot")
+            | ("v8", "isStringOneByteRepresentation")
+            | ("v8", "queryObjects")
+            | ("v8", "startCpuProfile")
+            | ("v8", "writeHeapSnapshot")
             // #3679: v8.startupSnapshot / v8.promiseHooks namespace methods read
             // as callable values (`typeof v8.startupSnapshot.isBuildingSnapshot
             // === "function"`). Invocation routes through

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2514 entries across 106 modules
+// Coverage: 2520 entries across 106 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -3612,11 +3612,19 @@ declare module "v8" {
   /** stdlib */
   export function deserialize(...args: any[]): any;
   /** stdlib */
+  export function getCppHeapStatistics(...args: any[]): any;
+  /** stdlib */
   export function getHeapCodeStatistics(...args: any[]): any;
+  /** stdlib */
+  export function getHeapSnapshot(...args: any[]): any;
   /** stdlib */
   export function getHeapSpaceStatistics(...args: any[]): any;
   /** stdlib */
   export function getHeapStatistics(...args: any[]): any;
+  /** stdlib */
+  export function isStringOneByteRepresentation(...args: any[]): any;
+  /** stdlib */
+  export function queryObjects(...args: any[]): any;
   /** stdlib */
   export function serialize(...args: any[]): any;
   /** stdlib */
@@ -3624,9 +3632,13 @@ declare module "v8" {
   /** stdlib */
   export function setHeapSnapshotNearHeapLimit(...args: any[]): any;
   /** stdlib */
+  export function startCpuProfile(...args: any[]): any;
+  /** stdlib */
   export function stopCoverage(...args: any[]): any;
   /** stdlib */
   export function takeCoverage(...args: any[]): any;
+  /** stdlib */
+  export function writeHeapSnapshot(...args: any[]): any;
 }
 
 declare module "validator" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2514 entries across 106 modules.
+Total: 2520 entries across 106 modules.
 
 ## Modules
 
@@ -3154,14 +3154,18 @@ Total: 2514 entries across 106 modules.
 - `cachedDataVersionTag` — module
 - `createHook` — instance *(class: `promiseHooks`)*
 - `deserialize` — module
+- `getCppHeapStatistics` — module
 - `getHeapCodeStatistics` — module
+- `getHeapSnapshot` — module
 - `getHeapSpaceStatistics` — module
 - `getHeapStatistics` — module
 - `isBuildingSnapshot` — instance *(class: `startupSnapshot`)*
+- `isStringOneByteRepresentation` — module
 - `onAfter` — instance *(class: `promiseHooks`)*
 - `onBefore` — instance *(class: `promiseHooks`)*
 - `onInit` — instance *(class: `promiseHooks`)*
 - `onSettled` — instance *(class: `promiseHooks`)*
+- `queryObjects` — module
 - `readDouble` — instance *(class: `Deserializer`)*
 - `readHeader` — instance *(class: `Deserializer`)*
 - `readRawBytes` — instance *(class: `Deserializer`)*
@@ -3174,11 +3178,13 @@ Total: 2514 entries across 106 modules.
 - `setFlagsFromString` — module
 - `setHeapSnapshotNearHeapLimit` — module
 - `start` — instance *(class: `GCProfiler`)*
+- `startCpuProfile` — module
 - `stop` — instance *(class: `GCProfiler`)*
 - `stopCoverage` — module
 - `takeCoverage` — module
 - `writeDouble` — instance *(class: `Serializer`)*
 - `writeHeader` — instance *(class: `Serializer`)*
+- `writeHeapSnapshot` — module
 - `writeRawBytes` — instance *(class: `Serializer`)*
 - `writeUint32` — instance *(class: `Serializer`)*
 - `writeUint64` — instance *(class: `Serializer`)*

--- a/test-parity/node-suite/v8/exports/diagnostics-surface.ts
+++ b/test-parity/node-suite/v8/exports/diagnostics-surface.ts
@@ -1,0 +1,21 @@
+// #3904: node:v8 modern diagnostics/profiler named exports surface.
+import * as v8 from "node:v8";
+import {
+  getCppHeapStatistics,
+  getHeapSnapshot,
+  isStringOneByteRepresentation,
+  queryObjects,
+  startCpuProfile,
+  writeHeapSnapshot,
+} from "node:v8";
+
+for (const [name, value] of [
+  ["getCppHeapStatistics", getCppHeapStatistics],
+  ["getHeapSnapshot", getHeapSnapshot],
+  ["isStringOneByteRepresentation", isStringOneByteRepresentation],
+  ["queryObjects", queryObjects],
+  ["startCpuProfile", startCpuProfile],
+  ["writeHeapSnapshot", writeHeapSnapshot],
+] as const) {
+  console.log(name, typeof value, value.length, typeof (v8 as any)[name]);
+}


### PR DESCRIPTION
## Summary

Closes #3904. Adds the modern `node:v8` diagnostics/profiler named exports Node ships in its ESM namespace but Perry's manifest omitted (so `import { queryObjects, getCppHeapStatistics, ... } from "node:v8"` failed `perry check`): `getCppHeapStatistics`, `getHeapSnapshot`, `isStringOneByteRepresentation`, `queryObjects`, `startCpuProfile`, `writeHeapSnapshot`.

## Implementation
- `crates/perry-api-manifest/src/entries.rs` — six `method("v8", …)` rows.
- `crates/perry-runtime/src/object/native_module.rs` — the six added to `is_native_module_callable_export` (named/namespace reads are function-valued) + `native_callable_export_arity` (Node `.length`: `getCppHeapStatistics`/`startCpuProfile` 0, `getHeapSnapshot`/`isStringOneByteRepresentation`/`queryObjects` 1, `writeHeapSnapshot` 2).
- `test-parity/node-suite/v8/exports/diagnostics-surface.ts` + regenerated `docs/api/perry.d.ts` / `reference.md`.

## Validation
- Fixture **byte-identical** to `node --experimental-strip-types` in both no-opt and auto-optimize builds (typeof + `.length` + namespace identity).
- `manifest_consistency` 5/5, `cargo fmt --all -- --check` clean.

## Scope
Export-surface/manifest parity. Deeper behavior of `getHeapSnapshot`/`writeHeapSnapshot` remains tracked by #3140.
