### PR TITLE
fix(Array): multi-arg Array(...) / new Array(...) build the element list (#3985 partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1078 — fix(Array): multi-arg Array(...) / new Array(...) build the element list (#3985, partial)
+
+`Array(0, 1, 0, 1)` and `new Array(1, 2, 3)` returned a **length-0** array instead of `[0,1,0,1]` / `[1,2,3]`. `lower_builtin_new`'s `"Array"` arm handled the empty (`Array()`), single-number (`Array(5)` → sparse length), and single-value (`Array("x")` → one element) cases, but **returned `Ok(None)` for ≥2 args**, falling back to a generic path that produced an empty array.
+
+Fix (`crates/perry-codegen/src/lower_call/builtin.rs`): a multi-arg `Array(a, b, c, …)` is the element-list form — semantically identical to the `[a, b, c, …]` literal — so it now delegates to `lower_array_literal(ctx, args)`. Both the call form `Array(...)` and `new Array(...)` route through here, so both are fixed.
+
+Validated against `node --experimental-strip-types`: `Array(0,1,0,1)` → `[0,1,0,1]` (length 4), `new Array(1,2,3)` → `[1,2,3]`, `new Array("x","y")` → `["x","y"]`; `Array(5)` (sparse length 5), `Array()`, and `Array("only")` unchanged; `perry-codegen` array tests + object/array node-suite sweep green. This is a focused sub-fix of #3985 — the deeper Array-exotic prototype-identity cases (`[].toString === Array.prototype.toString`, `Array.isArray(Array.prototype)`) remain open there.
+
 ## v0.5.1077 — node:v8: expose modern diagnostics/profiler named exports (#3904)
 
 Perry's `node:v8` manifest omitted several function-valued exports Node ships in the ESM namespace, so `import { queryObjects, getCppHeapStatistics, ... } from "node:v8"` failed `perry check` before runtime. Added `getCppHeapStatistics`, `getHeapSnapshot`, `isStringOneByteRepresentation`, `queryObjects`, `startCpuProfile`, and `writeHeapSnapshot` as function-valued exports (Node `.length` values preserved).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1077
+**Current Version:** 0.5.1078
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1077"
+version = "0.5.1078"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1077"
+version = "0.5.1078"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1077"
+version = "0.5.1078"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1077"
+version = "0.5.1078"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1077"
+version = "0.5.1078"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -16,7 +16,7 @@
 use anyhow::Result;
 use perry_hir::Expr;
 
-use crate::expr::{lower_expr, nanbox_pointer_inline, unbox_to_i64, FnCtx};
+use crate::expr::{lower_array_literal, lower_expr, nanbox_pointer_inline, unbox_to_i64, FnCtx};
 use crate::nanbox::double_literal;
 use crate::types::{DOUBLE, I32, I64};
 
@@ -760,20 +760,27 @@ pub(super) fn lower_builtin_new(
         "Array" => {
             // `new Array()` → empty array, `new Array(n)` → length-n sparse
             // array after runtime validation, and `new Array(value)` with a
-            // non-number argument → one-element array. Multi-arg calls fall
-            // back to the generic Expr::New path.
-            let blk = ctx.block();
-            let handle = if args.is_empty() {
-                blk.call(I64, "js_array_create", &[])
-            } else if args.len() == 1 {
+            // non-number argument → one-element array.
+            if args.is_empty() {
+                let blk = ctx.block();
+                let handle = blk.call(I64, "js_array_create", &[]);
+                let blk = ctx.block();
+                return Ok(Some(nanbox_pointer_inline(blk, &handle)));
+            }
+            if args.len() == 1 {
                 let value = lower_expr(ctx, &args[0])?;
                 let blk = ctx.block();
-                blk.call(I64, "js_array_constructor_single", &[(DOUBLE, &value)])
-            } else {
-                return Ok(None);
-            };
-            let blk = ctx.block();
-            Ok(Some(nanbox_pointer_inline(blk, &handle)))
+                let handle = blk.call(I64, "js_array_constructor_single", &[(DOUBLE, &value)]);
+                let blk = ctx.block();
+                return Ok(Some(nanbox_pointer_inline(blk, &handle)));
+            }
+            // #3985: `Array(a, b, c, ...)` / `new Array(a, b, ...)` with ≥2 args
+            // is the element-list form — semantically identical to the
+            // `[a, b, c, ...]` literal (only the single-number form means
+            // "length"). Previously this returned `Ok(None)` and fell back to a
+            // generic path that produced a length-0 array.
+            let arr = lower_array_literal(ctx, args)?;
+            Ok(Some(arr))
         }
         "Response" => {
             // new Response(body?, init?) — init = { status?, statusText?, headers? }


### PR DESCRIPTION
## fix(Array): multi-arg `Array(...)` / `new Array(...)` build the element list (#3985, partial)

```ts
Array(0, 1, 0, 1).length    // was 0  → now 4   ([0,1,0,1])
new Array(1, 2, 3).length   // was 0  → now 3   ([1,2,3])
```

### Root cause
`lower_builtin_new`'s `"Array"` arm (`crates/perry-codegen/src/lower_call/builtin.rs`) handled:
- `Array()` → empty
- `Array(5)` → sparse length-5
- `Array("x")` → one-element

…but **returned `Ok(None)` for ≥2 args**, falling back to a generic path that produced a length-0 array.

### Fix
A multi-arg `Array(a, b, c, …)` is the element-list form — semantically identical to the `[a, b, c, …]` literal — so it now delegates to `lower_array_literal(ctx, args)` (the same lowering array literals use, unchanged). Both `Array(...)` and `new Array(...)` route through `lower_builtin_new`, so both are fixed.

### Validation (vs `node --experimental-strip-types`)
- `Array(0,1,0,1)` → `[0,1,0,1]` (len 4); `new Array(1,2,3)` → `[1,2,3]`; `new Array("x","y")` → `["x","y"]` ✅
- `Array(5)` (sparse len 5), `Array()`, `Array("only")` → unchanged ✅
- `perry-codegen` array unit tests + object/array node-suite sweep green ✅

This is a focused sub-fix of #3985. The deeper Array-exotic prototype-identity cases (`[].toString === Array.prototype.toString`, `Array.isArray(Array.prototype)`) are foundational rework and remain open under #3985.
