### PR TITLE
fix(http2): expose server/client/default export surface (#3905)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1079 — node:http2: expose server/client/default export surface (#3905)
+
+Perry's `node:http2` manifest claimed `createSecureServer`, the settings helpers, `performServerHandshake`, `sensitiveHeaders`, `constants`, and the request/response classes, but omitted the non-secure server factory, the client-session factory, and the module default — so `import { connect, createServer } from "node:http2"` (and `import http2 from "node:http2"`) failed `perry check` before runtime.
+
+- **`crates/perry-api-manifest/src/entries.rs`** — `method("http2","createServer")`, `method("http2","connect")`, `property("http2","default")`.
+- **`crates/perry-runtime/src/object/native_module.rs`** — `connect` added to `is_native_module_callable_export` (function-valued; `createServer` was already callable) + `native_callable_export_arity` (Node `.length`: `connect` 3, `createServer` 2); the `"http2"` property arm returns the module namespace for `default`.
+- **`test-parity/node-suite/http2/exports/server-client-surface.ts`** — new fixture (typeof/`.length`, namespace identity, default-import object + its `connect`/`createServer`); byte-identical to `node --experimental-strip-types`.
+
+Export-surface/manifest parity only; deeper server/client session behavior (and `createSecureServer({})` construction, #3884) stays tracked separately.
+
 ## v0.5.1078 — fix(Array): multi-arg Array(...) / new Array(...) build the element list (#3985, partial)
 
 `Array(0, 1, 0, 1)` and `new Array(1, 2, 3)` returned a **length-0** array instead of `[0,1,0,1]` / `[1,2,3]`. `lower_builtin_new`'s `"Array"` arm handled the empty (`Array()`), single-number (`Array(5)` → sparse length), and single-value (`Array("x")` → one element) cases, but **returned `Ok(None)` for ≥2 args**, falling back to a generic path that produced an empty array.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1078
+**Current Version:** 0.5.1079
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1078"
+version = "0.5.1079"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1078"
+version = "0.5.1079"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1078"
+version = "0.5.1079"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1078"
+version = "0.5.1079"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1078"
+version = "0.5.1079"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -4778,6 +4778,13 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // read matches Node's `typeof` / `name` / `length` shape; wired through
     // `is_native_module_callable_export` / `native_callable_export_arity`.
     method("http2", "performServerHandshake", false, None),
+    // #3905: remaining public ESM export surface — the non-secure server
+    // factory, the client-session factory, and the module default (namespace
+    // object). `createServer` is already runtime-callable; these unblock the
+    // named/default imports that Node accepts.
+    method("http2", "createServer", false, None),
+    method("http2", "connect", false, None),
+    property("http2", "default"),
     internal_class("http2", "Http2SecureServer"),
     class("http2", "Http2ServerRequest"),
     class("http2", "Http2ServerResponse"),

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -2178,6 +2178,10 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ("net", "Socket") => Some(1),
         // #3720: `http2.performServerHandshake(socket[, options])` — length 1.
         ("http2", "performServerHandshake") => Some(1),
+        // #3905: Node `.length` — connect(authority,options,listener)=3,
+        // createServer(options,handler)=2.
+        ("http2", "connect") => Some(3),
+        ("http2", "createServer") => Some(2),
         // #3712: node:http module-level helper exports.
         ("http", "validateHeaderName" | "validateHeaderValue") => Some(2),
         ("http", "setMaxIdleHTTPParsers" | "setGlobalProxyFromEnv") => Some(1),
@@ -3673,6 +3677,9 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("http2", "createServer")
             | ("http2", "createSecureServer")
             | ("http2", "Server")
+            // #3905: `http2.connect(authority[, options][, listener])` client
+            // session factory reads as a function.
+            | ("http2", "connect")
             // #3720: module-level handshake helper reads as a function.
             | ("http2", "performServerHandshake")
             // #3680/#3679: node:v8 class constructors + diagnostic-control
@@ -5260,6 +5267,9 @@ pub(crate) unsafe fn get_native_module_constant(
         "http2" => match property {
             "constants" => Some(create_sub_namespace("http2.constants")),
             "sensitiveHeaders" => Some(crate::node_http2_constants::sensitive_headers_symbol()),
+            // #3905: `import http2 from "node:http2"` — default is the module
+            // namespace object.
+            "default" => Some(native_namespace_or_create("http2", namespace_obj)),
             _ => None,
         },
         "http2.constants" => crate::node_http2_constants::constant(property),

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2520 entries across 106 modules
+// Coverage: 2523 entries across 106 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -1720,9 +1720,16 @@ declare module "http2" {
   /** stdlib */
   export const constants: any;
   /** stdlib */
+  const _default: any;
+  export default _default;
+  /** stdlib */
   export const sensitiveHeaders: any;
   /** stdlib */
+  export function connect(...args: any[]): any;
+  /** stdlib */
   export function createSecureServer(...args: any[]): any;
+  /** stdlib */
+  export function createServer(...args: any[]): any;
   /** stdlib */
   export function getDefaultSettings(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2520 entries across 106 modules.
+Total: 2523 entries across 106 modules.
 
 ## Modules
 
@@ -1527,7 +1527,9 @@ Total: 2520 entries across 106 modules.
 
 ### Methods
 
+- `connect` — module
 - `createSecureServer` — module
+- `createServer` — module
 - `getDefaultSettings` — module
 - `getPackedSettings` — module
 - `getUnpackedSettings` — module
@@ -1536,6 +1538,7 @@ Total: 2520 entries across 106 modules.
 ### Properties
 
 - `constants`
+- `default`
 - `sensitiveHeaders`
 
 ## `https`

--- a/test-parity/node-suite/http2/exports/server-client-surface.ts
+++ b/test-parity/node-suite/http2/exports/server-client-surface.ts
@@ -1,0 +1,18 @@
+// #3905: node:http2 server/client/handshake/sensitiveHeaders export surface.
+import http2Default from "node:http2";
+import * as http2 from "node:http2";
+import {
+  connect,
+  createServer,
+  performServerHandshake,
+  sensitiveHeaders,
+} from "node:http2";
+
+console.log("connect:", typeof connect, connect.length);
+console.log("createServer:", typeof createServer, createServer.length);
+console.log("performServerHandshake:", typeof performServerHandshake);
+console.log("sensitiveHeaders:", typeof sensitiveHeaders);
+console.log("namespace connect:", typeof http2.connect);
+console.log("default:", typeof http2Default);
+console.log("default.connect:", typeof http2Default.connect);
+console.log("default.createServer:", typeof http2Default.createServer);


### PR DESCRIPTION
## Summary

Closes #3905. Adds the remaining public `node:http2` ESM exports Perry's manifest omitted: the non-secure server factory `createServer`, the client-session factory `connect`, and the module `default` (namespace object). `performServerHandshake` and `sensitiveHeaders` were already present. Before this, `import { connect, createServer } from "node:http2"` and `import http2 from "node:http2"` failed `perry check`.

## Implementation
- `crates/perry-api-manifest/src/entries.rs` — `method("http2","createServer")`, `method("http2","connect")`, `property("http2","default")`.
- `crates/perry-runtime/src/object/native_module.rs` — `connect` added to `is_native_module_callable_export` (function-valued; `createServer` was already runtime-callable) + `native_callable_export_arity` (Node `.length`: `connect` 3, `createServer` 2); the `"http2"` property arm returns the module namespace for `default`.
- `test-parity/node-suite/http2/exports/server-client-surface.ts` + regenerated docs.

## Validation
- Fixture **byte-identical** to `node --experimental-strip-types` in both no-opt and auto-optimize builds (typeof/`.length`, namespace identity, default-import object + its `connect`/`createServer`).
- `manifest_consistency` 5/5, `cargo fmt --all -- --check` clean.

## Scope
Export-surface/manifest parity. Deeper server/client session behavior and `createSecureServer({})` construction (#3884) remain tracked separately.
