### PR TITLE
fix(https): request/get/Agent value-reads resolve to functions (#3697)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1080 — node:https: request/get/Agent value-reads resolve to functions (#3697)
+
+`node:https` advertised `request`, `get`, and `Agent` in the API manifest, but reading them as values — `import { request } from "node:https"` or `https.request` — returned `undefined` (only the direct call form `https.request(...)` worked, via the codegen dispatch table). They were missing from `is_native_module_callable_export`, so the bound-value read fell through to `undefined`.
+
+- **`crates/perry-runtime/src/object/native_module.rs`** — `("https","request")`, `("https","get")`, `("https","Agent")` added to `is_native_module_callable_export` (so value reads return the bound function) + `native_callable_export_arity` (Node `.length`: `request` 0, `get` 3, `Agent` 1).
+- **`test-parity/node-suite/https/exports/module-surface.ts`** — new fixture (typeof/`.length`, named-import identity `=== https.X`); byte-identical to `node --experimental-strip-types`.
+
+Import/module-surface parity (closes #3697/#3695). Deeper `Agent` instance behavior, client overloads, and server controls stay tracked separately. (The sibling `node:http` request/get/Agent value reads have the same shape and remain available via the dispatch table for calls.)
+
 ## v0.5.1079 — node:http2: expose server/client/default export surface (#3905)
 
 Perry's `node:http2` manifest claimed `createSecureServer`, the settings helpers, `performServerHandshake`, `sensitiveHeaders`, `constants`, and the request/response classes, but omitted the non-secure server factory, the client-session factory, and the module default — so `import { connect, createServer } from "node:http2"` (and `import http2 from "node:http2"`) failed `perry check` before runtime.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1079
+**Current Version:** 0.5.1080
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1079"
+version = "0.5.1080"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1079"
+version = "0.5.1080"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1079"
+version = "0.5.1080"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1079"
+version = "0.5.1080"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1079"
+version = "0.5.1080"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -2182,6 +2182,10 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         // createServer(options,handler)=2.
         ("http2", "connect") => Some(3),
         ("http2", "createServer") => Some(2),
+        // #3697: node:https module-level exports (Node `.length`).
+        ("https", "request") => Some(0),
+        ("https", "get") => Some(3),
+        ("https", "Agent") => Some(1),
         // #3712: node:http module-level helper exports.
         ("http", "validateHeaderName" | "validateHeaderValue") => Some(2),
         ("http", "setMaxIdleHTTPParsers" | "setGlobalProxyFromEnv") => Some(1),
@@ -3674,6 +3678,13 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("http", "Server")
             | ("https", "createServer")
             | ("https", "Server")
+            // #3697: `https.request` / `https.get` / `https.Agent` value reads
+            // (named/namespace imports) must be function-valued. The call form
+            // already lowers through the codegen NATIVE_MODULE_TABLE; without
+            // these the bound-value read returned `undefined`.
+            | ("https", "request")
+            | ("https", "get")
+            | ("https", "Agent")
             | ("http2", "createServer")
             | ("http2", "createSecureServer")
             | ("http2", "Server")

--- a/test-parity/node-suite/https/exports/module-surface.ts
+++ b/test-parity/node-suite/https/exports/module-surface.ts
@@ -1,0 +1,15 @@
+// #3697: node:https top-level export surface (request/get/Agent/Server/createServer).
+import * as https from "node:https";
+import { Agent, Server, createServer, get, request } from "node:https";
+
+console.log("request:", typeof https.request, https.request.length);
+console.log("get:", typeof https.get, https.get.length);
+console.log("Agent:", typeof https.Agent, https.Agent.length);
+console.log("Server:", typeof https.Server);
+console.log("createServer:", typeof https.createServer);
+console.log("globalAgent:", typeof https.globalAgent);
+console.log("named request:", typeof request, request === https.request);
+console.log("named get:", typeof get, get === https.get);
+console.log("named Agent:", typeof Agent, Agent === https.Agent);
+console.log("named Server:", typeof Server);
+console.log("named createServer:", typeof createServer);


### PR DESCRIPTION
## Summary

Closes #3697 (and its duplicate #3695). `node:https` advertised `request`, `get`, and `Agent` in the API manifest, but reading them as values — `import { request } from "node:https"` or `https.request` — returned `undefined`. Only the direct call form `https.request(...)` worked (via the codegen `NATIVE_MODULE_TABLE`); the value-read path fell through to `undefined` because they were missing from `is_native_module_callable_export`.

## Implementation
- `crates/perry-runtime/src/object/native_module.rs` — `("https","request")`, `("https","get")`, `("https","Agent")` added to `is_native_module_callable_export` (value reads now return the bound function value) + `native_callable_export_arity` (Node `.length`: `request` 0, `get` 3, `Agent` 1).
- `test-parity/node-suite/https/exports/module-surface.ts` — new fixture.

## Validation
- Fixture **byte-identical** to `node --experimental-strip-types` in both no-opt and auto-optimize builds: `typeof`/`.length` for `request`/`get`/`Agent`/`Server`/`createServer`/`globalAgent`, plus named-import identity (`request === https.request`, etc.).
- `cargo fmt --all -- --check` clean. No manifest change (entries already present → no `.d.ts` diff).

## Scope
Import/module-surface parity. Deeper `Agent` instance behavior, client overloads, and server controls remain tracked separately.
