### PR TITLE
runtime/string: fix remaining String parity tail cases

### DIFF
--- a/crates/perry-runtime/src/object/polymorphic_index.rs
+++ b/crates/perry-runtime/src/object/polymorphic_index.rs
@@ -35,21 +35,14 @@ pub extern "C" fn js_object_get_index_polymorphic(obj_handle: i64, idx: f64) -> 
     if raw < 0x1000 {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
-    let idx_i32 = idx as i32;
-    if idx_i32 < 0 {
-        // Negative numeric keys → string keys on the object path.
-        let s = idx_i32.to_string();
-        let key = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
-        let v = js_object_get_field_by_name(raw as *mut ObjectHeader, key);
-        return f64::from_bits(v.bits());
-    }
-
     if crate::buffer::is_registered_buffer(raw as usize) {
+        let idx_i32 = idx as i32;
         let byte_val =
             crate::buffer::js_buffer_get(raw as *const crate::buffer::BufferHeader, idx_i32);
         return byte_val as f64;
     }
     if crate::typedarray::lookup_typed_array_kind(raw as usize).is_some() {
+        let idx_i32 = idx as i32;
         return crate::typedarray::js_typed_array_get(
             raw as *const crate::typedarray::TypedArrayHeader,
             idx_i32,
@@ -63,6 +56,19 @@ pub extern "C" fn js_object_get_index_polymorphic(obj_handle: i64, idx: f64) -> 
         }
         *(gc_header_addr as *const u8)
     };
+
+    if gc_type == crate::gc::GC_TYPE_STRING {
+        return crate::string::js_string_index_get(raw as *const crate::StringHeader, idx);
+    }
+
+    let idx_i32 = idx as i32;
+    if idx_i32 < 0 {
+        // Negative numeric keys → string keys on the object path.
+        let s = idx_i32.to_string();
+        let key = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+        let v = js_object_get_field_by_name(raw as *mut ObjectHeader, key);
+        return f64::from_bits(v.bits());
+    }
 
     if gc_type == crate::gc::GC_TYPE_ARRAY || gc_type == crate::gc::GC_TYPE_LAZY_ARRAY {
         return crate::array::js_array_get_f64(

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -47,7 +47,8 @@ pub use append::js_string_append;
 pub use base64_codec::{js_atob, js_btoa};
 pub use char_ops::{
     js_string_at, js_string_char_at, js_string_char_code_at, js_string_code_point_at,
-    js_string_from_char_code, js_string_from_code_point, js_string_to_char_array,
+    js_string_from_char_code, js_string_from_code_point, js_string_index_get,
+    js_string_to_char_array,
 };
 pub use compare::{
     js_string_compare, js_string_ends_with, js_string_ends_with_at, js_string_equals,

--- a/test-files/test_issue_3987_string_tail.ts
+++ b/test-files/test_issue_3987_string_tail.ts
@@ -1,0 +1,37 @@
+function check(label: string, condition: boolean): void {
+  if (!condition) {
+    throw new Error(label);
+  }
+}
+
+function checkEq(label: string, actual: string, expected: string): void {
+  if (actual !== expected) {
+    throw new Error(label + ": " + actual + " !== " + expected);
+  }
+}
+
+checkEq("number exponent upper threshold", String(1000000000000000000000), "1e+21");
+checkEq("number exponent lower threshold", String(0.0000001), "1e-7");
+checkEq("array string coercion", String(new Array(1, 2, 3)), "1,2,3");
+
+const s = "globglob";
+check("string NaN index", (s as any)[NaN] === undefined);
+check("string Infinity index", (s as any)[Infinity] === undefined);
+check("string negative index", (s as any)[-1] === undefined);
+check("string fractional index", (s as any)[1.5] === undefined);
+check("string out-of-range index", (s as any)[99] === undefined);
+check("string canonical numeric index", (s as any)[0] === "g");
+check("string string numeric index", (s as any)["1"] === "l");
+check("string noncanonical string index", (s as any)["01"] === undefined);
+
+let sideEffects = 0;
+function extra(): number {
+  sideEffects += 1;
+  return 99;
+}
+
+check("charAt ignores extra args", s.charAt(0, extra(), extra(), extra()) === "g");
+check("charCodeAt ignores extra args", s.charCodeAt(0, extra(), extra(), extra()) === 103);
+check("ignored extra args are evaluated", sideEffects === 6);
+
+console.log("string-tail-3987 ok");


### PR DESCRIPTION
Fixes the remaining String parity tail from #3987 after #3996 landed the Object boxing/String-wrapper subset.

Base: c98df110773a8b4244b9677ffd295b3171d9a8d7

Summary:
- Route String(number) through Perry's JS number formatter for Node exponent thresholds.
- Add string exotic indexed property reads so invalid keys return undefined while canonical in-range indices return one-character strings.
- Preserve upstream Array exotic lowering for multi-arg new Array(...), so String(new Array(1,2,3)) matches Node on current main.
- Permit extra args for charAt/charCodeAt/at/codePointAt while still evaluating ignored args.
- Add focused fixture test-files/test_issue_3987_string_tail.ts.

DeepWiki:
- Saved full response locally at target/deepwiki/string-tostring-indexing.md

Verification from the implementation thread before final rebase:
- cargo check -p perry-runtime
- cargo check -p perry-codegen
- cargo build -p perry
- cargo build -p perry-runtime
- node --experimental-strip-types test-files/test_issue_3987_string_tail.ts
- PERRY_NO_AUTO_OPTIMIZE=1 target/debug/perry run test-files/test_issue_3987_string_tail.ts
- PERRY_NO_AUTO_OPTIMIZE=1 target/debug/perry run test-files/test_gap_object_string_wrappers.ts
- git diff --check

Post-rebase check:
- git diff --check HEAD~1..HEAD

Test262:
- Not run because the suite is not vendored; test-compat/test262 only contains README/features/pinned-sha/preamble.

Residual risk:
- Full auto-optimize stdlib archive build was not completed locally because the machine repeatedly exhausted disk while compiling unrelated heavy stdlib dependencies.