### PR TITLE
Fix first-request fetch handle collisions

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/media.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/media.rs
@@ -451,7 +451,7 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
         ret: NR_VOID,
     },
     // zlib Transform-stream factories (#1843 cluster 1). Each returns an i64
-    // stream handle (0x60000+ range) NaN-boxed with POINTER_TAG; subsequent
+    // stream handle (zlib small-handle range) NaN-boxed with POINTER_TAG; subsequent
     // `.write`/`.end`/`.on`/`.pipe`/`.flush`/`.close` lose their static type
     // and route through HANDLE_METHOD_DISPATCH → `dispatch_zlib_stream`
     // (crates/perry-stdlib/src/common/dispatch.rs). `options` is NaN-boxed f64.

--- a/crates/perry-ffi/src/handle.rs
+++ b/crates/perry-ffi/src/handle.rs
@@ -18,7 +18,9 @@
 //! Each `i64` is allocated atomically from a counter starting at 1
 //! — `0` is reserved as `INVALID_HANDLE` so `register_handle` can
 //! never produce a falsy value (matches JS truthiness semantics
-//! for type checks like `if (handle)`).
+//! for type checks like `if (handle)`). Visible ids stop before
+//! `0x40000`; the pointer-tagged small-handle band above that is
+//! reserved for Web Fetch and proxy handles.
 //!
 //! perry-stdlib has its own copy of this same registry (in
 //! `crates/perry-stdlib/src/common/handle.rs`). They are separate
@@ -26,7 +28,10 @@
 //! up via perry-stdlib's `get_handle`, and vice versa. Programs
 //! that link both registries (e.g. via the well-known flip) just
 //! end up with two `DashMap` statics; each wrapper consults the
-//! registry it was compiled against, so handles never collide.
+//! registry it was compiled against. Values returned to JS can still collide
+//! at the runtime dispatch layer if two subsystems expose the same
+//! `POINTER_TAG | id` bits, so handle families that participate in generic
+//! property/method dispatch reserve disjoint visible id ranges.
 //!
 //! # Safety
 //!
@@ -58,7 +63,10 @@ pub type Handle = i64;
 pub const INVALID_HANDLE: Handle = 0;
 
 static HANDLES: Lazy<DashMap<Handle, Box<dyn Any + Send + Sync>>> = Lazy::new(DashMap::new);
-static NEXT_HANDLE: AtomicI64 = AtomicI64::new(1);
+const FFI_HANDLE_ID_START: Handle = 1;
+const FFI_HANDLE_ID_END: Handle = 0x40000;
+
+static NEXT_HANDLE: AtomicI64 = AtomicI64::new(FFI_HANDLE_ID_START);
 static ROOT_SCANNERS: Lazy<Mutex<Vec<fn(&mut dyn FnMut(f64))>>> =
     Lazy::new(|| Mutex::new(Vec::new()));
 static MUTABLE_ROOT_SCANNERS: Lazy<Mutex<Vec<NamedGcMutableRootScanner>>> =
@@ -185,8 +193,16 @@ impl<'a> GcRootVisitor<'a> {
 /// across threads (tokio workers may resolve promises that touch
 /// handle data while the main thread is also touching it).
 pub fn register_handle<T: 'static + Send + Sync>(value: T) -> Handle {
-    let handle = NEXT_HANDLE.fetch_add(1, Ordering::SeqCst);
+    let handle = next_handle_id();
     HANDLES.insert(handle, Box::new(value));
+    handle
+}
+
+fn next_handle_id() -> Handle {
+    let handle = NEXT_HANDLE.fetch_add(1, Ordering::SeqCst);
+    if handle >= FFI_HANDLE_ID_END {
+        panic!("perry-ffi handle id range exhausted before reserved Web handle bands");
+    }
     handle
 }
 
@@ -496,6 +512,7 @@ mod tests {
     fn round_trip_simple_value() {
         let h = register_handle(42_i64);
         assert_ne!(h, INVALID_HANDLE);
+        assert!(h < FFI_HANDLE_ID_END);
         let v = with_handle::<i64, _, _>(h, |v| *v).expect("present");
         assert_eq!(v, 42);
         assert!(drop_handle(h));

--- a/crates/perry-runtime/src/builtins/arithmetic.rs
+++ b/crates/perry-runtime/src/builtins/arithmetic.rs
@@ -213,7 +213,7 @@ pub extern "C" fn js_value_typeof(value: f64) -> *mut StringHeader {
         // …) — small ids bit-OR'd with POINTER_TAG, not real heap pointers,
         // which always live above 0x100000. `typeof aHandle` is "object".
         // Reading a fake handle's `[ptr+12]` type tag otherwise segfaults
-        // (e.g. zlib's 0x60000 stream base).
+        // (e.g. zlib's reserved stream base).
         let ptr = jsval.as_pointer::<u8>();
         if !ptr.is_null() && (ptr as usize) >= 0x100000 {
             // Symbols: registered in SYMBOL_POINTERS (handles both gc_malloc'd

--- a/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
+++ b/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
@@ -39,7 +39,7 @@ pub(super) unsafe fn boxed_primitive_base_for_object(
 unsafe fn boxed_primitive_payload_for_object(
     obj_ptr: *const crate::object::ObjectHeader,
 ) -> Option<(u32, f64)> {
-    if obj_ptr.is_null() {
+    if obj_ptr.is_null() || (obj_ptr as usize) < 0x100000 {
         return None;
     }
     let class_id = (*obj_ptr).class_id;
@@ -164,12 +164,12 @@ pub(crate) fn boxed_primitive_payload(value: f64) -> Option<(u32, f64)> {
     let bits = value.to_bits();
     let ptr = if jv.is_pointer() {
         jv.as_pointer::<crate::object::ObjectHeader>() as *mut crate::object::ObjectHeader
-    } else if (bits >> 48) == 0 && bits >= (crate::gc::GC_HEADER_SIZE as u64) + 0x1000 {
+    } else if (bits >> 48) == 0 && bits >= 0x100000 {
         bits as *mut crate::object::ObjectHeader
     } else {
         return None;
     };
-    if ptr.is_null() || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+    if ptr.is_null() || (ptr as usize) < 0x100000 {
         return None;
     }
     unsafe { boxed_primitive_payload_for_object(ptr) }
@@ -242,4 +242,15 @@ pub extern "C" fn js_boxed_symbol_new(value: f64) -> f64 {
     register_boxed_primitive_payload(obj, value);
     attach_boxed_primitive_prototype(obj, CLASS_ID_BOXED_SYMBOL);
     crate::value::js_nanbox_pointer(obj as i64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn boxed_primitive_probe_rejects_pointer_tagged_native_handles() {
+        let fetch_family_handle = crate::value::js_nanbox_pointer(0x40001);
+        assert!(boxed_primitive_payload(fetch_family_handle).is_none());
+    }
 }

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -2502,7 +2502,7 @@ pub fn is_class_object_ptr(ptr: *const u8) -> bool {
     // timers, …) bit-OR'd with POINTER_TAG, not real heap pointers — real
     // objects always live well above 0x100000. The previous 0x1008 floor only
     // caught the tiny net/fastify id space; a mid-range handle (e.g. zlib's
-    // 0x60000 stream base, #1843) sailed past it and this function then
+    // zlib stream base, #1843) sailed past it and this function then
     // segfaulted dereferencing `[handle - 8]` as a GcHeader. 0x100000 is the
     // same handle/real-pointer threshold `js_native_call_method` already uses.
     if ptr.is_null() || (ptr as usize) < 0x100000 {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -352,7 +352,7 @@ pub extern "C" fn js_object_set_field(obj: *mut ObjectHeader, field_index: u32, 
 /// method body and crashing on the bogus `this` pointer.
 #[no_mangle]
 pub extern "C" fn js_object_get_class_id(obj: *const ObjectHeader) -> u32 {
-    if obj.is_null() || (obj as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+    if obj.is_null() || (obj as usize) < 0x100000 {
         return 0;
     }
     let addr = obj as usize;
@@ -1149,7 +1149,7 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
         let f = f64::from_bits(obj.to_bits());
         if key_val.is_any_string() && f.is_finite() && f > 0.0 && f.fract() == 0.0 {
             let id = f as usize;
-            if (0x40000..0x100000).contains(&id) {
+            if (0x100000..0x200000).contains(&id) {
                 if let Some(probe) = crate::object::stream_handle_probe() {
                     unsafe {
                         if probe(id) {
@@ -1449,10 +1449,10 @@ pub extern "C" fn js_object_get_field_by_name(
     // Node. `js_proxy_is_proxy` validates the value is a *registered* proxy so a
     // real heap object whose address happens to be small isn't misrouted.
     {
-        // Proxy ids live in [0x50000, 0x100000); `js_proxy_is_proxy` confirms
+        // Proxy ids live in [0xF0000, 0x100000); `js_proxy_is_proxy` confirms
         // it is a *registered* proxy before we route to the proxy getter.
         let addr = obj as u64;
-        if (0x50000..0x100000).contains(&addr) && !key.is_null() {
+        if (0xF0000..0x100000).contains(&addr) && !key.is_null() {
             const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
             let boxed = f64::from_bits(POINTER_TAG | (addr & 0x0000_FFFF_FFFF_FFFF));
             if crate::proxy::js_proxy_is_proxy(boxed) != 0 {
@@ -1735,9 +1735,9 @@ pub extern "C" fn js_object_get_field_by_name(
         }
     }
     // #1670: Web Streams handles are returned as `id as f64` (a normal
-    // float, NOT NaN-boxed) in the reserved range 0x40000..0x100000, so an
-    // inline `res.body.locked` reaches this generic field-get with `obj`
-    // carrying the float bits of the stream id (e.g. 0x4110_… for 262144).
+    // float, NOT NaN-boxed) just above the pointer-tagged small-handle band, so
+    // an inline `res.body.locked` reaches this generic field-get with `obj`
+    // carrying the IEEE-754 bits of the stream id.
     // The NaN-box-strip + small-handle branches below don't recognise it
     // (top16 is an ordinary exponent, not a tag; the value as a pointer is
     // far above 0x100000), so it would be dereferenced as a heap pointer →
@@ -1751,7 +1751,7 @@ pub extern "C" fn js_object_get_field_by_name(
         let f = f64::from_bits(obj as u64);
         if !key.is_null() && f.is_finite() && f > 0.0 && f.fract() == 0.0 {
             let id = f as usize;
-            if (0x40000..0x100000).contains(&id) {
+            if (0x100000..0x200000).contains(&id) {
                 if let Some(probe) = crate::object::stream_handle_probe() {
                     unsafe {
                         if probe(id) {

--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -198,7 +198,10 @@ pub extern "C" fn js_value_is_promise(value: f64) -> i32 {
         return 0;
     }
     let ptr_usize = (bits & crate::value::POINTER_MASK) as usize;
-    if ptr_usize < 0x10000 {
+    // Pointer-tagged native handles (Fetch/Headers/Timers/etc.) also carry
+    // small payloads. They are not GC allocations and must not be probed as
+    // Promise headers before the handle dispatch tables see them.
+    if ptr_usize < 0x100000 {
         return 0;
     }
     unsafe {
@@ -1511,6 +1514,12 @@ mod tests {
         let key = crate::string::js_string_from_bytes(b"then".as_ptr(), 4);
         js_object_set_field_by_name(obj, key, js_nanbox_pointer(then as i64));
         js_nanbox_pointer(obj as i64)
+    }
+
+    #[test]
+    fn promise_probe_rejects_pointer_tagged_native_handles() {
+        let fetch_family_handle = js_nanbox_pointer(0x40001);
+        assert_eq!(js_value_is_promise(fetch_family_handle), 0);
     }
 
     extern "C" fn test_thenable_resolve_twice(

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -60,14 +60,12 @@ const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
 const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
 
 /// Tag bits high enough to live inside a 48-bit pointer slot but low enough
-/// that real heap pointers never collide. We offset the index so the returned
-/// "pointer" is always > 0x40000 (well above the handle-dispatch threshold
-/// `0x100000` used by some runtime paths? — actually handle dispatch fires
-/// under 0x100000). We intentionally pick < 0x100000 so the proxy cannot be
-/// mistaken for a real heap allocation and a conservative GC scan treats the
-/// value as a non-pointer. Any operation on a proxy MUST go through the
-/// Proxy* dispatch helpers in this module.
-const PROXY_TAG_BASE: u64 = 0x0005_0000;
+/// that real heap pointers never collide. Keep proxies near the top of the
+/// runtime's `< 0x100000` small-handle band so Web Fetch handles can occupy a
+/// broad disjoint range below this without sharing visible `POINTER_TAG | id`
+/// bits with a proxy. Any operation on a proxy MUST go through the Proxy*
+/// dispatch helpers in this module.
+const PROXY_TAG_BASE: u64 = 0x000F_0000;
 
 fn encode_proxy_id(id: u64) -> i64 {
     (PROXY_TAG_BASE + id) as i64

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -532,7 +532,7 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
     }
 
     // zlib Transform streams (#1843): `zlib.createGzip()` etc. return handles
-    // in the 0x60000+ range; their `.write`/`.end`/`.on`/`.pipe`/`.flush`/
+    // in the zlib small-handle range; their `.write`/`.end`/`.on`/`.pipe`/`.flush`/
     // `.params`/`.reset`/`.close` calls lose their static type and route here.
     // Gated on the registry AND the method vocabulary so a handle-id reused
     // across another subsystem's registry can't misroute (handle id-spaces
@@ -1405,7 +1405,8 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
     // id-range + registry membership so unrelated small-handle reads are
     // untouched.
     #[cfg(feature = "bundled-streams")]
-    if (0x40000..0x100000).contains(&(handle as usize))
+    if (crate::streams::STREAM_HANDLE_ID_START..crate::streams::STREAM_HANDLE_ID_END)
+        .contains(&(handle as usize))
         && crate::streams::js_stream_handle_is_registered(handle as usize)
     {
         return crate::streams::dispatch_stream_property(handle as f64, property_name);

--- a/crates/perry-stdlib/src/common/handle.rs
+++ b/crates/perry-stdlib/src/common/handle.rs
@@ -21,12 +21,25 @@ pub const INVALID_HANDLE: Handle = 0;
 /// Global handle registry using DashMap for concurrent access
 static HANDLES: Lazy<DashMap<Handle, Box<dyn Any + Send + Sync>>> = Lazy::new(DashMap::new);
 
-/// Next handle ID (0 is reserved for invalid/null)
-static NEXT_HANDLE: AtomicI64 = AtomicI64::new(1);
+const COMMON_HANDLE_ID_START: Handle = 1;
+const COMMON_HANDLE_ID_END: Handle = 0x40000;
+
+/// Next handle ID (0 is reserved for invalid/null). The visible low range stops
+/// before Web Fetch's pointer-tagged handle band so generic dispatch cannot
+/// confuse native wrappers with Fetch Request/Headers/Response handles.
+static NEXT_HANDLE: AtomicI64 = AtomicI64::new(COMMON_HANDLE_ID_START);
+
+fn next_handle_id() -> Handle {
+    let handle = NEXT_HANDLE.fetch_add(1, Ordering::SeqCst);
+    if handle >= COMMON_HANDLE_ID_END {
+        panic!("common native handle id range exhausted before reserved Web handle bands");
+    }
+    handle
+}
 
 /// Register an object and get a handle to it
 pub fn register_handle<T: 'static + Send + Sync>(value: T) -> Handle {
-    let handle = NEXT_HANDLE.fetch_add(1, Ordering::SeqCst);
+    let handle = next_handle_id();
     HANDLES.insert(handle, Box::new(value));
     handle
 }
@@ -161,6 +174,7 @@ mod tests {
         let handle = register_handle(value);
 
         assert!(handle != INVALID_HANDLE);
+        assert!(handle < COMMON_HANDLE_ID_END);
 
         let retrieved: Option<&String> = get_handle(handle);
         assert!(retrieved.is_some());

--- a/crates/perry-stdlib/src/fetch/body_metadata.rs
+++ b/crates/perry-stdlib/src/fetch/body_metadata.rs
@@ -62,10 +62,7 @@ lazy_static::lazy_static! {
 }
 
 fn alloc_form_data(store: FormDataStore) -> usize {
-    let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
-    let id = *id_guard;
-    *id_guard += 1;
-    drop(id_guard);
+    let id = alloc_fetch_handle_id();
     FORM_DATA_REGISTRY.lock().unwrap().insert(id, store);
     id
 }
@@ -190,10 +187,7 @@ pub extern "C" fn js_fetch_response_redirected(handle: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_response_static_error() -> f64 {
-    let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
-    let id = *id_guard;
-    *id_guard += 1;
-    drop(id_guard);
+    let id = alloc_fetch_handle_id();
     FETCH_RESPONSES.lock().unwrap().insert(
         id,
         FetchResponse {

--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -22,17 +22,22 @@ use perry_runtime::js_get_string_pointer_unified;
 /// i64, mirroring `js_get_string_pointer_unified`).
 ///
 /// A `ReadableStream` handle — e.g. another Response's `.body` — is a plain
-/// numeric f64 id allocated from `0x40000` with no NaN-box tag, so the generic
-/// string coercion would stringify the handle to its number (`"262144"`) and
-/// discard the real bytes. Hono re-wraps responses to mutate headers via
-/// `new Response(res.body, res)`, so the body must be DRAINED from the stream's
-/// buffered chunks instead. Any non-stream value falls back to the normal
-/// coercion, so plain string bodies (`c.json`/`c.text`) are unaffected.
+/// numeric f64 id with no NaN-box tag, so the generic string coercion would
+/// stringify the handle to its number and discard the real bytes. Hono re-wraps
+/// responses to mutate headers via `new Response(res.body, res)`, so the body
+/// must be DRAINED from the stream's buffered chunks instead. Any non-stream
+/// value falls back to the normal coercion, so plain string bodies
+/// (`c.json`/`c.text`) are unaffected.
 #[no_mangle]
 pub extern "C" fn js_response_body_init_ptr(value: f64) -> i64 {
-    // Stream ids live in [0x40000, 0x100000); a non-integral or out-of-range
-    // value can't be one, so we skip the registry probe for the common cases.
-    if value.is_finite() && value.fract() == 0.0 && (262144.0..1048576.0).contains(&value) {
+    // A non-integral or out-of-range value can't be a stream, so skip the
+    // registry probe for the common cases.
+    if value.is_finite()
+        && value.fract() == 0.0
+        && ((crate::streams::STREAM_HANDLE_ID_START as f64)
+            ..(crate::streams::STREAM_HANDLE_ID_END as f64))
+            .contains(&value)
+    {
         let id = value as usize;
         // kind == 1 ⇒ live ReadableStream.
         if crate::streams::js_stream_handle_kind(id) == 1 {

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -42,6 +42,11 @@ use validation::{
     normalize_method,
 };
 
+// Web Fetch handles must stay below the `0x100000` small-handle cutoff while
+// avoiding the low native-id range exposed by `node:http` (#3973/#3974 via #4004).
+pub(crate) const FETCH_HANDLE_ID_START: usize = 0x40000;
+pub(crate) const FETCH_HANDLE_ID_END: usize = 0xE0000;
+
 // Response handle storage
 lazy_static::lazy_static! {
     static ref FETCH_RESPONSES: Mutex<HashMap<usize, FetchResponse>> = Mutex::new(HashMap::new());
@@ -52,8 +57,9 @@ lazy_static::lazy_static! {
     /// runtime handle-dispatch arms (`dispatch_request_method` /
     /// `dispatch_response_method` / …) distinguish handle types by
     /// registry-membership alone for any-typed / computed-key calls, where the
-    /// static type was lost. Streams keep their own high-range scheme.
-    static ref NEXT_FETCH_HANDLE_ID: Mutex<usize> = Mutex::new(1);
+    /// static type was lost. The counter starts in a high subrange to avoid
+    /// colliding with perry-ffi handles exposed by `node:http`.
+    static ref NEXT_FETCH_HANDLE_ID: Mutex<usize> = Mutex::new(FETCH_HANDLE_ID_START);
     static ref STREAM_HANDLES: Mutex<HashMap<usize, StreamState>> = Mutex::new(HashMap::new());
     static ref NEXT_STREAM_ID: Mutex<usize> = Mutex::new(1);
 
@@ -74,6 +80,34 @@ lazy_static::lazy_static! {
         .tcp_keepalive(std::time::Duration::from_secs(60))
         .build()
         .unwrap_or_else(|_| reqwest::Client::new());
+}
+
+fn alloc_fetch_handle_id() -> usize {
+    let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
+    let id = *id_guard;
+    if id >= FETCH_HANDLE_ID_END {
+        panic!("Web Fetch handle id range exhausted");
+    }
+    *id_guard += 1;
+    id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_handle_ids_use_high_small_handle_range() {
+        assert!(FETCH_HANDLE_ID_START >= 0x40000);
+        assert!(FETCH_HANDLE_ID_END <= 0x100000);
+
+        let native_id = crate::common::register_handle("native-request-marker".to_string());
+        let id = alloc_fetch_handle_id();
+        assert!((native_id as usize) < FETCH_HANDLE_ID_START);
+        assert!((FETCH_HANDLE_ID_START..FETCH_HANDLE_ID_END).contains(&id));
+        assert_ne!(native_id as usize, id);
+        crate::common::drop_handle(native_id);
+    }
 }
 
 struct StreamState {
@@ -241,10 +275,7 @@ pub unsafe extern "C" fn js_fetch_get(url_ptr: *const StringHeader) -> *mut perr
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
                 // Store response
-                let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
-                let response_id = *id_guard;
-                *id_guard += 1;
-                drop(id_guard);
+                let response_id = alloc_fetch_handle_id();
 
                 FETCH_RESPONSES.lock().unwrap().insert(
                     response_id,
@@ -319,10 +350,7 @@ pub unsafe extern "C" fn js_fetch_get_with_auth(
 
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
-                let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
-                let response_id = *id_guard;
-                *id_guard += 1;
-                drop(id_guard);
+                let response_id = alloc_fetch_handle_id();
 
                 FETCH_RESPONSES.lock().unwrap().insert(
                     response_id,
@@ -399,10 +427,7 @@ pub unsafe extern "C" fn js_fetch_post_with_auth(
 
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
-                let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
-                let response_id = *id_guard;
-                *id_guard += 1;
-                drop(id_guard);
+                let response_id = alloc_fetch_handle_id();
 
                 FETCH_RESPONSES.lock().unwrap().insert(
                     response_id,
@@ -482,10 +507,7 @@ pub unsafe extern "C" fn js_fetch_post(
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
                 // Store response
-                let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
-                let response_id = *id_guard;
-                *id_guard += 1;
-                drop(id_guard);
+                let response_id = alloc_fetch_handle_id();
 
                 FETCH_RESPONSES.lock().unwrap().insert(
                     response_id,
@@ -584,10 +606,7 @@ pub unsafe extern "C" fn js_fetch_with_options(
                 let body = response.bytes().await.unwrap_or_default().to_vec();
 
                 // Store response
-                let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
-                let response_id = *id_guard;
-                *id_guard += 1;
-                drop(id_guard);
+                let response_id = alloc_fetch_handle_id();
 
                 FETCH_RESPONSES.lock().unwrap().insert(
                     response_id,
@@ -1137,19 +1156,13 @@ impl BlobData {
 }
 
 pub(crate) fn alloc_blob(data: BlobData) -> usize {
-    let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
-    let id = *id_guard;
-    *id_guard += 1;
-    drop(id_guard);
+    let id = alloc_fetch_handle_id();
     BLOB_REGISTRY.lock().unwrap().insert(id, data);
     id
 }
 
 fn alloc_headers(store: HeadersStore) -> usize {
-    let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
-    let id = *id_guard;
-    *id_guard += 1;
-    drop(id_guard);
+    let id = alloc_fetch_handle_id();
     HEADERS_REGISTRY.lock().unwrap().insert(id, store);
     id
 }
@@ -1161,10 +1174,7 @@ fn alloc_response(
     body: Vec<u8>,
     body_present: bool,
 ) -> usize {
-    let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
-    let id = *id_guard;
-    *id_guard += 1;
-    drop(id_guard);
+    let id = alloc_fetch_handle_id();
     FETCH_RESPONSES.lock().unwrap().insert(
         id,
         FetchResponse {
@@ -1300,10 +1310,7 @@ pub extern "C" fn js_response_clone(handle: f64) -> f64 {
         })
     };
     if let Some(new_resp) = cloned {
-        let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
-        let new_id = *id_guard;
-        *id_guard += 1;
-        drop(id_guard);
+        let new_id = alloc_fetch_handle_id();
         FETCH_RESPONSES.lock().unwrap().insert(new_id, new_resp);
         return handle_to_f64(new_id);
     }
@@ -1730,10 +1737,7 @@ pub unsafe extern "C" fn js_request_new(
     } else {
         HeadersStore::default()
     };
-    let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
-    let id = *id_guard;
-    *id_guard += 1;
-    drop(id_guard);
+    let id = alloc_fetch_handle_id();
     REQUEST_REGISTRY.lock().unwrap().insert(
         id,
         RequestRecord {
@@ -1876,10 +1880,7 @@ pub extern "C" fn js_request_clone(handle: f64) -> f64 {
         })
     };
     if let Some(new_req) = cloned {
-        let mut id_guard = NEXT_FETCH_HANDLE_ID.lock().unwrap();
-        let new_id = *id_guard;
-        *id_guard += 1;
-        drop(id_guard);
+        let new_id = alloc_fetch_handle_id();
         REQUEST_REGISTRY.lock().unwrap().insert(new_id, new_req);
         return handle_to_f64(new_id);
     }

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -124,6 +124,9 @@ unsafe impl Send for WritableStreamData {}
 unsafe impl Send for ReaderData {}
 unsafe impl Send for WriterData {}
 
+pub(crate) const STREAM_HANDLE_ID_START: usize = 0x100000;
+pub(crate) const STREAM_HANDLE_ID_END: usize = 0x200000;
+
 lazy_static::lazy_static! {
     static ref READABLE_STREAMS: Mutex<HashMap<usize, ReadableStreamData>> = Mutex::new(HashMap::new());
     static ref WRITABLE_STREAMS: Mutex<HashMap<usize, WritableStreamData>> = Mutex::new(HashMap::new());
@@ -131,17 +134,12 @@ lazy_static::lazy_static! {
     static ref READERS: Mutex<HashMap<usize, ReaderData>> = Mutex::new(HashMap::new());
     static ref WRITERS: Mutex<HashMap<usize, WriterData>> = Mutex::new(HashMap::new());
     // #1545: ONE id counter shared across all five Web Streams registries.
-    // Two reasons: (1) ids are globally unique across readable/writable/
-    // transform/reader/writer, so the runtime handle dispatcher can tell which
-    // registry a handle belongs to unambiguously; (2) the high base (0x40000)
-    // puts stream handles well above every other handle subsystem's id range
-    // (commander/fastify/net/... all start at 1 and never approach it), so a
-    // stream handle never collides with another subsystem's handle while still
-    // staying under the 0x100000 small-handle detection threshold. This is what
-    // lets `js_handle_method_dispatch` safely route stream methods at runtime
-    // for receivers whose static type the codegen lost (e.g.
-    // `src.pipeThrough(ts).getReader()`, `ts.readable.getReader()`).
-    static ref NEXT_STREAM_ID: Mutex<usize> = Mutex::new(0x40000);
+    // Stream handles are raw numeric f64 values, not POINTER_TAG small handles,
+    // so they live just above the runtime's `< 0x100000` small-handle band.
+    // That keeps them disjoint from Fetch/native/proxy pointer-tagged ids while
+    // the runtime's finite-number stream probes still route dynamic calls like
+    // `src.pipeThrough(ts).getReader()`.
+    static ref NEXT_STREAM_ID: Mutex<usize> = Mutex::new(STREAM_HANDLE_ID_START);
 }
 
 static GC_REGISTERED: std::sync::Once = std::sync::Once::new();
@@ -241,6 +239,9 @@ fn scan_stream_roots_mut(visitor: &mut perry_runtime::gc::RuntimeRootVisitor<'_>
 fn next_id(slot: &Mutex<usize>) -> usize {
     let mut guard = slot.lock().unwrap();
     let id = *guard;
+    if id >= STREAM_HANDLE_ID_END {
+        panic!("Web Streams handle id range exhausted");
+    }
     *guard += 1;
     id
 }
@@ -2183,7 +2184,7 @@ pub extern "C" fn js_stream_handle_is_registered(id: usize) -> bool {
 /// 4 = writer, 5 = TransformStream.
 #[no_mangle]
 pub extern "C" fn js_stream_handle_kind(id: usize) -> u8 {
-    if !(0x40000..0x100000).contains(&id) {
+    if !(STREAM_HANDLE_ID_START..STREAM_HANDLE_ID_END).contains(&id) {
         return 0;
     }
     if READABLE_STREAMS
@@ -2226,8 +2227,9 @@ pub extern "C" fn js_stream_handle_kind(id: usize) -> u8 {
 /// `js_handle_method_dispatch` with a bare numeric handle.
 ///
 /// Because every Web Streams handle now lives in one shared id space based at
-/// `0x40000` (see `NEXT_STREAM_ID`), the handle is (a) recognisable by range
-/// and (b) present in exactly one of the five registries, so routing by
+/// `STREAM_HANDLE_ID_START` (see `NEXT_STREAM_ID`), the handle is (a)
+/// recognisable by range and (b) present in exactly one of the five registries,
+/// so routing by
 /// `(registry-membership, method-name)` is unambiguous and can never collide
 /// with another handle subsystem. Returns `None` when the handle isn't a stream
 /// handle or the method isn't a stream method, so the generic dispatcher falls
@@ -2238,7 +2240,7 @@ pub(crate) unsafe fn dispatch_stream_method(
     args: &[f64],
 ) -> Option<f64> {
     let id = handle as usize;
-    if !(0x40000..0x100000).contains(&id) {
+    if !(STREAM_HANDLE_ID_START..STREAM_HANDLE_ID_END).contains(&id) {
         return None;
     }
     let arg0 = args
@@ -2470,6 +2472,19 @@ pub fn drain_readable_into_bytes(stream_id: usize) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stream_ids_live_outside_pointer_tag_small_handle_band() {
+        let id = next_id(&NEXT_STREAM_ID);
+        assert!(
+            (STREAM_HANDLE_ID_START..STREAM_HANDLE_ID_END).contains(&id),
+            "stream id {id:#x} must stay in the raw numeric stream band"
+        );
+        assert!(
+            id >= 0x100000,
+            "stream id {id:#x} must not overlap pointer-tagged small handles"
+        );
+    }
 
     #[test]
     fn root_scanner_emits_callbacks_chunks_and_promises() {

--- a/crates/perry-stdlib/src/zlib.rs
+++ b/crates/perry-stdlib/src/zlib.rs
@@ -461,7 +461,7 @@ pub unsafe extern "C" fn js_zlib_brotli_decompress(data_value: f64, callback_val
 // `zlib.createGzip()` / `createGunzip()` / `createDeflate()` /
 // `createInflate()` / `createDeflateRaw()` / `createInflateRaw()` /
 // `createUnzip()` / `createBrotliCompress()` / `createBrotliDecompress()`
-// return small-int handles (base 0x60000, under the 0x100000 small-handle
+// return small-int handles (base 0xE0000, under the 0x100000 small-handle
 // dispatch threshold) that the codegen NaN-boxes with POINTER_TAG. Subsequent
 // `s.write()` / `s.end()` / `s.on()` / `s.pipe()` calls lose their static type
 // and route through `js_native_call_method` → HANDLE_METHOD_DISPATCH →
@@ -505,8 +505,11 @@ lazy_static::lazy_static! {
     static ref ZLIB_LISTENERS: Mutex<HashMap<i64, HashMap<String, Vec<i64>>>> =
         Mutex::new(HashMap::new());
     static ref ZLIB_PENDING_EVENTS: Mutex<Vec<ZlibEvent>> = Mutex::new(Vec::new());
-    static ref NEXT_ZLIB_ID: Mutex<i64> = Mutex::new(0x60000);
+    static ref NEXT_ZLIB_ID: Mutex<i64> = Mutex::new(ZLIB_STREAM_HANDLE_ID_START);
 }
+
+const ZLIB_STREAM_HANDLE_ID_START: i64 = 0xE0000;
+const ZLIB_STREAM_HANDLE_ID_END: i64 = 0xF0000;
 
 static ZLIB_GC_REGISTERED: std::sync::Once = std::sync::Once::new();
 
@@ -546,6 +549,9 @@ fn scan_zlib_roots(visitor: &mut perry_runtime::gc::RuntimeRootVisitor<'_>) {
 fn next_zlib_id() -> i64 {
     let mut g = NEXT_ZLIB_ID.lock().unwrap();
     let id = *g;
+    if id >= ZLIB_STREAM_HANDLE_ID_END {
+        panic!("zlib stream handle id range exhausted");
+    }
     *g += 1;
     id
 }
@@ -1271,6 +1277,15 @@ pub unsafe extern "C" fn js_zlib_native_dispatch(
 #[cfg(test)]
 mod stream_tests {
     use super::*;
+
+    #[test]
+    fn zlib_stream_ids_live_in_dedicated_small_handle_band() {
+        let id = next_zlib_id();
+        assert!(
+            (ZLIB_STREAM_HANDLE_ID_START..ZLIB_STREAM_HANDLE_ID_END).contains(&id),
+            "zlib stream id {id:#x} must stay in the zlib small-handle band"
+        );
+    }
 
     /// Drive the streaming codec like the FFI ops do: write + drain, flush +
     /// drain between chunks, then finish — reassembling the full stream.


### PR DESCRIPTION
Fixes #3973.
Fixes #3974.
Addresses #4004.

## Summary
- Verified the current issue trail: #3973 now points away from the original GC hypothesis, and #4004 identifies the first-request failure as a JS-visible handle collision between Web Fetch `Request` handles and `node:http` IncomingMessage handles.
- Split the small native-handle namespace into disjoint ranges: common/ffi `<0x40000`, Web Fetch `0x40000..0xE0000`, zlib `0xE0000..0xF0000`, proxy `0xF0000..0x100000`, and raw numeric Web Streams `0x100000..0x200000`.
- Added exhaustion guards and tightened runtime probes so pointer-tagged native handles are not dereferenced as heap objects after moving fetch/stream ids into higher bands.

## Verification / reproduction
- Final base SHA: `5406a5060b21a49cf151055008f4c0a397d20743`.
- Read #3973, #3974, and #4004 with `gh issue view`; searched for overlapping PRs before coding and found no open/merged PR covering this root-cause path.
- Full Skelpo CMS repro was not available locally. I used a focused compiled probe at ignored path `target/repro_issue_4004.ts` that creates a `node:http` server, constructs a Web `Request` from the IncomingMessage, and dynamically calls `request.headers.get()` on the first and second requests.
- Probe result after the fix: both requests returned `HTTP/1.1 200 OK`; server logs showed `request 1 headers.get function` and `request 2 headers.get function`.
- DeepWiki reference saved at ignored path `target/deepwiki/gc-forwarding-pointer-tags.md`.

## Tests run
- `cargo fmt --check`
- `git diff --check` and `git diff --cached --check`
- `cargo test -p perry-stdlib fetch_handle_ids_use_high_small_handle_range -- --nocapture`
- `cargo test -p perry-stdlib zlib_stream_ids_live_in_dedicated_small_handle_band -- --nocapture`
- `cargo test -p perry-stdlib stream_ids_live_outside_pointer_tag_small_handle_band -- --nocapture`
- `cargo test -p perry-stdlib test_register_and_get -- --nocapture`
- `cargo test -p perry-runtime boxed_primitive_probe_rejects_pointer_tagged_native_handles -- --nocapture`
- `cargo test -p perry-runtime promise_probe_rejects_pointer_tagged_native_handles -- --nocapture`
- `cargo test -p perry-ffi round_trip_simple_value -- --nocapture`
- `cargo run --quiet --bin perry -- target/repro_issue_4004.ts -o target/repro_issue_4004_bin`, then first/second `curl` requests against the probe server

## Residual risks
- The full Skelpo/Hono app was not available, so the app-level repro is covered by the issue evidence plus the focused runtime probe.
- Reserved ranges are finite and now panic on exhaustion instead of silently colliding.
- `perry-ext-fetch` still has its own low internal counters; #4004 names the stdlib Web Fetch path used by this Hono/node:http failure. If a future `node-fetch` path routes those ids through generic dispatch with node/http, mirror this allocator split there.
- Existing warning noise and duplicate `node:http` linker-symbol warnings remain unrelated.