### PR TITLE
fix(number->string): scientific notation in String()/concat/template coercion (#3987 partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1081 — fix(number→string): scientific notation in String()/concat/template coercion (#3987, partial)
+
+`String(1e21)`, `"" + 1e21`, and `` `${1e21}` `` printed `1000000000000000000000` instead of `1e+21`, and `String(0.0000001)` printed `0.0000001` instead of `1e-7`. Only `n.toString()` was correct — it routed through `js_number_to_string`, which already applies the ECMAScript NumberToString exponent rule (scientific notation for `|n| >= 1e21` or `|n| < 1e-6`). The three *coercion* paths each had their own number formatter using Rust's full-decimal `format!("{}")`:
+
+- `js_string_coerce` (`String(x)` / `Expr::StringCoerce`) — `builtins/numbers.rs`
+- the 2-arg concat fast path (`"" + n`) and `format_number_into` (`js_string_concat_chain`, template literals) — `string/concat.rs`
+
+Fix: extracted the canonical formatting into `string::js_format_f64`, refactored `js_number_to_string` onto it, and routed all three coercion sites through it. Rust's `format!("{}")` also risked truncating `Number.MAX_VALUE`'s ~309-digit decimal into the fixed 32-byte concat buffers — scientific notation avoids that too.
+
+Validated against `node --experimental-strip-types`: 26 representative numbers (incl. `1e21`, `1e-7`, `1.5e30`, `-2.5e-10`, `NaN`, `±Infinity`, `±0`, integers, fractions) across all four paths (`String`/`+`/template/`.toString`) are byte-identical; `perry-runtime` string (97) + numbers (18) unit tests green; string/console node-suite sweep clean (the one diff is the pre-existing stack-trace-fidelity gap). Focused sub-fix of #3987 — its `new String(...)` wrapper `.length`, indexed-read, and array-ToString cases remain open there.
+
 ## v0.5.1080 — node:https: request/get/Agent value-reads resolve to functions (#3697)
 
 `node:https` advertised `request`, `get`, and `Agent` in the API manifest, but reading them as values — `import { request } from "node:https"` or `https.request` — returned `undefined` (only the direct call form `https.request(...)` worked, via the codegen dispatch table). They were missing from `is_native_module_callable_export`, so the bound-value read fell through to `undefined`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1080
+**Current Version:** 0.5.1081
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1080"
+version = "0.5.1081"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1080"
+version = "0.5.1081"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1080"
+version = "0.5.1081"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1080"
+version = "0.5.1081"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1080"
+version = "0.5.1081"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/builtins/numbers.rs
+++ b/crates/perry-runtime/src/builtins/numbers.rs
@@ -476,23 +476,11 @@ pub extern "C" fn js_string_coerce(value: f64) -> *mut StringHeader {
     } else if jsval.is_int32() {
         jsval.as_int32().to_string()
     } else {
-        // Regular number
-        let n = value;
-        if n.is_nan() {
-            "NaN".to_string()
-        } else if n.is_infinite() {
-            if n > 0.0 {
-                "Infinity".to_string()
-            } else {
-                "-Infinity".to_string()
-            }
-        } else if n == 0.0 {
-            "0".to_string()
-        } else if n.fract() == 0.0 && n.abs() < (i64::MAX as f64) {
-            (n as i64).to_string()
-        } else {
-            n.to_string()
-        }
+        // Regular number — ECMAScript NumberToString. #3987: route through the
+        // shared `js_format_f64` so `String(1e21)` → "1e+21" / `String(1e-7)`
+        // → "1e-7" (scientific notation for |n| >= 1e21 / < 1e-6) instead of
+        // Rust's full-decimal `to_string()`, matching `.toString()` and Node.
+        crate::string::js_format_f64(value)
     };
 
     js_string_from_bytes(result.as_ptr(), result.len() as u32)

--- a/crates/perry-runtime/src/string/concat.rs
+++ b/crates/perry-runtime/src/string/concat.rs
@@ -244,7 +244,9 @@ pub extern "C" fn js_string_concat_value(
             num_buf[0] = b'0';
             num_len = 1;
         } else {
-            let s = format!("{}", value);
+            // #3987: match ECMAScript NumberToString (scientific notation for
+            // |n| >= 1e21 / < 1e-6) instead of Rust's full-decimal `{}`.
+            let s = super::format::js_format_f64(value);
             let len = s.len().min(num_buf.len());
             num_buf[..len].copy_from_slice(&s.as_bytes()[..len]);
             num_len = len;
@@ -495,7 +497,9 @@ pub(crate) fn format_number_into(value: f64, buf: &mut [u8; 32]) -> usize {
         buf[0] = b'0';
         return 1;
     }
-    let s = format!("{}", value);
+    // #3987: match ECMAScript NumberToString (scientific notation for
+    // |n| >= 1e21 / < 1e-6) instead of Rust's full-decimal `{}`.
+    let s = super::format::js_format_f64(value);
     let len = s.len().min(buf.len());
     buf[..len].copy_from_slice(&s.as_bytes()[..len]);
     len
@@ -552,7 +556,9 @@ pub extern "C" fn js_value_concat_string(
             num_buf[0] = b'0';
             num_len = 1;
         } else {
-            let s = format!("{}", value);
+            // #3987: match ECMAScript NumberToString (scientific notation for
+            // |n| >= 1e21 / < 1e-6) instead of Rust's full-decimal `{}`.
+            let s = super::format::js_format_f64(value);
             let len = s.len().min(num_buf.len());
             num_buf[..len].copy_from_slice(&s.as_bytes()[..len]);
             num_len = len;

--- a/crates/perry-runtime/src/string/format.rs
+++ b/crates/perry-runtime/src/string/format.rs
@@ -48,7 +48,23 @@ pub extern "C" fn js_number_to_string(value: f64) -> *mut StringHeader {
     }
 
     // Format the number as a string per JS semantics.
-    let s = if value.is_nan() {
+    let s = js_format_f64(value);
+
+    let bytes = s.as_bytes();
+    js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
+}
+
+/// ECMAScript `Number::toString` formatting, returning the Rust `String`.
+///
+/// Shared by `js_number_to_string` (the `.toString()` path) and the
+/// string-concat fast paths so `String(n)`, `"" + n`, and `` `${n}` `` all
+/// match Node — notably scientific notation when `|n| >= 1e21` or
+/// `|n| < 1e-6` (#3987). Previously the concat fast paths used a bare
+/// `format!("{}", n)`, which emits the full decimal form (e.g.
+/// `1000000000000000000000` for `1e21`) and could even truncate
+/// `Number.MAX_VALUE`'s ~309-digit decimal into a fixed stack buffer.
+pub(crate) fn js_format_f64(value: f64) -> String {
+    if value.is_nan() {
         "NaN".to_string()
     } else if value.is_infinite() {
         if value > 0.0 {
@@ -74,10 +90,7 @@ pub extern "C" fn js_number_to_string(value: f64) -> *mut StringHeader {
         } else {
             format!("{}", value)
         }
-    };
-
-    let bytes = s.as_bytes();
-    js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
+    }
 }
 
 /// GC root scanner for the small-integer string cache.

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -64,6 +64,7 @@ pub use concat::{
     js_value_concat_string,
 };
 pub(crate) use format::fix_exponent_format;
+pub(crate) use format::js_format_f64;
 pub use format::{
     js_number_to_exponential, js_number_to_fixed, js_number_to_precision, js_number_to_string,
     scan_small_int_cache_roots, scan_small_int_cache_roots_mut,


### PR DESCRIPTION
## fix(number→string): scientific notation in String()/concat/template coercion (#3987, partial)

```ts
String(1e21)        // was 1000000000000000000000  → now 1e+21
"" + 1e21           // was 1000000000000000000000  → now 1e+21
`${1e21}`           // was 1000000000000000000000  → now 1e+21
String(0.0000001)   // was 0.0000001              → now 1e-7
(1e21).toString()   // already correct: 1e+21
```

### Root cause
Only `n.toString()` was correct — it routes through `js_number_to_string`, which already applies the ECMAScript `Number::toString` exponent rule (scientific notation for `|n| >= 1e21` or `|n| < 1e-6`). The three **coercion** paths each had their own number formatter using Rust's full-decimal `format!("{}")`:
- `js_string_coerce` (`String(x)` / `Expr::StringCoerce`) — `builtins/numbers.rs`
- the 2-arg concat fast path (`"" + n`) and `format_number_into` (template literals / `js_string_concat_chain`) — `string/concat.rs`

### Fix
Extracted the canonical formatting into `string::js_format_f64`, refactored `js_number_to_string` onto it, and routed all three coercion sites through it. (Rust's `format!("{}")` also risked truncating `Number.MAX_VALUE`'s ~309-digit decimal into the fixed 32-byte concat buffers — scientific notation avoids that.)

### Validation (vs `node --experimental-strip-types`)
- 26 representative numbers (`1e21`, `1e-7`, `1.5e30`, `-2.5e-10`, `NaN`, `±Infinity`, `±0`, integers, fractions) × all four paths (`String` / `+` / template / `.toString`) — **byte-identical** ✅
- `perry-runtime` string (97) + numbers (18) unit tests green ✅
- string/console node-suite sweep clean (the one diff is the pre-existing stack-trace-fidelity gap) ✅

Focused sub-fix of #3987 — its `new String(...)` wrapper `.length`, indexed-read, and array-ToString cases remain open there.
