### PR TITLE
fix(String): charAt/at/codePointAt/charCodeAt ignore extra args (#3987 partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1082 — fix(String): charAt/at/codePointAt/charCodeAt ignore extra args instead of compile-failing (#3987, partial)
+
+`"hello".charAt(1, 2, 3, 4)` (and `.at`, `.codePointAt`, `.charCodeAt` with >1 arg) failed to **compile** — codegen `bail!`ed with `String.charAt expects at most 1 arg, got 4` even though `perry check` passed. JavaScript ignores extra arguments to these methods.
+
+Fix (`crates/perry-codegen/src/lower_string_method.rs`): the four index-taking string methods now use `args[0]` as the index and lower any remaining args for their **side effects** (evaluated left-to-right, results discarded), per JS call semantics — instead of erroring. `charAt(1, (c = 5))` now returns `"e"` and still assigns `c`.
+
+Validated against `node --experimental-strip-types`: `charAt(1,2,3,4)`→`e`, `at(1,9,9)`→`e`, `codePointAt(0,9)`→`104`, `charCodeAt(0,9,9)`→`104`, extra-arg side effects run; normal usage (no-arg, OOB, negative index, emoji surrogate pairs) byte-identical. Focused sub-fix of #3987 — its indexed-read (`s[NaN]`), `new String(...)` wrapper, and array-ToString cases remain open there.
+
 ## v0.5.1081 — fix(number→string): scientific notation in String()/concat/template coercion (#3987, partial)
 
 `String(1e21)`, `"" + 1e21`, and `` `${1e21}` `` printed `1000000000000000000000` instead of `1e+21`, and `String(0.0000001)` printed `0.0000001` instead of `1e-7`. Only `n.toString()` was correct — it routed through `js_number_to_string`, which already applies the ECMAScript NumberToString exponent rule (scientific notation for `|n| >= 1e21` or `|n| < 1e-6`). The three *coercion* paths each had their own number formatter using Rust's full-decimal `format!("{}")`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1081
+**Current Version:** 0.5.1082
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1081"
+version = "0.5.1082"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1081"
+version = "0.5.1082"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1081"
+version = "0.5.1082"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1081"
+version = "0.5.1082"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1081"
+version = "0.5.1082"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -224,17 +224,17 @@ pub(crate) fn lower_string_method(
             // #2787: a missing index defaults to 0; the provided index is
             // coerced with JS `ToIntegerOrInfinity` (undefined/NaN -> 0) rather
             // than a raw `fptosi`, which is UB on a NaN bit pattern.
-            if args.len() > 1 {
-                bail!(
-                    "perry-codegen: String.charAt expects at most 1 arg, got {}",
-                    args.len()
-                );
-            }
+            // #3987: JS ignores extra args to `charAt` but still evaluates them
+            // (left-to-right, for side effects). Use args[0] as the index and
+            // lower the rest, discarding their values, instead of bailing.
             let idx_d = if args.is_empty() {
                 crate::nanbox::double_literal(0.0)
             } else {
                 lower_expr(ctx, &args[0])?
             };
+            for extra in args.iter().skip(1) {
+                let _ = lower_expr(ctx, extra)?;
+            }
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
             let idx_i32 = blk.call(I32, "js_string_index_to_i32", &[(DOUBLE, &idx_d)]);
@@ -345,17 +345,15 @@ pub(crate) fn lower_string_method(
         "at" => {
             // #2787: missing index -> 0; JS index coercion (undefined/NaN -> 0).
             // `js_string_at` already resolves negative indices relative to len.
-            if args.len() > 1 {
-                bail!(
-                    "perry-codegen: String.at expects at most 1 arg, got {}",
-                    args.len()
-                );
-            }
+            // #3987: ignore extra args (still evaluate for side effects).
             let idx_d = if args.is_empty() {
                 crate::nanbox::double_literal(0.0)
             } else {
                 lower_expr(ctx, &args[0])?
             };
+            for extra in args.iter().skip(1) {
+                let _ = lower_expr(ctx, extra)?;
+            }
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
             let idx_i32 = blk.call(I32, "js_string_index_to_i32", &[(DOUBLE, &idx_d)]);
@@ -368,17 +366,15 @@ pub(crate) fn lower_string_method(
         }
         "codePointAt" => {
             // #2787: missing index -> 0; JS index coercion (undefined/NaN -> 0).
-            if args.len() > 1 {
-                bail!(
-                    "perry-codegen: String.codePointAt expects at most 1 arg, got {}",
-                    args.len()
-                );
-            }
+            // #3987: ignore extra args (still evaluate for side effects).
             let idx_d = if args.is_empty() {
                 crate::nanbox::double_literal(0.0)
             } else {
                 lower_expr(ctx, &args[0])?
             };
+            for extra in args.iter().skip(1) {
+                let _ = lower_expr(ctx, extra)?;
+            }
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
             let idx_i32 = blk.call(I32, "js_string_index_to_i32", &[(DOUBLE, &idx_d)]);
@@ -391,17 +387,15 @@ pub(crate) fn lower_string_method(
         }
         "charCodeAt" => {
             // #2787: missing index -> 0; JS index coercion (undefined/NaN -> 0).
-            if args.len() > 1 {
-                bail!(
-                    "perry-codegen: String.charCodeAt expects at most 1 arg, got {}",
-                    args.len()
-                );
-            }
+            // #3987: ignore extra args (still evaluate for side effects).
             let idx_d = if args.is_empty() {
                 crate::nanbox::double_literal(0.0)
             } else {
                 lower_expr(ctx, &args[0])?
             };
+            for extra in args.iter().skip(1) {
+                let _ = lower_expr(ctx, extra)?;
+            }
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
             let idx_i32 = blk.call(I32, "js_string_index_to_i32", &[(DOUBLE, &idx_d)]);


### PR DESCRIPTION
## fix(String): `charAt`/`at`/`codePointAt`/`charCodeAt` ignore extra args instead of compile-failing (#3987, partial)

```ts
"hello".charAt(1, 2, 3, 4)   // was: codegen error → now "e"
```

`"hello".charAt(1, 2, 3, 4)` (and `.at`, `.codePointAt`, `.charCodeAt` with >1 arg) failed to **compile** — codegen `bail!`ed with `String.charAt expects at most 1 arg, got 4`, even though `perry check` passed. JavaScript ignores extra arguments to these methods (but still evaluates them).

### Fix
`crates/perry-codegen/src/lower_string_method.rs`: the four index-taking string methods now use `args[0]` as the index and lower any remaining args for their **side effects** (left-to-right, results discarded), per JS call semantics — instead of erroring.

### Validation (vs `node --experimental-strip-types`)
- `charAt(1,2,3,4)`→`e`, `at(1,9,9)`→`e`, `codePointAt(0,9)`→`104`, `charCodeAt(0,9,9)`→`104` ✅
- extra-arg side effects evaluated: `charAt(1, (c = 5))` → `"e"` and `c === 5` ✅
- normal usage byte-identical: no-arg, out-of-bounds, negative `at`, emoji surrogate `codePointAt` ✅
- fmt clean.

Focused sub-fix of #3987 — its indexed-read (`s[NaN]`), `new String(...)` wrapper `.length`, and array-ToString cases remain open there.
