### PR TITLE
fix(String): indexed reads use CanonicalNumericIndexString semantics (#3987 partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1084 — fix(String): indexed reads use CanonicalNumericIndexString semantics (#3987, partial)
+
+`s[NaN]`, `s[Infinity]`, `s[-1]`, `s[1.5]`, and out-of-range `s[10]` returned `""` (or a wrong/truncated char) instead of `undefined`, and `s["1"]` returned the char at index 0 instead of index 1. Codegen lowered string `s[key]` by `fptosi`-truncating the key (so `1.5`→`1`, `NaN`→`0`) and calling `js_string_char_at`, which returns `""` for out-of-range/negative — never `undefined` — and mis-resolved string keys.
+
+Fix: new runtime `js_string_index_get(s, key)` (`crates/perry-runtime/src/string/char_ops.rs`) implements ECMAScript CanonicalNumericIndexString — it returns the single UTF-16 code-unit string only when `key` is a canonical array index (a non-negative integer, or a numeric string that round-trips its `ToString`, e.g. `"1"`) within `[0, length)`; every other key (`NaN`/`Infinity`/negatives/fractions/OOB/`"01"`/non-numeric) returns `undefined`. Codegen (`expr/index_get.rs`) now routes string-receiver `IndexGet` to it with the **raw** NaN-boxed key (no `fptosi`).
+
+Validated against `node --experimental-strip-types`: `s[NaN]`/`s[Infinity]`/`s[-1]`/`s[1.5]`/`s[10]`→`undefined`, `s[0]`/`s[2]`→chars, `s["1"]`→`"e"`; loops, variable/expression indices, nested `arr[i][j]`, and object numeric-string keys all match. `perry-runtime` char_ops/string unit tests green; url/path/querystring node-suite sweep 217/0 (no regression). The lone-surrogate (astral `"😀"[1]`) result is unchanged — that's the documented WTF-8 categorical gap, not affected by this change. Focused sub-fix of #3987 — its `new String(...)` wrapper own-`length` case remains open.
+
 ## v0.5.1083 — fix(process.getBuiltinModule): punycode methods dispatch (decode/encode/toASCII/toUnicode)
 
 `process.getBuiltinModule("punycode")` returned a module whose `decode`/`encode`/`toASCII`/`toUnicode` were callable but returned `undefined` — so `punycode.decode("maana-pta")` gave `undefined` instead of `"mañana"`. (Direct `import punycode from "node:punycode"` already worked.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1083
+**Current Version:** 0.5.1084
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1083"
+version = "0.5.1084"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1083"
+version = "0.5.1084"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1083"
+version = "0.5.1084"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1083"
+version = "0.5.1084"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1083"
+version = "0.5.1084"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -541,13 +541,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 let idx_d = lower_expr(ctx, index)?;
                 let blk = ctx.block();
                 let s_handle = unbox_to_i64(blk, &s_box);
-                let idx_i32 = blk.fptosi(DOUBLE, &idx_d, I32);
-                let result = blk.call(
-                    I64,
-                    "js_string_char_at",
-                    &[(I64, &s_handle), (I32, &idx_i32)],
-                );
-                return Ok(nanbox_string_inline(blk, &result));
+                // #3987: route through the canonical-index runtime helper (it
+                // takes the raw NaN-boxed key, not an `fptosi`'d i32) so a valid
+                // array index returns its char and every non-canonical key
+                // (`NaN`, `1.5`, negatives, OOB, `"01"`, non-numeric strings)
+                // returns `undefined` — matching ECMAScript / Node — instead of
+                // truncating the index and returning `""` for OOB.
+                return Ok(blk.call(
+                    DOUBLE,
+                    "js_string_index_get",
+                    &[(I64, &s_handle), (DOUBLE, &idx_d)],
+                ));
             }
             // Issue #514: when the receiver's static type is genuinely
             // unknown (`Type::Any` / `Type::Unknown`) and the index is

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -494,6 +494,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_string_trim_start", I64, &[I64]);
     module.declare_function("js_string_trim_end", I64, &[I64]);
     module.declare_function("js_string_char_at", I64, &[I64, I32]);
+    // #3987: `s[key]` canonical-index read — returns the char (NaN-boxed string)
+    // for a valid array index, else NaN-boxed `undefined`. Takes the raw key.
+    module.declare_function("js_string_index_get", DOUBLE, &[I64, DOUBLE]);
     // #2787: NaN-safe JS index coercion (undefined/NaN -> 0, trunc, clamp) for
     // the char-access methods, replacing a raw `fptosi` that is UB on a NaN.
     module.declare_function("js_string_index_to_i32", I32, &[DOUBLE]);

--- a/crates/perry-runtime/src/string/char_ops.rs
+++ b/crates/perry-runtime/src/string/char_ops.rs
@@ -68,6 +68,73 @@ pub extern "C" fn js_string_char_code_at(s: *const StringHeader, index: i32) -> 
     f64::NAN
 }
 
+/// `s[key]` indexed read with ECMAScript CanonicalNumericIndexString semantics
+/// (#3987): returns the single-UTF-16-code-unit string at `key` only when `key`
+/// is a canonical array index — a non-negative integer (or a numeric string
+/// that round-trips, e.g. `"1"`) within `[0, length)`. Every other key returns
+/// `undefined`: `NaN`, `Infinity`, negatives, fractions like `1.5`,
+/// out-of-range indices, non-canonical strings like `"01"` / `" 1"` / `"1.0"`,
+/// and non-numeric keys. Previously codegen `fptosi`'d the key and called
+/// `js_string_char_at`, which truncated `1.5`→`1`, mapped `NaN`→`0`, returned
+/// `""` (not `undefined`) for OOB/negatives, and mis-resolved string keys.
+#[no_mangle]
+pub extern "C" fn js_string_index_get(s: *const StringHeader, key: f64) -> f64 {
+    const UNDEFINED: f64 = f64::from_bits(crate::value::TAG_UNDEFINED);
+    if !is_valid_string_ptr(s) {
+        return UNDEFINED;
+    }
+    let len = unsafe { (*s).utf16_len } as u64;
+    let jsval = crate::value::JSValue::from_bits(key.to_bits());
+
+    let idx: u64 = if jsval.is_int32() {
+        let i = jsval.as_int32();
+        if i < 0 {
+            return UNDEFINED;
+        }
+        i as u64
+    } else if jsval.is_number() {
+        // Real double: only a finite, non-negative integer is an array index.
+        if !key.is_finite() || key < 0.0 || key.fract() != 0.0 {
+            return UNDEFINED;
+        }
+        key as u64 // saturating; an out-of-range magnitude fails the bound below
+    } else if jsval.is_any_string() {
+        match crate::builtins::jsvalue_string_content(key).and_then(|k| canonical_string_index(&k))
+        {
+            Some(i) => i,
+            None => return UNDEFINED,
+        }
+    } else {
+        return UNDEFINED;
+    };
+
+    if idx >= len {
+        return UNDEFINED;
+    }
+    let ptr = js_string_char_at(s, idx as i32);
+    crate::value::js_nanbox_string(ptr as i64)
+}
+
+/// Parse a property-key string into a canonical array index per
+/// `CanonicalNumericIndexString`: the string must equal the exact `ToString` of
+/// the resulting non-negative integer, so `"0"`→0 and `"12"`→12 are canonical
+/// but `"01"`, `"1.0"`, `"+1"`, `" 1"`, `"1e0"`, and `""` are not. Indices must
+/// be below `2^32 - 1` (the array-index ceiling).
+fn canonical_string_index(s: &str) -> Option<u64> {
+    if s == "0" {
+        return Some(0);
+    }
+    let bytes = s.as_bytes();
+    if bytes.is_empty() || bytes[0] == b'0' || !bytes.iter().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let n: u64 = s.parse().ok()?;
+    if n >= u32::MAX as u64 {
+        return None;
+    }
+    Some(n)
+}
+
 /// Get character at UTF-16 code unit index (returns single-character string).
 /// For a BMP character this returns the character itself; for a surrogate half
 /// of an astral character this returns the lone surrogate (matching JS behavior).


### PR DESCRIPTION
## fix(String): indexed reads use CanonicalNumericIndexString semantics (#3987, partial)

```ts
"abc"[NaN]       // was ""  → now undefined
"abc"[1.5]       // was "b" → now undefined
"abc"[-1]        // was ""  → now undefined
"abc"[10]        // was ""  → now undefined
"abc"["1"]       // was "a" → now "b"   (canonical string index)
"abc"[0]         // "a"     (unchanged)
```

### Root cause
Codegen lowered string `s[key]` by `fptosi`-truncating the key (`1.5`→`1`, `NaN`→`0`) and calling `js_string_char_at`, which returns `""` for out-of-range/negative — never `undefined` — and mis-resolved string keys.

### Fix
New runtime `js_string_index_get(s, key)` (`crates/perry-runtime/src/string/char_ops.rs`) implements ECMAScript **CanonicalNumericIndexString**: returns the single UTF-16 code-unit string only when `key` is a canonical array index (a non-negative integer, or a numeric string that round-trips its `ToString`, e.g. `"1"`) within `[0, length)`; every other key (`NaN`/`Infinity`/negatives/fractions/OOB/`"01"`/non-numeric) returns `undefined`. Codegen (`expr/index_get.rs`) now routes string-receiver `IndexGet` to it with the **raw** NaN-boxed key (no `fptosi`).

### Validation (vs `node --experimental-strip-types`)
- Invalid keys → `undefined`; valid integer indices → chars; `s["1"]` → `"e"` ✅
- Loops, variable/expression indices, nested `arr[i][j]`, object numeric-string keys all match ✅
- `perry-runtime` char_ops + string unit tests green ✅
- url/path/querystring node-suite sweep **217/0** (no regression) ✅
- Lone-surrogate astral (`"😀"[1]`) result unchanged — the documented WTF-8 categorical gap, not affected here.

Focused sub-fix of #3987 — its `new String(...)` wrapper own-`length` case remains open there.
