### PR TITLE
[codex] Fix TSX JSX runtime docs

### DIFF
--- a/crates/perry-codegen/src/lower_call/extern_func.rs
+++ b/crates/perry-codegen/src/lower_call/extern_func.rs
@@ -1297,10 +1297,10 @@ pub fn try_lower_extern_func_call(
         // the ABI is uniform regardless of whether the type arg is a string or
         // a component reference — avoiding the PTR vs DOUBLE divergence that
         // the generic ExternFuncRef path would otherwise produce for string
-        // literals.  The runtime stubs `js_jsx`/`js_jsxs` are no-op link
-        // stubs that return TAG_UNDEFINED; real JSX rendering should be
-        // implemented by importing a JSX runtime package (e.g. react or
-        // preact) via the `perry.compilePackages` mechanism.
+        // literals.  The runtime adapter `js_jsx`/`js_jsxs` handles Perry's
+        // built-in TSX path: intrinsic HTML-style tags render to boxed HTML,
+        // fragments render their children, and function components are called
+        // with the props object.
         //
         // perry/tui JSX intrinsic rewriter (#689). When the first arg
         // is `ExternFuncRef { name: "__perry_jsx_intrinsic::<mod>::<method>__" }`
@@ -1311,10 +1311,10 @@ pub fn try_lower_extern_func_call(
         // to the same widget builder the function-call form would.
         // Today this covers Box + Text from `perry/tui`; other
         // intrinsics (Spacer / Input / Spinner / List / Select /
-        // ProgressBar / Table / Tabs / TextArea) are listed as
-        // follow-up scope in #689 and continue to fall through to
-        // `js_jsx` (returns TAG_UNDEFINED until the rewriter is
-        // extended).
+        // ProgressBar / Table / Tabs / TextArea) are listed as follow-up
+        // scope in #689 and continue to fall through to `js_jsx`; the runtime
+        // returns `undefined` for those unrecognised intrinsic sentinels until
+        // the rewriter is extended.
         "jsx" | "jsxs" => {
             if let Some(call) = try_rewrite_perry_tui_jsx_intrinsic(ctx, name == "jsxs", args)? {
                 return Ok(Some(call));

--- a/crates/perry-codegen/src/lower_call/jsx.rs
+++ b/crates/perry-codegen/src/lower_call/jsx.rs
@@ -86,7 +86,8 @@ fn split_children_from_props(props: &Expr) -> (Vec<(String, Expr)>, Option<Expr>
 ///
 /// Follow-up scope (#689): Spacer, Input, Spinner, List, Select,
 /// ProgressBar, Table, Tabs, TextArea. All currently fall through to
-/// `js_jsx` and return TAG_UNDEFINED until the rewriter is extended.
+/// `js_jsx`; the runtime returns `undefined` for those unrecognised intrinsic
+/// sentinels until the rewriter is extended.
 pub(super) fn try_rewrite_perry_tui_jsx_intrinsic(
     ctx: &mut FnCtx<'_>,
     _is_jsxs: bool,

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1727,15 +1727,13 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_map_group_by", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_array_from_async", DOUBLE, &[DOUBLE]);
 
-    // ========== JSX runtime stubs (issue #277) ==========
-    // `js_jsx(type, props)` and `js_jsxs(type, props)` are no-op stubs that
-    // let TSX/JSX files compile and link without a real JSX runtime package.
-    // The codegen intercepts ExternFuncRef { name: "jsx" } / "jsxs" in
-    // `lower_call.rs` and routes them here with both args as DOUBLE
-    // (NaN-boxed), bypassing the string→PTR conversion the generic path
-    // would apply to string literals.  When a real JSX runtime is imported
-    // via `perry.compilePackages` the imported symbol takes precedence and
-    // these stubs are never called.
+    // ========== JSX runtime adapter (issue #277, #1653) ==========
+    // `js_jsx(type, props)` and `js_jsxs(type, props)` are Perry's built-in
+    // TSX/JSX runtime entry points. Codegen intercepts
+    // ExternFuncRef { name: "jsx" } / "jsxs" in `lower_call.rs` and routes
+    // them here with both args as DOUBLE (NaN-boxed), bypassing the string→PTR
+    // conversion the generic path would apply to string literals. The runtime
+    // handles HTML-style intrinsics, fragments, and function components.
     module.declare_function("js_jsx", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_jsxs", DOUBLE, &[DOUBLE, DOUBLE]);
 }

--- a/crates/perry-hir/src/jsx.rs
+++ b/crates/perry-hir/src/jsx.rs
@@ -48,8 +48,8 @@ pub(crate) fn lower_jsx_element(ctx: &mut LoweringContext, jsx: &ast::JSXElement
         }
     }
 
-    // Use the original exported names (not the local __jsx/__jsxs aliases) so Perry
-    // generates the correct wrapper symbol names: __wrapper_jsx / __wrapper_jsxs.
+    // Use Perry's built-in extern names so codegen can route TSX straight to
+    // the native `js_jsx` / `js_jsxs` runtime adapter.
     let func_name = if children.len() > 1 { "jsxs" } else { "jsx" };
     match children.len() {
         0 => {}
@@ -90,7 +90,8 @@ pub(crate) fn lower_jsx_fragment(
         }
     }
 
-    // Use original exported names for correct wrapper symbol generation.
+    // Use Perry's built-in extern names for the same runtime routing as
+    // ordinary JSX elements.
     let func_name = if children.len() > 1 { "jsxs" } else { "jsx" };
     let mut props_fields: Vec<(String, Expr)> = Vec::new();
     match children.len() {

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -323,33 +323,10 @@ pub fn lower_module_full(
     // synthesize a real concrete class extending `SomeClass`.
     pre_scan_mixin_functions(ast_module, &mut ctx);
 
-    // For .tsx files, pre-register JSX runtime symbols so JSX expressions can be lowered.
-    // This injects an automatic import of { jsx, jsxs } from "react/jsx-runtime"
-    // (remapped to perry-react via the user's packageAliases).
-    // Fragment is NOT imported — it's inlined as the string "__Fragment" directly in JSX lowering.
-    if source_file_path.ends_with(".tsx") {
-        ctx.register_imported_func("__jsx".to_string(), "jsx".to_string());
-        ctx.register_imported_func("__jsxs".to_string(), "jsxs".to_string());
-        module.imports.push(Import {
-            source: "react/jsx-runtime".to_string(),
-            specifiers: vec![
-                ImportSpecifier::Named {
-                    local: "__jsx".to_string(),
-                    imported: "jsx".to_string(),
-                },
-                ImportSpecifier::Named {
-                    local: "__jsxs".to_string(),
-                    imported: "jsxs".to_string(),
-                },
-            ],
-            is_native: false,
-            module_kind: ModuleKind::NativeCompiled,
-            resolved_path: None,
-            type_only: false,
-            is_dynamic: false,
-            is_dynamic_target: false,
-        });
-    }
+    // JSX expressions lower directly to the built-in `jsx`/`jsxs` externs in
+    // `jsx.rs`. Do not synthesize a `react/jsx-runtime` import here: codegen
+    // routes those extern names to Perry's runtime adapter, and making the
+    // module graph resolve a fake package only produces a misleading warning.
 
     // Pre-scan: Find all function names that have implementations (bodies)
     // This is needed to properly handle TypeScript function overloads where

--- a/crates/perry-runtime/src/node_submodules/hono_jsx.rs
+++ b/crates/perry-runtime/src/node_submodules/hono_jsx.rs
@@ -1,8 +1,8 @@
 //! #1671 — `hono/jsx/server` and `hono/jsx/streaming` import surfaces.
 //!
 //! Perry renders JSX with the built-in `js_jsx` runtime (codegen routes every
-//! `jsx`/`jsxs` call there unconditionally; the injected `react/jsx-runtime`
-//! import is vestigial — see #1653). These two hono submodules exist for code
+//! `jsx`/`jsxs` call there unconditionally; `.tsx` does not need a package
+//! import for that built-in path). These two hono submodules exist for code
 //! that imports the runtime / streaming helpers *directly* rather than relying
 //! on the JSX transform:
 //!

--- a/docs/src/language/supported-features.md
+++ b/docs/src/language/supported-features.md
@@ -205,27 +205,30 @@ The GC uses conservative stack scanning to find roots and supports arena-allocat
 ## JSX/TSX
 
 Perry's parser and HIR understand JSX syntax (parsed via SWC, lowered in
-`crates/perry-hir/src/jsx.rs`), but the runtime `_jsx` / `_jsxs` symbols are
-not yet linked, so a `.tsx` file fails at the link stage today. The
-canonical pattern is the function-call form Perry's UI examples already use
-(`Text("hi")` instead of `<Text>hi</Text>`).
+`crates/perry-hir/src/jsx.rs`) and `.tsx` files link through Perry's built-in
+`jsx()` / `jsxs()` runtime path. You do not need a local
+`react/jsx-runtime` package just to compile TSX.
 
-```text
-// Planned JSX shape (parses but doesn't link yet — issue: runtime _jsx symbols):
+```tsx
+import { Box, Text } from "perry/tui";
 
 function Greeting({ name }: { name: string }) {
   return <Text>{`Hello, ${name}!`}</Text>;
 }
 
-<Button onClick={() => console.log("clicked")}>Click me</Button>
-
-<>
-  <Text>Line 1</Text>
-  <Text>Line 2</Text>
-</>
+const page = <div className="card"><Greeting name="Perry" /></div>;
+const app = <Box><Greeting name="TUI" /></Box>;
 ```
 
-JSX elements are transformed to function calls via the `jsx()`/`jsxs()` runtime.
+JSX elements are transformed to function calls via the `jsx()` / `jsxs()`
+runtime. Perry's built-in adapter supports HTML-style intrinsic tags,
+fragments, function components, and compile-time rewrites for `perry/tui`
+`Box` / `Text` so those TUI JSX forms lower to the same native builders as the
+function-call form.
+
+Caveat: this is Perry's TSX runtime, not React DOM or full React reconciler
+semantics. For `perry/ui`, or for `perry/tui` intrinsics whose JSX rewrite has
+not landed yet, the function-call form remains the canonical native API.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- remove the synthetic `.tsx` `react/jsx-runtime` import from HIR lowering
- update JSX lowering/codegen/runtime comments to describe the built-in Perry `js_jsx` / `js_jsxs` path
- update supported-features docs so they no longer claim TSX fails at link time

## Why
The docs and comments were stale. Current Perry links TSX through its built-in JSX runtime adapter, and the synthetic `react/jsx-runtime` import only made module collection print a misleading unresolved-import warning.

## Validation
- `cargo check -p perry-hir -p perry-codegen -p perry` passed with existing warning noise
- `target/debug/perry compile --no-auto-optimize test-files/test_perry_tui_inkcompat_counter_jsx.tsx -o /tmp/perry_counter_jsx_pr && printf '++q' | /tmp/perry_counter_jsx_pr` passed and printed `FINAL=2`
- `target/debug/perry compile --no-auto-optimize test-files/test_issue_679_perry_tui_jsx_audit.tsx -o /tmp/perry_jsx_audit_pr && /tmp/perry_jsx_audit_pr` passed all JSX audit markers
- `git diff --check` passed

## Notes
The generated gettext catalogs under `docs/po/` still contain the old English msgids. `mdbook` / `mdbook-xgettext` were not available locally, so this PR updates the canonical English docs source and leaves catalog regeneration to the normal docs i18n workflow.