### PR TITLE
fix(diagnostics_channel): drop non-Node withStoreScope; null bindStore transform throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1088 — fix(diagnostics_channel): drop non-Node withStoreScope; null bindStore transform throws
+
+Two `node:diagnostics_channel` store-subsystem parity fixes (epic #3839):
+
+1. **`withStoreScope` removed.** Node's Channel prototype is exactly `{subscribe, unsubscribe, publish, bindStore, unbindStore, runStores, hasSubscribers}` — there is no `withStoreScope`. Perry registered one, so `typeof ch.withStoreScope` was `"function"` (Node: `"undefined"`) and `using scope = ch.withStoreScope(...)` ran a whole block instead of throwing. Dropped the `set_field_value(obj, "withStoreScope", …)` registration in `diag_channel_object`; the unwired `diag_channel_with_store_scope` helper is retained `#[allow(dead_code)]`.
+
+2. **`null` transform is non-callable.** `bindStore(store, null)` classified `null` as the no-transform case (like `undefined`), so `runStores` passed the data straight into the store. Node (v25.x) treats a `null` (or any non-callable, non-`undefined`) transform as a function call that throws `TypeError: transform is not a function` when `runStores` invokes it, leaving the store unset. Narrowed the `StoreTransform::None` classification in `diag_channel_bind_store` to **only** `undefined` (`TAG_UNDEFINED`); `null` and other non-callables now map to `StoreTransform::NonCallable`.
+
+Fixes `diagnostics_channel/stores/with-store-scope.ts` and `…/non-callable-transform.ts`.
+
 ## v0.5.1087 — fix(diagnostics_channel): tracePromise fires asyncStart/asyncEnd for non-thenable returns
 
 `tracingChannel(...).tracePromise(fn, ctx)` where `fn` returns a **non-thenable** plain value published only `start` and `end`, omitting `asyncStart`/`asyncEnd`. Node implements `tracePromise` as `Promise.resolve(fn())`, so a non-thenable return is wrapped in an already-resolved promise and still publishes the async pair — Node emits `start|end|asyncStart|asyncEnd`. The non-thenable `else` branch in `diag_trace_promise` (`node_submodules/diagnostics.rs`) set the context `result` and published `end` but returned without publishing `events[2]`/`events[3]`; it now mirrors the fulfilled-promise path. Fixes `test-parity/node-suite/diagnostics_channel/tracing/trace-promise-non-thenable.ts`. Advances the diagnostics_channel semantic-parity epic (#3839).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1087
+**Current Version:** 0.5.1088
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1087"
+version = "0.5.1088"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1087"
+version = "0.5.1088"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1087"
+version = "0.5.1088"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1087"
+version = "0.5.1088"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1087"
+version = "0.5.1088"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/node_submodules/diagnostics.rs
+++ b/crates/perry-runtime/src/node_submodules/diagnostics.rs
@@ -877,15 +877,11 @@ pub(crate) fn ensure_channel(name: f64) -> i64 {
         method_closure(cast1(diag_channel_unbind_store), 1, id),
     );
     set_field_value(obj, "runStores", run_stores_method_closure(id));
-    set_field_value(
-        obj,
-        "withStoreScope",
-        method_closure(
-            cast1(super::diagnostics_tail::diag_channel_with_store_scope),
-            1,
-            id,
-        ),
-    );
+    // Node's diagnostics_channel Channel prototype is exactly
+    // {subscribe, unsubscribe, publish, bindStore, unbindStore, runStores,
+    // hasSubscribers} — there is no `withStoreScope`. Exposing one made
+    // `typeof ch.withStoreScope` "function" where Node has "undefined" and let
+    // `using scope = ch.withStoreScope(...)` run instead of throwing.
     DIAG_CHANNEL_BY_KEY.with(|m| {
         m.borrow_mut().insert(key, id);
     });
@@ -1112,11 +1108,14 @@ pub(crate) extern "C" fn diag_channel_bind_store(
 ) -> f64 {
     ensure_subscriber_owner_thread();
     let id = method_id(closure);
-    // An omitted, explicit `undefined`, or `null` transform is the
-    // no-transform case in Node 26; a callable is stored as-is; any other
-    // value is remembered as a non-callable transform so `runStores` can
-    // reproduce Node's uncaught `TypeError: transform is not a function`.
-    let transform = if matches!(transform.to_bits(), TAG_UNDEFINED | crate::value::TAG_NULL) {
+    // Only an omitted or explicit `undefined` transform is the no-transform
+    // case; a callable is stored as-is; ANY other value — including `null` —
+    // is remembered as a non-callable transform so `runStores` reproduces
+    // Node's uncaught `TypeError: transform is not a function` (verified
+    // against Node v25.x: `bindStore(s, null)` throws when runStores invokes
+    // it, leaving the store unset, whereas `bindStore(s, undefined)` passes
+    // the data through).
+    let transform = if transform.to_bits() == TAG_UNDEFINED {
         StoreTransform::None
     } else if valid_closure_value(transform) {
         StoreTransform::Callable(transform)

--- a/crates/perry-runtime/src/node_submodules/diagnostics_tail.rs
+++ b/crates/perry-runtime/src/node_submodules/diagnostics_tail.rs
@@ -118,6 +118,10 @@ pub(crate) extern "C" fn diag_store_scope_dispose(closure: *const ClosureHeader)
     undefined()
 }
 
+// Not wired to a Channel method: Node has no `withStoreScope` on the
+// diagnostics_channel Channel. Retained (unused) so the store-scope machinery
+// it exercises stays available if a future Node revision adds the API.
+#[allow(dead_code)]
 pub(crate) extern "C" fn diag_channel_with_store_scope(
     closure: *const ClosureHeader,
     data: f64,


### PR DESCRIPTION
## Summary

Two `node:diagnostics_channel` store-subsystem parity fixes (epic #3839).

### 1. `withStoreScope` removed

Node's Channel prototype is exactly `{subscribe, unsubscribe, publish, bindStore, unbindStore, runStores, hasSubscribers}` (verified via `Object.getOwnPropertyNames` on v25.8.0) — there is **no** `withStoreScope`. Perry registered one, so `typeof ch.withStoreScope` was `"function"` where Node has `"undefined"`, and `using scope = ch.withStoreScope(...)` ran a whole block instead of throwing.

Dropped the `set_field_value(obj, "withStoreScope", …)` registration in `diag_channel_object`; the now-unwired `diag_channel_with_store_scope` helper is retained `#[allow(dead_code)]`.

### 2. `null` `bindStore` transform is non-callable

`bindStore(store, null)` classified `null` as the no-transform case (like `undefined`), so `runStores` passed the data straight into the store. Node (v25.x) treats a `null` — or any non-callable, non-`undefined` — transform as a function call that throws `TypeError: transform is not a function` when `runStores` invokes it, leaving the store unset.

Narrowed the `StoreTransform::None` classification in `diag_channel_bind_store` to **only** `undefined` (`TAG_UNDEFINED`); `null` and other non-callables now map to `StoreTransform::NonCallable`.

## Verification

- `diagnostics_channel/stores/with-store-scope.ts` and `…/non-callable-transform.ts` now match Node byte-for-byte.
- Full `diagnostics_channel` sweep: remaining diffs are all **pre-existing and unrelated** to these paths — `bounded/run-and-scope` (uses `BoundedChannel`, which v25.8.0 doesn't export → node SyntaxError), `worker/*` (node `ERR_MODULE_NOT_FOUND` for the worker module in this env), and `imports/namespace-default-shape` (default-import identity). None touch the `bindStore`-null / `withStoreScope` code paths.
