### PR TITLE
[codex] fix async catch params after await

### DIFF
--- a/crates/perry-transform/src/generator/break_continue.rs
+++ b/crates/perry-transform/src/generator/break_continue.rs
@@ -350,10 +350,10 @@ pub fn collect_vars_recursive(stmts: &[Stmt], vars: &mut Vec<(LocalId, String, T
             } => {
                 collect_vars_recursive(body, vars);
                 if let Some(c) = catch {
-                    // Hoist the catch parameter so the .throw() closure can assign to it.
-                    if let Some((pid, pname)) = &c.param {
-                        vars.push((*pid, pname.clone(), Type::Any));
-                    }
+                    // Catch params are hoisted only for catch routes that
+                    // linearize_body lifts into the async throw path. Ordinary
+                    // post-await Stmt::Try bodies must keep codegen's direct
+                    // catch binding slot.
                     collect_vars_recursive(&c.body, vars);
                 }
                 if let Some(f) = finally {

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -20,6 +20,7 @@ pub enum StateExit {
 #[derive(Clone)]
 pub struct CatchRoute {
     pub param_id: Option<LocalId>,
+    pub param_name: Option<String>,
     pub body: Vec<Stmt>,
     pub protected_start_state: u32,
     pub post_catch_state: u32,
@@ -628,9 +629,14 @@ pub fn linearize_body(
                 // Stash the catch so transform_generator_function can inline it
                 // into the .throw() closure later.
                 if let Some(catch_clause) = catch {
-                    let param_id = catch_clause.param.as_ref().map(|(id, _)| *id);
+                    let (param_id, param_name) = catch_clause
+                        .param
+                        .as_ref()
+                        .map(|(id, name)| (Some(*id), Some(name.clone())))
+                        .unwrap_or((None, None));
                     catches.push(CatchRoute {
                         param_id,
+                        param_name,
                         body: catch_clause.body.clone(),
                         protected_start_state,
                         post_catch_state,

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -109,10 +109,9 @@ pub fn transform_generator_function_with_extra_captures(
     });
 
     // Collect hoisted var IDs first so we know which Lets to rewrite
-    let hoisted_ids: std::collections::HashSet<LocalId> = collect_hoisted_vars(&func.body)
-        .iter()
-        .map(|(id, _, _)| *id)
-        .collect();
+    let hoisted_for_rewrite = collect_hoisted_vars(&func.body);
+    let hoisted_ids: std::collections::HashSet<LocalId> =
+        hoisted_for_rewrite.iter().map(|(id, _, _)| *id).collect();
 
     // Rewrite `Let { id, init: Some(expr) }` → `Expr(LocalSet(id, expr))` for hoisted
     // variables inside state bodies. Without this, the Let creates a fresh local that
@@ -273,7 +272,17 @@ pub fn transform_generator_function_with_extra_captures(
 
     // Hoist variable declarations from the original body — collected
     // here (before the prealloc emit) so the prealloc set is complete.
-    let hoisted = collect_hoisted_vars(&func.body);
+    let mut hoisted = hoisted_for_rewrite;
+    for route in &catches {
+        if let (Some(param_id), Some(param_name)) = (route.param_id, route.param_name.as_ref()) {
+            if !hoisted.iter().any(|(id, _, _)| *id == param_id) {
+                // Lifted catch routes run in the async throw arm, outside
+                // codegen's normal Stmt::Try catch binding path, so their
+                // params need cross-state boxes.
+                hoisted.push((param_id, param_name.clone(), Type::Any));
+            }
+        }
+    }
 
     // Issue #1029: the state-machine internals (`state`, `done`, `sent`)
     // plus hoisted user-vars and the transform-allocated `extra_local_ids`

--- a/tests/test_issue_4036_async_try_catch_after_await.sh
+++ b/tests/test_issue_4036_async_try_catch_after_await.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Regression for #4036: a try/catch that appears after an earlier await in an
+# async function must still receive synchronous throws from the post-await
+# continuation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY:-$REPO_ROOT/target/release/perry}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build --release -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+COMPILE_ENV=(env PERRY_ALLOW_UNIMPLEMENTED=1)
+if [[ -f "$REPO_ROOT/target/debug/libperry_runtime.a" || -f "$REPO_ROOT/target/release/libperry_runtime.a" ]]; then
+    COMPILE_ENV=(env PERRY_ALLOW_UNIMPLEMENTED=1 PERRY_NO_AUTO_OPTIMIZE=1)
+fi
+
+cat > "$TMPDIR/main.ts" << 'EOF'
+function boom() {
+  throw "call-boom";
+}
+
+function syncCatch() {
+  try {
+    throw "sync-boom";
+  } catch (e: any) {
+    console.log("sync caught:", e);
+  }
+}
+
+async function noPriorAwait() {
+  try {
+    throw "no-await-boom";
+  } catch (e: any) {
+    console.log("no-await caught:", e);
+  }
+}
+
+async function directPostAwait() {
+  await 0;
+  try {
+    throw "direct-boom";
+  } catch (e: any) {
+    console.log("direct caught:", e);
+  }
+}
+
+async function callPostAwait() {
+  await 0;
+  try {
+    boom();
+  } catch (e: any) {
+    console.log("call caught:", e);
+  }
+}
+
+async function promiseResolvePostAwait() {
+  await Promise.resolve(1);
+  try {
+    throw new Error("promise-boom");
+  } catch (e: any) {
+    console.log("promise caught:", e.message);
+  }
+}
+
+async function rejectedAwaitStillWorks() {
+  try {
+    await Promise.reject("reject-boom");
+    console.log("reject unexpectedly resolved");
+  } catch (e: any) {
+    console.log("reject caught:", e);
+  }
+}
+
+syncCatch();
+await noPriorAwait();
+await directPostAwait();
+await callPostAwait();
+await promiseResolvePostAwait();
+await rejectedAwaitStillWorks();
+console.log("done");
+EOF
+
+"${COMPILE_ENV[@]}" "$PERRY" compile --no-cache "$TMPDIR/main.ts" -o "$TMPDIR/test_bin" \
+    >"$TMPDIR/compile.log" 2>&1 || {
+        echo "FAIL: compile failed"
+        sed 's/^/    /' "$TMPDIR/compile.log" | tail -80
+        exit 1
+    }
+
+RUN_OUTPUT="$("$TMPDIR/test_bin" 2>&1)"
+
+EXPECTED="sync caught: sync-boom
+no-await caught: no-await-boom
+direct caught: direct-boom
+call caught: call-boom
+promise caught: promise-boom
+reject caught: reject-boom
+done"
+
+if [[ "$RUN_OUTPUT" == "$EXPECTED" ]]; then
+    echo "PASS"
+    exit 0
+fi
+
+echo "FAIL: async post-await try/catch output changed"
+echo "Expected:"
+echo "$EXPECTED"
+echo
+echo "Got:"
+echo "$RUN_OUTPUT"
+exit 1


### PR DESCRIPTION
## Summary

Fixes #4036.

- Keep ordinary post-await `Stmt::Try` catch parameters on codegen's direct catch binding path instead of hoisting them into boxed state-machine captures.
- Preserve catch-parameter boxing only for catch routes that `linearize_body` lifts into the async throw/rejected-await path.
- Add regression coverage for direct synchronous throws and sync-throwing calls inside `try/catch` after a prior `await`, plus the issue boundary cases.

The fix follows the TypeScript async/generator lowering reference from `reference/deepwiki/typescript-async-try-catch-reference.md`: resumed async continuations must preserve the active catch route without corrupting the catch binding used by synchronous throws.

## Tests

- `cargo check -p perry-transform`
- `cargo test -p perry-transform`
- `cargo build -p perry`
- `PERRY=target/debug/perry bash tests/test_issue_4036_async_try_catch_after_await.sh`
- `PERRY=target/debug/perry bash tests/test_issue_3583_async_semantic_parity.sh`
- `bash tests/test_try_block_no_leak_on_return.sh`
- Compiled and ran: `tests/test_async_simple.ts`, `tests/test_async_func.ts`, `tests/test_async_chain.ts`, `tests/test_async_two_locals.ts`, `tests/test_try_catch.ts`
- Reproduced the original minimal script before the fix; after the fix it prints `caught: boom` then `done`.
