### PR TITLE
runtime/date: align Date constructor, prototype brand, and stringification

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -41,6 +41,11 @@ fn is_array_only_method_name(name: &str) -> bool {
     )
 }
 
+fn is_date_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
+    matches!(object, Expr::DateNew(_))
+        || receiver_class_name(ctx, object).as_deref() == Some("Date")
+}
+
 /// Try to lower a `Call { callee: PropertyGet { .. } }` via the
 /// string/array/class/Map/Set/Promise/fetch/static/instance dispatch tower.
 pub fn try_lower_property_get_method_call(
@@ -129,6 +134,7 @@ pub fn try_lower_property_get_method_call(
         && args.len() == 1
         && !is_string_expr(ctx, object)
         && !is_array_expr(ctx, object)
+        && !is_date_receiver(ctx, object)
         && is_string_expr(ctx, &args[0])
     {
         let has_user_to_string = receiver_class_name(ctx, object)
@@ -186,6 +192,7 @@ pub fn try_lower_property_get_method_call(
         && args.len() == 1
         && !is_string_expr(ctx, object)
         && !is_array_expr(ctx, object)
+        && !is_date_receiver(ctx, object)
     {
         // Only treat as radix call if class doesn't have toString.
         let has_user_to_string = receiver_class_name(ctx, object)
@@ -230,6 +237,7 @@ pub fn try_lower_property_get_method_call(
         && args.len() <= 1
         && !is_string_expr(ctx, object)
         && !is_array_expr(ctx, object)
+        && !is_date_receiver(ctx, object)
     {
         // Check whether the receiver class (if any) defines
         // toString itself or via inheritance.

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -430,23 +430,14 @@ pub(super) fn lower_assign(ctx: &mut LoweringContext, assign: &ast::AssignExpr) 
                             let inner_obj = unwrap_ts(inner.obj.as_ref());
                             if let ast::Expr::Ident(cls_ident) = inner_obj {
                                 let cls_name = cls_ident.sym.to_string();
-                                // Prefer the LocalGet route whenever `<ident>`
-                                // resolves to a function-valued local — even
-                                // when a sibling FuncRef exists. The inner
-                                // function-decl path in `lower_decl.rs` emits
-                                // a `Stmt::Let { init: Some(Closure{…}) }`
-                                // that the matching `new M(args)` site reads
-                                // via the same LocalGet, so the closure value
-                                // at registration time and construct time
-                                // share NaN-boxed bits (the
-                                // `FUNCTION_CLASS_IDS` key). Routing through
-                                // FuncRef instead would emit a singleton
-                                // wrapper closure at the register site whose
-                                // pointer differs from the function-decl's
-                                // Let closure — registration and construct
-                                // would then key on different bits and
-                                // dispatch would miss.
-                                if ctx.lookup_class(&cls_name).is_some() {
+                                // Built-in Date has a real runtime prototype object;
+                                // Date.prototype writes must remain ordinary property sets.
+                                if cls_name == "Date"
+                                    && ctx.lookup_local(&cls_name).is_none()
+                                    && ctx.lookup_func(&cls_name).is_none()
+                                {
+                                    None
+                                } else if ctx.lookup_class(&cls_name).is_some() {
                                     Some(ProtoOwner::Class(cls_name))
                                 } else if let Some(local_id) = ctx.lookup_local(&cls_name) {
                                     if ctx.function_valued_locals.contains(&local_id) {

--- a/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
@@ -40,7 +40,7 @@ fn new_callee_name(ctx: &LoweringContext, new_expr: &ast::NewExpr) -> Option<Str
 
 pub(super) fn try_url_date_weakref_instance(
     ctx: &mut LoweringContext,
-    call: &ast::CallExpr,
+    _call: &ast::CallExpr,
     expr: &ast::Expr,
     mut args: Vec<Expr>,
 ) -> Result<Result<Expr, Vec<Expr>>> {
@@ -270,17 +270,6 @@ pub(super) fn try_url_date_weakref_instance(
                     "valueOf" => {
                         let date_expr = lower_expr(ctx, &member.obj)?;
                         return Ok(Ok(Expr::DateValueOf(Box::new(date_expr))));
-                    }
-                    // #2089: `date.toString()` — full local date string (or
-                    // "Invalid Date"). `toString` exists on EVERY value, so this
-                    // arm must fire ONLY when the receiver is statically a Date;
-                    // otherwise it would hijack `bigint.toString()` /
-                    // `urlSearchParams.toString()` / etc. An `any`-typed Date
-                    // receiver falls through to generic dispatch, which routes a
-                    // DateCell through `js_jsvalue_to_string` (also #2089-aware).
-                    "toString" if recv_class == Some("Date") => {
-                        let date_expr = lower_expr(ctx, &member.obj)?;
-                        return Ok(Ok(Expr::DateToString(Box::new(date_expr))));
                     }
                     "toDateString" => {
                         let date_expr = lower_expr(ctx, &member.obj)?;

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -94,6 +94,14 @@ pub(crate) extern "C" fn global_this_builtin_noop_thunk(
     f64::from_bits(crate::value::TAG_UNDEFINED)
 }
 
+extern "C" fn global_this_date_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    _arg: f64,
+) -> f64 {
+    let string = crate::date::js_date_to_string(crate::date::js_date_new());
+    crate::value::js_nanbox_string(string as i64)
+}
+
 extern "C" fn global_this_eval_thunk(
     _closure: *const crate::closure::ClosureHeader,
     source: f64,
@@ -605,7 +613,11 @@ extern "C" fn object_prototype_to_string_thunk(
             unsafe {
                 let gc_header = raw.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
                 let gc_type = (*gc_header).obj_type;
-                if gc_type == crate::gc::GC_TYPE_ARRAY || gc_type == crate::gc::GC_TYPE_LAZY_ARRAY {
+                if gc_type == crate::gc::GC_TYPE_DATE_CELL {
+                    b"[object Date]"
+                } else if gc_type == crate::gc::GC_TYPE_ARRAY
+                    || gc_type == crate::gc::GC_TYPE_LAZY_ARRAY
+                {
                     b"[object Array]"
                 } else if gc_type == crate::gc::GC_TYPE_ERROR {
                     b"[object Error]"
@@ -629,6 +641,14 @@ extern "C" fn object_prototype_is_prototype_of_thunk(
     f64::from_bits(
         JSValue::bool(unsafe { super::js_object_is_prototype_of_value(this_value, value) }).bits(),
     )
+}
+
+extern "C" fn date_prototype_to_string_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    let string = crate::date::js_date_to_string(this_value);
+    crate::value::js_nanbox_string(string as i64)
 }
 
 extern "C" fn object_prototype_value_of_thunk(
@@ -1084,6 +1104,7 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             "BroadcastChannel" => {
                 crate::messaging::js_broadcast_channel_constructor_call_error as *const u8
             }
+            "Date" => global_this_date_thunk as *const u8,
             "Storage" => crate::web_storage::storage_constructor_illegal as *const u8,
             "Crypto" | "CryptoKey" | "SubtleCrypto" => {
                 webcrypto_illegal_constructor_thunk as *const u8
@@ -1100,6 +1121,9 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         match name {
             "Array" => {
                 crate::closure::js_register_closure_rest(func_ptr, 0);
+            }
+            "Date" => {
+                crate::closure::js_register_closure_arity(func_ptr, 1);
             }
             "Object" | "String" | "Number" | "Boolean" | "BroadcastChannel" => {
                 crate::closure::js_register_closure_arity(func_ptr, 1);
@@ -2195,13 +2219,24 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
                     ("toLocaleDateString", 0),
                     ("toLocaleString", 0),
                     ("toLocaleTimeString", 0),
-                    ("toString", 0),
                     ("toTimeString", 0),
                     ("toUTCString", 0),
                     ("valueOf", 0),
                 ],
             );
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+            install_proto_method(
+                proto_obj,
+                "isPrototypeOf",
+                object_prototype_is_prototype_of_thunk as *const u8,
+                1,
+            );
+            install_proto_method(
+                proto_obj,
+                "toString",
+                date_prototype_to_string_thunk as *const u8,
+                0,
+            );
         }
         "RegExp" => {
             install_noop_proto_methods(

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1663,6 +1663,11 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
     } else {
         0
     };
+    if raw_addr >= 0x1000 && crate::date::is_date_cell_addr(raw_addr) {
+        let bytes = b"[object Date]";
+        let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+        return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
+    }
     if raw_addr >= 0x1000 && crate::buffer::is_registered_buffer(raw_addr) {
         let tag = if crate::buffer::crypto_key_meta(raw_addr).is_some() {
             "CryptoKey"

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1664,8 +1664,7 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
         0
     };
     if raw_addr >= 0x1000 && crate::date::is_date_cell_addr(raw_addr) {
-        let bytes = b"[object Date]";
-        let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+        let str_ptr = crate::string::js_string_from_bytes(b"[object Date]".as_ptr(), 13);
         return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
     }
     if raw_addr >= 0x1000 && crate::buffer::is_registered_buffer(raw_addr) {

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -318,6 +318,19 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
         None => return false,
     };
 
+    if crate::date::is_date_value(target) {
+        let ctor = crate::object::js_get_global_this_builtin_value(b"Date".as_ptr(), 4);
+        let ctor_ptr = crate::value::js_nanbox_get_pointer(ctor) as usize;
+        if ctor_ptr == 0 {
+            return false;
+        }
+        let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
+        if let Some(proto_ptr) = object_ptr_from_value(proto) {
+            return std::ptr::addr_eq(proto_ptr, receiver_ptr);
+        }
+        return false;
+    }
+
     let target_jsval = JSValue::from_bits(target.to_bits());
     if !target_jsval.is_pointer() {
         return false;
@@ -928,6 +941,31 @@ pub unsafe extern "C" fn js_native_call_method(
                 }
             }
         }
+    }
+
+    if crate::date::is_date_value(object) && method_name == "toString" {
+        let ctor = crate::object::js_get_global_this_builtin_value(b"Date".as_ptr(), 4);
+        let ctor_ptr = crate::value::js_nanbox_get_pointer(ctor) as usize;
+        if ctor_ptr != 0 {
+            let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
+            if let Some(proto_ptr) = object_ptr_from_value(proto) {
+                let key = crate::string::js_string_from_bytes(
+                    method_name_ptr as *const u8,
+                    method_name_len as u32,
+                );
+                let value = crate::object::js_object_get_field_by_name(proto_ptr, key);
+                if !value.is_undefined() {
+                    let value_f64 = f64::from_bits(value.bits());
+                    let prev_this = IMPLICIT_THIS.with(|c| c.replace(object.to_bits()));
+                    let result =
+                        crate::closure::js_native_call_value(value_f64, args_ptr, args_len);
+                    IMPLICIT_THIS.with(|c| c.set(prev_this));
+                    return result;
+                }
+            }
+        }
+        let string = crate::date::js_date_to_string(object);
+        return f64::from_bits(JSValue::string_ptr(string).bits());
     }
 
     // Symbols: Symbol.for() pointers are Box-leaked (no GcHeader), so the


### PR DESCRIPTION
Fixes #4031.

## What changed

- Makes callable `Date()` return a current Date string instead of the old constructor noop result.
- Installs real `Date.prototype.toString` / `isPrototypeOf` thunks and routes Date instance `toString()` through the current prototype method so overwritten methods are respected.
- Brands Date cells as `[object Date]` for `Object.prototype.toString`.
- Keeps builtin `Date.prototype.* = ...` writes on the ordinary runtime prototype object instead of rewriting them into user-class prototype registration.
- Lets codegen Date `toString()` calls fall through to runtime method dispatch instead of the universal `js_jsvalue_to_string` fast path.

## Reference

- DeepWiki response saved at `target/deepwiki/date-constructor-brand.md`.

## Evidence

Base/HEAD before edits:

- Branch: `codex/date-constructor-brand`
- Base SHA: `132fb26cf461eced3da6bc86e04f680557c49400`
- Final commit: `7fb1da55da84fda98f165b46a5027caa143b999b`

Issue baseline from #4031:

- `pass=24`, `runtime-fail=56`, `parity=30.0%`

After this change:

- `scripts/test262_subset.py --root vendor/test262 --dir built-ins/Date --max 80 --timeout 8 --sample-cap 20 --report /tmp/perry-c262-date.json`
- Result: `pass=47`, `diff=0`, `runtime-fail=33`, `compile-fail=0`, `skip=0`, `parity=58.8%`

Focused smoke:

- `target/release/perry run target/date-smoke.js`
- Result: `date smoke ok`

Build:

- `cargo build --release -p perry`

## Residual Risks

- Remaining sampled Date failures are intentionally outside this PR-sized scope: poisoned value coercion/ordering, Date static descriptor/prototype edge cases, TimeClip negative zero, and broader Date.UTC coercion behavior.
- Locale/Intl formatting, historical timezone accuracy, and full parse edge cases remain deferred per #4031.
