### PR TITLE
runtime/binary-data: complete ArrayBuffer/DataView view semantics

### DIFF
--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -391,6 +391,7 @@ pub(super) fn init_static_fields_early(
         // built-in error subclass, register this class's id.
         let mut cur: Option<String> = c.extends_name.clone();
         let mut extends_error = false;
+        let mut extends_data_view = false;
         let mut depth = 0usize;
         while let Some(name) = cur {
             if matches!(
@@ -405,6 +406,10 @@ pub(super) fn init_static_fields_early(
                     | "AggregateError"
             ) {
                 extends_error = true;
+                break;
+            }
+            if name == "DataView" {
+                extends_data_view = true;
                 break;
             }
             // Walk user-defined ancestor chain.
@@ -423,6 +428,15 @@ pub(super) fn init_static_fields_early(
                 let cid_str = cid.to_string();
                 ctx.block().call_void(
                     "js_register_class_extends_error",
+                    &[(crate::types::I32, &cid_str)],
+                );
+            }
+        }
+        if extends_data_view {
+            if let Some(&cid) = ctx.class_ids.get(&c.name) {
+                let cid_str = cid.to_string();
+                ctx.block().call_void(
+                    "js_register_class_extends_data_view",
                     &[(crate::types::I32, &cid_str)],
                 );
             }

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -672,6 +672,34 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &[(I64, &ctor_handle), (I64, &key_raw)],
                     ));
                 }
+                // #4033: `ArrayBuffer.isView` must also work as a value
+                // (`const isView = ArrayBuffer.isView; isView(view)`). Bare
+                // builtin receivers are collapsed to `GlobalGet(0)`, so recover
+                // the populated constructor closure and read the reified static.
+                if property == "isView" {
+                    let ctor_idx = ctx.strings.intern("ArrayBuffer");
+                    let ctor_bytes_global =
+                        format!("@{}", ctx.strings.entry(ctor_idx).bytes_global);
+                    let ctor_len = "ArrayBuffer".len().to_string();
+                    let ctor = ctx.block().call(
+                        DOUBLE,
+                        "js_get_global_this_builtin_value",
+                        &[(PTR, &ctor_bytes_global), (I64, &ctor_len)],
+                    );
+                    let key_idx = ctx.strings.intern(property);
+                    let key_handle_global =
+                        format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                    let blk = ctx.block();
+                    let ctor_handle = unbox_to_i64(blk, &ctor);
+                    let key_box = blk.load(DOUBLE, &key_handle_global);
+                    let key_bits = blk.bitcast_double_to_i64(&key_box);
+                    let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
+                    return Ok(blk.call(
+                        DOUBLE,
+                        "js_object_get_field_by_name_f64",
+                        &[(I64, &ctor_handle), (I64, &key_raw)],
+                    ));
+                }
                 if property == "f16round" {
                     let math_idx = ctx.strings.intern("Math");
                     let math_bytes_global =

--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -119,9 +119,6 @@ pub(super) fn lower_builtin_new(
         // Uint8Array — i.e. ArrayBuffers — are aliased rather than
         // copied). SharedArrayBuffer uses the same storage allocation with a
         // separate runtime registry so util.types can distinguish it.
-        // Non-numeric arg shapes (`new ArrayBuffer(undefined)` etc.) coerce to
-        // 0 — matches Node/bun's `ToIndex(length)` step for the typical
-        // undefined-arg case.
         "ArrayBuffer" | "SharedArrayBuffer" => {
             let size_box = if !args.is_empty() {
                 lower_expr(ctx, &args[0])?
@@ -129,13 +126,12 @@ pub(super) fn lower_builtin_new(
                 double_literal(0.0)
             };
             let blk = ctx.block();
-            let size_i32 = blk.fptosi(DOUBLE, &size_box, I32);
             let runtime = if class_name == "SharedArrayBuffer" {
-                "js_shared_array_buffer_new"
+                "js_shared_array_buffer_new_value"
             } else {
-                "js_array_buffer_new"
+                "js_array_buffer_new_value"
             };
-            let handle = blk.call(I64, runtime, &[(I32, &size_i32)]);
+            let handle = blk.call(I64, runtime, &[(DOUBLE, &size_box)]);
             Ok(Some(nanbox_pointer_inline(blk, &handle)))
         }
         "Uint8Array" if args.len() >= 2 => {
@@ -157,8 +153,8 @@ pub(super) fn lower_builtin_new(
         }
         // Minimal DataView support for BufferSource consumers such as
         // StringDecoder: Perry models ArrayBuffer/Uint8Array storage as a
-        // BufferHeader, so `new DataView(buffer)` can alias the same backing
-        // pointer for byte-extraction call sites.
+        // BufferHeader, so `new DataView(buffer)` can create a registered view
+        // over that backing store for byte-extraction call sites.
         "DataView" => {
             // Pass the raw NaN-boxed arguments (undefined when absent) so the
             // runtime can apply the spec's ToIndex/range validation and throw

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -977,6 +977,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // is a runtime expression (function arg holding class ref).
     module.declare_function("js_instanceof_dynamic", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_register_class_extends_error", VOID, &[I32]);
+    module.declare_function("js_register_class_extends_data_view", VOID, &[I32]);
     module.declare_function("js_register_class_id", VOID, &[I32]);
     // #1021 NestJS: surface Perry class names to V8 so `metatype.name`
     // is non-empty. Codegen emits one call per registered class id at

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -525,6 +525,8 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     // bytes that subsequent `new Uint8Array(ab)` views ALIAS via shared pointer.
     module.declare_function("js_array_buffer_new", I64, &[I32]);
     module.declare_function("js_shared_array_buffer_new", I64, &[I32]);
+    module.declare_function("js_array_buffer_new_value", I64, &[DOUBLE]);
+    module.declare_function("js_shared_array_buffer_new_value", I64, &[DOUBLE]);
     // JSON full-featured stringify/parse (replacer + indent + reviver).
     module.declare_function("js_json_stringify_full", I64, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_json_parse_with_reviver", I64, &[I64, I64]);

--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -588,6 +588,25 @@ fn zeroed_array_buffer_storage(size: i32) -> *mut BufferHeader {
     buf
 }
 
+fn throw_array_buffer_range_error() -> ! {
+    crate::fs::validate::throw_range_error_with_code("Invalid array buffer length")
+}
+
+fn array_buffer_to_index(value: f64) -> i32 {
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if jv.is_undefined() {
+        return 0;
+    }
+    let n = jv.to_number();
+    if n.is_nan() {
+        return 0;
+    }
+    if n < 0.0 || n > i32::MAX as f64 {
+        throw_array_buffer_range_error();
+    }
+    n.trunc() as i32
+}
+
 /// `new ArrayBuffer(size)` — allocate a zero-filled buffer of `size` bytes.
 /// Issue #579: pre-fix, `ArrayBuffer` had no constructor handler so it fell
 /// through to the empty-ObjectHeader placeholder path, and `new Uint8Array(ab)`
@@ -604,6 +623,11 @@ pub extern "C" fn js_array_buffer_new(size: i32) -> *mut BufferHeader {
     buf
 }
 
+#[no_mangle]
+pub extern "C" fn js_array_buffer_new_value(size_value: f64) -> *mut BufferHeader {
+    js_array_buffer_new(array_buffer_to_index(size_value))
+}
+
 /// `new SharedArrayBuffer(size)` — same BufferHeader backing store as
 /// ArrayBuffer, tracked in a distinct side registry for util.types predicates.
 #[no_mangle]
@@ -611,6 +635,11 @@ pub extern "C" fn js_shared_array_buffer_new(size: i32) -> *mut BufferHeader {
     let buf = zeroed_array_buffer_storage(size);
     mark_as_shared_array_buffer(buf as usize);
     buf
+}
+
+#[no_mangle]
+pub extern "C" fn js_shared_array_buffer_new_value(size_value: f64) -> *mut BufferHeader {
+    js_shared_array_buffer_new(array_buffer_to_index(size_value))
 }
 
 /// `Type(buffer) is not Object` → `TypeError` (DataView spec step 2). Also
@@ -656,11 +685,10 @@ fn dataview_to_index(value: f64, what: &str) -> i64 {
 }
 
 /// `new DataView(buffer, byteOffset?, byteLength?)` — Perry models a DataView
-/// as a `BufferHeader` over the backing `ArrayBuffer`. With `byteOffset == 0`
-/// and no explicit length the view aliases the backing pointer directly
-/// (zero-copy; writes are visible through sibling `Uint8Array` views). A
-/// non-zero offset or explicit length produces a registered slice view so the
-/// numeric accessors index relative to the view start (#2878).
+/// as a `BufferHeader` view over the backing `ArrayBuffer`. Even a full-span
+/// `new DataView(buffer)` gets its own registered view header so brand checks
+/// can distinguish the DataView receiver from the backing ArrayBuffer while
+/// preserving write propagation through the shared view registry.
 ///
 /// `offset_value` / `length_value` are NaN-boxed JS values (the raw arguments,
 /// `undefined` when absent) so the spec's `ToIndex`/range validation can run
@@ -702,14 +730,7 @@ pub extern "C" fn js_data_view_new(value: f64, offset_value: f64, length_value: 
         requested
     };
 
-    // Fast path: full-buffer zero-offset view aliases the backing pointer
-    // directly (zero-copy; preserves the existing StringDecoder consumer).
-    if offset == 0 && view_len == total_len {
-        mark_as_data_view(addr);
-        return value;
-    }
-
-    // Otherwise build a registered slice view so the numeric accessors index
+    // Build a registered view so the numeric accessors index
     // relative to the view start and `.byteOffset`/`.byteLength`/`.buffer`
     // report the right values — including the zero-length edge cases
     // (`offset == total_len`) that `js_buffer_slice` would otherwise collapse

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -41,12 +41,13 @@ pub use header::{
 
 // ---- Re-exports: Buffer.from / alloc / concat (FFI) ----
 pub use from::{
-    js_array_buffer_new, js_buffer_alloc, js_buffer_alloc_fill_value, js_buffer_alloc_unsafe,
-    js_buffer_concat, js_buffer_concat_with_length, js_buffer_fill, js_buffer_fill_range,
-    js_buffer_fill_value_range, js_buffer_from_array, js_buffer_from_arraybuffer_slice,
-    js_buffer_from_string, js_buffer_from_value, js_data_view_new, js_encoding_tag_from_value,
-    js_shared_array_buffer_new, js_uint8array_alloc, js_uint8array_from_array, js_uint8array_new,
-    js_uint8array_view,
+    js_array_buffer_new, js_array_buffer_new_value, js_buffer_alloc, js_buffer_alloc_fill_value,
+    js_buffer_alloc_unsafe, js_buffer_concat, js_buffer_concat_with_length, js_buffer_fill,
+    js_buffer_fill_range, js_buffer_fill_value_range, js_buffer_from_array,
+    js_buffer_from_arraybuffer_slice, js_buffer_from_string, js_buffer_from_value,
+    js_data_view_new, js_encoding_tag_from_value, js_shared_array_buffer_new,
+    js_shared_array_buffer_new_value, js_uint8array_alloc, js_uint8array_from_array,
+    js_uint8array_new, js_uint8array_view,
 };
 
 // ---- Re-exports: predicates / byteLength (FFI) ----

--- a/crates/perry-runtime/src/object/data_view_registry.rs
+++ b/crates/perry-runtime/src/object/data_view_registry.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+/// Global registry of class IDs that extend the built-in DataView class.
+static EXTENDS_DATA_VIEW_REGISTRY: RwLock<Option<std::collections::HashSet<u32>>> =
+    RwLock::new(None);
+
+/// Mark a user-defined class as extending the built-in DataView class.
+#[no_mangle]
+pub extern "C" fn js_register_class_extends_data_view(class_id: u32) {
+    let mut registry = EXTENDS_DATA_VIEW_REGISTRY.write().unwrap();
+    if registry.is_none() {
+        *registry = Some(std::collections::HashSet::new());
+    }
+    registry.as_mut().unwrap().insert(class_id);
+}
+
+/// Check if a class id extends the built-in DataView class.
+pub(crate) fn extends_builtin_data_view(class_id: u32) -> bool {
+    let registry = EXTENDS_DATA_VIEW_REGISTRY.read().unwrap();
+    if let Some(reg) = registry.as_ref() {
+        if reg.contains(&class_id) {
+            return true;
+        }
+        let mut current = class_id;
+        let parent_reg = super::CLASS_REGISTRY.read().unwrap();
+        if let Some(pr) = parent_reg.as_ref() {
+            for _ in 0..32 {
+                match pr.get(&current).copied() {
+                    Some(parent) if parent != 0 => {
+                        if reg.contains(&parent) {
+                            return true;
+                        }
+                        current = parent;
+                    }
+                    _ => break,
+                }
+            }
+        }
+    }
+    false
+}

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -749,6 +749,83 @@ extern "C" fn array_prototype_slice_thunk(
     f64::from_bits(crate::value::js_nanbox_pointer(result as i64).to_bits())
 }
 
+fn array_buffer_receiver_addr() -> Option<usize> {
+    let this_bits = IMPLICIT_THIS.with(|c| c.get());
+    let this_jsv = JSValue::from_bits(this_bits);
+    let raw = if this_jsv.is_pointer() {
+        (this_bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else if this_bits >> 48 == 0 && this_bits > 0x10000 {
+        this_bits as usize
+    } else {
+        return None;
+    };
+    if crate::buffer::is_registered_buffer(raw) && crate::buffer::is_array_buffer(raw) {
+        Some(raw)
+    } else {
+        None
+    }
+}
+
+fn array_buffer_brand_error() -> ! {
+    super::object_ops::throw_object_type_error(
+        b"Method get ArrayBuffer.prototype.byteLength called on incompatible receiver",
+    )
+}
+
+extern "C" fn array_buffer_byte_length_getter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    match array_buffer_receiver_addr() {
+        Some(addr) => {
+            let buf = addr as *const crate::buffer::BufferHeader;
+            f64::from_bits(
+                crate::value::JSValue::number(crate::buffer::js_buffer_length(buf) as f64).bits(),
+            )
+        }
+        None => array_buffer_brand_error(),
+    }
+}
+
+extern "C" fn array_buffer_is_view_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    let jv = JSValue::from_bits(value.to_bits());
+    let addr = if jv.is_pointer() {
+        (value.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else if value.to_bits() >> 48 == 0 && value.to_bits() > 0x10000 {
+        value.to_bits() as usize
+    } else {
+        0
+    };
+    let is_view = (addr != 0
+        && !crate::buffer::is_any_array_buffer(addr)
+        && (crate::buffer::is_uint8array_buffer(addr) || crate::buffer::is_data_view(addr)))
+        || jsvalue_extends_data_view(value)
+        || crate::typedarray::lookup_typed_array_kind(addr).is_some();
+    f64::from_bits(crate::value::JSValue::bool(is_view).bits())
+}
+
+fn jsvalue_extends_data_view(value: f64) -> bool {
+    let v = JSValue::from_bits(value.to_bits());
+    if !v.is_pointer() {
+        return false;
+    }
+    let ptr = v.as_pointer::<u8>();
+    if ptr.is_null() || !crate::object::is_valid_obj_ptr(ptr) {
+        return false;
+    }
+    unsafe {
+        let gc_header = ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        if (*gc_header).obj_type != crate::gc::GC_TYPE_OBJECT {
+            return false;
+        }
+        let obj = ptr as *const ObjectHeader;
+        let class_id = (*obj).class_id;
+        class_id != 0 && crate::object::extends_builtin_data_view(class_id)
+    }
+}
+
 /// Resolve the `IMPLICIT_THIS` receiver to a `(typed-array ptr, kind)` if it
 /// is a typed array, else `None`. Backs the `%TypedArray%.prototype` accessor
 /// getters installed for reflection (#2060) — these fire when user code does
@@ -1798,6 +1875,15 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
             install_constructor_static(ctor, "from", array_from_thunk as *const u8, 1, false);
             install_constructor_static(ctor, "of", array_of_thunk as *const u8, 0, true);
         }
+        "ArrayBuffer" => {
+            install_constructor_static(
+                ctor,
+                "isView",
+                array_buffer_is_view_thunk as *const u8,
+                1,
+                false,
+            );
+        }
         "Response" => {
             install_constructor_static(
                 ctor,
@@ -2041,6 +2127,37 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
                     ("with", 2),
                 ],
             );
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
+        "ArrayBuffer" => {
+            install_noop_proto_methods(proto_obj, &[("slice", 2)]);
+            unsafe {
+                crate::closure::js_register_closure_arity(
+                    array_buffer_byte_length_getter_thunk as *const u8,
+                    0,
+                );
+                let getter = crate::closure::js_closure_alloc(
+                    array_buffer_byte_length_getter_thunk as *const u8,
+                    0,
+                );
+                if !getter.is_null() {
+                    let getter_bits = crate::value::js_nanbox_pointer(getter as i64).to_bits();
+                    install_builtin_getter(proto_obj, "byteLength", getter_bits);
+                    set_accessor_descriptor(
+                        proto_obj as usize,
+                        "byteLength".to_string(),
+                        AccessorDescriptor {
+                            get: getter_bits,
+                            set: 0,
+                        },
+                    );
+                    set_property_attrs(
+                        proto_obj as usize,
+                        "byteLength".to_string(),
+                        PropertyAttrs::new(true, false, true),
+                    );
+                }
+            }
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
         "Object" => {

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1557,6 +1557,10 @@ static CLASS_REGISTRY: RwLock<Option<HashMap<u32, u32>>> = RwLock::new(None);
 /// Global registry of class IDs that extend the built-in Error class
 static EXTENDS_ERROR_REGISTRY: RwLock<Option<std::collections::HashSet<u32>>> = RwLock::new(None);
 
+/// Global registry of class IDs that extend the built-in DataView class
+static EXTENDS_DATA_VIEW_REGISTRY: RwLock<Option<std::collections::HashSet<u32>>> =
+    RwLock::new(None);
+
 /// Per-class `Symbol.hasInstance` static hook. Maps class_id → raw function
 /// pointer with signature `extern "C" fn(value: f64) -> f64` (NaN-boxed
 /// TAG_TRUE / TAG_FALSE result). Populated at module init from
@@ -1800,6 +1804,42 @@ pub extern "C" fn js_register_class_extends_error(class_id: u32) {
 /// Check if a class id extends the built-in Error class
 pub(crate) fn extends_builtin_error(class_id: u32) -> bool {
     let registry = EXTENDS_ERROR_REGISTRY.read().unwrap();
+    if let Some(reg) = registry.as_ref() {
+        if reg.contains(&class_id) {
+            return true;
+        }
+        let mut current = class_id;
+        let parent_reg = CLASS_REGISTRY.read().unwrap();
+        if let Some(pr) = parent_reg.as_ref() {
+            for _ in 0..32 {
+                match pr.get(&current).copied() {
+                    Some(parent) if parent != 0 => {
+                        if reg.contains(&parent) {
+                            return true;
+                        }
+                        current = parent;
+                    }
+                    _ => break,
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Mark a user-defined class as extending the built-in DataView class.
+#[no_mangle]
+pub extern "C" fn js_register_class_extends_data_view(class_id: u32) {
+    let mut registry = EXTENDS_DATA_VIEW_REGISTRY.write().unwrap();
+    if registry.is_none() {
+        *registry = Some(std::collections::HashSet::new());
+    }
+    registry.as_mut().unwrap().insert(class_id);
+}
+
+/// Check if a class id extends the built-in DataView class.
+pub(crate) fn extends_builtin_data_view(class_id: u32) -> bool {
+    let registry = EXTENDS_DATA_VIEW_REGISTRY.read().unwrap();
     if let Some(reg) = registry.as_ref() {
         if reg.contains(&class_id) {
             return true;

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -32,6 +32,7 @@ mod class_gc_roots;
 mod class_handles;
 mod class_registry;
 mod collection_proto_thunks;
+mod data_view_registry;
 mod delete_rest;
 mod descriptors;
 mod field_get_set;
@@ -67,6 +68,7 @@ pub(crate) use class_gc_roots::{
     test_seed_class_parent_closure_root,
 };
 pub use class_registry::*;
+pub(crate) use data_view_registry::extends_builtin_data_view;
 pub use delete_rest::*;
 pub use descriptors::*;
 pub use field_get_set::*;
@@ -1557,10 +1559,6 @@ static CLASS_REGISTRY: RwLock<Option<HashMap<u32, u32>>> = RwLock::new(None);
 /// Global registry of class IDs that extend the built-in Error class
 static EXTENDS_ERROR_REGISTRY: RwLock<Option<std::collections::HashSet<u32>>> = RwLock::new(None);
 
-/// Global registry of class IDs that extend the built-in DataView class
-static EXTENDS_DATA_VIEW_REGISTRY: RwLock<Option<std::collections::HashSet<u32>>> =
-    RwLock::new(None);
-
 /// Per-class `Symbol.hasInstance` static hook. Maps class_id → raw function
 /// pointer with signature `extern "C" fn(value: f64) -> f64` (NaN-boxed
 /// TAG_TRUE / TAG_FALSE result). Populated at module init from
@@ -1804,42 +1802,6 @@ pub extern "C" fn js_register_class_extends_error(class_id: u32) {
 /// Check if a class id extends the built-in Error class
 pub(crate) fn extends_builtin_error(class_id: u32) -> bool {
     let registry = EXTENDS_ERROR_REGISTRY.read().unwrap();
-    if let Some(reg) = registry.as_ref() {
-        if reg.contains(&class_id) {
-            return true;
-        }
-        let mut current = class_id;
-        let parent_reg = CLASS_REGISTRY.read().unwrap();
-        if let Some(pr) = parent_reg.as_ref() {
-            for _ in 0..32 {
-                match pr.get(&current).copied() {
-                    Some(parent) if parent != 0 => {
-                        if reg.contains(&parent) {
-                            return true;
-                        }
-                        current = parent;
-                    }
-                    _ => break,
-                }
-            }
-        }
-    }
-    false
-}
-
-/// Mark a user-defined class as extending the built-in DataView class.
-#[no_mangle]
-pub extern "C" fn js_register_class_extends_data_view(class_id: u32) {
-    let mut registry = EXTENDS_DATA_VIEW_REGISTRY.write().unwrap();
-    if registry.is_none() {
-        *registry = Some(std::collections::HashSet::new());
-    }
-    registry.as_mut().unwrap().insert(class_id);
-}
-
-/// Check if a class id extends the built-in DataView class.
-pub(crate) fn extends_builtin_data_view(class_id: u32) -> bool {
-    let registry = EXTENDS_DATA_VIEW_REGISTRY.read().unwrap();
     if let Some(reg) = registry.as_ref() {
         if reg.contains(&class_id) {
             return true;

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1304,14 +1304,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("util", "isAnyArrayBuffer") => {
             bool_tag(crate::buffer::is_any_array_buffer(ptr_addr(arg(0))))
         }
-        ("util", "isArrayBufferView") => {
-            let addr = ptr_addr(arg(0));
-            bool_tag(
-                crate::buffer::is_uint8array_buffer(addr)
-                    || crate::buffer::is_data_view(addr)
-                    || typed_kind(arg(0)).is_some(),
-            )
-        }
+        ("util", "isArrayBufferView") => crate::object::js_util_types_is_array_buffer_view(arg(0)),
         ("util", "isTypedArray") => bool_tag(typed_kind(arg(0)).is_some()),
         ("util", "isUint8Array") => {
             bool_tag(typed_kind(arg(0)) == Some(crate::typedarray::KIND_UINT8))

--- a/crates/perry-runtime/src/object/util_types.rs
+++ b/crates/perry-runtime/src/object/util_types.rs
@@ -28,6 +28,26 @@ fn jsvalue_addr(v: f64) -> usize {
     }
 }
 
+fn jsvalue_extends_data_view(value: f64) -> bool {
+    let v = JSValue::from_bits(value.to_bits());
+    if !v.is_pointer() {
+        return false;
+    }
+    let ptr = v.as_pointer::<u8>();
+    if ptr.is_null() || !crate::object::is_valid_obj_ptr(ptr) {
+        return false;
+    }
+    unsafe {
+        let gc_header = ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        if (*gc_header).obj_type != crate::gc::GC_TYPE_OBJECT {
+            return false;
+        }
+        let obj = ptr as *const ObjectHeader;
+        let class_id = (*obj).class_id;
+        class_id != 0 && crate::object::extends_builtin_data_view(class_id)
+    }
+}
+
 #[inline]
 fn jsvalue_typed_array_kind(v: f64) -> Option<u8> {
     let addr = jsvalue_addr(v);
@@ -176,15 +196,19 @@ pub extern "C" fn js_util_types_is_any_array_buffer(value: f64) -> f64 {
 pub extern "C" fn js_util_types_is_array_buffer_view(value: f64) -> f64 {
     let addr = jsvalue_addr(value);
     nanbox_bool(
-        crate::buffer::is_uint8array_buffer(addr)
-            || crate::buffer::is_data_view(addr)
+        !crate::buffer::is_any_array_buffer(addr)
+            && (crate::buffer::is_uint8array_buffer(addr)
+                || crate::buffer::is_data_view(addr)
+                || jsvalue_extends_data_view(value))
             || jsvalue_typed_array_kind(value).is_some(),
     )
 }
 
 #[no_mangle]
 pub extern "C" fn js_util_types_is_data_view(value: f64) -> f64 {
-    nanbox_bool(crate::buffer::is_data_view(jsvalue_addr(value)))
+    nanbox_bool(
+        crate::buffer::is_data_view(jsvalue_addr(value)) || jsvalue_extends_data_view(value),
+    )
 }
 
 #[no_mangle]

--- a/target/deepwiki/arraybuffer-dataview-semantics.md
+++ b/target/deepwiki/arraybuffer-dataview-semantics.md
@@ -1,0 +1,1035 @@
+# DeepWiki Response
+
+Repository: `boa-dev/boa`
+Question: For implementing ECMAScript ordinary ArrayBuffer and DataView semantics, summarize the ArrayBuffer constructor/prototype/static surface, ArrayBuffer.isView behavior, DataView internal slots and subclass recognition, ArrayBuffer.prototype.byteLength getter descriptors and brand checks, ArrayBuffer.prototype.slice bounds/defaults, and where to avoid scope creep into SharedArrayBuffer, resizable/growable buffers, transfer semantics, or TypedArray transform methods. Focus on implementation-relevant details and tests.
+Search: https://deepwiki.com/search/for-implementing-ecmascript-or_a7d60b37-9322-46df-a259-cc0dbd9f8cd4
+
+**Question**: For implementing ECMAScript ordinary ArrayBuffer and DataView semantics, summarize the ArrayBuffer constructor/prototype/static surface, ArrayBuffer.isView behavior, DataView internal slots and subclass recognition, ArrayBuffer.prototype.byteLength getter descriptors and brand checks, ArrayBuffer.prototype.slice bounds/defaults, and where to avoid scope creep into SharedArrayBuffer, resizable/growable buffers, transfer semantics, or TypedArray transform methods. Focus on implementation-relevant details and tests.
+
+This response summarizes the implementation of ECMAScript `ArrayBuffer` and `DataView` semantics in the Boa engine, focusing on the constructor, prototype, static methods, internal slots, and brand checks, while also highlighting areas to avoid scope creep.
+
+## ArrayBuffer Constructor, Prototype, and Static Surface
+
+The `ArrayBuffer` object in Boa is represented by the `ArrayBuffer` struct [1](#ref-q1-1) . Its constructor, `ArrayBuffer::constructor`, handles the creation of new `ArrayBuffer` instances [2](#ref-q1-2) . It takes a `byteLength` and an optional `maxByteLength` to allocate the buffer [3](#ref-q1-3) . The `ArrayBuffer::allocate` function performs the actual memory allocation and initialization of internal slots like `[[ArrayBufferData]]`, `[[ArrayBufferByteLength]]`, and `[[ArrayBufferMaxByteLength]]` [4](#ref-q1-4) .
+
+The `ArrayBuffer` prototype defines several accessors and methods:
+*   `ArrayBuffer.prototype.byteLength`: A getter that returns the length of the `ArrayBuffer` in bytes [5](#ref-q1-5) .
+*   `ArrayBuffer.prototype.resizable`: A getter that indicates if the `ArrayBuffer` can be resized [6](#ref-q1-6) .
+*   `ArrayBuffer.prototype.maxByteLength`: A getter that returns the maximum byte length of a resizable `ArrayBuffer` [7](#ref-q1-7) .
+*   `ArrayBuffer.prototype.slice`: Creates a new `ArrayBuffer` that contains a copy of the bytes from the original `ArrayBuffer` within the specified range [8](#ref-q1-8) .
+*   `ArrayBuffer[@@species]`: A static accessor that returns the `this` value, allowing subclasses to define their own constructor for `slice` operations [9](#ref-q1-9) .
+
+## ArrayBuffer.isView Behavior
+
+The static method `ArrayBuffer.isView` determines if an argument is an `ArrayBuffer` view (either a `TypedArray` or a `DataView`) [10](#ref-q1-10) . It checks if the argument is an object and if it has a `[[ViewedArrayBuffer]]` internal slot, which is present in both `TypedArray` and `DataView` objects [11](#ref-q1-11) .
+
+## DataView Internal Slots and Subclass Recognition
+
+The `DataView` object is represented by the `DataView` struct [12](#ref-q1-12) . It has the following internal slots [13](#ref-q1-13) :
+*   `[[ViewedArrayBuffer]]`: A reference to the underlying `ArrayBuffer` or `SharedArrayBuffer` [14](#ref-q1-14) .
+*   `[[ByteLength]]`: The length of the `DataView` in bytes [15](#ref-q1-15) .
+*   `[[ByteOffset]]`: The offset in bytes from the start of the `[[ViewedArrayBuffer]]` [16](#ref-q1-16) .
+
+The `DataView` constructor, `DataView::constructor`, validates the `buffer`, `byteOffset`, and `byteLength` arguments and initializes these internal slots [17](#ref-q1-17) . Subclass recognition is handled by `OrdinaryCreateFromConstructor`, which uses the `new_target` to determine the prototype chain [18](#ref-q1-18) .
+
+## ArrayBuffer.prototype.byteLength Getter Descriptors and Brand Checks
+
+The `ArrayBuffer.prototype.byteLength` getter performs a brand check to ensure that `this` value is an `ArrayBuffer` instance [5](#ref-q1-5) . If the `this` value is not an `ArrayBuffer` object, it throws a `TypeError` [19](#ref-q1-19) . It then checks if the buffer is detached; if so, it returns `+0𝔽` [20](#ref-q1-20) . The property is configured with `Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE` [21](#ref-q1-21) .
+
+## ArrayBuffer.prototype.slice Bounds and Defaults
+
+The `ArrayBuffer.prototype.slice` method extracts a portion of the `ArrayBuffer` [22](#ref-q1-22) . It performs several checks:
+*   **Brand Check**: Ensures `this` is an `ArrayBuffer` [23](#ref-q1-23) .
+*   **Detached Buffer Check**: Throws a `TypeError` if the buffer is detached [24](#ref-q1-24) .
+*   **Bounds Calculation**: `start` and `end` arguments are converted to `relativeStart` and `relativeEnd` using `ToIndex` and clamped to the buffer's length [25](#ref-q1-25) . If `end` is `undefined`, it defaults to the buffer's length [26](#ref-q1-26) .
+*   **Species Constructor**: Uses `SpeciesConstructor` to create a new `ArrayBuffer` instance, allowing subclasses to control the type of the returned buffer [27](#ref-q1-27) .
+*   **Copying Data**: The relevant bytes are copied from the original buffer to the new buffer [28](#ref-q1-28) .
+
+## Avoiding Scope Creep
+
+The implementation explicitly avoids scope creep into `SharedArrayBuffer`, resizable/growable buffers, transfer semantics, or `TypedArray` transform methods by:
+*   **SharedArrayBuffer**: `ArrayBuffer` methods like `byteLength` and `slice` explicitly check if the buffer is a `SharedArrayBuffer` and throw a `TypeError` if it is [29](#ref-q1-29)  [30](#ref-q1-30) . The `SharedArrayBuffer` is a distinct type [31](#ref-q1-31) .
+*   **Resizable/Growable Buffers**: While `ArrayBuffer` supports `max_byte_len` for resizable buffers [32](#ref-q1-32) , the `resize` method explicitly checks if the buffer is fixed-length before allowing resizing [33](#ref-q1-33) .
+*   **Transfer Semantics**: Transfer methods (`transfer`, `transferToFixedLength`) are guarded by an experimental feature flag [34](#ref-q1-34) , indicating they are not part of the ordinary `ArrayBuffer` semantics by default.
+*   **TypedArray Transform Methods**: The prompt does not mention `TypedArray` transform methods, and the provided context for `ArrayBuffer` and `DataView` does not show any direct integration or scope creep into these methods. `TypedArray` objects are views over `ArrayBuffer`s, but their specific transform methods are handled within the `TypedArray` implementation [35](#ref-q1-35) .
+
+## Implementation-Relevant Details and Tests
+
+The `ArrayBuffer` and `DataView` implementations are built upon the `JsData` trait [36](#ref-q1-36)  [37](#ref-q1-37) , and their methods are registered using `BuiltInBuilder` [38](#ref-q1-38)  [39](#ref-q1-39) .
+
+Testing for `ArrayBuffer` includes checks for `detach` functionality and conversion to `Vec<u8>` [40](#ref-q1-40) . The `js262` test harness also provides a `$262.detachArrayBuffer()` function to test the detachment behavior [41](#ref-q1-41) .
+
+## Notes
+
+The `AlignedVec` type is used for the underlying data storage of `ArrayBuffer` [42](#ref-q1-42) , which ensures proper memory alignment for efficient access. The `DataView` implementation includes methods for getting and setting various numeric types (`getBigInt64`, `setFloat32`, etc.) [43](#ref-q1-43) , which involve endianness handling [44](#ref-q1-44)  [45](#ref-q1-45) .
+
+Wiki pages you might want to explore:
+- [Standard Builtins (boa-dev/boa)](/wiki/boa-dev/boa#3.1)
+- [Glossary (boa-dev/boa)](/wiki/boa-dev/boa#7)
+
+View this search on DeepWiki: https://deepwiki.com/search/for-implementing-ecmascript-or_a7d60b37-9322-46df-a259-cc0dbd9f8cd4
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `core/engine/src/builtins/array_buffer/mod.rs:200-202`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L200-L202)
+
+```rust
+/// The internal representation of an `ArrayBuffer` object.
+#[derive(Debug, Clone, Trace, Finalize, JsData)]
+pub struct ArrayBuffer {
+```
+
+<a id="ref-q1-2"></a>
+### [2] `core/engine/src/builtins/array_buffer/mod.rs:429-451`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L429-L451)
+
+```rust
+    fn constructor(
+        new_target: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. If NewTarget is undefined, throw a TypeError exception.
+        if new_target.is_undefined() {
+            return Err(JsNativeError::typ()
+                .with_message("ArrayBuffer.constructor called with undefined new target")
+                .into());
+        }
+
+        // 2. Let byteLength be ? ToIndex(length).
+        let byte_len = args.get_or_undefined(0).to_index(context)?;
+
+        // 3. Let requestedMaxByteLength be ? GetArrayBufferMaxByteLengthOption(options).
+        let max_byte_len = get_max_byte_len(args.get_or_undefined(1), context)?;
+
+        // 4. Return ? AllocateArrayBuffer(NewTarget, byteLength, requestedMaxByteLength).
+        Ok(Self::allocate(new_target, byte_len, max_byte_len, context)?
+            .upcast()
+            .into())
+    }
+```
+
+<a id="ref-q1-3"></a>
+### [3] `core/engine/src/builtins/array_buffer/mod.rs:442-445`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L442-L445)
+
+```rust
+        let byte_len = args.get_or_undefined(0).to_index(context)?;
+
+        // 3. Let requestedMaxByteLength be ? GetArrayBufferMaxByteLengthOption(options).
+        let max_byte_len = get_max_byte_len(args.get_or_undefined(1), context)?;
+```
+
+<a id="ref-q1-4"></a>
+### [4] `core/engine/src/builtins/array_buffer/mod.rs:868-917`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L868-L917)
+
+```rust
+    pub(crate) fn allocate(
+        constructor: &JsValue,
+        byte_len: u64,
+        max_byte_len: Option<u64>,
+        context: &mut Context,
+    ) -> JsResult<JsObject<ArrayBuffer>> {
+        // 1. Let slots be « [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] ».
+        // 2. If maxByteLength is present and maxByteLength is not empty, let allocatingResizableBuffer be true; otherwise let allocatingResizableBuffer be false.
+        // 3. If allocatingResizableBuffer is true, then
+        //     a. If byteLength > maxByteLength, throw a RangeError exception.
+        //     b. Append [[ArrayBufferMaxByteLength]] to slots.
+        if let Some(max_byte_len) = max_byte_len
+            && byte_len > max_byte_len
+        {
+            return Err(JsNativeError::range()
+                .with_message("`length` cannot be bigger than `maxByteLength`")
+                .into());
+        }
+
+        // 4. Let obj be ? OrdinaryCreateFromConstructor(constructor, "%ArrayBuffer.prototype%", slots).
+        let prototype = get_prototype_from_constructor(
+            constructor,
+            StandardConstructors::array_buffer,
+            context,
+        )?;
+
+        // 5. Let block be ? CreateByteDataBlock(byteLength).
+        // Preemptively allocate for `max_byte_len` if possible.
+        //     a. If it is not possible to create a Data Block block consisting of maxByteLength bytes, throw a RangeError exception.
+        //     b. NOTE: Resizable ArrayBuffers are designed to be implementable with in-place growth. Implementations may
+        //        throw if, for example, virtual memory cannot be reserved up front.
+        let block = create_byte_data_block(byte_len, max_byte_len, context)?;
+
+        let obj = JsObject::new(
+            context.root_shape(),
+            prototype,
+            Self {
+                // 6. Set obj.[[ArrayBufferData]] to block.
+                // 7. Set obj.[[ArrayBufferByteLength]] to byteLength.
+                data: Some(block),
+                // 8. If allocatingResizableBuffer is true, then
+                //    c. Set obj.[[ArrayBufferMaxByteLength]] to maxByteLength.
+                max_byte_len,
+                detach_key: JsValue::undefined(),
+            },
+        );
+
+        // 9. Return obj.
+        Ok(obj)
+    }
+```
+
+<a id="ref-q1-5"></a>
+### [5] `core/engine/src/builtins/array_buffer/mod.rs:491-512`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L491-L512)
+
+```rust
+    pub(crate) fn get_byte_length(
+        this: &JsValue,
+        _args: &[JsValue],
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let O be the this value.
+        // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+        // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+        let object = this.as_object();
+        let buf = object
+            .as_ref()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("get ArrayBuffer.prototype.byteLength called with invalid `this`")
+            })?;
+
+        // 4. If IsDetachedBuffer(O) is true, return +0𝔽.
+        // 5. Let length be O.[[ArrayBufferByteLength]].
+        // 6. Return 𝔽(length).
+        Ok(buf.len().into())
+    }
+```
+
+<a id="ref-q1-6"></a>
+### [6] `core/engine/src/builtins/array_buffer/mod.rs:548-570`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L548-L570)
+
+```rust
+    /// [`get ArrayBuffer.prototype.resizable`][spec].
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.resizable
+    pub(crate) fn get_resizable(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let O be the this value.
+        // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+        // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+        let object = this.as_object();
+        let buf = object
+            .as_ref()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("get ArrayBuffer.prototype.resizable called with invalid `this`")
+            })?;
+
+        // 4. If IsFixedLengthArrayBuffer(O) is false, return true; otherwise return false.
+        Ok(JsValue::from(!buf.is_fixed_len()))
+    }
+```
+
+<a id="ref-q1-7"></a>
+### [7] `core/engine/src/builtins/array_buffer/mod.rs:517-545`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L517-L545)
+
+```rust
+    pub(crate) fn get_max_byte_length(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let O be the this value.
+        // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+        // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+        let object = this.as_object();
+        let buf = object
+            .as_ref()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message(
+                    "get ArrayBuffer.prototype.maxByteLength called with invalid `this`",
+                )
+            })?;
+
+        // 4. If IsDetachedBuffer(O) is true, return +0𝔽.
+        let Some(data) = buf.bytes() else {
+            return Ok(JsValue::from(0));
+        };
+
+        // 5. If IsFixedLengthArrayBuffer(O) is true, then
+        //     a. Let length be O.[[ArrayBufferByteLength]].
+        // 6. Else,
+        //     a. Let length be O.[[ArrayBufferMaxByteLength]].
+        // 7. Return 𝔽(length).
+        Ok(buf.max_byte_len.unwrap_or(data.len() as u64).into())
+```
+
+<a id="ref-q1-8"></a>
+### [8] `core/engine/src/builtins/array_buffer/mod.rs:648-746`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L648-L746)
+
+```rust
+    fn slice(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        // 1. Let O be the this value.
+        // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+        // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+        let buf = this
+            .as_object()
+            .and_then(|o| o.clone().downcast::<Self>().ok())
+            .ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("ArrayBuffer.slice called with invalid `this` value")
+            })?;
+
+        let len = {
+            let buf = buf.borrow();
+            // 4. If IsDetachedBuffer(O) is true, throw a TypeError exception.
+            if buf.data().is_detached() {
+                return Err(JsNativeError::typ()
+                    .with_message("ArrayBuffer.slice called with detached buffer")
+                    .into());
+            }
+            // 5. Let len be O.[[ArrayBufferByteLength]].
+            buf.data().len() as u64
+        };
+
+        // 6. Let relativeStart be ? ToIntegerOrInfinity(start).
+        // 7. If relativeStart = -∞, let first be 0.
+        // 8. Else if relativeStart < 0, let first be max(len + relativeStart, 0).
+        // 9. Else, let first be min(relativeStart, len).
+        let first = Array::get_relative_start(context, args.get_or_undefined(0), len)?;
+
+        // 10. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToIntegerOrInfinity(end).
+        // 11. If relativeEnd = -∞, let final be 0.
+        // 12. Else if relativeEnd < 0, let final be max(len + relativeEnd, 0).
+        // 13. Else, let final be min(relativeEnd, len).
+        let final_ = Array::get_relative_end(context, args.get_or_undefined(1), len)?;
+
+        // 14. Let newLen be max(final - first, 0).
+        let new_len = final_.saturating_sub(first);
+
+        // 15. Let ctor be ? SpeciesConstructor(O, %ArrayBuffer%).
+        let ctor = buf
+            .clone()
+            .upcast()
+            .species_constructor(StandardConstructors::array_buffer, context)?;
+
+        // 16. Let new be ? Construct(ctor, « 𝔽(newLen) »).
+        let new = ctor.construct(&[new_len.into()], Some(&ctor), context)?;
+
+        // 17. Perform ? RequireInternalSlot(new, [[ArrayBufferData]]).
+        // 18. If IsSharedArrayBuffer(new) is true, throw a TypeError exception.
+        let Ok(new) = new.downcast::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("ArrayBuffer constructor returned invalid object")
+                .into());
+        };
+
+        // 20. If SameValue(new, O) is true, throw a TypeError exception.
+        if JsObject::equals(&buf, &new) {
+            return Err(JsNativeError::typ()
+                .with_message("new ArrayBuffer is the same as this ArrayBuffer")
+                .into());
+        }
+
+        {
+            // 19. If IsDetachedBuffer(new) is true, throw a TypeError exception.
+            // 25. Let toBuf be new.[[ArrayBufferData]].
+            let mut new = new.borrow_mut();
+            let Some(to_buf) = new.data_mut().bytes_mut() else {
+                return Err(JsNativeError::typ()
+                    .with_message("ArrayBuffer constructor returned detached ArrayBuffer")
+                    .into());
+            };
+
+            // 21. If new.[[ArrayBufferByteLength]] < newLen, throw a TypeError exception.
+            if (to_buf.len() as u64) < new_len {
+                return Err(JsNativeError::typ()
+                    .with_message("new ArrayBuffer length too small")
+                    .into());
+            }
+
+            // 22. NOTE: Side-effects of the above steps may have detached O.
+            // 23. If IsDetachedBuffer(O) is true, throw a TypeError exception.
+            // 24. Let fromBuf be O.[[ArrayBufferData]].
+            let buf = buf.borrow();
+            let Some(from_buf) = buf.data().bytes() else {
+                return Err(JsNativeError::typ()
+                    .with_message("ArrayBuffer detached while ArrayBuffer.slice was running")
+                    .into());
+            };
+
+            // 26. Perform CopyDataBlockBytes(toBuf, 0, fromBuf, first, newLen).
+            let first = first as usize;
+            let new_len = new_len as usize;
+            to_buf[..new_len].copy_from_slice(&from_buf[first..first + new_len]);
+        }
+
+        // 27. Return new.
+        Ok(new.upcast().into())
+    }
+```
+
+<a id="ref-q1-9"></a>
+### [9] `core/engine/src/builtins/array_buffer/mod.rs:479-483`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L479-L483)
+
+```rust
+    #[allow(clippy::unnecessary_wraps)]
+    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        // 1. Return the this value.
+        Ok(this.clone())
+    }
+```
+
+<a id="ref-q1-10"></a>
+### [10] `core/engine/src/builtins/array_buffer/mod.rs:455-471`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L455-L471)
+
+```rust
+    /// `ArrayBuffer.isView ( arg )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-arraybuffer.isview
+    #[allow(clippy::unnecessary_wraps)]
+    fn is_view(_: &JsValue, args: &[JsValue], _context: &mut Context) -> JsResult<JsValue> {
+        // 1. If Type(arg) is not Object, return false.
+        // 2. If arg has a [[ViewedArrayBuffer]] internal slot, return true.
+        // 3. Return false.
+        Ok(args
+            .get_or_undefined(0)
+            .as_object()
+            .is_some_and(|obj| obj.is::<TypedArray>() || obj.is::<DataView>())
+            .into())
+    }
+```
+
+<a id="ref-q1-11"></a>
+### [11] `core/engine/src/builtins/array_buffer/mod.rs:463-470`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L463-L470)
+
+```rust
+        // 1. If Type(arg) is not Object, return false.
+        // 2. If arg has a [[ViewedArrayBuffer]] internal slot, return true.
+        // 3. Return false.
+        Ok(args
+            .get_or_undefined(0)
+            .as_object()
+            .is_some_and(|obj| obj.is::<TypedArray>() || obj.is::<DataView>())
+            .into())
+```
+
+<a id="ref-q1-12"></a>
+### [12] `core/engine/src/builtins/dataview/mod.rs:37-39`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/dataview/mod.rs#L37-L39)
+
+```rust
+/// The internal representation of a `DataView` object.
+#[derive(Debug, Clone, Trace, Finalize, JsData)]
+pub struct DataView {
+```
+
+<a id="ref-q1-13"></a>
+### [13] `core/engine/src/builtins/dataview/mod.rs:40-42`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/dataview/mod.rs#L40-L42)
+
+```rust
+    pub(crate) viewed_array_buffer: BufferObject,
+    pub(crate) byte_length: Option<u64>,
+    pub(crate) byte_offset: u64,
+```
+
+<a id="ref-q1-14"></a>
+### [14] `core/engine/src/builtins/dataview/mod.rs:40`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/dataview/mod.rs#L40)
+
+```rust
+    pub(crate) viewed_array_buffer: BufferObject,
+```
+
+<a id="ref-q1-15"></a>
+### [15] `core/engine/src/builtins/dataview/mod.rs:41`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/dataview/mod.rs#L41)
+
+```rust
+    pub(crate) byte_length: Option<u64>,
+```
+
+<a id="ref-q1-16"></a>
+### [16] `core/engine/src/builtins/dataview/mod.rs:42`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/dataview/mod.rs#L42)
+
+```rust
+    pub(crate) byte_offset: u64,
+```
+
+<a id="ref-q1-17"></a>
+### [17] `core/engine/src/builtins/dataview/mod.rs:193-312`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/dataview/mod.rs#L193-L312)
+
+```rust
+    fn constructor(
+        new_target: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. If NewTarget is undefined, throw a TypeError exception.
+        if new_target.is_undefined() {
+            return Err(JsNativeError::typ()
+                .with_message("cannot call `DataView` constructor without `new`")
+                .into());
+        }
+        let byte_len = args.get_or_undefined(2);
+
+        // 2. Perform ? RequireInternalSlot(buffer, [[ArrayBufferData]]).
+        let buffer = args
+            .get_or_undefined(0)
+            .as_object()
+            .and_then(|o| o.clone().into_buffer_object().ok())
+            .ok_or_else(|| JsNativeError::typ().with_message("buffer must be an ArrayBuffer"))?;
+
+        // 3. Let offset be ? ToIndex(byteOffset).
+        let offset = args.get_or_undefined(1).to_index(context)?;
+
+        let (buf_byte_len, is_fixed_len) = {
+            let buffer = buffer.as_buffer();
+
+            // 4. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+            let Some(slice) = buffer.bytes(Ordering::SeqCst) else {
+                return Err(JsNativeError::typ()
+                    .with_message("ArrayBuffer is detached")
+                    .into());
+            };
+
+            // 5. Let bufferByteLength be ArrayBufferByteLength(buffer, seq-cst).
+            let buf_len = slice.len() as u64;
+
+            // 6. If offset > bufferByteLength, throw a RangeError exception.
+            if offset > buf_len {
+                return Err(JsNativeError::range()
+                    .with_message("Start offset is outside the bounds of the buffer")
+                    .into());
+            }
+
+            // 7. Let bufferIsFixedLength be IsFixedLengthArrayBuffer(buffer).
+
+            (buf_len, buffer.is_fixed_len())
+        };
+
+        // 8. If byteLength is undefined, then
+        let view_byte_len = if byte_len.is_undefined() {
+            // a. If bufferIsFixedLength is true, then
+            //     i. Let viewByteLength be bufferByteLength - offset.
+            // b. Else,
+            //     i. Let viewByteLength be auto.
+            is_fixed_len.then_some(buf_byte_len - offset)
+        } else {
+            // 9. Else,
+            //     a. Let viewByteLength be ? ToIndex(byteLength).
+            let byte_len = byte_len.to_index(context)?;
+
+            //     b. If offset + viewByteLength > bufferByteLength, throw a RangeError exception.
+            if offset + byte_len > buf_byte_len {
+                return Err(JsNativeError::range()
+                    .with_message("Invalid data view length")
+                    .into());
+            }
+            Some(byte_len)
+        };
+
+        // 10. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%DataView.prototype%",
+        //     « [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]] »).
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardConstructors::data_view, context)?;
+
+        // 11. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+        // 12. Set bufferByteLength to ArrayBufferByteLength(buffer, seq-cst).
+        let Some(buf_byte_len) = buffer
+            .as_buffer()
+            .bytes(Ordering::SeqCst)
+            .map(|s| s.len() as u64)
+        else {
+            return Err(JsNativeError::typ()
+                .with_message("ArrayBuffer can't be detached")
+                .into());
+        };
+
+        // 13. If offset > bufferByteLength, throw a RangeError exception.
+        if offset > buf_byte_len {
+            return Err(JsNativeError::range()
+                .with_message("DataView offset outside of buffer array bounds")
+                .into());
+        }
+
+        // 14. If byteLength is not undefined, then
+        //     a. If offset + viewByteLength > bufferByteLength, throw a RangeError exception.
+        if !byte_len.is_undefined()
+            && let Some(view_byte_len) = view_byte_len
+            && offset + view_byte_len > buf_byte_len
+        {
+            return Err(JsNativeError::range()
+                .with_message("DataView offset outside of buffer array bounds")
+                .into());
+        }
+
+        let obj = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            Self {
+                // 15. Set O.[[ViewedArrayBuffer]] to buffer.
+                viewed_array_buffer: buffer,
+                // 16. Set O.[[ByteLength]] to viewByteLength.
+                byte_length: view_byte_len,
+                // 17. Set O.[[ByteOffset]] to offset.
+                byte_offset: offset,
+            },
+        );
+
+        // 18. Return O.
+        Ok(obj.into())
+    }
+```
+
+<a id="ref-q1-18"></a>
+### [18] `core/engine/src/builtins/dataview/mod.rs:262-266`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/dataview/mod.rs#L262-L266)
+
+```rust
+        // 10. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%DataView.prototype%",
+        //     « [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]] »).
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardConstructors::data_view, context)?;
+```
+
+<a id="ref-q1-19"></a>
+### [19] `core/engine/src/builtins/array_buffer/mod.rs:499-506`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L499-L506)
+
+```rust
+        let object = this.as_object();
+        let buf = object
+            .as_ref()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("get ArrayBuffer.prototype.byteLength called with invalid `this`")
+            })?;
+```
+
+<a id="ref-q1-20"></a>
+### [20] `core/engine/src/builtins/array_buffer/mod.rs:508`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L508)
+
+```rust
+        // 4. If IsDetachedBuffer(O) is true, return +0𝔽.
+```
+
+<a id="ref-q1-21"></a>
+### [21] `core/engine/src/builtins/array_buffer/mod.rs:363-367`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L363-L367)
+
+```rust
+                js_string!("byteLength"),
+                Some(get_byte_length),
+                None,
+                flag_attributes,
+            )
+```
+
+<a id="ref-q1-22"></a>
+### [22] `core/engine/src/builtins/array_buffer/mod.rs:642-647`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L642-L647)
+
+```rust
+    /// `ArrayBuffer.prototype.slice ( start, end )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice
+```
+
+<a id="ref-q1-23"></a>
+### [23] `core/engine/src/builtins/array_buffer/mod.rs:652-658`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L652-L658)
+
+```rust
+        let buf = this
+            .as_object()
+            .and_then(|o| o.clone().downcast::<Self>().ok())
+            .ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("ArrayBuffer.slice called with invalid `this` value")
+            })?;
+```
+
+<a id="ref-q1-24"></a>
+### [24] `core/engine/src/builtins/array_buffer/mod.rs:663-666`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L663-L666)
+
+```rust
+            if buf.data().is_detached() {
+                return Err(JsNativeError::typ()
+                    .with_message("ArrayBuffer.slice called with detached buffer")
+                    .into());
+```
+
+<a id="ref-q1-25"></a>
+### [25] `core/engine/src/builtins/array_buffer/mod.rs:672-682`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L672-L682)
+
+```rust
+        // 6. Let relativeStart be ? ToIntegerOrInfinity(start).
+        // 7. If relativeStart = -∞, let first be 0.
+        // 8. Else if relativeStart < 0, let first be max(len + relativeStart, 0).
+        // 9. Else, let first be min(relativeStart, len).
+        let first = Array::get_relative_start(context, args.get_or_undefined(0), len)?;
+
+        // 10. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToIntegerOrInfinity(end).
+        // 11. If relativeEnd = -∞, let final be 0.
+        // 12. Else if relativeEnd < 0, let final be max(len + relativeEnd, 0).
+        // 13. Else, let final be min(relativeEnd, len).
+        let final_ = Array::get_relative_end(context, args.get_or_undefined(1), len)?;
+```
+
+<a id="ref-q1-26"></a>
+### [26] `core/engine/src/builtins/array_buffer/mod.rs:678`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L678)
+
+```rust
+        // 10. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToIntegerOrInfinity(end).
+```
+
+<a id="ref-q1-27"></a>
+### [27] `core/engine/src/builtins/array_buffer/mod.rs:687-691`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L687-L691)
+
+```rust
+        // 15. Let ctor be ? SpeciesConstructor(O, %ArrayBuffer%).
+        let ctor = buf
+            .clone()
+            .upcast()
+            .species_constructor(StandardConstructors::array_buffer, context)?;
+```
+
+<a id="ref-q1-28"></a>
+### [28] `core/engine/src/builtins/array_buffer/mod.rs:738-741`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L738-L741)
+
+```rust
+            // 26. Perform CopyDataBlockBytes(toBuf, 0, fromBuf, first, newLen).
+            let first = first as usize;
+            let new_len = new_len as usize;
+            to_buf[..new_len].copy_from_slice(&from_buf[first..first + new_len]);
+```
+
+<a id="ref-q1-29"></a>
+### [29] `core/engine/src/builtins/array_buffer/mod.rs:498`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L498)
+
+```rust
+        // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+```
+
+<a id="ref-q1-30"></a>
+### [30] `core/engine/src/builtins/array_buffer/mod.rs:651`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L651)
+
+```rust
+        // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+```
+
+<a id="ref-q1-31"></a>
+### [31] `core/engine/src/builtins/array_buffer/mod.rs:22`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L22)
+
+```rust
+pub use shared::SharedArrayBuffer;
+```
+
+<a id="ref-q1-32"></a>
+### [32] `core/engine/src/builtins/array_buffer/mod.rs:207`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L207)
+
+```rust
+    /// The `[[ArrayBufferMaxByteLength]]` internal slot.
+```
+
+<a id="ref-q1-33"></a>
+### [33] `core/engine/src/builtins/array_buffer/mod.rs:271-275`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L271-L275)
+
+```rust
+    pub fn resize(&mut self, new_byte_length: u64) -> JsResult<()> {
+        let Some(max_byte_len) = self.max_byte_len else {
+            return Err(JsNativeError::typ()
+                .with_message("ArrayBuffer.resize: cannot resize a fixed-length buffer")
+                .into());
+```
+
+<a id="ref-q1-34"></a>
+### [34] `core/engine/src/builtins/array_buffer/mod.rs:396-401`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L396-L401)
+
+```rust
+            .method(Self::transfer::<false>, js_string!("transfer"), 0)
+            .method(
+                Self::transfer::<true>,
+                js_string!("transferToFixedLength"),
+                0,
+            );
+```
+
+<a id="ref-q1-35"></a>
+### [35] `core/engine/src/builtins/typed_array/object.rs:31-37`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/typed_array/object.rs#L31-L37)
+
+<a id="ref-q1-36"></a>
+### [36] `core/engine/src/builtins/array_buffer/mod.rs:201`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L201)
+
+```rust
+#[derive(Debug, Clone, Trace, Finalize, JsData)]
+```
+
+<a id="ref-q1-37"></a>
+### [37] `core/engine/src/builtins/dataview/mod.rs:38`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/dataview/mod.rs#L38)
+
+```rust
+#[derive(Debug, Clone, Trace, Finalize, JsData)]
+```
+
+<a id="ref-q1-38"></a>
+### [38] `core/engine/src/builtins/array_buffer/mod.rs:354-403`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L354-L403)
+
+```rust
+        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+            .static_accessor(
+                JsSymbol::species(),
+                Some(get_species),
+                None,
+                Attribute::CONFIGURABLE,
+            )
+            .static_method(Self::is_view, js_string!("isView"), 1)
+            .accessor(
+                js_string!("byteLength"),
+                Some(get_byte_length),
+                None,
+                flag_attributes,
+            )
+            .accessor(
+                js_string!("resizable"),
+                Some(get_resizable),
+                None,
+                flag_attributes,
+            )
+            .accessor(
+                js_string!("maxByteLength"),
+                Some(get_max_byte_length),
+                None,
+                flag_attributes,
+            )
+            .method(Self::js_resize, js_string!("resize"), 1)
+            .method(Self::slice, js_string!("slice"), 2)
+            .property(
+                JsSymbol::to_string_tag(),
+                Self::NAME,
+                Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
+            );
+
+        #[cfg(feature = "experimental")]
+        let builder = builder
+            .accessor(
+                js_string!("detached"),
+                Some(get_detached),
+                None,
+                flag_attributes,
+            )
+            .method(Self::transfer::<false>, js_string!("transfer"), 0)
+            .method(
+                Self::transfer::<true>,
+                js_string!("transferToFixedLength"),
+                0,
+            );
+
+        builder.build();
+```
+
+<a id="ref-q1-39"></a>
+### [39] `core/engine/src/builtins/dataview/mod.rs:112-162`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/dataview/mod.rs#L112-L162)
+
+```rust
+        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+            .accessor(
+                js_string!("buffer"),
+                Some(get_buffer),
+                None,
+                flag_attributes,
+            )
+            .accessor(
+                js_string!("byteLength"),
+                Some(get_byte_length),
+                None,
+                flag_attributes,
+            )
+            .accessor(
+                js_string!("byteOffset"),
+                Some(get_byte_offset),
+                None,
+                flag_attributes,
+            )
+            .method(Self::get_big_int64, js_string!("getBigInt64"), 1)
+            .method(Self::get_big_uint64, js_string!("getBigUint64"), 1)
+            .method(Self::get_float32, js_string!("getFloat32"), 1)
+            .method(Self::get_float64, js_string!("getFloat64"), 1)
+            .method(Self::get_int8, js_string!("getInt8"), 1)
+            .method(Self::get_int16, js_string!("getInt16"), 1)
+            .method(Self::get_int32, js_string!("getInt32"), 1)
+            .method(Self::get_uint8, js_string!("getUint8"), 1)
+            .method(Self::get_uint16, js_string!("getUint16"), 1)
+            .method(Self::get_uint32, js_string!("getUint32"), 1)
+            .method(Self::set_big_int64, js_string!("setBigInt64"), 2)
+            .method(Self::set_big_uint64, js_string!("setBigUint64"), 2)
+            .method(Self::set_float32, js_string!("setFloat32"), 2)
+            .method(Self::set_float64, js_string!("setFloat64"), 2)
+            .method(Self::set_int8, js_string!("setInt8"), 2)
+            .method(Self::set_int16, js_string!("setInt16"), 2)
+            .method(Self::set_int32, js_string!("setInt32"), 2)
+            .method(Self::set_uint8, js_string!("setUint8"), 2)
+            .method(Self::set_uint16, js_string!("setUint16"), 2)
+            .method(Self::set_uint32, js_string!("setUint32"), 2)
+            .property(
+                JsSymbol::to_string_tag(),
+                Self::NAME,
+                Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
+            );
+
+        #[cfg(feature = "float16")]
+        let builder = builder
+            .method(Self::get_float16, js_string!("getFloat16"), 1)
+            .method(Self::set_float16, js_string!("setFloat16"), 2);
+
+        builder.build();
+```
+
+<a id="ref-q1-40"></a>
+### [40] `core/engine/src/object/builtins/jsarraybuffer.rs:365-374`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/builtins/jsarraybuffer.rs#L365-L374)
+
+```rust
+        let context = &mut Context::default();
+
+        let data = AlignedVec::from_iter(0, [1u8, 2, 3, 4, 5]);
+        let buffer = JsArrayBuffer::from_byte_block(data, context).unwrap();
+
+        assert_eq!(buffer.to_vec(), Some(vec![1u8, 2, 3, 4, 5]));
+
+        buffer.detach(&JsValue::undefined()).unwrap();
+        assert_eq!(buffer.to_vec(), None);
+    }
+```
+
+<a id="ref-q1-41"></a>
+### [41] `tests/tester/src/exec/js262.rs:147-172`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/tests/tester/src/exec/js262.rs#L147-L172)
+
+```rust
+/// The `$262.detachArrayBuffer()` function.
+///
+/// Implements the `DetachArrayBuffer` abstract operation.
+fn detach_array_buffer(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    fn type_err() -> JsNativeError {
+        JsNativeError::typ().with_message("The provided object was not an ArrayBuffer")
+    }
+
+    // 1. Assert: IsSharedArrayBuffer(arrayBuffer) is false.
+    let object = args.first().and_then(JsValue::as_object);
+    let mut array_buffer = object
+        .as_ref()
+        .and_then(|o| o.downcast_mut::<ArrayBuffer>())
+        .ok_or_else(type_err)?;
+
+    // 2. If key is not present, set key to undefined.
+    let key = args.get_or_undefined(1);
+
+    // 3. If SameValue(arrayBuffer.[[ArrayBufferDetachKey]], key) is false, throw a TypeError exception.
+    // 4. Set arrayBuffer.[[ArrayBufferData]] to null.
+    // 5. Set arrayBuffer.[[ArrayBufferByteLength]] to 0.
+    array_buffer.detach(key)?;
+
+    // 6. Return NormalCompletion(null).
+    Ok(JsValue::null())
+}
+```
+
+<a id="ref-q1-42"></a>
+### [42] `core/engine/src/builtins/array_buffer/mod.rs:205`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array_buffer/mod.rs#L205)
+
+```rust
+    data: Option<AlignedVec<u8>>,
+```
+
+<a id="ref-q1-43"></a>
+### [43] `core/engine/src/builtins/dataview/mod.rs:131-150`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/dataview/mod.rs#L131-L150)
+
+```rust
+            .method(Self::get_big_int64, js_string!("getBigInt64"), 1)
+            .method(Self::get_big_uint64, js_string!("getBigUint64"), 1)
+            .method(Self::get_float32, js_string!("getFloat32"), 1)
+            .method(Self::get_float64, js_string!("getFloat64"), 1)
+            .method(Self::get_int8, js_string!("getInt8"), 1)
+            .method(Self::get_int16, js_string!("getInt16"), 1)
+            .method(Self::get_int32, js_string!("getInt32"), 1)
+            .method(Self::get_uint8, js_string!("getUint8"), 1)
+            .method(Self::get_uint16, js_string!("getUint16"), 1)
+            .method(Self::get_uint32, js_string!("getUint32"), 1)
+            .method(Self::set_big_int64, js_string!("setBigInt64"), 2)
+            .method(Self::set_big_uint64, js_string!("setBigUint64"), 2)
+            .method(Self::set_float32, js_string!("setFloat32"), 2)
+            .method(Self::set_float64, js_string!("setFloat64"), 2)
+            .method(Self::set_int8, js_string!("setInt8"), 2)
+            .method(Self::set_int16, js_string!("setInt16"), 2)
+            .method(Self::set_int32, js_string!("setInt32"), 2)
+            .method(Self::set_uint8, js_string!("setUint8"), 2)
+            .method(Self::set_uint16, js_string!("setUint16"), 2)
+            .method(Self::set_uint32, js_string!("setUint32"), 2)
+```
+
+<a id="ref-q1-44"></a>
+### [44] `core/engine/src/builtins/dataview/mod.rs:509-512`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/dataview/mod.rs#L509-L512)
+
+```rust
+            if is_little_endian {
+                value.to_little_endian()
+            } else {
+                value.to_big_endian()
+```
+
+<a id="ref-q1-45"></a>
+### [45] `core/engine/src/builtins/dataview/mod.rs:849-852`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/dataview/mod.rs#L849-L852)
+
+```rust
+            let value = if is_little_endian {
+                value.to_little_endian()
+            } else {
+                value.to_big_endian()
+```


### PR DESCRIPTION
## Summary

Fixes #4033 by filling the ordinary ArrayBuffer/DataView semantics needed by binary-heavy packages:

- add validated `ArrayBuffer` / `SharedArrayBuffer` constructor length coercion so huge or negative sizes throw `RangeError` before truncation/allocation
- install `ArrayBuffer.isView` as a real callable static and support value extraction (`const isView = ArrayBuffer.isView`)
- install `ArrayBuffer.prototype.byteLength` as an accessor with brand checks and descriptor metadata
- keep full-span `DataView` instances distinct from their backing `ArrayBuffer` while preserving view registry write propagation
- recognize direct DataView instances, DataView subclasses, and existing typed views in `ArrayBuffer.isView` / `util.types.isArrayBufferView`

## DeepWiki

Required reference saved at:

- `target/deepwiki/arraybuffer-dataview-semantics.md`

Queried `boa-dev/boa` for ArrayBuffer constructor/prototype/static surface, `ArrayBuffer.isView`, DataView internal slot/subclass recognition, byteLength getter descriptors/brand checks, slice bounds/defaults, and avoiding SharedArrayBuffer/resizable scope creep.

## Evidence

Base SHA: `132fb26cf461eced3da6bc86e04f680557c49400`
Commit: `bbf96e3e3`

Issue baseline for the requested subset was:

- `pass=40 runtime-fail=40 parity=50.0%`

After this change:

```text
scripts/test262_subset.py --root vendor/test262 --dir built-ins/ArrayBuffer built-ins/DataView --max 80 --timeout 8 --sample-cap 20 --report /tmp/perry-c262-arraybuffer-dataview.json

pass           47
diff           0
runtime-fail   33
compile-fail   0
skip           0
judged         80
parity:        58.8%
report:        /tmp/perry-c262-arraybuffer-dataview.json
```

Focused smoke covered representative #4033 failures:

- huge ArrayBuffer lengths throw `RangeError`
- `typeof ArrayBuffer.isView === "function"`
- extracted `const isView = ArrayBuffer.isView` is callable
- `ArrayBuffer.isView(new DataView(ab)) === true`
- `ArrayBuffer.isView(new (class extends DataView {})(ab)) === true`
- `ArrayBuffer.isView(ab) === false`
- `ArrayBuffer.prototype.byteLength` descriptor/getter/brand checks work
- `ab.slice(1).byteLength === 3`

Additional commands run:

```text
cargo fmt --all --check
git diff --check
cargo build --release -p perry
cargo build --release -p perry-runtime -p perry-stdlib
PERRY_NO_AUTO_OPTIMIZE=1 target/release/perry run test-files/test_parity_buffer.ts
PERRY_NO_AUTO_OPTIMIZE=1 target/release/perry run test-files/test_gap_fetch_reqresp_2640_2643.ts
PERRY_NO_AUTO_OPTIMIZE=1 target/release/perry run test-files/test_issue_3988_typedarray_static_accessors.ts
PERRY_NO_AUTO_OPTIMIZE=1 target/release/perry run test-files/test_gap_dataview_2878_2877_2879.ts
```

## Residual risks

- This intentionally avoids SharedArrayBuffer/Atomics, resizable/growable buffers, transfer semantics, and broad TypedArray transform-method work.
- Remaining c262 failures include broader constructor/prototype descriptor completeness, species/slice edge cases, and typed-array subclass view recognition beyond the DataView subclass recognition fixed here.
- DataView subclass recognition is modeled for view/brand predicates; this does not attempt a full JS internal-slot object model for arbitrary subclass byte access beyond Perry's existing DataView paths.
