### PR TITLE
fix(json): JSON.parse throws a real SyntaxError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1090 — fix(json): JSON.parse throws a real SyntaxError
+
+`JSON.parse` on invalid input threw a **bare string** instead of a `SyntaxError` object, so `err instanceof SyntaxError` was `false` and `err.constructor.name` was `undefined` — breaking the standard `try { JSON.parse(x) } catch (e) { if (e instanceof SyntaxError) … }` idiom and test262 error-identity assertions. All four throw sites in `js_json_parse`/`json/parse_api.rs` (null input, empty input, and the two invalid-token paths) built the thrown value with `JSValue::string_ptr(msg_ptr)` rather than the `syntax_error_value` helper that already wraps `js_syntaxerror_new`. Routed them through `syntax_error_value` so `JSON.parse("")`, `JSON.parse("x")`, etc. now throw real `SyntaxError` instances (with `name`/`constructor`/`instanceof` all correct), matching Node. The separate parser-leniency gap (accepting trailing/multiple-token input) remains tracked by #4030.
+
 ## v0.5.1089 — fix(runtime): Object.prototype.toString.call(date) is [object Date]
 
 `Object.prototype.toString.call(new Date())` returned `"[object Object]"` instead of `"[object Date]"`. A Perry `Date` is a NaN-boxed pointer to a `DateCell` (#2089), and `js_object_to_string` (`object/mod.rs`) discriminated heap pointers into `Array`/`Error`/`Object` by GC-header type but had no `Date` arm, so dates fell through to the generic `Object` tag. Added a `crate::date::is_date_value` check (the same brand predicate `instanceof Date` uses) before the heap discrimination, covering valid dates and Invalid Date alike. Advances the Date conformance issue (#4031).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1089
+**Current Version:** 0.5.1090
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1089"
+version = "0.5.1090"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1089"
+version = "0.5.1090"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1089"
+version = "0.5.1090"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1089"
+version = "0.5.1090"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1089"
+version = "0.5.1090"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/json/parse_api.rs
+++ b/crates/perry-runtime/src/json/parse_api.rs
@@ -127,9 +127,9 @@ pub unsafe fn js_json_parse_result(text_ptr: *const StringHeader) -> Result<JSVa
 pub unsafe extern "C" fn js_json_parse(text_ptr: *const StringHeader) -> JSValue {
     if text_ptr.is_null() {
         let msg = "Unexpected end of JSON input";
-        let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-        let err_val = JSValue::string_ptr(msg_ptr);
-        crate::exception::js_throw(f64::from_bits(err_val.bits()));
+        // Node throws a real `SyntaxError` here, not a bare string — so
+        // `err instanceof SyntaxError` / `err.constructor.name` work.
+        crate::exception::js_throw(syntax_error_value(msg));
     }
     let len = (*text_ptr).byte_len as usize;
     let data_ptr = (text_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
@@ -207,9 +207,9 @@ pub unsafe extern "C" fn js_json_parse(text_ptr: *const StringHeader) -> JSValue
 
     if len == 0 {
         let msg = "Unexpected end of JSON input";
-        let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-        let err_val = JSValue::string_ptr(msg_ptr);
-        crate::exception::js_throw(f64::from_bits(err_val.bits()));
+        // Node throws a real `SyntaxError` here, not a bare string — so
+        // `err instanceof SyntaxError` / `err.constructor.name` work.
+        crate::exception::js_throw(syntax_error_value(msg));
     }
 
     // #64 follow-up: opportunistic pre-parse cleanup. When parse runs in a
@@ -267,9 +267,9 @@ pub unsafe extern "C" fn js_json_parse(text_ptr: *const StringHeader) -> JSValue
             let preview_len = len.min(50);
             let preview = std::str::from_utf8(&bytes[..preview_len]).unwrap_or("???");
             let msg = format!("JSON parse error: Unexpected token: {}", preview);
-            let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-            let err_val = JSValue::string_ptr(msg_ptr);
-            crate::exception::js_throw(f64::from_bits(err_val.bits()));
+            // Throw a real `SyntaxError` (not a bare string) to match Node's
+            // error identity for invalid JSON.
+            crate::exception::js_throw(syntax_error_value(&msg));
         }
     }
 
@@ -450,9 +450,9 @@ pub unsafe extern "C" fn js_json_parse_typed_array(
             let preview_len = len.min(50);
             let preview = std::str::from_utf8(&bytes[..preview_len]).unwrap_or("???");
             let msg = format!("JSON parse error: Unexpected token: {}", preview);
-            let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-            let err_val = JSValue::string_ptr(msg_ptr);
-            crate::exception::js_throw(f64::from_bits(err_val.bits()));
+            // Throw a real `SyntaxError` (not a bare string) to match Node's
+            // error identity for invalid JSON.
+            crate::exception::js_throw(syntax_error_value(&msg));
         }
     }
 


### PR DESCRIPTION
## Summary

`JSON.parse` on invalid input threw a **bare string** instead of a `SyntaxError` object, so `err instanceof SyntaxError` was `false` and `err.constructor.name` was `undefined` — breaking the standard `try { JSON.parse(x) } catch (e) { if (e instanceof SyntaxError) … }` idiom and test262 error-identity assertions.

## Fix

All four throw sites in `js_json_parse` (`crates/perry-runtime/src/json/parse_api.rs`) — null input, empty input, and the two invalid-token paths — built the thrown value with `JSValue::string_ptr(msg_ptr)` rather than the `syntax_error_value` helper that already wraps `js_syntaxerror_new`. Routed them through `syntax_error_value`.

## Verification

- `JSON.parse("")`, `JSON.parse("x")`, `JSON.parse("@")` now throw values where `constructor.name === "SyntaxError"`, `e instanceof SyntaxError`, and `e instanceof Error` are all true (and `typeof e === "object"`), matching Node.
- Valid parses (`{"a":1}`, `[1,2,3]`) unaffected.
- `json` + `globals` regression sweep (42 fixtures): all `json/*` pass; the only diffs are pre-existing/unrelated (`globals/builtin-name-length-descriptors` #3655, `globals/storage-globals` web-storage, two `webassembly-*` deep-WASM).

The separate parser-leniency gap (accepting trailing/multiple-token input) remains tracked by #4030.
