### PR TITLE
Fix Error and JSON parse runtime parity

### DIFF
--- a/crates/perry-codegen/src/expr/array_methods.rs
+++ b/crates/perry-codegen/src/expr/array_methods.rs
@@ -328,11 +328,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let msg = lower_expr(ctx, message)?;
             let c = lower_expr(ctx, cause)?;
             let blk = ctx.block();
-            let msg_handle = unbox_to_i64(blk, &msg);
             let err_handle = blk.call(
                 I64,
-                "js_error_new_with_cause",
-                &[(I64, &msg_handle), (DOUBLE, &c)],
+                "js_error_new_with_cause_from_value",
+                &[(DOUBLE, &msg), (DOUBLE, &c)],
             );
             Ok(nanbox_pointer_inline(blk, &err_handle))
         }
@@ -348,12 +347,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let msg = lower_expr(ctx, message)?;
             let opts = lower_expr(ctx, options)?;
             let blk = ctx.block();
-            let msg_handle = unbox_to_i64(blk, &msg);
             let kind_lit = (*kind as i64).to_string();
             let err_handle = blk.call(
                 I64,
-                "js_error_new_kind_with_options",
-                &[(I32, &kind_lit), (I64, &msg_handle), (DOUBLE, &opts)],
+                "js_error_new_kind_with_options_from_value",
+                &[(I32, &kind_lit), (DOUBLE, &msg), (DOUBLE, &opts)],
             );
             Ok(nanbox_pointer_inline(blk, &err_handle))
         }

--- a/crates/perry-codegen/src/expr/math_simple.rs
+++ b/crates/perry-codegen/src/expr/math_simple.rs
@@ -93,8 +93,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             if let Some(msg_expr) = opt_msg {
                 let msg = lower_expr(ctx, msg_expr)?;
                 let blk = ctx.block();
-                let msg_handle = unbox_to_i64(blk, &msg);
-                let err_handle = blk.call(I64, "js_error_new_with_message", &[(I64, &msg_handle)]);
+                let err_handle = blk.call(I64, "js_error_new_from_value", &[(DOUBLE, &msg)]);
                 Ok(nanbox_pointer_inline(blk, &err_handle))
             } else {
                 let err_handle = ctx.block().call(I64, "js_error_new", &[]);

--- a/crates/perry-codegen/src/expr/os_uri_dates.rs
+++ b/crates/perry-codegen/src/expr/os_uri_dates.rs
@@ -413,29 +413,41 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::TypeErrorNew(msg) => {
             let m = lower_expr(ctx, msg)?;
             let blk = ctx.block();
-            let msg_handle = unbox_to_i64(blk, &m);
-            let err_handle = blk.call(I64, "js_typeerror_new", &[(I64, &msg_handle)]);
+            let err_handle = blk.call(
+                I64,
+                "js_error_new_kind_from_value",
+                &[(I32, "1"), (DOUBLE, &m)],
+            );
             Ok(nanbox_pointer_inline(blk, &err_handle))
         }
         Expr::RangeErrorNew(msg) => {
             let m = lower_expr(ctx, msg)?;
             let blk = ctx.block();
-            let msg_handle = unbox_to_i64(blk, &m);
-            let err_handle = blk.call(I64, "js_rangeerror_new", &[(I64, &msg_handle)]);
+            let err_handle = blk.call(
+                I64,
+                "js_error_new_kind_from_value",
+                &[(I32, "2"), (DOUBLE, &m)],
+            );
             Ok(nanbox_pointer_inline(blk, &err_handle))
         }
         Expr::SyntaxErrorNew(msg) => {
             let m = lower_expr(ctx, msg)?;
             let blk = ctx.block();
-            let msg_handle = unbox_to_i64(blk, &m);
-            let err_handle = blk.call(I64, "js_syntaxerror_new", &[(I64, &msg_handle)]);
+            let err_handle = blk.call(
+                I64,
+                "js_error_new_kind_from_value",
+                &[(I32, "4"), (DOUBLE, &m)],
+            );
             Ok(nanbox_pointer_inline(blk, &err_handle))
         }
         Expr::ReferenceErrorNew(msg) => {
             let m = lower_expr(ctx, msg)?;
             let blk = ctx.block();
-            let msg_handle = unbox_to_i64(blk, &m);
-            let err_handle = blk.call(I64, "js_referenceerror_new", &[(I64, &msg_handle)]);
+            let err_handle = blk.call(
+                I64,
+                "js_error_new_kind_from_value",
+                &[(I32, "3"), (DOUBLE, &m)],
+            );
             Ok(nanbox_pointer_inline(blk, &err_handle))
         }
         Expr::NumberIsSafeInteger(operand) => {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -270,6 +270,14 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_array_concat_new", I64, &[I64, I64]);
     module.declare_function("js_error_new", I64, &[]);
     module.declare_function("js_error_new_with_message", I64, &[I64]);
+    module.declare_function("js_error_new_from_value", I64, &[DOUBLE]);
+    module.declare_function("js_error_new_kind_from_value", I64, &[I32, DOUBLE]);
+    module.declare_function("js_error_new_with_cause_from_value", I64, &[DOUBLE, DOUBLE]);
+    module.declare_function(
+        "js_error_new_kind_with_options_from_value",
+        I64,
+        &[I32, DOUBLE, DOUBLE],
+    );
     // `new assert.AssertionError({...})` — Expr::NewDynamic special-case.
     module.declare_function("js_assert_assertion_error_ctor", DOUBLE, &[DOUBLE]);
     // Issue #462: thrown by PropertyGet codegen on undefined/null receiver.

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -1131,18 +1131,10 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
 
                 if args.is_empty() {
                     return match class_name.as_str() {
-                        "TypeError" => {
-                            Ok(Expr::TypeErrorNew(Box::new(Expr::String("".to_string()))))
-                        }
-                        "RangeError" => {
-                            Ok(Expr::RangeErrorNew(Box::new(Expr::String("".to_string()))))
-                        }
-                        "ReferenceError" => Ok(Expr::ReferenceErrorNew(Box::new(Expr::String(
-                            "".to_string(),
-                        )))),
-                        "SyntaxError" => {
-                            Ok(Expr::SyntaxErrorNew(Box::new(Expr::String("".to_string()))))
-                        }
+                        "TypeError" => Ok(Expr::TypeErrorNew(Box::new(Expr::Undefined))),
+                        "RangeError" => Ok(Expr::RangeErrorNew(Box::new(Expr::Undefined))),
+                        "ReferenceError" => Ok(Expr::ReferenceErrorNew(Box::new(Expr::Undefined))),
+                        "SyntaxError" => Ok(Expr::SyntaxErrorNew(Box::new(Expr::Undefined))),
                         _ => Ok(Expr::ErrorNew(None)),
                     };
                 } else {

--- a/crates/perry-runtime/src/error.rs
+++ b/crates/perry-runtime/src/error.rs
@@ -27,6 +27,10 @@ pub const ERROR_KIND_AGGREGATE_ERROR: u32 = 5;
 pub const ERROR_KIND_EVAL_ERROR: u32 = 6;
 pub const ERROR_KIND_URI_ERROR: u32 = 7;
 
+const ERROR_FLAG_HAS_MESSAGE: u32 = 1 << 0;
+const ERROR_FLAG_HAS_CAUSE: u32 = 1 << 1;
+const ERROR_FLAG_HAS_ERRORS: u32 = 1 << 2;
+
 /// Special class IDs for `instanceof` checks (must match perry-codegen/src/expr.rs)
 pub const CLASS_ID_ERROR: u32 = 0xFFFF0001;
 pub const CLASS_ID_TYPE_ERROR: u32 = 0xFFFF0010;
@@ -50,6 +54,8 @@ pub struct ErrorHeader {
     pub object_type: u32,
     /// Error kind discriminator (TypeError, RangeError, etc.)
     pub error_kind: u32,
+    /// Own-property presence bits for spec-visible slots.
+    pub flags: u32,
     /// Error message as a string pointer
     pub message: *mut StringHeader,
     /// Error name (e.g., "Error", "TypeError")
@@ -77,6 +83,7 @@ unsafe fn alloc_error(
     kind: u32,
     name_bytes: &[u8],
     message: *mut StringHeader,
+    has_message: bool,
 ) -> *mut ErrorHeader {
     let scope = crate::gc::RuntimeHandleScope::new();
     // #321 frontier issue #69 (sibling to #2230's `dyn_index_get` guard):
@@ -127,6 +134,11 @@ unsafe fn alloc_error(
 
     (*ptr).object_type = OBJECT_TYPE_ERROR;
     (*ptr).error_kind = kind;
+    (*ptr).flags = if has_message {
+        ERROR_FLAG_HAS_MESSAGE
+    } else {
+        0
+    };
     (*ptr).message = message_handle.get_raw_const_ptr::<StringHeader>() as *mut StringHeader;
     (*ptr).name = error_name_handle.get_raw_const_ptr::<StringHeader>() as *mut StringHeader;
     (*ptr).stack = stack_handle.get_raw_const_ptr::<StringHeader>() as *mut StringHeader;
@@ -142,6 +154,7 @@ pub(crate) unsafe fn error_set_cause(error: *mut ErrorHeader, cause: f64) {
         &(*error).cause as *const f64 as usize,
         cause.to_bits(),
     );
+    (*error).flags |= ERROR_FLAG_HAS_CAUSE;
 }
 
 pub(crate) unsafe fn error_set_errors(
@@ -153,18 +166,19 @@ pub(crate) unsafe fn error_set_errors(
         &(*error).errors as *const _ as usize,
         errors as u64,
     );
+    (*error).flags |= ERROR_FLAG_HAS_ERRORS;
 }
 
 /// Create a new Error with no message
 #[no_mangle]
 pub extern "C" fn js_error_new() -> *mut ErrorHeader {
-    unsafe { alloc_error(ERROR_KIND_ERROR, b"Error", std::ptr::null_mut()) }
+    unsafe { alloc_error(ERROR_KIND_ERROR, b"Error", std::ptr::null_mut(), false) }
 }
 
 /// Create a new Error with a message
 #[no_mangle]
 pub extern "C" fn js_error_new_with_message(message: *mut StringHeader) -> *mut ErrorHeader {
-    unsafe { alloc_error(ERROR_KIND_ERROR, b"Error", message) }
+    unsafe { alloc_error(ERROR_KIND_ERROR, b"Error", message, true) }
 }
 
 /// Create a new Error-like object with a custom `.name` and stack prefix.
@@ -172,7 +186,7 @@ pub(crate) fn js_error_new_with_name_message(
     name: &'static [u8],
     message: *mut StringHeader,
 ) -> *mut ErrorHeader {
-    unsafe { alloc_error(ERROR_KIND_ERROR, name, message) }
+    unsafe { alloc_error(ERROR_KIND_ERROR, name, message, true) }
 }
 
 /// Create a new Error-like object with a dynamically supplied `.name`.
@@ -180,7 +194,7 @@ pub(crate) fn js_error_new_with_name_message_bytes(
     name: &[u8],
     message: *mut StringHeader,
 ) -> *mut ErrorHeader {
-    unsafe { alloc_error(ERROR_KIND_ERROR, name, message) }
+    unsafe { alloc_error(ERROR_KIND_ERROR, name, message, true) }
 }
 
 /// Create a new Error with a message and a cause (raw f64 NaN-boxed)
@@ -190,7 +204,7 @@ pub extern "C" fn js_error_new_with_cause(
     cause: f64,
 ) -> *mut ErrorHeader {
     unsafe {
-        let ptr = alloc_error(ERROR_KIND_ERROR, b"Error", message);
+        let ptr = alloc_error(ERROR_KIND_ERROR, b"Error", message, true);
         error_set_cause(ptr, cause);
         ptr
     }
@@ -199,19 +213,19 @@ pub extern "C" fn js_error_new_with_cause(
 /// Create a new TypeError with a message
 #[no_mangle]
 pub extern "C" fn js_typeerror_new(message: *mut StringHeader) -> *mut ErrorHeader {
-    unsafe { alloc_error(ERROR_KIND_TYPE_ERROR, b"TypeError", message) }
+    unsafe { alloc_error(ERROR_KIND_TYPE_ERROR, b"TypeError", message, true) }
 }
 
 /// Create a new RangeError with a message
 #[no_mangle]
 pub extern "C" fn js_rangeerror_new(message: *mut StringHeader) -> *mut ErrorHeader {
-    unsafe { alloc_error(ERROR_KIND_RANGE_ERROR, b"RangeError", message) }
+    unsafe { alloc_error(ERROR_KIND_RANGE_ERROR, b"RangeError", message, true) }
 }
 
 /// Create a new ReferenceError with a message
 #[no_mangle]
 pub extern "C" fn js_referenceerror_new(message: *mut StringHeader) -> *mut ErrorHeader {
-    unsafe { alloc_error(ERROR_KIND_REFERENCE_ERROR, b"ReferenceError", message) }
+    unsafe { alloc_error(ERROR_KIND_REFERENCE_ERROR, b"ReferenceError", message, true) }
 }
 
 thread_local! {
@@ -288,19 +302,19 @@ static KEEP_JS_THROW_ERROR_WITH_CODE: unsafe extern "C" fn(
 /// Create a new SyntaxError with a message
 #[no_mangle]
 pub extern "C" fn js_syntaxerror_new(message: *mut StringHeader) -> *mut ErrorHeader {
-    unsafe { alloc_error(ERROR_KIND_SYNTAX_ERROR, b"SyntaxError", message) }
+    unsafe { alloc_error(ERROR_KIND_SYNTAX_ERROR, b"SyntaxError", message, true) }
 }
 
 /// Create a new EvalError with a message
 #[no_mangle]
 pub extern "C" fn js_evalerror_new(message: *mut StringHeader) -> *mut ErrorHeader {
-    unsafe { alloc_error(ERROR_KIND_EVAL_ERROR, b"EvalError", message) }
+    unsafe { alloc_error(ERROR_KIND_EVAL_ERROR, b"EvalError", message, true) }
 }
 
 /// Create a new URIError with a message
 #[no_mangle]
 pub extern "C" fn js_urierror_new(message: *mut StringHeader) -> *mut ErrorHeader {
-    unsafe { alloc_error(ERROR_KIND_URI_ERROR, b"URIError", message) }
+    unsafe { alloc_error(ERROR_KIND_URI_ERROR, b"URIError", message, true) }
 }
 
 /// Create a new AggregateError with an errors array and a message
@@ -310,7 +324,12 @@ pub extern "C" fn js_aggregateerror_new(
     message: *mut StringHeader,
 ) -> *mut ErrorHeader {
     unsafe {
-        let ptr = alloc_error(ERROR_KIND_AGGREGATE_ERROR, b"AggregateError", message);
+        let ptr = alloc_error(
+            ERROR_KIND_AGGREGATE_ERROR,
+            b"AggregateError",
+            message,
+            !message.is_null(),
+        );
         error_set_errors(ptr, errors);
         ptr
     }
@@ -368,7 +387,7 @@ pub extern "C" fn js_error_new_kind_with_options(
         } else {
             kind
         };
-        let ptr = alloc_error(resolved_kind, name, message);
+        let ptr = alloc_error(resolved_kind, name, message, !message.is_null());
         apply_cause_from_options(ptr, options);
         ptr
     }
@@ -379,6 +398,70 @@ fn throw_not_iterable_type_error() -> ! {
     let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
     let err = js_typeerror_new(msg);
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+fn error_kind_name(kind: u32) -> (&'static [u8], u32) {
+    match kind {
+        ERROR_KIND_TYPE_ERROR => (b"TypeError", ERROR_KIND_TYPE_ERROR),
+        ERROR_KIND_RANGE_ERROR => (b"RangeError", ERROR_KIND_RANGE_ERROR),
+        ERROR_KIND_REFERENCE_ERROR => (b"ReferenceError", ERROR_KIND_REFERENCE_ERROR),
+        ERROR_KIND_SYNTAX_ERROR => (b"SyntaxError", ERROR_KIND_SYNTAX_ERROR),
+        ERROR_KIND_AGGREGATE_ERROR => (b"AggregateError", ERROR_KIND_AGGREGATE_ERROR),
+        ERROR_KIND_EVAL_ERROR => (b"EvalError", ERROR_KIND_EVAL_ERROR),
+        ERROR_KIND_URI_ERROR => (b"URIError", ERROR_KIND_URI_ERROR),
+        _ => (b"Error", ERROR_KIND_ERROR),
+    }
+}
+
+fn coerce_error_message_value(value: f64) -> Option<*mut StringHeader> {
+    let jsv = crate::value::JSValue::from_bits(value.to_bits());
+    if jsv.is_undefined() {
+        return None;
+    }
+    if unsafe { crate::symbol::js_is_symbol(value) != 0 } {
+        let msg = js_string_from_bytes(b"Cannot convert a Symbol value to a string".as_ptr(), 41);
+        let err = js_typeerror_new(msg);
+        crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+    }
+    Some(crate::builtins::js_string_coerce(value))
+}
+
+#[no_mangle]
+pub extern "C" fn js_error_new_from_value(value: f64) -> *mut ErrorHeader {
+    js_error_new_kind_from_value(ERROR_KIND_ERROR, value)
+}
+
+#[no_mangle]
+pub extern "C" fn js_error_new_kind_from_value(kind: u32, value: f64) -> *mut ErrorHeader {
+    let (name, resolved_kind) = error_kind_name(kind);
+    unsafe {
+        match coerce_error_message_value(value) {
+            Some(message) => alloc_error(resolved_kind, name, message, true),
+            None => alloc_error(resolved_kind, name, std::ptr::null_mut(), false),
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_error_new_with_cause_from_value(value: f64, cause: f64) -> *mut ErrorHeader {
+    unsafe {
+        let ptr = js_error_new_from_value(value);
+        error_set_cause(ptr, cause);
+        ptr
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_error_new_kind_with_options_from_value(
+    kind: u32,
+    value: f64,
+    options: f64,
+) -> *mut ErrorHeader {
+    unsafe {
+        let ptr = js_error_new_kind_from_value(kind, value);
+        apply_cause_from_options(ptr, options);
+        ptr
+    }
 }
 
 /// #2838/#2836: full `new AggregateError(errors, message?, options?)`
@@ -406,7 +489,12 @@ pub extern "C" fn js_aggregateerror_new_full(
         Err(_) => throw_not_iterable_type_error(),
     };
     unsafe {
-        let ptr = alloc_error(ERROR_KIND_AGGREGATE_ERROR, b"AggregateError", message);
+        let ptr = alloc_error(
+            ERROR_KIND_AGGREGATE_ERROR,
+            b"AggregateError",
+            message,
+            !message.is_null(),
+        );
         error_set_errors(ptr, arr);
         apply_cause_from_options(ptr, options);
         ptr
@@ -455,6 +543,41 @@ pub extern "C" fn js_error_get_name(error: *mut ErrorHeader) -> *mut StringHeade
             return js_string_from_bytes(b"Error".as_ptr(), 5);
         }
         (*error).name
+    }
+}
+
+pub(crate) unsafe fn js_error_has_own_property(error: *mut ErrorHeader, key: &str) -> bool {
+    if error.is_null() {
+        return false;
+    }
+    if crate::node_submodules::error_user_prop(error as usize, key).is_some() {
+        return true;
+    }
+    match key {
+        "message" => ((*error).flags & ERROR_FLAG_HAS_MESSAGE) != 0,
+        "cause" => ((*error).flags & ERROR_FLAG_HAS_CAUSE) != 0,
+        "errors" => ((*error).flags & ERROR_FLAG_HAS_ERRORS) != 0,
+        "stack" => true,
+        _ => false,
+    }
+}
+
+pub(crate) unsafe fn js_error_builtin_own_property_is_enumerable(
+    error: *mut ErrorHeader,
+    key: &str,
+) -> Option<bool> {
+    if error.is_null() {
+        return Some(false);
+    }
+    if crate::node_submodules::error_user_prop(error as usize, key).is_some() {
+        return Some(true);
+    }
+    match key {
+        "message" if ((*error).flags & ERROR_FLAG_HAS_MESSAGE) != 0 => Some(false),
+        "cause" if ((*error).flags & ERROR_FLAG_HAS_CAUSE) != 0 => Some(false),
+        "errors" if ((*error).flags & ERROR_FLAG_HAS_ERRORS) != 0 => Some(false),
+        "stack" => Some(false),
+        _ => None,
     }
 }
 
@@ -613,18 +736,8 @@ unsafe fn read_string_header_owned(ptr: *const StringHeader) -> String {
 #[no_mangle]
 pub extern "C" fn js_error_to_string(error: *mut ErrorHeader) -> *mut StringHeader {
     unsafe {
-        // Instance overrides (`err.name = ...` / `err.message = ...`) recorded
-        // in the per-error side table take precedence over the baked
-        // ErrorHeader values — Node's `Error.prototype.toString` reads the
-        // overridable `name`/`message` own properties, ToString-coercing them.
-        let name = match crate::node_submodules::error_user_prop(error as usize, "name") {
-            Some(v) => read_string_header_owned(crate::value::js_jsvalue_to_string(v)),
-            None => read_string_header_owned(js_error_get_name(error)),
-        };
-        let message = match crate::node_submodules::error_user_prop(error as usize, "message") {
-            Some(v) => read_string_header_owned(crate::value::js_jsvalue_to_string(v)),
-            None => read_string_header_owned(js_error_get_message(error)),
-        };
+        let name = error_to_string_part(error, "name", js_error_get_name(error), "Error");
+        let message = error_to_string_part(error, "message", js_error_get_message(error), "");
         let result = if name.is_empty() {
             message
         } else if message.is_empty() {
@@ -634,6 +747,22 @@ pub extern "C" fn js_error_to_string(error: *mut ErrorHeader) -> *mut StringHead
         };
         js_string_from_bytes(result.as_ptr(), result.len() as u32)
     }
+}
+
+unsafe fn error_to_string_part(
+    error: *mut ErrorHeader,
+    key: &str,
+    fallback: *const StringHeader,
+    undefined_default: &str,
+) -> String {
+    if let Some(value) = crate::node_submodules::error_user_prop(error as usize, key) {
+        let value_jsv = crate::value::JSValue::from_bits(value.to_bits());
+        if value_jsv.is_undefined() {
+            return undefined_default.to_string();
+        }
+        return read_string_header_owned(crate::value::js_jsvalue_to_string(value));
+    }
+    read_string_header_owned(fallback)
 }
 
 /// Get the cause property of an Error (raw f64 NaN-boxed value)

--- a/crates/perry-runtime/src/gc/tests/alloc.rs
+++ b/crates/perry-runtime/src/gc/tests/alloc.rs
@@ -652,6 +652,7 @@ fn alloc_malloc_kind_test_object(obj_type: u8) -> *mut u8 {
                     crate::error::ErrorHeader {
                         object_type: crate::error::OBJECT_TYPE_ERROR,
                         error_kind: crate::error::ERROR_KIND_ERROR,
+                        flags: 0,
                         message: std::ptr::null_mut(),
                         name: std::ptr::null_mut(),
                         stack: std::ptr::null_mut(),

--- a/crates/perry-runtime/src/gc/tests/support.rs
+++ b/crates/perry-runtime/src/gc/tests/support.rs
@@ -89,6 +89,7 @@ pub(super) unsafe fn alloc_old_test_error() -> *mut crate::error::ErrorHeader {
         crate::error::ErrorHeader {
             object_type: crate::error::OBJECT_TYPE_ERROR,
             error_kind: crate::error::ERROR_KIND_ERROR,
+            flags: 0,
             message: std::ptr::null_mut(),
             name: std::ptr::null_mut(),
             stack: std::ptr::null_mut(),

--- a/crates/perry-runtime/src/json/parse_api.rs
+++ b/crates/perry-runtime/src/json/parse_api.rs
@@ -50,6 +50,10 @@ fn syntax_error_value(message: &str) -> f64 {
     f64::from_bits(JSValue::pointer(err as *const u8).bits())
 }
 
+fn throw_syntax_error(message: &str) -> ! {
+    crate::exception::js_throw(syntax_error_value(message))
+}
+
 fn is_json_null_literal(bytes: &[u8]) -> bool {
     let Some(start) = bytes
         .iter()
@@ -126,14 +130,18 @@ pub unsafe fn js_json_parse_result(text_ptr: *const StringHeader) -> Result<JSVa
 #[no_mangle]
 pub unsafe extern "C" fn js_json_parse(text_ptr: *const StringHeader) -> JSValue {
     if text_ptr.is_null() {
-        let msg = "Unexpected end of JSON input";
-        // Node throws a real `SyntaxError` here, not a bare string — so
-        // `err instanceof SyntaxError` / `err.constructor.name` work.
-        crate::exception::js_throw(syntax_error_value(msg));
+        throw_syntax_error("Unexpected end of JSON input");
     }
     let len = (*text_ptr).byte_len as usize;
     let data_ptr = (text_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
     let bytes = std::slice::from_raw_parts(data_ptr, len);
+
+    if len == 0 {
+        throw_syntax_error("Unexpected end of JSON input");
+    }
+    if let Err(err) = serde_json::from_slice::<serde_json::Value>(bytes) {
+        throw_syntax_error(&format!("JSON parse error: {}", err));
+    }
 
     crate::gc::gc_collect_pending_suppressed_parse();
 
@@ -205,13 +213,6 @@ pub unsafe extern "C" fn js_json_parse(text_ptr: *const StringHeader) -> JSValue
         // and handles non-array roots.
     }
 
-    if len == 0 {
-        let msg = "Unexpected end of JSON input";
-        // Node throws a real `SyntaxError` here, not a bare string — so
-        // `err instanceof SyntaxError` / `err.constructor.name` work.
-        crate::exception::js_throw(syntax_error_value(msg));
-    }
-
     // #64 follow-up: opportunistic pre-parse cleanup. When parse runs in a
     // tight loop (e.g. `for (let i=0; i<N; i++) JSON.parse(blob);`), each
     // call suppresses GC for its duration, and the post-parse malloc-trigger
@@ -267,15 +268,11 @@ pub unsafe extern "C" fn js_json_parse(text_ptr: *const StringHeader) -> JSValue
             let preview_len = len.min(50);
             let preview = std::str::from_utf8(&bytes[..preview_len]).unwrap_or("???");
             let msg = format!("JSON parse error: Unexpected token: {}", preview);
-            // Throw a real `SyntaxError` (not a bare string) to match Node's
-            // error identity for invalid JSON.
-            crate::exception::js_throw(syntax_error_value(&msg));
+            throw_syntax_error(&msg);
         } else if parser.has_trailing_content() {
             // Literal `null` followed by trailing tokens (`JSON.parse("null x")`)
             // — reject like any other trailing-token case.
-            crate::exception::js_throw(syntax_error_value(
-                "Unexpected non-whitespace character after JSON",
-            ));
+            throw_syntax_error("Unexpected non-whitespace character after JSON");
         }
     } else if parser.has_trailing_content() {
         // A valid value was parsed but non-whitespace input remains

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1248,27 +1248,21 @@ pub unsafe extern "C" fn js_new_function_construct(
             // error instance with the right `.name`.
             "Error" | "TypeError" | "RangeError" | "ReferenceError" | "SyntaxError"
             | "EvalError" | "URIError" => {
-                let has_msg = !args.is_empty() && args[0].to_bits() != crate::value::TAG_UNDEFINED;
-                let message = if has_msg {
-                    crate::builtins::js_string_coerce(args[0])
+                let kind = match name {
+                    "TypeError" => crate::error::ERROR_KIND_TYPE_ERROR,
+                    "RangeError" => crate::error::ERROR_KIND_RANGE_ERROR,
+                    "ReferenceError" => crate::error::ERROR_KIND_REFERENCE_ERROR,
+                    "SyntaxError" => crate::error::ERROR_KIND_SYNTAX_ERROR,
+                    "EvalError" => crate::error::ERROR_KIND_EVAL_ERROR,
+                    "URIError" => crate::error::ERROR_KIND_URI_ERROR,
+                    _ => crate::error::ERROR_KIND_ERROR,
+                };
+                let message = if args.is_empty() {
+                    f64::from_bits(crate::value::TAG_UNDEFINED)
                 } else {
-                    std::ptr::null_mut()
+                    args[0]
                 };
-                let error = match name {
-                    "TypeError" => crate::error::js_typeerror_new(message),
-                    "RangeError" => crate::error::js_rangeerror_new(message),
-                    "ReferenceError" => crate::error::js_referenceerror_new(message),
-                    "SyntaxError" => crate::error::js_syntaxerror_new(message),
-                    "EvalError" => crate::error::js_evalerror_new(message),
-                    "URIError" => crate::error::js_urierror_new(message),
-                    _ => {
-                        if has_msg {
-                            crate::error::js_error_new_with_message(message)
-                        } else {
-                            crate::error::js_error_new()
-                        }
-                    }
-                };
+                let error = crate::error::js_error_new_kind_from_value(kind, message);
                 return crate::value::js_nanbox_pointer(error as i64);
             }
             // #2889: `new (rebound RegExp)(pattern, flags)`.

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2283,6 +2283,12 @@ pub extern "C" fn js_object_get_field_by_name(
                         let v = crate::error::js_error_get_cause(err_ptr);
                         return JSValue::from_bits(v.to_bits());
                     }
+                    b"toString" => {
+                        let this_f64 =
+                            f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+                        let result = js_class_method_bind(this_f64, b"toString".as_ptr(), 8);
+                        return JSValue::from_bits(result.to_bits());
+                    }
                     b"constructor" => {
                         let name = match (*err_ptr).error_kind {
                             crate::error::ERROR_KIND_TYPE_ERROR => b"TypeError".as_slice(),

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -145,6 +145,60 @@ pub(crate) extern "C" fn typed_array_constructor_call_thunk(
     super::object_ops::throw_object_type_error(b"Constructor %TypedArray% requires 'new'")
 }
 
+fn error_constructor_call(kind: u32, message: f64) -> f64 {
+    let error = crate::error::js_error_new_kind_from_value(kind, message);
+    crate::value::js_nanbox_pointer(error as i64)
+}
+
+extern "C" fn error_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    message: f64,
+) -> f64 {
+    error_constructor_call(crate::error::ERROR_KIND_ERROR, message)
+}
+
+extern "C" fn type_error_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    message: f64,
+) -> f64 {
+    error_constructor_call(crate::error::ERROR_KIND_TYPE_ERROR, message)
+}
+
+extern "C" fn range_error_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    message: f64,
+) -> f64 {
+    error_constructor_call(crate::error::ERROR_KIND_RANGE_ERROR, message)
+}
+
+extern "C" fn reference_error_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    message: f64,
+) -> f64 {
+    error_constructor_call(crate::error::ERROR_KIND_REFERENCE_ERROR, message)
+}
+
+extern "C" fn syntax_error_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    message: f64,
+) -> f64 {
+    error_constructor_call(crate::error::ERROR_KIND_SYNTAX_ERROR, message)
+}
+
+extern "C" fn eval_error_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    message: f64,
+) -> f64 {
+    error_constructor_call(crate::error::ERROR_KIND_EVAL_ERROR, message)
+}
+
+extern "C" fn uri_error_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    message: f64,
+) -> f64 {
+    error_constructor_call(crate::error::ERROR_KIND_URI_ERROR, message)
+}
+
 pub(crate) extern "C" fn webcrypto_illegal_constructor_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
@@ -649,6 +703,73 @@ extern "C" fn date_prototype_to_string_thunk(
     let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
     let string = crate::date::js_date_to_string(this_value);
     crate::value::js_nanbox_string(string as i64)
+}
+
+extern "C" fn object_prototype_has_own_property_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    key: f64,
+) -> f64 {
+    let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    unsafe {
+        super::js_native_call_method(
+            this_value,
+            b"hasOwnProperty".as_ptr() as *const i8,
+            "hasOwnProperty".len(),
+            &key as *const f64,
+            1,
+        )
+    }
+}
+
+extern "C" fn error_prototype_to_string_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    let this_jsv = crate::value::JSValue::from_bits(this_value.to_bits());
+    if !this_jsv.is_pointer() || this_jsv.is_null() || this_jsv.is_undefined() {
+        super::object_ops::throw_object_type_error(
+            b"Error.prototype.toString called on non-object",
+        );
+    }
+    let raw = crate::value::js_nanbox_get_pointer(this_value) as *const u8;
+    if raw.is_null() || !crate::object::is_valid_obj_ptr(raw) {
+        super::object_ops::throw_object_type_error(
+            b"Error.prototype.toString called on non-object",
+        );
+    }
+
+    let name = error_to_string_property(this_value, b"name", "Error");
+    let message = error_to_string_property(this_value, b"message", "");
+    let result = if name.is_empty() {
+        message
+    } else if message.is_empty() {
+        name
+    } else {
+        format!("{name}: {message}")
+    };
+    let s = crate::string::js_string_from_bytes(result.as_ptr(), result.len() as u32);
+    crate::value::js_nanbox_string(s as i64)
+}
+
+fn error_to_string_property(this_value: f64, key: &'static [u8], default: &str) -> String {
+    let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+    let obj = crate::value::js_nanbox_get_pointer(this_value) as *const ObjectHeader;
+    let value = crate::object::js_object_get_field_by_name_f64(obj, key_ptr);
+    let value_jsv = crate::value::JSValue::from_bits(value.to_bits());
+    if value_jsv.is_undefined() {
+        return default.to_string();
+    }
+    let string = crate::value::js_jsvalue_to_string(value);
+    unsafe { string_header_to_owned(string) }
+}
+
+unsafe fn string_header_to_owned(ptr: *const crate::StringHeader) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    let data = (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    let len = (*ptr).byte_len as usize;
+    String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned()
 }
 
 extern "C" fn object_prototype_value_of_thunk(
@@ -1174,6 +1295,13 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             // global value coerce like the bare-call lowering does.
             "Number" => global_this_number_thunk as *const u8,
             "Boolean" => global_this_boolean_thunk as *const u8,
+            "Error" => error_constructor_call_thunk as *const u8,
+            "TypeError" => type_error_constructor_call_thunk as *const u8,
+            "RangeError" => range_error_constructor_call_thunk as *const u8,
+            "ReferenceError" => reference_error_constructor_call_thunk as *const u8,
+            "SyntaxError" => syntax_error_constructor_call_thunk as *const u8,
+            "EvalError" => eval_error_constructor_call_thunk as *const u8,
+            "URIError" => uri_error_constructor_call_thunk as *const u8,
             "MessageChannel" => {
                 crate::messaging::js_message_channel_constructor_call_error as *const u8
             }
@@ -1203,6 +1331,10 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
                 crate::closure::js_register_closure_arity(func_ptr, 1);
             }
             "Object" | "String" | "Number" | "Boolean" | "BroadcastChannel" => {
+                crate::closure::js_register_closure_arity(func_ptr, 1);
+            }
+            "Error" | "TypeError" | "RangeError" | "ReferenceError" | "SyntaxError"
+            | "EvalError" | "URIError" => {
                 crate::closure::js_register_closure_arity(func_ptr, 1);
             }
             "MessageChannel" | "MessagePort" | "Storage" => {
@@ -1305,6 +1437,7 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             // entry point — works in tandem with `.call`/`.apply` since
             // those arms (#970) rebind IMPLICIT_THIS before forwarding.
             populate_builtin_prototype_methods(name, proto_obj);
+            install_error_prototype_data_properties(name, proto_obj);
             if matches!(name, "MessageChannel" | "MessagePort" | "BroadcastChannel") {
                 crate::messaging::populate_messaging_prototype(name, proto_obj, ctor_value);
             }
@@ -2209,10 +2342,13 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
                 object_prototype_value_of_thunk as *const u8,
                 0,
             );
-            install_noop_proto_methods(
+            install_proto_method(
                 proto_obj,
-                &[("hasOwnProperty", 1), ("propertyIsEnumerable", 1)],
+                "hasOwnProperty",
+                object_prototype_has_own_property_thunk as *const u8,
+                1,
             );
+            install_noop_proto_methods(proto_obj, &[("propertyIsEnumerable", 1)]);
         }
         "Function" => {
             install_proto_method(
@@ -2472,10 +2608,27 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
             }
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
-        "Error" | "TypeError" | "RangeError" | "SyntaxError" | "ReferenceError" | "EvalError"
-        | "URIError" => {
-            install_noop_proto_methods(proto_obj, &[("toString", 0)]);
+        "Error" | "TypeError" | "RangeError" | "SyntaxError" | "ReferenceError"
+        | "AggregateError" | "EvalError" | "URIError" => {
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+            install_proto_method(
+                proto_obj,
+                "toString",
+                error_prototype_to_string_thunk as *const u8,
+                0,
+            );
+            install_proto_method(
+                proto_obj,
+                "isPrototypeOf",
+                object_prototype_is_prototype_of_thunk as *const u8,
+                1,
+            );
+            install_proto_method(
+                proto_obj,
+                "hasOwnProperty",
+                object_prototype_has_own_property_thunk as *const u8,
+                1,
+            );
         }
         // Typed-array constructors: keep the reified per-kind prototype
         // method set (#2142) on each per-kind `.prototype` so direct
@@ -2534,6 +2687,44 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
         }
         _ => {}
     }
+}
+
+fn install_error_prototype_data_properties(builtin_name: &str, proto_obj: *mut ObjectHeader) {
+    let name = match builtin_name {
+        "Error" | "TypeError" | "RangeError" | "SyntaxError" | "ReferenceError"
+        | "AggregateError" | "EvalError" | "URIError" => builtin_name,
+        _ => return,
+    };
+    if proto_obj.is_null() {
+        return;
+    }
+
+    let name_key = crate::string::js_string_from_bytes(b"name".as_ptr(), 4);
+    let name_value =
+        crate::string::js_string_from_bytes(name.as_bytes().as_ptr(), name.len() as u32);
+    js_object_set_field_by_name(
+        proto_obj,
+        name_key,
+        crate::value::js_nanbox_string(name_value as i64),
+    );
+    super::set_builtin_property_attrs(
+        proto_obj as usize,
+        "name".to_string(),
+        super::PropertyAttrs::new(true, false, true),
+    );
+
+    let message_key = crate::string::js_string_from_bytes(b"message".as_ptr(), 7);
+    let message_value = crate::string::js_string_from_bytes(b"".as_ptr(), 0);
+    js_object_set_field_by_name(
+        proto_obj,
+        message_key,
+        crate::value::js_nanbox_string(message_value as i64),
+    );
+    super::set_builtin_property_attrs(
+        proto_obj as usize,
+        "message".to_string(),
+        super::PropertyAttrs::new(true, false, true),
+    );
 }
 
 fn install_webcrypto_proto_method(

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -15,13 +15,8 @@ use std::ptr;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::RwLock;
 
-// ---------------------------------------------------------------------------
 // Submodules (issue #1103): behavior-preserving split of the former
-// 11.2k-line object.rs. Each submodule does `use super::*;` so the
-// shared state/helpers that remain in this trunk module stay reachable;
-// everything public is re-exported here so no symbol moves in the public
-// surface (all `#[no_mangle]` FFI entry points keep their exact symbol).
-// ---------------------------------------------------------------------------
+// 11.2k-line object.rs. Public re-exports keep FFI symbols stable.
 mod alloc;
 mod array_object_ops;
 mod assert;
@@ -51,6 +46,7 @@ mod object_ops;
 mod object_ops_frozen;
 mod polymorphic_index;
 pub(crate) mod prototype_chain;
+mod prototype_helpers;
 mod reflect_support;
 mod util_types;
 mod websocket_global;
@@ -84,6 +80,7 @@ pub(crate) use native_module_stream::*;
 pub use object_ops::*;
 pub use object_ops_frozen::*;
 pub use polymorphic_index::*;
+pub(crate) use prototype_helpers::*;
 pub(crate) use reflect_support::*;
 pub use util_types::*;
 

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -387,7 +387,9 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
             Some(info) => info,
             None => return false,
         };
-        if target_gc_type != crate::gc::GC_TYPE_CLOSURE {
+        if target_gc_type != crate::gc::GC_TYPE_CLOSURE
+            && target_gc_type != crate::gc::GC_TYPE_ERROR
+        {
             return false;
         }
     }
@@ -704,6 +706,19 @@ pub unsafe extern "C" fn js_native_call_method(
     }
 
     let jsval = JSValue::from_bits(object.to_bits());
+
+    if method_name == "toString" && jsval.is_pointer() {
+        let raw = crate::value::js_nanbox_get_pointer(object) as *const u8;
+        if !raw.is_null() && crate::object::is_valid_obj_ptr(raw) {
+            unsafe {
+                let gc = raw.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+                if (*gc).obj_type == crate::gc::GC_TYPE_ERROR {
+                    let s = crate::error::js_error_to_string(raw as *mut crate::error::ErrorHeader);
+                    return f64::from_bits(JSValue::string_ptr(s).bits());
+                }
+            }
+        }
+    }
 
     if let Some((_, payload)) = crate::builtins::boxed_primitive_payload(object) {
         match method_name {
@@ -2741,6 +2756,17 @@ pub unsafe extern "C" fn js_native_call_method(
                 if raw >= crate::gc::GC_HEADER_SIZE + 0x1000 {
                     let gc_header = (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE)
                         as *const crate::gc::GcHeader;
+                    if (*gc_header).obj_type == crate::gc::GC_TYPE_ERROR {
+                        let present = super::has_own_helpers::str_from_string_header(key_str)
+                            .map(|key| {
+                                crate::error::js_error_has_own_property(
+                                    raw as *mut crate::error::ErrorHeader,
+                                    key,
+                                )
+                            })
+                            .unwrap_or(false);
+                        return f64::from_bits(JSValue::bool(present).bits());
+                    }
                     if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
                         let present = super::has_own_helpers::array_own_key_present(
                             raw as *const crate::array::ArrayHeader,
@@ -2802,6 +2828,18 @@ pub unsafe extern "C" fn js_native_call_method(
             if raw >= crate::gc::GC_HEADER_SIZE + 0x1000 {
                 let gc_header =
                     (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+                if (*gc_header).obj_type == crate::gc::GC_TYPE_ERROR {
+                    let Some(key_name) = super::has_own_helpers::str_from_string_header(key_str)
+                    else {
+                        return f64::from_bits(JSValue::bool(false).bits());
+                    };
+                    let enumerable = crate::error::js_error_builtin_own_property_is_enumerable(
+                        raw as *mut crate::error::ErrorHeader,
+                        key_name,
+                    )
+                    .unwrap_or(false);
+                    return f64::from_bits(JSValue::bool(enumerable).bits());
+                }
                 if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
                     let Some(key_name) = super::has_own_helpers::str_from_string_header(key_str)
                     else {

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1429,37 +1429,6 @@ pub extern "C" fn js_object_create(proto_value: f64) -> f64 {
     f64::from_bits((obj as u64) | 0x7FFD_0000_0000_0000)
 }
 
-/// Object.freeze(obj) — sets the frozen flag and drops `writable` +
-/// `configurable` on every existing key so per-key descriptor lookups report
-/// the post-freeze state. Returns the object.
-fn constructor_dynamic_prototype(obj: *const ObjectHeader) -> Option<f64> {
-    if obj.is_null() {
-        return None;
-    }
-    let key =
-        crate::string::js_string_from_bytes(b"constructor".as_ptr(), b"constructor".len() as u32);
-    let constructor = js_object_get_field_by_name_f64(obj, key);
-    let bits = constructor.to_bits();
-    let top16 = bits >> 48;
-    if top16 != 0x7FFD {
-        return None;
-    }
-    let raw_addr = (bits & crate::value::POINTER_MASK) as usize;
-    if raw_addr < (crate::gc::GC_HEADER_SIZE as usize) + 0x1000 {
-        return None;
-    }
-    let gc = unsafe { gc_header_for(raw_addr as *const ObjectHeader) };
-    if unsafe { (*gc).obj_type } != crate::gc::GC_TYPE_CLOSURE {
-        return None;
-    }
-    let proto = crate::closure::closure_get_dynamic_prop(raw_addr, "prototype");
-    if crate::value::JSValue::from_bits(proto.to_bits()).is_undefined() {
-        None
-    } else {
-        Some(proto)
-    }
-}
-
 /// Object.getPrototypeOf(obj):
 /// - For an INT32-tagged class ref (top16 == 0x7FFE) — return the parent
 ///   class ref via CLASS_REGISTRY's parent_class_id chain, or null at
@@ -1642,28 +1611,6 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
         }
     }
     f64::from_bits(TAG_NULL)
-}
-
-fn error_kind_prototype_value(kind: u32) -> Option<f64> {
-    let name = match kind {
-        crate::error::ERROR_KIND_TYPE_ERROR => "TypeError",
-        crate::error::ERROR_KIND_RANGE_ERROR => "RangeError",
-        crate::error::ERROR_KIND_REFERENCE_ERROR => "ReferenceError",
-        crate::error::ERROR_KIND_SYNTAX_ERROR => "SyntaxError",
-        crate::error::ERROR_KIND_EVAL_ERROR => "EvalError",
-        crate::error::ERROR_KIND_URI_ERROR => "URIError",
-        crate::error::ERROR_KIND_AGGREGATE_ERROR => "AggregateError",
-        _ => "Error",
-    };
-    let ctor = js_get_global_this_builtin_value(name.as_ptr(), name.len());
-    let ctor_jsv = crate::value::JSValue::from_bits(ctor.to_bits());
-    if !ctor_jsv.is_pointer() {
-        return None;
-    }
-    let ctor_ptr = ctor_jsv.as_pointer::<crate::closure::ClosureHeader>() as usize;
-    let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
-    let proto_jsv = crate::value::JSValue::from_bits(proto.to_bits());
-    proto_jsv.is_pointer().then_some(proto)
 }
 
 /// `Object.defineProperties(target, descriptors)` — iterate the descriptor

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -525,6 +525,23 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
                     .unwrap_or(false);
                 return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
             }
+            if ptr >= crate::gc::GC_HEADER_SIZE + 0x1000
+                && crate::object::is_valid_obj_ptr(ptr as *const u8)
+            {
+                let gc_header =
+                    (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+                if (*gc_header).obj_type == crate::gc::GC_TYPE_ERROR {
+                    let present = super::has_own_helpers::str_from_string_header(key_str)
+                        .map(|key| {
+                            crate::error::js_error_has_own_property(
+                                ptr as *mut crate::error::ErrorHeader,
+                                key,
+                            )
+                        })
+                        .unwrap_or(false);
+                    return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
+                }
+            }
         }
 
         let obj = extract_obj_ptr(obj_value);
@@ -1538,6 +1555,12 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                         return f64::from_bits(crate::value::js_nanbox_pointer(p as i64).to_bits());
                     }
                 }
+                if (*gc).obj_type == crate::gc::GC_TYPE_ERROR {
+                    let err = raw_addr as *const crate::error::ErrorHeader;
+                    if let Some(proto) = error_kind_prototype_value((*err).error_kind) {
+                        return proto;
+                    }
+                }
                 if (*gc).obj_type == crate::gc::GC_TYPE_ARRAY {
                     if let Some(proto) = super::array_get_prototype_of_addr(raw_addr as usize) {
                         return proto;
@@ -1588,6 +1611,12 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                         return f64::from_bits(crate::value::js_nanbox_pointer(p as i64).to_bits());
                     }
                 }
+                if (*gc).obj_type == crate::gc::GC_TYPE_ERROR {
+                    let err = bits as *const crate::error::ErrorHeader;
+                    if let Some(proto) = error_kind_prototype_value((*err).error_kind) {
+                        return proto;
+                    }
+                }
                 if (*gc).obj_type == crate::gc::GC_TYPE_ARRAY {
                     if let Some(proto) = super::array_get_prototype_of_addr(bits as usize) {
                         return proto;
@@ -1613,6 +1642,28 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
         }
     }
     f64::from_bits(TAG_NULL)
+}
+
+fn error_kind_prototype_value(kind: u32) -> Option<f64> {
+    let name = match kind {
+        crate::error::ERROR_KIND_TYPE_ERROR => "TypeError",
+        crate::error::ERROR_KIND_RANGE_ERROR => "RangeError",
+        crate::error::ERROR_KIND_REFERENCE_ERROR => "ReferenceError",
+        crate::error::ERROR_KIND_SYNTAX_ERROR => "SyntaxError",
+        crate::error::ERROR_KIND_EVAL_ERROR => "EvalError",
+        crate::error::ERROR_KIND_URI_ERROR => "URIError",
+        crate::error::ERROR_KIND_AGGREGATE_ERROR => "AggregateError",
+        _ => "Error",
+    };
+    let ctor = js_get_global_this_builtin_value(name.as_ptr(), name.len());
+    let ctor_jsv = crate::value::JSValue::from_bits(ctor.to_bits());
+    if !ctor_jsv.is_pointer() {
+        return None;
+    }
+    let ctor_ptr = ctor_jsv.as_pointer::<crate::closure::ClosureHeader>() as usize;
+    let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
+    let proto_jsv = crate::value::JSValue::from_bits(proto.to_bits());
+    proto_jsv.is_pointer().then_some(proto)
 }
 
 /// `Object.defineProperties(target, descriptors)` — iterate the descriptor

--- a/crates/perry-runtime/src/object/prototype_helpers.rs
+++ b/crates/perry-runtime/src/object/prototype_helpers.rs
@@ -1,0 +1,52 @@
+use super::*;
+
+pub(crate) fn constructor_dynamic_prototype(obj: *const ObjectHeader) -> Option<f64> {
+    if obj.is_null() {
+        return None;
+    }
+    let key =
+        crate::string::js_string_from_bytes(b"constructor".as_ptr(), b"constructor".len() as u32);
+    let constructor = js_object_get_field_by_name_f64(obj, key);
+    let bits = constructor.to_bits();
+    let top16 = bits >> 48;
+    if top16 != 0x7FFD {
+        return None;
+    }
+    let raw_addr = (bits & crate::value::POINTER_MASK) as usize;
+    if raw_addr < (crate::gc::GC_HEADER_SIZE as usize) + 0x1000 {
+        return None;
+    }
+    let gc = unsafe { gc_header_for(raw_addr as *const ObjectHeader) };
+    if unsafe { (*gc).obj_type } != crate::gc::GC_TYPE_CLOSURE {
+        return None;
+    }
+    let proto = crate::closure::closure_get_dynamic_prop(raw_addr, "prototype");
+    let proto_jsv = crate::value::JSValue::from_bits(proto.to_bits());
+    if proto_jsv.is_undefined() {
+        None
+    } else {
+        Some(proto)
+    }
+}
+
+pub(crate) fn error_kind_prototype_value(kind: u32) -> Option<f64> {
+    let name = match kind {
+        crate::error::ERROR_KIND_TYPE_ERROR => "TypeError",
+        crate::error::ERROR_KIND_RANGE_ERROR => "RangeError",
+        crate::error::ERROR_KIND_REFERENCE_ERROR => "ReferenceError",
+        crate::error::ERROR_KIND_SYNTAX_ERROR => "SyntaxError",
+        crate::error::ERROR_KIND_EVAL_ERROR => "EvalError",
+        crate::error::ERROR_KIND_URI_ERROR => "URIError",
+        crate::error::ERROR_KIND_AGGREGATE_ERROR => "AggregateError",
+        _ => "Error",
+    };
+    let ctor = js_get_global_this_builtin_value(name.as_ptr(), name.len());
+    let ctor_jsv = crate::value::JSValue::from_bits(ctor.to_bits());
+    if !ctor_jsv.is_pointer() {
+        return None;
+    }
+    let ctor_ptr = ctor_jsv.as_pointer::<crate::closure::ClosureHeader>() as usize;
+    let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
+    let proto_jsv = crate::value::JSValue::from_bits(proto.to_bits());
+    proto_jsv.is_pointer().then_some(proto)
+}


### PR DESCRIPTION
## Summary

Fixes focused Error and JSON.parse runtime parity for #4030 and #4032:

- routes Error-family construction through value-aware message coercion so `undefined` omits the own `message` slot and `Symbol` throws a real `TypeError`
- wires callable `Error`/native Error subclass globals to return real Error objects, matching `new` identity/prototype behavior for the base family
- gives Error objects/prototypes Node-compatible own-property visibility for `message`, `cause`, `errors`, `stack`, plus `Error.prototype.name/message/toString`
- validates JSON.parse input with a full JSON grammar check before the fast parser so invalid grammar and trailing/multiple tokens throw real `SyntaxError`

## DeepWiki

Required DeepWiki reference saved at:

`target/deepwiki/error-json-semantics.md`

Repository/question used: `boa-dev/boa`, covering Error construction/subclasses, prototype/name/message/toString descriptors, JSON.parse grammar rejection, SyntaxError identity, and abrupt completion propagation.

## Before/After Evidence

Before representative repros on this branch failed on:

- `new Error(Symbol())` did not throw `TypeError`
- `Error.prototype.isPrototypeOf(new Error())` / callable `Error()` identity failed
- Error own `message` visibility/enumerability was inconsistent
- `Error.prototype.toString` ignored `name`/`message` override rules
- `JSON.parse("{} {}")` did not throw a real `SyntaxError`

After representative smoke passes in both direct and `PERRY_NO_AUTO_OPTIMIZE=1 perry compile` modes, covering:

- `new Error(Symbol())` and `Error(Symbol())` throw `TypeError`
- `Error.prototype.isPrototypeOf(new Error())` and `Error.prototype.isPrototypeOf(Error())`
- own/non-enumerable `message`, `Error.name`, `Error.prototype.name/message`
- Error toString name/message override cases
- `JSON.parse("{} {}")` throws an object with `SyntaxError.prototype` in its chain

## Tests Run

- `cargo fmt`
- `cargo build --release -p perry-runtime -p perry-stdlib`
- `cargo build --release -p perry`
- Representative compile-mode smoke with `PERRY_ALLOW_UNIMPLEMENTED=1 PERRY_NO_AUTO_OPTIMIZE=1 target/release/perry compile ...`
- `scripts/test262_subset.py --root vendor/test262 --dir built-ins/Error built-ins/SyntaxError built-ins/TypeError built-ins/RangeError built-ins/ReferenceError built-ins/AggregateError --max 80 --timeout 8 --sample-cap 20 --report /tmp/perry-c262-error.json`
  - After: pass=16 diff=0 runtime-fail=23 compile-fail=0 skip=0 parity=41.0%
  - Earlier stale/runtime-before signal while fixing: pass=5 diff=0 runtime-fail=28 compile-fail=6 skip=0 parity=12.8%
- `scripts/test262_subset.py --root vendor/test262 --dir built-ins/JSON --max 100 --timeout 8 --sample-cap 25 --report /tmp/perry-c262-json.json`
  - After: pass=57 diff=0 runtime-fail=43 compile-fail=0 skip=0 parity=57.0%

Final base SHA: `132fb26cf461eced3da6bc86e04f680557c49400`.

## Residual Risks

- Error descriptor/prototype-chain coverage still has broader Test262 gaps, including `Function.prototype.isPrototypeOf(Error.constructor)`, descriptor helper visibility, `Object.prototype.isPrototypeOf(Error.prototype)`, and Symbol-valued toString property throws.
- JSON.parse reviver/proxy/object-coercion and JSON namespace descriptor parity are intentionally not broadened here.
- AggregateError `errors`/`cause` tail behavior and stack formatting are not expanded beyond shared Error slot visibility.
